### PR TITLE
feat(namespaces): rebuildable catalog for configured and dynamic scopes (#1499)

### DIFF
--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -5,6 +5,7 @@ Namespaces allow multiple agents to share one Engram installation while keeping 
 ## Key Config
 
 - `namespacesEnabled` (default: false)
+- `namespaceCatalogEnabled` (default: true; inert unless `namespacesEnabled` — see [Namespace Catalog](#namespace-catalog-issue-1499))
 - `defaultNamespace` (default: `default`)
 - `sharedNamespace` (default: `shared`)
 - `namespacePolicies`: list of namespaces and read/write principals
@@ -171,6 +172,50 @@ curl -X POST http://localhost:4318/engram/v1/observe \
 
 See the [Standalone Server Guide](guides/standalone-server.md) for full multi-tenant setup instructions.
 
+## Namespace Catalog (issue #1499)
+
+The **namespace catalog** is a rebuildable metadata index that lets Remnic
+*enumerate* the configured and dynamically-created namespaces that exist or
+should be maintained — for maintenance fanout, QMD indexing diagnostics,
+dashboard listings, and `doctor`. The filesystem remains the source of truth;
+the catalog is downstream metadata and is fully rebuildable from disk.
+
+- **Storage:** an append-and-compact JSON-lines log at
+  `<memoryDir>/state/namespaces.jsonl`. Touches (read/write/maintenance) are
+  cheap single appends; reads fold the log into current state (last-record-wins);
+  `rebuild` rewrites it atomically (temp file + rename).
+- **Metadata only:** the catalog stores namespace names, kinds, timestamps, and
+  resolved storage dirs. It NEVER holds raw memory content or secrets.
+- **No authorization:** catalog presence grants *no* access. Read/write access
+  still flows through namespace policies (`principalFromSessionKey*`,
+  `namespacePolicies`). The catalog never makes an access decision.
+- **Inert when disabled:** the catalog is a no-op (enumerates nothing, writes
+  nothing) unless `namespacesEnabled: true`. Set `namespaceCatalogEnabled: false`
+  to opt out even when namespaces are enabled. Single-namespace behavior is
+  unchanged.
+
+How namespaces are discovered:
+
+- **config** — `default`, `shared`, and explicit `namespacePolicies` entries.
+- **write / read** — recorded on hot-path writes and recall reads (best-effort;
+  a catalog write failure never crashes the primary memory op).
+- **scan** — `rebuild` walks `<memoryDir>/namespaces/<token>` directories,
+  rejects/reports symlinked or escaping roots, decodes the namespace token, and
+  infers each record's `kind` (`default`, `shared`, `project`, `branch`,
+  `team-project`, `explicit`, `legacy`).
+
+Rebuild from disk (dry-run first):
+
+```bash
+openclaw engram namespaces rebuild --dry-run   # show the plan, write nothing
+openclaw engram namespaces rebuild --apply     # rewrite state/namespaces.jsonl
+openclaw engram namespaces rebuild --apply --json
+```
+
+Rebuild preserves known metadata (timestamps, principal hints) where safe,
+preserves the legacy/default-root compatibility case, and reports ambiguous
+roots instead of silently misclassifying them.
+
 ## CLI
 
 First-class namespace commands:
@@ -179,6 +224,8 @@ First-class namespace commands:
 openclaw engram namespaces ls
 openclaw engram namespaces verify
 openclaw engram namespaces migrate --to default --dry-run
+openclaw engram namespaces rebuild --dry-run
+openclaw engram namespaces rebuild --apply
 ```
 
 When namespaces are enabled, these commands also accept `--namespace <ns>`:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4151,6 +4151,11 @@
         "default": false,
         "description": "Enable multi-agent namespaces (v3.0). Default off."
       },
+      "namespaceCatalogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+      },
       "defaultNamespace": {
         "type": "string",
         "default": "default",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -4151,6 +4151,11 @@
         "default": false,
         "description": "Enable multi-agent namespaces (v3.0). Default off."
       },
+      "namespaceCatalogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+      },
       "defaultNamespace": {
         "type": "string",
         "default": "default",

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1692,6 +1692,13 @@ export class EngramAccessHttpServer {
           const resolved = await this.service.getWritableStorageForNamespace(namespace, principal);
           return resolved.storage;
         },
+        // Catalog write touch (issue #1499 sweep): a contradiction merge writes a
+        // new memory directly to the resolved namespace storage, bypassing the
+        // extraction write path. Record it so QMD maintenance / writtenSince
+        // don't miss the write. Best-effort and failure-tolerant.
+        onMergedMemoryWritten: (namespace, storageDir) => {
+          this.service.recordCatalogWrite(namespace, storageDir);
+        },
       });
       this.respondJson(res, 200, result);
       return;

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -3210,6 +3210,13 @@ export class EngramMcpServer {
             const resolved = await this.service.getWritableStorageForNamespace(namespace, effectivePrincipal);
             return resolved.storage;
           },
+          // Catalog write touch (issue #1499 sweep): a contradiction merge writes
+          // a new memory directly to the resolved namespace storage, bypassing the
+          // extraction write path. Record it so QMD maintenance / writtenSince
+          // don't miss the write. Best-effort and failure-tolerant.
+          onMergedMemoryWritten: (namespace, storageDir) => {
+            this.service.recordCatalogWrite(namespace, storageDir);
+          },
         });
       }
       case "engram.contradiction_scan_run":

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -7076,6 +7076,18 @@ export class EngramAccessService {
     return this.orchestrator.storage;
   }
 
+  /**
+   * Best-effort catalog write touch delegate (issue #1499 sweep). HTTP/MCP
+   * surfaces resolve a per-namespace storage and write through it directly (e.g.
+   * a contradiction merge), bypassing the extraction write path that owns
+   * `markCatalogWrite`. They call this to record the write so a (possibly
+   * dynamic) namespace's `lastWriteAt` stays accurate and QMD maintenance does
+   * not miss it. Fire-and-forget and failure-tolerant on the orchestrator side.
+   */
+  recordCatalogWrite(namespace?: string, storageDir?: string): void {
+    this.orchestrator.recordCatalogWrite(namespace, storageDir);
+  }
+
   get configRef(): PluginConfig {
     return this.orchestrator.config;
   }

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4150,6 +4150,65 @@ export function registerCli(
           console.log("\nOK");
         });
 
+      namespacesCmd
+        .command("rebuild")
+        .description(
+          "Rebuild the namespace catalog from disk (issue #1499). Scans configured + dynamic namespace roots safely and rewrites <memoryDir>/state/namespaces.jsonl",
+        )
+        .option("--dry-run", "Show the rebuilt catalog without writing it")
+        .option("--apply", "Write the rebuilt catalog to disk")
+        .option("--json", "Emit the rebuild result as JSON")
+        .action(async (optionsRaw: unknown) => {
+          const options =
+            optionsRaw && typeof optionsRaw === "object"
+              ? (optionsRaw as { dryRun?: boolean; apply?: boolean; json?: boolean })
+              : {};
+          // Default to a non-destructive dry run unless --apply is given.
+          // Reject contradictory flags rather than silently choosing one.
+          if (options.dryRun === true && options.apply === true) {
+            throw new Error("Pass only one of --dry-run or --apply, not both.");
+          }
+          const dryRun = options.apply !== true;
+
+          if (!orchestrator.namespaceCatalog.enabled) {
+            const note =
+              "Namespace catalog is inert: it only runs when namespacesEnabled is true and namespaceCatalogEnabled is not false.";
+            if (options.json === true) {
+              console.log(
+                JSON.stringify({ dryRun, enabled: false, records: [], skipped: [], note }, null, 2),
+              );
+            } else {
+              console.log(note);
+            }
+            return;
+          }
+
+          const result = await orchestrator.namespaceCatalog.rebuildFromDisk({ dryRun });
+
+          if (options.json === true) {
+            console.log(JSON.stringify({ enabled: true, ...result }, null, 2));
+            return;
+          }
+
+          console.log("=== Namespace Catalog Rebuild ===\n");
+          console.log(`mode: ${dryRun ? "dry-run" : "apply"}`);
+          console.log(`namespaces: ${result.records.length}`);
+          for (const record of result.records) {
+            console.log(
+              `${record.namespace}\n  kind: ${record.kind}\n  storage: ${record.storageDir}\n  discovered-by: ${record.discoveredBy}`,
+            );
+          }
+
+          if (result.skipped.length > 0) {
+            console.log("\nSkipped / ambiguous roots:");
+            for (const skip of result.skipped) {
+              console.log(`- ${skip.token} (${skip.reason})${skip.detail ? `: ${skip.detail}` : ""}`);
+            }
+          }
+
+          console.log(dryRun ? "\nDRY RUN" : "\nOK");
+        });
+
       cmd
         .command("export")
         .description("Export Remnic memory to JSON, Markdown bundle, or SQLite")

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4193,6 +4193,16 @@ export function registerCli(
             } else {
               console.log(note);
             }
+            // Exit-code parity with the enabled path (cursor Medium — NFb5W): an
+            // inert catalog rewrote NOTHING, so a `--apply` (dryRun=false) did NOT
+            // apply. The enabled path sets `exitCode = 1` whenever a non-dry-run
+            // rebuild reports `applied: false`; an inert `--apply` is exactly that
+            // case, so exit-code-only automation must see a non-zero exit rather
+            // than read a no-op apply as a completed rebuild. A `--dry-run` (or the
+            // default dry run) inert call stays exit 0 — it never promised to write.
+            if (!dryRun) {
+              process.exitCode = 1;
+            }
             return;
           }
 

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4187,6 +4187,13 @@ export function registerCli(
 
           if (options.json === true) {
             console.log(JSON.stringify({ enabled: true, ...result }, null, 2));
+            // Mirror the non-JSON failure signal (round 6, codex P2 — NEFoa): an
+            // `--apply` that could not acquire the lock returns `applied: false`
+            // and rewrote nothing, so automation must see a non-zero exit even in
+            // JSON mode rather than treating a no-op apply as a successful rebuild.
+            if (!dryRun && result.applied === false) {
+              process.exitCode = 1;
+            }
             return;
           }
 

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4179,8 +4179,16 @@ export function registerCli(
             const note =
               "Namespace catalog is inert: it only runs when namespacesEnabled is true and namespaceCatalogEnabled is not false.";
             if (options.json === true) {
+              // Include `applied: false` so the inert JSON payload carries the SAME
+              // shape as the enabled path (cursor Low — NFDBM). An inert catalog
+              // rewrote nothing, so a `--apply` did NOT apply; automation that keys
+              // on `applied` must not misread a missing field as a completed rebuild.
               console.log(
-                JSON.stringify({ dryRun, enabled: false, records: [], skipped: [], note }, null, 2),
+                JSON.stringify(
+                  { dryRun, enabled: false, applied: false, records: [], skipped: [], note },
+                  null,
+                  2,
+                ),
               );
             } else {
               console.log(note);

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4206,7 +4206,20 @@ export function registerCli(
             }
           }
 
-          console.log(dryRun ? "\nDRY RUN" : "\nOK");
+          if (dryRun) {
+            console.log("\nDRY RUN");
+          } else if (result.applied) {
+            console.log("\nOK");
+          } else {
+            // An --apply that could not acquire the cross-process rebuild lock
+            // ran compute-only and did NOT rewrite the catalog (NBn3n/NBsGG).
+            // Report the non-mutation explicitly and exit non-zero so scripts
+            // and operators retry rather than assume the rebuild persisted.
+            console.log(
+              "\nNOT APPLIED: another rebuild holds the lock; the catalog was NOT rewritten. Retry shortly.",
+            );
+            process.exitCode = 1;
+          }
         });
 
       cmd

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8955,6 +8955,13 @@ export function registerCli(
               }
               return orchestrator.getStorageForNamespace(requested || orchestrator.config.defaultNamespace);
             },
+            // Catalog write touch (issue #1499 sweep): a contradiction merge can
+            // write a new memory to a dynamic namespace via the CLI resolve path,
+            // bypassing the extraction write path. Record it so QMD maintenance /
+            // writtenSince don't miss the write. Best-effort and failure-tolerant.
+            onMergedMemoryWritten: (namespace, storageDir) => {
+              orchestrator.recordCatalogWrite(namespace, storageDir);
+            },
           });
           console.log(result.message);
           if (result.affectedIds.length > 0) {

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -1291,3 +1291,37 @@ test("parseConfig rejects connectors.gmail.pollIntervalMs above maximum (25h)", 
     /pollIntervalMs/,
   );
 });
+
+// ── issue #1499 / CLAUDE.md rule #36: namespaceCatalogEnabled opt-out coercion.
+// A string "false"/"0"/"no"/"off" from CLI/env/JSON config must disable the
+// catalog, not stay truthy. Defaults to enabled when absent/unrecognized.
+test("parseConfig namespaceCatalogEnabled defaults to true when absent", () => {
+  assert.equal(parseConfig({}).namespaceCatalogEnabled, true);
+});
+
+test('parseConfig namespaceCatalogEnabled="false" (string) → false (rule #36)', () => {
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "false" }).namespaceCatalogEnabled, false);
+});
+
+test('parseConfig namespaceCatalogEnabled="0" (string) → false', () => {
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "0" }).namespaceCatalogEnabled, false);
+});
+
+test('parseConfig namespaceCatalogEnabled="no"/"off" (strings) → false', () => {
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "no" }).namespaceCatalogEnabled, false);
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "off" }).namespaceCatalogEnabled, false);
+});
+
+test("parseConfig namespaceCatalogEnabled=false (boolean) → false", () => {
+  assert.equal(parseConfig({ namespaceCatalogEnabled: false }).namespaceCatalogEnabled, false);
+});
+
+test('parseConfig namespaceCatalogEnabled="true" (string) → true', () => {
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "true" }).namespaceCatalogEnabled, true);
+});
+
+test("parseConfig namespaceCatalogEnabled unrecognized value → defaults to true", () => {
+  // An unrecognized string is treated as absent (default on), not silently
+  // coerced to false — matching coerceBooleanLike(...) ?? true semantics.
+  assert.equal(parseConfig({ namespaceCatalogEnabled: "maybe" }).namespaceCatalogEnabled, true);
+});

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -1320,8 +1320,14 @@ test('parseConfig namespaceCatalogEnabled="true" (string) → true', () => {
   assert.equal(parseConfig({ namespaceCatalogEnabled: "true" }).namespaceCatalogEnabled, true);
 });
 
-test("parseConfig namespaceCatalogEnabled unrecognized value → defaults to true", () => {
-  // An unrecognized string is treated as absent (default on), not silently
-  // coerced to false — matching coerceBooleanLike(...) ?? true semantics.
-  assert.equal(parseConfig({ namespaceCatalogEnabled: "maybe" }).namespaceCatalogEnabled, true);
+test("parseConfig namespaceCatalogEnabled present-but-unrecognized → throws (rule #51, codex NI42R)", () => {
+  // A PRESENT but unrecognized value is rejected, not silently defaulted to
+  // enabled — mirrors resolveEmitLegacyTools (CLAUDE.md rule #51: reject invalid
+  // input instead of silently defaulting). Absent still defaults to true.
+  assert.throws(
+    () => parseConfig({ namespaceCatalogEnabled: "maybe" }),
+    /namespaceCatalogEnabled must be a boolean-like value/,
+  );
+  assert.throws(() => parseConfig({ namespaceCatalogEnabled: "flase" }), /boolean-like value/);
+  assert.throws(() => parseConfig({ namespaceCatalogEnabled: 2 }), /boolean-like value/);
 });

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -384,6 +384,27 @@ function resolveEmitLegacyTools(configValue: unknown): boolean {
   return true;
 }
 
+/**
+ * Resolve the `namespaceCatalogEnabled` opt-out (issue #1499). A boolean-like
+ * value ("false"/"0"/"no"/"off" etc.) is honored; a PRESENT but unrecognized
+ * value ("flase", 2) is REJECTED rather than silently defaulting to enabled
+ * (CLAUDE.md rule #51 — reject invalid input instead of silently defaulting),
+ * mirroring `resolveEmitLegacyTools`. Defaults to enabled only when absent.
+ */
+function resolveNamespaceCatalogEnabled(configValue: unknown): boolean {
+  const ACCEPTED = "true/false/1/0/yes/no/on/off";
+  if (configValue !== undefined && configValue !== null) {
+    const coerced = coerceBooleanLike(configValue);
+    if (coerced === undefined) {
+      throw new Error(
+        `namespaceCatalogEnabled must be a boolean-like value (${ACCEPTED}); got ${JSON.stringify(configValue)}`,
+      );
+    }
+    return coerced;
+  }
+  return true;
+}
+
 export function isOpenaiApiKeyDisabled(value: unknown): boolean {
   return value === false || (typeof value === "string" && value.trim().toLowerCase() === "false");
 }
@@ -2590,11 +2611,12 @@ export function parseConfig(raw: unknown): PluginConfig {
     namespacesEnabled: cfg.namespacesEnabled === true,
     // Namespace catalog (issue #1499): default ON, but only does anything when
     // namespacesEnabled is also true (the catalog is inert otherwise). Operators
-    // opt out with namespaceCatalogEnabled: false. Parse via coerceBooleanLike
-    // so string/number opt-outs from CLI/env/JSON ("false", "0", "no", "off")
-    // are honored rather than staying truthy (CLAUDE.md rule #36); default to
-    // enabled only when the value is absent or unrecognized.
-    namespaceCatalogEnabled: coerceBooleanLike(cfg.namespaceCatalogEnabled) ?? true,
+    // opt out with namespaceCatalogEnabled: false. Boolean-like opt-outs from
+    // CLI/env/JSON ("false", "0", "no", "off") are honored (CLAUDE.md rule #36);
+    // a PRESENT but unrecognized value ("flase", 2) is REJECTED rather than
+    // silently defaulting to enabled (CLAUDE.md rule #51); default to enabled
+    // only when the value is absent.
+    namespaceCatalogEnabled: resolveNamespaceCatalogEnabled(cfg.namespaceCatalogEnabled),
     // NOTE: namespace identifiers are intentionally NOT sanitized here — the
     // codebase rejects unsafe namespaces at the point of use (see
     // codex-materialize-runner and NamespaceStorageRouter / resolveNamespaceDir),

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2590,8 +2590,11 @@ export function parseConfig(raw: unknown): PluginConfig {
     namespacesEnabled: cfg.namespacesEnabled === true,
     // Namespace catalog (issue #1499): default ON, but only does anything when
     // namespacesEnabled is also true (the catalog is inert otherwise). Operators
-    // opt out with namespaceCatalogEnabled: false.
-    namespaceCatalogEnabled: cfg.namespaceCatalogEnabled !== false,
+    // opt out with namespaceCatalogEnabled: false. Parse via coerceBooleanLike
+    // so string/number opt-outs from CLI/env/JSON ("false", "0", "no", "off")
+    // are honored rather than staying truthy (CLAUDE.md rule #36); default to
+    // enabled only when the value is absent or unrecognized.
+    namespaceCatalogEnabled: coerceBooleanLike(cfg.namespaceCatalogEnabled) ?? true,
     // NOTE: namespace identifiers are intentionally NOT sanitized here — the
     // codebase rejects unsafe namespaces at the point of use (see
     // codex-materialize-runner and NamespaceStorageRouter / resolveNamespaceDir),

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2588,6 +2588,10 @@ export function parseConfig(raw: unknown): PluginConfig {
 
     // v3.0 namespaces (default off)
     namespacesEnabled: cfg.namespacesEnabled === true,
+    // Namespace catalog (issue #1499): default ON, but only does anything when
+    // namespacesEnabled is also true (the catalog is inert otherwise). Operators
+    // opt out with namespaceCatalogEnabled: false.
+    namespaceCatalogEnabled: cfg.namespaceCatalogEnabled !== false,
     // NOTE: namespace identifiers are intentionally NOT sanitized here — the
     // codebase rejects unsafe namespaces at the point of use (see
     // codex-materialize-runner and NamespaceStorageRouter / resolveNamespaceDir),

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1892,6 +1892,109 @@ test("executeResolution merge records exactly one catalog write touch for the pa
   }
 });
 
+// NH3X3: supersede-only resolutions (keep-a / keep-b) also mutate the namespace,
+// so they must record a catalog touch — post-commit, never on rollback.
+
+test("executeResolution keep-a records exactly one catalog write touch on success", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const storage = makeResolutionStorage({ dir: "/tmp/work-namespace-storage" });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-a", {
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-b-002"]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "keep-a");
+    assert.deepEqual(catalogTouches, [
+      { namespace: "work", storageDir: "/tmp/work-namespace-storage" },
+    ]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution keep-b records exactly one catalog write touch on success", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const storage = makeResolutionStorage({ dir: "/tmp/work-namespace-storage" });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-b", {
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-a-001"]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "keep-b");
+    assert.deepEqual(catalogTouches, [
+      { namespace: "work", storageDir: "/tmp/work-namespace-storage" },
+    ]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution keep-a records NO catalog write touch when resolution persistence fails and rolls back", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const pairFile = path.join(dir, ".review", "contradictions", `${written.pairId}.json`);
+    const storage = makeResolutionStorage({
+      dir: "/tmp/work-namespace-storage",
+      onSupersede: () => {
+        fs.rmSync(pairFile, { force: true });
+      },
+    });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-a", {
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.match(result.message, /Resolution persistence failed; rolled back memory changes/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.deepEqual(catalogTouches, [], "a rolled-back keep-a must not record a catalog write touch");
+    assert.equal(readPair(dir, written.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+// Non-mutating verbs never touch the catalog (no namespace memory changed).
+test("executeResolution both-valid records no catalog write touch", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const storage = makeResolutionStorage({ dir: "/tmp/work-namespace-storage" });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "both-valid", {
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, []);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "both-valid");
+    assert.deepEqual(catalogTouches, [], "both-valid mutates no namespace memory — no catalog touch");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("executeResolution merge rolls back the first supersession when the second fails", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {
@@ -2603,9 +2706,10 @@ test("executeResolution merge fires onMergedMemoryWritten with the pair namespac
   }
 });
 
-// Negative: reusing an EXISTING merged memory id is not a new durable write, so the
-// catalog touch must NOT fire (avoids spurious lastWriteAt refreshes / double-count).
-test("executeResolution merge does not fire onMergedMemoryWritten when reusing an existing merged id", async () => {
+// Reusing an EXISTING merged memory id still supersedes BOTH sources — a durable
+// namespace mutation — so the catalog touch MUST fire so `lastWriteAt` refreshes
+// (NH3X3). It fires exactly once, post-commit.
+test("executeResolution merge fires onMergedMemoryWritten exactly once when reusing an existing merged id", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {
     const written = writePair(dir, makePair({ namespace: "project-origin-dynamic" }));
@@ -2615,7 +2719,7 @@ test("executeResolution merge does not fire onMergedMemoryWritten when reusing a
     let touchCount = 0;
 
     const result = await executeResolution(dir, storage, written.pairId, "merge", {
-      mergedMemoryId: "mem-merged-003", // pre-existing — no new write
+      mergedMemoryId: "mem-merged-003", // pre-existing merged memory, sources still superseded
       storageForNamespace: () => storage,
       onMergedMemoryWritten: () => {
         touchCount += 1;
@@ -2623,7 +2727,8 @@ test("executeResolution merge does not fire onMergedMemoryWritten when reusing a
     });
 
     assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
-    assert.equal(touchCount, 0, "reusing an existing merged memory must not record a catalog write touch");
+    assert.equal(touchCount, 1, "reusing an existing merged memory still supersedes both sources — record one touch");
+    assert.equal(readPair(dir, written.pairId)?.resolution, "merge");
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -2489,3 +2489,69 @@ test("readPair returns null for non-object JSON", async () => {
     await cleanup();
   }
 });
+
+// ── issue #1499 sweep: a contradiction merge that CREATES a new merged memory
+// writes durable data to the pair's (possibly dynamic) namespace storage,
+// bypassing the extraction write path. executeResolution must invoke
+// onMergedMemoryWritten(namespace, storageDir) so the caller records the catalog
+// write — otherwise a dynamic namespace whose only durable mutation is a merge
+// stays invisible to QMD maintenance / writtenSince.
+test("executeResolution merge fires onMergedMemoryWritten with the pair namespace when a new memory is created", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "project-origin-dynamic" }));
+    const storage = makeResolutionStorage();
+    (storage as { dir?: string }).dir = "/memory/namespaces/project-origin-dynamic-token";
+
+    const touches: Array<{ namespace?: string; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact for dynamic namespace",
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        touches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
+    assert.equal(touches.length, 1, "exactly one catalog write touch for a created merge memory");
+    assert.equal(
+      touches[0]!.namespace,
+      "project-origin-dynamic",
+      "the catalog touch carries the pair's (dynamic) namespace",
+    );
+    assert.equal(
+      touches[0]!.storageDir,
+      "/memory/namespaces/project-origin-dynamic-token",
+      "the catalog touch carries the resolved namespace storage dir",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+// Negative: reusing an EXISTING merged memory id is not a new durable write, so the
+// catalog touch must NOT fire (avoids spurious lastWriteAt refreshes / double-count).
+test("executeResolution merge does not fire onMergedMemoryWritten when reusing an existing merged id", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "project-origin-dynamic" }));
+    const storage = makeResolutionStorage();
+    (storage as { dir?: string }).dir = "/memory/namespaces/project-origin-dynamic-token";
+
+    let touchCount = 0;
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedMemoryId: "mem-merged-003", // pre-existing — no new write
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: () => {
+        touchCount += 1;
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
+    assert.equal(touchCount, 0, "reusing an existing merged memory must not record a catalog write touch");
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -91,6 +91,7 @@ function makeResolutionStorage(options: {
   failRollbackFor?: string;
   partialSupersedeBeforeFailureFor?: string;
   onSupersede?: (oldId: string, newId: string) => void;
+  dir?: string;
 } = {}) {
   const memories = new Map<string, MemoryFile>([
     ["mem-a-001", makeMemory("mem-a-001")],
@@ -111,6 +112,7 @@ function makeResolutionStorage(options: {
     supersedeCalls,
     frontmatterWrites,
     removedFactHashIds,
+    dir: options.dir ?? "/tmp/contradiction-namespace-storage",
     async getMemoryById(id: string) {
       const memory = memories.get(id);
       return memory ? cloneMemory(memory) : null;
@@ -1814,6 +1816,77 @@ test("executeResolution rolls back memory changes when pair resolution persisten
     assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
     assert.equal(storage.memories.get("mem-b-002")?.frontmatter.supersededBy, undefined);
     assert.equal(readPair(dir, written.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ── Catalog-write touch ordering (NH1dX, rule #25) ──────────────────────────────
+// The merge catalog touch (onMergedMemoryWritten) must fire ONLY after the
+// resolution durably commits past the rollback point. If resolvePair fails and
+// the merge rolls back, NO catalog write may be recorded for a write that did
+// not survive.
+
+test("executeResolution merge records NO catalog write touch when resolution persistence fails and rolls back", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const pairFile = path.join(dir, ".review", "contradictions", `${written.pairId}.json`);
+    // Force resolvePair to fail by removing the pair file once supersession runs,
+    // mirroring the existing rollback test. This drives the rollback path.
+    const storage = makeResolutionStorage({
+      dir: "/tmp/work-namespace-storage",
+      onSupersede: () => {
+        fs.rmSync(pairFile, { force: true });
+      },
+    });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.match(result.message, /Resolution persistence failed; rolled back memory changes/);
+    assert.deepEqual(result.affectedIds, []);
+    // The merged memory was created then cleaned up by the rollback, and the
+    // resolution never persisted — so the catalog touch must NOT have fired.
+    assert.deepEqual(
+      catalogTouches,
+      [],
+      "no catalog write touch may be recorded for a rolled-back merge",
+    );
+    assert.equal(readPair(dir, written.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge records exactly one catalog write touch for the pair namespace on success", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const storage = makeResolutionStorage({ dir: "/tmp/work-namespace-storage" });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.match(result.message, /Both memories superseded by merged/);
+    assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "merge");
+    // Exactly one touch, carrying the pair namespace and the routed storage dir.
+    assert.deepEqual(catalogTouches, [
+      { namespace: "work", storageDir: "/tmp/work-namespace-storage" },
+    ]);
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1972,6 +1972,39 @@ test("executeResolution keep-a records NO catalog write touch when resolution pe
   }
 });
 
+test("executeResolution keep-a records a catalog write touch when resolution persistence fails and rollback is incomplete", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ namespace: "work" }));
+    const pairFile = path.join(dir, ".review", "contradictions", `${written.pairId}.json`);
+    const storage = makeResolutionStorage({
+      dir: "/tmp/work-namespace-storage",
+      failRollbackFor: "mem-b-002",
+      onSupersede: () => {
+        fs.rmSync(pairFile, { force: true });
+      },
+    });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-a", {
+      storageForNamespace: () => storage,
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
+    });
+
+    assert.match(result.message, /Resolution persistence failed; rollback incomplete/);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, "superseded");
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.supersededBy, "mem-a-001");
+    assert.deepEqual(catalogTouches, [
+      { namespace: "work", storageDir: "/tmp/work-namespace-storage" },
+    ]);
+    assert.equal(readPair(dir, written.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
 // Non-mutating verbs never touch the catalog (no namespace memory changed).
 test("executeResolution both-valid records no catalog write touch", async () => {
   const { dir, cleanup } = await makeTempDir();
@@ -2124,9 +2157,13 @@ test("executeResolution merge keeps created replacement when rollback fails", as
       failSupersedeFor: "mem-b-002",
       failRollbackFor: "mem-a-001",
     });
+    const catalogTouches: Array<{ namespace: string | undefined; storageDir: string }> = [];
 
     const result = await executeResolution(dir, storage, written.pairId, "merge", {
       mergedContent: "merged canonical fact",
+      onMergedMemoryWritten: (namespace, storageDir) => {
+        catalogTouches.push({ namespace, storageDir });
+      },
     });
 
     const mergedId = storage.supersedeCalls[0]?.newId;
@@ -2136,6 +2173,9 @@ test("executeResolution merge keeps created replacement when rollback fails", as
     assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, mergedId);
     assert.equal(storage.memories.get(mergedId)?.content, "merged canonical fact");
     assert.deepEqual(storage.removedFactHashIds, []);
+    assert.deepEqual(catalogTouches, [
+      { namespace: undefined, storageDir: "/tmp/contradiction-namespace-storage" },
+    ]);
     assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
   } finally {
     await cleanup();

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -5,11 +5,11 @@
  * reimplement supersession logic here (rule 22: deduplicate resolution).
  */
 
+import { log } from "../logger.js";
 import type { StorageManager } from "../storage.js";
 import type { MemoryCategory, MemoryFile } from "../types.js";
 import type { ResolutionVerb } from "./contradiction-review.js";
-import { resolvePair, readPair } from "./contradiction-review.js";
-import { log } from "../logger.js";
+import { readPair, resolvePair } from "./contradiction-review.js";
 
 export interface ResolutionResult {
   pairId: string;
@@ -30,19 +30,19 @@ export interface ExecuteResolutionOptions {
   /** Resolve storage for the pair namespace, or the default namespace for legacy unscoped pairs. */
   storageForNamespace?: (namespace: string | undefined) => StorageManager | Promise<StorageManager>;
   /**
-   * Best-effort hook invoked after a contradiction resolution that MUTATED the
-   * namespace's memory files has DURABLY committed (issue #1499 sweep, NH1dX /
-   * NH3X3). Every mutating verb — `merge` (creates a new memory and supersedes
-   * both sources), `keep-a`, and `keep-b` (supersede the losing source + rewrite
+   * Best-effort hook invoked after a contradiction resolution leaves a durable
+   * mutation in the namespace's memory files (issue #1499 sweep, NH1dX / NH3X3).
+   * Every mutating verb — `merge` (creates a new memory and supersedes both
+   * sources), `keep-a`, and `keep-b` (supersede the losing source + rewrite
    * frontmatter) — writes directly to the pair's (possibly DYNAMIC) namespace
    * storage, bypassing the extraction write path that records catalog writes. So
    * without this the namespace's `lastWriteAt` stays stale and QMD maintenance /
    * `writtenSince` can skip a namespace whose only post-write mutation is
-   * resolving a contradiction. It fires ONLY after `resolvePair` persists the
-   * resolution past the rollback point: if the resolution fails and the memory
-   * changes are rolled back, this is never called, so the catalog never records a
-   * write that did not survive (rule #25). Non-mutating verbs (`both-valid`,
-   * `needs-more-context`) never trigger it. Callers wire this to
+   * resolving a contradiction. It fires after the resolution commits, or after a
+   * failed resolution/rollback path when durable memory changes are still left on
+   * disk. If a failure rolls back cleanly, this is never called, so the catalog
+   * never records a write that did not survive (rule #25). Non-mutating verbs
+   * (`both-valid`, `needs-more-context`) never trigger it. Callers wire this to
    * `Orchestrator.recordCatalogWrite(namespace, storageDir)`. Must be
    * failure-tolerant: it is fire-and-forget and must never affect resolution.
    */
@@ -99,17 +99,12 @@ export async function executeResolution(
   let message = "";
   let supersedeFailed = false;
   let rollbackAfterResolveFailure: (() => Promise<boolean>) | null = null;
-  // Deferred catalog-write touch for any resolution that MUTATES this namespace's
-  // memory files (issue #1499 sweep, NH1dX / NH3X3). Rule #25: never record a
-  // success marker / catalog touch before the new state is durably committed past
-  // the rollback point. Every mutating verb (merge, keep-a, keep-b) supersedes a
-  // source and/or writes a fresh merged memory, but the resolution is not durable
-  // until `resolvePair` persists below. If that persistence FAILS and
-  // `rollbackAfterResolveFailure` restores the changes, no catalog write actually
-  // survived — so the touch must fire ONLY after the whole resolution durably
-  // succeeds. We arm it in each mutating branch and invoke it exactly once at the
-  // post-commit point. Non-mutating verbs (both-valid, needs-more-context) leave
-  // it null.
+  // Deferred catalog-write touch for any resolution that leaves durable namespace
+  // memory mutations (issue #1499 sweep, NH1dX / NH3X3). Rule #25: never record a
+  // catalog touch for a write that is fully rolled back. Successful mutating
+  // resolutions invoke it after `resolvePair` persists. Failed paths invoke it
+  // only when rollback inspection shows the namespace still differs from the
+  // pre-mutation snapshot.
   let recordCatalogWriteTouch: (() => void) | null = null;
   // Returns the deferred touch fn for a mutating verb (or null when the caller
   // wired no catalog hook), so each branch assigns `recordCatalogWriteTouch`
@@ -121,6 +116,30 @@ export async function executeResolution(
     const namespace = pair.namespace;
     const storageDir = resolutionStorage.dir;
     return () => onMergedMemoryWritten(namespace, storageDir);
+  };
+  const catalogWriteTouch = buildCatalogTouch();
+  const recordCatalogWriteTouchSafely = (context: string, touch = catalogWriteTouch): void => {
+    if (!touch) return;
+    try {
+      touch();
+    } catch (err) {
+      log.warn(
+        "[contradiction-resolution] catalog write touch failed for pair=%s context=%s: %s",
+        pairId,
+        context,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  };
+  const touchCatalogIfRollbackLeftChange = async (
+    context: string,
+    snapshots: MemoryFile[],
+    replacement?: Extract<MergeReplacement, { ok: true }>,
+  ): Promise<void> => {
+    if (!catalogWriteTouch) return;
+    if (await rollbackLeftDurableMutation(resolutionStorage, snapshots, replacement)) {
+      recordCatalogWriteTouchSafely(context);
+    }
   };
 
   switch (verb) {
@@ -141,7 +160,7 @@ export async function executeResolution(
           restoreMemorySnapshot(resolutionStorage, sourceB!, "contradiction-resolution:keep-a-rollback");
         // keep-a superseded idB in this namespace — record a catalog touch once
         // the resolution durably commits (NH3X3).
-        recordCatalogWriteTouch = buildCatalogTouch();
+        recordCatalogWriteTouch = catalogWriteTouch;
         message = `Kept ${idA}, superseded ${idB}`;
       }
       else {
@@ -149,6 +168,9 @@ export async function executeResolution(
         const rolledBack = sourceB
           ? await restoreMemorySnapshot(resolutionStorage, sourceB, "contradiction-resolution:keep-a-rollback")
           : false;
+        if (sourceB && !rolledBack) {
+          await touchCatalogIfRollbackLeftChange("keep-a-rollback-incomplete", [sourceB]);
+        }
         message = rolledBack
           ? `Supersede failed for ${idB}; restored ${idB} and did not resolve`
           : `Supersede failed for ${idB}; rollback incomplete for ${idB} and pair is not resolved`;
@@ -172,7 +194,7 @@ export async function executeResolution(
           restoreMemorySnapshot(resolutionStorage, sourceA!, "contradiction-resolution:keep-b-rollback");
         // keep-b superseded idA in this namespace — record a catalog touch once
         // the resolution durably commits (NH3X3).
-        recordCatalogWriteTouch = buildCatalogTouch();
+        recordCatalogWriteTouch = catalogWriteTouch;
         message = `Kept ${idB}, superseded ${idA}`;
       }
       else {
@@ -180,6 +202,9 @@ export async function executeResolution(
         const rolledBack = sourceA
           ? await restoreMemorySnapshot(resolutionStorage, sourceA, "contradiction-resolution:keep-b-rollback")
           : false;
+        if (sourceA && !rolledBack) {
+          await touchCatalogIfRollbackLeftChange("keep-b-rollback-incomplete", [sourceA]);
+        }
         message = rolledBack
           ? `Supersede failed for ${idA}; restored ${idA} and did not resolve`
           : `Supersede failed for ${idA}; rollback incomplete for ${idA} and pair is not resolved`;
@@ -204,6 +229,9 @@ export async function executeResolution(
         if (rolledBackA) {
           await cleanupCreatedReplacement(resolutionStorage, replacement);
         }
+        else {
+          await touchCatalogIfRollbackLeftChange("merge-first-rollback-incomplete", [replacement.sourceA], replacement);
+        }
         break;
       }
 
@@ -220,6 +248,13 @@ export async function executeResolution(
           ].filter(Boolean).join(", ")} and pair is not resolved`;
         if (rolledBackA && rolledBackB) {
           await cleanupCreatedReplacement(resolutionStorage, replacement);
+        }
+        else {
+          await touchCatalogIfRollbackLeftChange(
+            "merge-second-rollback-incomplete",
+            [replacement.sourceA, replacement.sourceB],
+            replacement,
+          );
         }
         break;
       }
@@ -243,7 +278,7 @@ export async function executeResolution(
       // that must refresh `lastWriteAt` (NH3X3). Otherwise a dynamic namespace
       // whose only durable mutation is a contradiction merge stays invisible to
       // QMD maintenance / `writtenSince`. Best-effort on the caller side.
-      recordCatalogWriteTouch = buildCatalogTouch();
+      recordCatalogWriteTouch = catalogWriteTouch;
       message = `Both memories superseded by merged ${replacement.mergedId}`;
       break;
     }
@@ -275,9 +310,12 @@ export async function executeResolution(
         affectedIds.length = 0;
         message = rolledBack
           ? `Resolution persistence failed; rolled back memory changes and did not resolve ${pairId}`
-          : `Resolution persistence failed; rollback incomplete and pair is not resolved`;
+          : "Resolution persistence failed; rollback incomplete and pair is not resolved";
+        if (!rolledBack && recordCatalogWriteTouch) {
+          recordCatalogWriteTouchSafely("resolve-persistence-rollback-incomplete", recordCatalogWriteTouch);
+        }
       } else {
-        message = `Resolution persistence failed; pair is not resolved`;
+        message = "Resolution persistence failed; pair is not resolved";
       }
     } else if (recordCatalogWriteTouch) {
       // The resolution durably committed (memory mutated AND the resolution
@@ -285,15 +323,7 @@ export async function executeResolution(
       // catalog write for the namespace mutation (NH1dX / NH3X3, rule #25).
       // Best-effort: the caller's callback swallows errors; guard here so a
       // throwing callback never derails a successful resolution.
-      try {
-        recordCatalogWriteTouch();
-      } catch (err) {
-        log.warn(
-          "[contradiction-resolution] catalog write touch failed for pair=%s: %s",
-          pairId,
-          err instanceof Error ? err.message : err,
-        );
-      }
+      recordCatalogWriteTouchSafely("resolved", recordCatalogWriteTouch);
     }
   }
   log.info("[contradiction-resolution] pair=%s verb=%s affected=%d", pairId, verb, affectedIds.length);
@@ -447,6 +477,50 @@ async function restoreMemorySnapshot(
     );
     return false;
   }
+}
+
+async function rollbackLeftDurableMutation(
+  storage: StorageManager,
+  snapshots: MemoryFile[],
+  replacement?: Extract<MergeReplacement, { ok: true }>,
+): Promise<boolean> {
+  for (const snapshot of snapshots) {
+    try {
+      const current = await storage.getMemoryById(snapshot.frontmatter.id);
+      if (!current) return true;
+      if (supersessionStateChanged(current, snapshot)) return true;
+    } catch (err) {
+      log.warn(
+        "[contradiction-resolution] rollback inspection failed for %s: %s",
+        snapshot.frontmatter.id,
+        err instanceof Error ? err.message : err,
+      );
+      return true;
+    }
+  }
+
+  if (replacement?.created) {
+    try {
+      return (await storage.getMemoryById(replacement.mergedId)) !== null;
+    } catch (err) {
+      log.warn(
+        "[contradiction-resolution] rollback replacement inspection failed for %s: %s",
+        replacement.mergedId,
+        err instanceof Error ? err.message : err,
+      );
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function supersessionStateChanged(current: MemoryFile, snapshot: MemoryFile): boolean {
+  return (
+    current.frontmatter.status !== snapshot.frontmatter.status ||
+    current.frontmatter.supersededBy !== snapshot.frontmatter.supersededBy ||
+    current.frontmatter.supersededAt !== snapshot.frontmatter.supersededAt
+  );
 }
 
 async function cleanupCreatedReplacement(storage: StorageManager, replacement: Extract<MergeReplacement, { ok: true }>): Promise<void> {

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -29,6 +29,16 @@ export interface ExecuteResolutionOptions {
   mergedCategory?: MemoryCategory;
   /** Resolve storage for the pair namespace, or the default namespace for legacy unscoped pairs. */
   storageForNamespace?: (namespace: string | undefined) => StorageManager | Promise<StorageManager>;
+  /**
+   * Best-effort hook invoked after a NEW merged memory is durably written (issue
+   * #1499 sweep). The merge verb persists a brand-new memory directly to the
+   * pair's (possibly DYNAMIC) namespace storage, bypassing the extraction write
+   * path that records catalog writes — so without this the namespace's
+   * `lastWriteAt` stays stale and QMD maintenance can miss the write. Callers wire
+   * this to `Orchestrator.recordCatalogWrite(namespace, storageDir)`. Must be
+   * failure-tolerant: it is fire-and-forget and must never affect resolution.
+   */
+  onMergedMemoryWritten?: (namespace: string | undefined, storageDir: string) => void;
 }
 
 const VALID_VERBS: ResolutionVerb[] = ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"];
@@ -186,6 +196,16 @@ export async function executeResolution(
         }
         return rolledBackA && rolledBackB;
       };
+      // Catalog write touch (issue #1499 sweep): a NEW merged memory was durably
+      // written to the pair's (possibly dynamic) namespace storage. Notify the
+      // caller so it can record the write in the catalog — otherwise a dynamic
+      // namespace whose only durable mutation is a contradiction merge stays
+      // invisible to QMD maintenance / `writtenSince`. Only fire when a fresh
+      // memory was created (an existing merged-id reuse is not a new write).
+      // Best-effort: the callback is failure-tolerant on the caller side.
+      if (replacement.created && options.onMergedMemoryWritten) {
+        options.onMergedMemoryWritten(pair.namespace, resolutionStorage.dir);
+      }
       message = `Both memories superseded by merged ${replacement.mergedId}`;
       break;
     }

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -30,13 +30,17 @@ export interface ExecuteResolutionOptions {
   /** Resolve storage for the pair namespace, or the default namespace for legacy unscoped pairs. */
   storageForNamespace?: (namespace: string | undefined) => StorageManager | Promise<StorageManager>;
   /**
-   * Best-effort hook invoked after a NEW merged memory is durably written (issue
-   * #1499 sweep). The merge verb persists a brand-new memory directly to the
-   * pair's (possibly DYNAMIC) namespace storage, bypassing the extraction write
-   * path that records catalog writes — so without this the namespace's
-   * `lastWriteAt` stays stale and QMD maintenance can miss the write. Callers wire
-   * this to `Orchestrator.recordCatalogWrite(namespace, storageDir)`. Must be
-   * failure-tolerant: it is fire-and-forget and must never affect resolution.
+   * Best-effort hook invoked after a NEW merged memory's resolution has DURABLY
+   * committed (issue #1499 sweep, NH1dX). The merge verb persists a brand-new
+   * memory directly to the pair's (possibly DYNAMIC) namespace storage, bypassing
+   * the extraction write path that records catalog writes — so without this the
+   * namespace's `lastWriteAt` stays stale and QMD maintenance can miss the write.
+   * It fires ONLY after `resolvePair` persists the resolution past the rollback
+   * point: if the resolution fails and the merge is rolled back, this is never
+   * called, so the catalog never records a write that did not survive (rule #25).
+   * Callers wire this to `Orchestrator.recordCatalogWrite(namespace, storageDir)`.
+   * Must be failure-tolerant: it is fire-and-forget and must never affect
+   * resolution.
    */
   onMergedMemoryWritten?: (namespace: string | undefined, storageDir: string) => void;
 }
@@ -91,6 +95,16 @@ export async function executeResolution(
   let message = "";
   let supersedeFailed = false;
   let rollbackAfterResolveFailure: (() => Promise<boolean>) | null = null;
+  // Deferred catalog-write touch for a NEW merged memory (issue #1499 sweep,
+  // NH1dX). Rule #25: never record a success marker / catalog touch before the
+  // new state is durably committed past the rollback point. The merge verb
+  // supersedes both sources and writes a fresh merged memory, but the resolution
+  // is not durable until `resolvePair` persists below. If that persistence FAILS
+  // and `rollbackAfterResolveFailure` restores the sources + removes the merged
+  // memory, no catalog write actually survived — so the touch must fire ONLY
+  // after the whole resolution durably succeeds. We stash it here and invoke it
+  // exactly once at the post-commit point.
+  let recordMergedCatalogWrite: (() => void) | null = null;
 
   switch (verb) {
     case "keep-a": {
@@ -196,15 +210,20 @@ export async function executeResolution(
         }
         return rolledBackA && rolledBackB;
       };
-      // Catalog write touch (issue #1499 sweep): a NEW merged memory was durably
-      // written to the pair's (possibly dynamic) namespace storage. Notify the
-      // caller so it can record the write in the catalog — otherwise a dynamic
+      // Catalog write touch (issue #1499 sweep): a NEW merged memory was written
+      // to the pair's (possibly dynamic) namespace storage — but the resolution
+      // is not durable yet (resolvePair persists below, and a failure rolls the
+      // merge back). Defer the touch so it fires ONLY after the resolution
+      // commits past the rollback point (NH1dX, rule #25). Otherwise a dynamic
       // namespace whose only durable mutation is a contradiction merge stays
-      // invisible to QMD maintenance / `writtenSince`. Only fire when a fresh
-      // memory was created (an existing merged-id reuse is not a new write).
+      // invisible to QMD maintenance / `writtenSince`. Only arm the touch when a
+      // fresh memory was created (an existing merged-id reuse is not a new write).
       // Best-effort: the callback is failure-tolerant on the caller side.
       if (replacement.created && options.onMergedMemoryWritten) {
-        options.onMergedMemoryWritten(pair.namespace, resolutionStorage.dir);
+        const onMergedMemoryWritten = options.onMergedMemoryWritten;
+        const namespace = pair.namespace;
+        const storageDir = resolutionStorage.dir;
+        recordMergedCatalogWrite = () => onMergedMemoryWritten(namespace, storageDir);
       }
       message = `Both memories superseded by merged ${replacement.mergedId}`;
       break;
@@ -240,6 +259,21 @@ export async function executeResolution(
           : `Resolution persistence failed; rollback incomplete and pair is not resolved`;
       } else {
         message = `Resolution persistence failed; pair is not resolved`;
+      }
+    } else if (recordMergedCatalogWrite) {
+      // The merge resolution durably committed (sources superseded AND the
+      // resolution persisted past the rollback point). Only now is it safe to
+      // record the catalog write for the new merged memory (NH1dX, rule #25).
+      // Best-effort: the caller's callback swallows errors; guard here so a
+      // throwing callback never derails a successful resolution.
+      try {
+        recordMergedCatalogWrite();
+      } catch (err) {
+        log.warn(
+          "[contradiction-resolution] catalog write touch failed for pair=%s: %s",
+          pairId,
+          err instanceof Error ? err.message : err,
+        );
       }
     }
   }

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -30,17 +30,21 @@ export interface ExecuteResolutionOptions {
   /** Resolve storage for the pair namespace, or the default namespace for legacy unscoped pairs. */
   storageForNamespace?: (namespace: string | undefined) => StorageManager | Promise<StorageManager>;
   /**
-   * Best-effort hook invoked after a NEW merged memory's resolution has DURABLY
-   * committed (issue #1499 sweep, NH1dX). The merge verb persists a brand-new
-   * memory directly to the pair's (possibly DYNAMIC) namespace storage, bypassing
-   * the extraction write path that records catalog writes — so without this the
-   * namespace's `lastWriteAt` stays stale and QMD maintenance can miss the write.
-   * It fires ONLY after `resolvePair` persists the resolution past the rollback
-   * point: if the resolution fails and the merge is rolled back, this is never
-   * called, so the catalog never records a write that did not survive (rule #25).
-   * Callers wire this to `Orchestrator.recordCatalogWrite(namespace, storageDir)`.
-   * Must be failure-tolerant: it is fire-and-forget and must never affect
-   * resolution.
+   * Best-effort hook invoked after a contradiction resolution that MUTATED the
+   * namespace's memory files has DURABLY committed (issue #1499 sweep, NH1dX /
+   * NH3X3). Every mutating verb — `merge` (creates a new memory and supersedes
+   * both sources), `keep-a`, and `keep-b` (supersede the losing source + rewrite
+   * frontmatter) — writes directly to the pair's (possibly DYNAMIC) namespace
+   * storage, bypassing the extraction write path that records catalog writes. So
+   * without this the namespace's `lastWriteAt` stays stale and QMD maintenance /
+   * `writtenSince` can skip a namespace whose only post-write mutation is
+   * resolving a contradiction. It fires ONLY after `resolvePair` persists the
+   * resolution past the rollback point: if the resolution fails and the memory
+   * changes are rolled back, this is never called, so the catalog never records a
+   * write that did not survive (rule #25). Non-mutating verbs (`both-valid`,
+   * `needs-more-context`) never trigger it. Callers wire this to
+   * `Orchestrator.recordCatalogWrite(namespace, storageDir)`. Must be
+   * failure-tolerant: it is fire-and-forget and must never affect resolution.
    */
   onMergedMemoryWritten?: (namespace: string | undefined, storageDir: string) => void;
 }
@@ -95,16 +99,29 @@ export async function executeResolution(
   let message = "";
   let supersedeFailed = false;
   let rollbackAfterResolveFailure: (() => Promise<boolean>) | null = null;
-  // Deferred catalog-write touch for a NEW merged memory (issue #1499 sweep,
-  // NH1dX). Rule #25: never record a success marker / catalog touch before the
-  // new state is durably committed past the rollback point. The merge verb
-  // supersedes both sources and writes a fresh merged memory, but the resolution
-  // is not durable until `resolvePair` persists below. If that persistence FAILS
-  // and `rollbackAfterResolveFailure` restores the sources + removes the merged
-  // memory, no catalog write actually survived — so the touch must fire ONLY
-  // after the whole resolution durably succeeds. We stash it here and invoke it
-  // exactly once at the post-commit point.
-  let recordMergedCatalogWrite: (() => void) | null = null;
+  // Deferred catalog-write touch for any resolution that MUTATES this namespace's
+  // memory files (issue #1499 sweep, NH1dX / NH3X3). Rule #25: never record a
+  // success marker / catalog touch before the new state is durably committed past
+  // the rollback point. Every mutating verb (merge, keep-a, keep-b) supersedes a
+  // source and/or writes a fresh merged memory, but the resolution is not durable
+  // until `resolvePair` persists below. If that persistence FAILS and
+  // `rollbackAfterResolveFailure` restores the changes, no catalog write actually
+  // survived — so the touch must fire ONLY after the whole resolution durably
+  // succeeds. We arm it in each mutating branch and invoke it exactly once at the
+  // post-commit point. Non-mutating verbs (both-valid, needs-more-context) leave
+  // it null.
+  let recordCatalogWriteTouch: (() => void) | null = null;
+  // Returns the deferred touch fn for a mutating verb (or null when the caller
+  // wired no catalog hook), so each branch assigns `recordCatalogWriteTouch`
+  // directly in the function body — keeping TS control-flow narrowing intact at
+  // the post-commit invocation below.
+  const buildCatalogTouch = (): (() => void) | null => {
+    if (!options.onMergedMemoryWritten) return null;
+    const onMergedMemoryWritten = options.onMergedMemoryWritten;
+    const namespace = pair.namespace;
+    const storageDir = resolutionStorage.dir;
+    return () => onMergedMemoryWritten(namespace, storageDir);
+  };
 
   switch (verb) {
     case "keep-a": {
@@ -122,6 +139,9 @@ export async function executeResolution(
         affectedIds.push(idB);
         rollbackAfterResolveFailure = async () =>
           restoreMemorySnapshot(resolutionStorage, sourceB!, "contradiction-resolution:keep-a-rollback");
+        // keep-a superseded idB in this namespace — record a catalog touch once
+        // the resolution durably commits (NH3X3).
+        recordCatalogWriteTouch = buildCatalogTouch();
         message = `Kept ${idA}, superseded ${idB}`;
       }
       else {
@@ -150,6 +170,9 @@ export async function executeResolution(
         affectedIds.push(idA);
         rollbackAfterResolveFailure = async () =>
           restoreMemorySnapshot(resolutionStorage, sourceA!, "contradiction-resolution:keep-b-rollback");
+        // keep-b superseded idA in this namespace — record a catalog touch once
+        // the resolution durably commits (NH3X3).
+        recordCatalogWriteTouch = buildCatalogTouch();
         message = `Kept ${idB}, superseded ${idA}`;
       }
       else {
@@ -210,21 +233,17 @@ export async function executeResolution(
         }
         return rolledBackA && rolledBackB;
       };
-      // Catalog write touch (issue #1499 sweep): a NEW merged memory was written
-      // to the pair's (possibly dynamic) namespace storage — but the resolution
-      // is not durable yet (resolvePair persists below, and a failure rolls the
-      // merge back). Defer the touch so it fires ONLY after the resolution
-      // commits past the rollback point (NH1dX, rule #25). Otherwise a dynamic
-      // namespace whose only durable mutation is a contradiction merge stays
-      // invisible to QMD maintenance / `writtenSince`. Only arm the touch when a
-      // fresh memory was created (an existing merged-id reuse is not a new write).
-      // Best-effort: the callback is failure-tolerant on the caller side.
-      if (replacement.created && options.onMergedMemoryWritten) {
-        const onMergedMemoryWritten = options.onMergedMemoryWritten;
-        const namespace = pair.namespace;
-        const storageDir = resolutionStorage.dir;
-        recordMergedCatalogWrite = () => onMergedMemoryWritten(namespace, storageDir);
-      }
+      // Catalog write touch (issue #1499 sweep): the merge supersedes BOTH sources
+      // (and, when created, writes a fresh merged memory) in the pair's (possibly
+      // dynamic) namespace storage — but the resolution is not durable yet
+      // (resolvePair persists below, and a failure rolls the merge back). Defer
+      // the touch so it fires ONLY after the resolution commits past the rollback
+      // point (NH1dX, rule #25). Arm it for EVERY successful merge — even reusing
+      // an existing merged-id still supersedes both sources, a namespace mutation
+      // that must refresh `lastWriteAt` (NH3X3). Otherwise a dynamic namespace
+      // whose only durable mutation is a contradiction merge stays invisible to
+      // QMD maintenance / `writtenSince`. Best-effort on the caller side.
+      recordCatalogWriteTouch = buildCatalogTouch();
       message = `Both memories superseded by merged ${replacement.mergedId}`;
       break;
     }
@@ -260,14 +279,14 @@ export async function executeResolution(
       } else {
         message = `Resolution persistence failed; pair is not resolved`;
       }
-    } else if (recordMergedCatalogWrite) {
-      // The merge resolution durably committed (sources superseded AND the
-      // resolution persisted past the rollback point). Only now is it safe to
-      // record the catalog write for the new merged memory (NH1dX, rule #25).
+    } else if (recordCatalogWriteTouch) {
+      // The resolution durably committed (memory mutated AND the resolution
+      // persisted past the rollback point). Only now is it safe to record the
+      // catalog write for the namespace mutation (NH1dX / NH3X3, rule #25).
       // Best-effort: the caller's callback swallows errors; guard here so a
       // throwing callback never derails a successful resolution.
       try {
-        recordMergedCatalogWrite();
+        recordCatalogWriteTouch();
       } catch (err) {
         log.warn(
           "[contradiction-resolution] catalog write touch failed for pair=%s: %s",

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -435,6 +435,10 @@ export async function persistExplicitCapture(
     expiresAt: candidate.expiresAt,
     source: source === "inline" ? "explicit-inline" : "explicit",
   });
+  // Record the catalog write touch (issue #1499, round 5 codex P2). Explicit
+  // captures bypass the extraction write path, so without this their namespace
+  // never updates `lastWriteAt`. Best-effort and failure-tolerant.
+  if (resolvedNamespace) orchestrator.recordCatalogWrite(resolvedNamespace, storage.dir);
 
   const created = new Date().toISOString();
   const event: MemoryLifecycleEvent = {
@@ -531,6 +535,10 @@ export async function queueExplicitCaptureForReview(
     entityRef: sanitizeReviewMetadata(input.entityRef),
     source: source === "inline" ? "explicit-inline-review" : "explicit-review",
   });
+  // Record the catalog write touch (issue #1499, round 5 codex P2): a queued
+  // review capture still writes memory to the namespace's root, so its
+  // `lastWriteAt` must reflect the write. Best-effort and failure-tolerant.
+  if (queueNamespace) orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
   const created = await storage.getMemoryById(id);
   if (created) {
     await storage.writeMemoryFrontmatter(created, {

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -437,8 +437,13 @@ export async function persistExplicitCapture(
   });
   // Record the catalog write touch (issue #1499, round 5 codex P2). Explicit
   // captures bypass the extraction write path, so without this their namespace
-  // never updates `lastWriteAt`. Best-effort and failure-tolerant.
-  if (resolvedNamespace) orchestrator.recordCatalogWrite(resolvedNamespace, storage.dir);
+  // never updates `lastWriteAt`. An undefined namespace means the DEFAULT root
+  // (round 6, codex P2), which recordCatalogWrite resolves. The method is an
+  // optional best-effort hook — guard so Orchestrator-like callers without it
+  // don't break (rule #33). Best-effort and failure-tolerant.
+  if (typeof orchestrator.recordCatalogWrite === "function") {
+    orchestrator.recordCatalogWrite(resolvedNamespace, storage.dir);
+  }
 
   const created = new Date().toISOString();
   const event: MemoryLifecycleEvent = {
@@ -535,10 +540,13 @@ export async function queueExplicitCaptureForReview(
     entityRef: sanitizeReviewMetadata(input.entityRef),
     source: source === "inline" ? "explicit-inline-review" : "explicit-review",
   });
-  // Record the catalog write touch (issue #1499, round 5 codex P2): a queued
-  // review capture still writes memory to the namespace's root, so its
-  // `lastWriteAt` must reflect the write. Best-effort and failure-tolerant.
-  if (queueNamespace) orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
+  // Record the catalog write touch (issue #1499, round 5/6 codex P2): a queued
+  // review capture still writes memory to the namespace's root (the DEFAULT root
+  // when undefined), so its `lastWriteAt` must reflect the write. Guarded
+  // optional hook (rule #33). Best-effort and failure-tolerant.
+  if (typeof orchestrator.recordCatalogWrite === "function") {
+    orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
+  }
   const created = await storage.getMemoryById(id);
   if (created) {
     await storage.writeMemoryFrontmatter(created, {

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -540,13 +540,6 @@ export async function queueExplicitCaptureForReview(
     entityRef: sanitizeReviewMetadata(input.entityRef),
     source: source === "inline" ? "explicit-inline-review" : "explicit-review",
   });
-  // Record the catalog write touch (issue #1499, round 5/6 codex P2): a queued
-  // review capture still writes memory to the namespace's root (the DEFAULT root
-  // when undefined), so its `lastWriteAt` must reflect the write. Guarded
-  // optional hook (rule #33). Best-effort and failure-tolerant.
-  if (typeof orchestrator.recordCatalogWrite === "function") {
-    orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
-  }
   const created = await storage.getMemoryById(id);
   if (created) {
     await storage.writeMemoryFrontmatter(created, {
@@ -557,6 +550,16 @@ export async function queueExplicitCaptureForReview(
       reasonCode: reason,
       ruleVersion: "explicit-capture.v1",
     });
+  }
+  // Record the catalog write touch (issue #1499, round 5/6 codex P2; NIhUg). A
+  // queued review capture writes memory to the namespace's root (the DEFAULT root
+  // when undefined), so its `lastWriteAt` must reflect the write — but only AFTER
+  // the memory reaches its intended durable `pending_review` state. Recording the
+  // touch before the frontmatter update (rule #25) would mark a write that may not
+  // have reached its intended state if `writeMemoryFrontmatter` failed. Guarded
+  // optional hook (rule #33). Best-effort and failure-tolerant.
+  if (typeof orchestrator.recordCatalogWrite === "function") {
+    orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
   }
   const event: MemoryLifecycleEvent = {
     eventId: `mle-${randomUUID()}`,

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -540,26 +540,28 @@ export async function queueExplicitCaptureForReview(
     entityRef: sanitizeReviewMetadata(input.entityRef),
     source: source === "inline" ? "explicit-inline-review" : "explicit-review",
   });
-  const created = await storage.getMemoryById(id);
-  if (created) {
-    await storage.writeMemoryFrontmatter(created, {
-      status: "pending_review",
-      updated: new Date().toISOString(),
-    }, {
-      actor: explicitCaptureActor(source),
-      reasonCode: reason,
-      ruleVersion: "explicit-capture.v1",
-    });
-  }
-  // Record the catalog write touch (issue #1499, round 5/6 codex P2; NIhUg). A
-  // queued review capture writes memory to the namespace's root (the DEFAULT root
-  // when undefined), so its `lastWriteAt` must reflect the write — but only AFTER
-  // the memory reaches its intended durable `pending_review` state. Recording the
-  // touch before the frontmatter update (rule #25) would mark a write that may not
-  // have reached its intended state if `writeMemoryFrontmatter` failed. Guarded
-  // optional hook (rule #33). Best-effort and failure-tolerant.
-  if (typeof orchestrator.recordCatalogWrite === "function") {
-    orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
+  try {
+    const created = await storage.getMemoryById(id);
+    if (created) {
+      await storage.writeMemoryFrontmatter(created, {
+        status: "pending_review",
+        updated: new Date().toISOString(),
+      }, {
+        actor: explicitCaptureActor(source),
+        reasonCode: reason,
+        ruleVersion: "explicit-capture.v1",
+      });
+    }
+  } finally {
+    // Record the catalog write touch (issue #1499, round 5/6 codex P2; NIhUg).
+    // A queued review capture writes memory to the namespace's root (the DEFAULT
+    // root when undefined), so its `lastWriteAt` must reflect the write once
+    // `writeMemory` returns an id. If the later pending-review frontmatter update
+    // fails, the memory file is still durable and must not disappear from
+    // writtenSince/maintenance scheduling. Guarded optional hook (rule #33).
+    if (typeof orchestrator.recordCatalogWrite === "function") {
+      orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
+    }
   }
   const event: MemoryLifecycleEvent = {
     eventId: `mle-${randomUUID()}`,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -323,6 +323,16 @@ export { MeilisearchBackend } from "./search/meilisearch-backend.js";
 
 export { buildEntityRecallSection } from "./entity-retrieval.js";
 export { resolvePrincipal } from "./namespaces/principal.js";
+export {
+  NamespaceCatalog,
+  type NamespaceRecord,
+  type NamespaceKind,
+  type NamespaceDiscoverySource,
+  type NamespaceCatalogFilter,
+  type NamespaceTouchMetadata,
+  type NamespaceCatalogRebuildResult,
+  type NamespaceCatalogSkippedRoot,
+} from "./namespaces/catalog.js";
 
 // ---------------------------------------------------------------------------
 // Trust zones

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import type { PluginConfig } from "../types.js";
-import { namespaceIdentityToken } from "./identity.js";
+import { namespaceIdentityFromToken, namespaceIdentityToken } from "./identity.js";
 import { NamespaceCatalog } from "./catalog.js";
 import {
   NamespaceStorageRouter,
@@ -2967,6 +2967,93 @@ test("inert rebuild --apply exits non-zero; inert --dry-run stays zero (NFb5W)",
     );
   } finally {
     process.exitCode = savedExitCode;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NRcCD (codex P2): preserve cataloged token-shaped raw roots during rebuild ──
+// A DYNAMIC namespace literally named `ns-616c706861` (= the canonical token of
+// `alpha`) is served from a legacy raw root `namespaces/ns-616c706861` and already
+// owns a catalog row from the write path. Before the fix, the rebuild scanner
+// decoded that dir to `alpha`, emitting an `alpha` row at the raw root, while the
+// final live-row remerge kept the real `ns-616c706861` row too — TWO rows at the
+// SAME storageDir, fanning QMD/maintenance out under the wrong namespace. The fix
+// prefers the LITERAL dir name when it is already a KNOWN (cataloged) namespace.
+test("rebuildFromDisk keeps a cataloged token-shaped raw root as the literal namespace (NRcCD)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // The raw root is literally named like alpha's canonical token.
+    const literalNs = namespaceIdentityToken("alpha"); // "ns-616c706861"
+    assert.equal(
+      namespaceIdentityFromToken(literalNs),
+      "alpha",
+      "precondition: the dir name decodes to alpha — the ambiguity this test exercises",
+    );
+    const rawRoot = path.join(memoryDir, "namespaces", literalNs);
+    // Legacy raw root holding memory data.
+    await mkdir(path.join(rawRoot, "facts"), { recursive: true });
+    await writeFile(path.join(rawRoot, "facts", "f1.md"), "# synthetic\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Write-path row: the dynamic namespace is cataloged at its raw root verbatim.
+    await catalog.markWrite(literalNs, { discoveredBy: "write", storageDir: rawRoot });
+    const seeded = await catalog.getNamespaceRecord(literalNs);
+    assert.ok(seeded, "precondition: literal namespace has a catalog row before rebuild");
+    assert.equal(path.resolve(seeded!.storageDir), path.resolve(rawRoot));
+
+    const result = await catalog.rebuildFromDisk();
+
+    // EXACTLY ONE row points at the raw root, and it is the LITERAL namespace.
+    const atRawRoot = result.records.filter(
+      (r) => path.resolve(r.storageDir) === path.resolve(rawRoot),
+    );
+    assert.equal(
+      atRawRoot.length,
+      1,
+      `rebuild must produce exactly one catalog row for ${rawRoot}, got: ${atRawRoot
+        .map((r) => r.namespace)
+        .join(", ")}`,
+    );
+    assert.equal(
+      atRawRoot[0]?.namespace,
+      literalNs,
+      "the surviving row must be the literal namespace, not the decoded alias",
+    );
+    assert.ok(
+      !result.records.some((r) => r.namespace === "alpha"),
+      "rebuild must NOT emit a decoded `alpha` alias row when the literal owner exists",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Control: a genuine tokenized dir with NO literal owner (no cataloged row keyed
+// by the raw token) still decodes back to its identity, exactly as before. This
+// guards against the NRcCD fix over-suppressing the canonical decode.
+test("rebuildFromDisk still decodes a tokenized root with no literal owner (NRcCD control)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const token = namespaceIdentityToken("alpha"); // tokenized dir for `alpha`
+    await mkdir(path.join(memoryDir, "namespaces", token, "facts"), { recursive: true });
+    await writeFile(
+      path.join(memoryDir, "namespaces", token, "facts", "f1.md"),
+      "# synthetic\n",
+      "utf8",
+    );
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    assert.ok(
+      result.records.some((r) => r.namespace === "alpha"),
+      "with no literal owner, a tokenized dir still decodes to its identity",
+    );
+    assert.ok(
+      !result.records.some((r) => r.namespace === token),
+      "the literal token form must NOT appear when nothing owns it",
+    );
+  } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -2160,6 +2160,37 @@ test("an explicit storageDir that is a regular FILE at the token dir is rejected
   }
 });
 
+// ── NHIdt (codex P2): a NOT-YET-EXISTING leaf whose nearest existing ANCESTOR is a
+// regular FILE must be rejected. `realpath(parent)` succeeds and resolves inside
+// memoryDir for a file `<memoryDir>/namespaces`, so a containment-only ancestor
+// check would ACCEPT a leaf that can never be created (no child dir under a file).
+// We place a FILE at `namespaces` and pass an explicit non-existent leaf under it;
+// the touch must not persist that escaping/uncreatable path.
+test("an explicit storageDir whose nearest existing ancestor is a FILE is rejected (NHIdt)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-fileancestor";
+    const token = namespaceIdentityToken(ns);
+    // `<memoryDir>/namespaces` is a regular FILE, not a directory.
+    const namespacesAsFile = path.join(memoryDir, "namespaces");
+    await writeFile(namespacesAsFile, "# not a directory\n", "utf8");
+    // The explicit leaf does not exist; its nearest existing ancestor is the file.
+    const leafUnderFile = path.join(namespacesAsFile, token);
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: leafUnderFile });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record is still created");
+    assert.notEqual(
+      path.resolve(record!.storageDir),
+      path.resolve(leafUnderFile),
+      "a leaf whose nearest existing ancestor is a file must not be persisted as a root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDo8C): an ASYNC onResolve hook that REJECTS must not
 // crash storage resolution — the rejection must be swallowed (best-effort).
 test("an async onResolve hook rejection does not crash storage resolution", async () => {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1589,3 +1589,86 @@ test("a catalog write preserves a token-shaped literal namespace name verbatim",
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NCzT4): the configured-namespace seeding step must NOT
+// persist an escaping `storageDir` for a configured non-default namespace whose
+// token dir is a symlink pointing OUTSIDE memoryDir. It must reject it (skipped:
+// escape) just like the scan loop does, BEFORE the record is seeded/rewritten.
+test("rebuild --apply rejects a configured namespace whose token dir escapes via symlink", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    const ns = "team-pi-project-origin-escape";
+    const token = namespaceIdentityToken(ns);
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    await mkdir(path.join(outside, "evil"), { recursive: true });
+    // The configured namespace's token dir is a symlink escaping memoryDir.
+    await symlink(path.join(outside, "evil"), path.join(memoryDir, "namespaces", token), "dir");
+
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, {
+        namespacePolicies: [{ name: ns }],
+      } as unknown as Partial<PluginConfig>),
+    );
+    const result = await catalog.rebuildFromDisk();
+    const record = result.records.find((r) => r.namespace === ns);
+    assert.ok(
+      !record,
+      "a configured namespace whose token dir escapes memoryDir must NOT be seeded",
+    );
+    assert.ok(
+      result.skipped.some((s) => s.reason === "escape" && s.token === token),
+      "the escaping configured token dir must be reported as skipped (escape)",
+    );
+    // Persisted log must not carry an escaping storageDir for the namespace.
+    const raw = await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8").catch(() => "");
+    assert.ok(!raw.includes(path.join(outside, "evil")), "no escaping storageDir may be persisted");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (codex P2 — NCzT6): a rebuild must release ONLY its own lock. If
+// another process broke our (stale) lock and acquired a REPLACEMENT before our
+// finally runs, we must NOT unlink that replacement. We simulate this by swapping
+// the lock file for a foreign-owned one during the rebuild and asserting the
+// foreign lock survives.
+test("a rebuild releases only its own lock, not a replacement foreign lock", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-lockowner";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Drive the rebuild, but mid-flight (during the scan's loadCompacted) replace
+    // the lock file with a FOREIGN-owned one, simulating a process that broke our
+    // stale lock and acquired a replacement.
+    // A foreign owner id (UUID-shaped, not this instance's) so the rebuild's
+    // ownership check correctly treats it as NOT self-held and leaves it alone.
+    const foreignOwnerId = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    const foreignLock = `999999 ${foreignOwnerId} ${new Date().toISOString()}\n`;
+    const handle = catalog as unknown as { loadCompacted: () => Promise<Map<string, unknown>> };
+    const original = handle.loadCompacted.bind(catalog);
+    let swapped = false;
+    handle.loadCompacted = async () => {
+      if (!swapped) {
+        swapped = true;
+        await writeFile(lockPath, foreignLock, "utf8");
+      }
+      return original();
+    };
+
+    await catalog.rebuildFromDisk();
+
+    // The foreign replacement lock must still exist (we only release our own).
+    const after = await readFile(lockPath, "utf8").catch(() => "");
+    assert.equal(after, foreignLock, "a rebuild must not unlink a replacement foreign lock");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -785,6 +785,171 @@ test("explicit storageDir contained under namespaces/ is accepted", async () => 
       record?.storageDir,
       legacyDir,
       "a contained explicit dir must be persisted as-is",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue #1 (cursor Medium): when both a legacy raw-name dir and a
+// tokenized dir hold data for the same namespace, rebuild must prefer the
+// TOKENIZED root (matching NamespaceStorageRouter), not let last-readdir-wins
+// pick arbitrarily.
+test("rebuildFromDisk prefers the tokenized root over a legacy dual root", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-dual";
+    const token = namespaceIdentityToken(ns);
+    const tokenizedDir = path.join(memoryDir, "namespaces", token);
+    const legacyDir = path.join(memoryDir, "namespaces", ns);
+    // Both roots hold data for the same namespace.
+    await mkdir(path.join(tokenizedDir, "facts"), { recursive: true });
+    await mkdir(path.join(legacyDir, "facts"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+    const rec = result.records.find((r) => r.namespace === ns);
+    assert.ok(rec, "expected the dual-root namespace to be cataloged");
+    assert.equal(
+      rec?.storageDir,
+      tokenizedDir,
+      "rebuild must prefer the tokenized root for a dual-root namespace",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue #2 (cursor Medium): reads must not surface an out-of-root
+// storageDir. A tampered/pre-fix jsonl record with an absolute path outside
+// memoryDir must be sanitized to the resolved safe root on enumeration.
+test("listNamespaces/getNamespaceRecord sanitize an out-of-root storageDir on read", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    const ns = "project-origin-tampered";
+    const token = namespaceIdentityToken(ns);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    // Hand-craft a record whose storageDir escapes memoryDir (tampered file).
+    const evil = path.join(outside, "evil");
+    const line = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date().toISOString(),
+      storageDir: evil,
+      discoveredBy: "write",
+    });
+    await writeFile(path.join(stateDir, "namespaces.jsonl"), line + "\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const viaGet = await catalog.getNamespaceRecord(ns);
+    assert.ok(viaGet, "record should be returned");
+    assert.ok(
+      !viaGet!.storageDir.startsWith(outside),
+      "getNamespaceRecord must not surface an out-of-root storageDir",
+    );
+    assert.equal(
+      viaGet!.storageDir,
+      path.join(memoryDir, "namespaces", token),
+      "out-of-root dir must be sanitized to the resolved safe root",
+    );
+
+    const viaList = await catalog.listNamespaces();
+    const listed = viaList.find((r) => r.namespace === ns);
+    assert.ok(
+      listed && !listed.storageDir.startsWith(outside),
+      "listNamespaces must not surface an out-of-root storageDir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue #3 (codex P2): an explicit storageDir that is lexically
+// contained but is a SYMLINK escaping memoryDir must be rejected (the round-4
+// containment check was lexical only).
+test("explicit storageDir that is a symlink escaping memoryDir is rejected", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    const ns = "project-origin-symlink";
+    const token = namespaceIdentityToken(ns);
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    await mkdir(path.join(outside, "target"), { recursive: true });
+    const linkPath = path.join(memoryDir, "namespaces", token);
+    try {
+      await symlink(path.join(outside, "target"), linkPath, "dir");
+    } catch {
+      // Some CI environments disallow symlinks; skip gracefully.
+      return;
+    }
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // The symlink path is lexically under namespaces/ but escapes via realpath.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: linkPath });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record should be created");
+    // The REALPATH of the persisted storage dir must stay inside memoryDir — a
+    // lexical-only check (the round-4 behavior) would wrongly accept the symlink
+    // whose realpath escapes to `outside`.
+    const memoryReal = await realpath(memoryDir);
+    const outsideReal = await realpath(outside);
+    let persistedReal: string;
+    try {
+      persistedReal = await realpath(record!.storageDir);
+    } catch {
+      // The fallback resolved token dir may not exist on disk; use the lexical
+      // path, which is by construction inside memoryDir.
+      persistedReal = record!.storageDir;
+    }
+    assert.ok(
+      !persistedReal.startsWith(outsideReal),
+      "a symlink-escaping explicit dir must not be persisted (realpath must stay inside memoryDir)",
+    );
+    assert.ok(
+      persistedReal.startsWith(memoryReal) ||
+        record!.storageDir === path.join(memoryDir, "namespaces", token),
+      "persisted dir must be the trusted resolved root, not the escaping symlink target",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue #4 (codex P2): a cross-process append (simulated by a SECOND
+// NamespaceCatalog instance — a distinct in-process write chain, standing in for
+// the gateway process) that lands during a rebuild must survive. The in-chain
+// re-merge under the rebuild lock folds the latest on-disk touch fields into the
+// rewrite.
+test("rebuildFromDisk re-merges a concurrent cross-instance write touch", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-xproc";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    // "CLI" catalog runs the rebuild; "gateway" catalog is a separate instance
+    // (separate writeChain) that records a write touch concurrently.
+    const cli = new NamespaceCatalog(makeConfig(memoryDir));
+    const gateway = new NamespaceCatalog(makeConfig(memoryDir));
+
+    await Promise.all([
+      cli.rebuildFromDisk(),
+      gateway.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir }),
+    ]);
+
+    // A fresh reader must see the write touch preserved (not clobbered by the
+    // rebuild's rewrite).
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reader.getNamespaceRecord(ns);
+    assert.ok(record, "namespace must exist after concurrent rebuild + cross-instance write");
+    assert.ok(
+      record?.lastWriteAt,
+      "a cross-instance write landing during rebuild must survive the rewrite",
     );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { PluginConfig } from "../types.js";
+import { namespaceIdentityToken } from "./identity.js";
+import { NamespaceCatalog } from "./catalog.js";
+import { NamespaceStorageRouter } from "./storage.js";
+
+function makeConfig(memoryDir: string, overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    memoryDir,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    qmdCollection: "remnic",
+    entitySchemas: {},
+    inlineSourceAttributionFormat: undefined,
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+async function mkMemoryDir(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "remnic-ns-catalog-"));
+}
+
+test("markWrite registers a dynamic project namespace in the catalog", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite("project-origin-abc123", { discoveredBy: "write" });
+
+    const record = await catalog.getNamespaceRecord("project-origin-abc123");
+    assert.ok(record, "expected record to exist");
+    assert.equal(record?.namespace, "project-origin-abc123");
+    assert.equal(record?.kind, "project");
+    assert.ok(record?.lastWriteAt, "expected lastWriteAt to be set");
+    assert.equal(record?.discoveredBy, "write");
+    assert.ok(record?.storageDir.includes("namespaces"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("configured default and shared namespaces appear in the catalog after register", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.registerConfiguredNamespaces();
+
+    const list = await catalog.listNamespaces();
+    assert.ok(list.some((r) => r.namespace === "default" && r.kind === "default"));
+    assert.ok(list.some((r) => r.namespace === "shared" && r.kind === "shared"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk finds existing tokenized namespace directories", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "team-pi-project-origin-abc123";
+    await mkdir(path.join(memoryDir, "namespaces", namespaceIdentityToken(ns), "facts"), {
+      recursive: true,
+    });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    assert.equal(result.dryRun, false);
+    assert.ok(result.records.some((r) => r.namespace === ns));
+    const fromDisk = result.records.find((r) => r.namespace === ns);
+    assert.equal(fromDisk?.kind, "team-project");
+    assert.equal(fromDisk?.discoveredBy, "scan");
+
+    // Persisted: a fresh catalog reads it back.
+    const reloaded = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reloaded.getNamespaceRecord(ns);
+    assert.ok(record, "expected rebuilt record to persist");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk dry-run does not write the catalog file", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await mkdir(path.join(memoryDir, "namespaces", namespaceIdentityToken("alpha"), "facts"), {
+      recursive: true,
+    });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk({ dryRun: true });
+    assert.equal(result.dryRun, true);
+    assert.ok(result.records.some((r) => r.namespace === "alpha"));
+
+    const catalogFile = path.join(memoryDir, "state", "namespaces.jsonl");
+    let exists = true;
+    try {
+      await readFile(catalogFile, "utf8");
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, "dry-run must not write the catalog file");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk preserves the legacy default root (memoryDir) compatibility case", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // Legacy layout: facts live directly in memoryDir, no namespaces/ subdir.
+    await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+    await writeFile(path.join(memoryDir, "facts", "f1.md"), "# synthetic\n", "utf8");
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    const def = result.records.find((r) => r.namespace === "default");
+    assert.ok(def, "expected default namespace record");
+    assert.equal(def?.kind, "default");
+    // Legacy default root resolves to memoryDir itself, not a tokenized dir.
+    assert.equal(def?.storageDir, memoryDir);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk reports symlinked namespace roots instead of trusting them", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    await mkdir(path.join(outside, "secret"), { recursive: true });
+    const linkPath = path.join(memoryDir, "namespaces", namespaceIdentityToken("evil"));
+    try {
+      await symlink(outside, linkPath, "dir");
+    } catch {
+      // Some CI environments disallow symlinks; skip gracefully.
+      return;
+    }
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      result.skipped.some((s) => s.reason === "symlink"),
+      "expected symlinked root to be reported as skipped",
+    );
+    assert.ok(
+      !result.records.some((r) => r.storageDir.startsWith(outside)),
+      "must not catalog a root that escapes memoryDir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+test("unsafe namespace tokens are rejected by mark APIs", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await assert.rejects(() => catalog.markWrite("../escape"));
+    await assert.rejects(() => catalog.markRead("a/b"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("markRead/markWrite/markMaintenance update only metadata, never content", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // Place a synthetic memory file we can assert is untouched.
+    const factDir = path.join(memoryDir, "namespaces", namespaceIdentityToken("alpha"), "facts");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "f1.md");
+    await writeFile(factPath, "# synthetic fact\nbody\n", "utf8");
+    const before = await readFile(factPath, "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markRead("alpha");
+    await catalog.markWrite("alpha");
+    await catalog.markMaintenance("alpha", "dreams");
+
+    const after = await readFile(factPath, "utf8");
+    assert.equal(after, before, "memory content must not be modified by catalog touches");
+
+    const record = await catalog.getNamespaceRecord("alpha");
+    assert.ok(record?.lastReadAt);
+    assert.ok(record?.lastWriteAt);
+    assert.ok(record?.lastMaintenanceAt?.dreams);
+
+    // Catalog file must contain only metadata, never the fact body.
+    const raw = await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+    assert.ok(!raw.includes("synthetic fact"));
+    assert.ok(!raw.includes("body"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk is idempotent", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await mkdir(path.join(memoryDir, "namespaces", namespaceIdentityToken("alpha"), "facts"), {
+      recursive: true,
+    });
+    await mkdir(path.join(memoryDir, "namespaces", namespaceIdentityToken("beta"), "entities"), {
+      recursive: true,
+    });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const first = await catalog.rebuildFromDisk();
+    const firstRaw = await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+
+    const catalog2 = new NamespaceCatalog(makeConfig(memoryDir));
+    const second = await catalog2.rebuildFromDisk();
+    const secondRaw = await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+
+    const names = (recs: { namespace: string }[]) => recs.map((r) => r.namespace).sort();
+    assert.deepEqual(names(first.records), names(second.records));
+    assert.equal(firstRaw, secondRaw, "rebuild output must be byte-identical when run twice");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("catalog records can be consumed by a fake maintenance scheduler", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite("project-origin-abc123");
+    await catalog.markWrite("shared");
+
+    // Fake scheduler: fan out a job over all catalog namespaces and record it.
+    const records = await catalog.listNamespaces();
+    const jobName = "compaction";
+    for (const r of records) {
+      await catalog.markMaintenance(r.namespace, jobName);
+    }
+
+    const after = await catalog.listNamespaces();
+    assert.ok(after.length >= 2);
+    for (const r of after) {
+      assert.ok(r.lastMaintenanceAt?.[jobName], `expected ${r.namespace} to have maintenance ts`);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("listNamespaces supports filtering by kind and discoveredBy", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.registerConfiguredNamespaces();
+    await catalog.markWrite("project-origin-abc123", { discoveredBy: "write" });
+
+    const projects = await catalog.listNamespaces({ kind: "project" });
+    assert.ok(projects.every((r) => r.kind === "project"));
+    assert.ok(projects.some((r) => r.namespace === "project-origin-abc123"));
+
+    const written = await catalog.listNamespaces({ discoveredBy: "write" });
+    assert.ok(written.every((r) => r.discoveredBy === "write"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("catalog is inert (no-op) when namespaces are disabled", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir, { namespacesEnabled: false }));
+    await catalog.markWrite("project-origin-abc123");
+    await catalog.markRead("shared");
+    await catalog.registerConfiguredNamespaces();
+
+    const list = await catalog.listNamespaces();
+    assert.deepEqual(list, [], "disabled catalog must enumerate nothing");
+
+    // No catalog file should be created when disabled.
+    let exists = true;
+    try {
+      await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, "disabled catalog must not write to disk");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("catalog tolerates corrupt / non-object JSONL lines on read", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const file = path.join(stateDir, "namespaces.jsonl");
+    // Mix of garbage, JSON null, valid record, and a valid record missing fields.
+    const validToken = namespaceIdentityToken("alpha");
+    const lines = [
+      "not json at all",
+      "null",
+      "123",
+      JSON.stringify({ namespace: "" }), // invalid: empty namespace
+      JSON.stringify({
+        namespace: "alpha",
+        identityToken: validToken,
+        kind: "explicit",
+        createdAt: new Date().toISOString(),
+        storageDir: path.join(memoryDir, "namespaces", validToken),
+        discoveredBy: "write",
+      }),
+    ];
+    await writeFile(file, lines.join("\n") + "\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const list = await catalog.listNamespaces();
+    assert.equal(list.length, 1);
+    assert.equal(list[0]?.namespace, "alpha");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageRouter integration: catalog registers namespace on storageFor", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const catalog = new NamespaceCatalog(config);
+    const router = new NamespaceStorageRouter(config, {
+      onResolve: (namespace, storageDir) => {
+        void catalog.registerResolved(namespace, storageDir);
+      },
+    });
+    await router.storageFor("project-origin-abc123");
+    // allow the fire-and-forget registration to settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    const record = await catalog.getNamespaceRecord("project-origin-abc123");
+    assert.ok(record, "storageFor should have registered the namespace");
+    assert.equal(record?.discoveredBy, "config");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -736,3 +736,57 @@ test("rebuildFromDisk preserves prior write provenance for a configured namespac
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 4, Issue #4 (codex P2): an explicit metadata.storageDir from a
+// markWrite/registerResolved caller must be containment-checked before it is
+// persisted. An out-of-memoryDir path must NOT end up as the namespace's
+// catalog storageDir; the catalog falls back to the trusted resolved dir.
+test("explicit storageDir outside memoryDir is rejected (containment)", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const ns = "project-origin-escape";
+    const evilDir = path.join(outside, "evil");
+
+    // A bad hook passes an arbitrary path outside memoryDir.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: evilDir });
+
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record should still be created");
+    assert.ok(
+      !record!.storageDir.startsWith(outside),
+      "catalog must not persist a storage dir outside memoryDir",
+    );
+    // Falls back to the trusted tokenized root under <memoryDir>/namespaces.
+    assert.equal(
+      record!.storageDir,
+      path.join(memoryDir, "namespaces", namespaceIdentityToken(ns)),
+      "rejected explicit dir must fall back to the resolved namespaces/<token> root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// A legitimate explicit storageDir contained under <memoryDir>/namespaces (the
+// router's resolved dir, incl. a legacy raw-name dir) is accepted verbatim.
+test("explicit storageDir contained under namespaces/ is accepted", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const ns = "project-origin-ok";
+    // A legacy raw-name dir under namespaces/ (what the router may resolve to).
+    const legacyDir = path.join(memoryDir, "namespaces", ns);
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: legacyDir });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.equal(
+      record?.storageDir,
+      legacyDir,
+      "a contained explicit dir must be persisted as-is",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1468,6 +1468,61 @@ test("rebuild --apply STILL purges a row whose on-disk root never exists (NFJV8 
   }
 });
 
+// ── NGLz5 (codex P2): the created-after-scan keep branch must REVALIDATE the
+// namespace key (from the untrusted log) with the SAME safety gate the scan uses
+// before re-checking its live root. An UNSAFE namespace row (pre-fix / tampered
+// `namespaces.jsonl`) whose tokenized dir happens to exist with data was SKIPPED
+// by the scan as unsafe — so it is absent from `rebuilt` by design, not deletion.
+// Without re-validating, the keep branch would resurrect it and `--apply` would
+// rewrite the catalog with a namespace the hot touch/config/scan paths all reject.
+// The unsafe row must be DROPPED (purged), not kept.
+test("rebuild --apply does NOT resurrect an UNSAFE namespace row even if its token dir has data (NGLz5)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // Unsafe per isSafeRouteNamespace (space + `!`); its identity token still
+    // hex-encodes, so we can create a real on-disk tokenized dir with data.
+    const ns = "unsafe ns!";
+    const token = namespaceIdentityToken(ns);
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    // The unsafe namespace's tokenized dir EXISTS with memory data — the scan
+    // still skips it as unsafe, so it never enters `rebuilt`.
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    const unsafeRow = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      storageDir: tokenDir,
+      discoveredBy: "write",
+      lastWriteAt: new Date().toISOString(),
+    });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Inject the unsafe row on the re-merge read (the dir already exists on disk),
+    // so the keep branch's live-root recheck WOULD pass — only the safety gate
+    // stops it.
+    injectConcurrentReadOnSecondLoad(catalog, logPath, unsafeRow);
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "an unsafe namespace row must not be resurrected by the created-after-scan keep branch",
+    );
+
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    assert.equal(
+      await reader.getNamespaceRecord(ns),
+      null,
+      "an unsafe namespace must not appear in the rebuilt catalog after --apply",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 6 (codex P2 — NAUf7): a touch that TIMES OUT waiting for another
 // process's active rebuild lock must DROP the append rather than read/append into
 // the rebuild's snapshot→rename window (the lost-append race). We hold a non-stale

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1969,6 +1969,40 @@ test("explicit storageDir under a symlinked-out parent (non-existent leaf) is re
   }
 });
 
+// ── NF21i (codex P2): an explicit storageDir that EXISTS as a regular FILE (not a
+// directory) must be REJECTED by the containment check. We place the file at the
+// namespace's OWN canonical token dir path (`namespaces/<token>`) so it passes the
+// namespace-ownership check (isStorageDirForNamespace) and the ONLY thing that can
+// reject it is the directory check inside isContainedStorageDir. A file is
+// lexically contained and its realpath stays inside memoryDir, so pre-fix it was
+// accepted and persisted as a broken root. Post-fix the file root is rejected and
+// the touch falls back to a safe contained root (CLAUDE.md rule #24).
+test("an explicit storageDir that is a regular FILE at the token dir is rejected (NF21i)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-fileroot";
+    const token = namespaceIdentityToken(ns);
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    // The namespace's canonical token dir path is occupied by a regular FILE.
+    const tokenPathAsFile = path.join(memoryDir, "namespaces", token);
+    await writeFile(tokenPathAsFile, "# not a directory\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenPathAsFile });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record is still created");
+    // The file at the token path must NOT be persisted as the namespace's root —
+    // a storage root must be a directory. (Pre-fix the file was accepted verbatim.)
+    assert.notEqual(
+      path.resolve(record!.storageDir),
+      path.resolve(tokenPathAsFile),
+      "a regular file must not be persisted as a namespace storage root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDo8C): an ASYNC onResolve hook that REJECTS must not
 // crash storage resolution — the rejection must be swallowed (best-effort).
 test("an async onResolve hook rejection does not crash storage resolution", async () => {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1896,3 +1896,270 @@ test("compaction preserves both touch fields from concurrent cross-process snaps
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NEOFS): the DEFAULT namespace's seeded root must also be
+// containment-checked. If `resolveDefaultNamespaceRoot()` returns a
+// `namespaces/<default-token>` symlink escaping memoryDir (empty legacy default +
+// symlinked tokenized dir with a marker), rebuild must NOT persist that escaping
+// path for the default record — it falls back to the trusted memoryDir root.
+test("rebuild does not persist an escaping symlinked default root", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    // An outside tree WITH a storage marker, linked from the default token dir.
+    await mkdir(path.join(outside, "evildefault", "facts"), { recursive: true });
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    const defaultToken = namespaceIdentityToken("default");
+    await symlink(
+      path.join(outside, "evildefault"),
+      path.join(memoryDir, "namespaces", defaultToken),
+      "dir",
+    );
+
+    // Sanity: the router-level resolver would pick the escaping symlinked dir.
+    const resolved = await resolveDefaultNamespaceRoot(makeConfig(memoryDir));
+    assert.equal(
+      path.resolve(resolved),
+      path.resolve(path.join(memoryDir, "namespaces", defaultToken)),
+      "resolveDefaultNamespaceRoot picks the symlinked default token dir",
+    );
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+    const def = result.records.find((r) => r.namespace === "default");
+    assert.ok(def, "the default record exists");
+    // The default storageDir must NOT resolve outside memoryDir.
+    const realOutside = await realpath(outside).catch(() => outside);
+    const realDefault = await realpath(def!.storageDir).catch(() => def!.storageDir);
+    assert.ok(
+      !realDefault.startsWith(realOutside),
+      "the default record must not carry an escaping storageDir",
+    );
+    assert.equal(
+      path.resolve(def!.storageDir),
+      path.resolve(memoryDir),
+      "an escaping default root falls back to the trusted memoryDir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (codex P2 — NEZkA): HELD-MUTEX rebuild lock. The crux invariant:
+// no `namespaces.jsonl` append can occur between a rebuild's final
+// `loadCompacted()` and its atomic `rename()`. Previously a touch only POLLED for
+// the lock (`waitForRebuildLockClear`) then read+appended WITHOUT holding it — a
+// check-then-act gap. If a touch passed the check while no lock existed, a rebuild
+// could then acquire the lock, run its final load, and rename OVER the touch's
+// later append → the append is silently lost-then-overwritten despite the lock.
+//
+// The two `NamespaceCatalog` instances below have independent write chains and
+// distinct lock owner ids, exactly like two PROCESSES (the gateway writer vs. the
+// CLI rebuilder). Two protected test seams let us reproduce the precise lost-append
+// interleaving deterministically:
+//   1. the writer pauses inside its touch critical section (post lock-decision);
+//   2. the rebuilder pauses in its load→rename window (lock held).
+// A barrier coordinates them so the touch's append, if it can happen, lands inside
+// the rebuilder's load→rename window.
+//
+// With the OLD check-then-append code the writer's `waitForRebuildLockClear`
+// returns true (it ran before any lock existed), the writer appends inside the
+// window, and the rebuild's rename CLOBBERS it → the assertion FAILS. With the
+// held mutex the writer cannot ACQUIRE the lock while the rebuilder holds it, so
+// its append cannot land in the window: it either blocks until release (landing
+// AFTER the rename, preserved) or is cleanly dropped — never lost-then-overwritten.
+class SeamCatalog extends NamespaceCatalog {
+  setTouchSeam(fn: (() => Promise<void>) | undefined): void {
+    (this as unknown as { onTouchCriticalSectionForTest?: () => Promise<void> }).onTouchCriticalSectionForTest =
+      fn;
+  }
+  setRebuildBeforeRenameSeam(fn: (() => Promise<void>) | undefined): void {
+    (this as unknown as { onRebuildBeforeRenameForTest?: () => Promise<void> }).onRebuildBeforeRenameForTest =
+      fn;
+  }
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+test("a touch append cannot land inside a rebuild's load→rename window (held mutex)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-held-mutex";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    // On-disk data so rebuild discovers the namespace as a scan record (no
+    // lastWriteAt of its own); the racing write touch is what supplies lastWriteAt.
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    // Separate instances == separate processes (separate writeChain + lock owner).
+    const writer = new SeamCatalog(makeConfig(memoryDir));
+    const rebuilder = new SeamCatalog(makeConfig(memoryDir));
+
+    // Barriers to force the exact lost-append interleaving regardless of timing.
+    const writerInSection = deferred(); // writer has entered its touch critical section
+    const rebuilderInWindow = deferred(); // rebuilder is in its load→rename window
+    let writerObservedLockHeld = false;
+
+    // Writer pauses right after its lock decision, INSIDE the critical section:
+    // signal we are here, then wait for the rebuilder to reach its rename window
+    // before proceeding to append. (With the held mutex the writer only reaches
+    // this seam if it ACQUIRED the lock — so we also record whether the rebuilder
+    // could acquire concurrently.)
+    writer.setTouchSeam(async () => {
+      writerInSection.resolve();
+      // Bounded wait so a held-mutex run (where the rebuilder can NEVER reach its
+      // window concurrently because the writer holds the lock) does not hang.
+      await Promise.race([
+        rebuilderInWindow.promise,
+        new Promise<void>((r) => setTimeout(r, 1500)),
+      ]);
+    });
+
+    // Rebuilder, inside its load→rename window (lock held): signal, then wait for
+    // the writer to be in its section so an OLD-code append would land here.
+    rebuilder.setRebuildBeforeRenameSeam(async () => {
+      rebuilderInWindow.resolve();
+      writerObservedLockHeld = true;
+      await Promise.race([
+        writerInSection.promise,
+        new Promise<void>((r) => setTimeout(r, 1500)),
+      ]);
+      // Brief settle so an OLD-code writer (already past its no-lock check) has a
+      // chance to append inside this window before we rename.
+      await new Promise<void>((r) => setTimeout(r, 200));
+    });
+
+    // Fire both concurrently. The writer's markWrite is best-effort and must never
+    // throw; the rebuild applies.
+    const [, rebuildResult] = await Promise.all([
+      writer.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir }),
+      rebuilder.rebuildFromDisk(),
+    ]);
+
+    assert.ok(writerObservedLockHeld, "the rebuilder must have reached its rename window");
+
+    // INVARIANT: the write touch is never silently lost-then-overwritten. With the
+    // held mutex it lands AFTER the rebuild's rename (preserved) or is cleanly
+    // dropped; it can NOT be clobbered mid-window. A fresh reader sees it preserved.
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reader.getNamespaceRecord(ns);
+    assert.ok(record, "namespace must exist after the concurrent rebuild + write");
+    assert.ok(
+      record?.lastWriteAt,
+      "the write touch must survive the rebuild — not be clobbered inside its load→rename window",
+    );
+    // The rebuild itself applied (held the lock and rewrote).
+    assert.equal(rebuildResult.applied, true, "rebuild --apply held the lock and rewrote");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Companion: a touch that CANNOT acquire the held lock within the bounded wait
+// (a foreign, non-stale, heartbeated rebuild lock is held by "another process")
+// must DROP its append best-effort — it must NEVER append without the lock and
+// NEVER crash the primary memory op. Here the foreign lock never releases within
+// the touch's wait, so the touch degrades to a no-op (dropped) rather than racing.
+test("a touch drops (never crashes, never appends) when it cannot acquire the held lock", async () => {
+  const memoryDir = await mkMemoryDir();
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  try {
+    const ns = "project-origin-lock-drop";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    // Foreign held lock: a different PID + a real UUID owner id (so it is NOT
+    // mistaken for self) + a fresh mtime. A heartbeat keeps it fresh so it is
+    // never broken as stale during the touch's bounded wait.
+    const foreignOwner = "00000000-0000-4000-8000-000000000000";
+    await writeFile(lockPath, `999999 ${foreignOwner} ${new Date().toISOString()}\n`, "utf8");
+    heartbeat = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 250);
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const started = Date.now();
+    // Must resolve (best-effort drop), never reject.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+    const waited = Date.now() - started;
+
+    // The append was DROPPED: no record was written because the lock never cleared.
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.equal(record, null, "a touch that cannot acquire the lock must NOT append");
+    // It must have given up within the bounded wait, not blocked forever.
+    assert.ok(waited < 12_000, "the dropped touch must return within the bounded wait");
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (kilo P2 — NER8P): `namespaces rebuild --apply --json` must EXIT
+// NON-ZERO when the rebuild could not be applied (lock contention →
+// `applied: false`), mirroring the non-JSON path. Otherwise JSON-mode automation
+// treats a no-op apply as success. The CLI's `--json` apply branch sets
+// `process.exitCode = 1` iff `!dryRun && !result.applied`. We drive a real
+// `rebuildFromDisk` under lock contention (so `applied === false`) and apply the
+// exact CLI rule, asserting the non-zero exit signal — restoring `process.exitCode`
+// afterward so this test cannot leak a failure code into the runner.
+test("rebuild --apply --json exits non-zero when the rebuild was not applied (NER8P)", async () => {
+  const memoryDir = await mkMemoryDir();
+  const savedExitCode = process.exitCode;
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  try {
+    const ns = "project-origin-json-noapply";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    // Foreign, non-stale, heartbeated lock held by "another process" so the apply
+    // cannot acquire the lock and returns applied:false (compute-only).
+    const foreignOwner = "00000000-0000-4000-8000-0000000000aa";
+    await writeFile(lockPath, `999999 ${foreignOwner} ${new Date().toISOString()}\n`, "utf8");
+    heartbeat = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 250);
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Mirror the CLI: --apply means dryRun=false.
+    const dryRun = false;
+    const result = await catalog.rebuildFromDisk({ dryRun });
+    assert.equal(result.applied, false, "a contended apply must report applied=false");
+
+    // The EXACT decision the CLI `--json` apply branch makes (cli.ts).
+    process.exitCode = undefined;
+    if (!dryRun && !result.applied) {
+      process.exitCode = 1;
+    }
+    assert.equal(
+      process.exitCode,
+      1,
+      "a JSON apply that was not applied must set a non-zero exit code so automation detects the no-op",
+    );
+
+    // Sanity: a successful apply (no contention) must NOT set a non-zero exit.
+    clearInterval(heartbeat);
+    heartbeat = undefined;
+    await rm(lockPath, { force: true });
+    process.exitCode = undefined;
+    const ok = await catalog.rebuildFromDisk({ dryRun: false });
+    assert.equal(ok.applied, true, "an uncontended apply applies");
+    if (!ok.applied) process.exitCode = 1;
+    assert.notEqual(process.exitCode, 1, "a successful apply must not exit non-zero");
+  } finally {
+    if (heartbeat) clearInterval(heartbeat);
+    process.exitCode = savedExitCode;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import type { PluginConfig } from "../types.js";
 import { namespaceIdentityToken } from "./identity.js";
 import { NamespaceCatalog } from "./catalog.js";
-import { NamespaceStorageRouter } from "./storage.js";
+import { NamespaceStorageRouter, resolveDefaultNamespaceRoot } from "./storage.js";
 
 function makeConfig(memoryDir: string, overrides: Partial<PluginConfig> = {}): PluginConfig {
   return {
@@ -517,6 +517,148 @@ test("chunked write path contract: markWrite updates lastWriteAt for the namespa
     const record = await catalog.getNamespaceRecord(ns);
     assert.ok(record?.lastWriteAt, "chunked write must update lastWriteAt");
     assert.equal(record?.storageDir, storageDir);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 2, Issue A (cursor High + codex P2): a hot-path touch that lands
+// while `rebuildFromDisk --apply` is running must NOT be discarded by the
+// atomic rewrite. Round 1 snapshotted catalog state OUTSIDE the write chain and
+// then rewrote from that snapshot, so a touch appended after the snapshot but
+// before the rewrite was lost. Now the entire scan → load → rewrite runs inside
+// ONE serialized critical section, so a concurrent markWrite either lands before
+// the rebuild's in-chain load (folded into the rewrite) or after the rewrite
+// (its own later critical turn re-reads the rewritten file and re-appends). Run
+// many rounds so the assertion never depends on one lucky scheduling.
+test("rebuildFromDisk --apply does not drop a concurrent markWrite touch", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    for (let i = 0; i < 30; i++) {
+      const ns = `project-origin-rebuild-race-${i}`;
+      const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+      // Give the namespace on-disk data so rebuild discovers it as a scan record
+      // (with no lastWriteAt). The racing markWrite is what supplies lastWriteAt.
+      await mkdir(path.join(storageDir, "facts"), { recursive: true });
+
+      // Fire rebuild and a write touch concurrently without awaiting between.
+      await Promise.all([
+        catalog.rebuildFromDisk(),
+        catalog.markWrite(ns, { discoveredBy: "write", storageDir }),
+      ]);
+
+      const record = await catalog.getNamespaceRecord(ns);
+      assert.ok(
+        record,
+        `round ${i}: namespace must exist after concurrent rebuild + write`,
+      );
+      assert.ok(
+        record?.lastWriteAt,
+        `round ${i}: a markWrite racing rebuildFromDisk --apply must not be dropped`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Companion: markRead and registerResolved touches racing a rebuild are also
+// preserved (the lost-touch class covers all touch kinds, not just write).
+test("rebuildFromDisk --apply preserves concurrent markRead / registerResolved touches", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    for (let i = 0; i < 20; i++) {
+      const ns = `project-origin-rebuild-rr-${i}`;
+      const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+      await mkdir(path.join(storageDir, "facts"), { recursive: true });
+      await Promise.all([
+        catalog.rebuildFromDisk(),
+        catalog.markRead(ns, { discoveredBy: "read" }),
+        catalog.registerResolved(ns, storageDir),
+      ]);
+      const record = await catalog.getNamespaceRecord(ns);
+      assert.ok(record, `round ${i}: namespace must survive concurrent rebuild`);
+      assert.ok(
+        record?.lastReadAt,
+        `round ${i}: a markRead racing rebuildFromDisk must not be dropped`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// `--dry-run` must remain non-mutating even though it now takes the critical
+// section for a consistent read.
+test("rebuildFromDisk dry-run takes the critical section but writes nothing", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await mkdir(path.join(memoryDir, "namespaces", namespaceIdentityToken("gamma"), "facts"), {
+      recursive: true,
+    });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk({ dryRun: true });
+    assert.equal(result.dryRun, true);
+    assert.ok(result.records.some((r) => r.namespace === "gamma"));
+    let exists = true;
+    try {
+      await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, "dry-run must not write the catalog file");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 2, Issue C (codex P2): the rebuilt default record's storageDir must
+// match the runtime router's `defaultNamespaceRoot`. While legacy default data
+// lives directly under memoryDir, the router keeps the default root at
+// memoryDir even if a tokenized `namespaces/<default-token>` dir also exists.
+// Rebuild must NOT overwrite the default record with the tokenized path, or
+// maintenance/QMD would read a different default root than live reads.
+test("rebuildFromDisk keeps default storageDir aligned with the router (legacy data present)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    // Legacy default data lives directly under memoryDir.
+    await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+    await writeFile(path.join(memoryDir, "facts", "legacy.md"), "# legacy\n", "utf8");
+    // AND a tokenized default dir also exists with data — the divergent case.
+    const tokenizedDefaultDir = path.join(
+      memoryDir,
+      "namespaces",
+      namespaceIdentityToken(config.defaultNamespace),
+    );
+    await mkdir(path.join(tokenizedDefaultDir, "facts"), { recursive: true });
+    await writeFile(path.join(tokenizedDefaultDir, "facts", "tok.md"), "# tok\n", "utf8");
+
+    // Resolve what the runtime router would use for the default root.
+    const routerRoot = await resolveDefaultNamespaceRoot(config);
+    assert.equal(
+      routerRoot,
+      memoryDir,
+      "router keeps default root at memoryDir while legacy data exists",
+    );
+
+    const catalog = new NamespaceCatalog(config);
+    const result = await catalog.rebuildFromDisk();
+    const def = result.records.find((r) => r.namespace === config.defaultNamespace);
+    assert.ok(def, "expected a default namespace record");
+    assert.equal(def?.kind, "default");
+    assert.equal(
+      def?.storageDir,
+      routerRoot,
+      "rebuilt default storageDir must equal the router's defaultNamespaceRoot, not the tokenized path",
+    );
+    assert.notEqual(
+      def?.storageDir,
+      tokenizedDefaultDir,
+      "rebuild must not point the default record at the tokenized dir while legacy data exists",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -6,7 +6,11 @@ import test from "node:test";
 import type { PluginConfig } from "../types.js";
 import { namespaceIdentityToken } from "./identity.js";
 import { NamespaceCatalog } from "./catalog.js";
-import { NamespaceStorageRouter, resolveDefaultNamespaceRoot } from "./storage.js";
+import {
+  NamespaceStorageRouter,
+  resolveDefaultNamespaceRoot,
+  resolveNamespaceStorageRoot,
+} from "./storage.js";
 
 function makeConfig(memoryDir: string, overrides: Partial<PluginConfig> = {}): PluginConfig {
   return {
@@ -951,6 +955,110 @@ test("rebuildFromDisk re-merges a concurrent cross-instance write touch", async 
       record?.lastWriteAt,
       "a cross-instance write landing during rebuild must survive the rewrite",
     );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 4, Issue #1 (cursor Medium): a read touch with no explicit storageDir
+// must record the SAME on-disk root the router resolves — a legacy raw-name dir
+// when that is where the data lives — not the lexical tokenized guess.
+test("markRead records the router-aligned legacy raw-name root, not the tokenized guess", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-legacy";
+    // Data lives ONLY in the legacy raw-name dir (no tokenized dir) — exactly
+    // what NamespaceStorageRouter.namespaceRoot would route to.
+    const legacyDir = path.join(memoryDir, "namespaces", ns);
+    await mkdir(path.join(legacyDir, "facts"), { recursive: true });
+
+    const expectedRoot = await resolveNamespaceStorageRoot(makeConfig(memoryDir), ns);
+    assert.equal(expectedRoot, legacyDir, "router resolves the legacy raw-name dir");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markRead(ns, { discoveredBy: "read" });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record should be created by the read touch");
+    assert.equal(
+      record?.storageDir,
+      legacyDir,
+      "read touch must record the router-aligned legacy root, not namespaces/<token>",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 4, Issue #2 (codex P2): rebuild --apply must PURGE a stale dynamic
+// namespace whose on-disk root was deleted, rather than re-adding it from the
+// re-read log forever.
+test("rebuildFromDisk purges a stale namespace whose root was removed", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-gone";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // First touch + rebuild catalogs the namespace from its on-disk root.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+    await catalog.rebuildFromDisk();
+    assert.ok(
+      await catalog.getNamespaceRecord(ns),
+      "namespace should be present while its root exists",
+    );
+
+    // Delete the on-disk root, then reconcile via rebuild.
+    await rm(tokenDir, { recursive: true, force: true });
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "rebuild must purge a stale namespace whose root was removed",
+    );
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    assert.equal(
+      await reader.getNamespaceRecord(ns),
+      null,
+      "purged namespace must not reappear on a fresh read",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 4, Issue #3 (codex P2): catalog WRITERS respect the rebuild lock. A
+// touch defers (bounded) while another process holds the rebuild lock, so it
+// appends to the freshly-rewritten log rather than into the snapshot→rename
+// window. Here we simulate a held cross-process lock with a non-stale lock file
+// and assert the touch still completes (degrades gracefully, never hangs) and
+// is preserved.
+test("a touch defers to a held rebuild lock and is preserved", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-locked";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    // Simulate another process holding the rebuild lock (foreign PID, fresh mtime).
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    await writeFile(lockPath, `999999 ${new Date().toISOString()}\n`, "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const started = Date.now();
+    // Release the foreign lock shortly after the touch begins waiting so the
+    // bounded wait clears well before its deadline.
+    setTimeout(() => {
+      rm(lockPath, { force: true }).catch(() => undefined);
+    }, 150);
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+    const waited = Date.now() - started;
+
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record?.lastWriteAt, "the deferred touch must still be recorded");
+    // It should have waited for the lock to clear (≥ ~100ms) but nowhere near
+    // the 5s max-wait deadline.
+    assert.ok(waited < 4000, "a touch must never block near the full lock deadline");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -995,6 +995,35 @@ test("rebuildFromDisk skips non-canonical raw namespace roots", async () => {
   }
 });
 
+test("rebuildFromDisk preserves a raw ns-default namespace root", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const rawNs = "ns-default";
+    const rawDir = path.join(memoryDir, "namespaces", rawNs);
+    await mkdir(path.join(rawDir, "facts"), { recursive: true });
+    await writeFile(path.join(rawDir, "facts", "f1.md"), "# synthetic\n", "utf8");
+
+    assert.equal(
+      namespaceIdentityFromToken(rawNs),
+      "",
+      "precondition: ns-default is the reserved empty/default identity token",
+    );
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+    const rec = result.records.find((r) => r.namespace === rawNs);
+
+    assert.ok(rec, "rebuild must preserve a routeable raw namespace named ns-default");
+    assert.equal(path.resolve(rec.storageDir), path.resolve(rawDir));
+    assert.ok(
+      !result.skipped.some((s) => s.token === rawNs && s.reason === "unsafe"),
+      "the reserved-token decode must fall back to the raw namespace before unsafe checks",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 5, Issue #2 (cursor Medium): reads must not surface an out-of-root
 // storageDir. A tampered/pre-fix jsonl record with an absolute path outside
 // memoryDir must be sanitized to the resolved safe root on enumeration.

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1817,3 +1817,37 @@ test("an async onResolve hook rejection does not crash storage resolution", asyn
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NDxiS): a configured non-default namespace must be seeded
+// with the ROUTER-resolved root, not a blanket tokenized dir. When a legacy raw
+// root (`namespaces/<rawname>`) already exists, the router serves it, so the
+// catalog must record that runtime path — not `namespaces/<token>`.
+test("rebuild seeds a configured namespace at its router-resolved (legacy raw) root", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "team-pi-project-origin-cfg";
+    // An EMPTY legacy raw-name root exists (no memory data) for this configured
+    // policy namespace. The scan SKIPS empty roots, so only the configured
+    // seeding determines the storageDir — which must match the router's choice.
+    const legacyRaw = path.join(memoryDir, "namespaces", ns);
+    await mkdir(legacyRaw, { recursive: true });
+
+    const policyCfg = makeConfig(memoryDir, {
+      namespacePolicies: [{ name: ns }],
+    } as unknown as Partial<PluginConfig>);
+    const routerRoot = await resolveNamespaceStorageRoot(policyCfg, ns);
+    assert.equal(routerRoot, legacyRaw, "router resolves the empty legacy raw root when it exists");
+
+    const catalog = new NamespaceCatalog(policyCfg);
+    const result = await catalog.rebuildFromDisk();
+    const rec = result.records.find((r) => r.namespace === ns);
+    assert.ok(rec, "the configured namespace is catalogued");
+    assert.equal(
+      path.resolve(rec!.storageDir),
+      path.resolve(legacyRaw),
+      "a configured namespace must be seeded at its router-resolved root, not the tokenized dir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -966,6 +966,35 @@ test("rebuildFromDisk prefers the tokenized root over a legacy dual root", async
   }
 });
 
+test("rebuildFromDisk skips non-canonical raw namespace roots", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-spaced";
+    const rawDir = path.join(memoryDir, "namespaces", `${ns} `);
+    await mkdir(path.join(rawDir, "facts"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    assert.equal(
+      result.records.some((r) => r.namespace === ns && path.resolve(r.storageDir) === path.resolve(rawDir)),
+      false,
+      "rebuild must not attach the canonical namespace to a non-canonical raw root",
+    );
+    assert.equal(
+      result.records.some((r) => path.resolve(r.storageDir) === path.resolve(rawDir)),
+      false,
+      "no catalog record may point at a raw root the router cannot resolve",
+    );
+    assert.ok(
+      result.skipped.some((s) => s.token === `${ns} ` && s.reason === "unsafe" && s.detail === `${ns} `),
+      "the non-canonical raw root should be reported as an unsafe skip",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 5, Issue #2 (cursor Medium): reads must not surface an out-of-root
 // storageDir. A tampered/pre-fix jsonl record with an absolute path outside
 // memoryDir must be sanitized to the resolved safe root on enumeration.

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -2425,6 +2425,13 @@ class SeamCatalog extends NamespaceCatalog {
     (this as unknown as { onRebuildAfterScanForTest?: () => Promise<void> }).onRebuildAfterScanForTest =
       fn;
   }
+  setBreakStaleSeam(fn: (() => Promise<void>) | undefined): void {
+    (this as unknown as { onBeforeBreakStaleUnlinkForTest?: () => Promise<void> }).onBeforeBreakStaleUnlinkForTest =
+      fn;
+  }
+  async callBreakStaleRebuildLock(): Promise<void> {
+    await (this as unknown as { breakStaleRebuildLock: () => Promise<void> }).breakStaleRebuildLock();
+  }
 }
 
 function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
@@ -2600,6 +2607,81 @@ test("a touch drops (never crashes, never appends) when it cannot acquire the he
     assert.ok(waited < 12_000, "the dropped touch must return within the bounded wait");
   } finally {
     if (heartbeat) clearInterval(heartbeat);
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NG7Bg (codex P2): breaking a STALE lock must not delete a REPLACEMENT lock
+// created in the race window. Two processes can both judge the same lock stale;
+// one removes it and creates a fresh lock, and the other's later unlink would
+// delete that fresh holder's ACTIVE lock based on the stale identity it read
+// earlier — leaving the fresh holder running its critical section unprotected. The
+// break now re-validates the lock identity immediately before unlinking and skips
+// the unlink when a replacement (different owner/timestamp) is present. We simulate
+// the replacement via the post-judgment seam and assert the fresh lock survives.
+test("breakStaleRebuildLock does not delete a replacement lock created in the race window (NG7Bg)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+
+    // 1) A genuinely STALE lock (owner A, mtime well past the stale threshold).
+    const staleIdentity = `111111 aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa ${new Date(
+      Date.now() - 120_000,
+    ).toISOString()}\n`;
+    await writeFile(lockPath, staleIdentity, "utf8");
+    const old = new Date(Date.now() - 120_000);
+    await utimes(lockPath, old, old);
+
+    const breaker = new SeamCatalog(makeConfig(memoryDir));
+    // 2) In the race window (after staleness is judged, before unlink), a DIFFERENT
+    //    process removes the stale lock and creates a FRESH replacement (owner B,
+    //    current mtime).
+    const replacementIdentity = `222222 bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb ${new Date().toISOString()}\n`;
+    breaker.setBreakStaleSeam(async () => {
+      await writeFile(lockPath, replacementIdentity, "utf8");
+      const now = new Date();
+      await utimes(lockPath, now, now);
+      breaker.setBreakStaleSeam(undefined);
+    });
+
+    await breaker.callBreakStaleRebuildLock();
+
+    // 3) The replacement lock must STILL exist with its own identity — it was not
+    //    deleted based on the stale identity the breaker read earlier.
+    const after = await readFile(lockPath, "utf8").catch(() => "");
+    assert.equal(
+      after,
+      replacementIdentity,
+      "a replacement lock created in the race window must NOT be unlinked",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// NG7Bg baseline: a genuinely stale lock with an UNCHANGED identity is still broken
+// (the fix must not stop legitimate stale-lock recovery).
+test("breakStaleRebuildLock still removes a stale lock whose identity is unchanged (NG7Bg baseline)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    const stale = `333333 cccccccc-cccc-4ccc-8ccc-cccccccccccc ${new Date(
+      Date.now() - 120_000,
+    ).toISOString()}\n`;
+    await writeFile(lockPath, stale, "utf8");
+    const old = new Date(Date.now() - 120_000);
+    await utimes(lockPath, old, old);
+
+    const breaker = new SeamCatalog(makeConfig(memoryDir));
+    await breaker.callBreakStaleRebuildLock();
+
+    const exists = await readFile(lockPath, "utf8").then(() => true, () => false);
+    assert.equal(exists, false, "an unchanged stale lock must still be broken");
+  } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1150,6 +1150,48 @@ test("rebuildFromDisk purges a stale namespace whose root was removed", async ()
   }
 });
 
+// NIw0F (codex P2): a scanned namespace root whose only marker child is BOGUS —
+// e.g. `facts` is a regular file (or symlink) instead of a real directory —
+// must NOT be treated as live. Downstream `scanMemoryDir` throws on a
+// symlinked/non-directory category root, so cataloging it would make
+// catalog-driven QMD maintenance fail repeatedly on a root with no usable data.
+test("rebuildFromDisk does not catalog a namespace whose only marker child is a non-directory file", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-bogus";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(tokenDir, { recursive: true });
+    // `facts` exists but is a regular FILE, not a category directory — bogus.
+    await writeFile(path.join(tokenDir, "facts"), "not a directory\n", "utf8");
+
+    const result = await new NamespaceCatalog(makeConfig(memoryDir)).rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "a namespace whose only marker is a non-directory file must not be cataloged as live",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Companion to NIw0F: a real category DIRECTORY marker still makes the root live.
+test("rebuildFromDisk catalogs a namespace whose facts marker is a real directory", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-realfacts";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    const result = await new NamespaceCatalog(makeConfig(memoryDir)).rebuildFromDisk();
+    assert.ok(
+      result.records.some((r) => r.namespace === ns),
+      "a namespace with a real facts directory must be cataloged as live",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // NH-FH (cursor Medium): when the configured default name carries surrounding
 // whitespace, catalog records key it by its NORMALIZED (trimmed) identity, but
 // default-namespace exemptions and memoryDir-ownership checks must compare against

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -937,6 +937,65 @@ test("listNamespaces/getNamespaceRecord sanitize an out-of-root storageDir on re
   }
 });
 
+// ── NGZqr (codex P2): the READ sanitizer must REJECT an unsafe non-default
+// namespace NAME, not only sanitize its storageDir. A pre-fix/tampered jsonl row
+// with an unsafe namespace (e.g. `../evil`) was surfaced by listNamespaces/
+// getNamespaceRecord because the sanitizer only fixed storageDir — and
+// isStorageDirForNamespace can still build a tokenized root for such a name, so
+// the storageDir check alone passes. The hot touch + rebuild scan paths reject
+// these names with isSafeRouteNamespace; the read boundary must agree, or
+// maintenance/QMD could enumerate a namespace those paths reject.
+test("listNamespaces/getNamespaceRecord drop an UNSAFE namespace row on read (NGZqr)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const unsafeNs = "../evil"; // fails isSafeRouteNamespace (parent ref + slash)
+    const safeNs = "project-origin-ok";
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lines = [
+      // A tampered/pre-fix row carrying an unsafe namespace name.
+      JSON.stringify({
+        namespace: unsafeNs,
+        identityToken: namespaceIdentityToken(unsafeNs),
+        kind: "project",
+        createdAt: new Date().toISOString(),
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(unsafeNs)),
+        discoveredBy: "write",
+      }),
+      // A normal, safe row that MUST still be returned.
+      JSON.stringify({
+        namespace: safeNs,
+        identityToken: namespaceIdentityToken(safeNs),
+        kind: "project",
+        createdAt: new Date().toISOString(),
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(safeNs)),
+        discoveredBy: "write",
+      }),
+    ];
+    await writeFile(path.join(stateDir, "namespaces.jsonl"), lines.join("\n") + "\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // The unsafe namespace must NOT be surfaced by either read surface.
+    assert.equal(
+      await catalog.getNamespaceRecord(unsafeNs),
+      null,
+      "getNamespaceRecord must drop an unsafe namespace row",
+    );
+    const list = await catalog.listNamespaces();
+    assert.ok(
+      !list.some((r) => r.namespace === unsafeNs),
+      "listNamespaces must not surface an unsafe namespace row",
+    );
+    // The safe namespace is unaffected.
+    assert.ok(
+      list.some((r) => r.namespace === safeNs),
+      "a safe namespace row must still be enumerated",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 5, Issue #3 (codex P2): an explicit storageDir that is lexically
 // contained but is a SYMLINK escaping memoryDir must be rejected (the round-4
 // containment check was lexical only).

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -161,6 +161,37 @@ test("rebuildFromDisk reports symlinked namespace roots instead of trusting them
   }
 });
 
+test("rebuildFromDisk rejects roots with malformed category markers even when a sibling marker is valid", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-bad-category-marker";
+    const token = namespaceIdentityToken(ns);
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    await mkdir(tokenDir, { recursive: true });
+    await writeFile(path.join(tokenDir, "facts"), "not a directory", "utf8");
+    await mkdir(path.join(tokenDir, "state"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "a root with a malformed scan category marker must not be catalogued",
+    );
+    assert.ok(
+      result.skipped.some(
+        (s) =>
+          s.token === token &&
+          s.reason === "unsafe" &&
+          s.detail?.includes("facts: expected directory"),
+      ),
+      "the malformed category marker must be reported as an unsafe skipped root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 8 (codex P2 — NE9K_): the `namespaces` SCAN ROOT itself must be
 // containment-checked BEFORE `readdir` follows it. If `<memoryDir>/namespaces` is
 // a symlink to an outside tree, readdir would enumerate that arbitrary tree

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -373,6 +373,83 @@ test("catalog tolerates corrupt / non-object JSONL lines on read", async () => {
   }
 });
 
+test("catalog quarantines malformed JSONL record fields at the parse boundary", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const file = path.join(stateDir, "namespaces.jsonl");
+    const now = new Date().toISOString();
+    const validToken = namespaceIdentityToken("valid");
+    const lines = [
+      JSON.stringify({
+        namespace: "bad-kind",
+        identityToken: namespaceIdentityToken("bad-kind"),
+        kind: "bogus",
+        createdAt: now,
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken("bad-kind")),
+        discoveredBy: "write",
+      }),
+      JSON.stringify({
+        namespace: "bad-source",
+        identityToken: namespaceIdentityToken("bad-source"),
+        kind: "explicit",
+        createdAt: now,
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken("bad-source")),
+        discoveredBy: "telepathy",
+      }),
+      JSON.stringify({
+        namespace: "bad-token",
+        identityToken: namespaceIdentityToken("other"),
+        kind: "explicit",
+        createdAt: now,
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken("bad-token")),
+        discoveredBy: "write",
+      }),
+      JSON.stringify({
+        namespace: "bad-created",
+        identityToken: namespaceIdentityToken("bad-created"),
+        kind: "explicit",
+        createdAt: "not-a-date",
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken("bad-created")),
+        discoveredBy: "write",
+      }),
+      JSON.stringify({
+        namespace: " valid ",
+        identityToken: validToken,
+        kind: "project",
+        createdAt: now,
+        storageDir: path.join(memoryDir, "namespaces", validToken),
+        discoveredBy: "write",
+        lastReadAt: "not-a-date",
+        lastWriteAt: "not-a-date",
+        lastMaintenanceAt: {
+          bad: "not-a-date",
+          ok: now,
+        },
+      }),
+    ];
+    await writeFile(file, lines.join("\n") + "\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const list = await catalog.listNamespaces();
+
+    assert.deepEqual(
+      list.map((r) => r.namespace),
+      ["valid"],
+      "invalid enum/token/timestamp records must not surface",
+    );
+    assert.equal(list[0]?.identityToken, validToken);
+    assert.equal(list[0]?.kind, "project");
+    assert.equal(list[0]?.discoveredBy, "write");
+    assert.equal(list[0]?.lastReadAt, undefined);
+    assert.equal(list[0]?.lastWriteAt, undefined);
+    assert.deepEqual(list[0]?.lastMaintenanceAt, { ok: now });
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("StorageRouter integration: catalog registers namespace on storageFor", async () => {
   const memoryDir = await mkMemoryDir();
   try {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1150,6 +1150,35 @@ test("rebuildFromDisk purges a stale namespace whose root was removed", async ()
   }
 });
 
+// NH-FH (cursor Medium): when the configured default name carries surrounding
+// whitespace, catalog records key it by its NORMALIZED (trimmed) identity, but
+// default-namespace exemptions and memoryDir-ownership checks must compare against
+// the SAME normalized form — otherwise the default row is misclassified, dropped
+// at read, or given the wrong storage root.
+test("a whitespace-padded default namespace is still recognized as the default row", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // The configured default name has surrounding whitespace; records use the
+    // trimmed key "default".
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir, { defaultNamespace: "  default  " }));
+    await catalog.registerConfiguredNamespaces();
+
+    // The default row reads back (not dropped) under its normalized identity,
+    // classified as kind "default", and rooted at memoryDir — NOT a tokenized
+    // non-default route dir.
+    const record = await catalog.getNamespaceRecord("default");
+    assert.ok(record, "the default row must survive read sanitization despite a padded config name");
+    assert.equal(record?.kind, "default", "padded default config name must classify as the default row");
+    assert.equal(
+      path.resolve(record!.storageDir),
+      path.resolve(memoryDir),
+      "the default namespace must own the legacy memoryDir root, not a tokenized non-default dir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // NH3Xy (codex P2): a fallback root must NOT prove a non-default namespace's
 // liveness during rebuild --apply. When a dynamic namespace's own token root is a
 // symlink/escape (skipped by the scan) but a stale touch row remains, the liveness

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -663,3 +663,76 @@ test("rebuildFromDisk keeps default storageDir aligned with the router (legacy d
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 3, Issue #1 (cursor Medium): rebuild must NOT skip a tokenized
+// namespace root that only holds a `state/` dir — the router counts the `state`
+// runtime child (includeRuntimeState) when deciding a root has storage, so a
+// namespace the router actively resolves would otherwise vanish from the
+// rebuilt catalog after --apply.
+test("rebuildFromDisk catalogs a tokenized root that only has a state dir", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-stateonly";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    // Only a runtime `state/` child — no content category dirs.
+    await mkdir(path.join(tokenDir, "state"), { recursive: true });
+
+    const config = makeConfig(memoryDir);
+    // The router treats this root as present (runtime state counts as a marker).
+    const router = new NamespaceStorageRouter(config);
+    const sm = await router.storageFor(ns);
+    assert.equal(sm.dir, tokenDir, "router resolves the state-only tokenized root");
+
+    const catalog = new NamespaceCatalog(config);
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      result.records.some((r) => r.namespace === ns),
+      "rebuild must catalog a state-only root the router resolves",
+    );
+    assert.ok(
+      !result.skipped.some((s) => s.token === namespaceIdentityToken(ns)),
+      "state-only root must not be reported as skipped",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 3, Issue #2 (cursor Low): rebuild must preserve creation-only
+// provenance. A configured/policy namespace first DISCOVERED via a write touch
+// keeps discoveredBy:"write" after rebuild — rebuild must not reset it to
+// "config" just because it is listed in policies. Mirrors the touch-path
+// creation-only invariant.
+test("rebuildFromDisk preserves prior write provenance for a configured namespace", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "explicit-policy-ns";
+    const config = makeConfig(memoryDir, {
+      namespacePolicies: [{ name: ns } as any],
+    });
+    const catalog = new NamespaceCatalog(config);
+
+    // First seen via a write — provenance is "write", with on-disk data so the
+    // scan branch also discovers it.
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+    assert.equal(
+      (await catalog.getNamespaceRecord(ns))?.discoveredBy,
+      "write",
+      "precondition: namespace discovered via write",
+    );
+
+    await catalog.rebuildFromDisk();
+
+    const after = await catalog.getNamespaceRecord(ns);
+    assert.equal(
+      after?.discoveredBy,
+      "write",
+      "rebuild must preserve prior write provenance, not reset configured ns to config",
+    );
+    assert.ok(after?.lastWriteAt, "rebuild must preserve the lastWriteAt touch field");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1758,3 +1758,62 @@ test("read sanitizer substitutes a contained cross-namespace storageDir", async 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NDo79): an explicit storageDir whose LEAF does not exist
+// yet but whose existing parent (`namespaces/`) is a SYMLINK escaping memoryDir
+// must be rejected. Lexical containment alone would accept it, then a later mkdir
+// would follow the symlink outside the memory root. The touch must fall back to a
+// safe root instead of persisting the escaping path.
+test("explicit storageDir under a symlinked-out parent (non-existent leaf) is rejected", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    // Replace <memoryDir>/namespaces with a symlink to an outside dir.
+    await mkdir(path.join(outside, "evilroot"), { recursive: true });
+    await symlink(path.join(outside, "evilroot"), path.join(memoryDir, "namespaces"), "dir");
+
+    const ns = "project-origin-symparent";
+    // The leaf does not exist yet; its parent (namespaces/) is the escaping link.
+    const escapingLeaf = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: escapingLeaf });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record is still created");
+    // The caller's explicit dir resolves (via the symlinked `namespaces/` parent)
+    // OUTSIDE memoryDir, so it must be REJECTED — the catalog must not persist the
+    // exact escaping path the caller supplied. Pre-fix, `isContainedStorageDir`
+    // accepted the non-existent leaf and recorded it verbatim.
+    assert.notEqual(
+      path.resolve(record!.storageDir),
+      path.resolve(escapingLeaf),
+      "a storageDir escaping via a symlinked parent must not be persisted verbatim",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (codex P2 — NDo8C): an ASYNC onResolve hook that REJECTS must not
+// crash storage resolution — the rejection must be swallowed (best-effort).
+test("an async onResolve hook rejection does not crash storage resolution", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    let called = 0;
+    const router = new NamespaceStorageRouter(makeConfig(memoryDir), {
+      onResolve: async () => {
+        called += 1;
+        throw new Error("async hook failure");
+      },
+    });
+    // Must not throw or produce an unhandled rejection that fails the test.
+    const sm = await router.storageFor("default");
+    assert.ok(sm, "storage resolution succeeds despite a rejecting async hook");
+    // Give the swallowed rejection a tick to settle.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.ok(called >= 1, "the async hook was invoked");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1436,3 +1436,156 @@ test("rebuild --apply skips an unsafe configured namespace", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (cursor Medium / codex P2 — NBn3n/NBsGG): `applied` reflects whether
+// the rebuild actually rewrote the log. A normal apply sets applied=true; a
+// dry-run sets applied=false; an apply that cannot acquire the lock (compute-only)
+// sets applied=false so the CLI does not report unqualified success.
+test("rebuildFromDisk reports applied=true on a normal apply and false on dry-run", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-applied";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+
+    const dry = await catalog.rebuildFromDisk({ dryRun: true });
+    assert.equal(dry.applied, false, "a dry-run never applies");
+
+    const apply = await catalog.rebuildFromDisk();
+    assert.equal(apply.applied, true, "a normal apply that holds the lock applies");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk reports applied=false when it cannot acquire the lock", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-noapply";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    // Hold a non-stale FOREIGN lock for the whole rebuild so acquisition times out.
+    await writeFile(lockPath, `999999 ${new Date().toISOString()}\n`, "utf8");
+    const hb = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 1_000);
+    hb.unref?.();
+    try {
+      const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+      const result = await catalog.rebuildFromDisk();
+      assert.equal(result.dryRun, false, "this is an apply, not a dry-run");
+      assert.equal(
+        result.applied,
+        false,
+        "an apply that cannot acquire the lock must report applied=false (compute-only)",
+      );
+    } finally {
+      clearInterval(hb);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (cursor Low — NBn3w): registerConfiguredNamespaces must SKIP an
+// unsafe configured name (e.g. `sharedNamespace: "../evil"`) instead of throwing
+// and aborting the whole batch, so the remaining safe names still register.
+test("registerConfiguredNamespaces skips an unsafe configured name without aborting", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, {
+        sharedNamespace: "../evil",
+        namespacePolicies: [{ name: "team-pi-project-origin-safe" }],
+      } as unknown as Partial<PluginConfig>),
+    );
+    // Must not throw despite the unsafe sharedNamespace.
+    await catalog.registerConfiguredNamespaces();
+    const list = await catalog.listNamespaces();
+    assert.ok(list.some((r) => r.namespace === "default"), "default still registered");
+    assert.ok(
+      list.some((r) => r.namespace === "team-pi-project-origin-safe"),
+      "a safe policy name after the unsafe one still registers",
+    );
+    assert.ok(
+      !list.some((r) => r.namespace === "../evil"),
+      "the unsafe configured name must not be registered",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (codex P2 — NBsGP): two catalog instances in the SAME process
+// sharing a memoryDir must not treat each other's rebuild lock as self-held. A
+// touch on instance B must DROP its append while instance A holds the lock,
+// instead of skipping the wait (same PID) and appending into A's window.
+test("a same-process second instance does not treat another instance's lock as self-held", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-twoinstances";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+
+    // Instance A writes a lock with ITS OWN owner id (a UUID) — same PID as B.
+    const instanceA = new NamespaceCatalog(makeConfig(memoryDir));
+    const aOwnerId = (instanceA as unknown as { lockOwnerId: string }).lockOwnerId;
+    await writeFile(lockPath, `${process.pid} ${aOwnerId} ${new Date().toISOString()}\n`, "utf8");
+    const hb = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 1_000);
+    hb.unref?.();
+
+    try {
+      // Instance B (different owner id, same PID) must NOT consider A's lock
+      // self-held; its touch waits then DROPS on timeout (no append).
+      const instanceB = new NamespaceCatalog(makeConfig(memoryDir));
+      const started = Date.now();
+      await instanceB.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+      const waited = Date.now() - started;
+      assert.ok(waited >= 4_000, "instance B must wait on instance A's lock, not skip it as self");
+      assert.equal(
+        await instanceB.getNamespaceRecord(ns),
+        null,
+        "instance B's touch must DROP while instance A's lock is held (no overwrite race)",
+      );
+    } finally {
+      clearInterval(hb);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 7 (codex P2 — NBsFz): a token-SHAPED raw namespace name must be
+// preserved by a catalog write touch, not decoded into a different identity. We
+// drive the orchestrator-side derivation indirectly: a markWrite with an explicit
+// storageDir under a legacy raw-name dir whose name merely looks like a token
+// keeps the literal name. (Covered end-to-end via the orchestrator; here we
+// assert the catalog preserves whatever namespace it is given verbatim.)
+test("a catalog write preserves a token-shaped literal namespace name verbatim", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // A raw name that merely LOOKS like a token (hex-suffixed) but is the literal
+    // configured/dynamic namespace. The catalog stores exactly what it is given.
+    const literal = "ns-616c706861";
+    const rawDir = path.join(memoryDir, "namespaces", literal);
+    await mkdir(path.join(rawDir, "facts"), { recursive: true });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(literal, { discoveredBy: "write", storageDir: rawDir });
+    const record = await catalog.getNamespaceRecord(literal);
+    assert.ok(record, "the literal token-shaped namespace must exist");
+    assert.equal(record?.namespace, literal, "the literal name must be preserved, not decoded");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -3223,6 +3223,68 @@ test("listNamespaces drops stale decoded aliases for catalog-owned token-shaped 
   }
 });
 
+test("rebuildFromDisk merges touch fields from dropped root aliases", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const literalNs = namespaceIdentityToken("alpha");
+    const rawRoot = path.join(memoryDir, "namespaces", literalNs);
+    await mkdir(path.join(rawRoot, "facts"), { recursive: true });
+    await writeFile(path.join(rawRoot, "facts", "f1.md"), "# synthetic\n", "utf8");
+
+    const literalWrite = new Date("2026-01-01T00:00:00.000Z");
+    const literalMaintenance = new Date("2026-01-01T01:00:00.000Z");
+    const aliasWrite = new Date("2026-01-02T00:00:00.000Z");
+    const aliasMaintenance = new Date("2026-01-02T01:00:00.000Z");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(literalNs, {
+      discoveredBy: "write",
+      storageDir: rawRoot,
+      at: literalWrite,
+    });
+    await catalog.markMaintenance(literalNs, "qmd", literalMaintenance);
+    await catalog.markWrite("alpha", {
+      discoveredBy: "write",
+      storageDir: rawRoot,
+      at: aliasWrite,
+    });
+    await catalog.markMaintenance("alpha", "qmd", aliasMaintenance);
+
+    const result = await catalog.rebuildFromDisk();
+    const atRawRoot = result.records.filter(
+      (record) => path.resolve(record.storageDir) === path.resolve(rawRoot),
+    );
+
+    assert.equal(atRawRoot.length, 1, "rebuild must keep only one owner for a storage root");
+    assert.equal(atRawRoot[0]?.namespace, literalNs, "the literal root owner must survive");
+    assert.equal(
+      atRawRoot[0]?.lastWriteAt,
+      aliasWrite.toISOString(),
+      "the surviving owner must inherit the newer write touch from the dropped alias",
+    );
+    assert.equal(
+      atRawRoot[0]?.lastMaintenanceAt?.qmd,
+      aliasMaintenance.toISOString(),
+      "the surviving owner must inherit the newer maintenance touch from the dropped alias",
+    );
+
+    const writtenSince = await catalog.listNamespaces({
+      writtenSince: new Date("2026-01-01T12:00:00.000Z"),
+    });
+    assert.ok(
+      writtenSince.some((record) => record.namespace === literalNs),
+      "writtenSince must still include the root after the alias row is collapsed",
+    );
+    assert.equal(
+      await catalog.getNamespaceRecord("alpha"),
+      null,
+      "the decoded alias must stay collapsed after preserving its touch fields",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("listNamespaces prefers configured token owners over stale literal token aliases", async () => {
   const memoryDir = await mkMemoryDir();
   try {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -384,10 +384,13 @@ test("register does not overwrite prior discoveredBy on an existing record", asy
   }
 });
 
-// Symmetric: a record first registered via config keeps discoveredBy:"config"
-// after a routing resolve (no spurious downgrade either), and a later explicit
-// write touch still updates lastWriteAt without rewriting provenance.
-test("explicit discoveredBy is only applied at record creation, not on later touches", async () => {
+// A record first PRE-REGISTERED via the router's onResolve hook (config) is
+// UPGRADED to "write" by a later real write touch (round 6, codex P2 — NBPmT):
+// `storageFor()` fires registerResolved (config) before recordCatalogWrite runs,
+// so without the upgrade `listNamespaces({ discoveredBy: "write" })` would miss a
+// genuinely-written namespace. A non-write touch (read/register) still preserves
+// provenance.
+test("a write upgrades a config pre-registration to write provenance (NBPmT)", async () => {
   const memoryDir = await mkMemoryDir();
   try {
     const catalog = new NamespaceCatalog(makeConfig(memoryDir));
@@ -397,12 +400,29 @@ test("explicit discoveredBy is only applied at record creation, not on later tou
     );
     assert.equal((await catalog.getNamespaceRecord("project-origin-xyz"))?.discoveredBy, "config");
 
-    // A later write touch carries discoveredBy:"write" but must NOT relabel the
-    // already-discovered record.
+    // A later read touch must NOT relabel the config pre-registration.
+    await catalog.markRead("project-origin-xyz", { discoveredBy: "read" });
+    assert.equal(
+      (await catalog.getNamespaceRecord("project-origin-xyz"))?.discoveredBy,
+      "config",
+      "a read touch preserves config provenance (only a write upgrades it)",
+    );
+
+    // A real write touch UPGRADES the config pre-registration to "write".
     await catalog.markWrite("project-origin-xyz", { discoveredBy: "write" });
     const after = await catalog.getNamespaceRecord("project-origin-xyz");
-    assert.equal(after?.discoveredBy, "config", "existing provenance is preserved");
+    assert.equal(
+      after?.discoveredBy,
+      "write",
+      "a real write upgrades a config-only pre-registration to write provenance",
+    );
     assert.ok(after?.lastWriteAt, "write touch still records lastWriteAt");
+    // listNamespaces({ discoveredBy: "write" }) now finds the written namespace.
+    const writeList = await catalog.listNamespaces({ discoveredBy: "write" });
+    assert.ok(
+      writeList.some((r) => r.namespace === "project-origin-xyz"),
+      "a written namespace must be discoverable by discoveredBy:write filter",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -1328,6 +1348,90 @@ test("a touch drops its append when the rebuild-lock wait times out", async () =
     } finally {
       clearInterval(heartbeat);
     }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 6 (codex P2 — NBPmY): a MUTATING rebuild that CANNOT acquire the
+// cross-process lock (another rebuild holds it) must run compute-only — it must
+// NOT perform its load/rename window unlocked, or a second unlocked rename could
+// clobber a concurrent gateway touch. We hold a non-stale FOREIGN lock for the
+// whole rebuild and assert the on-disk log is left untouched (no rewrite).
+test("a mutating rebuild that cannot acquire the lock does NOT rewrite the log", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-unlocked";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    // Seed a known log so we can detect whether the unlocked rebuild rewrote it.
+    const seeded = JSON.stringify({
+      namespace: ns,
+      identityToken: namespaceIdentityToken(ns),
+      kind: "project",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      storageDir: tokenDir,
+      discoveredBy: "write",
+      lastWriteAt: new Date(Date.now() - 30_000).toISOString(),
+    });
+    await writeFile(logPath, seeded + "\n", "utf8");
+    const before = await readFile(logPath, "utf8");
+
+    // Hold a non-stale FOREIGN rebuild lock for the whole rebuild so acquisition
+    // times out and the rebuild runs unlocked (compute-only).
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    await writeFile(lockPath, `999999 ${new Date().toISOString()}\n`, "utf8");
+    const hb = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 1_000);
+    hb.unref?.();
+
+    try {
+      const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+      const result = await catalog.rebuildFromDisk();
+      // The rebuild still computes/returns records (compute-only) ...
+      assert.ok(result.records.some((r) => r.namespace === ns), "compute-only rebuild still returns records");
+      // ... but must NOT have rewritten the on-disk log while unlocked.
+      const after = await readFile(logPath, "utf8");
+      assert.equal(after, before, "an unlocked mutating rebuild must NOT rewrite the log (NBPmY)");
+    } finally {
+      clearInterval(hb);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 6 (codex P2 — NBPmO): rebuild must NOT admit an UNSAFE configured
+// namespace (e.g. a `sharedNamespace`/`namespacePolicies[].name` like `../evil`)
+// into the catalog. The hot touch/scan paths reject these; rebuild must too. The
+// default namespace stays exempt (may be a non-route literal).
+test("rebuild --apply skips an unsafe configured namespace", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const unsafe = "../evil";
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, { sharedNamespace: unsafe } as Partial<PluginConfig>),
+    );
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === unsafe),
+      "an unsafe configured namespace must not be added to the catalog by rebuild",
+    );
+    assert.ok(
+      result.skipped.some((s) => s.reason === "unsafe" && s.detail === unsafe),
+      "an unsafe configured namespace must be reported as skipped",
+    );
+    // The default namespace is still catalogued (exempt from the safety gate).
+    assert.ok(
+      result.records.some((r) => r.namespace === "default"),
+      "the default namespace must still be catalogued",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1339,6 +1339,135 @@ test("rebuild --apply still folds a concurrent touch for a SURVIVING namespace",
   }
 });
 
+// ── NFJV8 (codex P2): a dynamic namespace CREATED on disk AFTER the rebuild's
+// directory scan but BEFORE its final cross-process re-merge must be KEPT, not
+// purged. The scan snapshot missed the brand-new root, yet a gateway markWrite
+// already appended a row that shows up in the re-merge's `latest` read. Pre-fix,
+// that row (absent from `rebuilt`) was dropped as if the namespace was deleted,
+// silently rewriting the catalog without a live, on-disk namespace. The fix
+// re-checks the namespace's storage root on disk RIGHT NOW (same symlink/realpath/
+// containment + memory-data safety as the scan): exists ⇒ keep (created-after-scan
+// is live), confirmed-gone ⇒ purge (preserving the NATqU removed-root fix).
+//
+// We reuse the second-load injection seam, but ALSO create the namespace's facts
+// dir on the SECOND load — so the dir appears AFTER the scan's `readdir` ran but
+// BEFORE the re-merge's purge re-check, exactly modelling create-after-scan.
+function injectCreatedAfterScanOnSecondLoad(
+  catalog: NamespaceCatalog,
+  logPath: string,
+  injectLine: string,
+  rootFactsDir: string,
+): void {
+  const handle = catalog as unknown as LoadCompactedHandle;
+  const original = handle.loadCompacted.bind(catalog);
+  let calls = 0;
+  handle.loadCompacted = async () => {
+    calls += 1;
+    if (calls === 2) {
+      // 1) The namespace's root is created on disk now (after the scan snapshot).
+      await mkdir(rootFactsDir, { recursive: true });
+      // 2) The gateway's concurrent markWrite row, present in this re-merge read.
+      const prev = await readFile(logPath, "utf8").catch(() => "");
+      await writeFile(logPath, prev + injectLine + "\n", "utf8");
+    }
+    return original();
+  };
+}
+
+test("rebuild --apply KEEPS a namespace created on disk after the scan but before the re-merge", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-postscan";
+    const token = namespaceIdentityToken(ns);
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    // The row a gateway markWrite would have appended for the brand-new namespace.
+    // Its on-disk root does NOT exist at scan time; it is created (with memory
+    // data) on the second load, so the scan misses it but the re-check finds it.
+    const writeAt = new Date().toISOString();
+    const fresh = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 1_000).toISOString(),
+      storageDir: tokenDir,
+      discoveredBy: "write",
+      lastWriteAt: writeAt,
+    });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    injectCreatedAfterScanOnSecondLoad(catalog, logPath, fresh, path.join(tokenDir, "facts"));
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      result.records.some((r) => r.namespace === ns),
+      "a namespace created on disk after the scan but before the re-merge must be KEPT, not purged",
+    );
+
+    // Persisted + its live write timestamp preserved so writtenSince/maintenance
+    // can find it without waiting for another touch or rebuild.
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reader.getNamespaceRecord(ns);
+    assert.ok(record, "created-after-scan namespace must be persisted in the catalog");
+    assert.equal(
+      record?.lastWriteAt,
+      writeAt,
+      "the live write timestamp for a created-after-scan namespace must be preserved",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// NFJV8 inverse guard: a row whose root is GENUINELY gone (never created on disk)
+// must STILL be purged — the re-check distinguishes created-after-scan (root
+// EXISTS now) from a removed/never-present root (confirmed ABSENT), so it does not
+// reintroduce the NATqU resurrection bug. Same injection seam, but the dir is
+// never created, so the disk re-check confirms absence and the row is dropped.
+test("rebuild --apply STILL purges a row whose on-disk root never exists (NFJV8 does not regress NATqU)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-ghost";
+    const token = namespaceIdentityToken(ns);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    const stale = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      storageDir: path.join(memoryDir, "namespaces", token),
+      discoveredBy: "write",
+      lastWriteAt: new Date().toISOString(),
+    });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Inject the concurrent row on the second load WITHOUT creating the dir, so the
+    // re-check confirms the root is absent on disk and the row is purged.
+    injectConcurrentReadOnSecondLoad(catalog, logPath, stale);
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "a row whose on-disk root never exists must still be purged after the disk re-check",
+    );
+
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    assert.equal(
+      await reader.getNamespaceRecord(ns),
+      null,
+      "ghost-root namespace must not reappear after the disk re-check confirms absence",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 6 (codex P2 — NAUf7): a touch that TIMES OUT waiting for another
 // process's active rebuild lock must DROP the append rather than read/append into
 // the rebuild's snapshot→rename window (the lost-append race). We hold a non-stale
@@ -1858,6 +1987,84 @@ test("an async onResolve hook rejection does not crash storage resolution", asyn
     // Give the swallowed rejection a tick to settle.
     await new Promise((r) => setTimeout(r, 10));
     assert.ok(called >= 1, "the async hook was invoked");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NFJV- (codex P2): the once-per-namespace resolve-hook dedup must account for
+// IN-FLIGHT async registrations. The catalog's onResolve hook is async (returns
+// registerResolved(...)), so the `notifiedResolved` map is only set after the
+// promise settles. A burst of storageFor() cache hits for the SAME namespace
+// before the first append finishes must NOT each fire their own registration —
+// otherwise hot recall/extraction grows namespaces.jsonl with duplicate touches.
+test("concurrent storageFor() for one namespace fires the resolve hook ONCE while it is in-flight", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    let calls = 0;
+    // A deferred promise we resolve manually, so every concurrent storageFor()
+    // call observes the registration as still IN-FLIGHT (not yet settled).
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const router = new NamespaceStorageRouter(makeConfig(memoryDir), {
+      onResolve: async () => {
+        calls += 1;
+        await gate;
+      },
+    });
+
+    // Fire N concurrent resolutions for the SAME namespace while the first hook
+    // is still awaiting `gate`. Pre-fix, all N pass the post-settle dedup guard
+    // and fire N hooks; post-fix the in-flight marker collapses them to one.
+    const N = 8;
+    await Promise.all(Array.from({ length: N }, () => router.storageFor("project-origin-inflight")));
+    assert.equal(calls, 1, "only one resolve hook may fire while the registration is in-flight");
+
+    // Let the in-flight registration settle, then a steady-state cache hit must
+    // still be a catalog no-op (now deduped via notifiedResolved).
+    release();
+    await new Promise((r) => setTimeout(r, 10));
+    await router.storageFor("project-origin-inflight");
+    assert.equal(calls, 1, "a steady-state cache hit after settle must not re-fire the hook");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NFJV- inverse: a DROPPED registration (hook returns false — e.g. the touch
+// could not acquire the rebuild lock) must clear the in-flight marker so a LATER
+// storageFor() RETRIES it. A dropped touch must remain retryable, not be
+// permanently suppressed by the in-flight dedup.
+test("a dropped resolve registration (hook returns false) is retried on a later storageFor()", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    let calls = 0;
+    let result: boolean | void = false; // first registration is DROPPED
+    const router = new NamespaceStorageRouter(makeConfig(memoryDir), {
+      onResolve: async () => {
+        calls += 1;
+        return result;
+      },
+    });
+
+    await router.storageFor("project-origin-retry");
+    // Give the async hook a tick to settle and clear the in-flight marker.
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(calls, 1, "the hook fired once for the dropped registration");
+
+    // Now the registration will succeed; a later resolve must RETRY (not be
+    // suppressed by a stale in-flight/notified marker from the dropped attempt).
+    result = undefined; // success (legacy void)
+    await router.storageFor("project-origin-retry");
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(calls, 2, "a dropped registration must be retried on the next storageFor()");
+
+    // After a SUCCESSFUL registration, further cache hits are deduped (no retry).
+    await router.storageFor("project-origin-retry");
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(calls, 2, "a successful registration is not re-fired on subsequent cache hits");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -345,3 +345,179 @@ test("StorageRouter integration: catalog registers namespace on storageFor", asy
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Issue 1 (cursor[bot]): the register/resolve hook must NOT clobber prior
+// provenance on an existing record. A namespace first discovered via a `write`
+// touch must keep discoveredBy:"write" even after later routing resolves fire
+// the `config` register hook (including on router cache hits).
+test("register does not overwrite prior discoveredBy on an existing record", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // First seen via a write — provenance is "write".
+    await catalog.markWrite("project-origin-abc123", { discoveredBy: "write" });
+    const afterWrite = await catalog.getNamespaceRecord("project-origin-abc123");
+    assert.equal(afterWrite?.discoveredBy, "write");
+    const createdAt = afterWrite?.createdAt;
+
+    // A later routing resolve fires the register hook with discoveredBy:"config".
+    await catalog.registerResolved(
+      "project-origin-abc123",
+      path.join(memoryDir, "namespaces", namespaceIdentityToken("project-origin-abc123")),
+    );
+
+    const afterRegister = await catalog.getNamespaceRecord("project-origin-abc123");
+    assert.equal(
+      afterRegister?.discoveredBy,
+      "write",
+      "register must preserve prior write provenance, not reset it to config",
+    );
+    assert.equal(afterRegister?.createdAt, createdAt, "createdAt is creation-only and must be preserved");
+    // The write touch field is still present (register does not erase it).
+    assert.ok(afterRegister?.lastWriteAt, "lastWriteAt must survive the register touch");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Symmetric: a record first registered via config keeps discoveredBy:"config"
+// after a routing resolve (no spurious downgrade either), and a later explicit
+// write touch still updates lastWriteAt without rewriting provenance.
+test("explicit discoveredBy is only applied at record creation, not on later touches", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.registerResolved(
+      "project-origin-xyz",
+      path.join(memoryDir, "namespaces", namespaceIdentityToken("project-origin-xyz")),
+    );
+    assert.equal((await catalog.getNamespaceRecord("project-origin-xyz"))?.discoveredBy, "config");
+
+    // A later write touch carries discoveredBy:"write" but must NOT relabel the
+    // already-discovered record.
+    await catalog.markWrite("project-origin-xyz", { discoveredBy: "write" });
+    const after = await catalog.getNamespaceRecord("project-origin-xyz");
+    assert.equal(after?.discoveredBy, "config", "existing provenance is preserved");
+    assert.ok(after?.lastWriteAt, "write touch still records lastWriteAt");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Issue 4 (codex P2): concurrent fire-and-forget touches for the same
+// namespace must each read the latest record inside the serialized chain and
+// merge their fields — none may be dropped by a racing append winning
+// compaction. Fire many touches without awaiting between them, then assert the
+// final compacted record retains read + write + maintenance + register fields.
+test("concurrent touches on one namespace preserve all fields (no dropped metadata)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken("project-origin-race"));
+
+    // Kick off near-simultaneous touches of every kind; do NOT await between
+    // them so the read-modify-append sections must serialize correctly.
+    await Promise.all([
+      catalog.markRead("project-origin-race", { discoveredBy: "read" }),
+      catalog.markWrite("project-origin-race", { discoveredBy: "write" }),
+      catalog.markMaintenance("project-origin-race", "dreams"),
+      catalog.registerResolved("project-origin-race", storageDir),
+      catalog.markMaintenance("project-origin-race", "compaction"),
+    ]);
+
+    const record = await catalog.getNamespaceRecord("project-origin-race");
+    assert.ok(record, "expected a record after concurrent touches");
+    assert.ok(record?.lastReadAt, "lastReadAt must survive concurrent touches");
+    assert.ok(record?.lastWriteAt, "lastWriteAt must survive concurrent touches");
+    assert.ok(record?.lastMaintenanceAt?.dreams, "dreams maintenance ts must survive");
+    assert.ok(record?.lastMaintenanceAt?.compaction, "compaction maintenance ts must survive");
+    // Exactly one logical namespace record after compaction.
+    const list = await catalog.listNamespaces();
+    assert.equal(
+      list.filter((r) => r.namespace === "project-origin-race").length,
+      1,
+      "compaction must fold concurrent appends into a single record",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Tighter race: a register firing concurrently with read+write must not drop
+// the write's lastWriteAt or the read's lastReadAt (the exact scenario the
+// codex thread called out — the router hook is fire-and-forget alongside the
+// hot-path read/write touches). Run several rounds on distinct namespaces so
+// the assertion does not depend on one lucky scheduling.
+test("concurrent register + markWrite + markRead never drops touch fields", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    for (let i = 0; i < 25; i++) {
+      const ns = `project-origin-rw-${i}`;
+      const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+      await Promise.all([
+        catalog.registerResolved(ns, storageDir),
+        catalog.markWrite(ns, { discoveredBy: "write" }),
+        catalog.markRead(ns, { discoveredBy: "read" }),
+      ]);
+      const record = await catalog.getNamespaceRecord(ns);
+      assert.ok(record?.lastWriteAt, `round ${i}: write must survive a racing register/read`);
+      assert.ok(record?.lastReadAt, `round ${i}: read must survive a racing register/write`);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Issue 3 (cursor + codex): a string "false"/"0" opt-out from CLI/env/JSON
+// must keep the catalog inert (no jsonl writes), matching the boolean opt-out.
+// parseConfig is what coerces these strings; assert the catalog honors the
+// resulting flag end to end by feeding it a config whose flag is the coerced
+// boolean.
+test("catalog is inert when namespaceCatalogEnabled is false (string opt-out coerced)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    // Simulate the post-parseConfig state for `namespaceCatalogEnabled: "false"`
+    // / "0": the coerced boolean is false, so the catalog must do nothing.
+    const catalog = new NamespaceCatalog(
+      makeConfig(memoryDir, { namespaceCatalogEnabled: false }),
+    );
+    assert.equal(catalog.enabled, false, "catalog must report disabled");
+    await catalog.markWrite("project-origin-abc123", { discoveredBy: "write" });
+    await catalog.markRead("shared");
+    await catalog.registerConfiguredNamespaces();
+
+    assert.deepEqual(await catalog.listNamespaces(), [], "disabled catalog enumerates nothing");
+    let exists = true;
+    try {
+      await readFile(path.join(memoryDir, "state", "namespaces.jsonl"), "utf8");
+    } catch {
+      exists = false;
+    }
+    assert.equal(exists, false, "opted-out catalog must not write the jsonl file");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Issue 2 (cursor[bot]): the chunked extraction path writes the parent memory
+// then `continue`s past the non-chunked write, so it must record its OWN write
+// touch. This asserts the catalog contract the orchestrator's chunked branch now
+// relies on: a markWrite (as fired by the chunked path) updates lastWriteAt for
+// the target namespace exactly like the non-chunked path.
+test("chunked write path contract: markWrite updates lastWriteAt for the namespace", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const ns = "project-origin-chunked";
+    const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    // This is exactly the call the orchestrator chunked branch now makes
+    // (markCatalogWrite -> markWrite with discoveredBy "write" + storageDir).
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record?.lastWriteAt, "chunked write must update lastWriteAt");
+    assert.equal(record?.storageDir, storageDir);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -3163,3 +3163,33 @@ test("rebuildFromDisk still decodes a tokenized root with no literal owner (NRcC
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("listNamespaces drops stale decoded aliases for catalog-owned token-shaped roots", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const literalNs = namespaceIdentityToken("alpha");
+    const rawRoot = path.join(memoryDir, "namespaces", literalNs);
+    await mkdir(path.join(rawRoot, "facts"), { recursive: true });
+    await writeFile(path.join(rawRoot, "facts", "f1.md"), "# synthetic\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite(literalNs, { discoveredBy: "write", storageDir: rawRoot });
+    await catalog.markRead("alpha", { discoveredBy: "read", storageDir: rawRoot });
+
+    const atRawRoot = (await catalog.listNamespaces()).filter(
+      (record) => path.resolve(record.storageDir) === path.resolve(rawRoot),
+    );
+    assert.deepEqual(
+      atRawRoot.map((record) => record.namespace),
+      [literalNs],
+      "the read API must expose only the catalog-owned literal namespace for a shared root",
+    );
+    assert.equal(
+      await catalog.getNamespaceRecord("alpha"),
+      null,
+      "status lookup must not report a stale alias that listNamespaces drops",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -3193,3 +3193,42 @@ test("listNamespaces drops stale decoded aliases for catalog-owned token-shaped 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("listNamespaces prefers configured token owners over stale literal token aliases", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const literalNs = namespaceIdentityToken("alpha");
+    const tokenRoot = path.join(memoryDir, "namespaces", literalNs);
+    await mkdir(path.join(tokenRoot, "facts"), { recursive: true });
+    await writeFile(path.join(tokenRoot, "facts", "f1.md"), "# synthetic\n", "utf8");
+
+    const config = makeConfig(memoryDir, {
+      namespacePolicies: [
+        {
+          name: "alpha",
+          readPrincipals: [],
+          writePrincipals: [],
+        },
+      ],
+    });
+    const catalog = new NamespaceCatalog(config);
+    await catalog.markWrite(literalNs, { discoveredBy: "write", storageDir: tokenRoot });
+    await catalog.markWrite("alpha", { discoveredBy: "write", storageDir: tokenRoot });
+
+    const atTokenRoot = (await catalog.listNamespaces()).filter(
+      (record) => path.resolve(record.storageDir) === path.resolve(tokenRoot),
+    );
+    assert.deepEqual(
+      atTokenRoot.map((record) => record.namespace),
+      ["alpha"],
+      "configured namespaces must own their tokenized root over a stale literal alias",
+    );
+    assert.equal(
+      await catalog.getNamespaceRecord(literalNs),
+      null,
+      "status lookup must not report the stale literal alias that listNamespaces drops",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1059,6 +1059,94 @@ test("a touch defers to a held rebuild lock and is preserved", async () => {
     // It should have waited for the lock to clear (≥ ~100ms) but nowhere near
     // the 5s max-wait deadline.
     assert.ok(waited < 4000, "a touch must never block near the full lock deadline");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue A (cursor/codex Medium/P2): when a NON-default namespace's
+// router-resolved root fails containment (the LEGACY raw-name dir the router
+// would pick is a symlink escaping memoryDir) but the namespace's own TOKENIZED
+// dir is clean, the touch fallback must record that clean token dir — NOT
+// memoryDir, which is the DEFAULT namespace's tree. Recording memoryDir would
+// misdirect maintenance fanout at the default namespace's data.
+test("a non-default namespace falls back to its own clean token dir, not the default memoryDir", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    const ns = "project-origin-fallback";
+    const token = namespaceIdentityToken(ns);
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    await mkdir(path.join(outside, "target", "facts"), { recursive: true });
+    // The legacy raw-name dir is a symlink escaping memoryDir; the tokenized dir
+    // is a clean, contained directory with data.
+    const legacyDir = path.join(memoryDir, "namespaces", ns);
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    try {
+      await symlink(path.join(outside, "target"), legacyDir, "dir");
+    } catch {
+      return; // symlinks unsupported in this CI env
+    }
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Force the resolved root to fail containment by passing the escaping legacy
+    // dir as the explicit storageDir; the fallback must be the clean token dir.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: legacyDir });
+    const record = await catalog.getNamespaceRecord(ns);
+    assert.ok(record, "record should be created");
+    assert.notEqual(
+      path.resolve(record!.storageDir),
+      path.resolve(memoryDir),
+      "a non-default namespace must NOT fall back to the default memoryDir root",
+    );
+    assert.equal(
+      record!.storageDir,
+      tokenDir,
+      "fallback must be the namespace's own clean token dir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+// ── Round 5, Issue B (cursor/codex Medium/P2): a rebuild holding the lock must
+// HEARTBEAT the lock file so a long scan is not treated as stale. We assert the
+// lock file's mtime is refreshed while a rebuild runs longer than a heartbeat
+// interval. (We can't easily slow the real scan, so we verify the heartbeat
+// timer refreshes mtime by holding the lock via a slow concurrent rebuild and
+// observing the lock file is kept fresh — here we assert the mechanism exists by
+// confirming the lock file is removed cleanly after a normal rebuild and that a
+// stale foreign lock is still broken.)
+test("rebuild releases its lock cleanly and still breaks a stale foreign lock", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-hb";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    // Pre-place a STALE foreign lock (old mtime) — rebuild must break it and run.
+    await writeFile(lockPath, `999999 ${new Date(Date.now() - 60_000).toISOString()}\n`, "utf8");
+    const old = new Date(Date.now() - 60_000);
+    await utimes(lockPath, old, old);
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      result.records.some((r) => r.namespace === ns),
+      "rebuild must complete despite a stale foreign lock",
+    );
+    // Lock must be released after the rebuild (no leftover holder).
+    let lockExists = true;
+    try {
+      await stat(lockPath);
+    } catch {
+      lockExists = false;
+    }
+    assert.equal(lockExists, false, "rebuild must release its lock on completion");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1715,3 +1715,46 @@ test("markWrite rejects a cross-namespace explicit storageDir", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NDXHe): the READ sanitizer must also reject a contained
+// but CROSS-NAMESPACE root (a pre-fix/tampered jsonl record for `project-a` whose
+// storageDir is `project-b`'s token dir or memoryDir). listNamespaces /
+// getNamespaceRecord must substitute the namespace's OWN resolved root, keeping
+// read and write symmetric (rule 42).
+test("read sanitizer substitutes a contained cross-namespace storageDir", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const nsA = "project-origin-reada";
+    const nsB = "project-origin-readb";
+    const tokenA = namespaceIdentityToken(nsA);
+    const tokenB = namespaceIdentityToken(nsB);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    // A tampered/pre-fix record: A points at B's (contained) token dir.
+    const line = JSON.stringify({
+      namespace: nsA,
+      identityToken: tokenA,
+      kind: "project",
+      createdAt: new Date().toISOString(),
+      storageDir: path.join(memoryDir, "namespaces", tokenB),
+      discoveredBy: "write",
+    });
+    await writeFile(path.join(stateDir, "namespaces.jsonl"), line + "\n", "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const rec = await catalog.getNamespaceRecord(nsA);
+    assert.ok(rec, "record A is returned");
+    assert.notEqual(
+      path.resolve(rec!.storageDir),
+      path.resolve(path.join(memoryDir, "namespaces", tokenB)),
+      "read must NOT surface B's tree as A's root",
+    );
+    assert.equal(
+      path.resolve(rec!.storageDir),
+      path.resolve(path.join(memoryDir, "namespaces", tokenA)),
+      "read substitutes A's OWN resolved root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1851,3 +1851,48 @@ test("rebuild seeds a configured namespace at its router-resolved (legacy raw) r
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — ND6Cz): touches run on per-process write chains, so two
+// processes can each append a full snapshot for the same namespace carrying
+// DIFFERENT touch fields. Plain last-record-wins compaction would erase the
+// earlier snapshot's field; field-level merge during compaction preserves the
+// MAX of each touch field so no cross-process touch recency is lost.
+test("compaction preserves both touch fields from concurrent cross-process snapshots", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-xproc-merge";
+    const token = namespaceIdentityToken(ns);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+
+    const base = {
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 120_000).toISOString(),
+      storageDir: tokenDir,
+      discoveredBy: "write",
+    };
+    const writeAt = new Date(Date.now() - 60_000).toISOString();
+    const readAt = new Date(Date.now() - 30_000).toISOString();
+    // Process A appended a WRITE snapshot (only lastWriteAt); process B then
+    // appended a READ snapshot (only lastReadAt) built from the SAME prior state,
+    // so it lacks A's lastWriteAt. Last-record-wins would drop lastWriteAt.
+    const lineA = JSON.stringify({ ...base, lastWriteAt: writeAt });
+    const lineB = JSON.stringify({ ...base, lastReadAt: readAt });
+    await writeFile(path.join(stateDir, "namespaces.jsonl"), `${lineA}\n${lineB}\n`, "utf8");
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const rec = await catalog.getNamespaceRecord(ns);
+    assert.ok(rec, "the namespace is present after compaction");
+    assert.equal(rec?.lastReadAt, readAt, "the later read snapshot's lastReadAt survives");
+    assert.equal(
+      rec?.lastWriteAt,
+      writeAt,
+      "the earlier write snapshot's lastWriteAt is NOT erased by the later read snapshot",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -2230,6 +2230,10 @@ class SeamCatalog extends NamespaceCatalog {
     (this as unknown as { onRebuildBeforeRenameForTest?: () => Promise<void> }).onRebuildBeforeRenameForTest =
       fn;
   }
+  setRebuildAfterScanSeam(fn: (() => Promise<void>) | undefined): void {
+    (this as unknown as { onRebuildAfterScanForTest?: () => Promise<void> }).onRebuildAfterScanForTest =
+      fn;
+  }
 }
 
 function deferred<T = void>(): { promise: Promise<T>; resolve: (v: T) => void } {
@@ -2308,6 +2312,60 @@ test("a touch append cannot land inside a rebuild's load→rename window (held m
     );
     // The rebuild itself applied (held the lock and rewrote).
     assert.equal(rebuildResult.applied, true, "rebuild --apply held the lock and rewrote");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NFgCT (codex P2): the cross-process mutex is now SCOPED to the final
+// load→merge→rename window, NOT the disk scan. A gateway touch that races only the
+// (potentially long) SCAN phase must therefore NOT be blocked/dropped — it should
+// acquire the lock freely because the rebuild does not hold it during the scan.
+// We pause the rebuild AFTER its scan but BEFORE it acquires the lock (the new
+// after-scan seam), fire a cross-instance write touch there, and assert the touch
+// SUCCEEDS (the lock was free) and its write survives the rebuild. Pre-fix (lock
+// held across the whole scan) the touch would contend with the held lock.
+test("a touch racing only the rebuild SCAN phase is not blocked by the mutex (NFgCT)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-scan-race";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+
+    // Separate instances == separate processes (separate writeChain + lock owner).
+    const writer = new SeamCatalog(makeConfig(memoryDir));
+    const rebuilder = new SeamCatalog(makeConfig(memoryDir));
+
+    let seamFired = false;
+    // When the rebuild reaches the post-scan / pre-lock point, perform a
+    // cross-instance write touch. Because the rebuild has NOT yet acquired the
+    // lock, this touch must acquire it freely and APPEND (land a lastWriteAt), not
+    // contend with a held lock and drop. `markWrite` resolves to void; we prove it
+    // was NOT dropped by reading back the persisted record below. The touch
+    // resolving WITHOUT hanging here already proves the scan does not hold the lock
+    // (otherwise the writer would block on the very lock the rebuild owns).
+    rebuilder.setRebuildAfterScanSeam(async () => {
+      seamFired = true;
+      await writer.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+      // Clear the seam so it does not re-fire on any nested rebuild.
+      rebuilder.setRebuildAfterScanSeam(undefined);
+    });
+
+    const result = await rebuilder.rebuildFromDisk();
+    assert.ok(seamFired, "the post-scan / pre-lock seam must have fired");
+    assert.equal(result.applied, true, "the rebuild still held the lock for its final rewrite and applied");
+
+    // The write touch landed during the lockless scan window and SURVIVED — the
+    // rebuild's final re-merge re-reads the log under the lock and folds it. If the
+    // lock had been held across the scan, the touch would have timed out and been
+    // dropped (no lastWriteAt).
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reader.getNamespaceRecord(ns);
+    assert.ok(record, "namespace must exist after the scan-phase touch + rebuild");
+    assert.ok(
+      record?.lastWriteAt,
+      "a touch that landed during the lockless scan must NOT be dropped and must survive the rebuild's final re-merge",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -2411,6 +2469,48 @@ test("rebuild --apply --json exits non-zero when the rebuild was not applied (NE
     assert.notEqual(process.exitCode, 1, "a successful apply must not exit non-zero");
   } finally {
     if (heartbeat) clearInterval(heartbeat);
+    process.exitCode = savedExitCode;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── NFb5W (cursor Medium): an INERT catalog `namespaces rebuild --apply` rewrote
+// nothing, so exit-code-only automation must see a non-zero exit — the same
+// signal the enabled path emits for a non-dry-run rebuild that did not apply.
+// The CLI's inert branch returns early before `rebuildFromDisk`; it now sets
+// `process.exitCode = 1` iff `!dryRun` (apply), while a dry-run inert call stays
+// exit 0. We assert the exact inert-branch decision against a disabled catalog.
+test("inert rebuild --apply exits non-zero; inert --dry-run stays zero (NFb5W)", async () => {
+  const memoryDir = await mkMemoryDir();
+  const savedExitCode = process.exitCode;
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir, { namespacesEnabled: false }));
+    assert.equal(catalog.enabled, false, "an inert catalog reports disabled (the CLI gate)");
+
+    // INERT + --apply (dryRun=false): the CLI sets exitCode=1 before returning.
+    process.exitCode = undefined;
+    {
+      const dryRun = false; // --apply
+      if (!catalog.enabled && !dryRun) process.exitCode = 1;
+    }
+    assert.equal(
+      process.exitCode,
+      1,
+      "an inert `--apply` rewrote nothing and must exit non-zero so automation does not read it as a completed rebuild",
+    );
+
+    // INERT + --dry-run (default): no write was ever promised → exit stays 0.
+    process.exitCode = undefined;
+    {
+      const dryRun = true;
+      if (!catalog.enabled && !dryRun) process.exitCode = 1;
+    }
+    assert.notEqual(
+      process.exitCode,
+      1,
+      "an inert dry-run must not exit non-zero — it never promised to write",
+    );
+  } finally {
     process.exitCode = savedExitCode;
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1179,6 +1179,34 @@ test("a whitespace-padded default namespace is still recognized as the default r
   }
 });
 
+// NIabe (codex P2): when `defaultNamespace` carries surrounding whitespace,
+// `resolveDefaultNamespaceRoot` must build the LEGACY default root from the
+// NORMALIZED name so it still finds a live `namespaces/default` root. Building it
+// from the raw spaced name would look for `namespaces/<spaced>`, miss the real
+// root, and fall back to memoryDir/tokenized — pointing reads/writes/rebuild at
+// an empty root even though the router classifies the trimmed value as default.
+test("resolveDefaultNamespaceRoot finds the legacy default root under a whitespace-padded default name", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, { defaultNamespace: "  default  " });
+    // The live legacy default root is `namespaces/default` (the TRIMMED name) with
+    // data; memoryDir itself holds NO legacy data, so the resolver would otherwise
+    // fall back to memoryDir.
+    const legacyDefaultDir = path.join(memoryDir, "namespaces", "default");
+    await mkdir(path.join(legacyDefaultDir, "facts"), { recursive: true });
+    await writeFile(path.join(legacyDefaultDir, "facts", "live.md"), "# live\n", "utf8");
+
+    const root = await resolveDefaultNamespaceRoot(config);
+    assert.equal(
+      path.resolve(root),
+      path.resolve(legacyDefaultDir),
+      "the resolver must find the live namespaces/default root, not fall back to memoryDir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // NH3Xy (codex P2): a fallback root must NOT prove a non-default namespace's
 // liveness during rebuild --apply. When a dynamic namespace's own token root is a
 // symlink/escape (skipped by the scan) but a stale touch row remains, the liveness

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1725,6 +1725,49 @@ test("rebuild --apply skips an unsafe configured namespace", async () => {
   }
 });
 
+// ── NGnek (codex P2): a configured namespace with harmless surrounding whitespace
+// (e.g. `sharedNamespace: "shared "`) must be NORMALIZED before seeding, so the
+// catalog records the same identity + router-resolved root the live router uses.
+// Pre-fix, rebuild seeded a row for the RAW `"shared "` resolving to a
+// `namespaces/shared ` root that live reads/writes never touch — pointing
+// maintenance/QMD at the wrong directory.
+test("rebuild normalizes a configured namespace with surrounding whitespace (NGnek)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, { sharedNamespace: "shared " } as Partial<PluginConfig>);
+    const catalog = new NamespaceCatalog(config);
+    const result = await catalog.rebuildFromDisk();
+
+    // The catalog must record the TRIMMED identity, not the raw whitespace name.
+    assert.ok(
+      result.records.some((r) => r.namespace === "shared"),
+      "a configured namespace must be seeded under its normalized (trimmed) identity",
+    );
+    assert.ok(
+      !result.records.some((r) => r.namespace === "shared "),
+      "the raw whitespace namespace must NOT be seeded",
+    );
+    const shared = result.records.find((r) => r.namespace === "shared");
+    assert.ok(shared, "normalized shared namespace is catalogued");
+    // Its kind is correctly classified as `shared` (inferKind normalizes config).
+    assert.equal(shared!.kind, "shared", "the normalized namespace is classified as shared");
+    // Its storageDir must be the router-aligned root for the trimmed name, with no
+    // trailing-space directory component. The router itself trims, so resolving for
+    // "shared" yields the live root.
+    assert.equal(
+      path.resolve(shared!.storageDir),
+      path.resolve(await resolveNamespaceStorageRoot(config, "shared")),
+      "the normalized namespace resolves to the router root for the trimmed name",
+    );
+    assert.ok(
+      !shared!.storageDir.endsWith("shared "),
+      "the storageDir must not point at a trailing-space directory",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (cursor Medium / codex P2 — NBn3n/NBsGG): `applied` reflects whether
 // the rebuild actually rewrote the log. A normal apply sets applied=true; a
 // dry-run sets applied=false; an apply that cannot acquire the lock (compute-only)

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1151,3 +1151,184 @@ test("rebuild releases its lock cleanly and still breaks a stale foreign lock", 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 6 (cursor Medium — NATqU): the disk scan is AUTHORITATIVE for which
+// namespaces exist. A concurrent best-effort markRead/markWrite on a dynamic
+// namespace whose on-disk root was REMOVED must NOT resurrect its stale record
+// during the rebuild's final cross-process re-merge — that would defeat the
+// purge. To deterministically reproduce a cross-process touch landing AFTER the
+// rebuild's purge snapshot but BEFORE its final re-merge read, we wrap the
+// instance's internal `loadCompacted` so the stale log record is appended only
+// before the SECOND read. Under the pre-fix re-merge this row (absent from the
+// snapshot, so "concurrently touched") was resurrected; the scan-authoritative
+// fix drops it. Runtime monkey-patch via a typed handle keeps `tsc` clean.
+type LoadCompactedHandle = {
+  loadCompacted: () => Promise<Map<string, unknown>>;
+};
+
+function injectConcurrentReadOnSecondLoad(
+  catalog: NamespaceCatalog,
+  logPath: string,
+  injectLine: string,
+): void {
+  const handle = catalog as unknown as LoadCompactedHandle;
+  const original = handle.loadCompacted.bind(catalog);
+  let calls = 0;
+  handle.loadCompacted = async () => {
+    calls += 1;
+    // The rebuild reads twice: (1) the purge snapshot, (2) the cross-process
+    // re-merge. Inject the concurrent append only before the SECOND read so the
+    // re-merge sees a record the snapshot did not (prior !== fresh).
+    if (calls === 2) {
+      const prev = await readFile(logPath, "utf8").catch(() => "");
+      await writeFile(logPath, prev + injectLine + "\n", "utf8");
+    }
+    return original();
+  };
+}
+
+test("rebuild --apply does NOT resurrect a removed-root namespace touched concurrently mid-rebuild", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-purged";
+    const token = namespaceIdentityToken(ns);
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    // The stale record's on-disk root does NOT exist (its dir was never created),
+    // so the rebuild's disk scan will not find it — it must be purged.
+    const stale = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      storageDir: path.join(memoryDir, "namespaces", token),
+      discoveredBy: "write",
+      lastWriteAt: new Date().toISOString(),
+    });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    injectConcurrentReadOnSecondLoad(catalog, logPath, stale);
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "a concurrent touch must not resurrect a namespace whose on-disk root was removed",
+    );
+
+    // Persisted: a fresh reader must not see the resurrected record either.
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    assert.equal(
+      await reader.getNamespaceRecord(ns),
+      null,
+      "purged removed-root namespace must not reappear after a concurrent mid-rebuild touch",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 6 (cursor Medium — NATqU): a surviving namespace (still present on
+// disk) MUST still have its concurrent touch fields folded in by the re-merge —
+// the scan-authoritative fix only suppresses RESURRECTION of removed roots, it
+// must not regress the legitimate cross-process touch preservation.
+test("rebuild --apply still folds a concurrent touch for a SURVIVING namespace", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-survivor";
+    const token = namespaceIdentityToken(ns);
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const logPath = path.join(stateDir, "namespaces.jsonl");
+
+    // A concurrent write touch for the SURVIVING (on-disk) namespace, injected
+    // between the snapshot and re-merge reads. Its lastWriteAt must be preserved.
+    const writeAt = new Date().toISOString();
+    const concurrent = JSON.stringify({
+      namespace: ns,
+      identityToken: token,
+      kind: "project",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      storageDir: tokenDir,
+      discoveredBy: "write",
+      lastWriteAt: writeAt,
+    });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    injectConcurrentReadOnSecondLoad(catalog, logPath, concurrent);
+    await catalog.rebuildFromDisk();
+
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    const record = await reader.getNamespaceRecord(ns);
+    assert.ok(record, "surviving namespace must remain in the catalog");
+    assert.equal(
+      record?.lastWriteAt,
+      writeAt,
+      "a concurrent touch for a surviving namespace must be folded into the rebuild",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 6 (codex P2 — NAUf7): a touch that TIMES OUT waiting for another
+// process's active rebuild lock must DROP the append rather than read/append into
+// the rebuild's snapshot→rename window (the lost-append race). We hold a non-stale
+// FOREIGN lock for the whole touch so the bounded wait expires, then assert the
+// touch did NOT create/append a record (degrades gracefully, never hangs/crashes).
+test("a touch drops its append when the rebuild-lock wait times out", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const ns = "project-origin-locktimeout";
+    const tokenDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
+    await mkdir(path.join(tokenDir, "facts"), { recursive: true });
+    const stateDir = path.join(memoryDir, "state");
+    await mkdir(stateDir, { recursive: true });
+    const lockPath = path.join(stateDir, "namespaces.rebuild.lock");
+    // A FOREIGN (different PID), non-stale lock held for the entire touch. Keep
+    // its mtime fresh so the bounded wait never breaks it as stale and instead
+    // hits the deadline — forcing the drop.
+    await writeFile(lockPath, `999999 ${new Date().toISOString()}\n`, "utf8");
+    const heartbeat = setInterval(() => {
+      const now = new Date();
+      utimes(lockPath, now, now).catch(() => undefined);
+    }, 1_000);
+    heartbeat.unref?.();
+
+    try {
+      const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+      const started = Date.now();
+      await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+      const waited = Date.now() - started;
+
+      // The touch must have hit the bounded deadline (it could not clear the
+      // foreign lock) but must not block far beyond it.
+      assert.ok(waited >= 4_000, "touch should wait up to the lock deadline before dropping");
+      assert.ok(waited < 12_000, "touch must never block indefinitely on a held lock");
+
+      // CRITICAL: the append was DROPPED — no record was written for the
+      // namespace while the foreign rebuild lock was held.
+      const record = await catalog.getNamespaceRecord(ns);
+      assert.equal(
+        record,
+        null,
+        "a touch that times out on a held rebuild lock must NOT append (no overwrite race)",
+      );
+      // The log file must not have been created/appended by the dropped touch.
+      let logExists = true;
+      try {
+        await stat(path.join(stateDir, "namespaces.jsonl"));
+      } catch {
+        logExists = false;
+      }
+      assert.equal(logExists, false, "no namespaces.jsonl append should occur on a dropped touch");
+    } finally {
+      clearInterval(heartbeat);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1672,3 +1672,46 @@ test("a rebuild releases only its own lock, not a replacement foreign lock", asy
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NDATT): an explicit storageDir that is contained but
+// belongs to ANOTHER namespace's tree (or memoryDir for a non-default namespace)
+// must be REJECTED — it must not be persisted as this namespace's root. The touch
+// falls back to the namespace's own resolved root.
+test("markWrite rejects a cross-namespace explicit storageDir", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const nsA = "project-origin-aaa";
+    const nsB = "project-origin-bbb";
+    const tokenA = namespaceIdentityToken(nsA);
+    const tokenB = namespaceIdentityToken(nsB);
+    const bDir = path.join(memoryDir, "namespaces", tokenB);
+    await mkdir(path.join(bDir, "facts"), { recursive: true });
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // Attempt to record namespace A with namespace B's tree as its storageDir.
+    await catalog.markWrite(nsA, { discoveredBy: "write", storageDir: bDir });
+    const recordA = await catalog.getNamespaceRecord(nsA);
+    assert.ok(recordA, "namespace A record is still created");
+    assert.notEqual(
+      path.resolve(recordA!.storageDir),
+      path.resolve(bDir),
+      "A must NOT be recorded under B's tree (cross-namespace root)",
+    );
+    assert.equal(
+      path.resolve(recordA!.storageDir),
+      path.resolve(path.join(memoryDir, "namespaces", tokenA)),
+      "A falls back to its OWN resolved tokenized root",
+    );
+
+    // And memoryDir is rejected for a non-default namespace.
+    await catalog.markWrite(nsA, { discoveredBy: "write", storageDir: memoryDir });
+    const recordA2 = await catalog.getNamespaceRecord(nsA);
+    assert.notEqual(
+      path.resolve(recordA2!.storageDir),
+      path.resolve(memoryDir),
+      "a non-default namespace must not be recorded at memoryDir (default tree)",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -161,6 +161,51 @@ test("rebuildFromDisk reports symlinked namespace roots instead of trusting them
   }
 });
 
+// ── Round 8 (codex P2 — NE9K_): the `namespaces` SCAN ROOT itself must be
+// containment-checked BEFORE `readdir` follows it. If `<memoryDir>/namespaces` is
+// a symlink to an outside tree, readdir would enumerate that arbitrary tree
+// (leaking names / spending time on a huge dir) before the per-entry lstat checks
+// run. rebuild must NOT read a symlinked scan root: it reports it as one skipped
+// unsafe root and catalogs none of the outside entries.
+test("rebuildFromDisk rejects a symlinked namespaces scan root without enumerating it", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    // The outside tree contains tokenized namespace dirs WITH data that would be
+    // catalogued if the symlinked root were followed.
+    const leakedNs = "project-origin-leaked";
+    await mkdir(path.join(outside, namespaceIdentityToken(leakedNs), "facts"), { recursive: true });
+    // `<memoryDir>/namespaces` IS a symlink to the outside tree.
+    try {
+      await symlink(outside, path.join(memoryDir, "namespaces"), "dir");
+    } catch {
+      // Some CI environments disallow symlinks; skip gracefully.
+      return;
+    }
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    const result = await catalog.rebuildFromDisk();
+
+    // The outside namespace must NOT be enumerated/catalogued.
+    assert.ok(
+      !result.records.some((r) => r.namespace === leakedNs),
+      "a symlinked namespaces scan root must not be enumerated into the catalog",
+    );
+    assert.ok(
+      !result.records.some((r) => r.storageDir.startsWith(outside)),
+      "no record may point at a storageDir inside the symlinked-out scan root",
+    );
+    // The symlinked root is reported as one skipped unsafe root.
+    assert.ok(
+      result.skipped.some((s) => s.token === "namespaces" && s.reason === "symlink"),
+      "the symlinked namespaces scan root must be reported as skipped",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
 test("unsafe namespace tokens are rejected by mark APIs", async () => {
   const memoryDir = await mkMemoryDir();
   try {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1150,6 +1150,58 @@ test("rebuildFromDisk purges a stale namespace whose root was removed", async ()
   }
 });
 
+// NH3Xy (codex P2): a fallback root must NOT prove a non-default namespace's
+// liveness during rebuild --apply. When a dynamic namespace's own token root is a
+// symlink/escape (skipped by the scan) but a stale touch row remains, the liveness
+// recheck used to resolve the namespace to the DEFAULT `memoryDir` (the fallback)
+// and — because the default tree has data — wrongly KEEP the stale row pointing at
+// the default tree. The fix treats a non-default namespace that resolves only to
+// memoryDir as having no independent live root, so the stale row is purged.
+test("rebuildFromDisk purges a stale non-default namespace whose only resolvable root is the default memoryDir", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outside = await mkMemoryDir();
+  try {
+    // The DEFAULT namespace (memoryDir root) has data, so hasMemoryData(memoryDir)
+    // is true — this is what made the buggy fallback look "live".
+    await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+
+    const ns = "project-origin-skipped";
+    const token = namespaceIdentityToken(ns);
+    await mkdir(path.join(memoryDir, "namespaces"), { recursive: true });
+    // The namespace's OWN token dir is a symlink escaping memoryDir — the scan
+    // skips it as unsafe, and its fallback (token dir not contained) lands on
+    // memoryDir. Point the symlink at real outside data so a followed link would
+    // (wrongly) look populated.
+    await mkdir(path.join(outside, "target", "facts"), { recursive: true });
+    const tokenDir = path.join(memoryDir, "namespaces", token);
+    try {
+      await symlink(path.join(outside, "target"), tokenDir, "dir");
+    } catch {
+      return; // symlinks unsupported in this CI env
+    }
+
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    // A touch row exists for the namespace (the escaping legacy/explicit dir forces
+    // the resolved root to fail containment), but the scan skips its symlinked root.
+    await catalog.markWrite(ns, { discoveredBy: "write", storageDir: tokenDir });
+
+    const result = await catalog.rebuildFromDisk();
+    assert.ok(
+      !result.records.some((r) => r.namespace === ns),
+      "a non-default namespace that resolves only to the default memoryDir must be purged, not kept",
+    );
+    const reader = new NamespaceCatalog(makeConfig(memoryDir));
+    assert.equal(
+      await reader.getNamespaceRecord(ns),
+      null,
+      "the purged namespace must not reappear on a fresh read",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
 // ── Round 4, Issue #3 (codex P2): catalog WRITERS respect the rebuild lock. A
 // touch defers (bounded) while another process holds the rebuild lock, so it
 // appends to the freshly-rewritten log rather than into the snapshot→rename

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1356,6 +1356,22 @@ export class NamespaceCatalog {
           // inverse of NATqU, not a regression of it: a touch on a REMOVED root
           // re-checks as absent and is still purged below; only a root that EXISTS
           // on a fresh re-check is kept.
+          //
+          // SAFETY REVALIDATION (NGLz5, codex P2): the `ns` key comes from the
+          // UNTRUSTED log (`latest`), which may carry an unsafe namespace row from a
+          // pre-fix or tampered catalog. The disk SCAN validates every decoded
+          // namespace with `isSafeRouteNamespace` (default exempt) and SKIPS unsafe
+          // ones — so an unsafe namespace is absent from `rebuilt` by design, NOT
+          // because it was deleted. Without re-applying that exact check here, a
+          // matching tokenized dir on disk would let this branch RESURRECT the
+          // unsafe row, and `--apply` would rewrite the catalog with a namespace the
+          // hot touch/config/scan paths all reject — leaving maintenance/QMD able to
+          // enumerate an unsafe namespace after a rebuild that appeared to skip it.
+          // Apply the SAME default-exempt safety gate before the live-root recheck;
+          // an unsafe row is dropped (fall through to purge), never kept.
+          if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+            continue;
+          }
           if (await this.liveStorageRootExistsForRebuild(ns, memoryReal)) {
             // Created-after-scan: keep the live row. Re-resolve its storageDir to
             // the safe (router-aligned, contained) root so we never persist a

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { Dirent } from "node:fs";
 import {
   appendFile,
@@ -113,6 +114,15 @@ export interface NamespaceCatalogRebuildResult {
   records: NamespaceRecord[];
   /** Roots reported as ambiguous/unsafe rather than silently misclassified. */
   skipped: NamespaceCatalogSkippedRoot[];
+  /**
+   * Whether the rebuild actually rewrote the on-disk catalog (round 6, codex P2
+   * / cursor Medium — NBn3n/NBsGG). `false` for a dry-run, AND for an `--apply`
+   * that could NOT acquire the cross-process rebuild lock within the bounded wait
+   * (it ran compute-only to avoid clobbering a concurrent lock holder). Callers
+   * (CLI) must NOT report unqualified success when `applied` is false for a
+   * non-dry-run — the catalog was left unchanged and a retry is needed.
+   */
+  applied: boolean;
 }
 
 const CATALOG_FILE = "namespaces.jsonl";
@@ -298,6 +308,12 @@ export class NamespaceCatalog {
   private readonly stateDir: string;
   private readonly catalogPath: string;
   private readonly rebuildLockPath: string;
+  // Per-INSTANCE lock owner id (round 6, codex P2 — NBsGP). The rebuild lock
+  // file records this id, not just `process.pid`, so two NamespaceCatalog
+  // instances in the SAME process sharing a memoryDir are NOT mistaken for each
+  // other: a touch on instance B must still wait for instance A's rebuild lock
+  // (different owner id, same PID) instead of skipping as "self-held".
+  private readonly lockOwnerId: string = randomUUID();
   // Serialized write chain that recovers from rejection (CLAUDE.md rule #40)
   // so a single failed append cannot permanently poison subsequent writes.
   private writeChain: Promise<void> = Promise.resolve();
@@ -393,7 +409,18 @@ export class NamespaceCatalog {
     ]);
     for (const ns of names) {
       if (!ns) continue;
-      await this.register(ns, { discoveredBy: "config" });
+      // Skip unsafe configured names (e.g. a `sharedNamespace`/policy name like
+      // `../evil`) consistently with `rebuildFromDisk` (round 6, cursor Low —
+      // NBn3w). `register`→`validateNamespace` THROWS on unsafe tokens; without
+      // this guard one bad name would abort registration of all the rest. The
+      // default namespace is exempt (it may be a non-route literal). Each call is
+      // also wrapped so a single failure never blocks the remaining names.
+      if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) continue;
+      try {
+        await this.register(ns, { discoveredBy: "config" });
+      } catch {
+        // Best-effort: a single bad/unsafe name must not abort the batch.
+      }
     }
   }
 
@@ -700,7 +727,7 @@ export class NamespaceCatalog {
   ): Promise<NamespaceCatalogRebuildResult> {
     const dryRun = options?.dryRun === true;
     if (!this.enabled) {
-      return { dryRun, records: [], skipped: [] };
+      return { dryRun, records: [], skipped: [], applied: false };
     }
 
     // CONCURRENCY (Issue A — round 2): the entire scan → merge → rewrite runs
@@ -958,7 +985,11 @@ export class NamespaceCatalog {
       await this.rewriteUnchained(records);
     }
 
-    return { dryRun, records, skipped };
+    // `applied` is true only when we actually rewrote the log: never for a
+    // dry-run, and never for an `--apply` that ran compute-only because it could
+    // not acquire the lock (canMutate=false). Surfaces the real mutation state so
+    // the CLI does not report success on a skipped rewrite (NBn3n/NBsGG).
+    return { dryRun, records, skipped, applied: canMutate };
   }
 
   // ── Cross-process rebuild lock ───────────────────────────────────────────
@@ -1019,7 +1050,12 @@ export class NamespaceCatalog {
       try {
         const handle = await open(this.rebuildLockPath, "wx");
         try {
-          await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`, "utf8");
+          // Record PID, this instance's owner id, and a timestamp. The owner id
+          // distinguishes same-process instances (NBsGP).
+          await handle.writeFile(
+            `${process.pid} ${this.lockOwnerId} ${new Date().toISOString()}\n`,
+            "utf8",
+          );
         } catch {
           // Ignore write failures — the exclusive create already gave us the lock.
         } finally {
@@ -1100,11 +1136,29 @@ export class NamespaceCatalog {
     }
   }
 
-  /** Whether the rebuild lock file was written by THIS process (PID match). */
+  /**
+   * Whether the rebuild lock file was written by THIS instance (round 6, codex
+   * P2 — NBsGP). Matches the per-instance owner id, NOT just `process.pid`: two
+   * NamespaceCatalog instances in the same process share a PID, so a PID-only
+   * check would wrongly treat instance A's lock as self-held by instance B and
+   * let B's touch skip the wait and append into A's rebuild window. Falls back to
+   * the legacy PID-only form for lock files written before owner ids existed.
+   */
   private async rebuildLockHeldBySelf(): Promise<boolean> {
     try {
       const body = await readFile(this.rebuildLockPath, "utf8");
-      const pid = Number.parseInt(body.trim().split(/\s+/)[0] ?? "", 10);
+      const parts = body.trim().split(/\s+/);
+      const pid = Number.parseInt(parts[0] ?? "", 10);
+      const ownerId = parts[1];
+      // New format: "<pid> <uuid> <iso>". A UUID at parts[1] uniquely identifies
+      // the writing INSTANCE; only the same instance is self. The strict UUID
+      // shape avoids mistaking a legacy "<pid> <iso>" timestamp (also hyphenated)
+      // for an owner id.
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (ownerId && UUID_RE.test(ownerId)) {
+        return ownerId === this.lockOwnerId;
+      }
+      // Legacy format: "<pid> <iso>" (no owner id). Best-effort PID match.
       return Number.isFinite(pid) && pid === process.pid;
     } catch {
       return false;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -317,6 +317,19 @@ export class NamespaceCatalog {
   // Serialized write chain that recovers from rejection (CLAUDE.md rule #40)
   // so a single failed append cannot permanently poison subsequent writes.
   private writeChain: Promise<void> = Promise.resolve();
+  // Test-only seam (round 7 — NEZkA): fires inside a touch's HELD-lock critical
+  // section, after the lock is acquired but BEFORE the read→merge→append. A
+  // deterministic concurrency test installs a hook here to widen the (otherwise
+  // microscopic) window and prove that a cross-process rebuild CANNOT run its
+  // load→rename while a touch holds the lock. Never set in production code.
+  protected onTouchCriticalSectionForTest?: () => Promise<void>;
+  // Test-only seam (round 7 — NEZkA): fires inside a mutating rebuild's HELD-lock
+  // critical section, after the final cross-process re-merge `loadCompacted()` and
+  // BEFORE the atomic `rename()`. This is the EXACT window in which a check-then-
+  // append touch (the old bug) would clobber its append. A deterministic test
+  // installs a hook here to attempt a cross-instance touch in this window and
+  // assert the held mutex blocks it. Never set in production code.
+  protected onRebuildBeforeRenameForTest?: () => Promise<void>;
 
   constructor(private readonly config: PluginConfig) {
     this.memoryDir = config.memoryDir;
@@ -758,83 +771,101 @@ export class NamespaceCatalog {
     // the earlier touch's fields (CLAUDE.md rule #40 — the chain also recovers
     // from rejection). Reading inside the chain guarantees each touch sees the
     // most recent appended state, including any concurrent read/write/register.
-    return this.queueCritical(async () => {
-      // Cross-process serialization (round 4 + round 6, codex P2): a CLI
-      // `rebuild --apply` holds the rebuild lock across its final
-      // `loadCompacted()` → atomic `rename`. An append that lands inside that
-      // window is clobbered by the rename. `queueCritical` only serializes THIS
-      // process, so before reading and appending we wait (bounded) for any
-      // holder's lock to clear, then read the freshly-rewritten log. If the wait
-      // TIMES OUT while ANOTHER process still holds an active lock, we DROP the
-      // append: proceeding would re-introduce the lost-append race (the rebuild
-      // can rename over our append between its final load and rename). The
-      // catalog is rebuildable best-effort metadata, so skipping one touch is
-      // acceptable; it NEVER blocks forever or crashes the primary memory op.
-      const safeToAppend = await this.waitForRebuildLockClear();
-      if (!safeToAppend) return false;
+    // Cross-process serialization (round 7, codex P2 — NEZkA: HELD MUTEX). A CLI
+    // `rebuild --apply` holds the rebuild lock across its final `loadCompacted()`
+    // → atomic `rename`. Previously a touch only POLLED (`waitForRebuildLockClear`)
+    // for the lock before reading/appending WITHOUT holding it — a check-then-act
+    // gap: a touch could see no lock, a rebuild could then acquire the lock + run
+    // its final `loadCompacted()`, and the touch's later append would be clobbered
+    // by the rebuild's `rename()`. We now make the touch HOLD the SAME advisory
+    // lock for the WHOLE read → merge → append window. While the touch holds the
+    // lock, a rebuild in another process blocks on it (and vice-versa), so no
+    // append can land between a rebuild's final load and its rename. `queueCritical`
+    // serializes this within ONE process (so the OS lock is never self-contended in
+    // process); the file lock adds the missing CROSS-process exclusion. If the touch
+    // cannot ACQUIRE the lock within the bounded wait (another process's rebuild is
+    // mid-flight), it DROPS the append: the catalog is rebuildable best-effort
+    // metadata, so skipping one touch is acceptable; it NEVER blocks forever, NEVER
+    // appends without the lock, and NEVER crashes the primary memory op.
+    return this.queueCritical(async () =>
+      this.withHeldCatalogLock(async (acquired) => {
+        // Could not hold the lock (a cross-process rebuild is in its load→rename
+        // window). DROP rather than append into that window (the lost-append race
+        // this lock exists to prevent). Returning false also lets the router's
+        // resolve-hook dedup retry a dropped registration later.
+        if (!acquired) return false;
 
-      const records = await this.loadCompacted();
-      const existing = records.get(ns);
+        // Test-only seam: widen the held-lock window so a concurrency test can
+        // attempt a cross-process rebuild here and assert it is BLOCKED by this
+        // held lock (no-op in production).
+        if (this.onTouchCriticalSectionForTest) {
+          await this.onTouchCriticalSectionForTest();
+        }
 
-      // Containment-check any explicit storageDir before persisting it (round 4
-      // + round 5, codex P2). Never trust a caller-provided path verbatim;
-      // reject lexical escapes AND symlinks that escape via realpath.
-      const storageDir = await this.resolveTouchStorageDir(
-        ns,
-        metadata?.storageDir,
-        existing?.storageDir,
-      );
-      // Provenance (discoveredBy) and createdAt are CREATION-ONLY fields. Once a
-      // record exists they are preserved, so a routine routing/recall touch (or
-      // the router's `config` register hook firing on a cache hit) can never
-      // clobber the original discovery source — e.g. a `write`-discovered record
-      // is not reset to `config` by a later resolve. Touch fields (lastReadAt /
-      // lastWriteAt / lastMaintenanceAt) still update on every touch below.
-      const record: NamespaceRecord = existing
-        ? { ...existing }
-        : {
-            namespace: ns,
-            identityToken: namespaceIdentityToken(ns),
-            kind: metadata?.kind ?? inferKind(ns, this.config),
-            createdAt: nowIso,
-            storageDir,
-            discoveredBy:
-              metadata?.discoveredBy ??
-              (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
-          };
+        const records = await this.loadCompacted();
+        const existing = records.get(ns);
 
-      // Update mutable fields. storageDir, kind, and the principal/project hints
-      // may legitimately change over a namespace's lifetime, so they upsert.
-      record.storageDir = storageDir;
-      if (metadata?.kind) record.kind = metadata.kind;
-      if (metadata?.principal !== undefined) record.principal = metadata.principal;
-      if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
-      if (metadata?.branch !== undefined) record.branch = metadata.branch;
-      if (metadata?.parentNamespace !== undefined) record.parentNamespace = metadata.parentNamespace;
-      // PROVENANCE (creation-only, with one upgrade — round 6, codex P2 NBPmT):
-      // `discoveredBy` is otherwise preserved for existing records (a routine
-      // read/register/resolve never relabels it). The single exception is a real
-      // WRITE upgrading a record that was only PRE-REGISTERED by the router's
-      // `onResolve` hook (`discoveredBy: "config"`) before any data was written.
-      // Without this upgrade, `listNamespaces({ discoveredBy: "write" })` misses
-      // namespaces that were genuinely written, because `storageFor()` fires
-      // `registerResolved()` (config) before `recordCatalogWrite()` runs. We
-      // upgrade ONLY config→write — never downgrade write/read, never relabel a
-      // read-discovered record — so the authoritative "this namespace has been
-      // written" signal is recorded.
-      if (kind === "write" && existing && record.discoveredBy === "config") {
-        record.discoveredBy = "write";
-      }
+        // Containment-check any explicit storageDir before persisting it (round 4
+        // + round 5, codex P2). Never trust a caller-provided path verbatim;
+        // reject lexical escapes AND symlinks that escape via realpath.
+        const storageDir = await this.resolveTouchStorageDir(
+          ns,
+          metadata?.storageDir,
+          existing?.storageDir,
+        );
+        // Provenance (discoveredBy) and createdAt are CREATION-ONLY fields. Once a
+        // record exists they are preserved, so a routine routing/recall touch (or
+        // the router's `config` register hook firing on a cache hit) can never
+        // clobber the original discovery source — e.g. a `write`-discovered record
+        // is not reset to `config` by a later resolve. Touch fields (lastReadAt /
+        // lastWriteAt / lastMaintenanceAt) still update on every touch below.
+        const record: NamespaceRecord = existing
+          ? { ...existing }
+          : {
+              namespace: ns,
+              identityToken: namespaceIdentityToken(ns),
+              kind: metadata?.kind ?? inferKind(ns, this.config),
+              createdAt: nowIso,
+              storageDir,
+              discoveredBy:
+                metadata?.discoveredBy ??
+                (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
+            };
 
-      if (kind === "read") record.lastReadAt = nowIso;
-      if (kind === "write") record.lastWriteAt = nowIso;
-      if (kind === "maintenance" && jobName) {
-        record.lastMaintenanceAt = { ...(record.lastMaintenanceAt ?? {}), [jobName]: nowIso };
-      }
+        // Update mutable fields. storageDir, kind, and the principal/project hints
+        // may legitimately change over a namespace's lifetime, so they upsert.
+        record.storageDir = storageDir;
+        if (metadata?.kind) record.kind = metadata.kind;
+        if (metadata?.principal !== undefined) record.principal = metadata.principal;
+        if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
+        if (metadata?.branch !== undefined) record.branch = metadata.branch;
+        if (metadata?.parentNamespace !== undefined)
+          record.parentNamespace = metadata.parentNamespace;
+        // PROVENANCE (creation-only, with one upgrade — round 6, codex P2 NBPmT):
+        // `discoveredBy` is otherwise preserved for existing records (a routine
+        // read/register/resolve never relabels it). The single exception is a real
+        // WRITE upgrading a record that was only PRE-REGISTERED by the router's
+        // `onResolve` hook (`discoveredBy: "config"`) before any data was written.
+        // Without this upgrade, `listNamespaces({ discoveredBy: "write" })` misses
+        // namespaces that were genuinely written, because `storageFor()` fires
+        // `registerResolved()` (config) before `recordCatalogWrite()` runs. We
+        // upgrade ONLY config→write — never downgrade write/read, never relabel a
+        // read-discovered record — so the authoritative "this namespace has been
+        // written" signal is recorded.
+        if (kind === "write" && existing && record.discoveredBy === "config") {
+          record.discoveredBy = "write";
+        }
 
-      await this.appendUnchained(record);
-      return true;
-    });
+        if (kind === "read") record.lastReadAt = nowIso;
+        if (kind === "write") record.lastWriteAt = nowIso;
+        if (kind === "maintenance" && jobName) {
+          record.lastMaintenanceAt = { ...(record.lastMaintenanceAt ?? {}), [jobName]: nowIso };
+        }
+
+        await this.appendUnchained(record);
+        return true;
+      }),
+    );
   }
 
   // ── Rebuild from disk ────────────────────────────────────────────────────
@@ -872,12 +903,30 @@ export class NamespaceCatalog {
     if (dryRun) {
       return this.queueCritical(async () => this.rebuildInsideChain(dryRun, false));
     }
-    return this.withRebuildLock((acquired) =>
+    // A mutating rebuild HOLDS the same advisory lock that touches now hold (round
+    // 7, codex P2 — NEZkA). Because the touch path acquires this lock across its
+    // read→append window and the rebuild holds it across its final
+    // `loadCompacted()` → `rename()`, the two are mutually exclusive cross-process:
+    // no touch append can land between a rebuild's final load and its rename. The
+    // disk scan itself can stay lockless (it does not mutate); only the final
+    // read-merge-rename critical section requires the lock — `rebuildInsideChain`
+    // does that whole section while we hold it.
+    //
+    // LOCK ORDERING (round 7 — NEZkA): the file lock is acquired INSIDE
+    // `queueCritical`, identically to the touch path (`queueCritical` → file lock),
+    // NOT around it. A consistent acquire order is what prevents an in-process
+    // deadlock between a same-instance touch and rebuild: `queueCritical` fully
+    // serializes the two turns in this process, so when one turn holds the file
+    // lock the other is not even running — the OS lock is never self-contended
+    // in-process and a same-instance touch never stalls/drops behind its own
+    // rebuild. The file lock therefore adds ONLY the missing cross-process
+    // exclusion.
+    return this.queueCritical(async () =>
       // canMutate iff we actually hold the cross-process lock (round 6, codex P2
       // — NBPmY). If acquisition timed out, run compute-only: never perform the
       // load/rename window unlocked, or a second unlocked rename could clobber a
       // concurrent gateway touch and recreate the lost-append race.
-      this.queueCritical(async () => this.rebuildInsideChain(dryRun, acquired)),
+      this.withHeldCatalogLock((acquired) => this.rebuildInsideChain(dryRun, acquired)),
     );
   }
 
@@ -918,7 +967,16 @@ export class NamespaceCatalog {
     //    (the very helper the router uses) instead of reimplementing divergent
     //    "prefer tokenized dir if it has data" logic — while legacy data lives
     //    directly under memoryDir, this returns memoryDir, matching runtime.
-    const defaultStorageDir = await resolveDefaultNamespaceRoot(this.config);
+    const resolvedDefaultRoot = await resolveDefaultNamespaceRoot(this.config);
+    // CONTAINMENT (round 6, codex P2 — NEOFS): `resolveDefaultNamespaceRoot()` can
+    // return a `namespaces/<default-token>` symlink escaping memoryDir when the
+    // legacy default root is empty. The default record must never carry an
+    // escaping `storageDir`; fall back to the trusted `memoryDir` root when the
+    // resolved one fails containment. Computed ONCE so every later use (the
+    // configured-seeding step and the scan's default-dir re-apply) stays safe.
+    const defaultStorageDir = (await this.isContainedStorageDir(resolvedDefaultRoot))
+      ? resolvedDefaultRoot
+      : this.memoryDir;
     const legacyDefaultHasData = defaultStorageDir === this.memoryDir;
 
     for (const ns of configured) {
@@ -958,17 +1016,24 @@ export class NamespaceCatalog {
           storageDir = this.namespaceTokenDir(namespaceIdentityToken(ns));
         }
       }
-      // CONTAINMENT (round 6, codex P2 — NCzT4): verify the seeded path does not
-      // ESCAPE memoryDir before recording it. The scan below rejects
+      // CONTAINMENT (round 6, codex P2 — NCzT4/NEOFS): verify the seeded path does
+      // not ESCAPE memoryDir before recording it. The scan below rejects
       // escaping/symlinked roots, but this seeding runs FIRST, so without this
-      // check rebuild would persist an escaping `storageDir` for a configured
-      // namespace whose root is a symlink out of memoryDir. `isContainedStorageDir`
+      // check rebuild would persist an escaping `storageDir`. `isContainedStorageDir`
       // enforces the full lexical + symlink + realpath contract and allows a
       // not-yet-created path (a brand-new configured namespace seeds its canonical
-      // root).
-      if (ns !== this.config.defaultNamespace && !(await this.isContainedStorageDir(storageDir))) {
-        skipped.push({ token: namespaceIdentityToken(ns), reason: "escape", detail: storageDir });
-        continue;
+      // root). The DEFAULT namespace is also checked (NEOFS): if
+      // `resolveDefaultNamespaceRoot()` returns a `namespaces/<default-token>`
+      // symlink escaping memoryDir, we must NOT persist it. The default cannot be
+      // "skipped" (it must always exist), so it falls back to the trusted
+      // `memoryDir` root; a non-default namespace is skipped (escape).
+      if (!(await this.isContainedStorageDir(storageDir))) {
+        if (ns === this.config.defaultNamespace) {
+          storageDir = this.memoryDir;
+        } else {
+          skipped.push({ token: namespaceIdentityToken(ns), reason: "escape", detail: storageDir });
+          continue;
+        }
       }
       rebuilt.set(
         ns,
@@ -1139,6 +1204,12 @@ export class NamespaceCatalog {
     // timed out) returns the computed records WITHOUT renaming over the log, so
     // it can never clobber a concurrent lock holder's window.
     if (canMutate) {
+      // Test-only seam: the load→rename window where the old check-then-append
+      // touch could be clobbered. A concurrency test attempts a cross-instance
+      // touch here and asserts the held lock blocks it (no-op in production).
+      if (this.onRebuildBeforeRenameForTest) {
+        await this.onRebuildBeforeRenameForTest();
+      }
       await this.rewriteUnchained(records);
     }
 
@@ -1149,31 +1220,43 @@ export class NamespaceCatalog {
     return { dryRun, records, skipped, applied: canMutate };
   }
 
-  // ── Cross-process rebuild lock ───────────────────────────────────────────
+  // ── Cross-process catalog write lock (held mutex) ────────────────────────
 
   /**
-   * Run `fn` while holding a cross-process advisory lock (round 5, codex P2).
+   * Run `fn` while HOLDING the shared cross-process advisory lock (round 5, codex
+   * P2; generalized round 7 — NEZkA). This is the SINGLE mutex shared by BOTH the
+   * touch read→merge→append window AND the rebuild final load→merge→rename window,
+   * so a touch and a rebuild in different processes are mutually exclusive over
+   * their respective critical sections — closing the check-then-append gap where a
+   * polled-only touch could append into a rebuild's load→rename window.
+   *
    * Acquisition is atomic via `open(..., "wx")`. A lock older than
    * `REBUILD_LOCK_STALE_MS` is treated as a crashed holder and broken. After
    * `REBUILD_LOCK_MAX_WAIT_MS` of contention we proceed best-effort WITHOUT the
-   * lock rather than block a rebuild forever (the in-chain re-merge still
-   * recovers same-host appends). The lock is always released in `finally`.
+   * lock rather than block forever. The lock is always released in `finally`.
+   *
+   * IN-PROCESS SAFETY: every caller invokes this from inside (or wrapping) the
+   * per-process `queueCritical` chain, which serializes all catalog mutations in
+   * THIS process. So within one process only one logical holder attempts OS-lock
+   * acquisition at a time — the file lock is never self-contended in-process, and
+   * the lock is acquired and released within a single in-process turn. The file
+   * lock adds only the missing CROSS-process exclusion.
    *
    * HEARTBEAT (round 5, cursor/codex Medium/P2): while WE hold the lock a timer
    * refreshes its mtime every `REBUILD_LOCK_HEARTBEAT_MS`, so a legitimately long
-   * scan (> `REBUILD_LOCK_STALE_MS`) is not treated as a crashed holder and
-   * unlinked by another process/touch — which would let overlapping rewrites lose
+   * holder (> `REBUILD_LOCK_STALE_MS`) is not treated as a crashed holder and
+   * unlinked by another process — which would let overlapping windows lose
    * appends. Heartbeat failures are swallowed; the timer is always cleared in
    * `finally`.
    *
    * ACQUISITION RESULT (round 6, codex P2 — NBPmY): `fn` receives whether WE
-   * actually hold the lock. When acquisition TIMED OUT (another `rebuild --apply`
-   * holds it), a MUTATING rebuild must NOT perform its load/rename window
-   * unlocked — that second unlocked rename can clobber gateway touches that the
-   * first lock holder's window let through, recreating the lost-append race. The
-   * caller uses `acquired` to suppress the rewrite (compute-only) when unlocked.
+   * actually hold the lock. When acquisition TIMED OUT (another holder is active),
+   * a MUTATING rebuild must NOT perform its load/rename window unlocked, and a
+   * touch must NOT append unlocked — both would recreate the lost-append race. The
+   * caller uses `acquired` to run compute-only (rebuild) or DROP the append
+   * (touch) when unlocked.
    */
-  private async withRebuildLock<T>(fn: (acquired: boolean) => Promise<T>): Promise<T> {
+  private async withHeldCatalogLock<T>(fn: (acquired: boolean) => Promise<T>): Promise<T> {
     const acquired = await this.acquireRebuildLock();
     let heartbeat: ReturnType<typeof setInterval> | undefined;
     if (acquired) {
@@ -1249,55 +1332,6 @@ export class NamespaceCatalog {
       }
     } catch {
       // Lock vanished (released by holder) or stat failed — nothing to do.
-    }
-  }
-
-  /**
-   * Wait (bounded, best-effort) for a held rebuild lock to clear before a touch
-   * appends (round 4 + round 6, codex P2). This makes catalog WRITERS respect the
-   * rebuild lock — without it the lock only serialized rebuilds against each other
-   * while a gateway `markWrite` could append into the rebuild's snapshot→rename
-   * window and be lost. We poll up to `REBUILD_LOCK_MAX_WAIT_MS`, breaking a stale
-   * lock (crashed rebuild) so a touch is never blocked indefinitely. ALL failures
-   * are swallowed: a touch must degrade gracefully and never crash the primary op.
-   *
-   * RETURNS `true` when it is SAFE for the caller to read/append (no lock, the
-   * lock was stale and broken, or the lock is held by our own process), and
-   * `false` when the wait TIMED OUT while ANOTHER process still holds an active
-   * (non-stale) lock. On `false` the caller MUST NOT append: a different process's
-   * `rebuild --apply` can still be mid-flight between its final `loadCompacted()`
-   * and its atomic `rename()`, so an append now would be clobbered by that rename
-   * — the lost-append race this lock exists to prevent (round 6, codex P2). The
-   * catalog is rebuildable best-effort metadata, so dropping the touch is the
-   * correct trade-off vs. resurrecting/overwriting under the rebuild's rename.
-   *
-   * IMPORTANT: a lock held by OUR OWN process returns `true` (safe). An in-process
-   * rebuild already serializes against touches via `queueCritical`; waiting on our
-   * own lock here would deadlock (the rebuild holds the file lock then queues
-   * behind the very touch that is now waiting for it). Only a DIFFERENT process's
-   * lock (e.g. a separate CLI rebuild vs. the gateway) forces the wait/drop.
-   */
-  private async waitForRebuildLockClear(): Promise<boolean> {
-    const deadline = Date.now() + REBUILD_LOCK_MAX_WAIT_MS;
-    for (;;) {
-      let info;
-      try {
-        info = await stat(this.rebuildLockPath);
-      } catch {
-        // No lock file (or stat failed) — nothing to wait on; safe to append.
-        return true;
-      }
-      // A stale lock (crashed holder) must not block touches — break it.
-      if (Date.now() - info.mtimeMs > REBUILD_LOCK_STALE_MS) {
-        await unlink(this.rebuildLockPath).catch(() => undefined);
-        return true;
-      }
-      // Skip a lock held by our own process to avoid an in-process deadlock.
-      if (await this.rebuildLockHeldBySelf()) return true;
-      // Timed out while ANOTHER process's lock is still active: the caller must
-      // DROP the append rather than race the in-progress rebuild's rename.
-      if (Date.now() >= deadline) return false;
-      await new Promise((r) => setTimeout(r, REBUILD_LOCK_POLL_MS));
     }
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -634,6 +634,13 @@ export class NamespaceCatalog {
     } catch {
       memoryReal = path.resolve(this.memoryDir);
     }
+    // Reject a candidate beneath any SYMLINKED ancestor (codex NVuq5): even when
+    // the symlink currently resolves back inside memoryDir, the disk scanner
+    // rejects such a root, and a later retarget of the link would let
+    // maintenance/QMD follow the persisted path outside memoryDir. Mirror the
+    // scanner so touch/config seeding cannot persist a root under a symlinked
+    // namespace ancestor (the leaf itself is symlink-checked below).
+    if (await this.hasSymlinkedAncestor(candidate)) return false;
     try {
       const stat = await lstat(candidate);
       if (stat.isSymbolicLink()) return false;
@@ -660,6 +667,29 @@ export class NamespaceCatalog {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Reject a candidate whose path crosses a SYMLINKED ancestor strictly between
+   * memoryDir and the leaf (codex NVuq5). `realpath`-based containment accepts a
+   * symlinked `<memoryDir>/namespaces` that currently resolves back inside
+   * memoryDir, but the disk scanner rejects such a root and a later retarget would
+   * escape the memory tree — so refuse it here too. The leaf itself is
+   * symlink-checked by the caller; this walks only the intermediate ancestors.
+   */
+  private async hasSymlinkedAncestor(candidate: string): Promise<boolean> {
+    const stopAt = path.resolve(this.memoryDir);
+    let dir = path.dirname(path.resolve(candidate));
+    const root = path.parse(dir).root;
+    while (dir !== stopAt && dir !== root && dir !== path.dirname(dir)) {
+      try {
+        if ((await lstat(dir)).isSymbolicLink()) return true;
+      } catch {
+        // Ancestor does not exist yet — it cannot be a symlink; keep walking up.
+      }
+      dir = path.dirname(dir);
+    }
+    return false;
   }
 
   /**

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -497,14 +497,62 @@ export class NamespaceCatalog {
     return { ...record, storageDir: safe };
   }
 
-  async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
-    if (!this.enabled) return [];
+  private storageRootOwnershipRank(record: NamespaceRecord, resolvedStorageDir: string): number {
+    if (resolvedStorageDir === path.resolve(this.memoryDir)) {
+      return record.namespace === this.defaultNamespaceIdentity ? 0 : 3;
+    }
+
+    const leaf = path.basename(resolvedStorageDir);
+    if (record.namespace === leaf) return 0;
+    if (namespaceIdentityToken(record.namespace) === leaf) return 1;
+    return 2;
+  }
+
+  private preferStorageRootOwner(
+    current: NamespaceRecord,
+    candidate: NamespaceRecord,
+    resolvedStorageDir: string,
+  ): NamespaceRecord {
+    const currentRank = this.storageRootOwnershipRank(current, resolvedStorageDir);
+    const candidateRank = this.storageRootOwnershipRank(candidate, resolvedStorageDir);
+    if (candidateRank < currentRank) return candidate;
+    if (candidateRank > currentRank) return current;
+
+    const byName = candidate.namespace.localeCompare(current.namespace);
+    if (byName < 0) return candidate;
+    if (byName > 0) return current;
+    return candidate.identityToken.localeCompare(current.identityToken) < 0 ? candidate : current;
+  }
+
+  private dropDuplicateStorageRootAliases(records: NamespaceRecord[]): NamespaceRecord[] {
+    const byStorageDir = new Map<string, NamespaceRecord>();
+    for (const record of records) {
+      const resolvedStorageDir = path.resolve(record.storageDir);
+      const current = byStorageDir.get(resolvedStorageDir);
+      byStorageDir.set(
+        resolvedStorageDir,
+        current ? this.preferStorageRootOwner(current, record, resolvedStorageDir) : record,
+      );
+    }
+    return [...byStorageDir.values()];
+  }
+
+  private async loadSanitizedRecords(): Promise<NamespaceRecord[]> {
     const records = await this.loadCompacted();
     const sanitized = await Promise.all(
       [...records.values()].map((r) => this.sanitizeRecordForRead(r)),
     );
     // Drop unsafe-namespace rows (sanitizer returned null) at the read boundary.
-    let out = sanitized.filter((r): r is NamespaceRecord => r !== null);
+    // Then collapse duplicate root aliases so maintenance/QMD see exactly one
+    // namespace owner for a physical storage root, matching rebuild ownership.
+    return this.dropDuplicateStorageRootAliases(
+      sanitized.filter((r): r is NamespaceRecord => r !== null),
+    );
+  }
+
+  async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
+    if (!this.enabled) return [];
+    let out = await this.loadSanitizedRecords();
     if (filter?.kind) out = out.filter((r) => r.kind === filter.kind);
     if (filter?.discoveredBy) out = out.filter((r) => r.discoveredBy === filter.discoveredBy);
     if (filter?.writtenSince) {
@@ -527,9 +575,7 @@ export class NamespaceCatalog {
   async getNamespaceRecord(namespace: string): Promise<NamespaceRecord | null> {
     if (!this.enabled) return null;
     const ns = normalizeNamespaceIdentity(namespace);
-    const records = await this.loadCompacted();
-    const record = records.get(ns);
-    return record ? await this.sanitizeRecordForRead(record) : null;
+    return (await this.loadSanitizedRecords()).find((record) => record.namespace === ns) ?? null;
   }
 
   // ── Touch API (cheap, failure-tolerant) ─────────────────────────────────

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -377,6 +377,44 @@ export class NamespaceCatalog {
     return path.join(this.memoryDir, "namespaces", token);
   }
 
+  /**
+   * Whether a candidate storage dir satisfies the catalog containment contract:
+   * it is either the legacy default root (`memoryDir`) or lives under
+   * `<memoryDir>/namespaces/`. The router legitimately resolves a namespace to
+   * EITHER the tokenized dir or a legacy raw-name dir under `namespaces/`, so we
+   * accept any contained child rather than a single exact token path.
+   */
+  private isContainedStorageDir(candidate: string): boolean {
+    const resolved = path.resolve(candidate);
+    if (resolved === path.resolve(this.memoryDir)) return true;
+    const nsBase = path.resolve(path.join(this.memoryDir, "namespaces"));
+    const rel = path.relative(nsBase, resolved);
+    // Must be a strict descendant of namespaces/ (non-empty, no parent escape).
+    return rel.length > 0 && !rel.startsWith("..") && !path.isAbsolute(rel);
+  }
+
+  /**
+   * Resolve the storage dir to persist for a touch, validating any caller-
+   * provided `metadata.storageDir` against the catalog containment contract
+   * (round 4, codex P2). `markWrite`/`registerResolved` accept an explicit
+   * storageDir, but persisting it verbatim would let a bad hook or external
+   * consumer write an arbitrary path — including one outside `memoryDir` — into
+   * the catalog, handing maintenance/QMD an unsafe root. We accept an explicit
+   * (or previously-stored) dir ONLY when it stays contained under memoryDir;
+   * otherwise we drop it and fall back to the trusted resolved dir.
+   */
+  private resolveTouchStorageDir(
+    namespace: string,
+    explicit: string | undefined,
+    existingDir: string | undefined,
+  ): string {
+    if (explicit !== undefined && this.isContainedStorageDir(explicit)) return explicit;
+    // Don't let a record poisoned by a pre-fix out-of-containment write keep an
+    // unsafe dir alive across touches — only preserve a contained existing dir.
+    if (existingDir !== undefined && this.isContainedStorageDir(existingDir)) return existingDir;
+    return this.resolveStorageDir(namespace);
+  }
+
   private async touch(
     namespace: string,
     kind: "read" | "write" | "maintenance" | "register",
@@ -400,7 +438,9 @@ export class NamespaceCatalog {
       const records = await this.loadCompacted();
       const existing = records.get(ns);
 
-      const storageDir = metadata?.storageDir ?? existing?.storageDir ?? this.resolveStorageDir(ns);
+      // Containment-check any explicit storageDir before persisting it (round 4,
+      // codex P2). Never trust a caller-provided path verbatim.
+      const storageDir = this.resolveTouchStorageDir(ns, metadata?.storageDir, existing?.storageDir);
       // Provenance (discoveredBy) and createdAt are CREATION-ONLY fields. Once a
       // record exists they are preserved, so a routine routing/recall touch (or
       // the router's `config` register hook firing on a cache hit) can never

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -497,24 +497,45 @@ export class NamespaceCatalog {
     return { ...record, storageDir: safe };
   }
 
-  private storageRootOwnershipRank(record: NamespaceRecord, resolvedStorageDir: string): number {
+  private storageRootOwnershipRank(
+    record: NamespaceRecord,
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): number {
     if (resolvedStorageDir === path.resolve(this.memoryDir)) {
       return record.namespace === this.defaultNamespaceIdentity ? 0 : 3;
     }
 
     const leaf = path.basename(resolvedStorageDir);
-    if (record.namespace === leaf) return 0;
-    if (namespaceIdentityToken(record.namespace) === leaf) return 1;
-    return 2;
+    const tokenOwnsRoot = namespaceIdentityToken(record.namespace) === leaf;
+    if (tokenOwnsRoot && configured.has(record.namespace)) {
+      return 0;
+    }
+    if (record.namespace === leaf) return 1;
+    if (tokenOwnsRoot) return 2;
+    return 3;
+  }
+
+  private configuredNamespaceIdentities(): Set<string> {
+    return new Set(
+      [
+        this.config.defaultNamespace,
+        this.config.sharedNamespace,
+        ...this.config.namespacePolicies.map((p) => p.name),
+      ]
+        .map((n) => normalizeNamespaceIdentity(n))
+        .filter((n) => n.length > 0),
+    );
   }
 
   private preferStorageRootOwner(
     current: NamespaceRecord,
     candidate: NamespaceRecord,
     resolvedStorageDir: string,
+    configured: Set<string>,
   ): NamespaceRecord {
-    const currentRank = this.storageRootOwnershipRank(current, resolvedStorageDir);
-    const candidateRank = this.storageRootOwnershipRank(candidate, resolvedStorageDir);
+    const currentRank = this.storageRootOwnershipRank(current, resolvedStorageDir, configured);
+    const candidateRank = this.storageRootOwnershipRank(candidate, resolvedStorageDir, configured);
     if (candidateRank < currentRank) return candidate;
     if (candidateRank > currentRank) return current;
 
@@ -526,12 +547,13 @@ export class NamespaceCatalog {
 
   private dropDuplicateStorageRootAliases(records: NamespaceRecord[]): NamespaceRecord[] {
     const byStorageDir = new Map<string, NamespaceRecord>();
+    const configured = this.configuredNamespaceIdentities();
     for (const record of records) {
       const resolvedStorageDir = path.resolve(record.storageDir);
       const current = byStorageDir.get(resolvedStorageDir);
       byStorageDir.set(
         resolvedStorageDir,
-        current ? this.preferStorageRootOwner(current, record, resolvedStorageDir) : record,
+        current ? this.preferStorageRootOwner(current, record, resolvedStorageDir, configured) : record,
       );
     }
     return [...byStorageDir.values()];

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -107,6 +107,12 @@ const STATE_DIR = "state";
 
 // Children that indicate a directory holds Remnic memory data (used for legacy
 // default-root detection and to skip empty/non-data roots during rebuild).
+//
+// `state` is included to MATCH the router's storage-presence check
+// (`NamespaceStorageRouter` counts the `state` runtime child via
+// `includeRuntimeState: true`). Without it (round 3, cursor Medium) a namespace
+// the router actively resolves because it has only a `state/` dir would be
+// treated as absent by rebuild and vanish from the catalog after `--apply`.
 const MEMORY_DATA_CHILDREN = [
   ...ALL_CATEGORY_DIRS,
   "entities",
@@ -115,6 +121,7 @@ const MEMORY_DATA_CHILDREN = [
   "config",
   "summaries",
   "profile.md",
+  "state",
 ] as const;
 
 function isCatalogEnabled(config: PluginConfig): boolean {
@@ -611,12 +618,23 @@ export class NamespaceCatalog {
 
   /**
    * Merge a prior record's preserved metadata (timestamps, principal hints)
-   * onto a freshly-discovered record. Disk-derived fields (storageDir, kind,
-   * discoveredBy) take precedence from the new record.
+   * onto a freshly-discovered record. Disk-derived fields (storageDir, kind)
+   * take precedence from the new record.
+   *
+   * PROVENANCE (round 3, cursor Low): `discoveredBy` and `createdAt` are
+   * CREATION-ONLY — identical to the touch path's invariant. A rebuild must NOT
+   * reset a namespace first seen via a `write`/`read` touch back to `config`
+   * just because it is also listed in policies. So when a prior record exists we
+   * carry its `discoveredBy` forward; only brand-new records keep the fresh
+   * (config/scan) provenance.
    */
   private mergeForRebuild(prior: NamespaceRecord | undefined, fresh: NamespaceRecord): NamespaceRecord {
     if (!prior) return fresh;
-    const merged: NamespaceRecord = { ...fresh, createdAt: prior.createdAt ?? fresh.createdAt };
+    const merged: NamespaceRecord = {
+      ...fresh,
+      createdAt: prior.createdAt ?? fresh.createdAt,
+      discoveredBy: prior.discoveredBy ?? fresh.discoveredBy,
+    };
     if (prior.lastReadAt) merged.lastReadAt = prior.lastReadAt;
     if (prior.lastWriteAt) merged.lastWriteAt = prior.lastWriteAt;
     if (prior.lastMaintenanceAt) merged.lastMaintenanceAt = { ...prior.lastMaintenanceAt };

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -125,6 +125,25 @@ export interface NamespaceCatalogRebuildResult {
   applied: boolean;
 }
 
+const NAMESPACE_KINDS: readonly NamespaceKind[] = [
+  "default",
+  "self",
+  "shared",
+  "project",
+  "branch",
+  "team-project",
+  "explicit",
+  "legacy",
+];
+
+const NAMESPACE_DISCOVERY_SOURCES: readonly NamespaceDiscoverySource[] = [
+  "config",
+  "write",
+  "read",
+  "scan",
+  "migration",
+];
+
 const CATALOG_FILE = "namespaces.jsonl";
 const STATE_DIR = "state";
 const REBUILD_LOCK_FILE = "namespaces.rebuild.lock";
@@ -215,23 +234,49 @@ async function hasMemoryData(rootDir: string): Promise<boolean> {
   return false;
 }
 
+function isValidIsoTimestamp(value: string): boolean {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms);
+}
+
+function isNamespaceKind(value: unknown): value is NamespaceKind {
+  return typeof value === "string" && (NAMESPACE_KINDS as readonly string[]).includes(value);
+}
+
+function isNamespaceDiscoverySource(value: unknown): value is NamespaceDiscoverySource {
+  return typeof value === "string" && (NAMESPACE_DISCOVERY_SOURCES as readonly string[]).includes(value);
+}
+
 /**
  * Validate a JSONL line parsed value as a usable NamespaceRecord.
  * Rejects null / non-object / missing-field records (CLAUDE.md rule #18).
+ * Persisted enum and timestamp fields are also validated here so a syntactically
+ * valid but tampered/pre-fix line cannot surface impossible record states.
  */
 function coerceRecord(value: unknown): NamespaceRecord | null {
   if (typeof value !== "object" || value === null) return null;
   const v = value as Record<string, unknown>;
-  if (typeof v.namespace !== "string" || v.namespace.length === 0) return null;
+  if (typeof v.namespace !== "string") return null;
+  const namespace = normalizeNamespaceIdentity(v.namespace);
+  if (namespace.length === 0) return null;
   if (typeof v.identityToken !== "string" || v.identityToken.length === 0) return null;
+  const expectedIdentityToken = namespaceIdentityToken(namespace);
+  if (v.identityToken !== expectedIdentityToken) return null;
   if (typeof v.storageDir !== "string" || v.storageDir.length === 0) return null;
   if (typeof v.createdAt !== "string" || v.createdAt.length === 0) return null;
-  const kind = typeof v.kind === "string" ? (v.kind as NamespaceKind) : "explicit";
+  if (!isValidIsoTimestamp(v.createdAt)) return null;
+  const kind = v.kind === undefined ? "explicit" : isNamespaceKind(v.kind) ? v.kind : null;
+  if (!kind) return null;
   const discoveredBy =
-    typeof v.discoveredBy === "string" ? (v.discoveredBy as NamespaceDiscoverySource) : "scan";
+    v.discoveredBy === undefined
+      ? "scan"
+      : isNamespaceDiscoverySource(v.discoveredBy)
+        ? v.discoveredBy
+        : null;
+  if (!discoveredBy) return null;
   const record: NamespaceRecord = {
-    namespace: v.namespace,
-    identityToken: v.identityToken,
+    namespace,
+    identityToken: expectedIdentityToken,
     kind,
     createdAt: v.createdAt,
     storageDir: v.storageDir,
@@ -241,12 +286,16 @@ function coerceRecord(value: unknown): NamespaceRecord | null {
   if (typeof v.projectId === "string") record.projectId = v.projectId;
   if (typeof v.branch === "string") record.branch = v.branch;
   if (typeof v.parentNamespace === "string") record.parentNamespace = v.parentNamespace;
-  if (typeof v.lastReadAt === "string") record.lastReadAt = v.lastReadAt;
-  if (typeof v.lastWriteAt === "string") record.lastWriteAt = v.lastWriteAt;
+  if (typeof v.lastReadAt === "string" && isValidIsoTimestamp(v.lastReadAt)) {
+    record.lastReadAt = v.lastReadAt;
+  }
+  if (typeof v.lastWriteAt === "string" && isValidIsoTimestamp(v.lastWriteAt)) {
+    record.lastWriteAt = v.lastWriteAt;
+  }
   if (v.lastMaintenanceAt && typeof v.lastMaintenanceAt === "object") {
     const out: Record<string, string> = {};
     for (const [k, val] of Object.entries(v.lastMaintenanceAt as Record<string, unknown>)) {
-      if (typeof val === "string") out[k] = val;
+      if (typeof val === "string" && isValidIsoTimestamp(val)) out[k] = val;
     }
     if (Object.keys(out).length > 0) record.lastMaintenanceAt = out;
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1,6 +1,18 @@
 import path from "node:path";
 import type { Dirent } from "node:fs";
-import { appendFile, lstat, mkdir, readdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import type { PluginConfig } from "../types.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
 import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
@@ -104,6 +116,13 @@ export interface NamespaceCatalogRebuildResult {
 
 const CATALOG_FILE = "namespaces.jsonl";
 const STATE_DIR = "state";
+const REBUILD_LOCK_FILE = "namespaces.rebuild.lock";
+// A held lock older than this is treated as stale (a crashed rebuild) and broken.
+const REBUILD_LOCK_STALE_MS = 30_000;
+// Bounded acquisition: poll briefly, then proceed best-effort rather than block
+// a CLI rebuild forever behind a busy gateway.
+const REBUILD_LOCK_MAX_WAIT_MS = 5_000;
+const REBUILD_LOCK_POLL_MS = 50;
 
 // Children that indicate a directory holds Remnic memory data (used for legacy
 // default-root detection and to skip empty/non-data roots during rebuild).
@@ -185,6 +204,42 @@ function coerceRecord(value: unknown): NamespaceRecord | null {
   return record;
 }
 
+/** Later of two optional ISO timestamps (undefined-safe). */
+function laterIso(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  const am = Date.parse(a);
+  const bm = Date.parse(b);
+  if (!Number.isFinite(am)) return b;
+  if (!Number.isFinite(bm)) return a;
+  return bm > am ? b : a;
+}
+
+/**
+ * Fold the touch fields (lastReadAt / lastWriteAt / lastMaintenanceAt) from a
+ * freshly re-read on-disk record into the rebuilt record, taking the LATER
+ * timestamp per field (round 5 cross-process re-merge). Disk-derived fields
+ * (storageDir, kind, discoveredBy, createdAt, principal hints) are owned by the
+ * rebuilt record and left untouched — we only recover touch recency that a
+ * concurrent (possibly cross-process) writer recorded after our initial load.
+ */
+function mergeNewerTouchFields(base: NamespaceRecord, fresh: NamespaceRecord): NamespaceRecord {
+  const merged: NamespaceRecord = { ...base };
+  const lr = laterIso(base.lastReadAt, fresh.lastReadAt);
+  if (lr) merged.lastReadAt = lr;
+  const lw = laterIso(base.lastWriteAt, fresh.lastWriteAt);
+  if (lw) merged.lastWriteAt = lw;
+  if (base.lastMaintenanceAt || fresh.lastMaintenanceAt) {
+    const jobs: Record<string, string> = { ...(base.lastMaintenanceAt ?? {}) };
+    for (const [job, ts] of Object.entries(fresh.lastMaintenanceAt ?? {})) {
+      const latest = laterIso(jobs[job], ts);
+      if (latest) jobs[job] = latest;
+    }
+    if (Object.keys(jobs).length > 0) merged.lastMaintenanceAt = jobs;
+  }
+  return merged;
+}
+
 /**
  * Serialize a record with sorted keys (CLAUDE.md rule #38) so byte output is
  * stable across runs — required for idempotent rebuilds.
@@ -236,6 +291,7 @@ export class NamespaceCatalog {
   private readonly memoryDir: string;
   private readonly stateDir: string;
   private readonly catalogPath: string;
+  private readonly rebuildLockPath: string;
   // Serialized write chain that recovers from rejection (CLAUDE.md rule #40)
   // so a single failed append cannot permanently poison subsequent writes.
   private writeChain: Promise<void> = Promise.resolve();
@@ -244,6 +300,7 @@ export class NamespaceCatalog {
     this.memoryDir = config.memoryDir;
     this.stateDir = path.join(this.memoryDir, STATE_DIR);
     this.catalogPath = path.join(this.stateDir, CATALOG_FILE);
+    this.rebuildLockPath = path.join(this.stateDir, REBUILD_LOCK_FILE);
   }
 
   /** Whether the catalog is active (namespaces enabled and catalog not opted out). */
@@ -253,10 +310,26 @@ export class NamespaceCatalog {
 
   // ── Public enumeration API ──────────────────────────────────────────────
 
+  /**
+   * Sanitize a record's `storageDir` at the enumeration boundary (round 5,
+   * cursor Medium + codex P2). Reads return whatever is in `namespaces.jsonl`
+   * after schema checks only, so a tampered or pre-fix out-of-root path — whether
+   * a lexical escape OR a lexically-contained SYMLINK escaping via realpath —
+   * could be surfaced to maintenance/QMD until a rewrite occurs. We apply the
+   * SAME full containment contract used on the write path (`isContainedStorageDir`:
+   * lexical + symlink/realpath) and, when a record fails it, substitute the
+   * trusted resolved-and-safe root for that namespace before returning it.
+   */
+  private async sanitizeRecordForRead(record: NamespaceRecord): Promise<NamespaceRecord> {
+    if (await this.isContainedStorageDir(record.storageDir)) return record;
+    const safe = await this.resolveSafeStorageDir(record.namespace);
+    return { ...record, storageDir: safe };
+  }
+
   async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
     if (!this.enabled) return [];
     const records = await this.loadCompacted();
-    let out = [...records.values()];
+    let out = await Promise.all([...records.values()].map((r) => this.sanitizeRecordForRead(r)));
     if (filter?.kind) out = out.filter((r) => r.kind === filter.kind);
     if (filter?.discoveredBy) out = out.filter((r) => r.discoveredBy === filter.discoveredBy);
     if (filter?.writtenSince) {
@@ -280,7 +353,8 @@ export class NamespaceCatalog {
     if (!this.enabled) return null;
     const ns = normalizeNamespaceIdentity(namespace);
     const records = await this.loadCompacted();
-    return records.get(ns) ?? null;
+    const record = records.get(ns);
+    return record ? await this.sanitizeRecordForRead(record) : null;
   }
 
   // ── Touch API (cheap, failure-tolerant) ─────────────────────────────────
@@ -378,13 +452,14 @@ export class NamespaceCatalog {
   }
 
   /**
-   * Whether a candidate storage dir satisfies the catalog containment contract:
-   * it is either the legacy default root (`memoryDir`) or lives under
+   * Whether a candidate storage dir is LEXICALLY contained: it is either the
+   * legacy default root (`memoryDir`) or a strict descendant of
    * `<memoryDir>/namespaces/`. The router legitimately resolves a namespace to
    * EITHER the tokenized dir or a legacy raw-name dir under `namespaces/`, so we
-   * accept any contained child rather than a single exact token path.
+   * accept any contained child rather than a single exact token path. This is a
+   * pure string check — symlink escape is checked separately via realpath.
    */
-  private isContainedStorageDir(candidate: string): boolean {
+  private isLexicallyContained(candidate: string): boolean {
     const resolved = path.resolve(candidate);
     if (resolved === path.resolve(this.memoryDir)) return true;
     const nsBase = path.resolve(path.join(this.memoryDir, "namespaces"));
@@ -394,25 +469,82 @@ export class NamespaceCatalog {
   }
 
   /**
+   * Whether a candidate storage dir satisfies the catalog containment contract,
+   * including SYMLINK-escape rejection (round 5, codex P2). A lexically-contained
+   * path that is actually a symlink to an outside directory would let maintenance
+   * or QMD follow it outside `memoryDir`. We mirror `rebuildFromDisk`'s posture:
+   * the path must be lexically contained AND, if it exists on disk, neither the
+   * path itself a symlink nor its realpath escaping the memory root. Non-existent
+   * paths pass the realpath stage (nothing to follow yet) but still must be
+   * lexically contained.
+   */
+  private async isContainedStorageDir(candidate: string): Promise<boolean> {
+    if (!this.isLexicallyContained(candidate)) return false;
+    // The default/legacy memoryDir root is trusted as-is.
+    if (path.resolve(candidate) === path.resolve(this.memoryDir)) return true;
+    try {
+      const stat = await lstat(candidate);
+      if (stat.isSymbolicLink()) return false;
+    } catch {
+      // Does not exist yet — nothing to follow; lexical containment suffices.
+      return true;
+    }
+    try {
+      const real = await realpath(candidate);
+      let memoryReal: string;
+      try {
+        memoryReal = await realpath(this.memoryDir);
+      } catch {
+        memoryReal = path.resolve(this.memoryDir);
+      }
+      return isPathInside(memoryReal, real);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Resolve the storage dir to persist for a touch, validating any caller-
    * provided `metadata.storageDir` against the catalog containment contract
-   * (round 4, codex P2). `markWrite`/`registerResolved` accept an explicit
-   * storageDir, but persisting it verbatim would let a bad hook or external
-   * consumer write an arbitrary path — including one outside `memoryDir` — into
-   * the catalog, handing maintenance/QMD an unsafe root. We accept an explicit
-   * (or previously-stored) dir ONLY when it stays contained under memoryDir;
-   * otherwise we drop it and fall back to the trusted resolved dir.
+   * (round 4 + round 5, codex P2). `markWrite`/`registerResolved` accept an
+   * explicit storageDir, but persisting it verbatim would let a bad hook or
+   * external consumer write an arbitrary path — including one outside `memoryDir`
+   * or a symlink that escapes it — into the catalog, handing maintenance/QMD an
+   * unsafe root. We accept an explicit (or previously-stored) dir ONLY when it
+   * stays contained under memoryDir (lexically AND via realpath); otherwise we
+   * drop it and fall back to the trusted resolved dir.
    */
-  private resolveTouchStorageDir(
+  private async resolveTouchStorageDir(
     namespace: string,
     explicit: string | undefined,
     existingDir: string | undefined,
-  ): string {
-    if (explicit !== undefined && this.isContainedStorageDir(explicit)) return explicit;
+  ): Promise<string> {
+    if (explicit !== undefined && (await this.isContainedStorageDir(explicit))) return explicit;
     // Don't let a record poisoned by a pre-fix out-of-containment write keep an
     // unsafe dir alive across touches — only preserve a contained existing dir.
-    if (existingDir !== undefined && this.isContainedStorageDir(existingDir)) return existingDir;
-    return this.resolveStorageDir(namespace);
+    if (existingDir !== undefined && (await this.isContainedStorageDir(existingDir))) return existingDir;
+    return this.resolveSafeStorageDir(namespace);
+  }
+
+  /**
+   * Resolve the canonical storage dir for a namespace, but NEVER return a path
+   * that itself escapes the memory root via a symlink (round 5, codex P2). The
+   * lexical `resolveStorageDir` can return `<memoryDir>/namespaces/<token>` even
+   * when THAT very path is a symlink to an outside directory — so a rejected
+   * explicit symlink-escape would silently fall back to the same escaping path.
+   * If the resolved dir fails the full (lexical + realpath) containment contract,
+   * fall back to the trusted legacy `memoryDir` root, which is always contained.
+   */
+  private async resolveSafeStorageDir(namespace: string): Promise<string> {
+    let resolved: string;
+    try {
+      resolved = this.resolveStorageDir(namespace);
+    } catch {
+      // An unsafe namespace token would throw; fall back to the default root.
+      return this.memoryDir;
+    }
+    if (await this.isContainedStorageDir(resolved)) return resolved;
+    return this.memoryDir;
   }
 
   private async touch(
@@ -438,9 +570,14 @@ export class NamespaceCatalog {
       const records = await this.loadCompacted();
       const existing = records.get(ns);
 
-      // Containment-check any explicit storageDir before persisting it (round 4,
-      // codex P2). Never trust a caller-provided path verbatim.
-      const storageDir = this.resolveTouchStorageDir(ns, metadata?.storageDir, existing?.storageDir);
+      // Containment-check any explicit storageDir before persisting it (round 4
+      // + round 5, codex P2). Never trust a caller-provided path verbatim;
+      // reject lexical escapes AND symlinks that escape via realpath.
+      const storageDir = await this.resolveTouchStorageDir(
+        ns,
+        metadata?.storageDir,
+        existing?.storageDir,
+      );
       // Provenance (discoveredBy) and createdAt are CREATION-ONLY fields. Once a
       // record exists they are preserved, so a routine routing/recall touch (or
       // the router's `config` register hook firing on a cache hit) can never
@@ -505,7 +642,20 @@ export class NamespaceCatalog {
     // `rewriteUnchained` helper (mirroring `appendUnchained`) rather than a
     // helper that re-enters `queueCritical` — re-entering the chain from inside
     // a held turn would await the very entry this section holds.
-    return this.queueCritical(async () => this.rebuildInsideChain(dryRun));
+    //
+    // CROSS-PROCESS (round 5, codex P2): `queueCritical` only serializes this
+    // process's instance. A CLI `rebuild --apply` and the live gateway are
+    // SEPARATE processes with independent write chains, so a gateway append can
+    // still land between the CLI's load and its atomic rename. For the mutating
+    // path we additionally take a cross-process file lock AND re-merge the latest
+    // on-disk touches under that lock immediately before the rewrite (see
+    // `rebuildInsideChain`). A dry-run never mutates, so it skips the lock.
+    if (dryRun) {
+      return this.queueCritical(async () => this.rebuildInsideChain(dryRun));
+    }
+    return this.withRebuildLock(() =>
+      this.queueCritical(async () => this.rebuildInsideChain(dryRun)),
+    );
   }
 
   /**
@@ -570,6 +720,14 @@ export class NamespaceCatalog {
       entries = [];
     }
 
+    // Dual-root alignment (round 5, cursor Medium): when both a legacy raw-name
+    // dir and a tokenized dir hold data for the SAME namespace, the router
+    // prefers the tokenized root. Track which scanned namespaces were already
+    // sourced from their tokenized dir so a later legacy-named `readdir` entry
+    // cannot overwrite the tokenized record (and vice-versa: a tokenized entry
+    // always wins over a previously-set legacy one).
+    const scannedFromTokenized = new Set<string>();
+
     for (const entry of entries) {
       const token = entry.name;
       const fullPath = path.join(namespacesDir, token);
@@ -621,6 +779,17 @@ export class NamespaceCatalog {
         continue;
       }
 
+      // Dual-root preference: mirror the router, which uses the tokenized root
+      // over a legacy raw-name root when the tokenized one has data. `entry.name`
+      // is the on-disk dir name; it is the tokenized dir iff it equals the
+      // namespace's identity token. If we already recorded this namespace from
+      // its tokenized dir, a later legacy-named entry must not clobber it.
+      const isTokenizedEntry = token === namespaceIdentityToken(decoded);
+      if (rebuilt.has(decoded) && scannedFromTokenized.has(decoded) && !isTokenizedEntry) {
+        continue;
+      }
+      if (isTokenizedEntry) scannedFromTokenized.add(decoded);
+
       const prior = existing.get(decoded);
       rebuilt.set(
         decoded,
@@ -643,6 +812,26 @@ export class NamespaceCatalog {
       if (def) def.kind = "default";
     }
 
+    if (!dryRun) {
+      // CROSS-PROCESS re-merge (round 5, codex P2): under the rebuild lock,
+      // re-read the on-disk log ONE more time and fold any touch fields that
+      // landed AFTER our initial `loadCompacted()` (e.g. a gateway markWrite in
+      // another process) into the rebuilt records — last-write-wins per touch
+      // field. This recovers cross-process appends that completed during the
+      // scan, which the in-process `queueCritical` alone cannot see.
+      const latest = await this.loadCompacted();
+      for (const [ns, fresh] of latest) {
+        const current = rebuilt.get(ns);
+        if (!current) {
+          // A namespace that appeared purely via a concurrent touch (no on-disk
+          // root scanned) must survive the rewrite rather than be dropped.
+          rebuilt.set(ns, fresh);
+          continue;
+        }
+        rebuilt.set(ns, mergeNewerTouchFields(current, fresh));
+      }
+    }
+
     const records = [...rebuilt.values()].sort((a, b) => {
       const byName = a.namespace.localeCompare(b.namespace);
       if (byName !== 0) return byName;
@@ -654,6 +843,71 @@ export class NamespaceCatalog {
     }
 
     return { dryRun, records, skipped };
+  }
+
+  // ── Cross-process rebuild lock ───────────────────────────────────────────
+
+  /**
+   * Run `fn` while holding a cross-process advisory lock (round 5, codex P2).
+   * Acquisition is atomic via `open(..., "wx")`. A lock older than
+   * `REBUILD_LOCK_STALE_MS` is treated as a crashed holder and broken. After
+   * `REBUILD_LOCK_MAX_WAIT_MS` of contention we proceed best-effort WITHOUT the
+   * lock rather than block a rebuild forever (the in-chain re-merge still
+   * recovers same-host appends). The lock is always released in `finally`.
+   */
+  private async withRebuildLock<T>(fn: () => Promise<T>): Promise<T> {
+    const acquired = await this.acquireRebuildLock();
+    try {
+      return await fn();
+    } finally {
+      if (acquired) {
+        try {
+          await unlink(this.rebuildLockPath);
+        } catch {
+          // Best-effort release; a stale lock will be broken on next rebuild.
+        }
+      }
+    }
+  }
+
+  /** Try to acquire the rebuild lock; returns true if WE created it. */
+  private async acquireRebuildLock(): Promise<boolean> {
+    const deadline = Date.now() + REBUILD_LOCK_MAX_WAIT_MS;
+    await mkdir(this.stateDir, { recursive: true });
+    for (;;) {
+      try {
+        const handle = await open(this.rebuildLockPath, "wx");
+        try {
+          await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`, "utf8");
+        } catch {
+          // Ignore write failures — the exclusive create already gave us the lock.
+        } finally {
+          await handle.close();
+        }
+        return true;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
+          // Unexpected FS error — proceed best-effort without the lock.
+          return false;
+        }
+        // Lock exists: break it if stale, otherwise wait briefly.
+        await this.breakStaleRebuildLock();
+        if (Date.now() >= deadline) return false;
+        await new Promise((r) => setTimeout(r, REBUILD_LOCK_POLL_MS));
+      }
+    }
+  }
+
+  /** Remove the lock file if its mtime is older than the stale threshold. */
+  private async breakStaleRebuildLock(): Promise<void> {
+    try {
+      const info = await stat(this.rebuildLockPath);
+      if (Date.now() - info.mtimeMs > REBUILD_LOCK_STALE_MS) {
+        await unlink(this.rebuildLockPath).catch(() => undefined);
+      }
+    } catch {
+      // Lock vanished (released by holder) or stat failed — nothing to do.
+    }
   }
 
   /**

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -616,15 +616,19 @@ export class NamespaceCatalog {
     // from rejection). Reading inside the chain guarantees each touch sees the
     // most recent appended state, including any concurrent read/write/register.
     await this.queueCritical(async () => {
-      // Cross-process serialization (round 4, codex P2): a CLI `rebuild --apply`
-      // holds the rebuild lock across its final `loadCompacted()` → atomic
-      // `rename`. An append that lands inside that window is clobbered by the
-      // rename. `queueCritical` only serializes THIS process, so before reading
-      // and appending we wait (bounded) for any holder's lock to clear, then
-      // read the freshly-rewritten log. Degrades gracefully — a stale lock is
-      // ignored and a timeout proceeds best-effort so a touch NEVER blocks
-      // forever or crashes the primary memory op.
-      await this.waitForRebuildLockClear();
+      // Cross-process serialization (round 4 + round 6, codex P2): a CLI
+      // `rebuild --apply` holds the rebuild lock across its final
+      // `loadCompacted()` → atomic `rename`. An append that lands inside that
+      // window is clobbered by the rename. `queueCritical` only serializes THIS
+      // process, so before reading and appending we wait (bounded) for any
+      // holder's lock to clear, then read the freshly-rewritten log. If the wait
+      // TIMES OUT while ANOTHER process still holds an active lock, we DROP the
+      // append: proceeding would re-introduce the lost-append race (the rebuild
+      // can rename over our append between its final load and rename). The
+      // catalog is rebuildable best-effort metadata, so skipping one touch is
+      // acceptable; it NEVER blocks forever or crashes the primary memory op.
+      const safeToAppend = await this.waitForRebuildLockClear();
+      if (!safeToAppend) return;
 
       const records = await this.loadCompacted();
       const existing = records.get(ns);
@@ -882,19 +886,22 @@ export class NamespaceCatalog {
       for (const [ns, fresh] of latest) {
         const current = rebuilt.get(ns);
         if (!current) {
-          // A namespace absent from the rebuilt set was NOT discovered on disk
-          // (its root is empty/deleted) and is NOT configured. Re-adding it
-          // unconditionally would make rebuild unable to ever PURGE deleted
-          // dynamic namespaces from the log (round 4, codex P2). Only resurrect
-          // it when a CONCURRENT touch changed it after our initial snapshot
-          // (i.e. it is new since scan start, or its bytes differ from the
-          // `existing` snapshot). A record unchanged since the snapshot is a
-          // stale leftover for a removed root and is intentionally dropped.
-          const prior = existing.get(ns);
-          const concurrentlyTouched = !prior || serializeRecord(prior) !== serializeRecord(fresh);
-          if (concurrentlyTouched) rebuilt.set(ns, fresh);
+          // AUTHORITATIVE PURGE (round 6, cursor Medium — NATqU): the disk scan
+          // is the single source of truth for which namespaces EXIST. A namespace
+          // absent from `rebuilt` was NOT discovered on disk (its root is
+          // empty/deleted) and is NOT configured, so the rebuild is purging it.
+          // We must NOT resurrect it from the log — not even when a CONCURRENT
+          // best-effort `markRead`/`markWrite` touched it after our snapshot. A
+          // touch on a dynamic namespace whose on-disk root was removed only
+          // bumps a timestamp; re-inserting that row (with its stale `storageDir`)
+          // would defeat the purge the rebuild is meant to perform. Losing a touch
+          // timestamp for a deleted root is acceptable (the catalog is rebuildable
+          // best-effort metadata); resurrecting a purged record is not. Drop it.
           continue;
         }
+        // SURVIVING namespace (still present in the authoritative disk scan):
+        // fold in any newer touch fields that landed cross-process after our
+        // initial snapshot so a concurrent gateway markWrite is not lost.
         rebuilt.set(ns, mergeNewerTouchFields(current, fresh));
       }
     }
@@ -997,37 +1004,49 @@ export class NamespaceCatalog {
 
   /**
    * Wait (bounded, best-effort) for a held rebuild lock to clear before a touch
-   * appends (round 4, codex P2). This makes catalog WRITERS respect the rebuild
-   * lock — without it the lock only serialized rebuilds against each other while
-   * a gateway `markWrite` could append into the rebuild's snapshot→rename window
-   * and be lost. We poll up to `REBUILD_LOCK_MAX_WAIT_MS`, breaking a stale lock
-   * (crashed rebuild) so a touch is never blocked indefinitely. ALL failures are
-   * swallowed: a touch must degrade gracefully and never crash the primary op.
+   * appends (round 4 + round 6, codex P2). This makes catalog WRITERS respect the
+   * rebuild lock — without it the lock only serialized rebuilds against each other
+   * while a gateway `markWrite` could append into the rebuild's snapshot→rename
+   * window and be lost. We poll up to `REBUILD_LOCK_MAX_WAIT_MS`, breaking a stale
+   * lock (crashed rebuild) so a touch is never blocked indefinitely. ALL failures
+   * are swallowed: a touch must degrade gracefully and never crash the primary op.
    *
-   * IMPORTANT: a lock held by OUR OWN process is skipped. An in-process rebuild
-   * already serializes against touches via `queueCritical`; waiting on our own
-   * lock here would deadlock (the rebuild holds the file lock then queues behind
-   * the very touch that is now waiting for it). Only a DIFFERENT process's lock
-   * (e.g. a separate CLI rebuild vs. the gateway) needs the wait.
+   * RETURNS `true` when it is SAFE for the caller to read/append (no lock, the
+   * lock was stale and broken, or the lock is held by our own process), and
+   * `false` when the wait TIMED OUT while ANOTHER process still holds an active
+   * (non-stale) lock. On `false` the caller MUST NOT append: a different process's
+   * `rebuild --apply` can still be mid-flight between its final `loadCompacted()`
+   * and its atomic `rename()`, so an append now would be clobbered by that rename
+   * — the lost-append race this lock exists to prevent (round 6, codex P2). The
+   * catalog is rebuildable best-effort metadata, so dropping the touch is the
+   * correct trade-off vs. resurrecting/overwriting under the rebuild's rename.
+   *
+   * IMPORTANT: a lock held by OUR OWN process returns `true` (safe). An in-process
+   * rebuild already serializes against touches via `queueCritical`; waiting on our
+   * own lock here would deadlock (the rebuild holds the file lock then queues
+   * behind the very touch that is now waiting for it). Only a DIFFERENT process's
+   * lock (e.g. a separate CLI rebuild vs. the gateway) forces the wait/drop.
    */
-  private async waitForRebuildLockClear(): Promise<void> {
+  private async waitForRebuildLockClear(): Promise<boolean> {
     const deadline = Date.now() + REBUILD_LOCK_MAX_WAIT_MS;
     for (;;) {
       let info;
       try {
         info = await stat(this.rebuildLockPath);
       } catch {
-        // No lock file (or stat failed) — nothing to wait on.
-        return;
+        // No lock file (or stat failed) — nothing to wait on; safe to append.
+        return true;
       }
       // A stale lock (crashed holder) must not block touches — break it.
       if (Date.now() - info.mtimeMs > REBUILD_LOCK_STALE_MS) {
         await unlink(this.rebuildLockPath).catch(() => undefined);
-        return;
+        return true;
       }
       // Skip a lock held by our own process to avoid an in-process deadlock.
-      if (await this.rebuildLockHeldBySelf()) return;
-      if (Date.now() >= deadline) return;
+      if (await this.rebuildLockHeldBySelf()) return true;
+      // Timed out while ANOTHER process's lock is still active: the caller must
+      // DROP the append rather than race the in-progress rebuild's rename.
+      if (Date.now() >= deadline) return false;
       await new Promise((r) => setTimeout(r, REBUILD_LOCK_POLL_MS));
     }
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -551,10 +551,13 @@ export class NamespaceCatalog {
     for (const record of records) {
       const resolvedStorageDir = path.resolve(record.storageDir);
       const current = byStorageDir.get(resolvedStorageDir);
-      byStorageDir.set(
-        resolvedStorageDir,
-        current ? this.preferStorageRootOwner(current, record, resolvedStorageDir, configured) : record,
-      );
+      if (!current) {
+        byStorageDir.set(resolvedStorageDir, record);
+        continue;
+      }
+      const owner = this.preferStorageRootOwner(current, record, resolvedStorageDir, configured);
+      const alias = owner === current ? record : current;
+      byStorageDir.set(resolvedStorageDir, mergeNewerTouchFields(owner, alias));
     }
     return [...byStorageDir.values()];
   }
@@ -566,7 +569,8 @@ export class NamespaceCatalog {
     );
     // Drop unsafe-namespace rows (sanitizer returned null) at the read boundary.
     // Then collapse duplicate root aliases so maintenance/QMD see exactly one
-    // namespace owner for a physical storage root, matching rebuild ownership.
+    // namespace owner for a physical storage root, matching rebuild ownership,
+    // while preserving touch recency from every alias row.
     return this.dropDuplicateStorageRootAliases(
       sanitized.filter((r): r is NamespaceRecord => r !== null),
     );
@@ -1701,16 +1705,22 @@ export class NamespaceCatalog {
             // this stale alias from the untrusted log — that leaves TWO catalog rows
             // pointing at one root and fans maintenance/QMD out over the wrong
             // namespace. Enforce at most one row per storageDir: the scan's owner
-            // wins, the alias is dropped (falls through to purge).
+            // wins, the alias is dropped (falls through to purge) after folding
+            // its touch fields into the owner so recency filters/maintenance do
+            // not miss a real write.
             const resolvedSafe = path.resolve(safeDir);
-            let ownedByOther = false;
+            let owningNamespace: string | null = null;
             for (const [otherNs, otherRec] of rebuilt) {
               if (otherNs !== ns && path.resolve(otherRec.storageDir) === resolvedSafe) {
-                ownedByOther = true;
+                owningNamespace = otherNs;
                 break;
               }
             }
-            if (ownedByOther) continue;
+            if (owningNamespace) {
+              const owner = rebuilt.get(owningNamespace);
+              if (owner) rebuilt.set(owningNamespace, mergeNewerTouchFields(owner, fresh));
+              continue;
+            }
             rebuilt.set(ns, {
               ...fresh,
               storageDir: safeDir,

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1358,7 +1358,24 @@ export class NamespaceCatalog {
       // unambiguous fix lives on the WRITE path, where the caller knows the true
       // namespace and records it verbatim (NCQI0); the scanner cannot recover a
       // name the encoding cannot distinguish, so we keep the canonical decode.
-      const decoded = configured.has(token) ? token : namespaceIdentityFromToken(token) ?? token;
+      //
+      // NRcCD (round 9, codex P2 — same class as namespaceFromStorageDir/NRCve):
+      // the canonical decode is WRONG when a namespace LITERALLY named like the
+      // token already OWNS this root. A dynamic namespace served from a legacy raw
+      // root `namespaces/ns-616c706861` (named verbatim `ns-616c706861`) records a
+      // catalog row from the write path; that row is in `existing` (the prior
+      // load) here. If we still decoded to `alpha`, this scan would emit an `alpha`
+      // row at `fullPath`, and the final live-row remerge in `finishRebuild` would
+      // re-add the literal `ns-616c706861` row (its root still has data) — leaving
+      // TWO catalog rows at the SAME `storageDir`, fanning QMD/maintenance out under
+      // the wrong namespace. So, mirroring `namespaceFromStorageDir`'s "config/catalog
+      // match before decode" rule, prefer the LITERAL dir name when it is already a
+      // KNOWN namespace — configured OR present as a live/cataloged row in `existing`
+      // — and DO NOT also emit the decoded alias for that same root. A genuine
+      // tokenized dir with no literal owner (no `existing` row keyed by the raw
+      // token) still decodes as before.
+      const literalIsKnown = configured.has(token) || existing.has(token);
+      const decoded = literalIsKnown ? token : namespaceIdentityFromToken(token) ?? token;
       if (decoded !== defaultNs && !isSafeRouteNamespace(decoded)) {
         skipped.push({ token, reason: "unsafe", detail: decoded });
         continue;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -556,6 +556,15 @@ export class NamespaceCatalog {
     try {
       const stat = await lstat(candidate);
       if (stat.isSymbolicLink()) return false;
+      // Reject an EXISTING non-directory root (NF21i, codex P2; CLAUDE.md rule
+      // #24). A regular file (or socket/fifo) at `<memoryDir>/namespaces/<token>`
+      // is lexically contained and its realpath stays inside memoryDir, so the
+      // realpath check below would ACCEPT it — but a storage root must be a
+      // directory. Recording a file as a namespace root yields a broken install
+      // that only fails later when maintenance/QMD/mkdir treat it as a dir. The
+      // disk scan already skips non-directory entries; mirror that here so every
+      // containment consumer (resolve/touch/fallback/live-recheck) agrees.
+      if (!stat.isDirectory()) return false;
     } catch {
       // The leaf does not exist yet. Lexical containment is NOT sufficient: an
       // EXISTING ancestor (e.g. `<memoryDir>/namespaces`) could be a symlink to
@@ -730,14 +739,22 @@ export class NamespaceCatalog {
    * Preference order:
    *  1. The namespace's OWN lexical tokenized dir (`namespaces/<token>`) — so a
    *     non-default namespace is NOT pointed at the DEFAULT namespace's `memoryDir`
-   *     tree (which would misdirect maintenance fanout). This is returned only
-   *     when the token dir itself stays contained (it is not a symlink escaping
-   *     memoryDir).
+   *     tree (which would misdirect maintenance fanout). Returned only when the
+   *     token dir itself stays CONTAINED (it is not a symlink, and its realpath
+   *     does not escape memoryDir — e.g. via a symlinked `namespaces/` parent).
    *  2. `memoryDir` as a LAST resort — for the default namespace, an unsafe token
    *     that cannot build a contained path, OR the irreparable case where the
-   *     token dir IS a symlink escaping the root (so even its lexical path
-   *     resolves outside). Containment must win over tree-precision here: an
-   *     escaping path is strictly worse than the (contained) default root.
+   *     token dir's realpath escapes the root (so even its lexical path resolves
+   *     outside). NF21m note (codex P2): we deliberately do NOT record the lexical
+   *     token dir in that irreparable case — its realpath escapes memoryDir, and
+   *     the NDo79 contract REQUIRES that an escaping path is never persisted (a
+   *     later mkdir/maintenance/QMD op would follow it outside the root). Since no
+   *     contained namespace-specific path exists, containment wins: `memoryDir` is
+   *     the only safe root left. A namespace whose token dir's realpath escapes is
+   *     an irreparable on-disk state; recording the contained default root is
+   *     strictly safer than persisting an escaping one. The common case where the
+   *     token dir IS contained is handled by branch 1, so a healthy non-default
+   *     namespace never reaches `memoryDir`.
    */
   private async safeFallbackStorageDir(namespace: string): Promise<string> {
     if (namespace === this.config.defaultNamespace) return this.memoryDir;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1537,7 +1537,8 @@ export class NamespaceCatalog {
       // Match `storageFor()`'s canonical namespace identity. A raw root whose
       // spelling trims to another namespace (for example `namespaces/shared `)
       // is not a routeable live root and must not be catalogued from disk.
-      const rawDecoded = literalOwnsRoot ? token : namespaceIdentityFromToken(token) ?? token;
+      const tokenDecoded = literalOwnsRoot ? null : namespaceIdentityFromToken(token);
+      const rawDecoded = tokenDecoded && tokenDecoded.length > 0 ? tokenDecoded : token;
       const decoded = normalizeNamespaceIdentity(rawDecoded);
       if (decoded.length === 0 || rawDecoded !== decoded) {
         skipped.push({ token, reason: "unsafe", detail: rawDecoded });

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -16,7 +16,7 @@ import {
 import type { PluginConfig } from "../types.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
 import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
-import { resolveDefaultNamespaceRoot } from "./storage.js";
+import { resolveDefaultNamespaceRoot, resolveNamespaceStorageRoot } from "./storage.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
 /**
@@ -527,21 +527,35 @@ export class NamespaceCatalog {
   }
 
   /**
-   * Resolve the canonical storage dir for a namespace, but NEVER return a path
-   * that itself escapes the memory root via a symlink (round 5, codex P2). The
-   * lexical `resolveStorageDir` can return `<memoryDir>/namespaces/<token>` even
-   * when THAT very path is a symlink to an outside directory — so a rejected
-   * explicit symlink-escape would silently fall back to the same escaping path.
-   * If the resolved dir fails the full (lexical + realpath) containment contract,
-   * fall back to the trusted legacy `memoryDir` root, which is always contained.
+   * Resolve the canonical storage dir for a namespace as the LIVE ROUTER would,
+   * but NEVER return a path that escapes the memory root.
+   *
+   * Router alignment (round 4, cursor Medium): a read/register touch with no
+   * explicit storageDir previously used the lexical `resolveStorageDir`, which
+   * always picks `<memoryDir>/namespaces/<token>` (or `memoryDir` for the
+   * default). That diverges from `NamespaceStorageRouter`, which can route to a
+   * legacy raw-name dir or a migrated default root — so a recall touch could
+   * record a contained-but-WRONG root that maintenance/rebuild then targets. We
+   * now delegate to the shared `resolveNamespaceStorageRoot` (the very helper the
+   * router uses) so the catalog records the same on-disk root the router serves.
+   *
+   * Containment (round 5, codex P2): the resolved path can still be a symlink
+   * escaping memoryDir, so we run the full (lexical + realpath) containment
+   * contract and fall back to the trusted legacy `memoryDir` root — which is
+   * always contained — if it fails. The lexical `resolveStorageDir` is used as a
+   * last-resort guard for unsafe tokens that the router resolver would reject.
    */
   private async resolveSafeStorageDir(namespace: string): Promise<string> {
     let resolved: string;
     try {
-      resolved = this.resolveStorageDir(namespace);
+      resolved = await resolveNamespaceStorageRoot(this.config, namespace);
     } catch {
-      // An unsafe namespace token would throw; fall back to the default root.
-      return this.memoryDir;
+      try {
+        resolved = this.resolveStorageDir(namespace);
+      } catch {
+        // An unsafe namespace token would throw; fall back to the default root.
+        return this.memoryDir;
+      }
     }
     if (await this.isContainedStorageDir(resolved)) return resolved;
     return this.memoryDir;
@@ -567,6 +581,16 @@ export class NamespaceCatalog {
     // from rejection). Reading inside the chain guarantees each touch sees the
     // most recent appended state, including any concurrent read/write/register.
     await this.queueCritical(async () => {
+      // Cross-process serialization (round 4, codex P2): a CLI `rebuild --apply`
+      // holds the rebuild lock across its final `loadCompacted()` → atomic
+      // `rename`. An append that lands inside that window is clobbered by the
+      // rename. `queueCritical` only serializes THIS process, so before reading
+      // and appending we wait (bounded) for any holder's lock to clear, then
+      // read the freshly-rewritten log. Degrades gracefully — a stale lock is
+      // ignored and a timeout proceeds best-effort so a touch NEVER blocks
+      // forever or crashes the primary memory op.
+      await this.waitForRebuildLockClear();
+
       const records = await this.loadCompacted();
       const existing = records.get(ns);
 
@@ -823,9 +847,17 @@ export class NamespaceCatalog {
       for (const [ns, fresh] of latest) {
         const current = rebuilt.get(ns);
         if (!current) {
-          // A namespace that appeared purely via a concurrent touch (no on-disk
-          // root scanned) must survive the rewrite rather than be dropped.
-          rebuilt.set(ns, fresh);
+          // A namespace absent from the rebuilt set was NOT discovered on disk
+          // (its root is empty/deleted) and is NOT configured. Re-adding it
+          // unconditionally would make rebuild unable to ever PURGE deleted
+          // dynamic namespaces from the log (round 4, codex P2). Only resurrect
+          // it when a CONCURRENT touch changed it after our initial snapshot
+          // (i.e. it is new since scan start, or its bytes differ from the
+          // `existing` snapshot). A record unchanged since the snapshot is a
+          // stale leftover for a removed root and is intentionally dropped.
+          const prior = existing.get(ns);
+          const concurrentlyTouched = !prior || serializeRecord(prior) !== serializeRecord(fresh);
+          if (concurrentlyTouched) rebuilt.set(ns, fresh);
           continue;
         }
         rebuilt.set(ns, mergeNewerTouchFields(current, fresh));
@@ -907,6 +939,54 @@ export class NamespaceCatalog {
       }
     } catch {
       // Lock vanished (released by holder) or stat failed — nothing to do.
+    }
+  }
+
+  /**
+   * Wait (bounded, best-effort) for a held rebuild lock to clear before a touch
+   * appends (round 4, codex P2). This makes catalog WRITERS respect the rebuild
+   * lock — without it the lock only serialized rebuilds against each other while
+   * a gateway `markWrite` could append into the rebuild's snapshot→rename window
+   * and be lost. We poll up to `REBUILD_LOCK_MAX_WAIT_MS`, breaking a stale lock
+   * (crashed rebuild) so a touch is never blocked indefinitely. ALL failures are
+   * swallowed: a touch must degrade gracefully and never crash the primary op.
+   *
+   * IMPORTANT: a lock held by OUR OWN process is skipped. An in-process rebuild
+   * already serializes against touches via `queueCritical`; waiting on our own
+   * lock here would deadlock (the rebuild holds the file lock then queues behind
+   * the very touch that is now waiting for it). Only a DIFFERENT process's lock
+   * (e.g. a separate CLI rebuild vs. the gateway) needs the wait.
+   */
+  private async waitForRebuildLockClear(): Promise<void> {
+    const deadline = Date.now() + REBUILD_LOCK_MAX_WAIT_MS;
+    for (;;) {
+      let info;
+      try {
+        info = await stat(this.rebuildLockPath);
+      } catch {
+        // No lock file (or stat failed) — nothing to wait on.
+        return;
+      }
+      // A stale lock (crashed holder) must not block touches — break it.
+      if (Date.now() - info.mtimeMs > REBUILD_LOCK_STALE_MS) {
+        await unlink(this.rebuildLockPath).catch(() => undefined);
+        return;
+      }
+      // Skip a lock held by our own process to avoid an in-process deadlock.
+      if (await this.rebuildLockHeldBySelf()) return;
+      if (Date.now() >= deadline) return;
+      await new Promise((r) => setTimeout(r, REBUILD_LOCK_POLL_MS));
+    }
+  }
+
+  /** Whether the rebuild lock file was written by THIS process (PID match). */
+  private async rebuildLockHeldBySelf(): Promise<boolean> {
+    try {
+      const body = await readFile(this.rebuildLockPath, "utf8");
+      const pid = Number.parseInt(body.trim().split(/\s+/)[0] ?? "", 10);
+      return Number.isFinite(pid) && pid === process.pid;
+    } catch {
+      return false;
     }
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -342,6 +342,13 @@ export class NamespaceCatalog {
   // a cross-instance touch DURING the scan window and assert it is NOT blocked or
   // dropped — proving the scan no longer holds the mutex. Never set in production.
   protected onRebuildAfterScanForTest?: () => Promise<void>;
+  // Test-only seam (NG7Bg, codex P2): fires inside `breakStaleRebuildLock` AFTER it
+  // has judged the lock stale and captured its identity, but BEFORE the final
+  // re-validation+unlink. A deterministic test installs a hook here to REPLACE the
+  // lock file (a fresh holder created a new lock in the race window) and assert the
+  // break is skipped — the replacement's active lock is not deleted. Never set in
+  // production.
+  protected onBeforeBreakStaleUnlinkForTest?: () => Promise<void>;
 
   constructor(private readonly config: PluginConfig) {
     this.memoryDir = config.memoryDir;
@@ -1570,15 +1577,55 @@ export class NamespaceCatalog {
     }
   }
 
-  /** Remove the lock file if its mtime is older than the stale threshold. */
+  /**
+   * Remove the lock file if its mtime is older than the stale threshold.
+   *
+   * REPLACEMENT-SAFE (NG7Bg, codex P2): a plain `stat` → `unlink` has a TOCTOU
+   * window — two processes can both observe the SAME stale lock; one removes it and
+   * creates a FRESH lock, and the other's later `unlink` then deletes that fresh
+   * holder's ACTIVE lock based on the stale identity it read earlier, leaving the
+   * fresh holder running its critical section with no visible lock and reopening the
+   * lost-update race the mutex prevents. We therefore capture the lock's IDENTITY
+   * (its full content line: `<pid> <owner-uuid> <iso>`) when we judge it stale, then
+   * RE-READ immediately before unlinking and only remove it when the content is
+   * byte-identical AND still stale. A replacement lock has a different owner id /
+   * timestamp, so its content differs and we leave it untouched. We never unlink a
+   * lock whose mtime is now fresh (a heartbeat refreshed it) or whose identity
+   * changed (a replacement was created). This is best-effort: any mismatch/vanish
+   * simply skips the break and the caller polls again.
+   */
   private async breakStaleRebuildLock(): Promise<void> {
+    let staleIdentity: string;
     try {
       const info = await stat(this.rebuildLockPath);
-      if (Date.now() - info.mtimeMs > REBUILD_LOCK_STALE_MS) {
-        await unlink(this.rebuildLockPath).catch(() => undefined);
+      if (Date.now() - info.mtimeMs <= REBUILD_LOCK_STALE_MS) {
+        // Not stale (e.g. a live holder's heartbeat keeps it fresh) — leave it.
+        return;
       }
+      // Capture the exact identity we judged stale, so we can confirm it has not
+      // been replaced before we unlink.
+      staleIdentity = await readFile(this.rebuildLockPath, "utf8");
     } catch {
-      // Lock vanished (released by holder) or stat failed — nothing to do.
+      // Lock vanished (released by holder) or stat/read failed — nothing to do.
+      return;
+    }
+    // Test-only seam: simulate a replacement lock being created in the race window
+    // between the staleness judgment and the unlink (NG7Bg). No-op in production.
+    if (this.onBeforeBreakStaleUnlinkForTest) {
+      await this.onBeforeBreakStaleUnlinkForTest();
+    }
+    try {
+      // Re-validate immediately before unlinking: the lock must still carry the
+      // SAME identity AND still be stale. If a replacement lock was created in the
+      // window (different owner/timestamp) or a heartbeat refreshed the mtime, do
+      // NOT unlink — that would delete another process's ACTIVE lock.
+      const current = await readFile(this.rebuildLockPath, "utf8");
+      if (current !== staleIdentity) return; // replaced — leave the fresh lock
+      const recheck = await stat(this.rebuildLockPath);
+      if (Date.now() - recheck.mtimeMs <= REBUILD_LOCK_STALE_MS) return; // refreshed
+      await unlink(this.rebuildLockPath).catch(() => undefined);
+    } catch {
+      // The lock changed/vanished between checks — another process handled it.
     }
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1,0 +1,641 @@
+import path from "node:path";
+import type { Dirent } from "node:fs";
+import { appendFile, lstat, mkdir, readdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
+import type { PluginConfig } from "../types.js";
+import { isSafeRouteNamespace } from "../routing/engine.js";
+import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
+
+/**
+ * Rebuildable namespace catalog (issue #1499).
+ *
+ * Purpose: a downstream, rebuildable metadata index that lets Remnic ENUMERATE
+ * the configured and dynamically-created namespaces that exist or should be
+ * maintained. Filesystem memory remains the single source of truth; the catalog
+ * is derived metadata and can always be reconstructed from disk.
+ *
+ * Storage format: `<memoryDir>/state/namespaces.jsonl` — an append-and-compact
+ * JSON-lines log. We chose this over per-namespace sidecar files because:
+ *   - touches (markRead/markWrite/markMaintenance) are cheap single appends;
+ *   - it is naturally audit-friendly (the raw log preserves touch history);
+ *   - a single file makes enumeration trivial (no directory walk per call);
+ *   - last-record-wins compaction folds the log into the current state on read,
+ *     and `rebuildFromDisk` rewrites it atomically (temp file + rename).
+ *
+ * SECURITY:
+ *   - The catalog stores ONLY metadata (namespace names, kinds, timestamps,
+ *     resolved storage dirs). It NEVER holds raw memory content or secrets.
+ *   - Catalog presence grants NO authorization. Read/write access still flows
+ *     through the namespace policies in `principal.ts`; this module never makes
+ *     an access decision.
+ *   - All namespace tokens are validated with `isSafeRouteNamespace` (except the
+ *     configured default namespace, which is exempt at the routing layer) and
+ *     every storage dir is contained under `<memoryDir>/namespaces`.
+ *   - `rebuildFromDisk` rejects/reports symlinked roots that escape the memory
+ *     root rather than trusting them.
+ *
+ * LIFECYCLE: catalog write failures must NEVER crash a primary memory op.
+ * Callers should wrap touch calls in try/catch (or rely on the internal
+ * failure-tolerant append). The internal serialized write chain recovers from
+ * rejection so one failed append cannot poison subsequent writes.
+ */
+
+export type NamespaceKind =
+  | "default"
+  | "self"
+  | "shared"
+  | "project"
+  | "branch"
+  | "team-project"
+  | "explicit"
+  | "legacy";
+
+export type NamespaceDiscoverySource = "config" | "write" | "read" | "scan" | "migration";
+
+export interface NamespaceRecord {
+  namespace: string;
+  identityToken: string;
+  kind: NamespaceKind;
+  principal?: string;
+  projectId?: string;
+  branch?: string;
+  parentNamespace?: string;
+  createdAt: string;
+  lastReadAt?: string;
+  lastWriteAt?: string;
+  lastMaintenanceAt?: Record<string, string>;
+  storageDir: string;
+  discoveredBy: NamespaceDiscoverySource;
+}
+
+export interface NamespaceCatalogFilter {
+  kind?: NamespaceKind;
+  discoveredBy?: NamespaceDiscoverySource;
+  /** Only include namespaces written since this instant (inclusive lower bound). */
+  writtenSince?: Date;
+}
+
+export interface NamespaceTouchMetadata {
+  discoveredBy?: NamespaceDiscoverySource;
+  kind?: NamespaceKind;
+  principal?: string;
+  projectId?: string;
+  branch?: string;
+  parentNamespace?: string;
+  /** Explicit storage dir (when the caller already resolved it). */
+  storageDir?: string;
+  /** Override the touch timestamp (mainly for tests / migration replay). */
+  at?: Date;
+}
+
+export interface NamespaceCatalogSkippedRoot {
+  token: string;
+  reason: "symlink" | "escape" | "unsafe" | "error";
+  detail?: string;
+}
+
+export interface NamespaceCatalogRebuildResult {
+  dryRun: boolean;
+  records: NamespaceRecord[];
+  /** Roots reported as ambiguous/unsafe rather than silently misclassified. */
+  skipped: NamespaceCatalogSkippedRoot[];
+}
+
+const CATALOG_FILE = "namespaces.jsonl";
+const STATE_DIR = "state";
+
+// Children that indicate a directory holds Remnic memory data (used for legacy
+// default-root detection and to skip empty/non-data roots during rebuild).
+const MEMORY_DATA_CHILDREN = [
+  ...ALL_CATEGORY_DIRS,
+  "entities",
+  "artifacts",
+  "identity",
+  "config",
+  "summaries",
+  "profile.md",
+] as const;
+
+function isCatalogEnabled(config: PluginConfig): boolean {
+  // Inert unless namespaces are enabled. namespaceCatalogEnabled defaults to
+  // true (undefined => enabled) but is only honored when namespacesEnabled.
+  if (config.namespacesEnabled !== true) return false;
+  return (config as { namespaceCatalogEnabled?: boolean }).namespaceCatalogEnabled !== false;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await lstat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function hasMemoryData(rootDir: string): Promise<boolean> {
+  for (const child of MEMORY_DATA_CHILDREN) {
+    if (await pathExists(path.join(rootDir, child))) return true;
+  }
+  return false;
+}
+
+/**
+ * Validate a JSONL line parsed value as a usable NamespaceRecord.
+ * Rejects null / non-object / missing-field records (CLAUDE.md rule #18).
+ */
+function coerceRecord(value: unknown): NamespaceRecord | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.namespace !== "string" || v.namespace.length === 0) return null;
+  if (typeof v.identityToken !== "string" || v.identityToken.length === 0) return null;
+  if (typeof v.storageDir !== "string" || v.storageDir.length === 0) return null;
+  if (typeof v.createdAt !== "string" || v.createdAt.length === 0) return null;
+  const kind = typeof v.kind === "string" ? (v.kind as NamespaceKind) : "explicit";
+  const discoveredBy =
+    typeof v.discoveredBy === "string" ? (v.discoveredBy as NamespaceDiscoverySource) : "scan";
+  const record: NamespaceRecord = {
+    namespace: v.namespace,
+    identityToken: v.identityToken,
+    kind,
+    createdAt: v.createdAt,
+    storageDir: v.storageDir,
+    discoveredBy,
+  };
+  if (typeof v.principal === "string") record.principal = v.principal;
+  if (typeof v.projectId === "string") record.projectId = v.projectId;
+  if (typeof v.branch === "string") record.branch = v.branch;
+  if (typeof v.parentNamespace === "string") record.parentNamespace = v.parentNamespace;
+  if (typeof v.lastReadAt === "string") record.lastReadAt = v.lastReadAt;
+  if (typeof v.lastWriteAt === "string") record.lastWriteAt = v.lastWriteAt;
+  if (v.lastMaintenanceAt && typeof v.lastMaintenanceAt === "object") {
+    const out: Record<string, string> = {};
+    for (const [k, val] of Object.entries(v.lastMaintenanceAt as Record<string, unknown>)) {
+      if (typeof val === "string") out[k] = val;
+    }
+    if (Object.keys(out).length > 0) record.lastMaintenanceAt = out;
+  }
+  return record;
+}
+
+/**
+ * Serialize a record with sorted keys (CLAUDE.md rule #38) so byte output is
+ * stable across runs — required for idempotent rebuilds.
+ */
+function serializeRecord(record: NamespaceRecord): string {
+  const ordered: Record<string, unknown> = {};
+  const source = record as unknown as Record<string, unknown>;
+  for (const key of Object.keys(source).sort()) {
+    const value = source[key];
+    if (value === undefined) continue;
+    if (key === "lastMaintenanceAt" && value && typeof value === "object") {
+      const sortedJobs: Record<string, string> = {};
+      for (const jobKey of Object.keys(value as Record<string, string>).sort()) {
+        sortedJobs[jobKey] = (value as Record<string, string>)[jobKey]!;
+      }
+      ordered[key] = sortedJobs;
+      continue;
+    }
+    ordered[key] = value;
+  }
+  return JSON.stringify(ordered);
+}
+
+/**
+ * Infer the namespace kind from its name/structure using the same conventions
+ * as `coding-namespace.ts` (project-*, *-branch-*, team-*-project-*). Returns
+ * `explicit` when no structural signal is present. The caller can override.
+ */
+function inferKind(namespace: string, config: PluginConfig): NamespaceKind {
+  if (namespace === config.defaultNamespace) return "default";
+  if (namespace === config.sharedNamespace) return "shared";
+  if (config.namespacePolicies.some((p) => p.name === namespace)) return "explicit";
+  // Branch overlays embed "-branch-" (project-<id>-branch-<name>).
+  if (/-branch-|^project-[^-]+-branch-/.test(namespace) || namespace.includes("-branch-")) {
+    return "branch";
+  }
+  // Team-project promotions are prefixed team-*-project-*.
+  if (/^team-.*-project-/.test(namespace) || /^team-.*project-/.test(namespace)) {
+    return "team-project";
+  }
+  // Project overlays are "project-*" or "<principal>-project-*".
+  if (/^project-/.test(namespace) || /-project-/.test(namespace)) {
+    return "project";
+  }
+  return "explicit";
+}
+
+export class NamespaceCatalog {
+  private readonly memoryDir: string;
+  private readonly stateDir: string;
+  private readonly catalogPath: string;
+  // Serialized write chain that recovers from rejection (CLAUDE.md rule #40)
+  // so a single failed append cannot permanently poison subsequent writes.
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly config: PluginConfig) {
+    this.memoryDir = config.memoryDir;
+    this.stateDir = path.join(this.memoryDir, STATE_DIR);
+    this.catalogPath = path.join(this.stateDir, CATALOG_FILE);
+  }
+
+  /** Whether the catalog is active (namespaces enabled and catalog not opted out). */
+  get enabled(): boolean {
+    return isCatalogEnabled(this.config);
+  }
+
+  // ── Public enumeration API ──────────────────────────────────────────────
+
+  async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
+    if (!this.enabled) return [];
+    const records = await this.loadCompacted();
+    let out = [...records.values()];
+    if (filter?.kind) out = out.filter((r) => r.kind === filter.kind);
+    if (filter?.discoveredBy) out = out.filter((r) => r.discoveredBy === filter.discoveredBy);
+    if (filter?.writtenSince) {
+      const sinceMs = filter.writtenSince.getTime();
+      out = out.filter((r) => {
+        if (!r.lastWriteAt) return false;
+        const ms = Date.parse(r.lastWriteAt);
+        return Number.isFinite(ms) && ms >= sinceMs;
+      });
+    }
+    // Stable sort: namespace asc, identityToken as deterministic tiebreaker
+    // (CLAUDE.md rule #19 — comparator returns 0 only for truly-equal items).
+    return out.sort((a, b) => {
+      const byName = a.namespace.localeCompare(b.namespace);
+      if (byName !== 0) return byName;
+      return a.identityToken.localeCompare(b.identityToken);
+    });
+  }
+
+  async getNamespaceRecord(namespace: string): Promise<NamespaceRecord | null> {
+    if (!this.enabled) return null;
+    const ns = normalizeNamespaceIdentity(namespace);
+    const records = await this.loadCompacted();
+    return records.get(ns) ?? null;
+  }
+
+  // ── Touch API (cheap, failure-tolerant) ─────────────────────────────────
+
+  async markRead(namespace: string, metadata?: NamespaceTouchMetadata): Promise<void> {
+    await this.touch(namespace, "read", metadata);
+  }
+
+  async markWrite(namespace: string, metadata?: NamespaceTouchMetadata): Promise<void> {
+    await this.touch(namespace, "write", metadata);
+  }
+
+  async markMaintenance(namespace: string, jobName: string, at?: Date): Promise<void> {
+    if (typeof jobName !== "string" || jobName.trim().length === 0) {
+      throw new Error("markMaintenance requires a non-empty jobName");
+    }
+    await this.touch(namespace, "maintenance", { at }, jobName.trim());
+  }
+
+  /**
+   * Register namespaces known purely from config (default, shared, explicit
+   * policies). Source `config`. Cheap and idempotent.
+   */
+  async registerConfiguredNamespaces(): Promise<void> {
+    if (!this.enabled) return;
+    const names = new Set<string>([
+      this.config.defaultNamespace,
+      this.config.sharedNamespace,
+      ...this.config.namespacePolicies.map((p) => p.name),
+    ]);
+    for (const ns of names) {
+      if (!ns) continue;
+      await this.register(ns, { discoveredBy: "config" });
+    }
+  }
+
+  /**
+   * Register a namespace whose storage was just resolved by the router. Used as
+   * a fire-and-forget integration hook (`discoveredBy: config`). Storage dir is
+   * provided so we do not re-resolve it. Failure-tolerant.
+   */
+  async registerResolved(namespace: string, storageDir: string): Promise<void> {
+    if (!this.enabled) return;
+    await this.register(namespace, { discoveredBy: "config", storageDir });
+  }
+
+  /**
+   * Generic register/touch without changing read/write timestamps unless the
+   * source implies it. Validates the namespace and resolves a storage dir.
+   */
+  private async register(namespace: string, metadata: NamespaceTouchMetadata): Promise<void> {
+    await this.touch(namespace, "register", metadata);
+  }
+
+  private validateNamespace(namespace: string): string {
+    const ns = normalizeNamespaceIdentity(namespace);
+    if (ns.length === 0) throw new Error("empty namespace");
+    // The configured default namespace is exempt from isSafeRouteNamespace at
+    // the routing layer; honor the same exemption here, but everything still
+    // resolves through the contained storage-dir helper below.
+    if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+      throw new Error(`unsafe namespace: ${ns}`);
+    }
+    return ns;
+  }
+
+  /**
+   * Resolve the on-disk storage dir for a namespace WITHOUT trusting caller
+   * input. The default namespace may use the legacy memoryDir root; everything
+   * else lives under `<memoryDir>/namespaces/<token>`. Containment is enforced
+   * by rejecting separators/parent-refs in the token.
+   */
+  private resolveStorageDir(namespace: string): string {
+    if (namespace === this.config.defaultNamespace) {
+      // Default may resolve to the legacy memoryDir root OR a tokenized dir; we
+      // report memoryDir here as the canonical default root for the catalog.
+      // rebuildFromDisk refines this when a tokenized default dir holds data.
+      return this.memoryDir;
+    }
+    const token = namespaceIdentityToken(namespace);
+    return this.namespaceTokenDir(token);
+  }
+
+  private namespaceTokenDir(token: string): string {
+    if (
+      token.length === 0 ||
+      token.includes("/") ||
+      token.includes("\\") ||
+      token.includes("..") ||
+      path.isAbsolute(token)
+    ) {
+      throw new Error(`unsafe namespace token: ${token}`);
+    }
+    return path.join(this.memoryDir, "namespaces", token);
+  }
+
+  private async touch(
+    namespace: string,
+    kind: "read" | "write" | "maintenance" | "register",
+    metadata?: NamespaceTouchMetadata,
+    jobName?: string,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    const ns = this.validateNamespace(namespace);
+    const nowIso = (metadata?.at ?? new Date()).toISOString();
+    const records = await this.loadCompacted();
+    const existing = records.get(ns);
+
+    const storageDir = metadata?.storageDir ?? existing?.storageDir ?? this.resolveStorageDir(ns);
+    const record: NamespaceRecord = existing
+      ? { ...existing }
+      : {
+          namespace: ns,
+          identityToken: namespaceIdentityToken(ns),
+          kind: metadata?.kind ?? inferKind(ns, this.config),
+          createdAt: nowIso,
+          storageDir,
+          discoveredBy: metadata?.discoveredBy ?? (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
+        };
+
+    // Update mutable fields.
+    record.storageDir = storageDir;
+    if (metadata?.kind) record.kind = metadata.kind;
+    if (metadata?.principal !== undefined) record.principal = metadata.principal;
+    if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
+    if (metadata?.branch !== undefined) record.branch = metadata.branch;
+    if (metadata?.parentNamespace !== undefined) record.parentNamespace = metadata.parentNamespace;
+    if (metadata?.discoveredBy) record.discoveredBy = metadata.discoveredBy;
+
+    if (kind === "read") record.lastReadAt = nowIso;
+    if (kind === "write") record.lastWriteAt = nowIso;
+    if (kind === "maintenance" && jobName) {
+      record.lastMaintenanceAt = { ...(record.lastMaintenanceAt ?? {}), [jobName]: nowIso };
+    }
+
+    await this.append(record);
+  }
+
+  // ── Rebuild from disk ────────────────────────────────────────────────────
+
+  async rebuildFromDisk(
+    options?: { dryRun?: boolean },
+  ): Promise<NamespaceCatalogRebuildResult> {
+    const dryRun = options?.dryRun === true;
+    if (!this.enabled) {
+      return { dryRun, records: [], skipped: [] };
+    }
+
+    // Preserve existing known metadata where safe (CLAUDE.md preservation req).
+    const existing = await this.loadCompacted();
+    const skipped: NamespaceCatalogSkippedRoot[] = [];
+    const rebuilt = new Map<string, NamespaceRecord>();
+    const nowIso = new Date().toISOString();
+
+    let memoryReal: string | null = null;
+    try {
+      memoryReal = await realpath(this.memoryDir);
+    } catch {
+      memoryReal = this.memoryDir;
+    }
+
+    // 1) Configured namespaces always belong in the catalog.
+    const configured = new Set<string>([
+      this.config.defaultNamespace,
+      this.config.sharedNamespace,
+      ...this.config.namespacePolicies.map((p) => p.name),
+    ]);
+
+    // 2) Legacy/default root compatibility: if facts live directly under
+    //    memoryDir (no tokenized default dir), the default root IS memoryDir.
+    const defaultToken = namespaceIdentityToken(this.config.defaultNamespace);
+    const defaultTokenDir = this.namespaceTokenDir(defaultToken);
+    const defaultTokenHasData = await hasMemoryData(defaultTokenDir);
+    const legacyDefaultHasData = await hasMemoryData(this.memoryDir);
+    const defaultStorageDir =
+      defaultTokenHasData && (await pathExists(defaultTokenDir))
+        ? defaultTokenDir
+        : this.memoryDir;
+
+    for (const ns of configured) {
+      if (!ns) continue;
+      const storageDir = ns === this.config.defaultNamespace ? defaultStorageDir : this.namespaceTokenDir(namespaceIdentityToken(ns));
+      rebuilt.set(
+        ns,
+        this.mergeForRebuild(existing.get(ns), {
+          namespace: ns,
+          identityToken: namespaceIdentityToken(ns),
+          kind: inferKind(ns, this.config),
+          createdAt: existing.get(ns)?.createdAt ?? nowIso,
+          storageDir,
+          discoveredBy: "config",
+        }),
+      );
+    }
+
+    // 3) Scan the namespaces/ directory for tokenized roots.
+    const namespacesDir = path.join(this.memoryDir, "namespaces");
+    let entries: Dirent[] = [];
+    try {
+      entries = await readdir(namespacesDir, { withFileTypes: true });
+    } catch {
+      entries = [];
+    }
+
+    for (const entry of entries) {
+      const token = entry.name;
+      const fullPath = path.join(namespacesDir, token);
+      // Reject symlinks / escaping roots rather than trusting them.
+      let stat;
+      try {
+        stat = await lstat(fullPath);
+      } catch (err) {
+        skipped.push({ token, reason: "error", detail: err instanceof Error ? err.message : String(err) });
+        continue;
+      }
+      if (stat.isSymbolicLink()) {
+        skipped.push({ token, reason: "symlink", detail: fullPath });
+        continue;
+      }
+      if (!stat.isDirectory()) continue;
+      // Containment: realpath must stay inside the memory root.
+      try {
+        const real = await realpath(fullPath);
+        if (memoryReal && !isPathInside(memoryReal, real)) {
+          skipped.push({ token, reason: "escape", detail: real });
+          continue;
+        }
+      } catch (err) {
+        skipped.push({ token, reason: "error", detail: err instanceof Error ? err.message : String(err) });
+        continue;
+      }
+
+      // Decode the namespace from the token, falling back to the raw dir name.
+      const decoded = configured.has(token) ? token : namespaceIdentityFromToken(token) ?? token;
+      if (decoded !== this.config.defaultNamespace && !isSafeRouteNamespace(decoded)) {
+        skipped.push({ token, reason: "unsafe", detail: decoded });
+        continue;
+      }
+      // Only catalog roots that actually hold memory data (skip empty shells).
+      if (!(await hasMemoryData(fullPath))) continue;
+
+      const prior = existing.get(decoded);
+      rebuilt.set(
+        decoded,
+        this.mergeForRebuild(prior, {
+          namespace: decoded,
+          identityToken: namespaceIdentityToken(decoded),
+          kind: inferKind(decoded, this.config),
+          createdAt: prior?.createdAt ?? nowIso,
+          storageDir: fullPath,
+          // Configured-and-present namespaces keep config provenance; purely
+          // discovered ones are scan.
+          discoveredBy: configured.has(decoded) ? "config" : prior?.discoveredBy ?? "scan",
+        }),
+      );
+    }
+
+    // Mark legacy default root explicitly when applicable.
+    if (legacyDefaultHasData && defaultStorageDir === this.memoryDir) {
+      const def = rebuilt.get(this.config.defaultNamespace);
+      if (def) def.kind = "default";
+    }
+
+    const records = [...rebuilt.values()].sort((a, b) => {
+      const byName = a.namespace.localeCompare(b.namespace);
+      if (byName !== 0) return byName;
+      return a.identityToken.localeCompare(b.identityToken);
+    });
+
+    if (!dryRun) {
+      await this.rewriteAtomic(records);
+    }
+
+    return { dryRun, records, skipped };
+  }
+
+  /**
+   * Merge a prior record's preserved metadata (timestamps, principal hints)
+   * onto a freshly-discovered record. Disk-derived fields (storageDir, kind,
+   * discoveredBy) take precedence from the new record.
+   */
+  private mergeForRebuild(prior: NamespaceRecord | undefined, fresh: NamespaceRecord): NamespaceRecord {
+    if (!prior) return fresh;
+    const merged: NamespaceRecord = { ...fresh, createdAt: prior.createdAt ?? fresh.createdAt };
+    if (prior.lastReadAt) merged.lastReadAt = prior.lastReadAt;
+    if (prior.lastWriteAt) merged.lastWriteAt = prior.lastWriteAt;
+    if (prior.lastMaintenanceAt) merged.lastMaintenanceAt = { ...prior.lastMaintenanceAt };
+    if (prior.principal !== undefined) merged.principal = prior.principal;
+    if (prior.projectId !== undefined) merged.projectId = prior.projectId;
+    if (prior.branch !== undefined) merged.branch = prior.branch;
+    if (prior.parentNamespace !== undefined) merged.parentNamespace = prior.parentNamespace;
+    return merged;
+  }
+
+  // ── Persistence ──────────────────────────────────────────────────────────
+
+  /** Load the JSONL log and fold it into current state (last-record-wins). */
+  private async loadCompacted(): Promise<Map<string, NamespaceRecord>> {
+    const records = new Map<string, NamespaceRecord>();
+    let raw: string;
+    try {
+      raw = await readFile(this.catalogPath, "utf8");
+    } catch {
+      return records;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        // Skip corrupt lines (CLAUDE.md rule #18 robustness).
+        continue;
+      }
+      const record = coerceRecord(parsed);
+      if (!record) continue;
+      records.set(record.namespace, record);
+    }
+    return records;
+  }
+
+  /**
+   * Append a single record to the JSONL log. Serialized through a write chain
+   * that recovers from rejection (CLAUDE.md rule #40). Failure-tolerant: errors
+   * are surfaced to the caller's awaited promise but do not poison the chain.
+   */
+  private append(record: NamespaceRecord): Promise<void> {
+    const line = serializeRecord(record) + "\n";
+    const run = this.writeChain.then(async () => {
+      await mkdir(this.stateDir, { recursive: true });
+      await appendFile(this.catalogPath, line, "utf8");
+    });
+    // Keep the chain alive after a rejection so later writes still run.
+    this.writeChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /**
+   * Atomically rewrite the compacted catalog (temp file + rename) so a failed
+   * write never leaves a truncated/lost catalog (CLAUDE.md rule #54: write
+   * temp, then rename — never delete-before-write).
+   */
+  private async rewriteAtomic(records: NamespaceRecord[]): Promise<void> {
+    const body = records.map((r) => serializeRecord(r)).join("\n") + (records.length > 0 ? "\n" : "");
+    const run = this.writeChain.then(async () => {
+      await mkdir(this.stateDir, { recursive: true });
+      const tmp = `${this.catalogPath}.${process.pid}.${Date.now()}.tmp`;
+      await writeFile(tmp, body, "utf8");
+      await rename(tmp, this.catalogPath);
+    });
+    this.writeChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}
+
+function isPathInside(root: string, child: string): boolean {
+  const relative = path.relative(root, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -668,8 +668,20 @@ export class NamespaceCatalog {
       if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
       if (metadata?.branch !== undefined) record.branch = metadata.branch;
       if (metadata?.parentNamespace !== undefined) record.parentNamespace = metadata.parentNamespace;
-      // NOTE: discoveredBy is intentionally NOT reassigned here for existing
-      // records — see the creation-only rationale above (Issue 1 fix).
+      // PROVENANCE (creation-only, with one upgrade — round 6, codex P2 NBPmT):
+      // `discoveredBy` is otherwise preserved for existing records (a routine
+      // read/register/resolve never relabels it). The single exception is a real
+      // WRITE upgrading a record that was only PRE-REGISTERED by the router's
+      // `onResolve` hook (`discoveredBy: "config"`) before any data was written.
+      // Without this upgrade, `listNamespaces({ discoveredBy: "write" })` misses
+      // namespaces that were genuinely written, because `storageFor()` fires
+      // `registerResolved()` (config) before `recordCatalogWrite()` runs. We
+      // upgrade ONLY config→write — never downgrade write/read, never relabel a
+      // read-discovered record — so the authoritative "this namespace has been
+      // written" signal is recorded.
+      if (kind === "write" && existing && record.discoveredBy === "config") {
+        record.discoveredBy = "write";
+      }
 
       if (kind === "read") record.lastReadAt = nowIso;
       if (kind === "write") record.lastWriteAt = nowIso;
@@ -714,10 +726,14 @@ export class NamespaceCatalog {
     // on-disk touches under that lock immediately before the rewrite (see
     // `rebuildInsideChain`). A dry-run never mutates, so it skips the lock.
     if (dryRun) {
-      return this.queueCritical(async () => this.rebuildInsideChain(dryRun));
+      return this.queueCritical(async () => this.rebuildInsideChain(dryRun, false));
     }
-    return this.withRebuildLock(() =>
-      this.queueCritical(async () => this.rebuildInsideChain(dryRun)),
+    return this.withRebuildLock((acquired) =>
+      // canMutate iff we actually hold the cross-process lock (round 6, codex P2
+      // — NBPmY). If acquisition timed out, run compute-only: never perform the
+      // load/rename window unlocked, or a second unlocked rename could clobber a
+      // concurrent gateway touch and recreate the lost-append race.
+      this.queueCritical(async () => this.rebuildInsideChain(dryRun, acquired)),
     );
   }
 
@@ -726,7 +742,10 @@ export class NamespaceCatalog {
    * only be invoked from within the serialized chain so the load and the
    * rewrite are atomic with respect to concurrent touches.
    */
-  private async rebuildInsideChain(dryRun: boolean): Promise<NamespaceCatalogRebuildResult> {
+  private async rebuildInsideChain(
+    dryRun: boolean,
+    canMutate: boolean,
+  ): Promise<NamespaceCatalogRebuildResult> {
     // Read the LATEST persisted state inside the chain so any touch that landed
     // before this turn is folded in (and re-merged into the rewrite below).
     const existing = await this.loadCompacted();
@@ -760,6 +779,23 @@ export class NamespaceCatalog {
 
     for (const ns of configured) {
       if (!ns) continue;
+      // SAFETY (round 6, codex P2 — NBPmO): `parseConfig` intentionally preserves
+      // unsafe namespace strings (e.g. a `sharedNamespace`/`namespacePolicies[]`
+      // name like `../evil`) so sinks reject them. The hot touch/scan paths
+      // already reject via `isSafeRouteNamespace`; rebuild must NOT be the path
+      // that admits an unsafe configured namespace into the catalog. The default
+      // namespace is exempt (it may be a non-route literal), matching the scan
+      // loop's exemption below.
+      if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+        let token: string;
+        try {
+          token = namespaceIdentityToken(ns);
+        } catch {
+          token = ns;
+        }
+        skipped.push({ token, reason: "unsafe", detail: ns });
+        continue;
+      }
       const storageDir = ns === this.config.defaultNamespace ? defaultStorageDir : this.namespaceTokenDir(namespaceIdentityToken(ns));
       rebuilt.set(
         ns,
@@ -875,13 +911,15 @@ export class NamespaceCatalog {
       if (def) def.kind = "default";
     }
 
-    if (!dryRun) {
+    if (canMutate) {
       // CROSS-PROCESS re-merge (round 5, codex P2): under the rebuild lock,
       // re-read the on-disk log ONE more time and fold any touch fields that
       // landed AFTER our initial `loadCompacted()` (e.g. a gateway markWrite in
       // another process) into the rebuilt records — last-write-wins per touch
       // field. This recovers cross-process appends that completed during the
-      // scan, which the in-process `queueCritical` alone cannot see.
+      // scan, which the in-process `queueCritical` alone cannot see. Only runs
+      // when we hold the lock (round 6, codex P2 — NBPmY): an unlocked rebuild
+      // must not re-merge then rename, or it races a concurrent lock holder.
       const latest = await this.loadCompacted();
       for (const [ns, fresh] of latest) {
         const current = rebuilt.get(ns);
@@ -912,7 +950,11 @@ export class NamespaceCatalog {
       return a.identityToken.localeCompare(b.identityToken);
     });
 
-    if (!dryRun) {
+    // Only rewrite when we actually hold the cross-process lock (round 6, codex
+    // P2 — NBPmY). A dry-run never mutates; an unlocked rebuild (acquisition
+    // timed out) returns the computed records WITHOUT renaming over the log, so
+    // it can never clobber a concurrent lock holder's window.
+    if (canMutate) {
       await this.rewriteUnchained(records);
     }
 
@@ -935,8 +977,15 @@ export class NamespaceCatalog {
    * unlinked by another process/touch — which would let overlapping rewrites lose
    * appends. Heartbeat failures are swallowed; the timer is always cleared in
    * `finally`.
+   *
+   * ACQUISITION RESULT (round 6, codex P2 — NBPmY): `fn` receives whether WE
+   * actually hold the lock. When acquisition TIMED OUT (another `rebuild --apply`
+   * holds it), a MUTATING rebuild must NOT perform its load/rename window
+   * unlocked — that second unlocked rename can clobber gateway touches that the
+   * first lock holder's window let through, recreating the lost-append race. The
+   * caller uses `acquired` to suppress the rewrite (compute-only) when unlocked.
    */
-  private async withRebuildLock<T>(fn: () => Promise<T>): Promise<T> {
+  private async withRebuildLock<T>(fn: (acquired: boolean) => Promise<T>): Promise<T> {
     const acquired = await this.acquireRebuildLock();
     let heartbeat: ReturnType<typeof setInterval> | undefined;
     if (acquired) {
@@ -949,7 +998,7 @@ export class NamespaceCatalog {
       heartbeat.unref?.();
     }
     try {
-      return await fn();
+      return await fn(acquired);
     } finally {
       if (heartbeat) clearInterval(heartbeat);
       if (acquired) {

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -166,10 +166,43 @@ function isCatalogEnabled(config: PluginConfig): boolean {
   return (config as { namespaceCatalogEnabled?: boolean }).namespaceCatalogEnabled !== false;
 }
 
-async function pathExists(p: string): Promise<boolean> {
+// Marker children that MUST be a regular file rather than a directory. Everything
+// else in MEMORY_DATA_CHILDREN is a category/data DIRECTORY that downstream
+// indexers (`scanMemoryDir`) read — and which they reject when it is a symlink or
+// a non-directory. `profile.md` is the sole file marker.
+const FILE_MEMORY_DATA_CHILDREN = new Set<string>(["profile.md"]);
+
+/**
+ * Whether `child` under `rootDir` is a VALID, live memory-data marker (NIw0F,
+ * codex P2). Existence alone is not enough: a bogus marker — e.g. `facts` as a
+ * symlink or a regular file instead of a real directory — passes `lstat` but
+ * makes `scanMemoryDir` throw on the symlinked/non-directory category root, so a
+ * `rebuild --apply` that cataloged the namespace would then make catalog-driven
+ * QMD maintenance fail repeatedly on a root with no usable data. Validate the
+ * child's TYPE (and, for directories, that its realpath stays inside the root, so
+ * a symlink escaping the memory tree is never treated as live).
+ */
+async function isLiveMemoryDataMarker(rootDir: string, child: string): Promise<boolean> {
+  const childPath = path.join(rootDir, child);
+  let entry;
   try {
-    await lstat(p);
-    return true;
+    entry = await lstat(childPath);
+  } catch {
+    return false;
+  }
+  // Reject symlinked markers outright (scan parity — never follow them).
+  if (entry.isSymbolicLink()) return false;
+  if (FILE_MEMORY_DATA_CHILDREN.has(child)) {
+    // `profile.md` must be a regular file.
+    return entry.isFile();
+  }
+  // Category/data markers must be real directories whose realpath stays inside
+  // the namespace root (no escape via a symlinked ancestor).
+  if (!entry.isDirectory()) return false;
+  try {
+    const rootReal = await realpath(rootDir);
+    const childReal = await realpath(childPath);
+    return isPathInside(rootReal, childReal);
   } catch {
     return false;
   }
@@ -177,7 +210,7 @@ async function pathExists(p: string): Promise<boolean> {
 
 async function hasMemoryData(rootDir: string): Promise<boolean> {
   for (const child of MEMORY_DATA_CHILDREN) {
-    if (await pathExists(path.join(rootDir, child))) return true;
+    if (await isLiveMemoryDataMarker(rootDir, child)) return true;
   }
   return false;
 }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -330,6 +330,12 @@ export class NamespaceCatalog {
   // installs a hook here to attempt a cross-instance touch in this window and
   // assert the held mutex blocks it. Never set in production code.
   protected onRebuildBeforeRenameForTest?: () => Promise<void>;
+  // Test-only seam (NFgCT, codex P2): fires AFTER the lockless disk scan but
+  // BEFORE the rebuild acquires the cross-process file lock for its final
+  // load→merge→rename window. A deterministic test installs a hook here to attempt
+  // a cross-instance touch DURING the scan window and assert it is NOT blocked or
+  // dropped — proving the scan no longer holds the mutex. Never set in production.
+  protected onRebuildAfterScanForTest?: () => Promise<void>;
 
   constructor(private readonly config: PluginConfig) {
     this.memoryDir = config.memoryDir;
@@ -968,10 +974,16 @@ export class NamespaceCatalog {
     // 7, codex P2 — NEZkA). Because the touch path acquires this lock across its
     // read→append window and the rebuild holds it across its final
     // `loadCompacted()` → `rename()`, the two are mutually exclusive cross-process:
-    // no touch append can land between a rebuild's final load and its rename. The
-    // disk scan itself can stay lockless (it does not mutate); only the final
-    // read-merge-rename critical section requires the lock — `rebuildInsideChain`
-    // does that whole section while we hold it.
+    // no touch append can land between a rebuild's final load and its rename.
+    //
+    // SCOPED MUTEX (NFgCT, codex P2): the lock is acquired ONLY around the final
+    // load→merge→rename window, NOT the (potentially long) disk scan. The scan does
+    // not mutate, so holding the lock across it merely forces concurrent gateway
+    // touches to wait — and they DROP their append after `REBUILD_LOCK_MAX_WAIT_MS`,
+    // losing real `lastWriteAt`/new-namespace data the rewrite then misses. Keeping
+    // the scan lockless shrinks the window in which a touch must contend with the
+    // rebuild to just the final critical section, which is brief. `rebuildInsideChain`
+    // acquires `withHeldCatalogLock` itself, immediately before its re-merge+rewrite.
     //
     // LOCK ORDERING (round 7 — NEZkA): the file lock is acquired INSIDE
     // `queueCritical`, identically to the touch path (`queueCritical` → file lock),
@@ -981,24 +993,26 @@ export class NamespaceCatalog {
     // lock the other is not even running — the OS lock is never self-contended
     // in-process and a same-instance touch never stalls/drops behind its own
     // rebuild. The file lock therefore adds ONLY the missing cross-process
-    // exclusion.
-    return this.queueCritical(async () =>
-      // canMutate iff we actually hold the cross-process lock (round 6, codex P2
-      // — NBPmY). If acquisition timed out, run compute-only: never perform the
-      // load/rename window unlocked, or a second unlocked rename could clobber a
-      // concurrent gateway touch and recreate the lost-append race.
-      this.withHeldCatalogLock((acquired) => this.rebuildInsideChain(dryRun, acquired)),
-    );
+    // exclusion. `rebuildInsideChain` still runs entirely inside `queueCritical`;
+    // it just narrows the cross-process file lock to the final rewrite window.
+    return this.queueCritical(async () => this.rebuildInsideChain(dryRun, true));
   }
 
   /**
    * Body of `rebuildFromDisk`, run inside a single `queueCritical` turn. MUST
    * only be invoked from within the serialized chain so the load and the
-   * rewrite are atomic with respect to concurrent touches.
+   * rewrite are atomic with respect to concurrent touches (in-process).
+   *
+   * `wantMutate` is true for an `--apply` (the caller intends to rewrite). The
+   * cross-process file lock is acquired LATE — only around the final
+   * load→merge→rename window (NFgCT, codex P2) — never across the disk scan, so a
+   * long scan does not force concurrent gateway touches to wait (and drop their
+   * append). Whether the rewrite actually happened is reported via the result's
+   * `applied`: true only when `wantMutate` AND the lock was acquired.
    */
   private async rebuildInsideChain(
     dryRun: boolean,
-    canMutate: boolean,
+    wantMutate: boolean,
   ): Promise<NamespaceCatalogRebuildResult> {
     // Read the LATEST persisted state inside the chain so any touch that landed
     // before this turn is folded in (and re-merged into the rewrite below).
@@ -1249,6 +1263,47 @@ export class NamespaceCatalog {
       if (def) def.kind = "default";
     }
 
+    // ── Final critical section (SCOPED MUTEX — NFgCT, codex P2) ──────────────
+    // The disk scan above ran LOCKLESS (it only reads). Now, for a mutating
+    // rebuild, acquire the cross-process file lock ONLY for the
+    // load→merge→rename window — the brief section a concurrent touch must be
+    // excluded from. `canMutate` is true iff we ACTUALLY hold the lock: if
+    // acquisition timed out (`acquired === false`) we run compute-only and never
+    // re-merge+rewrite unlocked (which would race a concurrent lock holder and
+    // recreate the lost-append window). A dry-run skips the lock entirely.
+    if (!wantMutate) {
+      return this.finishRebuild(rebuilt, skipped, dryRun, false, memoryReal, nowIso);
+    }
+    // Test-only seam: the SCAN is now complete but the cross-process lock has NOT
+    // yet been acquired (NFgCT). A concurrency test attempts a cross-instance touch
+    // here and asserts it is NOT blocked/dropped — proving the scan is lockless.
+    if (this.onRebuildAfterScanForTest) {
+      await this.onRebuildAfterScanForTest();
+    }
+    return this.withHeldCatalogLock((acquired) =>
+      this.finishRebuild(rebuilt, skipped, dryRun, acquired, memoryReal, nowIso),
+    );
+  }
+
+  /**
+   * Final load→merge→rename window of a rebuild, factored out so the caller can
+   * run it WITHIN the cross-process file lock (NFgCT, codex P2) without holding
+   * that lock across the preceding disk scan. Re-reads the latest on-disk state,
+   * folds concurrent touches, then (when `canMutate`) atomically rewrites the log.
+   *
+   * `canMutate` records that the cross-process lock was actually held. The
+   * re-merge + rewrite run only when it is true — a dry-run, or an unlocked apply
+   * (lock-acquisition timeout), computes records but does NOT rename, so it can
+   * never clobber a concurrent lock holder's window. `applied` mirrors `canMutate`.
+   */
+  private async finishRebuild(
+    rebuilt: Map<string, NamespaceRecord>,
+    skipped: NamespaceCatalogSkippedRoot[],
+    dryRun: boolean,
+    canMutate: boolean,
+    memoryReal: string | null,
+    nowIso: string,
+  ): Promise<NamespaceCatalogRebuildResult> {
     if (canMutate) {
       // CROSS-PROCESS re-merge (round 5, codex P2): under the rebuild lock,
       // re-read the on-disk log ONE more time and fold any touch fields that

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1466,7 +1466,15 @@ export class NamespaceCatalog {
         configured.has(token) ||
         (literalRecord !== undefined &&
           path.resolve(literalRecord.storageDir) === path.resolve(fullPath));
-      const decoded = literalOwnsRoot ? token : namespaceIdentityFromToken(token) ?? token;
+      // Match `storageFor()`'s canonical namespace identity. A raw root whose
+      // spelling trims to another namespace (for example `namespaces/shared `)
+      // is not a routeable live root and must not be catalogued from disk.
+      const rawDecoded = literalOwnsRoot ? token : namespaceIdentityFromToken(token) ?? token;
+      const decoded = normalizeNamespaceIdentity(rawDecoded);
+      if (decoded.length === 0 || rawDecoded !== decoded) {
+        skipped.push({ token, reason: "unsafe", detail: rawDecoded });
+        continue;
+      }
       if (decoded !== defaultNs && !isSafeRouteNamespace(decoded)) {
         skipped.push({ token, reason: "unsafe", detail: decoded });
         continue;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -285,9 +285,15 @@ function serializeRecord(record: NamespaceRecord): string {
  * `explicit` when no structural signal is present. The caller can override.
  */
 function inferKind(namespace: string, config: PluginConfig): NamespaceKind {
-  if (namespace === config.defaultNamespace) return "default";
-  if (namespace === config.sharedNamespace) return "shared";
-  if (config.namespacePolicies.some((p) => p.name === namespace)) return "explicit";
+  // Compare against NORMALIZED config names (NGnek, codex P2): the catalog seeds
+  // normalized namespace identities, so a configured name with surrounding
+  // whitespace (e.g. `sharedNamespace: "shared "`) must still classify the
+  // normalized `"shared"` as `shared`, not fall through to `explicit`.
+  if (namespace === normalizeNamespaceIdentity(config.defaultNamespace)) return "default";
+  if (namespace === normalizeNamespaceIdentity(config.sharedNamespace)) return "shared";
+  if (config.namespacePolicies.some((p) => normalizeNamespaceIdentity(p.name) === namespace)) {
+    return "explicit";
+  }
   // Branch overlays embed "-branch-" (project-<id>-branch-<name>).
   if (/-branch-|^project-[^-]+-branch-/.test(namespace) || namespace.includes("-branch-")) {
     return "branch";
@@ -1064,11 +1070,29 @@ export class NamespaceCatalog {
     }
 
     // 1) Configured namespaces always belong in the catalog.
-    const configured = new Set<string>([
-      this.config.defaultNamespace,
-      this.config.sharedNamespace,
-      ...this.config.namespacePolicies.map((p) => p.name),
-    ]);
+    //
+    // NORMALIZE FIRST (NGnek, codex P2): the live router normalizes every namespace
+    // via `normalizeNamespaceIdentity` (a trim) in `storageFor()` before resolving
+    // storage, and `isSafeRouteNamespace` also trims before validating. So a
+    // configured name with harmless surrounding whitespace (e.g.
+    // `sharedNamespace: "shared "` or a policy name copied with a trailing space)
+    // would otherwise seed a catalog row for the RAW string and resolve a
+    // `namespaces/shared ` root the live reads/writes never use — pointing
+    // maintenance/QMD at the wrong directory after `rebuild --apply`. We normalize
+    // configured names here so the catalog seeds the SAME identity the router uses
+    // (rule #42: read/write resolve through the same normalization). The default
+    // namespace is normalized too and compared via its normalized form (`defaultNs`)
+    // wherever a configured/scanned name is matched against it below.
+    const defaultNs = normalizeNamespaceIdentity(this.config.defaultNamespace);
+    const configured = new Set<string>(
+      [
+        this.config.defaultNamespace,
+        this.config.sharedNamespace,
+        ...this.config.namespacePolicies.map((p) => p.name),
+      ]
+        .map((n) => normalizeNamespaceIdentity(n))
+        .filter((n) => n.length > 0),
+    );
 
     // 2) Default-root alignment (Issue C — round 2): the catalog's default
     //    record MUST point at the SAME root the runtime router resolves, or
@@ -1098,7 +1122,7 @@ export class NamespaceCatalog {
       // that admits an unsafe configured namespace into the catalog. The default
       // namespace is exempt (it may be a non-route literal), matching the scan
       // loop's exemption below.
-      if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+      if (ns !== defaultNs && !isSafeRouteNamespace(ns)) {
         let token: string;
         try {
           token = namespaceIdentityToken(ns);
@@ -1117,7 +1141,7 @@ export class NamespaceCatalog {
       // maintenance/QMD aligned with live reads. Falls back to the lexical token
       // dir if router resolution fails.
       let storageDir: string;
-      if (ns === this.config.defaultNamespace) {
+      if (ns === defaultNs) {
         storageDir = defaultStorageDir;
       } else {
         try {
@@ -1138,7 +1162,7 @@ export class NamespaceCatalog {
       // "skipped" (it must always exist), so it falls back to the trusted
       // `memoryDir` root; a non-default namespace is skipped (escape).
       if (!(await this.isContainedStorageDir(storageDir))) {
-        if (ns === this.config.defaultNamespace) {
+        if (ns === defaultNs) {
           storageDir = this.memoryDir;
         } else {
           skipped.push({ token: namespaceIdentityToken(ns), reason: "escape", detail: storageDir });
@@ -1244,7 +1268,7 @@ export class NamespaceCatalog {
       // namespace and records it verbatim (NCQI0); the scanner cannot recover a
       // name the encoding cannot distinguish, so we keep the canonical decode.
       const decoded = configured.has(token) ? token : namespaceIdentityFromToken(token) ?? token;
-      if (decoded !== this.config.defaultNamespace && !isSafeRouteNamespace(decoded)) {
+      if (decoded !== defaultNs && !isSafeRouteNamespace(decoded)) {
         skipped.push({ token, reason: "unsafe", detail: decoded });
         continue;
       }
@@ -1256,8 +1280,8 @@ export class NamespaceCatalog {
       // default record's root is owned by `resolveDefaultNamespaceRoot` above,
       // which mirrors the router. We still keep the default record (set in
       // step 1) but skip clobbering its root here.
-      if (decoded === this.config.defaultNamespace) {
-        const def = rebuilt.get(this.config.defaultNamespace);
+      if (decoded === defaultNs) {
+        const def = rebuilt.get(defaultNs);
         if (def) {
           def.storageDir = defaultStorageDir;
           def.kind = "default";
@@ -1294,7 +1318,7 @@ export class NamespaceCatalog {
 
     // Mark legacy default root explicitly when applicable.
     if (legacyDefaultHasData && defaultStorageDir === this.memoryDir) {
-      const def = rebuilt.get(this.config.defaultNamespace);
+      const def = rebuilt.get(defaultNs);
       if (def) def.kind = "default";
     }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -4,6 +4,7 @@ import { appendFile, lstat, mkdir, readdir, readFile, realpath, rename, writeFil
 import type { PluginConfig } from "../types.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
 import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+import { resolveDefaultNamespaceRoot } from "./storage.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
 /**
@@ -443,7 +444,31 @@ export class NamespaceCatalog {
       return { dryRun, records: [], skipped: [] };
     }
 
-    // Preserve existing known metadata where safe (CLAUDE.md preservation req).
+    // CONCURRENCY (Issue A — round 2): the entire scan → merge → rewrite runs
+    // inside ONE serialized critical section on the shared write chain. This
+    // closes the round-1 residual risk where a hot-path markRead/markWrite/
+    // registerResolved append could land AFTER the snapshot but BEFORE the
+    // atomic rewrite and then be discarded by the rewrite. Because touches also
+    // run through `queueCritical`, no append can interleave between the load
+    // (which now reads the latest persisted state, including touches that
+    // landed before this section started) and the rewrite. A `--dry-run` still
+    // takes the section for a consistent read but performs no mutation.
+    //
+    // Deadlock note: the rewrite inside this section uses the unchained
+    // `rewriteUnchained` helper (mirroring `appendUnchained`) rather than a
+    // helper that re-enters `queueCritical` — re-entering the chain from inside
+    // a held turn would await the very entry this section holds.
+    return this.queueCritical(async () => this.rebuildInsideChain(dryRun));
+  }
+
+  /**
+   * Body of `rebuildFromDisk`, run inside a single `queueCritical` turn. MUST
+   * only be invoked from within the serialized chain so the load and the
+   * rewrite are atomic with respect to concurrent touches.
+   */
+  private async rebuildInsideChain(dryRun: boolean): Promise<NamespaceCatalogRebuildResult> {
+    // Read the LATEST persisted state inside the chain so any touch that landed
+    // before this turn is folded in (and re-merged into the rewrite below).
     const existing = await this.loadCompacted();
     const skipped: NamespaceCatalogSkippedRoot[] = [];
     const rebuilt = new Map<string, NamespaceRecord>();
@@ -463,16 +488,15 @@ export class NamespaceCatalog {
       ...this.config.namespacePolicies.map((p) => p.name),
     ]);
 
-    // 2) Legacy/default root compatibility: if facts live directly under
-    //    memoryDir (no tokenized default dir), the default root IS memoryDir.
-    const defaultToken = namespaceIdentityToken(this.config.defaultNamespace);
-    const defaultTokenDir = this.namespaceTokenDir(defaultToken);
-    const defaultTokenHasData = await hasMemoryData(defaultTokenDir);
-    const legacyDefaultHasData = await hasMemoryData(this.memoryDir);
-    const defaultStorageDir =
-      defaultTokenHasData && (await pathExists(defaultTokenDir))
-        ? defaultTokenDir
-        : this.memoryDir;
+    // 2) Default-root alignment (Issue C — round 2): the catalog's default
+    //    record MUST point at the SAME root the runtime router resolves, or
+    //    maintenance/QMD consumers would read a different default root than
+    //    live reads. We delegate to the shared `resolveDefaultNamespaceRoot`
+    //    (the very helper the router uses) instead of reimplementing divergent
+    //    "prefer tokenized dir if it has data" logic — while legacy data lives
+    //    directly under memoryDir, this returns memoryDir, matching runtime.
+    const defaultStorageDir = await resolveDefaultNamespaceRoot(this.config);
+    const legacyDefaultHasData = defaultStorageDir === this.memoryDir;
 
     for (const ns of configured) {
       if (!ns) continue;
@@ -536,6 +560,20 @@ export class NamespaceCatalog {
       // Only catalog roots that actually hold memory data (skip empty shells).
       if (!(await hasMemoryData(fullPath))) continue;
 
+      // Default-root alignment (Issue C): never let a tokenized default dir
+      // overwrite the configured default's storageDir with `fullPath`. The
+      // default record's root is owned by `resolveDefaultNamespaceRoot` above,
+      // which mirrors the router. We still keep the default record (set in
+      // step 1) but skip clobbering its root here.
+      if (decoded === this.config.defaultNamespace) {
+        const def = rebuilt.get(this.config.defaultNamespace);
+        if (def) {
+          def.storageDir = defaultStorageDir;
+          def.kind = "default";
+        }
+        continue;
+      }
+
       const prior = existing.get(decoded);
       rebuilt.set(
         decoded,
@@ -565,7 +603,7 @@ export class NamespaceCatalog {
     });
 
     if (!dryRun) {
-      await this.rewriteAtomic(records);
+      await this.rewriteUnchained(records);
     }
 
     return { dryRun, records, skipped };
@@ -649,19 +687,19 @@ export class NamespaceCatalog {
   }
 
   /**
-   * Atomically rewrite the compacted catalog (temp file + rename) so a failed
-   * write never leaves a truncated/lost catalog (CLAUDE.md rule #54: write
-   * temp, then rename — never delete-before-write). Serialized against touches
-   * via the shared write chain.
+   * Atomic temp-file + rename rewrite (CLAUDE.md rule #54: write temp, then
+   * rename — never delete-before-write) WITHOUT re-entering the write chain.
+   * MUST only be called from inside a `queueCritical(...)` turn (e.g. the
+   * rebuild critical section, which already holds the serialized turn so its
+   * load and rewrite are atomic against concurrent touches). Re-entering the
+   * chain from within a held turn would deadlock.
    */
-  private async rewriteAtomic(records: NamespaceRecord[]): Promise<void> {
+  private async rewriteUnchained(records: NamespaceRecord[]): Promise<void> {
     const body = records.map((r) => serializeRecord(r)).join("\n") + (records.length > 0 ? "\n" : "");
-    await this.queueCritical(async () => {
-      await mkdir(this.stateDir, { recursive: true });
-      const tmp = `${this.catalogPath}.${process.pid}.${Date.now()}.tmp`;
-      await writeFile(tmp, body, "utf8");
-      await rename(tmp, this.catalogPath);
-    });
+    await mkdir(this.stateDir, { recursive: true });
+    const tmp = `${this.catalogPath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tmp, body, "utf8");
+    await rename(tmp, this.catalogPath);
   }
 }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1369,7 +1369,19 @@ export class NamespaceCatalog {
       }
       const record = coerceRecord(parsed);
       if (!record) continue;
-      records.set(record.namespace, record);
+      // Field-level touch merge during compaction (round 6, codex P2 — ND6Cz).
+      // Touches run on PER-PROCESS write chains, so two processes (a gateway write
+      // racing a CLI/second-server read or maintenance touch) can each load the
+      // same prior record and append a full snapshot. Plain last-record-wins
+      // compaction would then discard the earlier snapshot's `lastReadAt` /
+      // `lastWriteAt` / `lastMaintenanceAt`, erasing a real touch and skewing
+      // `writtenSince`. We instead take the LATER record as the base (most recent
+      // identity/disk-derived state) and fold in the MAX of each touch field from
+      // both, so no cross-process touch recency is lost without locking the hot
+      // touch path. A destructive overwrite of real memory is never at stake here
+      // — only best-effort recency metadata.
+      const prior = records.get(record.namespace);
+      records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
     }
     return records;
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -11,6 +11,7 @@ import {
   rename,
   stat,
   unlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import type { PluginConfig } from "../types.js";
@@ -123,6 +124,11 @@ const REBUILD_LOCK_STALE_MS = 30_000;
 // a CLI rebuild forever behind a busy gateway.
 const REBUILD_LOCK_MAX_WAIT_MS = 5_000;
 const REBUILD_LOCK_POLL_MS = 50;
+// Heartbeat: while a rebuild holds the lock it refreshes the lock file's mtime
+// on this interval so a long (>STALE_MS) scan is NOT mistaken for a crashed
+// holder and broken out from under it (round 5, cursor/codex Medium/P2). Must be
+// comfortably below STALE_MS so at least a couple of beats land per stale window.
+const REBUILD_LOCK_HEARTBEAT_MS = 10_000;
 
 // Children that indicate a directory holds Remnic memory data (used for legacy
 // default-root detection and to skip empty/non-data roots during rebuild).
@@ -541,23 +547,52 @@ export class NamespaceCatalog {
    *
    * Containment (round 5, codex P2): the resolved path can still be a symlink
    * escaping memoryDir, so we run the full (lexical + realpath) containment
-   * contract and fall back to the trusted legacy `memoryDir` root — which is
-   * always contained — if it fails. The lexical `resolveStorageDir` is used as a
-   * last-resort guard for unsafe tokens that the router resolver would reject.
+   * contract. When it FAILS we fall back to a NAMESPACE-SPECIFIC safe root, NOT
+   * a blanket `memoryDir`. Recording `memoryDir` for a non-default namespace
+   * would point enumeration/maintenance at the DEFAULT namespace's tree (round 5,
+   * cursor/codex Medium/P2) — a cross-namespace fanout error. The correct safe
+   * root is the namespace's own lexical tokenized dir
+   * (`<memoryDir>/namespaces/<token>`), which is always contained and is that
+   * namespace's canonical location (we record the lexical PATH as metadata; we do
+   * not follow the escaping symlink). Only the default namespace — or a token so
+   * unsafe even the lexical dir cannot be built — falls back to `memoryDir`.
    */
   private async resolveSafeStorageDir(namespace: string): Promise<string> {
     let resolved: string;
     try {
       resolved = await resolveNamespaceStorageRoot(this.config, namespace);
     } catch {
-      try {
-        resolved = this.resolveStorageDir(namespace);
-      } catch {
-        // An unsafe namespace token would throw; fall back to the default root.
-        return this.memoryDir;
-      }
+      return this.safeFallbackStorageDir(namespace);
     }
     if (await this.isContainedStorageDir(resolved)) return resolved;
+    return this.safeFallbackStorageDir(namespace);
+  }
+
+  /**
+   * The namespace-specific contained fallback root, used when the router-resolved
+   * root fails containment (round 5, cursor/codex Medium/P2).
+   *
+   * Preference order:
+   *  1. The namespace's OWN lexical tokenized dir (`namespaces/<token>`) — so a
+   *     non-default namespace is NOT pointed at the DEFAULT namespace's `memoryDir`
+   *     tree (which would misdirect maintenance fanout). This is returned only
+   *     when the token dir itself stays contained (it is not a symlink escaping
+   *     memoryDir).
+   *  2. `memoryDir` as a LAST resort — for the default namespace, an unsafe token
+   *     that cannot build a contained path, OR the irreparable case where the
+   *     token dir IS a symlink escaping the root (so even its lexical path
+   *     resolves outside). Containment must win over tree-precision here: an
+   *     escaping path is strictly worse than the (contained) default root.
+   */
+  private async safeFallbackStorageDir(namespace: string): Promise<string> {
+    if (namespace === this.config.defaultNamespace) return this.memoryDir;
+    let tokenDir: string;
+    try {
+      tokenDir = this.namespaceTokenDir(namespaceIdentityToken(namespace));
+    } catch {
+      return this.memoryDir;
+    }
+    if (await this.isContainedStorageDir(tokenDir)) return tokenDir;
     return this.memoryDir;
   }
 
@@ -886,12 +921,30 @@ export class NamespaceCatalog {
    * `REBUILD_LOCK_MAX_WAIT_MS` of contention we proceed best-effort WITHOUT the
    * lock rather than block a rebuild forever (the in-chain re-merge still
    * recovers same-host appends). The lock is always released in `finally`.
+   *
+   * HEARTBEAT (round 5, cursor/codex Medium/P2): while WE hold the lock a timer
+   * refreshes its mtime every `REBUILD_LOCK_HEARTBEAT_MS`, so a legitimately long
+   * scan (> `REBUILD_LOCK_STALE_MS`) is not treated as a crashed holder and
+   * unlinked by another process/touch — which would let overlapping rewrites lose
+   * appends. Heartbeat failures are swallowed; the timer is always cleared in
+   * `finally`.
    */
   private async withRebuildLock<T>(fn: () => Promise<T>): Promise<T> {
     const acquired = await this.acquireRebuildLock();
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+    if (acquired) {
+      heartbeat = setInterval(() => {
+        const now = new Date();
+        // Refresh mtime so age-based stale detection sees an active holder.
+        utimes(this.rebuildLockPath, now, now).catch(() => undefined);
+      }, REBUILD_LOCK_HEARTBEAT_MS);
+      // Don't keep the event loop alive solely for the heartbeat.
+      heartbeat.unref?.();
+    }
     try {
       return await fn();
     } finally {
+      if (heartbeat) clearInterval(heartbeat);
       if (acquired) {
         try {
           await unlink(this.rebuildLockPath);

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -227,7 +227,7 @@ async function isLiveMemoryDataMarker(rootDir: string, child: string): Promise<b
   }
 }
 
-async function hasMemoryData(rootDir: string): Promise<boolean> {
+export async function hasMemoryData(rootDir: string): Promise<boolean> {
   for (const child of MEMORY_DATA_CHILDREN) {
     if (await isLiveMemoryDataMarker(rootDir, child)) return true;
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -927,15 +927,32 @@ export class NamespaceCatalog {
         skipped.push({ token, reason: "unsafe", detail: ns });
         continue;
       }
-      const storageDir = ns === this.config.defaultNamespace ? defaultStorageDir : this.namespaceTokenDir(namespaceIdentityToken(ns));
-      // CONTAINMENT (round 6, codex P2 — NCzT4): before seeding a configured
-      // non-default record with its token path, verify that path does not ESCAPE
-      // memoryDir. The scan below rejects escaping/symlinked roots, but this
-      // seeding runs FIRST, so without this check rebuild would persist an escaping
-      // `storageDir` for a configured namespace whose token dir was replaced by an
-      // out-of-root symlink. `isContainedStorageDir` enforces the full lexical +
-      // symlink + realpath contract and allows a not-yet-created path (a brand-new
-      // configured namespace still seeds its canonical token path).
+      // ROUTER ALIGNMENT (round 6, codex P2 — NDxiS): seed a configured
+      // non-default namespace with the SAME root the runtime router resolves, not
+      // a blanket tokenized dir. `resolveNamespaceStorageRoot` returns the legacy
+      // RAW root when it exists and only prefers the tokenized root when that has
+      // storage markers — so a configured namespace with an empty legacy raw root
+      // (e.g. `namespaces/shared`) is catalogued at the runtime path, keeping
+      // maintenance/QMD aligned with live reads. Falls back to the lexical token
+      // dir if router resolution fails.
+      let storageDir: string;
+      if (ns === this.config.defaultNamespace) {
+        storageDir = defaultStorageDir;
+      } else {
+        try {
+          storageDir = await resolveNamespaceStorageRoot(this.config, ns);
+        } catch {
+          storageDir = this.namespaceTokenDir(namespaceIdentityToken(ns));
+        }
+      }
+      // CONTAINMENT (round 6, codex P2 — NCzT4): verify the seeded path does not
+      // ESCAPE memoryDir before recording it. The scan below rejects
+      // escaping/symlinked roots, but this seeding runs FIRST, so without this
+      // check rebuild would persist an escaping `storageDir` for a configured
+      // namespace whose root is a symlink out of memoryDir. `isContainedStorageDir`
+      // enforces the full lexical + symlink + realpath contract and allows a
+      // not-yet-created path (a brand-new configured namespace seeds its canonical
+      // root).
       if (ns !== this.config.defaultNamespace && !(await this.isContainedStorageDir(storageDir))) {
         skipped.push({ token: namespaceIdentityToken(ns), reason: "escape", detail: storageDir });
         continue;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -350,11 +350,22 @@ export class NamespaceCatalog {
   // production.
   protected onBeforeBreakStaleUnlinkForTest?: () => Promise<void>;
 
+  // Normalized (trimmed) default namespace identity (NH-FH, cursor Medium).
+  // Catalog records key namespaces by their NORMALIZED identity
+  // (`normalizeNamespaceIdentity`), but several default-namespace exemptions and
+  // memoryDir-ownership checks compared against the RAW `config.defaultNamespace`.
+  // If the configured default name carries surrounding whitespace the record key
+  // is trimmed while the comparison string is not, so the default row is
+  // misclassified, dropped at read time, or given the wrong storage root. Compare
+  // against this normalized form everywhere instead.
+  private readonly defaultNamespaceIdentity: string;
+
   constructor(private readonly config: PluginConfig) {
     this.memoryDir = config.memoryDir;
     this.stateDir = path.join(this.memoryDir, STATE_DIR);
     this.catalogPath = path.join(this.stateDir, CATALOG_FILE);
     this.rebuildLockPath = path.join(this.stateDir, REBUILD_LOCK_FILE);
+    this.defaultNamespaceIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
   }
 
   /** Whether the catalog is active (namespaces enabled and catalog not opted out). */
@@ -387,8 +398,10 @@ export class NamespaceCatalog {
    *     for that namespace (rule 42: read and write stay symmetric).
    */
   private async sanitizeRecordForRead(record: NamespaceRecord): Promise<NamespaceRecord | null> {
-    // Defense 1: drop an unsafe non-default namespace name entirely.
-    if (record.namespace !== this.config.defaultNamespace && !isSafeRouteNamespace(record.namespace)) {
+    // Defense 1: drop an unsafe non-default namespace name entirely. Compare
+    // against the NORMALIZED default identity — record keys are trimmed, so a raw
+    // whitespace-padded config default would never match the default row (NH-FH).
+    if (record.namespace !== this.defaultNamespaceIdentity && !isSafeRouteNamespace(record.namespace)) {
       return null;
     }
     // Defense 2: keep the record but substitute a safe storageDir when needed.
@@ -473,7 +486,11 @@ export class NamespaceCatalog {
       // this guard one bad name would abort registration of all the rest. The
       // default namespace is exempt (it may be a non-route literal). Each call is
       // also wrapped so a single failure never blocks the remaining names.
-      if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) continue;
+      // `names` carries RAW config values, so normalize before the default-exempt
+      // check — a whitespace-padded default must still be recognized (NH-FH).
+      if (normalizeNamespaceIdentity(ns) !== this.defaultNamespaceIdentity && !isSafeRouteNamespace(ns)) {
+        continue;
+      }
       try {
         await this.register(ns, { discoveredBy: "config" });
       } catch {
@@ -511,7 +528,7 @@ export class NamespaceCatalog {
     // The configured default namespace is exempt from isSafeRouteNamespace at
     // the routing layer; honor the same exemption here, but everything still
     // resolves through the contained storage-dir helper below.
-    if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+    if (ns !== this.defaultNamespaceIdentity && !isSafeRouteNamespace(ns)) {
       throw new Error(`unsafe namespace: ${ns}`);
     }
     return ns;
@@ -524,7 +541,7 @@ export class NamespaceCatalog {
    * by rejecting separators/parent-refs in the token.
    */
   private resolveStorageDir(namespace: string): string {
-    if (namespace === this.config.defaultNamespace) {
+    if (normalizeNamespaceIdentity(namespace) === this.defaultNamespaceIdentity) {
       // Default may resolve to the legacy memoryDir root OR a tokenized dir; we
       // report memoryDir here as the canonical default root for the catalog.
       // rebuildFromDisk refines this when a tokenized default dir holds data.
@@ -735,7 +752,7 @@ export class NamespaceCatalog {
       // Router resolution failed; rely on the lexical/default roots below.
     }
     // memoryDir is a valid root ONLY for the default namespace.
-    if (namespace === this.config.defaultNamespace) {
+    if (normalizeNamespaceIdentity(namespace) === this.defaultNamespaceIdentity) {
       valid.add(path.resolve(this.memoryDir));
       try {
         valid.add(path.resolve(await resolveDefaultNamespaceRoot(this.config)));
@@ -807,7 +824,7 @@ export class NamespaceCatalog {
    *     namespace never reaches `memoryDir`.
    */
   private async safeFallbackStorageDir(namespace: string): Promise<string> {
-    if (namespace === this.config.defaultNamespace) return this.memoryDir;
+    if (normalizeNamespaceIdentity(namespace) === this.defaultNamespaceIdentity) return this.memoryDir;
     let tokenDir: string;
     try {
       tokenDir = this.namespaceTokenDir(namespaceIdentityToken(namespace));
@@ -867,7 +884,7 @@ export class NamespaceCatalog {
     // attest its liveness — so if a non-default namespace resolved to `memoryDir`,
     // it has no independent contained root and must be treated as absent (purge).
     if (
-      namespace !== this.config.defaultNamespace &&
+      normalizeNamespaceIdentity(namespace) !== this.defaultNamespaceIdentity &&
       path.resolve(root) === path.resolve(this.memoryDir)
     ) {
       return false;
@@ -1452,7 +1469,7 @@ export class NamespaceCatalog {
           // enumerate an unsafe namespace after a rebuild that appeared to skip it.
           // Apply the SAME default-exempt safety gate before the live-root recheck;
           // an unsafe row is dropped (fall through to purge), never kept.
-          if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+          if (ns !== this.defaultNamespaceIdentity && !isSafeRouteNamespace(ns)) {
             continue;
           }
           if (await this.liveStorageRootExistsForRebuild(ns, memoryReal)) {

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1374,8 +1374,20 @@ export class NamespaceCatalog {
       // — and DO NOT also emit the decoded alias for that same root. A genuine
       // tokenized dir with no literal owner (no `existing` row keyed by the raw
       // token) still decodes as before.
-      const literalIsKnown = configured.has(token) || existing.has(token);
-      const decoded = literalIsKnown ? token : namespaceIdentityFromToken(token) ?? token;
+      // Root ownership (codex r3499938974): preserving the literal must be
+      // ROOT-based, not just key-based. A STALE cataloged row merely NAMED like
+      // the token (but whose storageDir is NOT this `fullPath`) must NOT win — a
+      // real dynamic `alpha` write served from this tokenized root would then be
+      // rebuilt under the stale literal name and the fresh `alpha` row dropped by
+      // the owned-by-other guard. So only prefer the literal when a CONFIGURED
+      // name matches OR an existing cataloged row named `token` actually OWNS this
+      // `fullPath`. A genuine tokenized root with no literal owner decodes.
+      const literalRecord = existing.get(token);
+      const literalOwnsRoot =
+        configured.has(token) ||
+        (literalRecord !== undefined &&
+          path.resolve(literalRecord.storageDir) === path.resolve(fullPath));
+      const decoded = literalOwnsRoot ? token : namespaceIdentityFromToken(token) ?? token;
       if (decoded !== defaultNs && !isSafeRouteNamespace(decoded)) {
         skipped.push({ token, reason: "unsafe", detail: decoded });
         continue;

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -746,6 +746,67 @@ export class NamespaceCatalog {
   }
 
   /**
+   * Re-check, NOW, whether a namespace's storage root currently EXISTS on disk
+   * with the SAME safety the directory scan uses (NFJV8, codex P2).
+   *
+   * The rebuild's final re-merge runs under the held lock and folds the freshly
+   * re-read log (`latest`) into the scanned `rebuilt` set. A namespace present in
+   * `latest` (a live touch row) but ABSENT from `rebuilt` is normally PURGED as
+   * deleted (the NATqU "disk scan is authoritative" rule). But there is a TOCTOU
+   * window: a dynamic namespace can be CREATED on disk AFTER `rebuildFromDisk()`
+   * already enumerated `namespaces/` but BEFORE this re-merge. The scan snapshot
+   * missed its new root, yet a gateway `markWrite` already appended a row for it.
+   * Blindly purging that row would rewrite the catalog WITHOUT a live namespace
+   * that now has data on disk, so `writtenSince`/maintenance/QMD consumers miss
+   * it until another touch or rebuild.
+   *
+   * So before purging, we re-resolve the namespace's safe storage root (the same
+   * router-aligned, containment-checked path the scan would have catalogued) and
+   * confirm it is a real, contained, non-symlink directory that actually holds
+   * memory data RIGHT NOW. If so the namespace was created-after-scan and is LIVE
+   * — KEEP its row. This is the precise inverse of NATqU and does NOT reintroduce
+   * it: a touch on a REMOVED root re-checks as ABSENT (no data on disk) and is
+   * still purged; only a root that EXISTS on a fresh re-check is kept.
+   *
+   * Mirrors the per-entry scan checks (symlink rejection + realpath containment +
+   * `hasMemoryData`) so a symlinked/escaping root is never resurrected.
+   */
+  private async liveStorageRootExistsForRebuild(
+    namespace: string,
+    memoryReal: string | null,
+  ): Promise<boolean> {
+    let root: string;
+    try {
+      // Use the SAME router-aligned, containment-enforcing resolver the catalog
+      // uses everywhere else. It never returns an escaping path (falls back to a
+      // namespace-specific contained root on containment failure).
+      root = await this.resolveSafeStorageDir(namespace);
+    } catch {
+      return false;
+    }
+    let stat;
+    try {
+      stat = await lstat(root);
+    } catch {
+      // Root does not exist on disk → genuinely absent → allow the purge.
+      return false;
+    }
+    // Reject a symlinked root rather than resurrecting it (scan parity).
+    if (stat.isSymbolicLink()) return false;
+    if (!stat.isDirectory()) return false;
+    // Realpath must stay inside the memory root (scan parity).
+    try {
+      const real = await realpath(root);
+      if (memoryReal && !isPathInside(memoryReal, real)) return false;
+    } catch {
+      return false;
+    }
+    // Only treat the root as a live namespace when it actually holds memory data,
+    // exactly as the scan does (empty shells are not catalogued).
+    return hasMemoryData(root);
+  }
+
+  /**
    * Record a namespace touch. Returns whether the touch actually APPENDED to the
    * log (round 6, codex P2 — NEFoX): a disabled catalog or a dropped append (the
    * NAUf7 rebuild-lock-timeout drop) returns `false`, so callers (e.g. the router
@@ -1209,9 +1270,37 @@ export class NamespaceCatalog {
           // best-effort `markRead`/`markWrite` touched it after our snapshot. A
           // touch on a dynamic namespace whose on-disk root was removed only
           // bumps a timestamp; re-inserting that row (with its stale `storageDir`)
-          // would defeat the purge the rebuild is meant to perform. Losing a touch
-          // timestamp for a deleted root is acceptable (the catalog is rebuildable
-          // best-effort metadata); resurrecting a purged record is not. Drop it.
+          // would defeat the purge the rebuild is meant to perform.
+          //
+          // CREATED-AFTER-SCAN RE-CHECK (NFJV8, codex P2): there is a TOCTOU
+          // window where a dynamic namespace is CREATED on disk AFTER the scan
+          // enumerated `namespaces/` but BEFORE this re-merge. Its new root was
+          // missed by the snapshot, yet a gateway `markWrite` already landed a row
+          // in `latest`. Purging that row would drop a LIVE namespace that now has
+          // data on disk. So before purging, re-check the namespace's storage root
+          // RIGHT NOW (with the same symlink/realpath/containment + memory-data
+          // safety the scan uses). If it currently EXISTS with data, the namespace
+          // was created-after-scan and is live — KEEP its row. This is the precise
+          // inverse of NATqU, not a regression of it: a touch on a REMOVED root
+          // re-checks as absent and is still purged below; only a root that EXISTS
+          // on a fresh re-check is kept.
+          if (await this.liveStorageRootExistsForRebuild(ns, memoryReal)) {
+            // Created-after-scan: keep the live row. Re-resolve its storageDir to
+            // the safe (router-aligned, contained) root so we never persist a
+            // touch's stale/escaping `storageDir`.
+            const safeDir = await this.resolveSafeStorageDir(ns);
+            rebuilt.set(ns, {
+              ...fresh,
+              storageDir: safeDir,
+              identityToken: namespaceIdentityToken(ns),
+              kind: fresh.kind ?? inferKind(ns, this.config),
+              createdAt: fresh.createdAt ?? nowIso,
+            });
+            continue;
+          }
+          // Confirmed absent on disk. Losing a touch timestamp for a deleted root
+          // is acceptable (the catalog is rebuildable best-effort metadata);
+          // resurrecting a purged record is not. Drop it.
           continue;
         }
         // SURVIVING namespace (still present in the authoritative disk scan):

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1527,6 +1527,22 @@ export class NamespaceCatalog {
             // the safe (router-aligned, contained) root so we never persist a
             // touch's stale/escaping `storageDir`.
             const safeDir = await this.resolveSafeStorageDir(ns);
+            // DUAL-ROOT GUARD (codex NR-td): if another rebuilt row already OWNS
+            // this exact storageDir (e.g. the decoded/configured owner of a
+            // token-shaped root that the disk scan resolved), do NOT also resurrect
+            // this stale alias from the untrusted log — that leaves TWO catalog rows
+            // pointing at one root and fans maintenance/QMD out over the wrong
+            // namespace. Enforce at most one row per storageDir: the scan's owner
+            // wins, the alias is dropped (falls through to purge).
+            const resolvedSafe = path.resolve(safeDir);
+            let ownedByOther = false;
+            for (const [otherNs, otherRec] of rebuilt) {
+              if (otherNs !== ns && path.resolve(otherRec.storageDir) === resolvedSafe) {
+                ownedByOther = true;
+                break;
+              }
+            }
+            if (ownedByOther) continue;
             rebuilt.set(ns, {
               ...fresh,
               storageDir: safeDir,

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -191,47 +191,81 @@ function isCatalogEnabled(config: PluginConfig): boolean {
 // a non-directory. `profile.md` is the sole file marker.
 const FILE_MEMORY_DATA_CHILDREN = new Set<string>(["profile.md"]);
 
+type MemoryDataMarkerStatus =
+  | { state: "absent" }
+  | { state: "valid" }
+  | { state: "invalid"; detail: string };
+
+type MemoryDataRootStatus = {
+  hasData: boolean;
+  invalidMarker?: string;
+};
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "ENOENT"
+  );
+}
+
 /**
- * Whether `child` under `rootDir` is a VALID, live memory-data marker (NIw0F,
- * codex P2). Existence alone is not enough: a bogus marker — e.g. `facts` as a
- * symlink or a regular file instead of a real directory — passes `lstat` but
- * makes `scanMemoryDir` throw on the symlinked/non-directory category root, so a
- * `rebuild --apply` that cataloged the namespace would then make catalog-driven
- * QMD maintenance fail repeatedly on a root with no usable data. Validate the
- * child's TYPE (and, for directories, that its realpath stays inside the root, so
- * a symlink escaping the memory tree is never treated as live).
+ * Inspect `child` under `rootDir` as a memory-data marker (NIw0F / PR #1506).
+ * Existence alone is not enough: a bogus marker — e.g. `facts` as a symlink or a
+ * regular file instead of a real directory — passes `lstat` but makes
+ * `scanMemoryDir` throw on the symlinked/non-directory category root. Returning
+ * a distinct `invalid` status lets root scans reject a namespace when ANY known
+ * marker is malformed, even if a sibling marker such as `state/` is valid.
  */
-async function isLiveMemoryDataMarker(rootDir: string, child: string): Promise<boolean> {
+async function inspectMemoryDataMarker(rootDir: string, child: string): Promise<MemoryDataMarkerStatus> {
   const childPath = path.join(rootDir, child);
   let entry;
   try {
     entry = await lstat(childPath);
-  } catch {
-    return false;
+  } catch (err) {
+    return isNotFoundError(err)
+      ? { state: "absent" }
+      : { state: "invalid", detail: `${child}: ${err instanceof Error ? err.message : String(err)}` };
   }
   // Reject symlinked markers outright (scan parity — never follow them).
-  if (entry.isSymbolicLink()) return false;
+  if (entry.isSymbolicLink()) return { state: "invalid", detail: `${child}: symlink` };
   if (FILE_MEMORY_DATA_CHILDREN.has(child)) {
     // `profile.md` must be a regular file.
-    return entry.isFile();
+    return entry.isFile()
+      ? { state: "valid" }
+      : { state: "invalid", detail: `${child}: expected file` };
   }
   // Category/data markers must be real directories whose realpath stays inside
   // the namespace root (no escape via a symlinked ancestor).
-  if (!entry.isDirectory()) return false;
+  if (!entry.isDirectory()) return { state: "invalid", detail: `${child}: expected directory` };
   try {
     const rootReal = await realpath(rootDir);
     const childReal = await realpath(childPath);
-    return isPathInside(rootReal, childReal);
-  } catch {
-    return false;
+    return isPathInside(rootReal, childReal)
+      ? { state: "valid" }
+      : { state: "invalid", detail: `${child}: escapes namespace root` };
+  } catch (err) {
+    return { state: "invalid", detail: `${child}: ${err instanceof Error ? err.message : String(err)}` };
   }
 }
 
-export async function hasMemoryData(rootDir: string): Promise<boolean> {
+async function inspectMemoryDataRoot(rootDir: string): Promise<MemoryDataRootStatus> {
+  let hasData = false;
   for (const child of MEMORY_DATA_CHILDREN) {
-    if (await isLiveMemoryDataMarker(rootDir, child)) return true;
+    const marker = await inspectMemoryDataMarker(rootDir, child);
+    if (marker.state === "invalid") {
+      return { hasData: false, invalidMarker: marker.detail };
+    }
+    if (marker.state === "valid") {
+      hasData = true;
+    }
   }
-  return false;
+  return { hasData };
+}
+
+export async function hasMemoryData(rootDir: string): Promise<boolean> {
+  return (await inspectMemoryDataRoot(rootDir)).hasData;
 }
 
 function isValidIsoTimestamp(value: string): boolean {
@@ -1553,7 +1587,20 @@ export class NamespaceCatalog {
         continue;
       }
       // Only catalog roots that actually hold memory data (skip empty shells).
-      if (!(await hasMemoryData(fullPath))) continue;
+      // A malformed PRESENT marker is different from an absent marker: if
+      // `facts/` is a file/symlink but `state/` is valid, cataloging the root
+      // would later make catalog-driven QMD scan the bad category directory and
+      // throw. Reject the whole root on the first malformed known marker.
+      const memoryData = await inspectMemoryDataRoot(fullPath);
+      if (memoryData.invalidMarker) {
+        skipped.push({
+          token,
+          reason: "unsafe",
+          detail: `invalid memory marker: ${memoryData.invalidMarker}`,
+        });
+        continue;
+      }
+      if (!memoryData.hasData) continue;
 
       // Default-root alignment (Issue C): never let a tokenized default dir
       // overwrite the configured default's storageDir with `fullPath`. The

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -352,19 +352,33 @@ export class NamespaceCatalog {
   // ── Public enumeration API ──────────────────────────────────────────────
 
   /**
-   * Sanitize a record's `storageDir` at the enumeration boundary (round 5,
-   * cursor Medium + codex P2; round 6 — NDXHe). Reads return whatever is in
-   * `namespaces.jsonl` after schema checks only, so a tampered or pre-fix
-   * out-of-root path — whether a lexical escape, a lexically-contained SYMLINK
-   * escaping via realpath, OR a contained-but-CROSS-NAMESPACE root (another
-   * namespace's tree / memoryDir for a non-default namespace) — could be surfaced
-   * to maintenance/QMD until a rewrite occurs. We apply the SAME contract as the
-   * write path: full containment (`isContainedStorageDir`: lexical +
-   * symlink/realpath) AND namespace ownership (`isStorageDirForNamespace`). When a
-   * record fails EITHER check we substitute the trusted resolved-and-safe root for
-   * that namespace before returning it (rule 42: read and write stay symmetric).
+   * Sanitize a record at the enumeration boundary (round 5, cursor Medium + codex
+   * P2; round 6 — NDXHe). Reads return whatever is in `namespaces.jsonl` after
+   * schema checks only, so a tampered or pre-fix row could surface unsafe data to
+   * maintenance/QMD until a rewrite occurs. Two distinct defenses:
+   *
+   *  1. UNSAFE NAMESPACE NAME (NGZqr, codex P2): an unsafe non-default namespace
+   *     (e.g. `../evil`, a name with separators, or >64 chars) is REJECTED outright
+   *     — return `null` so the caller drops it. The disk SCAN and the hot touch
+   *     path both reject such names with the SAME default-exempt `isSafeRouteNamespace`
+   *     gate, so the read boundary MUST agree, or `listNamespaces()`/`getNamespaceRecord()`
+   *     would expose a namespace those paths reject (note `isStorageDirForNamespace`
+   *     can still build a tokenized root even for `../evil`, so storageDir sanitation
+   *     alone does not catch it). The default namespace is exempt (it may be a
+   *     non-route literal), matching every other validation site.
+   *
+   *  2. UNSAFE storageDir: for an otherwise-valid namespace, apply the SAME contract
+   *     as the write path — full containment (`isContainedStorageDir`: lexical +
+   *     symlink/realpath) AND namespace ownership (`isStorageDirForNamespace`). When
+   *     a record fails EITHER check we substitute the trusted resolved-and-safe root
+   *     for that namespace (rule 42: read and write stay symmetric).
    */
-  private async sanitizeRecordForRead(record: NamespaceRecord): Promise<NamespaceRecord> {
+  private async sanitizeRecordForRead(record: NamespaceRecord): Promise<NamespaceRecord | null> {
+    // Defense 1: drop an unsafe non-default namespace name entirely.
+    if (record.namespace !== this.config.defaultNamespace && !isSafeRouteNamespace(record.namespace)) {
+      return null;
+    }
+    // Defense 2: keep the record but substitute a safe storageDir when needed.
     if (
       (await this.isContainedStorageDir(record.storageDir)) &&
       (await this.isStorageDirForNamespace(record.namespace, record.storageDir))
@@ -378,7 +392,11 @@ export class NamespaceCatalog {
   async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
     if (!this.enabled) return [];
     const records = await this.loadCompacted();
-    let out = await Promise.all([...records.values()].map((r) => this.sanitizeRecordForRead(r)));
+    const sanitized = await Promise.all(
+      [...records.values()].map((r) => this.sanitizeRecordForRead(r)),
+    );
+    // Drop unsafe-namespace rows (sanitizer returned null) at the read boundary.
+    let out = sanitized.filter((r): r is NamespaceRecord => r !== null);
     if (filter?.kind) out = out.filter((r) => r.kind === filter.kind);
     if (filter?.discoveredBy) out = out.filter((r) => r.discoveredBy === filter.discoveredBy);
     if (filter?.writtenSince) {

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -824,6 +824,18 @@ export class NamespaceCatalog {
         continue;
       }
       const storageDir = ns === this.config.defaultNamespace ? defaultStorageDir : this.namespaceTokenDir(namespaceIdentityToken(ns));
+      // CONTAINMENT (round 6, codex P2 — NCzT4): before seeding a configured
+      // non-default record with its token path, verify that path does not ESCAPE
+      // memoryDir. The scan below rejects escaping/symlinked roots, but this
+      // seeding runs FIRST, so without this check rebuild would persist an escaping
+      // `storageDir` for a configured namespace whose token dir was replaced by an
+      // out-of-root symlink. `isContainedStorageDir` enforces the full lexical +
+      // symlink + realpath contract and allows a not-yet-created path (a brand-new
+      // configured namespace still seeds its canonical token path).
+      if (ns !== this.config.defaultNamespace && !(await this.isContainedStorageDir(storageDir))) {
+        skipped.push({ token: namespaceIdentityToken(ns), reason: "escape", detail: storageDir });
+        continue;
+      }
       rebuilt.set(
         ns,
         this.mergeForRebuild(existing.get(ns), {
@@ -1034,7 +1046,15 @@ export class NamespaceCatalog {
       if (heartbeat) clearInterval(heartbeat);
       if (acquired) {
         try {
-          await unlink(this.rebuildLockPath);
+          // Release ONLY the lock still owned by THIS instance (round 6, codex
+          // P2 — NCzT6). If this rebuild paused long enough that another process
+          // treated our lock as stale, unlinked it, and acquired a REPLACEMENT,
+          // an unconditional unlink here would delete that other holder's active
+          // lock — letting writers/another rebuild proceed during its load/rename
+          // window and recreating the lost-append race. Verify ownership first.
+          if (await this.rebuildLockHeldBySelf()) {
+            await unlink(this.rebuildLockPath);
+          }
         } catch {
           // Best-effort release; a stale lock will be broken on next rebuild.
         }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -617,6 +617,14 @@ export class NamespaceCatalog {
    * on disk and verify its realpath stays inside `memoryReal` (round 6, codex P2
    * — NDo79). Rejects a non-existent leaf whose existing parent chain escapes
    * memoryDir via a symlink. Stops at memoryDir's resolved root.
+   *
+   * The nearest existing ancestor must also be a DIRECTORY (NHIdt, codex P2): if
+   * an existing parent such as `<memoryDir>/namespaces` is a regular FILE (or
+   * socket/fifo), `realpath(parent)` still succeeds and resolves inside memoryDir,
+   * so a containment-only check would ACCEPT a leaf that can never be created — you
+   * cannot mkdir a child under a file. We `lstat` the nearest existing ancestor and
+   * reject when it is not a directory, mirroring the leaf non-directory rejection
+   * (NF21i) and the disk scan, so every containment consumer agrees.
    */
   private async isNearestExistingAncestorContained(
     candidate: string,
@@ -628,13 +636,24 @@ export class NamespaceCatalog {
       const parent = path.dirname(dir);
       // Reached the filesystem root without finding an existing ancestor.
       if (parent === dir || dir === root) return false;
+      let real: string;
       try {
-        const real = await realpath(parent);
-        // The nearest existing ancestor must resolve inside the memory root.
-        return isPathInside(memoryReal, real) || real === memoryReal;
+        real = await realpath(parent);
       } catch {
         // Parent does not exist yet either — keep walking up.
         dir = parent;
+        continue;
+      }
+      // The nearest EXISTING ancestor must resolve inside the memory root...
+      if (!(isPathInside(memoryReal, real) || real === memoryReal)) return false;
+      // ...AND be a directory: a non-directory ancestor (e.g. a file occupying
+      // `namespaces`) cannot hold the not-yet-created leaf (NHIdt).
+      try {
+        const stat = await lstat(real);
+        return stat.isDirectory();
+      } catch {
+        // The ancestor vanished between realpath and lstat — treat as not usable.
+        return false;
       }
     }
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -434,20 +434,25 @@ export class NamespaceCatalog {
 
   /**
    * Register a namespace whose storage was just resolved by the router. Used as
-   * a fire-and-forget integration hook (`discoveredBy: config`). Storage dir is
-   * provided so we do not re-resolve it. Failure-tolerant.
+   * the router's integration hook (`discoveredBy: config`). Storage dir is
+   * provided so we do not re-resolve it. Failure-tolerant. Returns whether the
+   * registration actually APPENDED (round 6, codex P2 — NEFoX), so the router's
+   * resolve-hook dedup only marks a namespace notified when it truly persisted —
+   * a dropped append (disabled catalog or rebuild-lock-timeout drop) returns
+   * `false` and is retried on the next resolve.
    */
-  async registerResolved(namespace: string, storageDir: string): Promise<void> {
-    if (!this.enabled) return;
-    await this.register(namespace, { discoveredBy: "config", storageDir });
+  async registerResolved(namespace: string, storageDir: string): Promise<boolean> {
+    if (!this.enabled) return false;
+    return this.register(namespace, { discoveredBy: "config", storageDir });
   }
 
   /**
    * Generic register/touch without changing read/write timestamps unless the
    * source implies it. Validates the namespace and resolves a storage dir.
+   * Returns whether the touch actually appended.
    */
-  private async register(namespace: string, metadata: NamespaceTouchMetadata): Promise<void> {
-    await this.touch(namespace, "register", metadata);
+  private async register(namespace: string, metadata: NamespaceTouchMetadata): Promise<boolean> {
+    return this.touch(namespace, "register", metadata);
   }
 
   private validateNamespace(namespace: string): string {
@@ -727,13 +732,20 @@ export class NamespaceCatalog {
     return this.memoryDir;
   }
 
+  /**
+   * Record a namespace touch. Returns whether the touch actually APPENDED to the
+   * log (round 6, codex P2 — NEFoX): a disabled catalog or a dropped append (the
+   * NAUf7 rebuild-lock-timeout drop) returns `false`, so callers (e.g. the router
+   * resolve-hook dedup) can avoid marking a dropped registration as completed and
+   * suppressing its retry.
+   */
   private async touch(
     namespace: string,
     kind: "read" | "write" | "maintenance" | "register",
     metadata?: NamespaceTouchMetadata,
     jobName?: string,
-  ): Promise<void> {
-    if (!this.enabled) return;
+  ): Promise<boolean> {
+    if (!this.enabled) return false;
     // Validate up front (outside the chain) so caller-facing rejections — e.g.
     // an unsafe namespace token — surface immediately and deterministically,
     // not interleaved with serialized I/O.
@@ -746,7 +758,7 @@ export class NamespaceCatalog {
     // the earlier touch's fields (CLAUDE.md rule #40 — the chain also recovers
     // from rejection). Reading inside the chain guarantees each touch sees the
     // most recent appended state, including any concurrent read/write/register.
-    await this.queueCritical(async () => {
+    return this.queueCritical(async () => {
       // Cross-process serialization (round 4 + round 6, codex P2): a CLI
       // `rebuild --apply` holds the rebuild lock across its final
       // `loadCompacted()` → atomic `rename`. An append that lands inside that
@@ -759,7 +771,7 @@ export class NamespaceCatalog {
       // catalog is rebuildable best-effort metadata, so skipping one touch is
       // acceptable; it NEVER blocks forever or crashes the primary memory op.
       const safeToAppend = await this.waitForRebuildLockClear();
-      if (!safeToAppend) return;
+      if (!safeToAppend) return false;
 
       const records = await this.loadCompacted();
       const existing = records.get(ns);
@@ -821,6 +833,7 @@ export class NamespaceCatalog {
       }
 
       await this.appendUnchained(record);
+      return true;
     });
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -334,16 +334,24 @@ export class NamespaceCatalog {
 
   /**
    * Sanitize a record's `storageDir` at the enumeration boundary (round 5,
-   * cursor Medium + codex P2). Reads return whatever is in `namespaces.jsonl`
-   * after schema checks only, so a tampered or pre-fix out-of-root path — whether
-   * a lexical escape OR a lexically-contained SYMLINK escaping via realpath —
-   * could be surfaced to maintenance/QMD until a rewrite occurs. We apply the
-   * SAME full containment contract used on the write path (`isContainedStorageDir`:
-   * lexical + symlink/realpath) and, when a record fails it, substitute the
-   * trusted resolved-and-safe root for that namespace before returning it.
+   * cursor Medium + codex P2; round 6 — NDXHe). Reads return whatever is in
+   * `namespaces.jsonl` after schema checks only, so a tampered or pre-fix
+   * out-of-root path — whether a lexical escape, a lexically-contained SYMLINK
+   * escaping via realpath, OR a contained-but-CROSS-NAMESPACE root (another
+   * namespace's tree / memoryDir for a non-default namespace) — could be surfaced
+   * to maintenance/QMD until a rewrite occurs. We apply the SAME contract as the
+   * write path: full containment (`isContainedStorageDir`: lexical +
+   * symlink/realpath) AND namespace ownership (`isStorageDirForNamespace`). When a
+   * record fails EITHER check we substitute the trusted resolved-and-safe root for
+   * that namespace before returning it (rule 42: read and write stay symmetric).
    */
   private async sanitizeRecordForRead(record: NamespaceRecord): Promise<NamespaceRecord> {
-    if (await this.isContainedStorageDir(record.storageDir)) return record;
+    if (
+      (await this.isContainedStorageDir(record.storageDir)) &&
+      (await this.isStorageDirForNamespace(record.namespace, record.storageDir))
+    ) {
+      return record;
+    }
     const safe = await this.resolveSafeStorageDir(record.namespace);
     return { ...record, storageDir: safe };
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -1051,10 +1051,38 @@ export class NamespaceCatalog {
     // 3) Scan the namespaces/ directory for tokenized roots.
     const namespacesDir = path.join(this.memoryDir, "namespaces");
     let entries: Dirent[] = [];
+    // CONTAINMENT (round 8, codex P2 — NE9K_): check the `namespaces` ROOT itself
+    // BEFORE `readdir` follows it. If `<memoryDir>/namespaces` is a symlink (or its
+    // realpath escapes memoryDir), `readdir()` would enumerate an arbitrary outside
+    // tree — leaking names or spending time on a huge directory — even though the
+    // catalog rejects symlinked/escaping per-entry roots. The per-entry lstat/realpath
+    // checks below run AFTER the readdir, so they cannot prevent following an
+    // escaping ROOT. We lstat the root: if it is a symlink, OR its realpath escapes
+    // memoryDir, we DO NOT read it and report it as a single unsafe scan root.
+    let namespacesDirSafe = true;
     try {
-      entries = await readdir(namespacesDir, { withFileTypes: true });
+      const rootStat = await lstat(namespacesDir);
+      if (rootStat.isSymbolicLink()) {
+        namespacesDirSafe = false;
+      } else {
+        const realNamespacesDir = await realpath(namespacesDir);
+        if (memoryReal && !isPathInside(memoryReal, realNamespacesDir)) {
+          namespacesDirSafe = false;
+        }
+      }
     } catch {
-      entries = [];
+      // The `namespaces` dir does not exist yet (or lstat failed): nothing to scan,
+      // and there is no symlink to follow. Treat as an empty, safe scan.
+      namespacesDirSafe = true;
+    }
+    if (!namespacesDirSafe) {
+      skipped.push({ token: "namespaces", reason: "symlink", detail: namespacesDir });
+    } else {
+      try {
+        entries = await readdir(namespacesDir, { withFileTypes: true });
+      } catch {
+        entries = [];
+      }
     }
 
     // Dual-root alignment (round 5, cursor Medium): when both a legacy raw-name

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -376,39 +376,61 @@ export class NamespaceCatalog {
     jobName?: string,
   ): Promise<void> {
     if (!this.enabled) return;
+    // Validate up front (outside the chain) so caller-facing rejections — e.g.
+    // an unsafe namespace token — surface immediately and deterministically,
+    // not interleaved with serialized I/O.
     const ns = this.validateNamespace(namespace);
     const nowIso = (metadata?.at ?? new Date()).toISOString();
-    const records = await this.loadCompacted();
-    const existing = records.get(ns);
 
-    const storageDir = metadata?.storageDir ?? existing?.storageDir ?? this.resolveStorageDir(ns);
-    const record: NamespaceRecord = existing
-      ? { ...existing }
-      : {
-          namespace: ns,
-          identityToken: namespaceIdentityToken(ns),
-          kind: metadata?.kind ?? inferKind(ns, this.config),
-          createdAt: nowIso,
-          storageDir,
-          discoveredBy: metadata?.discoveredBy ?? (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
-        };
+    // Run the read → merge → append as a single serialized critical section so
+    // two concurrent touches for the same namespace cannot both observe the same
+    // stale record and then have the later append win compaction while dropping
+    // the earlier touch's fields (CLAUDE.md rule #40 — the chain also recovers
+    // from rejection). Reading inside the chain guarantees each touch sees the
+    // most recent appended state, including any concurrent read/write/register.
+    await this.queueCritical(async () => {
+      const records = await this.loadCompacted();
+      const existing = records.get(ns);
 
-    // Update mutable fields.
-    record.storageDir = storageDir;
-    if (metadata?.kind) record.kind = metadata.kind;
-    if (metadata?.principal !== undefined) record.principal = metadata.principal;
-    if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
-    if (metadata?.branch !== undefined) record.branch = metadata.branch;
-    if (metadata?.parentNamespace !== undefined) record.parentNamespace = metadata.parentNamespace;
-    if (metadata?.discoveredBy) record.discoveredBy = metadata.discoveredBy;
+      const storageDir = metadata?.storageDir ?? existing?.storageDir ?? this.resolveStorageDir(ns);
+      // Provenance (discoveredBy) and createdAt are CREATION-ONLY fields. Once a
+      // record exists they are preserved, so a routine routing/recall touch (or
+      // the router's `config` register hook firing on a cache hit) can never
+      // clobber the original discovery source — e.g. a `write`-discovered record
+      // is not reset to `config` by a later resolve. Touch fields (lastReadAt /
+      // lastWriteAt / lastMaintenanceAt) still update on every touch below.
+      const record: NamespaceRecord = existing
+        ? { ...existing }
+        : {
+            namespace: ns,
+            identityToken: namespaceIdentityToken(ns),
+            kind: metadata?.kind ?? inferKind(ns, this.config),
+            createdAt: nowIso,
+            storageDir,
+            discoveredBy:
+              metadata?.discoveredBy ??
+              (kind === "register" ? "config" : kind === "maintenance" ? "scan" : kind),
+          };
 
-    if (kind === "read") record.lastReadAt = nowIso;
-    if (kind === "write") record.lastWriteAt = nowIso;
-    if (kind === "maintenance" && jobName) {
-      record.lastMaintenanceAt = { ...(record.lastMaintenanceAt ?? {}), [jobName]: nowIso };
-    }
+      // Update mutable fields. storageDir, kind, and the principal/project hints
+      // may legitimately change over a namespace's lifetime, so they upsert.
+      record.storageDir = storageDir;
+      if (metadata?.kind) record.kind = metadata.kind;
+      if (metadata?.principal !== undefined) record.principal = metadata.principal;
+      if (metadata?.projectId !== undefined) record.projectId = metadata.projectId;
+      if (metadata?.branch !== undefined) record.branch = metadata.branch;
+      if (metadata?.parentNamespace !== undefined) record.parentNamespace = metadata.parentNamespace;
+      // NOTE: discoveredBy is intentionally NOT reassigned here for existing
+      // records — see the creation-only rationale above (Issue 1 fix).
 
-    await this.append(record);
+      if (kind === "read") record.lastReadAt = nowIso;
+      if (kind === "write") record.lastWriteAt = nowIso;
+      if (kind === "maintenance" && jobName) {
+        record.lastMaintenanceAt = { ...(record.lastMaintenanceAt ?? {}), [jobName]: nowIso };
+      }
+
+      await this.appendUnchained(record);
+    });
   }
 
   // ── Rebuild from disk ────────────────────────────────────────────────────
@@ -596,17 +618,17 @@ export class NamespaceCatalog {
   }
 
   /**
-   * Append a single record to the JSONL log. Serialized through a write chain
-   * that recovers from rejection (CLAUDE.md rule #40). Failure-tolerant: errors
-   * are surfaced to the caller's awaited promise but do not poison the chain.
+   * Serialize an arbitrary read-modify-write critical section through the single
+   * write chain. Every catalog mutation (touch read+merge+append, full rewrite)
+   * runs through this so they are mutually exclusive: a touch always reads the
+   * latest persisted state before appending, and a rebuild rewrite cannot
+   * interleave with a touch's append. The chain recovers from rejection
+   * (CLAUDE.md rule #40) — one failed section never poisons subsequent ones —
+   * while still surfacing the error to that section's awaited promise.
    */
-  private append(record: NamespaceRecord): Promise<void> {
-    const line = serializeRecord(record) + "\n";
-    const run = this.writeChain.then(async () => {
-      await mkdir(this.stateDir, { recursive: true });
-      await appendFile(this.catalogPath, line, "utf8");
-    });
-    // Keep the chain alive after a rejection so later writes still run.
+  private queueCritical<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.writeChain.then(fn);
+    // Keep the chain alive after a rejection so later sections still run.
     this.writeChain = run.then(
       () => undefined,
       () => undefined,
@@ -615,23 +637,31 @@ export class NamespaceCatalog {
   }
 
   /**
+   * Append a single record to the JSONL log WITHOUT re-serializing through the
+   * write chain. MUST only be called from inside a `queueCritical(...)` section
+   * (which already holds the serialized turn); calling it directly would bypass
+   * the read-before-append ordering that prevents lost-field races.
+   */
+  private async appendUnchained(record: NamespaceRecord): Promise<void> {
+    const line = serializeRecord(record) + "\n";
+    await mkdir(this.stateDir, { recursive: true });
+    await appendFile(this.catalogPath, line, "utf8");
+  }
+
+  /**
    * Atomically rewrite the compacted catalog (temp file + rename) so a failed
    * write never leaves a truncated/lost catalog (CLAUDE.md rule #54: write
-   * temp, then rename — never delete-before-write).
+   * temp, then rename — never delete-before-write). Serialized against touches
+   * via the shared write chain.
    */
   private async rewriteAtomic(records: NamespaceRecord[]): Promise<void> {
     const body = records.map((r) => serializeRecord(r)).join("\n") + (records.length > 0 ? "\n" : "");
-    const run = this.writeChain.then(async () => {
+    await this.queueCritical(async () => {
       await mkdir(this.stateDir, { recursive: true });
       const tmp = `${this.catalogPath}.${process.pid}.${Date.now()}.tmp`;
       await writeFile(tmp, body, "utf8");
       await rename(tmp, this.catalogPath);
     });
-    this.writeChain = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    return run;
   }
 }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -857,6 +857,21 @@ export class NamespaceCatalog {
     } catch {
       return false;
     }
+    // NH3Xy (codex P2): for a NON-default namespace, a generic fallback root is
+    // NOT proof of liveness. When the namespace's own token root was skipped by
+    // the scan as a symlink/escape, `resolveSafeStorageDir` can fall back to the
+    // DEFAULT namespace's `memoryDir`; `hasMemoryData()` on that shared default
+    // tree then returns true whenever the default namespace has any data, which
+    // would wrongly KEEP a stale project row now pointing at the default tree
+    // instead of purging the skipped namespace. Only the namespace's OWN root may
+    // attest its liveness — so if a non-default namespace resolved to `memoryDir`,
+    // it has no independent contained root and must be treated as absent (purge).
+    if (
+      namespace !== this.config.defaultNamespace &&
+      path.resolve(root) === path.resolve(this.memoryDir)
+    ) {
+      return false;
+    }
     let stat;
     try {
       stat = await lstat(root);

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -523,24 +523,55 @@ export class NamespaceCatalog {
     if (!this.isLexicallyContained(candidate)) return false;
     // The default/legacy memoryDir root is trusted as-is.
     if (path.resolve(candidate) === path.resolve(this.memoryDir)) return true;
+    let memoryReal: string;
+    try {
+      memoryReal = await realpath(this.memoryDir);
+    } catch {
+      memoryReal = path.resolve(this.memoryDir);
+    }
     try {
       const stat = await lstat(candidate);
       if (stat.isSymbolicLink()) return false;
     } catch {
-      // Does not exist yet — nothing to follow; lexical containment suffices.
-      return true;
+      // The leaf does not exist yet. Lexical containment is NOT sufficient: an
+      // EXISTING ancestor (e.g. `<memoryDir>/namespaces`) could be a symlink to
+      // outside memoryDir, so a future mkdir/maintenance/QMD op would follow the
+      // persisted root outside the root (round 6, codex P2 — NDo79). Verify the
+      // nearest EXISTING ancestor's realpath still resolves inside memoryDir.
+      return this.isNearestExistingAncestorContained(candidate, memoryReal);
     }
     try {
       const real = await realpath(candidate);
-      let memoryReal: string;
-      try {
-        memoryReal = await realpath(this.memoryDir);
-      } catch {
-        memoryReal = path.resolve(this.memoryDir);
-      }
       return isPathInside(memoryReal, real);
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Walk up from a not-yet-existing candidate to the nearest ancestor that exists
+   * on disk and verify its realpath stays inside `memoryReal` (round 6, codex P2
+   * — NDo79). Rejects a non-existent leaf whose existing parent chain escapes
+   * memoryDir via a symlink. Stops at memoryDir's resolved root.
+   */
+  private async isNearestExistingAncestorContained(
+    candidate: string,
+    memoryReal: string,
+  ): Promise<boolean> {
+    let dir = path.resolve(candidate);
+    const root = path.parse(dir).root;
+    for (;;) {
+      const parent = path.dirname(dir);
+      // Reached the filesystem root without finding an existing ancestor.
+      if (parent === dir || dir === root) return false;
+      try {
+        const real = await realpath(parent);
+        // The nearest existing ancestor must resolve inside the memory root.
+        return isPathInside(memoryReal, real) || real === memoryReal;
+      } catch {
+        // Parent does not exist yet either — keep walking up.
+        dir = parent;
+      }
     }
   }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -552,11 +552,76 @@ export class NamespaceCatalog {
     explicit: string | undefined,
     existingDir: string | undefined,
   ): Promise<string> {
-    if (explicit !== undefined && (await this.isContainedStorageDir(explicit))) return explicit;
+    // An explicit storageDir is accepted ONLY when it is both contained AND
+    // actually belongs to THIS namespace (round 6, codex P2 — NDATT). Containment
+    // alone let a caller pass another namespace's tree (e.g.
+    // `markWrite("project-a", { storageDir: ".../namespaces/<project-b-token>" })`)
+    // or `memoryDir` for a non-default namespace; `listNamespaces()` would then
+    // tell maintenance/QMD that `project-a` lives in another namespace's (or the
+    // default) tree — a cross-namespace root confusion. We reject a mismatched
+    // explicit root and fall back to the namespace's own resolved root.
+    if (
+      explicit !== undefined &&
+      (await this.isContainedStorageDir(explicit)) &&
+      (await this.isStorageDirForNamespace(namespace, explicit))
+    ) {
+      return explicit;
+    }
     // Don't let a record poisoned by a pre-fix out-of-containment write keep an
-    // unsafe dir alive across touches — only preserve a contained existing dir.
-    if (existingDir !== undefined && (await this.isContainedStorageDir(existingDir))) return existingDir;
+    // unsafe dir alive across touches — only preserve a contained existing dir
+    // that also belongs to this namespace.
+    if (
+      existingDir !== undefined &&
+      (await this.isContainedStorageDir(existingDir)) &&
+      (await this.isStorageDirForNamespace(namespace, existingDir))
+    ) {
+      return existingDir;
+    }
     return this.resolveSafeStorageDir(namespace);
+  }
+
+  /**
+   * Whether `candidate` is a legitimate storage root FOR `namespace` (round 6,
+   * codex P2 — NDATT). Accepts the namespace's router-resolved root, its canonical
+   * lexical tokenized dir, and (for the default namespace only) memoryDir. This
+   * prevents a contained-but-CROSS-NAMESPACE path — another namespace's tree, or
+   * memoryDir for a non-default namespace — from being persisted as this
+   * namespace's root. Compared on resolved (absolute) paths.
+   */
+  private async isStorageDirForNamespace(namespace: string, candidate: string): Promise<boolean> {
+    const resolvedCandidate = path.resolve(candidate);
+    const valid = new Set<string>();
+    // The namespace's canonical lexical TOKENIZED dir is always a valid root.
+    try {
+      valid.add(path.resolve(this.namespaceTokenDir(namespaceIdentityToken(namespace))));
+    } catch {
+      // Unsafe token cannot build a lexical dir; fall through to other roots.
+    }
+    // The namespace's legacy RAW-NAME dir (`namespaces/<rawname>`) is also a
+    // valid root — the router serves data from it when present, even before any
+    // dir exists on disk. Both forms belong to THIS namespace, never another's.
+    try {
+      valid.add(path.resolve(this.namespaceTokenDir(namespace)));
+    } catch {
+      // Unsafe raw name cannot build a lexical dir; rely on the other roots.
+    }
+    // The router-resolved root (whichever of the above it currently serves, a
+    // migrated default, etc.).
+    try {
+      valid.add(path.resolve(await resolveNamespaceStorageRoot(this.config, namespace)));
+    } catch {
+      // Router resolution failed; rely on the lexical/default roots below.
+    }
+    // memoryDir is a valid root ONLY for the default namespace.
+    if (namespace === this.config.defaultNamespace) {
+      valid.add(path.resolve(this.memoryDir));
+      try {
+        valid.add(path.resolve(await resolveDefaultNamespaceRoot(this.config)));
+      } catch {
+        // ignore; memoryDir already covers the common default case.
+      }
+    }
+    return valid.has(resolvedCandidate);
   }
 
   /**
@@ -894,7 +959,18 @@ export class NamespaceCatalog {
         continue;
       }
 
-      // Decode the namespace from the token, falling back to the raw dir name.
+      // Decode the namespace from the dir name. A configured dir name is used
+      // verbatim. Otherwise decode a genuine tokenized dir back to its identity,
+      // falling back to the raw dir name when it is not a decodable token.
+      //
+      // NDATN note (round 6, codex P2): a raw dir literally named like a CANONICAL
+      // token (e.g. `namespaces/ns-616c706861`, the canonical token of `alpha`) is
+      // inherently ambiguous from disk alone — the bytes are identical whether the
+      // namespace is `alpha` (in its tokenized dir) or the literal `ns-616c706861`
+      // (in a raw dir). Decoding a canonical token is the correct default. The
+      // unambiguous fix lives on the WRITE path, where the caller knows the true
+      // namespace and records it verbatim (NCQI0); the scanner cannot recover a
+      // name the encoding cannot distinguish, so we keep the canonical decode.
       const decoded = configured.has(token) ? token : namespaceIdentityFromToken(token) ?? token;
       if (decoded !== this.config.defaultNamespace && !isSafeRouteNamespace(decoded)) {
         skipped.push({ token, reason: "unsafe", detail: decoded });

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -257,7 +257,13 @@ export class NamespaceStorageRouter {
     if (this.notifiedResolved.get(namespace) === storageDir) return;
     this.notifiedResolved.set(namespace, storageDir);
     try {
-      hook(namespace, storageDir);
+      // Handle BOTH synchronous throws and asynchronous rejections (round 6,
+      // codex P2 — NDo8C). The hook is typed `void`, but a caller may supply an
+      // `async` function; its rejected promise would bypass this try/catch and,
+      // where unhandled rejections are fatal, crash storage resolution. Wrap in
+      // `Promise.resolve(...).catch()` so a best-effort catalog/register failure
+      // never propagates (CLAUDE.md gotcha #13).
+      Promise.resolve(hook(namespace, storageDir)).catch(() => undefined);
     } catch {
       // Intentionally swallow: catalog registration is best-effort metadata.
     }

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -181,6 +181,12 @@ export async function resolveNamespaceStorageRoot(
 export class NamespaceStorageRouter {
   private readonly cache = new Map<string, StorageManager>();
   private defaultNsRootResolved: string | null = null;
+  // Dedup the resolve hook (round 6, cursor Medium — NCNL2). Recall/extraction
+  // call `storageFor` repeatedly; firing `onResolve` (→ catalog loadCompacted +
+  // append) on every cache hit grows `namespaces.jsonl` without bound between
+  // rebuilds. We fire the hook only when the (namespace, storageDir) pair is new
+  // or its dir changed, so a steady-state cache hit is a no-op for the catalog.
+  private readonly notifiedResolved = new Map<string, string>();
 
   constructor(
     private readonly config: PluginConfig,
@@ -245,6 +251,11 @@ export class NamespaceStorageRouter {
   private notifyResolved(namespace: string, storageDir: string): void {
     const hook = this.hooks.onResolve;
     if (!hook) return;
+    // Skip when we've already notified this exact (namespace, storageDir) — a
+    // steady-state cache hit must not re-append to the catalog log (NCNL2). A
+    // changed dir (rare: migration/realignment) still re-fires once.
+    if (this.notifiedResolved.get(namespace) === storageDir) return;
+    this.notifiedResolved.set(namespace, storageDir);
     try {
       hook(namespace, storageDir);
     } catch {

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -197,6 +197,21 @@ export class NamespaceStorageRouter {
   // rebuilds. We fire the hook only when the (namespace, storageDir) pair is new
   // or its dir changed, so a steady-state cache hit is a no-op for the catalog.
   private readonly notifiedResolved = new Map<string, string>();
+  // In-flight resolve-hook dedup (NFJV-, codex P2). The catalog's `onResolve`
+  // hook is ASYNC (it returns `registerResolved(...)`), so `notifiedResolved` is
+  // only set after the hook's promise SETTLES. Without tracking the in-flight
+  // window, a burst of `storageFor()` cache hits for the SAME namespace before
+  // the first registration finishes would each pass the `notifiedResolved` guard
+  // and fire their OWN `onResolve` — queueing N duplicate catalog touches + lock
+  // acquisitions despite the once-per-namespace intent. We therefore record the
+  // (namespace → storageDir) being registered BEFORE awaiting the hook so a
+  // concurrent call for the same pair skips firing. On SUCCESS the pair is
+  // promoted to `notifiedResolved` (future calls skip permanently); on `false`
+  // (dropped touch — e.g. rebuild-lock timeout) OR rejection the in-flight marker
+  // is CLEARED so a later `storageFor()` can RETRY the dropped registration. The
+  // entry is always removed when the promise settles, so the map cannot grow
+  // unbounded (one transient entry per concurrently-resolving namespace).
+  private readonly inFlightResolved = new Map<string, string>();
 
   constructor(
     private readonly config: PluginConfig,
@@ -269,6 +284,13 @@ export class NamespaceStorageRouter {
     // RETRIED on the next cache hit instead of being suppressed forever (round 6,
     // cursor Medium — ND3EJ).
     if (this.notifiedResolved.get(namespace) === storageDir) return;
+    // In-flight dedup (NFJV-, codex P2): if a registration for this exact
+    // (namespace, storageDir) is already AWAITING its async hook, do not fire a
+    // second one. Without this, concurrent cache-hit bursts before the first
+    // append settles each pass the `notifiedResolved` guard above and queue
+    // duplicate catalog touches/lock acquisitions. A pair with a DIFFERENT
+    // in-flight dir (rare mid-migration realignment) still fires once.
+    if (this.inFlightResolved.get(namespace) === storageDir) return;
     try {
       // Handle BOTH synchronous throws and asynchronous rejections (round 6,
       // codex P2 — NDo8C). The hook may be `async`; its rejected promise would
@@ -278,21 +300,43 @@ export class NamespaceStorageRouter {
       // `false` means the registration was dropped/no-op (e.g. rebuild-lock
       // timeout), so we must NOT suppress its retry. `void`/`undefined` is treated
       // as success for legacy hooks. On rejection we leave it un-notified to retry.
+      //
+      // Record the in-flight marker BEFORE awaiting so concurrent calls for the
+      // same pair skip (NFJV-). It is always cleared once the promise settles, so
+      // the map holds at most one transient entry per concurrently-resolving
+      // namespace and cannot grow unbounded.
+      this.inFlightResolved.set(namespace, storageDir);
       Promise.resolve(hook(namespace, storageDir)).then(
         (persisted) => {
+          // Clear the in-flight marker ONLY if it is still ours (a newer resolve
+          // for a different dir may have replaced it).
+          if (this.inFlightResolved.get(namespace) === storageDir) {
+            this.inFlightResolved.delete(namespace);
+          }
           if (persisted !== false) {
             this.notifiedResolved.set(namespace, storageDir);
           }
+          // On `false` (dropped touch) we intentionally do NOT mark notified, so
+          // a later `storageFor()` retries the registration. Clearing the
+          // in-flight marker above is what re-enables that retry.
         },
         () => {
-          // Registration failed — do NOT mark as notified, so it is retried.
+          // Registration failed — clear in-flight AND do NOT mark as notified, so
+          // it is retried on the next cache hit.
+          if (this.inFlightResolved.get(namespace) === storageDir) {
+            this.inFlightResolved.delete(namespace);
+          }
           if (this.notifiedResolved.get(namespace) === storageDir) {
             this.notifiedResolved.delete(namespace);
           }
         },
       );
     } catch {
-      // Synchronous throw: leave the pair un-notified so a later resolve retries.
+      // Synchronous throw: clear any in-flight marker we just set and leave the
+      // pair un-notified so a later resolve retries.
+      if (this.inFlightResolved.get(namespace) === storageDir) {
+        this.inFlightResolved.delete(namespace);
+      }
     }
   }
 }

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -141,7 +141,15 @@ export async function resolveDefaultNamespaceRoot(config: PluginConfig): Promise
     return config.memoryDir;
   }
 
-  const legacyNsDir = resolveNamespaceDir(config.memoryDir, config.defaultNamespace);
+  // Build the legacy default root from the NORMALIZED (trimmed) name so a
+  // whitespace-padded `defaultNamespace` still finds the live `namespaces/default`
+  // root (NIabe). `storageFor()` classifies the trimmed value as the default, and
+  // the on-disk legacy dir is created under the trimmed name; using the raw spaced
+  // name here would look for `namespaces/<spaced>` and miss the real root, falling
+  // back to memoryDir/tokenized. `namespaceIdentityToken` already normalizes
+  // internally, so the tokenized path is unaffected.
+  const defaultIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
+  const legacyNsDir = resolveNamespaceDir(config.memoryDir, defaultIdentity);
   const tokenizedNsDir = resolveNamespaceDir(
     config.memoryDir,
     namespaceIdentityToken(config.defaultNamespace),

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -105,14 +105,24 @@ async function hasAnyNamespaceStorageMarker(
  * migrating existing data.
  */
 /**
- * Optional hooks for the storage router. `onResolve` fires (fire-and-forget)
- * whenever a namespace's storage is resolved/created, so a downstream consumer
- * (e.g. the namespace catalog, issue #1499) can register the namespace. The
- * hook MUST NOT throw into the router; the router invokes it defensively and a
- * hook failure never affects storage resolution.
+ * Optional hooks for the storage router. `onResolve` fires whenever a namespace's
+ * storage is resolved/created, so a downstream consumer (e.g. the namespace
+ * catalog, issue #1499) can register the namespace. The hook MUST NOT throw into
+ * the router; the router invokes it defensively and a hook failure never affects
+ * storage resolution.
+ *
+ * The hook MAY return (or resolve to) a boolean indicating whether the
+ * registration actually PERSISTED (round 6, codex P2 — NEFoX). When it resolves
+ * to `false` (a dropped/no-op registration), the router does NOT mark the
+ * (namespace, storageDir) pair as notified, so the next resolve RETRIES it
+ * instead of suppressing it forever. A `void`/`undefined` result is treated as
+ * success (legacy hooks).
  */
 export interface NamespaceStorageRouterHooks {
-  onResolve?: (namespace: string, storageDir: string) => void;
+  onResolve?: (
+    namespace: string,
+    storageDir: string,
+  ) => void | boolean | Promise<void | boolean>;
 }
 
 /**
@@ -261,13 +271,18 @@ export class NamespaceStorageRouter {
     if (this.notifiedResolved.get(namespace) === storageDir) return;
     try {
       // Handle BOTH synchronous throws and asynchronous rejections (round 6,
-      // codex P2 — NDo8C). The hook is typed `void`, but a caller may supply an
-      // `async` function; its rejected promise would bypass this try/catch and,
-      // where unhandled rejections are fatal, crash storage resolution. On success
-      // record the dedup marker; on failure clear it so a later resolve retries.
+      // codex P2 — NDo8C). The hook may be `async`; its rejected promise would
+      // bypass this try/catch and, where unhandled rejections are fatal, crash
+      // storage resolution. Mark the dedup pair as notified ONLY when the hook
+      // resolves to a PERSISTED result (round 6, codex P2 — NEFoX): a result of
+      // `false` means the registration was dropped/no-op (e.g. rebuild-lock
+      // timeout), so we must NOT suppress its retry. `void`/`undefined` is treated
+      // as success for legacy hooks. On rejection we leave it un-notified to retry.
       Promise.resolve(hook(namespace, storageDir)).then(
-        () => {
-          this.notifiedResolved.set(namespace, storageDir);
+        (persisted) => {
+          if (persisted !== false) {
+            this.notifiedResolved.set(namespace, storageDir);
+          }
         },
         () => {
           // Registration failed — do NOT mark as notified, so it is retried.

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -149,6 +149,35 @@ export async function resolveDefaultNamespaceRoot(config: PluginConfig): Promise
     : config.memoryDir;
 }
 
+/**
+ * Resolve the runtime storage root for ANY namespace exactly as the live router
+ * would (`NamespaceStorageRouter.namespaceRoot`). Shared so the rebuildable
+ * catalog records the SAME on-disk root the router routes to — a recall/read
+ * touch must not guess `namespaces/<token>` when the router actually serves a
+ * legacy raw-name dir or a migrated default root (CLAUDE.md rule #22/#42; round
+ * 4, cursor Medium). The default namespace delegates to `resolveDefaultNamespaceRoot`;
+ * every other namespace prefers the tokenized root when it has a storage marker,
+ * else a legacy raw-name dir when present, else the tokenized root.
+ */
+export async function resolveNamespaceStorageRoot(
+  config: PluginConfig,
+  namespace: string,
+): Promise<string> {
+  if (!config.namespacesEnabled) return config.memoryDir;
+  if (namespace === config.defaultNamespace) {
+    return resolveDefaultNamespaceRoot(config);
+  }
+  const legacyRoot = resolveNamespaceDir(config.memoryDir, namespace);
+  const tokenizedRoot = resolveNamespaceDir(config.memoryDir, namespaceIdentityToken(namespace));
+  if (
+    (await exists(tokenizedRoot)) &&
+    (await hasAnyNamespaceStorageMarker(tokenizedRoot, { includeRuntimeState: true }))
+  ) {
+    return tokenizedRoot;
+  }
+  return (await exists(legacyRoot)) ? legacyRoot : tokenizedRoot;
+}
+
 export class NamespaceStorageRouter {
   private readonly cache = new Map<string, StorageManager>();
   private defaultNsRootResolved: string | null = null;
@@ -169,12 +198,7 @@ export class NamespaceStorageRouter {
     if (namespace === this.config.defaultNamespace) {
       return this.defaultNsRootResolved ?? this.config.memoryDir;
     }
-    const legacyRoot = resolveNamespaceDir(this.config.memoryDir, namespace);
-    const tokenizedRoot = resolveNamespaceDir(this.config.memoryDir, namespaceIdentityToken(namespace));
-    if ((await exists(tokenizedRoot)) && (await hasAnyNamespaceStorageMarker(tokenizedRoot, { includeRuntimeState: true }))) {
-      return tokenizedRoot;
-    }
-    return (await exists(legacyRoot)) ? legacyRoot : tokenizedRoot;
+    return resolveNamespaceStorageRoot(this.config, namespace);
   }
 
   async storageFor(namespace: string): Promise<StorageManager> {

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -104,11 +104,25 @@ async function hasAnyNamespaceStorageMarker(
  * This avoids surprising "lost memories" when an install flips namespaces on without
  * migrating existing data.
  */
+/**
+ * Optional hooks for the storage router. `onResolve` fires (fire-and-forget)
+ * whenever a namespace's storage is resolved/created, so a downstream consumer
+ * (e.g. the namespace catalog, issue #1499) can register the namespace. The
+ * hook MUST NOT throw into the router; the router invokes it defensively and a
+ * hook failure never affects storage resolution.
+ */
+export interface NamespaceStorageRouterHooks {
+  onResolve?: (namespace: string, storageDir: string) => void;
+}
+
 export class NamespaceStorageRouter {
   private readonly cache = new Map<string, StorageManager>();
   private defaultNsRootResolved: string | null = null;
 
-  constructor(private readonly config: PluginConfig) {}
+  constructor(
+    private readonly config: PluginConfig,
+    private readonly hooks: NamespaceStorageRouterHooks = {},
+  ) {}
 
   private async defaultNamespaceRoot(): Promise<string> {
     if (!this.config.namespacesEnabled) {
@@ -162,12 +176,16 @@ export class NamespaceStorageRouter {
       root = await this.defaultNamespaceRoot();
       const cached = this.cache.get(ns);
       if (cached && cached.dir === root) {
+        this.notifyResolved(ns, root);
         return cached;
       }
     } else {
       const cached = this.cache.get(ns);
       root = await this.namespaceRoot(ns);
-      if (cached && cached.dir === root) return cached;
+      if (cached && cached.dir === root) {
+        this.notifyResolved(ns, root);
+        return cached;
+      }
     }
 
     const sm = new StorageManager(root, this.config.entitySchemas);
@@ -176,6 +194,21 @@ export class NamespaceStorageRouter {
     // matching the behaviour of the primary this.storage instance in the orchestrator.
     sm.citationTemplate = this.config.inlineSourceAttributionFormat;
     this.cache.set(ns, sm);
+    this.notifyResolved(ns, root);
     return sm;
+  }
+
+  /**
+   * Fire the resolve hook defensively. A hook failure (e.g. a catalog write
+   * error) MUST NOT crash storage resolution — see CLAUDE.md gotcha #13.
+   */
+  private notifyResolved(namespace: string, storageDir: string): void {
+    const hook = this.hooks.onResolve;
+    if (!hook) return;
+    try {
+      hook(namespace, storageDir);
+    } catch {
+      // Intentionally swallow: catalog registration is best-effort metadata.
+    }
   }
 }

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -251,21 +251,33 @@ export class NamespaceStorageRouter {
   private notifyResolved(namespace: string, storageDir: string): void {
     const hook = this.hooks.onResolve;
     if (!hook) return;
-    // Skip when we've already notified this exact (namespace, storageDir) — a
-    // steady-state cache hit must not re-append to the catalog log (NCNL2). A
-    // changed dir (rare: migration/realignment) still re-fires once.
+    // Skip when we've already SUCCESSFULLY notified this exact (namespace,
+    // storageDir) — a steady-state cache hit must not re-append to the catalog
+    // log (NCNL2). A changed dir (rare: migration/realignment) still re-fires
+    // once. We mark the pair as notified ONLY AFTER the hook succeeds, and CLEAR
+    // it on failure, so a dropped registration (e.g. rebuild-lock timeout) is
+    // RETRIED on the next cache hit instead of being suppressed forever (round 6,
+    // cursor Medium — ND3EJ).
     if (this.notifiedResolved.get(namespace) === storageDir) return;
-    this.notifiedResolved.set(namespace, storageDir);
     try {
       // Handle BOTH synchronous throws and asynchronous rejections (round 6,
       // codex P2 — NDo8C). The hook is typed `void`, but a caller may supply an
       // `async` function; its rejected promise would bypass this try/catch and,
-      // where unhandled rejections are fatal, crash storage resolution. Wrap in
-      // `Promise.resolve(...).catch()` so a best-effort catalog/register failure
-      // never propagates (CLAUDE.md gotcha #13).
-      Promise.resolve(hook(namespace, storageDir)).catch(() => undefined);
+      // where unhandled rejections are fatal, crash storage resolution. On success
+      // record the dedup marker; on failure clear it so a later resolve retries.
+      Promise.resolve(hook(namespace, storageDir)).then(
+        () => {
+          this.notifiedResolved.set(namespace, storageDir);
+        },
+        () => {
+          // Registration failed — do NOT mark as notified, so it is retried.
+          if (this.notifiedResolved.get(namespace) === storageDir) {
+            this.notifiedResolved.delete(namespace);
+          }
+        },
+      );
     } catch {
-      // Intentionally swallow: catalog registration is best-effort metadata.
+      // Synchronous throw: leave the pair un-notified so a later resolve retries.
     }
   }
 }

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -174,7 +174,10 @@ export async function resolveNamespaceStorageRoot(
   namespace: string,
 ): Promise<string> {
   if (!config.namespacesEnabled) return config.memoryDir;
-  if (namespace === config.defaultNamespace) {
+  // Compare on NORMALIZED identity so a whitespace-padded configured default name
+  // still routes to the default root rather than a tokenized non-default dir
+  // (NH-FH). The catalog keys records by the same normalized identity.
+  if (normalizeNamespaceIdentity(namespace) === normalizeNamespaceIdentity(config.defaultNamespace)) {
     return resolveDefaultNamespaceRoot(config);
   }
   const legacyRoot = resolveNamespaceDir(config.memoryDir, namespace);
@@ -213,10 +216,18 @@ export class NamespaceStorageRouter {
   // unbounded (one transient entry per concurrently-resolving namespace).
   private readonly inFlightResolved = new Map<string, string>();
 
+  // Normalized (trimmed) default namespace identity (NH-FH). `storageFor`
+  // normalizes its input, so default-namespace branches must compare against the
+  // normalized config default too — otherwise a whitespace-padded configured
+  // default name routes the default namespace to a tokenized non-default root.
+  private readonly defaultNamespaceIdentity: string;
+
   constructor(
     private readonly config: PluginConfig,
     private readonly hooks: NamespaceStorageRouterHooks = {},
-  ) {}
+  ) {
+    this.defaultNamespaceIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
+  }
 
   private async defaultNamespaceRoot(): Promise<string> {
     this.defaultNsRootResolved = await resolveDefaultNamespaceRoot(this.config);
@@ -226,7 +237,7 @@ export class NamespaceStorageRouter {
   private async namespaceRoot(namespace: string): Promise<string> {
     // NOTE: only used after defaultNamespaceRoot() resolution.
     if (!this.config.namespacesEnabled) return this.config.memoryDir;
-    if (namespace === this.config.defaultNamespace) {
+    if (normalizeNamespaceIdentity(namespace) === this.defaultNamespaceIdentity) {
       return this.defaultNsRootResolved ?? this.config.memoryDir;
     }
     return resolveNamespaceStorageRoot(this.config, namespace);
@@ -234,7 +245,7 @@ export class NamespaceStorageRouter {
 
   async storageFor(namespace: string): Promise<StorageManager> {
     const ns = normalizeNamespaceIdentity(namespace || this.config.defaultNamespace);
-    if (ns !== this.config.defaultNamespace && !isSafeRouteNamespace(ns)) {
+    if (ns !== this.defaultNamespaceIdentity && !isSafeRouteNamespace(ns)) {
       throw new Error(`unsafe namespace: ${ns}`);
     }
     // Even when the default namespace is exempt from the check above, every
@@ -243,7 +254,7 @@ export class NamespaceStorageRouter {
     // <memoryDir>/namespaces (CodeQL js/path-injection).
 
     let root: string;
-    if (ns === this.config.defaultNamespace) {
+    if (ns === this.defaultNamespaceIdentity) {
       root = await this.defaultNamespaceRoot();
       const cached = this.cache.get(ns);
       if (cached && cached.dir === root) {

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -115,6 +115,40 @@ export interface NamespaceStorageRouterHooks {
   onResolve?: (namespace: string, storageDir: string) => void;
 }
 
+/**
+ * Resolve the runtime storage root for the configured DEFAULT namespace.
+ *
+ * Shared between the live router (`NamespaceStorageRouter.defaultNamespaceRoot`)
+ * and the rebuildable catalog (`NamespaceCatalog.rebuildFromDisk`) so the two
+ * can never diverge (CLAUDE.md rule #22/#42 — read & write paths resolve through
+ * the same logic). The contract is: while legacy memory data still lives
+ * directly under `memoryDir`, the default root stays `memoryDir`; only once the
+ * legacy root is empty and a `namespaces/<default|token>` dir holds data does
+ * the default migrate into that tokenized/legacy-named dir.
+ */
+export async function resolveDefaultNamespaceRoot(config: PluginConfig): Promise<string> {
+  if (!config.namespacesEnabled) {
+    return config.memoryDir;
+  }
+
+  const legacyNsDir = resolveNamespaceDir(config.memoryDir, config.defaultNamespace);
+  const tokenizedNsDir = resolveNamespaceDir(
+    config.memoryDir,
+    namespaceIdentityToken(config.defaultNamespace),
+  );
+  const tokenizedHasData =
+    (await exists(tokenizedNsDir)) &&
+    (await hasAnyNamespaceStorageMarker(tokenizedNsDir, { includeRuntimeState: true }));
+  const nsDir = tokenizedHasData
+    ? tokenizedNsDir
+    : (await exists(legacyNsDir))
+      ? legacyNsDir
+      : tokenizedNsDir;
+  return (await exists(nsDir)) && !(await hasAnyLegacyData(config.memoryDir))
+    ? nsDir
+    : config.memoryDir;
+}
+
 export class NamespaceStorageRouter {
   private readonly cache = new Map<string, StorageManager>();
   private defaultNsRootResolved: string | null = null;
@@ -125,25 +159,7 @@ export class NamespaceStorageRouter {
   ) {}
 
   private async defaultNamespaceRoot(): Promise<string> {
-    if (!this.config.namespacesEnabled) {
-      this.defaultNsRootResolved = this.config.memoryDir;
-      return this.defaultNsRootResolved;
-    }
-
-    const legacyNsDir = resolveNamespaceDir(this.config.memoryDir, this.config.defaultNamespace);
-    const tokenizedNsDir = resolveNamespaceDir(
-      this.config.memoryDir,
-      namespaceIdentityToken(this.config.defaultNamespace),
-    );
-    const tokenizedHasData =
-      (await exists(tokenizedNsDir)) && (await hasAnyNamespaceStorageMarker(tokenizedNsDir, { includeRuntimeState: true }));
-    const nsDir = tokenizedHasData
-      ? tokenizedNsDir
-      : (await exists(legacyNsDir)) ? legacyNsDir : tokenizedNsDir;
-    this.defaultNsRootResolved =
-      (await exists(nsDir)) && !(await hasAnyLegacyData(this.config.memoryDir))
-        ? nsDir
-        : this.config.memoryDir;
+    this.defaultNsRootResolved = await resolveDefaultNamespaceRoot(this.config);
     return this.defaultNsRootResolved;
   }
 

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import {
   BulkImportBatchPartialFailureError,
   Orchestrator,
@@ -7,6 +10,7 @@ import {
 import { parseConfig } from "./config.js";
 import type { BufferTurn } from "./types.js";
 import type { ImportTurn } from "./bulk-import/types.js";
+import { namespaceIdentityToken } from "./namespaces/identity.js";
 
 function makeTurn(sessionKey: string, content: string): BufferTurn {
   return {
@@ -1778,8 +1782,16 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   let updateArg: string[] | undefined;
   let embedArg: string[] | undefined;
+  const memoryDir = path.join(os.tmpdir(), "remnic-qmd-maintenance-ngnei");
+  const dynamicNamespace = "project-origin-dynamic";
+  const dynamicStorageDir = path.join(
+    memoryDir,
+    "namespaces",
+    namespaceIdentityToken(dynamicNamespace),
+  );
 
   orchestrator.config = {
+    memoryDir,
     namespacesEnabled: true,
     defaultNamespace: "default",
     sharedNamespace: "shared",
@@ -1795,7 +1807,14 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
     async listNamespaces() {
       return [
         { namespace: "default" },
-        { namespace: "project-origin-dynamic" }, // dynamic, NOT configured
+        {
+          namespace: dynamicNamespace,
+          identityToken: namespaceIdentityToken(dynamicNamespace),
+          kind: "project",
+          createdAt: "2026-04-12T12:00:00.000Z",
+          storageDir: dynamicStorageDir,
+          discoveredBy: "write",
+        }, // dynamic, NOT configured
       ];
     },
   };
@@ -1813,14 +1832,82 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
 
   assert.ok(updateArg, "updateNamespaces must be called");
   assert.ok(
-    updateArg!.includes("project-origin-dynamic"),
+    updateArg!.includes(dynamicNamespace),
     "QMD update must cover the cataloged dynamic namespace, not just configured ones",
   );
-  assert.ok(updateArg!.includes("default") && updateArg!.includes("shared"), "configured namespaces remain covered");
   assert.ok(
-    embedArg && embedArg.includes("project-origin-dynamic"),
+    updateArg!.includes("default") && updateArg!.includes("shared"),
+    "configured namespaces remain covered",
+  );
+  assert.ok(
+    embedArg && embedArg.includes(dynamicNamespace),
     "QMD embed must cover the cataloged dynamic namespace",
   );
+});
+
+test("runQmdMaintenance skips cataloged dynamic namespaces whose live root is unsafe", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  let updateArg: string[] | undefined;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-unsafe-root-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-unsafe-target-"));
+  try {
+    const dynamicNamespace = "project-origin-symlinked";
+    const liveLegacyRoot = path.join(memoryDir, "namespaces", dynamicNamespace);
+    const catalogSafeRoot = path.join(
+      memoryDir,
+      "namespaces",
+      namespaceIdentityToken(dynamicNamespace),
+    );
+    await mkdir(path.dirname(liveLegacyRoot), { recursive: true });
+    await symlink(outsideDir, liveLegacyRoot, "dir");
+
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      qmdAutoEmbedEnabled: false,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [
+          {
+            namespace: dynamicNamespace,
+            identityToken: namespaceIdentityToken(dynamicNamespace),
+            kind: "project",
+            createdAt: "2026-04-12T12:00:00.000Z",
+            storageDir: catalogSafeRoot,
+            discoveredBy: "write",
+          },
+        ];
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespaces(ns: string[]) {
+        updateArg = ns;
+        return ns.length;
+      },
+      async embedNamespaces() {},
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    assert.ok(updateArg, "updateNamespaces must be called");
+    assert.deepEqual(
+      [...updateArg!].sort(),
+      ["default", "shared"],
+      "cataloged dynamic namespaces are skipped when the live router root differs from the catalog-sanitized root",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
 });
 
 // NGnei fallback: when the catalog is disabled, maintenance covers exactly the
@@ -1877,8 +1964,16 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   let updateArg: string[] | undefined;
   const abortController = new AbortController();
+  const memoryDir = path.join(os.tmpdir(), "remnic-startup-maintenance-nhzev");
+  const dynamicNamespace = "project-origin-dynamic";
+  const dynamicStorageDir = path.join(
+    memoryDir,
+    "namespaces",
+    namespaceIdentityToken(dynamicNamespace),
+  );
 
   orchestrator.config = {
+    memoryDir,
     namespacesEnabled: true,
     defaultNamespace: "default",
     sharedNamespace: "shared",
@@ -1894,7 +1989,14 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
     async listNamespaces() {
       return [
         { namespace: "default" },
-        { namespace: "project-origin-dynamic" }, // dynamic, catalog-ONLY, NOT configured
+        {
+          namespace: dynamicNamespace,
+          identityToken: namespaceIdentityToken(dynamicNamespace),
+          kind: "project",
+          createdAt: "2026-04-12T12:00:00.000Z",
+          storageDir: dynamicStorageDir,
+          discoveredBy: "write",
+        }, // dynamic, catalog-ONLY, NOT configured
       ];
     },
   };
@@ -1912,7 +2014,7 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
 
   assert.ok(updateArg, "startup updateNamespaces must be called");
   assert.ok(
-    updateArg!.includes("project-origin-dynamic"),
+    updateArg!.includes(dynamicNamespace),
     "startup sync must cover the cataloged dynamic namespace (NHZEV), not just configured ones",
   );
   assert.ok(

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1767,3 +1767,100 @@ test("runExtraction still clears the session buffer after persistence even if re
     "persisted reset flushes must still clear the session buffer even when the reset timeout aborts after persistence",
   );
 });
+
+// ── NGnei (codex P2): runQmdMaintenance must cover CATALOGED dynamic namespaces,
+// not only the configured set. An extraction writing to a coding-scoped/dynamic
+// namespace is made discoverable via the catalog; if maintenance embeds only
+// configuredNamespaces(), that namespace's QMD collection stays stale. We stub the
+// orchestrator internals and assert update/embed receive the UNION of configured +
+// cataloged namespaces.
+test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  let updateArg: string[] | undefined;
+  let embedArg: string[] | undefined;
+
+  orchestrator.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    qmdAutoEmbedEnabled: true,
+    qmdEmbedMinIntervalMs: 0,
+  };
+  orchestrator.qmdMaintenanceInFlight = false;
+  orchestrator.qmdMaintenancePending = true;
+  orchestrator.lastQmdEmbedAtMs = 0;
+  orchestrator.namespaceCatalog = {
+    enabled: true,
+    async listNamespaces() {
+      return [
+        { namespace: "default" },
+        { namespace: "project-origin-dynamic" }, // dynamic, NOT configured
+      ];
+    },
+  };
+  orchestrator.namespaceSearchRouter = {
+    async updateNamespaces(ns: string[]) {
+      updateArg = ns;
+      return ns.length;
+    },
+    async embedNamespaces(ns: string[]) {
+      embedArg = ns;
+    },
+  };
+
+  await orchestrator.runQmdMaintenance();
+
+  assert.ok(updateArg, "updateNamespaces must be called");
+  assert.ok(
+    updateArg!.includes("project-origin-dynamic"),
+    "QMD update must cover the cataloged dynamic namespace, not just configured ones",
+  );
+  assert.ok(updateArg!.includes("default") && updateArg!.includes("shared"), "configured namespaces remain covered");
+  assert.ok(
+    embedArg && embedArg.includes("project-origin-dynamic"),
+    "QMD embed must cover the cataloged dynamic namespace",
+  );
+});
+
+// NGnei fallback: when the catalog is disabled, maintenance covers exactly the
+// configured set (no catalog read), and a catalog read failure degrades to the
+// configured set rather than breaking maintenance.
+test("runQmdMaintenance falls back to configured namespaces when the catalog is disabled (NGnei)", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  let updateArg: string[] | undefined;
+
+  orchestrator.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    qmdAutoEmbedEnabled: false,
+    qmdEmbedMinIntervalMs: 0,
+  };
+  orchestrator.qmdMaintenanceInFlight = false;
+  orchestrator.qmdMaintenancePending = true;
+  orchestrator.lastQmdEmbedAtMs = 0;
+  orchestrator.namespaceCatalog = {
+    enabled: false,
+    async listNamespaces() {
+      throw new Error("catalog disabled — must not be read");
+    },
+  };
+  orchestrator.namespaceSearchRouter = {
+    async updateNamespaces(ns: string[]) {
+      updateArg = ns;
+      return ns.length;
+    },
+    async embedNamespaces() {},
+  };
+
+  await orchestrator.runQmdMaintenance();
+
+  assert.ok(updateArg, "updateNamespaces must be called");
+  assert.deepEqual(
+    [...updateArg!].sort(),
+    ["default", "shared"],
+    "a disabled catalog covers exactly the configured set",
+  );
+});

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1789,6 +1789,7 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
     "namespaces",
     namespaceIdentityToken(dynamicNamespace),
   );
+  await mkdir(path.join(dynamicStorageDir, "facts"), { recursive: true });
 
   orchestrator.config = {
     memoryDir,
@@ -1971,6 +1972,7 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
     "namespaces",
     namespaceIdentityToken(dynamicNamespace),
   );
+  await mkdir(path.join(dynamicStorageDir, "facts"), { recursive: true });
 
   orchestrator.config = {
     memoryDir,

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -1864,3 +1864,102 @@ test("runQmdMaintenance falls back to configured namespaces when the catalog is 
     "a disabled catalog covers exactly the configured set",
   );
 });
+
+// ── NHZEV (codex P2): the QMD STARTUP sync in deferredInitialize() must cover
+// cataloged dynamic namespaces too, not only configuredNamespaces(). A dynamic
+// namespace written before a daemon restart exists ONLY in the persisted catalog;
+// if the boot-time "sync current disk state" pass embeds only the configured set,
+// that namespace's QMD collection stays stale after restart. We drive
+// deferredInitialize() with stubbed internals and abort the signal right after the
+// sync (the next `if (signal.aborted) return;` bails before warmup), then assert the
+// startup updateNamespaces() received the UNION of configured + cataloged namespaces.
+test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV)", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  let updateArg: string[] | undefined;
+  const abortController = new AbortController();
+
+  orchestrator.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    qmdMaintenanceEnabled: true,
+  };
+  orchestrator.qmd = {
+    isAvailable: () => true,
+    async update() {},
+  };
+  orchestrator.namespaceCatalog = {
+    enabled: true,
+    async listNamespaces() {
+      return [
+        { namespace: "default" },
+        { namespace: "project-origin-dynamic" }, // dynamic, catalog-ONLY, NOT configured
+      ];
+    },
+  };
+  orchestrator.namespaceSearchRouter = {
+    async updateNamespaces(ns: string[]) {
+      updateArg = ns;
+      // Abort AFTER the startup sync records its arg so deferredInitialize bails
+      // at the next `if (signal.aborted) return;` before warmup/caches run.
+      abortController.abort();
+      return ns.length;
+    },
+  };
+
+  await orchestrator.deferredInitialize(abortController.signal);
+
+  assert.ok(updateArg, "startup updateNamespaces must be called");
+  assert.ok(
+    updateArg!.includes("project-origin-dynamic"),
+    "startup sync must cover the cataloged dynamic namespace (NHZEV), not just configured ones",
+  );
+  assert.ok(
+    updateArg!.includes("default") && updateArg!.includes("shared"),
+    "configured namespaces remain covered at startup",
+  );
+});
+
+// NHZEV fallback: a catalog read failure during startup sync must degrade to the
+// configured set rather than breaking deferredInitialize — same failure-tolerance
+// contract as runQmdMaintenance (maintenanceNamespaces swallows the read error).
+test("deferredInitialize startup sync falls back to configured set on catalog read failure (NHZEV)", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  let updateArg: string[] | undefined;
+  const abortController = new AbortController();
+
+  orchestrator.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    qmdMaintenanceEnabled: true,
+  };
+  orchestrator.qmd = {
+    isAvailable: () => true,
+    async update() {},
+  };
+  orchestrator.namespaceCatalog = {
+    enabled: true,
+    async listNamespaces() {
+      throw new Error("catalog read failed");
+    },
+  };
+  orchestrator.namespaceSearchRouter = {
+    async updateNamespaces(ns: string[]) {
+      updateArg = ns;
+      abortController.abort();
+      return ns.length;
+    },
+  };
+
+  await orchestrator.deferredInitialize(abortController.signal);
+
+  assert.ok(updateArg, "startup updateNamespaces must be called");
+  assert.deepEqual(
+    [...updateArg!].sort(),
+    ["default", "shared"],
+    "a catalog read failure degrades startup sync to the configured set",
+  );
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4118,17 +4118,6 @@ export class Orchestrator {
           },
         );
 
-        // Catalog write touch (issue #1499 sweep): semantic consolidation writes a
-        // new canonical memory directly to `targetStorage`, bypassing the
-        // extraction write path. Record the write so the namespace's `lastWriteAt`
-        // reflects this durable mutation. Best-effort and failure-tolerant; the
-        // namespace is decoded from the storage dir since this path has no routed
-        // namespace name.
-        this.markCatalogWrite(
-          this.namespaceFromStorageDir(targetStorage.dir),
-          targetStorage.dir,
-        );
-
         result.memoriesConsolidated++;
 
         // Archive originals
@@ -4177,6 +4166,16 @@ export class Orchestrator {
             result.memoriesArchived++;
           }
         }
+
+        // Catalog write touch (issue #1499 sweep): record AFTER the canonical
+        // write AND the archival of the superseded cluster memories, so
+        // lastWriteAt reflects every durable mutation in this consolidation, not
+        // just the merge write (cursor NUtCK). Best-effort; namespace decoded from
+        // the storage dir since this path has no routed namespace name.
+        this.markCatalogWrite(
+          this.namespaceFromStorageDir(targetStorage.dir),
+          targetStorage.dir,
+        );
 
         log.info(
           `[semantic-consolidation] consolidated ${cluster.memories.length} memories → ${canonicalId}`,
@@ -14297,15 +14296,6 @@ export class Orchestrator {
               contentHashSource: rawChunkedContent,
             },
           );
-          // Catalog touch (issue #1499): the chunked write path persists the
-          // parent memory then `continue`s past the non-chunked write below, so
-          // it must record its own write touch here or chunked writes would
-          // never update lastWriteAt. Best-effort and failure-tolerant; the
-          // non-chunked path records its touch separately, so this fires exactly
-          // once per write (no double-count). Use the KNOWN routed name, not a
-          // dir-decoded guess (NCQI0).
-          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
-
           // Write individual chunks with parent reference
           for (const chunk of chunkResult.chunks) {
             // Score each chunk's importance separately
@@ -14341,6 +14331,13 @@ export class Orchestrator {
               },
             );
           }
+
+          // Catalog touch (issue #1499): record AFTER all chunk writes so a
+          // partial chunked write (a failed `writeChunk`) does not mark a
+          // completed namespace write (cursor NUtB_). The chunked path `continue`s
+          // past the non-chunked touch below, so this fires exactly once per
+          // chunked write. Use the KNOWN routed name, not a dir-decoded guess.
+          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
 
           if (routedRuleId) {
             log.debug(
@@ -14552,10 +14549,6 @@ export class Orchestrator {
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
         },
       );
-      // Catalog touch (issue #1499): record the write so dynamic namespaces are
-      // discoverable after hot-path writes. Best-effort and failure-tolerant.
-      // Use the KNOWN routed name, not a dir-decoded guess (NCQI0).
-      this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
       if (routedRuleId) {
         log.debug(
           `routing applied for memory ${memoryId}: rule=${routedRuleId} category=${writeCategory} storage=${targetStorage.dir}`,
@@ -14580,6 +14573,11 @@ export class Orchestrator {
       } catch (err) {
         log.warn(`temporal-supersession: unexpected error: ${err}`);
       }
+      // Catalog touch (issue #1499): record AFTER the write AND temporal
+      // supersession, so lastWriteAt reflects every durable mutation in this
+      // extraction pass — not just the initial writeMemory (cursor NUtCT).
+      // Best-effort; uses the KNOWN routed name, not a dir-decoded guess (NCQI0).
+      this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
       trackBehaviorSignals(
         targetStorage,
         buildBehaviorSignalsForMemory({

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13902,6 +13902,16 @@ export class Orchestrator {
               contentHashSource: rawChunkedContent,
             },
           );
+          // Catalog touch (issue #1499): the chunked write path persists the
+          // parent memory then `continue`s past the non-chunked write below, so
+          // it must record its own write touch here or chunked writes would
+          // never update lastWriteAt. Best-effort and failure-tolerant; the
+          // non-chunked path records its touch separately, so this fires exactly
+          // once per write (no double-count).
+          this.markCatalogWrite(
+            this.namespaceFromStorageDir(targetStorage.dir),
+            targetStorage.dir,
+          );
 
           // Write individual chunks with parent reference
           for (const chunk of chunkResult.chunks) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2265,22 +2265,32 @@ export class Orchestrator {
     const defaultNs = normalizeNamespaceIdentity(this.config.defaultNamespace);
     if (ns !== defaultNs && !isSafeRouteNamespace(ns)) return;
 
-    const resolvedStorageDir = path.resolve(storageDir);
-    const resolvedMemoryDir = path.resolve(this.config.memoryDir);
-    const resolvedNamespacesDir = path.join(resolvedMemoryDir, "namespaces");
-    if (
-      resolvedStorageDir !== resolvedMemoryDir &&
-      !isPathInsideStorageRoot(resolvedNamespacesDir, resolvedStorageDir)
-    ) {
-      return;
-    }
+    if (!this.storageDirMatchesNamespaceHint(ns, storageDir)) return;
 
+    const resolvedStorageDir = path.resolve(storageDir);
     let hints = this.namespaceStorageDirHints.get(resolvedStorageDir);
     if (!hints) {
       hints = new Set<string>();
       this.namespaceStorageDirHints.set(resolvedStorageDir, hints);
     }
     hints.add(ns);
+  }
+
+  private storageDirMatchesNamespaceHint(namespace: string, storageDir: string): boolean {
+    const ns = normalizeNamespaceIdentity(namespace);
+    if (!ns) return false;
+
+    const resolvedStorageDir = path.resolve(storageDir);
+    const resolvedMemoryDir = path.resolve(this.config.memoryDir);
+    const defaultNs = normalizeNamespaceIdentity(this.config.defaultNamespace);
+    if (resolvedStorageDir === resolvedMemoryDir) return ns === defaultNs;
+
+    const resolvedNamespacesDir = path.join(resolvedMemoryDir, "namespaces");
+    if (!isPathInsideStorageRoot(resolvedNamespacesDir, resolvedStorageDir)) return false;
+
+    const rawRoot = path.resolve(resolvedNamespacesDir, ns);
+    const tokenRoot = path.resolve(resolvedNamespacesDir, namespaceIdentityToken(ns));
+    return resolvedStorageDir === rawRoot || resolvedStorageDir === tokenRoot;
   }
 
   private loadNamespaceStorageDirHintsFromCatalog(): void {
@@ -16412,9 +16422,10 @@ export class Orchestrator {
         new Date(b.frontmatter.created).getTime(),
     );
 
-    // Keep recent memories
-    const toKeep = sorted.slice(-this.config.summarizationRecentToKeep);
-    const toSummarize = sorted.slice(0, -this.config.summarizationRecentToKeep);
+    // Keep recent memories, with explicit zero handling so `slice(-0)` does not
+    // accidentally keep every memory out of the summarization candidate set.
+    const recentToKeep = Math.max(0, this.config.summarizationRecentToKeep);
+    const toSummarize = recentToKeep > 0 ? sorted.slice(0, -recentToKeep) : sorted;
 
     // Filter candidates for summarization
     const candidates = toSummarize.filter((m) => {
@@ -16469,19 +16480,19 @@ export class Orchestrator {
 
       await this.storage.writeSummary(summary);
 
-      // Catalog write touch (issue #1499 sweep): summarization writes a durable
-      // summary memory directly to the default-namespace `this.storage`, bypassing
-      // the extraction write path. Record the write so the namespace's
-      // `lastWriteAt` reflects this mutation. Best-effort and failure-tolerant.
-      this.markCatalogWrite(
-        this.namespaceFromStorageDir(this.storage.dir),
-        this.storage.dir,
-      );
-
       // Archive source memories
       const archived = await this.storage.archiveMemories(
         batch.map((m) => m.frontmatter.id),
         summary.id,
+      );
+
+      // Catalog write touch (issue #1499 sweep): summarization writes a durable
+      // summary and then rewrites source-memory archive status, bypassing the
+      // extraction write path. Record the touch after both mutations complete so
+      // `lastWriteAt` covers the final archived-state write.
+      this.markCatalogWrite(
+        this.namespaceFromStorageDir(this.storage.dir),
+        this.storage.dir,
       );
 
       log.info(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13511,6 +13511,13 @@ export class Orchestrator {
       // affect both the dedup fingerprint and importance (issue #519 procedure routing).
       let writeCategory = fact.category;
       let targetStorage = storage;
+      // Track the KNOWN target namespace NAME alongside targetStorage (round 6,
+      // codex P2 — NCQI0). Re-deriving it from `targetStorage.dir` mangles a raw
+      // namespace literally named like a canonical token (e.g. `ns-616c706861`
+      // served from its legacy raw dir decodes to `alpha`). We seed it from the
+      // base storage dir once, then carry the EXPLICIT routed name verbatim so
+      // the catalog write touch records the real namespace, not a decoded guess.
+      let targetNamespaceName = this.namespaceFromStorageDir(targetStorage.dir);
       let routedRuleId: string | undefined;
       let routedNamespaceExplicit = false;
       if (routeRules.length > 0) {
@@ -13527,6 +13534,7 @@ export class Orchestrator {
               targetStorage = await this.storageRouter.storageFor(
                 selected.target.namespace,
               );
+              targetNamespaceName = selected.target.namespace;
             }
           }
         } catch (err) {
@@ -13556,6 +13564,7 @@ export class Orchestrator {
             targetStorage = await this.storageRouter.storageFor(
               this.config.sharedNamespace,
             );
+            targetNamespaceName = this.config.sharedNamespace;
             log.debug(
               `scope-routing: fact "${fact.content.slice(0, 60)}…" routed to shared namespace (scope=global)`,
             );
@@ -13936,11 +13945,9 @@ export class Orchestrator {
           // it must record its own write touch here or chunked writes would
           // never update lastWriteAt. Best-effort and failure-tolerant; the
           // non-chunked path records its touch separately, so this fires exactly
-          // once per write (no double-count).
-          this.markCatalogWrite(
-            this.namespaceFromStorageDir(targetStorage.dir),
-            targetStorage.dir,
-          );
+          // once per write (no double-count). Use the KNOWN routed name, not a
+          // dir-decoded guess (NCQI0).
+          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
 
           // Write individual chunks with parent reference
           for (const chunk of chunkResult.chunks) {
@@ -14190,10 +14197,8 @@ export class Orchestrator {
       );
       // Catalog touch (issue #1499): record the write so dynamic namespaces are
       // discoverable after hot-path writes. Best-effort and failure-tolerant.
-      this.markCatalogWrite(
-        this.namespaceFromStorageDir(targetStorage.dir),
-        targetStorage.dir,
-      );
+      // Use the KNOWN routed name, not a dir-decoded guess (NCQI0).
+      this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
       if (routedRuleId) {
         log.debug(
           `routing applied for memory ${memoryId}: rule=${routedRuleId} category=${writeCategory} storage=${targetStorage.dir}`,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15058,6 +15058,11 @@ export class Orchestrator {
     log.info("running consolidation pass");
     let merged = 0;
     let invalidated = 0;
+    // Tracks whether any consolidation memory-item action (UPDATE / MERGE /
+    // INVALIDATE) durably rewrote memory state. A consolidation pass that only
+    // mutates memory items (no profile/entity updates) still changes the default
+    // namespace's data, so its catalog `lastWriteAt` must refresh too (NIBOi).
+    let memoryItemMutated = false;
 
     // Flush access tracking buffer first
     if (this.accessTrackingBuffer.size > 0) {
@@ -15101,6 +15106,7 @@ export class Orchestrator {
             : null;
           if (await this.storage.invalidateMemory(item.existingId)) {
             invalidated += 1;
+            memoryItemMutated = true;
             await this.embeddingFallback.removeFromIndex(item.existingId);
             if (toInvalidate?.path && toInvalidate.frontmatter?.created) {
               deindexMemory(
@@ -15122,6 +15128,7 @@ export class Orchestrator {
                 lineage: [item.existingId],
               },
             );
+            memoryItemMutated = true;
             await this.indexPersistedMemory(this.storage, item.existingId);
             // updateMemory() only changes content/updated/lineage — path, created, and tags
             // are preserved, so the temporal/tag index entry is already correct; no reindex needed.
@@ -15137,6 +15144,7 @@ export class Orchestrator {
                 lineage: [item.existingId, item.mergeWith],
               },
             );
+            memoryItemMutated = true;
             await this.indexPersistedMemory(this.storage, item.existingId);
             // updateMemory() only changes content/updated/supersedes/lineage — path, created, and tags
             // are preserved, so the temporal/tag index entry for the survivor is already correct.
@@ -15182,11 +15190,18 @@ export class Orchestrator {
     }
 
     // Catalog write touch (issue #1499 sweep): consolidation persists durable
-    // profile/entity updates directly to the default-namespace `this.storage`,
-    // bypassing the extraction write path. Record one write touch so the default
-    // namespace's `lastWriteAt` reflects this mutation. The default namespace is
-    // always configured/cataloged; this only refreshes its recency. Best-effort.
-    if (result.profileUpdates.length > 0 || result.entityUpdates.length > 0) {
+    // mutations directly to the default-namespace `this.storage`, bypassing the
+    // extraction write path. Record one write touch so the default namespace's
+    // `lastWriteAt` reflects this mutation. This covers BOTH profile/entity
+    // updates AND memory-item actions (UPDATE / MERGE / INVALIDATE) — a pass that
+    // only rewrites/invalidates memory items still changed durable state and must
+    // refresh recency (NIBOi). The default namespace is always configured/
+    // cataloged; this only refreshes its recency. Best-effort and failure-tolerant.
+    if (
+      memoryItemMutated ||
+      result.profileUpdates.length > 0 ||
+      result.entityUpdates.length > 0
+    ) {
       this.markCatalogWrite(
         this.namespaceFromStorageDir(this.storage.dir),
         this.storage.dir,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4115,6 +4115,7 @@ export class Orchestrator {
     }
 
     for (const cluster of clusters) {
+      let canonicalWriteCompleted = false;
       try {
         // Operator-aware prompt (issue #561 PR 3): ask the LLM to pick the
         // SPLIT/MERGE/UPDATE operator alongside the canonical output.  Falls
@@ -4238,6 +4239,7 @@ export class Orchestrator {
             derivedVia: operator,
           },
         );
+        canonicalWriteCompleted = true;
 
         result.memoriesConsolidated++;
 
@@ -4298,16 +4300,6 @@ export class Orchestrator {
           }
         }
 
-        // Catalog write touch (issue #1499 sweep): record AFTER the canonical
-        // write AND the archival of the superseded cluster memories, so
-        // lastWriteAt reflects every durable mutation in this consolidation, not
-        // just the merge write (cursor NUtCK). Best-effort; namespace decoded from
-        // the storage dir since this path has no routed namespace name.
-        this.markCatalogWrite(
-          this.namespaceFromStorageDir(targetStorage.dir),
-          targetStorage.dir,
-        );
-
         log.info(
           `[semantic-consolidation] consolidated ${cluster.memories.length} memories → ${canonicalId}`,
         );
@@ -4316,6 +4308,21 @@ export class Orchestrator {
           `[semantic-consolidation] cluster processing failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         result.errors++;
+      } finally {
+        if (canonicalWriteCompleted) {
+          // Catalog write touch (issue #1499 sweep): record after the canonical
+          // write and, on the happy path, after archival of superseded cluster
+          // memories, so `lastWriteAt` reflects every durable mutation in this
+          // consolidation (cursor NUtCK). The `finally` also covers partial
+          // failures where the canonical memory was written but a later archive
+          // step throws and the cluster catch continues (codex NY-dK).
+          // Best-effort; namespace decoded from the storage dir since this path
+          // has no routed namespace name.
+          this.markCatalogWrite(
+            this.namespaceFromStorageDir(targetStorage.dir),
+            targetStorage.dir,
+          );
+        }
       }
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14608,6 +14608,11 @@ export class Orchestrator {
               },
             );
           }
+          // Parent/chunk files are durable at this point. Record a write now so
+          // later indexing or promotion failures cannot leave the namespace out
+          // of catalog-driven `writtenSince` maintenance; the final touch below
+          // refreshes `lastWriteAt` after later durable writes on success.
+          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
 
           if (routedRuleId) {
             log.debug(
@@ -14741,13 +14746,11 @@ export class Orchestrator {
               }
             }
           } finally {
-            // Catalog touch (issue #1499): record AFTER all chunked source-namespace
-            // durable mutations — parent/chunk writes, temporal supersession,
-            // optional artifact writes, and graph-edge writes — so `lastWriteAt`
-            // cannot precede later file changes in the same extraction pass. The
-            // `finally` preserves a touch for already-written parent/chunk data if
-            // artifact persistence fails. Use the KNOWN routed name, not a
-            // dir-decoded guess.
+            // Catalog touch (issue #1499): refresh AFTER later chunked
+            // source-namespace durable mutations — temporal supersession, shared
+            // promotion, optional artifact writes, and graph-edge writes — so
+            // `lastWriteAt` cannot precede later file changes on successful
+            // completion. Use the KNOWN routed name, not a dir-decoded guess.
             this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
           }
           trackBehaviorSignals(
@@ -14984,6 +14987,20 @@ export class Orchestrator {
     // fact-less extraction that still persists durable data must record exactly one
     // base-namespace catalog touch after all writes complete (NHZEZ, codex P2).
     let durableNonFactWritten = false;
+    let durableNonFactTouchRecorded = false;
+    const touchBaseNonFactNamespace = () => {
+      const baseTouchNamespace =
+        baseNamespace && baseNamespace.length > 0
+          ? baseNamespace
+          : this.namespaceFromStorageDir(storage.dir);
+      this.markCatalogWrite(baseTouchNamespace, storage.dir);
+    };
+    const recordDurableNonFactWrite = () => {
+      durableNonFactWritten = true;
+      if (durableNonFactTouchRecorded) return;
+      durableNonFactTouchRecorded = true;
+      touchBaseNonFactNamespace();
+    };
     for (const entity of entities) {
       try {
         const name = (entity as any)?.name;
@@ -15010,7 +15027,7 @@ export class Orchestrator {
         });
         if (id) {
           trackPersistedId(storage, id);
-          durableNonFactWritten = true;
+          recordDurableNonFactWrite();
         }
       } catch (err) {
         log.warn(`persistExtraction: entity write failed: ${err}`);
@@ -15030,11 +15047,12 @@ export class Orchestrator {
             target: rel.target,
             label: rel.label,
           });
+          recordDurableNonFactWrite();
           await storage.addEntityRelationship(rel.target, {
             target: rel.source,
             label: `${rel.label} (reverse)`,
           });
-          durableNonFactWritten = true;
+          recordDurableNonFactWrite();
         } catch (err) {
           log.debug(`relationship persist failed: ${err}`);
         }
@@ -15063,7 +15081,7 @@ export class Orchestrator {
 
     if (profileUpdates.length > 0) {
       await storage.appendToProfile(profileUpdates);
-      durableNonFactWritten = true;
+      recordDurableNonFactWrite();
     }
 
     // Persist questions
@@ -15071,7 +15089,7 @@ export class Orchestrator {
       const id = await storage.writeQuestion(q.question, q.context, q.priority);
       if (id) {
         trackPersistedId(storage, id);
-        durableNonFactWritten = true;
+        recordDurableNonFactWrite();
       }
     }
 
@@ -15083,7 +15101,7 @@ export class Orchestrator {
     if (this.config.identityEnabled && result.identityReflection) {
       try {
         await storage.appendIdentityReflection(result.identityReflection);
-        durableNonFactWritten = true;
+        recordDurableNonFactWrite();
       } catch (err) {
         log.debug(`identity reflection write failed: ${err}`);
       }
@@ -15103,11 +15121,7 @@ export class Orchestrator {
     // already touched the base namespace this only refreshes `lastWriteAt`.
     // Best-effort and failure-tolerant (markCatalogWrite swallows errors).
     if (durableNonFactWritten) {
-      const baseTouchNamespace =
-        baseNamespace && baseNamespace.length > 0
-          ? baseNamespace
-          : this.namespaceFromStorageDir(storage.dir);
-      this.markCatalogWrite(baseTouchNamespace, storage.dir);
+      touchBaseNonFactNamespace();
     }
 
     // Save content-hash index after batch

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15194,28 +15194,24 @@ export class Orchestrator {
       });
     }
 
-    // Catalog write touch (issue #1499 sweep): consolidation persists durable
-    // mutations directly to the default-namespace `this.storage`, bypassing the
-    // extraction write path. Record one write touch so the default namespace's
-    // `lastWriteAt` reflects this mutation. This covers BOTH profile/entity
-    // updates AND memory-item actions (UPDATE / MERGE / INVALIDATE) — a pass that
-    // only rewrites/invalidates memory items still changed durable state and must
-    // refresh recency (NIBOi). The default namespace is always configured/
-    // cataloged; this only refreshes its recency. Best-effort and failure-tolerant.
-    if (
-      memoryItemMutated ||
-      result.profileUpdates.length > 0 ||
-      result.entityUpdates.length > 0
-    ) {
-      this.markCatalogWrite(
-        this.namespaceFromStorageDir(this.storage.dir),
-        this.storage.dir,
-      );
+    // Catalog write touch accounting (issue #1499 sweep): consolidation persists
+    // durable mutations directly to the default-namespace `this.storage`, bypassing
+    // the extraction write path. We do NOT touch here — later maintenance steps in
+    // this same function (entity-file merges, expired-commitment / TTL cleanup,
+    // fact archival) can ALSO mutate the namespace on a run with no LLM outputs
+    // (NIjwl). So we accumulate every durable mutation into `memoryItemMutated` and
+    // record ONE consolidated touch AFTER all mutation-producing steps complete,
+    // just before returning (rule #25: touch after the write commits). LLM
+    // profile/entity updates and memory-item actions (UPDATE / MERGE / INVALIDATE)
+    // count here (NIBOi).
+    if (result.profileUpdates.length > 0 || result.entityUpdates.length > 0) {
+      memoryItemMutated = true;
     }
 
     // Merge fragmented entity files
     const entitiesMerged = await this.storage.mergeFragmentedEntities();
     if (entitiesMerged > 0) {
+      memoryItemMutated = true;
       log.info(`merged ${entitiesMerged} fragmented entity files`);
     }
 
@@ -15238,6 +15234,7 @@ export class Orchestrator {
       this.config.commitmentDecayDays,
     );
     if (deletedCommitments.length > 0) {
+      memoryItemMutated = true;
       log.info(`cleaned ${deletedCommitments.length} expired commitments`);
       if (this.config.queryAwareIndexingEnabled) {
         for (const m of deletedCommitments) {
@@ -15267,6 +15264,7 @@ export class Orchestrator {
           lifecycle.transitionedToExpired.length > 0 ||
           lifecycle.deletedResolved.length > 0
         ) {
+          memoryItemMutated = true;
           log.info(
             `commitment ledger lifecycle: expired ${lifecycle.transitionedToExpired.length}, cleaned ${lifecycle.deletedResolved.length}`,
           );
@@ -15279,6 +15277,7 @@ export class Orchestrator {
     // Clean memories past their TTL (speculative memories auto-expire)
     const deletedTTL = await this.storage.cleanExpiredTTL();
     if (deletedTTL.length > 0) {
+      memoryItemMutated = true;
       log.info(`cleaned ${deletedTTL.length} TTL-expired memories`);
       if (this.config.queryAwareIndexingEnabled) {
         for (const m of deletedTTL) {
@@ -15324,6 +15323,7 @@ export class Orchestrator {
       if (this.config.factArchivalEnabled) {
         const archived = await this.runFactArchival(allMemories);
         if (archived > 0) {
+          memoryItemMutated = true;
           log.info(`archived ${archived} old low-importance facts`);
         }
       }
@@ -15528,6 +15528,21 @@ export class Orchestrator {
           log.warn(`consolidation observer failed (ignored): ${err}`);
         }
       }
+    }
+
+    // Consolidated catalog write touch (issue #1499 sweep; NIBOi + NIjwl). One
+    // touch covering EVERY durable namespace mutation this pass made — LLM
+    // profile/entity/memory-item actions AND cleanup-only maintenance (entity-file
+    // merges, expired-commitment / ledger-lifecycle / TTL cleanup, fact archival).
+    // Recorded here, after all mutation-producing steps, so a cleanup-only run that
+    // rewrote the store still refreshes `lastWriteAt` (rule #25). The default
+    // namespace is always configured/cataloged; `markWrite` is idempotent so this
+    // only refreshes recency. Best-effort and failure-tolerant.
+    if (memoryItemMutated) {
+      this.markCatalogWrite(
+        this.namespaceFromStorageDir(this.storage.dir),
+        this.storage.dir,
+      );
     }
 
     log.info("consolidation complete");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2297,6 +2297,52 @@ export class Orchestrator {
     return resolvedStorageDir === rawRoot || resolvedStorageDir === tokenRoot;
   }
 
+  private namespaceStorageDirHintOwnershipRank(
+    record: { namespace: string },
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): number {
+    if (resolvedStorageDir === path.resolve(this.config.memoryDir)) {
+      return record.namespace === normalizeNamespaceIdentity(this.config.defaultNamespace)
+        ? 0
+        : 3;
+    }
+
+    const leaf = path.basename(resolvedStorageDir);
+    const tokenOwnsRoot = namespaceIdentityToken(record.namespace) === leaf;
+    if (tokenOwnsRoot && configured.has(record.namespace)) return 0;
+    if (record.namespace === leaf) return 1;
+    if (tokenOwnsRoot) return 2;
+    return 3;
+  }
+
+  private preferNamespaceStorageDirHintOwner(
+    current: { namespace: string; identityToken: string; storageDir: string },
+    candidate: { namespace: string; identityToken: string; storageDir: string },
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): { namespace: string; identityToken: string; storageDir: string } {
+    const currentRank = this.namespaceStorageDirHintOwnershipRank(
+      current,
+      resolvedStorageDir,
+      configured,
+    );
+    const candidateRank = this.namespaceStorageDirHintOwnershipRank(
+      candidate,
+      resolvedStorageDir,
+      configured,
+    );
+    if (candidateRank < currentRank) return candidate;
+    if (candidateRank > currentRank) return current;
+
+    const byName = candidate.namespace.localeCompare(current.namespace);
+    if (byName < 0) return candidate;
+    if (byName > 0) return current;
+    return candidate.identityToken.localeCompare(current.identityToken) < 0
+      ? candidate
+      : current;
+  }
+
   private loadNamespaceStorageDirHintsFromCatalog(): void {
     if (this.namespaceStorageDirHintsLoaded || !this.namespaceCatalog.enabled) return;
     this.namespaceStorageDirHintsLoaded = true;
@@ -2310,6 +2356,10 @@ export class Orchestrator {
       return;
     }
 
+    const compactedByNamespace = new Map<
+      string,
+      { namespace: string; identityToken: string; storageDir: string }
+    >();
     for (const line of body.split(/\r?\n/)) {
       const trimmed = line.trim();
       if (!trimmed) continue;
@@ -2326,10 +2376,43 @@ export class Orchestrator {
         }
         const namespace = normalizeNamespaceIdentity(record.namespace);
         if (!namespace || record.identityToken !== namespaceIdentityToken(namespace)) continue;
-        this.rememberNamespaceStorageDirHint(namespace, record.storageDir);
+        compactedByNamespace.set(namespace, {
+          namespace,
+          identityToken: record.identityToken,
+          storageDir: record.storageDir,
+        });
       } catch {
         // Catalog hints are best-effort. The catalog reader still owns full recovery.
       }
+    }
+
+    const configured = new Set(
+      this.configuredNamespaces().map((namespace) => normalizeNamespaceIdentity(namespace)),
+    );
+    const preferredByStorageDir = new Map<
+      string,
+      { namespace: string; identityToken: string; storageDir: string }
+    >();
+    for (const record of compactedByNamespace.values()) {
+      if (!this.storageDirMatchesNamespaceHint(record.namespace, record.storageDir)) {
+        continue;
+      }
+      const resolvedStorageDir = path.resolve(record.storageDir);
+      const current = preferredByStorageDir.get(resolvedStorageDir);
+      preferredByStorageDir.set(
+        resolvedStorageDir,
+        current
+          ? this.preferNamespaceStorageDirHintOwner(
+              current,
+              record,
+              resolvedStorageDir,
+              configured,
+            )
+          : record,
+      );
+    }
+    for (const record of preferredByStorageDir.values()) {
+      this.rememberNamespaceStorageDirHint(record.namespace, record.storageDir);
     }
   }
 
@@ -14617,55 +14700,55 @@ export class Orchestrator {
                 intentEntityTypes: inferredIntent?.entityTypes,
               });
             }
+            // v8.2: graph edge building for chunked memories
+            if (this.config.multiGraphMemoryEnabled) {
+              try {
+                const graphContext = await ensureGraphContext(targetStorage);
+                const entityRef =
+                  typeof (fact as any).entityRef === "string"
+                    ? (fact as any).entityRef
+                    : undefined;
+                const parentRelPath = resolvePersistedMemoryRelativePath({
+                  memoryId: parentId,
+                  pathById: graphContext.memoryPathById,
+                  category: writeCategory,
+                });
+                graphContext.memoryPathById.set(parentId, parentRelPath);
+                appendMemoryToGraphContext({
+                  allMemsForGraph: graphContext.allMemsForGraph,
+                  storageDir: targetStorage.dir,
+                  memoryRelPath: parentRelPath,
+                  memoryId: parentId,
+                  category: writeCategory,
+                  content: fact.content ?? "",
+                  entityRef,
+                });
+                await this.buildGraphEdge(
+                  targetStorage,
+                  parentRelPath,
+                  entityRef,
+                  parentId,
+                  fact.content ?? "",
+                  graphContext.allMemsForGraph,
+                  graphContext.memoryPathById,
+                  threadIdForExtraction ?? undefined,
+                  threadEpisodeIdsForGraph,
+                  graphContext.previousPersistedRelPath,
+                );
+                graphContext.previousPersistedRelPath = parentRelPath;
+              } catch {
+                /* fail-open */
+              }
+            }
           } finally {
             // Catalog touch (issue #1499): record AFTER all chunked source-namespace
-            // durable mutations — parent/chunk writes, temporal supersession, and
-            // optional artifact writes — so `lastWriteAt` cannot precede later file
-            // changes in the same extraction pass (codex NYsKb / cursor NY68M).
-            // The `finally` preserves a touch for already-written parent/chunk data
-            // if artifact persistence fails. Use the KNOWN routed name, not a
+            // durable mutations — parent/chunk writes, temporal supersession,
+            // optional artifact writes, and graph-edge writes — so `lastWriteAt`
+            // cannot precede later file changes in the same extraction pass. The
+            // `finally` preserves a touch for already-written parent/chunk data if
+            // artifact persistence fails. Use the KNOWN routed name, not a
             // dir-decoded guess.
             this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
-          }
-          // v8.2: graph edge building for chunked memories
-          if (this.config.multiGraphMemoryEnabled) {
-            try {
-              const graphContext = await ensureGraphContext(targetStorage);
-              const entityRef =
-                typeof (fact as any).entityRef === "string"
-                  ? (fact as any).entityRef
-                  : undefined;
-              const parentRelPath = resolvePersistedMemoryRelativePath({
-                memoryId: parentId,
-                pathById: graphContext.memoryPathById,
-                category: writeCategory,
-              });
-              graphContext.memoryPathById.set(parentId, parentRelPath);
-              appendMemoryToGraphContext({
-                allMemsForGraph: graphContext.allMemsForGraph,
-                storageDir: targetStorage.dir,
-                memoryRelPath: parentRelPath,
-                memoryId: parentId,
-                category: writeCategory,
-                content: fact.content ?? "",
-                entityRef,
-              });
-              await this.buildGraphEdge(
-                targetStorage,
-                parentRelPath,
-                entityRef,
-                parentId,
-                fact.content ?? "",
-                graphContext.allMemsForGraph,
-                graphContext.memoryPathById,
-                threadIdForExtraction ?? undefined,
-                threadEpisodeIdsForGraph,
-                graphContext.previousPersistedRelPath,
-              );
-              graphContext.previousPersistedRelPath = parentRelPath;
-            } catch {
-              /* fail-open */
-            }
           }
           trackBehaviorSignals(
             targetStorage,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14511,13 +14511,6 @@ export class Orchestrator {
             );
           }
 
-          // Catalog touch (issue #1499): record AFTER all chunk writes so a
-          // partial chunked write (a failed `writeChunk`) does not mark a
-          // completed namespace write (cursor NUtB_). The chunked path `continue`s
-          // past the non-chunked touch below, so this fires exactly once per
-          // chunked write. Use the KNOWN routed name, not a dir-decoded guess.
-          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
-
           if (routedRuleId) {
             log.debug(
               `routing applied for chunked memory ${parentId}: rule=${routedRuleId} category=${writeCategory} storage=${targetStorage.dir}`,
@@ -14591,22 +14584,33 @@ export class Orchestrator {
             // directly for embedding-fallback sync of each chunk document.
             await this.indexPersistedMemory(targetStorage, chunkId);
           }
-          if (
-            this.config.verbatimArtifactsEnabled &&
-            this.config.verbatimArtifactCategories.includes(writeCategory) &&
-            fact.confidence >= this.config.verbatimArtifactsMinConfidence
-          ) {
-            // Reuse citedChunkedContent so the artifact carries the same citation
-            // timestamp as the parent memory write above (Fix #3 — duplicate-citation).
-            await targetStorage.writeArtifact(citedChunkedContent, {
-              confidence: fact.confidence,
-              tags: [...fact.tags, "artifact", "chunked-parent"],
-              artifactType: this.artifactTypeForCategory(writeCategory),
-              sourceMemoryId: parentId,
-              intentGoal: inferredIntent?.goal,
-              intentActionType: inferredIntent?.actionType,
-              intentEntityTypes: inferredIntent?.entityTypes,
-            });
+          try {
+            if (
+              this.config.verbatimArtifactsEnabled &&
+              this.config.verbatimArtifactCategories.includes(writeCategory) &&
+              fact.confidence >= this.config.verbatimArtifactsMinConfidence
+            ) {
+              // Reuse citedChunkedContent so the artifact carries the same citation
+              // timestamp as the parent memory write above (Fix #3 — duplicate-citation).
+              await targetStorage.writeArtifact(citedChunkedContent, {
+                confidence: fact.confidence,
+                tags: [...fact.tags, "artifact", "chunked-parent"],
+                artifactType: this.artifactTypeForCategory(writeCategory),
+                sourceMemoryId: parentId,
+                intentGoal: inferredIntent?.goal,
+                intentActionType: inferredIntent?.actionType,
+                intentEntityTypes: inferredIntent?.entityTypes,
+              });
+            }
+          } finally {
+            // Catalog touch (issue #1499): record AFTER all chunked source-namespace
+            // durable mutations — parent/chunk writes, temporal supersession, and
+            // optional artifact writes — so `lastWriteAt` cannot precede later file
+            // changes in the same extraction pass (codex NYsKb / cursor NY68M).
+            // The `finally` preserves a touch for already-written parent/chunk data
+            // if artifact persistence fails. Use the KNOWN routed name, not a
+            // dir-decoded guess.
+            this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
           }
           // v8.2: graph edge building for chunked memories
           if (this.config.multiGraphMemoryEnabled) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12549,6 +12549,9 @@ export class Orchestrator {
       storage,
       threadIdForExtraction,
       { sessionKey, principal, validAt: sourceValidAt },
+      // Pass the KNOWN base namespace (NHIdx) so the catalog write touch records the
+      // real namespace rather than a guess decoded from the storage dir.
+      selfNamespace,
     );
     let postPersistMetadataFailed = false;
     meta ??= await storage.loadMeta();
@@ -13066,6 +13069,7 @@ export class Orchestrator {
     storage: StorageManager,
     threadIdForExtraction?: string | null,
     sourceContext?: { sessionKey?: string; principal?: string; validAt?: string },
+    baseNamespace?: string,
   ): Promise<string[]> {
     // Inline source attribution (issue #369). When enabled, every extracted
     // fact is rewritten to carry a compact provenance tag inside its body so
@@ -13833,9 +13837,15 @@ export class Orchestrator {
       // codex P2 — NCQI0). Re-deriving it from `targetStorage.dir` mangles a raw
       // namespace literally named like a canonical token (e.g. `ns-616c706861`
       // served from its legacy raw dir decodes to `alpha`). We seed it from the
-      // base storage dir once, then carry the EXPLICIT routed name verbatim so
-      // the catalog write touch records the real namespace, not a decoded guess.
-      let targetNamespaceName = this.namespaceFromStorageDir(targetStorage.dir);
+      // EXPLICIT base namespace the caller used to obtain `storage` (NHIdx, codex
+      // P2) — `selfNamespace`/`writeNamespaceOverride` — so the catalog write touch
+      // records the real namespace, not a guess decoded from the directory. We only
+      // fall back to decoding the dir when no base namespace was passed (legacy
+      // callers). The EXPLICIT routed name (below) still overrides this verbatim.
+      let targetNamespaceName =
+        baseNamespace && baseNamespace.length > 0
+          ? baseNamespace
+          : this.namespaceFromStorageDir(targetStorage.dir);
       let routedRuleId: string | undefined;
       let routedNamespaceExplicit = false;
       if (routeRules.length > 0) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -298,6 +298,7 @@ import {
   type ConversationQmdRuntime,
 } from "./conversation-index/backend.js";
 import { NamespaceStorageRouter } from "./namespaces/storage.js";
+import { NamespaceCatalog } from "./namespaces/catalog.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import {
   canReadNamespace,
@@ -1753,6 +1754,8 @@ export function resolvePersistedMemoryRelativePath(options: {
 export class Orchestrator {
   readonly storage: StorageManager;
   private readonly storageRouter: NamespaceStorageRouter;
+  /** Rebuildable namespace catalog (issue #1499). Inert unless namespaces enabled. */
+  readonly namespaceCatalog: NamespaceCatalog;
   private readonly namespaceSearchRouter: NamespaceSearchRouter;
   qmd: SearchBackend;
   private readonly conversationQmd?: ConversationQmdRuntime;
@@ -2279,7 +2282,18 @@ export class Orchestrator {
       storageDir: config.profilingStorageDir || path.join(config.memoryDir, "profiling"),
       maxTraces: config.profilingMaxTraces,
     });
-    this.storageRouter = new NamespaceStorageRouter(config);
+    // Namespace catalog (issue #1499): downstream, rebuildable metadata index.
+    // Inert unless namespacesEnabled is true. Storage resolution registers
+    // namespaces via the router's onResolve hook; the touch is best-effort and
+    // a catalog write failure never affects storage resolution.
+    this.namespaceCatalog = new NamespaceCatalog(config);
+    this.storageRouter = new NamespaceStorageRouter(config, {
+      onResolve: (namespace, storageDir) => {
+        void this.namespaceCatalog
+          .registerResolved(namespace, storageDir)
+          .catch(() => undefined);
+      },
+    });
     this.namespaceSearchRouter = new NamespaceSearchRouter(
       config,
       this.storageRouter,
@@ -7118,6 +7132,11 @@ export class Orchestrator {
       recallNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
     } else {
       recallNamespaces = readableRecallNamespaces;
+    }
+    // Catalog touch (issue #1499): record reads against the recalled namespaces
+    // so the catalog reflects active read scopes. Best-effort, failure-tolerant.
+    if (this.namespaceCatalog.enabled) {
+      for (const ns of recallNamespaces) this.markCatalogRead(ns);
     }
     const qmdAvailable = this.qmd.isAvailable();
     let graphDecisionStatus: IntentDebugSnapshot["graphDecision"]["status"] =
@@ -14130,6 +14149,12 @@ export class Orchestrator {
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
         },
       );
+      // Catalog touch (issue #1499): record the write so dynamic namespaces are
+      // discoverable after hot-path writes. Best-effort and failure-tolerant.
+      this.markCatalogWrite(
+        this.namespaceFromStorageDir(targetStorage.dir),
+        targetStorage.dir,
+      );
       if (routedRuleId) {
         log.debug(
           `routing applied for memory ${memoryId}: rule=${routedRuleId} category=${writeCategory} storage=${targetStorage.dir}`,
@@ -18224,6 +18249,26 @@ export class Orchestrator {
     const m = resolvedStorageDir.match(/[\\/]namespaces[\\/]([^\\/]+)$/);
     if (!m?.[1]) return this.config.defaultNamespace;
     return namespaceIdentityFromToken(m[1]) ?? m[1];
+  }
+
+  /**
+   * Record a namespace write in the catalog (issue #1499). Best-effort and
+   * failure-tolerant: a catalog write error MUST NOT crash the primary memory
+   * write (CLAUDE.md gotcha #13, rule #40). Fire-and-forget by design.
+   */
+  private markCatalogWrite(namespace: string, storageDir?: string): void {
+    if (!this.namespaceCatalog.enabled) return;
+    void this.namespaceCatalog
+      .markWrite(namespace, { discoveredBy: "write", storageDir })
+      .catch(() => undefined);
+  }
+
+  /** Record a namespace read in the catalog. Best-effort, failure-tolerant. */
+  private markCatalogRead(namespace: string, storageDir?: string): void {
+    if (!this.namespaceCatalog.enabled) return;
+    void this.namespaceCatalog
+      .markRead(namespace, { discoveredBy: "read", storageDir })
+      .catch(() => undefined);
   }
 
   private async readAllMemoriesForNamespaces(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14791,17 +14791,31 @@ export class Orchestrator {
       }
     }
 
-    // Catalog touch for durable NON-FACT outputs (NHZEZ, codex P2). The per-fact
-    // `markCatalogWrite` above only fires inside the fact write loop, so an
-    // extraction that persists ONLY entities, relationships, profile updates, or
-    // questions (no facts) would record durable data to the BASE namespace's
-    // storage without ever touching the catalog — leaving that namespace's
-    // `lastWriteAt` stale so `listNamespaces({writtenSince})` / write-recency QMD
-    // maintenance miss the write. Entities/relationships/profile/questions are all
-    // written to the BASE `storage` (not the per-fact routed `targetStorage`), so
-    // we record ONE base-namespace touch here, after all non-fact writes complete.
-    // Use the KNOWN base namespace name, not a dir-decoded guess (NCQI0). One touch
-    // per namespace per extraction — `markWrite` is idempotent, so if the fact path
+    // Persist identity reflection. This writes durable namespace-local state, so
+    // an identity-ONLY extraction (no facts/entities/profile/questions) still
+    // counts as a durable non-fact write for the catalog touch below (NIIly).
+    // Only count it when the write actually succeeds (best-effort write); the
+    // touch is recorded AFTER this so a rolled-back/failed write never touches.
+    if (this.config.identityEnabled && result.identityReflection) {
+      try {
+        await storage.appendIdentityReflection(result.identityReflection);
+        durableNonFactWritten = true;
+      } catch (err) {
+        log.debug(`identity reflection write failed: ${err}`);
+      }
+    }
+
+    // Catalog touch for durable NON-FACT outputs (NHZEZ / NIIly, codex P2). The
+    // per-fact `markCatalogWrite` above only fires inside the fact write loop, so
+    // an extraction that persists ONLY entities, relationships, profile updates,
+    // questions, or an identity reflection (no facts) would record durable data to
+    // the BASE namespace's storage without ever touching the catalog — leaving that
+    // namespace's `lastWriteAt` stale so `listNamespaces({writtenSince})` /
+    // write-recency QMD maintenance miss the write. All of these are written to the
+    // BASE `storage` (not the per-fact routed `targetStorage`), so we record ONE
+    // base-namespace touch here, AFTER every non-fact write completes. Use the
+    // KNOWN base namespace name, not a dir-decoded guess (NCQI0). One touch per
+    // namespace per extraction — `markWrite` is idempotent, so if the fact path
     // already touched the base namespace this only refreshes `lastWriteAt`.
     // Best-effort and failure-tolerant (markCatalogWrite swallows errors).
     if (durableNonFactWritten) {
@@ -14810,15 +14824,6 @@ export class Orchestrator {
           ? baseNamespace
           : this.namespaceFromStorageDir(storage.dir);
       this.markCatalogWrite(baseTouchNamespace, storage.dir);
-    }
-
-    // Persist identity reflection
-    if (this.config.identityEnabled && result.identityReflection) {
-      try {
-        await storage.appendIdentityReflection(result.identityReflection);
-      } catch (err) {
-        log.debug(`identity reflection write failed: ${err}`);
-      }
     }
 
     // Save content-hash index after batch

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2470,7 +2470,6 @@ export class Orchestrator {
       if (path.resolve(liveRoot) !== path.resolve(record.storageDir)) {
         return false;
       }
-      if (record.lastWriteAt) return true;
       return hasMemoryData(liveRoot);
     } catch {
       return false;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4150,17 +4150,27 @@ export class Orchestrator {
                 this.contentHashIndex.remove(m.content);
               }
             }
-            await this.embeddingFallback.removeFromIndex(m.frontmatter.id);
-            if (
-              this.config.queryAwareIndexingEnabled &&
-              m.path &&
-              m.frontmatter?.created
-            ) {
-              deindexMemory(
-                targetStorage.dir,
-                m.path,
-                m.frontmatter.created,
-                m.frontmatter.tags ?? [],
+            // Best-effort index cleanup: a failure here (e.g. on-disk index save
+            // under disk-full) must NOT abort the archival loop and thereby skip
+            // the catalog write touch below for an already-durable canonical write
+            // (kilo NV0mh).
+            try {
+              await this.embeddingFallback.removeFromIndex(m.frontmatter.id);
+              if (
+                this.config.queryAwareIndexingEnabled &&
+                m.path &&
+                m.frontmatter?.created
+              ) {
+                deindexMemory(
+                  targetStorage.dir,
+                  m.path,
+                  m.frontmatter.created,
+                  m.frontmatter.tags ?? [],
+                );
+              }
+            } catch (cleanupErr) {
+              log.warn(
+                `[semantic-consolidation] index cleanup failed (non-fatal): ${cleanupErr}`,
               );
             }
             result.memoriesArchived++;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -18302,9 +18302,16 @@ export class Orchestrator {
    * namespaces never record `lastWriteAt`, so the catalog under-reports write
    * recency (round 5, codex P2). Fire-and-forget and failure-tolerant — a
    * catalog error must never affect the explicit write (gotcha #13, rule #40).
+   *
+   * An undefined/empty `namespace` means the write targeted the DEFAULT namespace
+   * (`getStorage(undefined)` routes there), so we record it under the configured
+   * default rather than skipping it (round 6, codex P2 — default `memory_store`
+   * and inline-note writes were missing from `writtenSince`/maintenance).
    */
-  recordCatalogWrite(namespace: string, storageDir?: string): void {
-    this.markCatalogWrite(namespace, storageDir);
+  recordCatalogWrite(namespace?: string, storageDir?: string): void {
+    const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
+    if (!ns) return;
+    this.markCatalogWrite(ns, storageDir);
   }
 
   /** Record a namespace read in the catalog. Best-effort, failure-tolerant. */

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2245,6 +2245,35 @@ export class Orchestrator {
     );
   }
 
+  /**
+   * Namespaces that QMD maintenance (update/embed) must cover: the CONFIGURED set
+   * PLUS every dynamic namespace recorded in the catalog (NGnei, codex P2). An
+   * extraction that writes to a coding-scoped/dynamic namespace (not in
+   * defaultNamespace/sharedNamespace/namespacePolicies) is only made discoverable
+   * via the catalog; if maintenance embeds only `configuredNamespaces()`, that
+   * namespace's QMD collection is never updated/embedded after writes and
+   * recall/search stays stale or empty until it is manually configured. We union in
+   * the catalog's namespaces so maintenance keeps dynamic namespaces fresh.
+   * `updateNamespaces`/`embedNamespaces` already trim, dedup, and skip
+   * unavailable/missing collections, so extra names are filtered safely. A catalog
+   * read failure must never break maintenance — fall back to the configured set.
+   */
+  private async maintenanceNamespaces(): Promise<string[]> {
+    const configured = this.configuredNamespaces();
+    if (!this.namespaceCatalog.enabled) return configured;
+    let cataloged: string[] = [];
+    try {
+      const records = await this.namespaceCatalog.listNamespaces();
+      cataloged = records.map((record) => record.namespace);
+    } catch {
+      // Best-effort: a catalog read failure must not break QMD maintenance.
+      cataloged = [];
+    }
+    return Array.from(
+      new Set([...configured, ...cataloged].map((value) => value.trim()).filter(Boolean)),
+    );
+  }
+
   private buildConfiguredQmdSearchOptions(
     queryText: string,
   ): SearchQueryOptions | undefined {
@@ -13001,25 +13030,28 @@ export class Orchestrator {
 
     try {
       if (this.config.namespacesEnabled) {
-        await this.namespaceSearchRouter.updateNamespaces(
-          this.configuredNamespaces(),
-        );
+        // Include cataloged dynamic namespaces, not just the configured set
+        // (NGnei) — resolve once and reuse for both update and embed.
+        const maintenanceNamespaces = await this.maintenanceNamespaces();
+        await this.namespaceSearchRouter.updateNamespaces(maintenanceNamespaces);
+        const now = Date.now();
+        if (
+          this.config.qmdAutoEmbedEnabled &&
+          now - this.lastQmdEmbedAtMs >= this.config.qmdEmbedMinIntervalMs
+        ) {
+          await this.namespaceSearchRouter.embedNamespaces(maintenanceNamespaces);
+          this.lastQmdEmbedAtMs = now;
+        }
       } else {
         await this.qmd.update();
-      }
-      const now = Date.now();
-      if (
-        this.config.qmdAutoEmbedEnabled &&
-        now - this.lastQmdEmbedAtMs >= this.config.qmdEmbedMinIntervalMs
-      ) {
-        if (this.config.namespacesEnabled) {
-          await this.namespaceSearchRouter.embedNamespaces(
-            this.configuredNamespaces(),
-          );
-        } else {
+        const now = Date.now();
+        if (
+          this.config.qmdAutoEmbedEnabled &&
+          now - this.lastQmdEmbedAtMs >= this.config.qmdEmbedMinIntervalMs
+        ) {
           await this.qmd.embed();
+          this.lastQmdEmbedAtMs = now;
         }
-        this.lastQmdEmbedAtMs = now;
       }
     } finally {
       this.qmdMaintenanceInFlight = false;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6,7 +6,7 @@ import {
 import path from "node:path";
 import os from "node:os";
 import { createHash, randomBytes } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import {
   mkdir,
   readdir,
@@ -299,7 +299,11 @@ import {
 } from "./conversation-index/backend.js";
 import { NamespaceStorageRouter } from "./namespaces/storage.js";
 import { NamespaceCatalog } from "./namespaces/catalog.js";
-import { namespaceIdentityFromToken, namespaceIdentityToken } from "./namespaces/identity.js";
+import {
+  namespaceIdentityFromToken,
+  namespaceIdentityToken,
+  normalizeNamespaceIdentity,
+} from "./namespaces/identity.js";
 import {
   canReadNamespace,
   defaultNamespaceForPrincipal,
@@ -328,6 +332,7 @@ import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
 import { TierMigrationExecutor } from "./tier-migration.js";
 import { decideTierTransition, type MemoryTier } from "./tier-routing.js";
 import {
+  isSafeRouteNamespace,
   selectRouteRule,
   type RouteRule,
   type RoutingEngineOptions,
@@ -1760,6 +1765,8 @@ export class Orchestrator {
   private readonly storageRouter: NamespaceStorageRouter;
   /** Rebuildable namespace catalog (issue #1499). Inert unless namespaces enabled. */
   readonly namespaceCatalog: NamespaceCatalog;
+  private readonly namespaceStorageDirHints = new Map<string, Set<string>>();
+  private namespaceStorageDirHintsLoaded = false;
   private readonly namespaceSearchRouter: NamespaceSearchRouter;
   qmd: SearchBackend;
   private readonly conversationQmd?: ConversationQmdRuntime;
@@ -2248,6 +2255,67 @@ export class Orchestrator {
     );
   }
 
+  private rememberNamespaceStorageDirHint(namespace: string, storageDir?: string): void {
+    if (!this.config.namespacesEnabled || !storageDir) return;
+    const ns = normalizeNamespaceIdentity(namespace);
+    if (!ns) return;
+    const defaultNs = normalizeNamespaceIdentity(this.config.defaultNamespace);
+    if (ns !== defaultNs && !isSafeRouteNamespace(ns)) return;
+
+    const resolvedStorageDir = path.resolve(storageDir);
+    const resolvedMemoryDir = path.resolve(this.config.memoryDir);
+    const resolvedNamespacesDir = path.join(resolvedMemoryDir, "namespaces");
+    if (
+      resolvedStorageDir !== resolvedMemoryDir &&
+      !isPathInsideStorageRoot(resolvedNamespacesDir, resolvedStorageDir)
+    ) {
+      return;
+    }
+
+    let hints = this.namespaceStorageDirHints.get(resolvedStorageDir);
+    if (!hints) {
+      hints = new Set<string>();
+      this.namespaceStorageDirHints.set(resolvedStorageDir, hints);
+    }
+    hints.add(ns);
+  }
+
+  private loadNamespaceStorageDirHintsFromCatalog(): void {
+    if (this.namespaceStorageDirHintsLoaded || !this.namespaceCatalog.enabled) return;
+    this.namespaceStorageDirHintsLoaded = true;
+    const catalogPath = path.join(this.config.memoryDir, "state", "namespaces.jsonl");
+    if (!existsSync(catalogPath)) return;
+
+    let body: string;
+    try {
+      body = readFileSync(catalogPath, "utf8");
+    } catch {
+      return;
+    }
+
+    for (const line of body.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+        const record = parsed as Record<string, unknown>;
+        if (
+          typeof record.namespace !== "string" ||
+          typeof record.storageDir !== "string" ||
+          typeof record.identityToken !== "string"
+        ) {
+          continue;
+        }
+        const namespace = normalizeNamespaceIdentity(record.namespace);
+        if (!namespace || record.identityToken !== namespaceIdentityToken(namespace)) continue;
+        this.rememberNamespaceStorageDirHint(namespace, record.storageDir);
+      } catch {
+        // Catalog hints are best-effort. The catalog reader still owns full recovery.
+      }
+    }
+  }
+
   /**
    * Namespaces that QMD maintenance (update/embed) must cover: the CONFIGURED set
    * PLUS every dynamic namespace recorded in the catalog (NGnei, codex P2). An
@@ -2392,8 +2460,10 @@ export class Orchestrator {
       // router's resolve-hook dedup only marks a namespace notified when the
       // catalog actually APPENDED. A dropped append (rebuild-lock timeout) or a
       // failure resolves to `false`/rejects, so the next `storageFor` retries.
-      onResolve: (namespace, storageDir) =>
-        this.namespaceCatalog.registerResolved(namespace, storageDir),
+      onResolve: (namespace, storageDir) => {
+        this.rememberNamespaceStorageDirHint(namespace, storageDir);
+        return this.namespaceCatalog.registerResolved(namespace, storageDir);
+      },
     });
     this.namespaceSearchRouter = new NamespaceSearchRouter(
       config,
@@ -18848,14 +18918,24 @@ export class Orchestrator {
     const dirName = m[1];
     // Token-shaped raw names (round 6, codex P2 — NBsFz): a dir name might be a
     // tokenized identity OR a literal raw namespace name that merely LOOKS like a
-    // token (e.g. a configured name `ns-616c706861`). The round-trip check below
+    // token (e.g. a configured or dynamic name `ns-616c706861`). The round-trip check below
     // (`namespaceIdentityToken(decoded) === dirName`) is TAUTOLOGICAL for a
     // canonical token string, so it cannot tell a tokenized dir for `alpha` apart
     // from the legacy raw root of a namespace literally named `ns-616c706861`
-    // (codex NRCve). A dir name that is itself a KNOWN (configured) namespace is
-    // therefore preserved as the literal namespace BEFORE attempting to decode it.
+    // (codex NRCve). A dir name that is itself a KNOWN namespace (configured or
+    // catalog-owned at this exact storage root) is therefore preserved as the
+    // literal namespace BEFORE attempting to decode it.
     if (this.configuredNamespaces().includes(dirName)) {
       return dirName;
+    }
+    this.loadNamespaceStorageDirHintsFromCatalog();
+    const hintedNamespaces = this.namespaceStorageDirHints.get(resolvedStorageDir);
+    if (hintedNamespaces?.has(dirName)) {
+      return dirName;
+    }
+    if (hintedNamespaces?.size === 1) {
+      const [hintedNamespace] = hintedNamespaces;
+      if (hintedNamespace) return hintedNamespace;
     }
     const decoded = namespaceIdentityFromToken(dirName);
     if (decoded && namespaceIdentityToken(decoded) === dirName) {
@@ -18871,6 +18951,7 @@ export class Orchestrator {
    */
   private markCatalogWrite(namespace: string, storageDir?: string): void {
     if (!this.namespaceCatalog.enabled) return;
+    this.rememberNamespaceStorageDirHint(namespace, storageDir);
     void this.namespaceCatalog
       .markWrite(namespace, { discoveredBy: "write", storageDir })
       .catch(() => undefined);
@@ -18899,6 +18980,7 @@ export class Orchestrator {
   /** Record a namespace read in the catalog. Best-effort, failure-tolerant. */
   private markCatalogRead(namespace: string, storageDir?: string): void {
     if (!this.namespaceCatalog.enabled) return;
+    this.rememberNamespaceStorageDirHint(namespace, storageDir);
     void this.namespaceCatalog
       .markRead(namespace, { discoveredBy: "read", storageDir })
       .catch(() => undefined);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13312,7 +13312,7 @@ export class Orchestrator {
                 // `createdAt` as the ordering anchor instead of the old fact's
                 // timestamp, ensuring supersession fires correctly even when
                 // the matching fact predates conflicting candidates.
-                await applyTemporalSupersession({
+                const hashDedupSupersession = await applyTemporalSupersession({
                   storage: sharedStorage,
                   newMemoryId: hashDedupMatchingFact.frontmatter.id,
                   entityRef: options.entityRef,
@@ -13321,6 +13321,19 @@ export class Orchestrator {
                   enabled: true,
                   useCallerTimestamp: true,
                 });
+                // Catalog touch (issue #1499 — codex P2 NElSf): this dedup branch
+                // returns WITHOUT reaching the post-write `markCatalogWrite` below,
+                // but `applyTemporalSupersession` mutated the shared namespace
+                // (it rewrote frontmatter to retire stale shared facts). When any
+                // ids were actually superseded, the shared namespace changed, so we
+                // must record the write — otherwise the shared record's
+                // `lastWriteAt` stays stale and `writtenSince` maintenance / QMD
+                // fanout skips the namespace after a supersession-only update.
+                // Best-effort and failure-tolerant (markCatalogWrite swallows
+                // errors); only touch when work happened to avoid spurious writes.
+                if (hashDedupSupersession.supersededIds.length > 0) {
+                  this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
+                }
                 // Active matching fact exists — normal short-circuit is safe.
                 return;
               }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7151,10 +7151,16 @@ export class Orchestrator {
     // zero (`topK: 0`, a disabled/zero `memories` recall section, etc.). The QMD
     // path explicitly returns before searching when `recallResultLimit <= 0`, so
     // no namespace is actually read and the touch would be spurious.
+    // Round 6 (codex P2 — NDXHa): also skip when the recall was ALREADY aborted.
+    // `throwIfRecallAborted` runs later (in the Phase 1 retrieval block), so an
+    // already-aborted recall exits before any QMD/fallback read — firing these
+    // fire-and-forget touches would set `lastReadAt` for a canceled recall and
+    // make catalog recency/maintenance treat it as a real read.
     if (
       this.namespaceCatalog.enabled &&
       recallMode !== "no_recall" &&
-      recallResultLimit > 0
+      recallResultLimit > 0 &&
+      !options.abortSignal?.aborted
     ) {
       for (const ns of recallNamespaces) this.markCatalogRead(ns);
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2288,11 +2288,12 @@ export class Orchestrator {
     // a catalog write failure never affects storage resolution.
     this.namespaceCatalog = new NamespaceCatalog(config);
     this.storageRouter = new NamespaceStorageRouter(config, {
-      onResolve: (namespace, storageDir) => {
-        void this.namespaceCatalog
-          .registerResolved(namespace, storageDir)
-          .catch(() => undefined);
-      },
+      // Return the registration promise (round 6, codex P2 — NEFoX) so the
+      // router's resolve-hook dedup only marks a namespace notified when the
+      // catalog actually APPENDED. A dropped append (rebuild-lock timeout) or a
+      // failure resolves to `false`/rejects, so the next `storageFor` retries.
+      onResolve: (namespace, storageDir) =>
+        this.namespaceCatalog.registerResolved(namespace, storageDir),
     });
     this.namespaceSearchRouter = new NamespaceSearchRouter(
       config,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13095,6 +13095,15 @@ export class Orchestrator {
             contentHashSource: rawContent,
           },
         );
+        // Catalog touch (issue #1499, Issue B — round 2): a shared-namespace
+        // promotion is the ONLY write the shared namespace receives on this
+        // path, so without this the shared record's lastWriteAt stays stale and
+        // `writtenSince` filters / maintenance fanout skip it. The hot-path
+        // source-namespace touch (markCatalogWrite on targetStorage.dir) uses a
+        // DIFFERENT storage dir (the routed source namespace), so this does not
+        // double-count the source. Best-effort and failure-tolerant — it must
+        // never crash the promotion (markCatalogWrite already swallows errors).
+        this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
         // PR #402 Finding 3 fix: run temporal supersession against the shared
         // namespace after the promoted write lands so stale shared-namespace
         // copies of the same entity attribute are retired.  Without this,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2782,6 +2782,14 @@ export class Orchestrator {
           await sm.ensureDirectories();
           await sm.loadAliases().catch(() => undefined);
         }
+        // Explicitly seed the catalog with all configured namespaces at startup
+        // (round 6, cursor Medium — NBLlR). The storageFor loop above fires the
+        // router's onResolve hook, but a warm router cache (reused instance
+        // across stop/start) can skip onResolve, leaving policy namespaces absent
+        // from the live catalog until an operator runs `rebuild --apply`. This
+        // call is cheap, idempotent, and best-effort: a catalog failure must
+        // never break initialization (rule #13, #40).
+        await this.namespaceCatalog.registerConfiguredNamespaces().catch(() => undefined);
       }
       await this.relevance.load();
       await this.negatives.load();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15220,6 +15220,10 @@ export class Orchestrator {
           5,
         );
         if (synthesized > 0) {
+          // Entity synthesis rewrites entity files — a durable namespace mutation,
+          // so record it for the catalog touch even when it is the only change in
+          // the pass (codex). Otherwise lastWriteAt goes stale.
+          memoryItemMutated = true;
           log.info(`refreshed ${synthesized} entity syntheses`);
         }
       } catch (err) {
@@ -15452,6 +15456,10 @@ export class Orchestrator {
         );
         if (profileResult) {
           await this.storage.writeProfile(profileResult.consolidatedProfile);
+          // Profile consolidation rewrites profile.md — a durable namespace
+          // mutation; record it for the catalog touch even when it is the only
+          // change in the pass (codex). Otherwise lastWriteAt goes stale.
+          memoryItemMutated = true;
           log.info(
             `profile.md consolidated: removed ${profileResult.removedCount} items — ${profileResult.summary}`,
           );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -297,8 +297,11 @@ import {
   type ConversationIndexBackendInspection,
   type ConversationQmdRuntime,
 } from "./conversation-index/backend.js";
-import { NamespaceStorageRouter } from "./namespaces/storage.js";
-import { NamespaceCatalog } from "./namespaces/catalog.js";
+import {
+  NamespaceStorageRouter,
+  resolveNamespaceStorageRoot,
+} from "./namespaces/storage.js";
+import { NamespaceCatalog, type NamespaceRecord } from "./namespaces/catalog.js";
 import {
   namespaceIdentityFromToken,
   namespaceIdentityToken,
@@ -2332,17 +2335,45 @@ export class Orchestrator {
   private async maintenanceNamespaces(): Promise<string[]> {
     const configured = this.configuredNamespaces();
     if (!this.namespaceCatalog.enabled) return configured;
+    const configuredSet = new Set(configured);
     let cataloged: string[] = [];
     try {
       const records = await this.namespaceCatalog.listNamespaces();
-      cataloged = records.map((record) => record.namespace);
+      const safeRecords = await Promise.all(
+        records.map(async (record) => {
+          const namespace = record.namespace.trim();
+          if (!namespace || configuredSet.has(namespace)) return null;
+          return (await this.isCatalogedMaintenanceRootLive(record))
+            ? namespace
+            : null;
+        }),
+      );
+      cataloged = safeRecords.filter(
+        (namespace): namespace is string => namespace !== null,
+      );
     } catch {
       // Best-effort: a catalog read failure must not break QMD maintenance.
       cataloged = [];
     }
     return Array.from(
-      new Set([...configured, ...cataloged].map((value) => value.trim()).filter(Boolean)),
+      new Set(
+        [...configured, ...cataloged].map((value) => value.trim()).filter(Boolean),
+      ),
     );
+  }
+
+  private async isCatalogedMaintenanceRootLive(
+    record: NamespaceRecord,
+  ): Promise<boolean> {
+    if (typeof record.storageDir !== "string" || record.storageDir.length === 0) {
+      return false;
+    }
+    try {
+      const liveRoot = await resolveNamespaceStorageRoot(this.config, record.namespace);
+      return path.resolve(liveRoot) === path.resolve(record.storageDir);
+    } catch {
+      return false;
+    }
   }
 
   private buildConfiguredQmdSearchOptions(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7138,9 +7138,16 @@ export class Orchestrator {
     // Round 3 (codex P2): gate behind the no_recall guard — when the planner
     // selects `no_recall` retrieval is skipped entirely (see the early return at
     // `recallMode === "no_recall"` below), so marking every readable namespace as
-    // read would falsely inflate `lastReadAt` / catalog recency for prompts that
-    // explicitly should not read memory.
-    if (this.namespaceCatalog.enabled && recallMode !== "no_recall") {
+    // read would falsely inflate `lastReadAt` / catalog recency.
+    // Round 4 (codex P2): also skip when the effective memory result limit is
+    // zero (`topK: 0`, a disabled/zero `memories` recall section, etc.). The QMD
+    // path explicitly returns before searching when `recallResultLimit <= 0`, so
+    // no namespace is actually read and the touch would be spurious.
+    if (
+      this.namespaceCatalog.enabled &&
+      recallMode !== "no_recall" &&
+      recallResultLimit > 0
+    ) {
       for (const ns of recallNamespaces) this.markCatalogRead(ns);
     }
     const qmdAvailable = this.qmd.isAvailable();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -18294,6 +18294,19 @@ export class Orchestrator {
       .catch(() => undefined);
   }
 
+  /**
+   * Public best-effort catalog write touch (issue #1499). User-facing explicit
+   * captures (`memory_store`) and review-queue approvals persist via
+   * `persistExplicitCapture()` → `storage.writeMemory()`, which bypasses the
+   * extraction write path that calls `markCatalogWrite`. Without this their
+   * namespaces never record `lastWriteAt`, so the catalog under-reports write
+   * recency (round 5, codex P2). Fire-and-forget and failure-tolerant — a
+   * catalog error must never affect the explicit write (gotcha #13, rule #40).
+   */
+  recordCatalogWrite(namespace: string, storageDir?: string): void {
+    this.markCatalogWrite(namespace, storageDir);
+  }
+
   /** Record a namespace read in the catalog. Best-effort, failure-tolerant. */
   private markCatalogRead(namespace: string, storageDir?: string): void {
     if (!this.namespaceCatalog.enabled) return;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -299,7 +299,7 @@ import {
 } from "./conversation-index/backend.js";
 import { NamespaceStorageRouter } from "./namespaces/storage.js";
 import { NamespaceCatalog } from "./namespaces/catalog.js";
-import { namespaceIdentityFromToken } from "./namespaces/identity.js";
+import { namespaceIdentityFromToken, namespaceIdentityToken } from "./namespaces/identity.js";
 import {
   canReadNamespace,
   defaultNamespaceForPrincipal,
@@ -18287,7 +18287,18 @@ export class Orchestrator {
       return this.config.defaultNamespace;
     const m = resolvedStorageDir.match(/[\\/]namespaces[\\/]([^\\/]+)$/);
     if (!m?.[1]) return this.config.defaultNamespace;
-    return namespaceIdentityFromToken(m[1]) ?? m[1];
+    const dirName = m[1];
+    // Token-shaped raw names (round 6, codex P2 — NBsFz): a dir name might be a
+    // tokenized identity OR a literal raw namespace name that merely LOOKS like a
+    // token (e.g. a configured name `ns-616c706861`). Decode ONLY when the dir is
+    // a genuine tokenized dir — i.e. the decoded identity round-trips back to the
+    // same dir name via `namespaceIdentityToken`. Otherwise the dir name IS the
+    // literal namespace and must be preserved, not decoded into a different name.
+    const decoded = namespaceIdentityFromToken(dirName);
+    if (decoded && namespaceIdentityToken(decoded) === dirName) {
+      return decoded;
+    }
+    return dirName;
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -301,7 +301,11 @@ import {
   NamespaceStorageRouter,
   resolveNamespaceStorageRoot,
 } from "./namespaces/storage.js";
-import { NamespaceCatalog, type NamespaceRecord } from "./namespaces/catalog.js";
+import {
+  NamespaceCatalog,
+  hasMemoryData,
+  type NamespaceRecord,
+} from "./namespaces/catalog.js";
 import {
   namespaceIdentityFromToken,
   namespaceIdentityToken,
@@ -2380,7 +2384,11 @@ export class Orchestrator {
     }
     try {
       const liveRoot = await resolveNamespaceStorageRoot(this.config, record.namespace);
-      return path.resolve(liveRoot) === path.resolve(record.storageDir);
+      if (path.resolve(liveRoot) !== path.resolve(record.storageDir)) {
+        return false;
+      }
+      if (record.lastWriteAt) return true;
+      return hasMemoryData(liveRoot);
     } catch {
       return false;
     }
@@ -14763,122 +14771,127 @@ export class Orchestrator {
       } catch (err) {
         log.warn(`temporal-supersession: unexpected error: ${err}`);
       }
-      // Catalog touch (issue #1499): record AFTER the write AND temporal
-      // supersession, so lastWriteAt reflects every durable mutation in this
-      // extraction pass — not just the initial writeMemory (cursor NUtCT).
-      // Best-effort; uses the KNOWN routed name, not a dir-decoded guess (NCQI0).
-      this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
-      trackBehaviorSignals(
-        targetStorage,
-        buildBehaviorSignalsForMemory({
-          memoryId,
+      try {
+        trackBehaviorSignals(
+          targetStorage,
+          buildBehaviorSignalsForMemory({
+            memoryId,
+            category: writeCategory,
+            content: fact.content,
+            namespace: this.namespaceFromStorageDir(targetStorage.dir),
+            confidence: fact.confidence,
+            source: "extraction",
+          }),
+        );
+        trackPersistedId(targetStorage, memoryId);
+        if (
+          threadEpisodeIdsForGraph &&
+          !threadEpisodeIdsForGraph.includes(memoryId)
+        ) {
+          threadEpisodeIdsForGraph.push(memoryId);
+        }
+        await this.indexPersistedMemory(targetStorage, memoryId);
+        await promoteMemoryToShared({
+          sourceStorage: targetStorage,
           category: writeCategory,
           content: fact.content,
-          namespace: this.namespaceFromStorageDir(targetStorage.dir),
           confidence: fact.confidence,
-          source: "extraction",
-        }),
-      );
-      trackPersistedId(targetStorage, memoryId);
-      if (
-        threadEpisodeIdsForGraph &&
-        !threadEpisodeIdsForGraph.includes(memoryId)
-      ) {
-        threadEpisodeIdsForGraph.push(memoryId);
-      }
-      await this.indexPersistedMemory(targetStorage, memoryId);
-      await promoteMemoryToShared({
-        sourceStorage: targetStorage,
-        category: writeCategory,
-        content: fact.content,
-        confidence: fact.confidence,
-        tags: fact.tags,
-        entityRef:
-          typeof (fact as any).entityRef === "string"
-            ? (fact as any).entityRef
-            : undefined,
-        structuredAttributes: fact.structuredAttributes,
-        sourceMemoryId: memoryId,
-        importance,
-        intentGoal: inferredIntent?.goal,
-        intentActionType: inferredIntent?.actionType,
-        intentEntityTypes: inferredIntent?.entityTypes,
-        memoryKind,
-        validAt: sourceContext?.validAt,
-        source: extractionWriteSource,
-      });
-      // v8.2: graph edge building (fail-open — errors caught inside GraphIndex)
-      if (this.config.multiGraphMemoryEnabled) {
-        try {
-          const graphContext = await ensureGraphContext(targetStorage);
-          const entityRef =
+          tags: fact.tags,
+          entityRef:
             typeof (fact as any).entityRef === "string"
               ? (fact as any).entityRef
-              : undefined;
-          const memoryRelPath = resolvePersistedMemoryRelativePath({
-            memoryId,
-            pathById: graphContext.memoryPathById,
-            category: writeCategory,
-          });
-          graphContext.memoryPathById.set(memoryId, memoryRelPath);
-          appendMemoryToGraphContext({
-            allMemsForGraph: graphContext.allMemsForGraph,
-            storageDir: targetStorage.dir,
-            memoryRelPath: memoryRelPath,
-            memoryId,
-            category: writeCategory,
-            content: fact.content ?? "",
-            entityRef,
-          });
-          await this.buildGraphEdge(
-            targetStorage,
-            memoryRelPath,
-            entityRef,
-            memoryId,
-            fact.content ?? "",
-            graphContext.allMemsForGraph,
-            graphContext.memoryPathById,
-            threadIdForExtraction ?? undefined,
-            threadEpisodeIdsForGraph,
-            graphContext.previousPersistedRelPath,
-          );
-          graphContext.previousPersistedRelPath = memoryRelPath;
-        } catch {
-          /* fail-open */
-        }
-      }
-      if (
-        this.config.verbatimArtifactsEnabled &&
-        this.config.verbatimArtifactCategories.includes(writeCategory) &&
-        fact.confidence >= this.config.verbatimArtifactsMinConfidence
-      ) {
-        // Reuse citedFactContent so the artifact carries the same citation
-        // timestamp as the memory write above (Fix #3 — duplicate-citation).
-        await targetStorage.writeArtifact(citedFactContent, {
-          confidence: fact.confidence,
-          tags: [...fact.tags, "artifact"],
-          artifactType: this.artifactTypeForCategory(writeCategory),
+              : undefined,
+          structuredAttributes: fact.structuredAttributes,
           sourceMemoryId: memoryId,
+          importance,
           intentGoal: inferredIntent?.goal,
           intentActionType: inferredIntent?.actionType,
           intentEntityTypes: inferredIntent?.entityTypes,
+          memoryKind,
+          validAt: sourceContext?.validAt,
+          source: extractionWriteSource,
         });
-      }
-      // Register in content-hash index after successful write.
-      // Thread 3 fix: canonicalize by stripping any pre-existing citation so
-      // the stored hash matches what the dedup check computes via
-      // stripCitationForTemplate before calling contentHashIndex.has().
-      if (this.contentHashIndex) {
-        const canonicalFactContent =
-          citationEnabled &&
-          hasCitationForTemplate(fact.content, citationTemplate)
-            ? stripCitationForTemplate(fact.content, citationTemplate)
-            : fact.content;
-        const hashRegisterKey =
-          writeCategory === "procedure"
-            ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
-            : canonicalFactContent;
-        this.contentHashIndex.add(hashRegisterKey);
+        // v8.2: graph edge building (fail-open — errors caught inside GraphIndex)
+        if (this.config.multiGraphMemoryEnabled) {
+          try {
+            const graphContext = await ensureGraphContext(targetStorage);
+            const entityRef =
+              typeof (fact as any).entityRef === "string"
+                ? (fact as any).entityRef
+                : undefined;
+            const memoryRelPath = resolvePersistedMemoryRelativePath({
+              memoryId,
+              pathById: graphContext.memoryPathById,
+              category: writeCategory,
+            });
+            graphContext.memoryPathById.set(memoryId, memoryRelPath);
+            appendMemoryToGraphContext({
+              allMemsForGraph: graphContext.allMemsForGraph,
+              storageDir: targetStorage.dir,
+              memoryRelPath: memoryRelPath,
+              memoryId,
+              category: writeCategory,
+              content: fact.content ?? "",
+              entityRef,
+            });
+            await this.buildGraphEdge(
+              targetStorage,
+              memoryRelPath,
+              entityRef,
+              memoryId,
+              fact.content ?? "",
+              graphContext.allMemsForGraph,
+              graphContext.memoryPathById,
+              threadIdForExtraction ?? undefined,
+              threadEpisodeIdsForGraph,
+              graphContext.previousPersistedRelPath,
+            );
+            graphContext.previousPersistedRelPath = memoryRelPath;
+          } catch {
+            /* fail-open */
+          }
+        }
+        if (
+          this.config.verbatimArtifactsEnabled &&
+          this.config.verbatimArtifactCategories.includes(writeCategory) &&
+          fact.confidence >= this.config.verbatimArtifactsMinConfidence
+        ) {
+          // Reuse citedFactContent so the artifact carries the same citation
+          // timestamp as the memory write above (Fix #3 — duplicate-citation).
+          await targetStorage.writeArtifact(citedFactContent, {
+            confidence: fact.confidence,
+            tags: [...fact.tags, "artifact"],
+            artifactType: this.artifactTypeForCategory(writeCategory),
+            sourceMemoryId: memoryId,
+            intentGoal: inferredIntent?.goal,
+            intentActionType: inferredIntent?.actionType,
+            intentEntityTypes: inferredIntent?.entityTypes,
+          });
+        }
+        // Register in content-hash index after successful write.
+        // Thread 3 fix: canonicalize by stripping any pre-existing citation so
+        // the stored hash matches what the dedup check computes via
+        // stripCitationForTemplate before calling contentHashIndex.has().
+        if (this.contentHashIndex) {
+          const canonicalFactContent =
+            citationEnabled &&
+            hasCitationForTemplate(fact.content, citationTemplate)
+              ? stripCitationForTemplate(fact.content, citationTemplate)
+              : fact.content;
+          const hashRegisterKey =
+            writeCategory === "procedure"
+              ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
+              : canonicalFactContent;
+          this.contentHashIndex.add(hashRegisterKey);
+        }
+      } finally {
+        // Catalog touch (issue #1499): record AFTER every synchronous
+        // source-namespace mutation in the non-chunked path: writeMemory,
+        // temporal supersession, graph edges, and optional verbatim artifacts.
+        // The `finally` preserves the write touch when post-write indexing or
+        // promotion fails after the canonical memory is already durable. Use the
+        // KNOWN routed name, not a dir-decoded guess (NCQI0).
+        this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
       }
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7135,7 +7135,12 @@ export class Orchestrator {
     }
     // Catalog touch (issue #1499): record reads against the recalled namespaces
     // so the catalog reflects active read scopes. Best-effort, failure-tolerant.
-    if (this.namespaceCatalog.enabled) {
+    // Round 3 (codex P2): gate behind the no_recall guard — when the planner
+    // selects `no_recall` retrieval is skipped entirely (see the early return at
+    // `recallMode === "no_recall"` below), so marking every readable namespace as
+    // read would falsely inflate `lastReadAt` / catalog recency for prompts that
+    // explicitly should not read memory.
+    if (this.namespaceCatalog.enabled && recallMode !== "no_recall") {
       for (const ns of recallNamespaces) this.markCatalogRead(ns);
     }
     const qmdAvailable = this.qmd.isAvailable();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15321,7 +15321,10 @@ export class Orchestrator {
 
     try {
       const deepSleepStartedAt = new Date().toISOString();
-      await this.runTierMigrationCycle(this.storage, "maintenance");
+      // Tier migrations move/rewrite memory files; count them as durable
+      // mutations for the catalog touch below (codex NThSW).
+      const tierMigration = await this.runTierMigrationCycle(this.storage, "maintenance");
+      if (tierMigration.migrated > 0) memoryItemMutated = true;
       allMemories = await this.storage.readAllMemories();
 
       // Fact archival pass (v6.0) — move old, low-importance, rarely-accessed facts to archive/

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -18747,10 +18747,15 @@ export class Orchestrator {
     const dirName = m[1];
     // Token-shaped raw names (round 6, codex P2 — NBsFz): a dir name might be a
     // tokenized identity OR a literal raw namespace name that merely LOOKS like a
-    // token (e.g. a configured name `ns-616c706861`). Decode ONLY when the dir is
-    // a genuine tokenized dir — i.e. the decoded identity round-trips back to the
-    // same dir name via `namespaceIdentityToken`. Otherwise the dir name IS the
-    // literal namespace and must be preserved, not decoded into a different name.
+    // token (e.g. a configured name `ns-616c706861`). The round-trip check below
+    // (`namespaceIdentityToken(decoded) === dirName`) is TAUTOLOGICAL for a
+    // canonical token string, so it cannot tell a tokenized dir for `alpha` apart
+    // from the legacy raw root of a namespace literally named `ns-616c706861`
+    // (codex NRCve). A dir name that is itself a KNOWN (configured) namespace is
+    // therefore preserved as the literal namespace BEFORE attempting to decode it.
+    if (this.configuredNamespaces().includes(dirName)) {
+      return dirName;
+    }
     const decoded = namespaceIdentityFromToken(dirName);
     if (decoded && namespaceIdentityToken(decoded) === dirName) {
       return decoded;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2949,8 +2949,15 @@ export class Orchestrator {
         const available = await this.qmd.probe();
         if (available) {
           log.info(`Search backend: available ${this.qmd.debugStatus()}`);
+          // Ensure collections at startup for the catalog-union namespace set, not
+          // just the configured set (issue #1499 sweep, same class as NHZEV): a
+          // dynamic namespace that exists only in the persisted catalog must have
+          // its QMD collection checked/ensured on boot so recall against it works
+          // after a restart. `registerConfiguredNamespaces()` already seeded the
+          // catalog above, so `maintenanceNamespaces()` is readable here; it falls
+          // back to the configured set on any catalog read failure.
           const namespaces = this.config.namespacesEnabled
-            ? this.configuredNamespaces()
+            ? await this.maintenanceNamespaces()
             : [this.config.defaultNamespace];
           const states = await Promise.all(
             namespaces.map(async (namespace) => {
@@ -3073,8 +3080,12 @@ export class Orchestrator {
       try {
         log.info("QMD startup sync: updating index to match current disk state");
         if (this.config.namespacesEnabled) {
+          // Cover cataloged dynamic namespaces at startup too (NHZEV, codex P2):
+          // a dynamic namespace written before a daemon restart must be synced on
+          // boot, not only by the debounced runQmdMaintenance() path. Same union +
+          // catalog-read-failure fallback as runQmdMaintenance.
           await this.namespaceSearchRouter.updateNamespaces(
-            this.configuredNamespaces(),
+            await this.maintenanceNamespaces(),
             { signal },
           );
         } else {
@@ -3352,9 +3363,16 @@ export class Orchestrator {
       this.namespaceSearchRouter.clearCache();
     }
 
-    // Ensure collections — namespace-aware when enabled
+    // Ensure collections — namespace-aware when enabled.
+    // Use the catalog-union namespace set (issue #1499 sweep, same class as
+    // NHZEV): this is the QMD startup-recovery sync that ensures collections AND
+    // runs `updateNamespaces(...)` below over the SAME `namespaces` set. A dynamic
+    // namespace that exists only in the persisted catalog must be ensured and
+    // re-synced here too, otherwise after a backend-was-unavailable-at-boot
+    // recovery its collection stays stale. Falls back to the configured set on any
+    // catalog read failure.
     const namespaces = this.config.namespacesEnabled
-      ? this.configuredNamespaces()
+      ? await this.maintenanceNamespaces()
       : [this.config.defaultNamespace];
 
     const states = await Promise.all(
@@ -4098,6 +4116,17 @@ export class Orchestrator {
             derivedFrom: derivedFromEntries.length > 0 ? derivedFromEntries : undefined,
             derivedVia: operator,
           },
+        );
+
+        // Catalog write touch (issue #1499 sweep): semantic consolidation writes a
+        // new canonical memory directly to `targetStorage`, bypassing the
+        // extraction write path. Record the write so the namespace's `lastWriteAt`
+        // reflects this durable mutation. Best-effort and failure-tolerant; the
+        // namespace is decoded from the storage dir since this path has no routed
+        // namespace name.
+        this.markCatalogWrite(
+          this.namespaceFromStorageDir(targetStorage.dir),
+          targetStorage.dir,
         );
 
         result.memoriesConsolidated++;
@@ -14665,6 +14694,12 @@ export class Orchestrator {
       }
     }
 
+    // Tracks whether THIS extraction persisted any durable, non-fact output to the
+    // BASE namespace's storage (entity / relationship / profile / question). The
+    // per-fact `markCatalogWrite` only fires inside the fact write loop, so a
+    // fact-less extraction that still persists durable data must record exactly one
+    // base-namespace catalog touch after all writes complete (NHZEZ, codex P2).
+    let durableNonFactWritten = false;
     for (const entity of entities) {
       try {
         const name = (entity as any)?.name;
@@ -14689,7 +14724,10 @@ export class Orchestrator {
             ? (entity as any).structuredSections
             : undefined,
         });
-        if (id) trackPersistedId(storage, id);
+        if (id) {
+          trackPersistedId(storage, id);
+          durableNonFactWritten = true;
+        }
       } catch (err) {
         log.warn(`persistExtraction: entity write failed: ${err}`);
       }
@@ -14712,6 +14750,7 @@ export class Orchestrator {
             target: rel.source,
             label: `${rel.label} (reverse)`,
           });
+          durableNonFactWritten = true;
         } catch (err) {
           log.debug(`relationship persist failed: ${err}`);
         }
@@ -14740,12 +14779,37 @@ export class Orchestrator {
 
     if (profileUpdates.length > 0) {
       await storage.appendToProfile(profileUpdates);
+      durableNonFactWritten = true;
     }
 
     // Persist questions
     for (const q of questions) {
       const id = await storage.writeQuestion(q.question, q.context, q.priority);
-      if (id) trackPersistedId(storage, id);
+      if (id) {
+        trackPersistedId(storage, id);
+        durableNonFactWritten = true;
+      }
+    }
+
+    // Catalog touch for durable NON-FACT outputs (NHZEZ, codex P2). The per-fact
+    // `markCatalogWrite` above only fires inside the fact write loop, so an
+    // extraction that persists ONLY entities, relationships, profile updates, or
+    // questions (no facts) would record durable data to the BASE namespace's
+    // storage without ever touching the catalog — leaving that namespace's
+    // `lastWriteAt` stale so `listNamespaces({writtenSince})` / write-recency QMD
+    // maintenance miss the write. Entities/relationships/profile/questions are all
+    // written to the BASE `storage` (not the per-fact routed `targetStorage`), so
+    // we record ONE base-namespace touch here, after all non-fact writes complete.
+    // Use the KNOWN base namespace name, not a dir-decoded guess (NCQI0). One touch
+    // per namespace per extraction — `markWrite` is idempotent, so if the fact path
+    // already touched the base namespace this only refreshes `lastWriteAt`.
+    // Best-effort and failure-tolerant (markCatalogWrite swallows errors).
+    if (durableNonFactWritten) {
+      const baseTouchNamespace =
+        baseNamespace && baseNamespace.length > 0
+          ? baseNamespace
+          : this.namespaceFromStorageDir(storage.dir);
+      this.markCatalogWrite(baseTouchNamespace, storage.dir);
     }
 
     // Persist identity reflection
@@ -15115,6 +15179,18 @@ export class Orchestrator {
           ? (entity as any).structuredSections
           : undefined,
       });
+    }
+
+    // Catalog write touch (issue #1499 sweep): consolidation persists durable
+    // profile/entity updates directly to the default-namespace `this.storage`,
+    // bypassing the extraction write path. Record one write touch so the default
+    // namespace's `lastWriteAt` reflects this mutation. The default namespace is
+    // always configured/cataloged; this only refreshes its recency. Best-effort.
+    if (result.profileUpdates.length > 0 || result.entityUpdates.length > 0) {
+      this.markCatalogWrite(
+        this.namespaceFromStorageDir(this.storage.dir),
+        this.storage.dir,
+      );
     }
 
     // Merge fragmented entity files
@@ -16169,6 +16245,15 @@ export class Orchestrator {
 
       await this.storage.writeSummary(summary);
 
+      // Catalog write touch (issue #1499 sweep): summarization writes a durable
+      // summary memory directly to the default-namespace `this.storage`, bypassing
+      // the extraction write path. Record the write so the namespace's
+      // `lastWriteAt` reflects this mutation. Best-effort and failure-tolerant.
+      this.markCatalogWrite(
+        this.namespaceFromStorageDir(this.storage.dir),
+        this.storage.dir,
+      );
+
       // Archive source memories
       const archived = await this.storage.archiveMemories(
         batch.map((m) => m.frontmatter.id),
@@ -16209,8 +16294,12 @@ export class Orchestrator {
   private static readonly IDENTITY_CONSOLIDATE_THRESHOLD = 8_000;
 
   private async autoConsolidateIdentity(): Promise<void> {
+    // Fan out over the catalog-union namespace set (issue #1499 sweep): a dynamic
+    // namespace that accumulated IDENTITY.md reflections must also be eligible for
+    // auto-consolidation, otherwise its identity file grows unbounded and is never
+    // consolidated. Falls back to the configured set on any catalog read failure.
     const namespaces = this.config.namespacesEnabled
-      ? this.configuredNamespaces()
+      ? await this.maintenanceNamespaces()
       : [this.config.defaultNamespace];
 
     for (const namespace of namespaces) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13532,15 +13532,6 @@ export class Orchestrator {
             contentHashSource: rawContent,
           },
         );
-        // Catalog touch (issue #1499, Issue B — round 2): a shared-namespace
-        // promotion is the ONLY write the shared namespace receives on this
-        // path, so without this the shared record's lastWriteAt stays stale and
-        // `writtenSince` filters / maintenance fanout skip it. The hot-path
-        // source-namespace touch (markCatalogWrite on targetStorage.dir) uses a
-        // DIFFERENT storage dir (the routed source namespace), so this does not
-        // double-count the source. Best-effort and failure-tolerant — it must
-        // never crash the promotion (markCatalogWrite already swallows errors).
-        this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
         // PR #402 Finding 3 fix: run temporal supersession against the shared
         // namespace after the promoted write lands so stale shared-namespace
         // copies of the same entity attribute are retired.  Without this,
@@ -13568,6 +13559,16 @@ export class Orchestrator {
             );
           }
         }
+        // Catalog touch (issue #1499, Issue B + ordering sweep): a shared-
+        // namespace promotion is the ONLY write the shared namespace receives on
+        // this path, so without this the shared record's lastWriteAt stays stale
+        // and `writtenSince` filters / maintenance fanout skip it. Record AFTER
+        // the promoted write and the shared temporal-supersession attempt so the
+        // catalog timestamp never precedes a later durable frontmatter mutation in
+        // the same promotion pass. The hot-path source-namespace touch uses a
+        // different storage dir, so this does not double-count the source.
+        // Best-effort and failure-tolerant — it must never crash the promotion.
+        this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
         trackPersistedId(sharedStorage, promotedId, {
           includeReturnedIds: false,
         });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16396,6 +16396,19 @@ export class Orchestrator {
         identityNamespace,
       );
       await storage.writeIdentityReflections("");
+      // NRcCL (codex P2): record a per-namespace catalog write for THIS namespace
+      // after the identity files are updated. This fan-out can mutate a dynamic
+      // namespace via `writeIdentity`/`writeIdentityReflections`, but the
+      // consolidation pass's only consolidated touch covers `this.storage` (the
+      // default) and only fires when `memoryItemMutated` was set by OTHER work — so
+      // a namespace whose sole mutation in the pass is identity consolidation would
+      // otherwise keep a stale `lastWriteAt`, making `listNamespaces({ writtenSince })`
+      // and catalog-recency consumers miss the write. Best-effort and
+      // failure-tolerant (`markCatalogWrite` swallows errors, never crashing the
+      // consolidation; gotcha #13, rule #40). No double-count with the consolidated
+      // touch above: that one is gated on `memoryItemMutated` (which identity
+      // consolidation does not set), and `markWrite` is idempotent regardless.
+      this.markCatalogWrite(namespace, storage.dir);
       log.info(
         `IDENTITY(${namespace}) consolidated: ${identityContent.length} → ${newContent.length} chars, ${result.learnedPatterns.length} patterns`,
       );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15296,7 +15296,12 @@ export class Orchestrator {
       try {
         const lightSleepStartedAt = new Date().toISOString();
         const lifecycleCorpus = await this.storage.readAllMemories();
-        await this.runLifecyclePolicyPass(lifecycleCorpus);
+        // Lifecycle frontmatter writes count as durable mutations for the catalog
+        // touch below (codex NR-tS), even when no other consolidation step set
+        // memoryItemMutated.
+        if ((await this.runLifecyclePolicyPass(lifecycleCorpus)) > 0) {
+          memoryItemMutated = true;
+        }
         await this.recordScheduledDreamsPhaseRun(
           "lightSleep",
           lifecycleCorpus.length,
@@ -15994,14 +15999,17 @@ export class Orchestrator {
 
   async runLifecyclePolicyNow(storage: StorageManager = this.storage): Promise<{ memoriesAssessed: number }> {
     const lifecycleCorpus = await storage.readAllMemories();
-    await this.runLifecyclePolicyPass(lifecycleCorpus, storage);
+    // Record the catalog write when the pass rewrote any frontmatter (codex NR-tS).
+    if ((await this.runLifecyclePolicyPass(lifecycleCorpus, storage)) > 0) {
+      this.markCatalogWrite(this.namespaceFromStorageDir(storage.dir), storage.dir);
+    }
     return { memoriesAssessed: lifecycleCorpus.length };
   }
 
   private async runLifecyclePolicyPass(
     allMemories: MemoryFile[],
     storage: StorageManager = this.storage,
-  ): Promise<void> {
+  ): Promise<number> {
     const now = new Date();
     const nowIso = now.toISOString();
     const countsByState: Record<LifecycleState, number> = {
@@ -16078,7 +16086,9 @@ export class Orchestrator {
       if (wrote) updatedCount += 1;
     }
 
-    if (!this.config.lifecycleMetricsEnabled) return;
+    // Report how many memories had frontmatter rewritten so callers can record a
+    // catalog write touch for lifecycle-only passes (codex NR-tS).
+    if (!this.config.lifecycleMetricsEnabled) return updatedCount;
 
     const total = evaluatedCount;
     const metrics = {
@@ -16103,6 +16113,7 @@ export class Orchestrator {
     );
     await mkdir(path.dirname(metricsPath), { recursive: true });
     await writeFile(metricsPath, JSON.stringify(metrics, null, 2), "utf-8");
+    return updatedCount;
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14573,46 +14573,50 @@ export class Orchestrator {
               contentHashSource: rawChunkedContent,
             },
           );
-          // Write individual chunks with parent reference
-          for (const chunk of chunkResult.chunks) {
-            // Score each chunk's importance separately
-            const chunkImportance = scoreImportance(
-              chunk.content,
-              writeCategory,
-              fact.tags,
-            );
-            const chunkWriteSource =
-              (fact as any).source === "proactive"
-                ? "chunking-proactive"
-                : "chunking";
+          try {
+            // Write individual chunks with parent reference
+            for (const chunk of chunkResult.chunks) {
+              // Score each chunk's importance separately
+              const chunkImportance = scoreImportance(
+                chunk.content,
+                writeCategory,
+                fact.tags,
+              );
+              const chunkWriteSource =
+                (fact as any).source === "proactive"
+                  ? "chunking-proactive"
+                  : "chunking";
 
-            await targetStorage.writeChunk(
-              parentId,
-              chunk.index,
-              chunkResult.chunks.length,
-              writeCategory,
-              // Each chunk carries its own inline citation so provenance
-              // survives when a single chunk is quoted in isolation.
-              applyInlineCitation(chunk.content),
-              {
-                confidence: fact.confidence,
-                tags: fact.tags,
-                entityRef: fact.entityRef,
-                source: chunkWriteSource,
-                importance: chunkImportance,
-                intentGoal: inferredIntent?.goal,
-                intentActionType: inferredIntent?.actionType,
-                intentEntityTypes: inferredIntent?.entityTypes,
-                memoryKind,
-                validAt: sourceContext?.validAt,
-              },
-            );
+              await targetStorage.writeChunk(
+                parentId,
+                chunk.index,
+                chunkResult.chunks.length,
+                writeCategory,
+                // Each chunk carries its own inline citation so provenance
+                // survives when a single chunk is quoted in isolation.
+                applyInlineCitation(chunk.content),
+                {
+                  confidence: fact.confidence,
+                  tags: fact.tags,
+                  entityRef: fact.entityRef,
+                  source: chunkWriteSource,
+                  importance: chunkImportance,
+                  intentGoal: inferredIntent?.goal,
+                  intentActionType: inferredIntent?.actionType,
+                  intentEntityTypes: inferredIntent?.entityTypes,
+                  memoryKind,
+                  validAt: sourceContext?.validAt,
+                },
+              );
+            }
+          } finally {
+            // The parent memory is durable once writeMemory returns `parentId`.
+            // Touch immediately around the chunk-write loop so a later chunk
+            // failure still surfaces the partially durable parent/chunk files to
+            // catalog-driven `writtenSince` maintenance. The final touch below
+            // still refreshes `lastWriteAt` after later durable writes on success.
+            this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
           }
-          // Parent/chunk files are durable at this point. Record a write now so
-          // later indexing or promotion failures cannot leave the namespace out
-          // of catalog-driven `writtenSince` maintenance; the final touch below
-          // refreshes `lastWriteAt` after later durable writes on success.
-          this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
 
           if (routedRuleId) {
             log.debug(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7151,19 +7151,11 @@ export class Orchestrator {
     // zero (`topK: 0`, a disabled/zero `memories` recall section, etc.). The QMD
     // path explicitly returns before searching when `recallResultLimit <= 0`, so
     // no namespace is actually read and the touch would be spurious.
-    // Round 6 (codex P2 — NDXHa): also skip when the recall was ALREADY aborted.
-    // `throwIfRecallAborted` runs later (in the Phase 1 retrieval block), so an
-    // already-aborted recall exits before any QMD/fallback read — firing these
-    // fire-and-forget touches would set `lastReadAt` for a canceled recall and
-    // make catalog recency/maintenance treat it as a real read.
-    if (
-      this.namespaceCatalog.enabled &&
-      recallMode !== "no_recall" &&
-      recallResultLimit > 0 &&
-      !options.abortSignal?.aborted
-    ) {
-      for (const ns of recallNamespaces) this.markCatalogRead(ns);
-    }
+    // NOTE: the catalog read touch is recorded LATER, immediately after the
+    // Phase 1 `throwIfRecallAborted` gate (round 6, codex P2 / cursor Medium —
+    // NDXHa/NDmle), so it fires only once retrieval is actually about to run.
+    // Recording it here (recall entry) would set `lastReadAt` for recalls that
+    // are aborted, error out, or short-circuit before any QMD/filesystem read.
     const qmdAvailable = this.qmd.isAvailable();
     let graphDecisionStatus: IntentDebugSnapshot["graphDecision"]["status"] =
       recallDecision.plannedMode === "graph_mode" ? "skipped" : "not_requested";
@@ -7354,6 +7346,21 @@ export class Orchestrator {
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
     throwIfRecallAborted(options.abortSignal);
+
+    // Catalog read touch (issue #1499): record reads against the recalled
+    // namespaces HERE — after the abort gate, immediately before retrieval
+    // actually runs — so `lastReadAt` reflects a real read, not a recall that was
+    // aborted/errored/short-circuited before reaching this point (round 3/4/6,
+    // codex/cursor — no_recall, zero-limit, aborted, and pre-read-error cases).
+    // `no_recall` already returned earlier, so it cannot reach here. Best-effort
+    // and failure-tolerant.
+    if (
+      this.namespaceCatalog.enabled &&
+      recallResultLimit > 0 &&
+      !options.abortSignal?.aborted
+    ) {
+      for (const ns of recallNamespaces) this.markCatalogRead(ns);
+    }
 
     // 0. Shared context (v4.0, optional)
     const sharedContextPromise = (async (): Promise<string | null> => {

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1292,6 +1292,17 @@ export interface PluginConfig {
 
   // v3.0 Multi-agent memory (namespaces)
   namespacesEnabled: boolean;
+  /**
+   * Enable the rebuildable namespace catalog (issue #1499). When enabled and
+   * `namespacesEnabled` is also true, storage resolution and read/write paths
+   * record cheap, failure-tolerant namespace touches in
+   * `<memoryDir>/state/namespaces.jsonl`. The catalog is downstream metadata —
+   * filesystem memory remains the source of truth, and the catalog is fully
+   * rebuildable from disk via `remnic namespaces rebuild`. The catalog is inert
+   * (a no-op that enumerates nothing) whenever `namespacesEnabled` is false, so
+   * existing single-namespace behavior is unchanged. Default on.
+   */
+  namespaceCatalogEnabled: boolean;
   defaultNamespace: string;
   sharedNamespace: string;
   principalFromSessionKeyMode: PrincipalFromSessionKeyMode;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -4151,6 +4151,11 @@
         "default": false,
         "description": "Enable multi-agent namespaces (v3.0). Default off."
       },
+      "namespaceCatalogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+      },
       "defaultNamespace": {
         "type": "string",
         "default": "default",

--- a/tests/consolidation-catalog-touch.test.ts
+++ b/tests/consolidation-catalog-touch.test.ts
@@ -137,3 +137,68 @@ test("cleanup-only consolidation (TTL expiry, no LLM outputs) records a catalog 
     await rm(workspaceDir, { recursive: true, force: true });
   }
 });
+
+test("summarization records the catalog write touch after source memories are archived", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-summary-touch-order-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      summarizationTriggerCount: 50,
+      summarizationRecentToKeep: 0,
+      summarizationProtectedTags: [],
+      summarizationImportanceThreshold: 1,
+    });
+
+    const orchestrator = Object.create(Orchestrator.prototype) as any;
+    const events: string[] = [];
+    orchestrator.config = config;
+    orchestrator.storage = {
+      dir: memoryDir,
+      writeSummary: async () => {
+        events.push("summary");
+      },
+      archiveMemories: async () => {
+        events.push("archive");
+        return 50;
+      },
+    };
+    orchestrator.extraction = {
+      summarizeMemories: async () => ({
+        summaryText: "compressed memory summary",
+        keyFacts: ["fact"],
+        keyEntities: ["entity"],
+      }),
+    };
+    orchestrator.namespaceFromStorageDir = () => config.defaultNamespace;
+    orchestrator.markCatalogWrite = () => {
+      events.push("touch");
+    };
+
+    const memories = Array.from({ length: 50 }, (_, index) => ({
+      path: path.join(memoryDir, `memory-${index}.md`),
+      content: `summarizable fact ${index}`,
+      frontmatter: {
+        id: `memory-${index}`,
+        category: "fact",
+        created: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        tags: [],
+        status: "active",
+        importance: { score: 0.1, level: "low", reasons: [], keywords: [] },
+      },
+    }));
+
+    await orchestrator.runSummarization(memories);
+
+    assert.deepEqual(
+      events,
+      ["summary", "archive", "touch"],
+      "catalog lastWriteAt touch must happen after archiveMemories rewrites source memories",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-catalog-touch.test.ts
+++ b/tests/consolidation-catalog-touch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * NIBOi (codex P2): a consolidation pass that performs ONLY memory-item actions
+ * (UPDATE / MERGE / INVALIDATE) — and produces no profile/entity updates — still
+ * durably rewrites memory state, so it must refresh the namespace catalog's
+ * `lastWriteAt`. Without the fix the touch gate only checked profile/entity
+ * updates, leaving the default namespace's write recency stale after
+ * consolidation-only mutations.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+
+test("consolidation with only an INVALIDATE memory-item action records a catalog write touch", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-consolidate-catalog-"));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-consolidate-ws-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      topicExtractionEnabled: false,
+      summarizationEnabled: false,
+      identityEnabled: false,
+      entitySummaryEnabled: false,
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    const storage = orchestrator.storage;
+
+    // runConsolidation only runs with >= 5 memories. Seed a corpus, then have the
+    // pass INVALIDATE one — a durable mutation with NO profile/entity updates.
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      ids.push(await storage.writeMemory("fact", `seed fact ${i}`, { source: "test" }));
+    }
+    const staleId = ids[0];
+    orchestrator.extraction = {
+      consolidate: async () => ({
+        items: [{ action: "INVALIDATE", existingId: staleId }],
+        profileUpdates: [],
+        entityUpdates: [],
+      }),
+    };
+
+    // Establish the default namespace in the catalog so we can observe its
+    // lastWriteAt advance (vs. an absent record).
+    await orchestrator.namespaceCatalog.registerConfiguredNamespaces();
+    const before = await orchestrator.namespaceCatalog.getNamespaceRecord(config.defaultNamespace);
+    const beforeWriteAt = before?.lastWriteAt;
+
+    await orchestrator.runConsolidationNow();
+
+    // The catalog touch is best-effort/fire-and-forget; let its serialized write
+    // chain settle, then read back the record.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const after = await orchestrator.namespaceCatalog.getNamespaceRecord(config.defaultNamespace);
+
+    assert.ok(after, "default namespace record must exist after consolidation");
+    assert.ok(
+      after!.lastWriteAt,
+      "consolidation-only memory-item mutation must record a catalog write touch",
+    );
+    if (beforeWriteAt) {
+      assert.ok(
+        new Date(after!.lastWriteAt!).getTime() >= new Date(beforeWriteAt).getTime(),
+        "lastWriteAt must advance (or hold) after a consolidation memory-item mutation",
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-catalog-touch.test.ts
+++ b/tests/consolidation-catalog-touch.test.ts
@@ -78,3 +78,62 @@ test("consolidation with only an INVALIDATE memory-item action records a catalog
     await rm(workspaceDir, { recursive: true, force: true });
   }
 });
+
+// NIjwl (codex P2): a consolidation pass with NO LLM outputs (empty items /
+// profile / entity) can still mutate the namespace via cleanup maintenance —
+// e.g. cleanExpiredTTL deleting an expired memory. Those cleanup-only mutations
+// run after the LLM-action block, so the catalog touch must be recorded after all
+// mutation-producing maintenance steps, or lastWriteAt stays stale.
+test("cleanup-only consolidation (TTL expiry, no LLM outputs) records a catalog write touch", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-consolidate-cleanup-"));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "remnic-consolidate-cleanup-ws-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      topicExtractionEnabled: false,
+      summarizationEnabled: false,
+      identityEnabled: false,
+      entitySummaryEnabled: false,
+      semanticConsolidationEnabled: false,
+      factArchivalEnabled: false,
+      lifecyclePolicyEnabled: false,
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    const storage = orchestrator.storage;
+
+    // Seed 5 memories (the consolidation floor); one is already TTL-expired so the
+    // cleanup step deletes it — a durable namespace mutation with NO LLM outputs.
+    for (let i = 0; i < 4; i += 1) {
+      await storage.writeMemory("fact", `keeper fact ${i}`, { source: "test" });
+    }
+    await storage.writeMemory("fact", "expired speculative fact", {
+      source: "test",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    // No LLM outputs at all — only cleanup will mutate the namespace.
+    orchestrator.extraction = {
+      consolidate: async () => ({ items: [], profileUpdates: [], entityUpdates: [] }),
+    };
+
+    await orchestrator.namespaceCatalog.registerConfiguredNamespaces();
+    await orchestrator.runConsolidationNow();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const record = await orchestrator.namespaceCatalog.getNamespaceRecord(config.defaultNamespace);
+    assert.ok(record, "default namespace record must exist after cleanup-only consolidation");
+    assert.ok(
+      record!.lastWriteAt,
+      "a cleanup-only consolidation (TTL expiry) must record a catalog write touch",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -311,6 +311,63 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
   );
 });
 
+// NIhUg (cursor Medium): the catalog write touch must fire only AFTER the queued
+// review memory reaches its intended durable `pending_review` state. If the
+// frontmatter update fails, no catalog write may be recorded (rule #25).
+test("queueExplicitCaptureForReview records NO catalog write when the pending_review frontmatter update fails", async () => {
+  const memories: Array<{ frontmatter: { id: string; status?: string }; content: string; path: string }> = [];
+  const storage = {
+    dir: "/synthetic/memory",
+    readAllMemories: async () => memories,
+    writeMemory: async (_category: string, content: string) => {
+      const id = `fact-${memories.length + 1}`;
+      memories.push({ frontmatter: { id, status: "active" }, content, path: `/tmp/${id}.md` });
+      return id;
+    },
+    getMemoryById: async (id: string) => memories.find((m) => m.frontmatter.id === id) ?? null,
+    // The pending_review frontmatter update fails — the memory never reaches its
+    // intended durable state, so no catalog touch may be recorded.
+    writeMemoryFrontmatter: async () => {
+      throw new Error("frontmatter write failed");
+    },
+    appendMemoryLifecycleEvents: async () => 1,
+  };
+  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacesEnabled: false,
+      namespacePolicies: [],
+    },
+    getStorage: async () => storage,
+    recordCatalogWrite(namespace?: string, storageDir?: string) {
+      recorded.push({ namespace, storageDir });
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      queueExplicitCaptureForReview(
+        orchestrator as never,
+        {
+          content: "A queued review capture whose pending_review update fails must not touch the catalog.",
+          category: "fact",
+          tags: ["operator-review"],
+        },
+        "inline",
+        new Error("queued for review"),
+      ),
+    /frontmatter write failed/,
+  );
+
+  assert.equal(
+    recorded.length,
+    0,
+    "a failed pending_review frontmatter update must not record a catalog write touch",
+  );
+});
+
 test("persistExplicitCapture rejects namespaces outside the configured policy", async () => {
   const storage = {
     hasFactContentHash: async () => false,

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -209,6 +209,108 @@ test("persistExplicitCapture writes lifecycle events and dedupes active duplicat
   assert.equal(lifecycleEvents.length, 1);
 });
 
+// ── Round 6 (codex P2 — NAUf4): a DEFAULT explicit capture (no `namespace`)
+// resolves `undefined` → writes to the default root, but must STILL record a
+// catalog WRITE so the default namespace's `lastWriteAt` is updated for
+// `writtenSince`/maintenance consumers. recordCatalogWrite resolves an
+// undefined/empty namespace to `config.defaultNamespace`.
+test("persistExplicitCapture records a catalog write for the DEFAULT namespace", async () => {
+  const storage = {
+    dir: "/synthetic/memory",
+    hasFactContentHash: async () => false,
+    isFactContentHashAuthoritative: async () => true,
+    readAllMemories: async () => [],
+    writeMemory: async () => "fact-default",
+    appendMemoryLifecycleEvents: async () => 1,
+  };
+  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacesEnabled: false,
+      namespacePolicies: [],
+    },
+    getStorage: async () => storage,
+    // Mirror the real method's default-resolution so the test exercises NAUf4.
+    recordCatalogWrite(namespace?: string, storageDir?: string) {
+      const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
+      recorded.push({ namespace: ns, storageDir });
+    },
+  };
+
+  await persistExplicitCapture(
+    orchestrator as never,
+    validateExplicitCaptureInput({
+      content: "A default-namespace explicit capture must still touch the catalog.",
+      category: "fact",
+    }),
+    "memory_capture",
+  );
+
+  assert.equal(recorded.length, 1, "default explicit capture must record exactly one catalog write");
+  assert.equal(
+    recorded[0]?.namespace,
+    "default",
+    "an undefined capture namespace must record the configured default in the catalog",
+  );
+  assert.equal(recorded[0]?.storageDir, "/synthetic/memory");
+});
+
+// ── Round 6 (codex P2 — NAUf4): the review-queue path has the same default-write
+// gap — a queued review capture without a namespace writes to the default root,
+// so it must also record a catalog write for the default namespace.
+test("queueExplicitCaptureForReview records a catalog write for the DEFAULT namespace", async () => {
+  const memories: Array<{ frontmatter: { id: string; status?: string }; content: string; path: string }> = [];
+  const storage = {
+    dir: "/synthetic/memory",
+    readAllMemories: async () => memories,
+    writeMemory: async (category: string, content: string) => {
+      const id = `fact-${memories.length + 1}`;
+      memories.push({ frontmatter: { id, status: "active" }, content, path: `/tmp/${id}.md` });
+      return id;
+    },
+    getMemoryById: async (id: string) => memories.find((m) => m.frontmatter.id === id) ?? null,
+    writeMemoryFrontmatter: async (memory: { frontmatter: { status?: string } }, patch: { status: string }) => {
+      memory.frontmatter.status = patch.status;
+      return memory;
+    },
+    appendMemoryLifecycleEvents: async () => 1,
+  };
+  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacesEnabled: false,
+      namespacePolicies: [],
+    },
+    getStorage: async () => storage,
+    recordCatalogWrite(namespace?: string, storageDir?: string) {
+      const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
+      recorded.push({ namespace: ns, storageDir });
+    },
+  };
+
+  await queueExplicitCaptureForReview(
+    orchestrator as never,
+    {
+      content: "A queued default-namespace review capture must touch the catalog too.",
+      category: "fact",
+      tags: ["operator-review"],
+    },
+    "inline",
+    new Error("queued for review"),
+  );
+
+  assert.equal(recorded.length, 1, "queued default review capture must record exactly one catalog write");
+  assert.equal(
+    recorded[0]?.namespace,
+    "default",
+    "an undefined review-queue namespace must record the configured default in the catalog",
+  );
+});
+
 test("persistExplicitCapture rejects namespaces outside the configured policy", async () => {
   const storage = {
     hasFactContentHash: async () => false,

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -311,13 +311,13 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
   );
 });
 
-// NIhUg (cursor Medium): the catalog write touch must fire only AFTER the queued
-// review memory reaches its intended durable `pending_review` state. If the
-// frontmatter update fails, no catalog write may be recorded (rule #25).
-test("queueExplicitCaptureForReview records NO catalog write when the pending_review frontmatter update fails", async () => {
+// NIhUg follow-up: once writeMemory returns an id, the queued review memory is
+// durable even if the pending_review frontmatter update later fails. The catalog
+// must still record the write so writtenSince/QMD maintenance can find the root.
+test("queueExplicitCaptureForReview records a catalog write when a post-write frontmatter update fails", async () => {
   const memories: Array<{ frontmatter: { id: string; status?: string }; content: string; path: string }> = [];
   const storage = {
-    dir: "/synthetic/memory",
+    dir: "/synthetic/team",
     readAllMemories: async () => memories,
     writeMemory: async (_category: string, content: string) => {
       const id = `fact-${memories.length + 1}`;
@@ -325,8 +325,8 @@ test("queueExplicitCaptureForReview records NO catalog write when the pending_re
       return id;
     },
     getMemoryById: async (id: string) => memories.find((m) => m.frontmatter.id === id) ?? null,
-    // The pending_review frontmatter update fails — the memory never reaches its
-    // intended durable state, so no catalog touch may be recorded.
+    // The pending_review frontmatter update fails after writeMemory has already
+    // created a durable memory.
     writeMemoryFrontmatter: async () => {
       throw new Error("frontmatter write failed");
     },
@@ -337,8 +337,8 @@ test("queueExplicitCaptureForReview records NO catalog write when the pending_re
     config: {
       defaultNamespace: "default",
       sharedNamespace: "shared",
-      namespacesEnabled: false,
-      namespacePolicies: [],
+      namespacesEnabled: true,
+      namespacePolicies: [{ name: "team" }],
     },
     getStorage: async () => storage,
     recordCatalogWrite(namespace?: string, storageDir?: string) {
@@ -351,8 +351,9 @@ test("queueExplicitCaptureForReview records NO catalog write when the pending_re
       queueExplicitCaptureForReview(
         orchestrator as never,
         {
-          content: "A queued review capture whose pending_review update fails must not touch the catalog.",
+          content: "A queued review capture whose pending_review update fails must still touch the catalog.",
           category: "fact",
+          namespace: "team",
           tags: ["operator-review"],
         },
         "inline",
@@ -363,9 +364,11 @@ test("queueExplicitCaptureForReview records NO catalog write when the pending_re
 
   assert.equal(
     recorded.length,
-    0,
-    "a failed pending_review frontmatter update must not record a catalog write touch",
+    1,
+    "a failed post-write frontmatter update must still record one catalog write touch",
   );
+  assert.deepEqual(recorded[0], { namespace: "team", storageDir: "/synthetic/team" });
+  assert.equal(memories.length, 1, "precondition: writeMemory created a durable memory before the failure");
 });
 
 test("persistExplicitCapture rejects namespaces outside the configured policy", async () => {

--- a/tests/namespaces-router.test.ts
+++ b/tests/namespaces-router.test.ts
@@ -253,3 +253,30 @@ test("v3 namespaces router propagates custom entity schemas to routed storage ma
     },
   ]);
 });
+
+// ── Round 7 (cursor Medium — NCNL2): the resolve hook must fire only ONCE per
+// (namespace, storageDir). Recall/extraction call `storageFor` repeatedly; firing
+// onResolve (→ catalog loadCompacted + append) on every cache hit grows the log
+// without bound between rebuilds. A steady-state cache hit must be a hook no-op.
+test("storageFor fires the resolve hook once per (namespace, dir), not on every cache hit", async () => {
+  const memoryDir = tmpDir("ns-router-resolve-dedup");
+  const cfg = baseConfig(memoryDir);
+  const resolves: Array<{ ns: string; dir: string }> = [];
+  const router = new NamespaceStorageRouter(cfg, {
+    onResolve: (ns, dir) => {
+      resolves.push({ ns, dir });
+    },
+  });
+
+  // First resolve fires the hook; subsequent cache hits for the same dir do not.
+  const a = await router.storageFor("default");
+  const b = await router.storageFor("default");
+  const c = await router.storageFor("default");
+  assert.equal(a, b, "cache hit returns the same StorageManager");
+  assert.equal(b, c, "cache hit returns the same StorageManager");
+  assert.equal(
+    resolves.filter((r) => r.ns === "default").length,
+    1,
+    "onResolve must fire exactly once for repeated cache hits on the same namespace/dir",
+  );
+});

--- a/tests/namespaces-router.test.ts
+++ b/tests/namespaces-router.test.ts
@@ -280,3 +280,38 @@ test("storageFor fires the resolve hook once per (namespace, dir), not on every 
     "onResolve must fire exactly once for repeated cache hits on the same namespace/dir",
   );
 });
+
+// ── Round 7 (cursor Medium — ND3EJ): a FAILED resolve-hook registration must not
+// be permanently suppressed by the dedup. If the first hook invocation rejects
+// (e.g. catalog append dropped on a rebuild-lock timeout), a later cache hit must
+// RETRY the hook rather than skip it forever.
+test("storageFor retries the resolve hook after a failed registration", async () => {
+  const memoryDir = tmpDir("ns-router-resolve-retry");
+  const cfg = baseConfig(memoryDir);
+  let calls = 0;
+  const router = new NamespaceStorageRouter(cfg, {
+    onResolve: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("first registration dropped");
+      // Subsequent calls succeed.
+    },
+  });
+
+  // First resolve fires the hook, which REJECTS — dedup must not be recorded.
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10)); // let the rejection settle
+  // A later cache hit must RE-FIRE the hook (retry) since the first failed.
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.ok(calls >= 2, "a failed registration must be retried on the next resolve");
+
+  // Once a hook succeeds, further cache hits are deduped (no unbounded growth).
+  const callsAfterSuccess = calls;
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(
+    calls,
+    callsAfterSuccess,
+    "after a successful registration, further cache hits are deduped",
+  );
+});

--- a/tests/namespaces-router.test.ts
+++ b/tests/namespaces-router.test.ts
@@ -315,3 +315,38 @@ test("storageFor retries the resolve hook after a failed registration", async ()
     "after a successful registration, further cache hits are deduped",
   );
 });
+
+// ── Round 7 (codex P2 — NEFoX): a resolve hook that RESOLVES TO `false` (a
+// dropped/no-op registration — e.g. the catalog touch returned without appending
+// under a rebuild-lock timeout) must NOT be marked notified, so a later cache hit
+// retries it. A `false` result is distinct from a thrown/rejected failure.
+test("storageFor retries a resolve hook that resolves to false (dropped registration)", async () => {
+  const memoryDir = tmpDir("ns-router-resolve-false");
+  const cfg = baseConfig(memoryDir);
+  let calls = 0;
+  const router = new NamespaceStorageRouter(cfg, {
+    onResolve: async () => {
+      calls += 1;
+      // First two registrations are DROPPED (false); the third persists (true).
+      return calls >= 3;
+    },
+  });
+
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.ok(calls >= 3, "a registration resolving to false must be retried, not suppressed");
+
+  // After the persisted (true) result, further cache hits are deduped.
+  const callsAfterPersist = calls;
+  await router.storageFor("default");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(
+    calls,
+    callsAfterPersist,
+    "after a persisted registration (true), further cache hits are deduped",
+  );
+});

--- a/tests/orchestrator-chunking-fallback.test.ts
+++ b/tests/orchestrator-chunking-fallback.test.ts
@@ -184,7 +184,7 @@ test("chunking fallback: falls back to recursive chunking when fallbackToRecursi
   assert.ok(ids.length >= 1, "fact should be persisted via recursive fallback");
 });
 
-test("chunked extraction records catalog touch after supersession and artifact writes", async () => {
+test("chunked extraction records catalog touch after supersession, artifact, and graph writes", async () => {
   installCapturingLogger();
   const { orchestrator, storage } = await makeOrchestrator({
     semanticChunkingEnabled: false,
@@ -195,6 +195,7 @@ test("chunked extraction records catalog touch after supersession and artifact w
     verbatimArtifactsEnabled: true,
     verbatimArtifactCategories: ["fact"],
     verbatimArtifactsMinConfidence: 0,
+    multiGraphMemoryEnabled: true,
   });
 
   await storage.writeMemory("fact", "Person A lives in Austin.", {
@@ -228,6 +229,10 @@ test("chunked extraction records catalog touch after supersession and artifact w
     return id;
   };
 
+  orchestrator.buildGraphEdge = async () => {
+    events.push("graph");
+  };
+
   orchestrator.markCatalogWrite = () => {
     events.push("touch");
   };
@@ -258,14 +263,16 @@ test("chunked extraction records catalog touch after supersession and artifact w
   const firstChunkIndex = events.indexOf("chunk");
   const supersessionIndex = events.indexOf("supersession");
   const artifactIndex = events.indexOf("artifact");
+  const graphIndex = events.indexOf("graph");
   const touchIndex = events.indexOf("touch");
 
   assert.notEqual(firstChunkIndex, -1, "precondition: recursive chunking wrote chunks");
   assert.notEqual(supersessionIndex, -1, "precondition: temporal supersession rewrote old fact");
   assert.notEqual(artifactIndex, -1, "precondition: verbatim artifact was written");
+  assert.notEqual(graphIndex, -1, "precondition: graph edge write was attempted");
   assert.notEqual(touchIndex, -1, "precondition: catalog touch was recorded");
   assert.ok(
-    touchIndex > supersessionIndex && touchIndex > artifactIndex,
-    `catalog touch must follow supersession and artifact writes; saw ${events.join(" -> ")}`,
+    touchIndex > supersessionIndex && touchIndex > artifactIndex && touchIndex > graphIndex,
+    `catalog touch must follow supersession, artifact, and graph writes; saw ${events.join(" -> ")}`,
   );
 });

--- a/tests/orchestrator-chunking-fallback.test.ts
+++ b/tests/orchestrator-chunking-fallback.test.ts
@@ -264,15 +264,67 @@ test("chunked extraction records catalog touch after supersession, artifact, and
   const supersessionIndex = events.indexOf("supersession");
   const artifactIndex = events.indexOf("artifact");
   const graphIndex = events.indexOf("graph");
-  const touchIndex = events.indexOf("touch");
+  const touchIndex = events.lastIndexOf("touch");
 
   assert.notEqual(firstChunkIndex, -1, "precondition: recursive chunking wrote chunks");
   assert.notEqual(supersessionIndex, -1, "precondition: temporal supersession rewrote old fact");
   assert.notEqual(artifactIndex, -1, "precondition: verbatim artifact was written");
   assert.notEqual(graphIndex, -1, "precondition: graph edge write was attempted");
-  assert.notEqual(touchIndex, -1, "precondition: catalog touch was recorded");
+  assert.notEqual(touchIndex, -1, "precondition: final catalog touch was recorded");
   assert.ok(
     touchIndex > supersessionIndex && touchIndex > artifactIndex && touchIndex > graphIndex,
     `catalog touch must follow supersession, artifact, and graph writes; saw ${events.join(" -> ")}`,
+  );
+});
+
+test("chunked extraction records catalog touch when post-parent indexing fails", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator({
+    semanticChunkingEnabled: false,
+    chunkingTargetTokens: 12,
+    chunkingMinTokens: 6,
+    chunkingOverlapSentences: 0,
+  });
+
+  const events: string[] = [];
+  const originalWriteChunk = storage.writeChunk.bind(storage);
+  storage.writeChunk = async (...args: Parameters<typeof storage.writeChunk>) => {
+    const id = await originalWriteChunk(...args);
+    events.push("chunk");
+    return id;
+  };
+  orchestrator.indexPersistedMemory = async () => {
+    events.push("index");
+    throw new Error("index boom");
+  };
+  orchestrator.markCatalogWrite = () => {
+    events.push("touch");
+  };
+
+  const longContent = Array.from(
+    { length: 20 },
+    (_, i) => `The namespace catalog failure regression sentence ${i} keeps this fact chunkable.`,
+  ).join(" ");
+
+  const extraction: ExtractionResult = {
+    facts: [fact(longContent)],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  await assert.rejects(
+    () => orchestrator.persistExtraction(extraction, storage, null),
+    /index boom/,
+  );
+
+  const firstChunkIndex = events.indexOf("chunk");
+  const touchIndex = events.indexOf("touch");
+  assert.notEqual(firstChunkIndex, -1, "precondition: chunk files were written");
+  assert.notEqual(touchIndex, -1, "catalog touch must run before the indexing error escapes");
+  assert.ok(
+    touchIndex > firstChunkIndex,
+    `catalog touch must follow durable chunk writes on failure; saw ${events.join(" -> ")}`,
   );
 });

--- a/tests/orchestrator-chunking-fallback.test.ts
+++ b/tests/orchestrator-chunking-fallback.test.ts
@@ -328,3 +328,59 @@ test("chunked extraction records catalog touch when post-parent indexing fails",
     `catalog touch must follow durable chunk writes on failure; saw ${events.join(" -> ")}`,
   );
 });
+
+test("chunked extraction records catalog touch when a later chunk write fails", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator({
+    semanticChunkingEnabled: false,
+    chunkingTargetTokens: 12,
+    chunkingMinTokens: 6,
+    chunkingOverlapSentences: 0,
+  });
+
+  const events: string[] = [];
+  const originalWriteChunk = storage.writeChunk.bind(storage);
+  let writeChunkCalls = 0;
+  storage.writeChunk = async (...args: Parameters<typeof storage.writeChunk>) => {
+    writeChunkCalls++;
+    if (writeChunkCalls === 1) {
+      const id = await originalWriteChunk(...args);
+      events.push("chunk");
+      return id;
+    }
+    events.push("chunk-fail");
+    throw new Error("later chunk failed");
+  };
+  orchestrator.markCatalogWrite = () => {
+    events.push("touch");
+  };
+
+  const longContent = Array.from(
+    { length: 20 },
+    (_, i) => `The later chunk failure regression sentence ${i} keeps this fact chunkable.`,
+  ).join(" ");
+
+  const extraction: ExtractionResult = {
+    facts: [fact(longContent)],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  await assert.rejects(
+    () => orchestrator.persistExtraction(extraction, storage, null),
+    /later chunk failed/,
+  );
+
+  const chunkIndex = events.indexOf("chunk");
+  const failureIndex = events.indexOf("chunk-fail");
+  const touchIndex = events.indexOf("touch");
+  assert.notEqual(chunkIndex, -1, "precondition: at least one chunk was durable");
+  assert.notEqual(failureIndex, -1, "precondition: a later chunk write failed");
+  assert.notEqual(touchIndex, -1, "partial chunk failure must still touch the catalog");
+  assert.ok(
+    touchIndex > failureIndex,
+    `catalog touch must run from the chunk-write finally after the failure; saw ${events.join(" -> ")}`,
+  );
+});

--- a/tests/orchestrator-chunking-fallback.test.ts
+++ b/tests/orchestrator-chunking-fallback.test.ts
@@ -183,3 +183,89 @@ test("chunking fallback: falls back to recursive chunking when fallbackToRecursi
   const ids = await orchestrator.persistExtraction(extraction, storage, null);
   assert.ok(ids.length >= 1, "fact should be persisted via recursive fallback");
 });
+
+test("chunked extraction records catalog touch after supersession and artifact writes", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator({
+    semanticChunkingEnabled: false,
+    chunkingTargetTokens: 12,
+    chunkingMinTokens: 6,
+    chunkingOverlapSentences: 0,
+    temporalSupersessionEnabled: true,
+    verbatimArtifactsEnabled: true,
+    verbatimArtifactCategories: ["fact"],
+    verbatimArtifactsMinConfidence: 0,
+  });
+
+  await storage.writeMemory("fact", "Person A lives in Austin.", {
+    source: "test",
+    entityRef: "person-a",
+    structuredAttributes: { city: "Austin" },
+    validAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  const events: string[] = [];
+  const originalWriteChunk = storage.writeChunk.bind(storage);
+  storage.writeChunk = async (...args: Parameters<typeof storage.writeChunk>) => {
+    const id = await originalWriteChunk(...args);
+    events.push("chunk");
+    return id;
+  };
+
+  const originalWriteMemoryFrontmatter = storage.writeMemoryFrontmatter.bind(storage);
+  storage.writeMemoryFrontmatter = async (
+    ...args: Parameters<typeof storage.writeMemoryFrontmatter>
+  ) => {
+    const result = await originalWriteMemoryFrontmatter(...args);
+    events.push("supersession");
+    return result;
+  };
+
+  const originalWriteArtifact = storage.writeArtifact.bind(storage);
+  storage.writeArtifact = async (...args: Parameters<typeof storage.writeArtifact>) => {
+    const id = await originalWriteArtifact(...args);
+    events.push("artifact");
+    return id;
+  };
+
+  orchestrator.markCatalogWrite = () => {
+    events.push("touch");
+  };
+
+  const longContent = Array.from(
+    { length: 20 },
+    (_, i) => `Person A now lives in NYC and this detailed sentence ${i} keeps the memory chunkable.`,
+  ).join(" ");
+
+  const extraction: ExtractionResult = {
+    facts: [
+      {
+        ...fact(longContent),
+        entityRef: "person-a",
+        structuredAttributes: { city: "NYC" },
+      },
+    ],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  await orchestrator.persistExtraction(extraction, storage, null, {
+    validAt: "2026-01-02T00:00:00.000Z",
+  });
+
+  const firstChunkIndex = events.indexOf("chunk");
+  const supersessionIndex = events.indexOf("supersession");
+  const artifactIndex = events.indexOf("artifact");
+  const touchIndex = events.indexOf("touch");
+
+  assert.notEqual(firstChunkIndex, -1, "precondition: recursive chunking wrote chunks");
+  assert.notEqual(supersessionIndex, -1, "precondition: temporal supersession rewrote old fact");
+  assert.notEqual(artifactIndex, -1, "precondition: verbatim artifact was written");
+  assert.notEqual(touchIndex, -1, "precondition: catalog touch was recorded");
+  assert.ok(
+    touchIndex > supersessionIndex && touchIndex > artifactIndex,
+    `catalog touch must follow supersession and artifact writes; saw ${events.join(" -> ")}`,
+  );
+});

--- a/tests/orchestrator-lifecycle-performance.test.ts
+++ b/tests/orchestrator-lifecycle-performance.test.ts
@@ -11,7 +11,7 @@ test("runLifecyclePolicyPass uses path-based frontmatter writes (no per-item cor
 
   assert.match(
     source,
-    /private async runLifecyclePolicyPass\(\s*allMemories: MemoryFile\[\],\s*storage: StorageManager = this\.storage,?\s*\): Promise<void> \{/m,
+    /private async runLifecyclePolicyPass\(\s*allMemories: MemoryFile\[\],\s*storage: StorageManager = this\.storage,?\s*\): Promise<number> \{/m,
     "expected runLifecyclePolicyPass helper",
   );
   assert.match(

--- a/tests/orchestrator-proactive-extraction.test.ts
+++ b/tests/orchestrator-proactive-extraction.test.ts
@@ -317,3 +317,46 @@ test("persistExtraction touches the catalog for a question-only (fact-less) extr
     "a question-only extraction must record a catalog write touch (lastWriteAt)",
   );
 });
+
+// ── NIIly (codex P2): an extraction that persists ONLY an identity reflection (no
+// facts, entities, profile updates, or questions) still writes durable
+// namespace-local state via appendIdentityReflection(). The durable-non-fact
+// catalog touch must therefore include identity reflection writes — otherwise an
+// identity-only extraction leaves lastWriteAt stale.
+test("persistExtraction touches the catalog for an identity-reflection-only extraction (NIIly)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-niily-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    identityEnabled: true,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+  });
+
+  const orchestrator = new Orchestrator(config) as any;
+  const ns = "project-origin-identityonly";
+  const storage = await orchestrator.storageRouter.storageFor(ns);
+  await storage.ensureDirectories();
+
+  const result: ExtractionResult = {
+    facts: [],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+    identityReflection: "I tend to ask clarifying questions before committing.",
+  };
+
+  await orchestrator.persistExtraction(result, storage, null, undefined, ns);
+  await new Promise((r) => setTimeout(r, 50));
+
+  const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+  assert.ok(record, "the base namespace is catalogued for an identity-only extraction");
+  assert.ok(
+    record.lastWriteAt,
+    "an identity-reflection-only extraction must record a catalog write touch (lastWriteAt)",
+  );
+});

--- a/tests/orchestrator-proactive-extraction.test.ts
+++ b/tests/orchestrator-proactive-extraction.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, mkdir } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import type { ExtractionResult } from "../src/types.js";
@@ -119,4 +119,75 @@ test("persistExtraction preserves base chunk source metadata while tagging proac
   assert.ok(proactiveChunk);
   assert.equal(baseChunk.frontmatter.source, "chunking");
   assert.equal(proactiveChunk.frontmatter.source, "chunking-proactive");
+});
+
+// ── NGnei/NHIdx (codex P2): the catalog WRITE TOUCH must record the KNOWN base
+// namespace, not a guess decoded from the storage dir. A namespace literally named
+// like a canonical token (e.g. `ns-616c706861`, the token of `alpha`) served from
+// its legacy raw dir `namespaces/ns-616c706861` would decode back to `alpha`, so
+// the write touch updated `alpha` while the real namespace got no lastWriteAt. We
+// pass the resolved base namespace into persistExtraction and assert the catalog
+// records the real (token-named) namespace.
+test("persistExtraction records the catalog write under the real namespace, not a dir-decoded guess (NHIdx)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-nhidx-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+  });
+
+  const orchestrator = new Orchestrator(config) as any;
+  // A namespace whose literal name is the canonical token of `alpha`. Pre-create
+  // its LEGACY RAW dir `namespaces/ns-616c706861` (with a marker) so the router
+  // serves THAT root — which is byte-identical to alpha's TOKENIZED dir, so
+  // decoding the directory alone yields `alpha` (the ambiguity NHIdx resolves by
+  // carrying the known base namespace).
+  const tokenNamedNs = "ns-616c706861";
+  await mkdir(path.join(memoryDir, "namespaces", tokenNamedNs, "facts"), { recursive: true });
+  const storage = await orchestrator.storageRouter.storageFor(tokenNamedNs);
+  await storage.ensureDirectories();
+  // Confirm the router serves the ambiguous legacy raw root (the bug precondition).
+  assert.ok(
+    storage.dir.endsWith(path.join("namespaces", tokenNamedNs)),
+    "the token-named namespace must be served from its legacy raw root for this test",
+  );
+
+  const result: ExtractionResult = {
+    facts: [
+      {
+        category: "fact",
+        content: "Memory written to a token-named namespace.",
+        confidence: 0.9,
+        tags: ["nhidx"],
+        source: "base",
+      },
+    ],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  };
+
+  // Pass the KNOWN base namespace (as runExtraction does via selfNamespace).
+  const ids = await orchestrator.persistExtraction(result, storage, null, undefined, tokenNamedNs);
+  assert.equal(ids.length, 1, "the fact is persisted");
+
+  // Give the best-effort async catalog write a tick to settle.
+  await new Promise((r) => setTimeout(r, 50));
+
+  // The catalog must record the REAL token-named namespace with a write touch...
+  const real = await orchestrator.namespaceCatalog.getNamespaceRecord(tokenNamedNs);
+  assert.ok(real, "the real token-named namespace is catalogued");
+  assert.ok(real.lastWriteAt, "the write touch is recorded under the real namespace");
+
+  // ...and must NOT have recorded the write under the dir-decoded `alpha`.
+  const decodedGuess = await orchestrator.namespaceCatalog.getNamespaceRecord("alpha");
+  assert.ok(
+    !decodedGuess || !decodedGuess.lastWriteAt,
+    "the write touch must not be misattributed to the dir-decoded namespace",
+  );
 });

--- a/tests/orchestrator-proactive-extraction.test.ts
+++ b/tests/orchestrator-proactive-extraction.test.ts
@@ -191,3 +191,129 @@ test("persistExtraction records the catalog write under the real namespace, not 
     "the write touch must not be misattributed to the dir-decoded namespace",
   );
 });
+
+// ── NHZEZ (codex P2): an extraction that persists ONLY entities/relationships (no
+// facts) still writes durable data to the base namespace, so the catalog must get a
+// write touch — otherwise that namespace's lastWriteAt stays stale and
+// writtenSince/QMD maintenance miss the write. The per-fact markCatalogWrite never
+// runs for a fact-less extraction; the new base-namespace touch covers it.
+test("persistExtraction touches the catalog for an entity-only (fact-less) extraction (NHZEZ)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-nhzez-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+  });
+
+  const orchestrator = new Orchestrator(config) as any;
+  const ns = "project-origin-entityonly";
+  const storage = await orchestrator.storageRouter.storageFor(ns);
+  await storage.ensureDirectories();
+
+  const result: ExtractionResult = {
+    facts: [], // NO facts — only an entity
+    entities: [
+      { name: "Acme Corp", type: "company", facts: ["Founded 2020."] },
+    ],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  };
+
+  const ids = await orchestrator.persistExtraction(result, storage, null, undefined, ns);
+  assert.ok(ids.length >= 0, "entity-only extraction completes");
+  await new Promise((r) => setTimeout(r, 50));
+
+  const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+  assert.ok(record, "the base namespace is catalogued for an entity-only extraction");
+  assert.ok(
+    record.lastWriteAt,
+    "an entity-only extraction must record a catalog write touch (lastWriteAt)",
+  );
+});
+
+// ── NHZEZ sweep (codex P2): the durable-non-fact catalog touch must also cover an
+// extraction that persists ONLY profile updates (no facts, no entities). Profile
+// updates are written via storage.appendToProfile() to the base namespace, after
+// the entity/relationship loop, so the consolidated post-write touch must include
+// them or a profile-only extraction leaves lastWriteAt stale.
+test("persistExtraction touches the catalog for a profile-only (fact-less) extraction (NHZEZ sweep)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-nhzez-profile-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+  });
+
+  const orchestrator = new Orchestrator(config) as any;
+  const ns = "project-origin-profileonly";
+  const storage = await orchestrator.storageRouter.storageFor(ns);
+  await storage.ensureDirectories();
+
+  const result: ExtractionResult = {
+    facts: [],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: ["Prefers async-first design."], // ONLY a profile update
+  };
+
+  await orchestrator.persistExtraction(result, storage, null, undefined, ns);
+  await new Promise((r) => setTimeout(r, 50));
+
+  const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+  assert.ok(record, "the base namespace is catalogued for a profile-only extraction");
+  assert.ok(
+    record.lastWriteAt,
+    "a profile-only extraction must record a catalog write touch (lastWriteAt)",
+  );
+});
+
+// ── NHZEZ sweep (codex P2): the durable-non-fact catalog touch must also cover an
+// extraction that persists ONLY questions (no facts, entities, or profile updates).
+// Questions are written via storage.writeQuestion() to the base namespace.
+test("persistExtraction touches the catalog for a question-only (fact-less) extraction (NHZEZ sweep)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-nhzez-question-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+  });
+
+  const orchestrator = new Orchestrator(config) as any;
+  const ns = "project-origin-questiononly";
+  const storage = await orchestrator.storageRouter.storageFor(ns);
+  await storage.ensureDirectories();
+
+  const result: ExtractionResult = {
+    facts: [],
+    entities: [],
+    relationships: [],
+    questions: [
+      { question: "What database does the project use?", context: "infra", priority: 0.5 },
+    ],
+    profileUpdates: [],
+  };
+
+  await orchestrator.persistExtraction(result, storage, null, undefined, ns);
+  await new Promise((r) => setTimeout(r, 50));
+
+  const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+  assert.ok(record, "the base namespace is catalogued for a question-only extraction");
+  assert.ok(
+    record.lastWriteAt,
+    "a question-only extraction must record a catalog write touch (lastWriteAt)",
+  );
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -850,3 +850,135 @@ test("semantic consolidation records a catalog write when archival fails after c
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── codex P2 (NZYYR): the non-chunked extraction path writes graph edges and
+// optional verbatim artifacts after the primary memory write. The source
+// namespace catalog touch must run after those later mutations, not between the
+// primary memory and the derived writes.
+test("persistExtraction records non-chunked source catalog touch after graph and artifact writes", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-nonchunk-touch-order-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      chunkingEnabled: false,
+      multiGraphMemoryEnabled: true,
+      verbatimArtifactsEnabled: true,
+      verbatimArtifactCategories: ["fact"],
+      verbatimArtifactsMinConfidence: 0,
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    const ns = "project-origin-nonchunk-order";
+    const storage = await orchestrator.getStorage(ns);
+    await storage.ensureDirectories();
+
+    const events: string[] = [];
+    orchestrator.buildGraphEdge = async () => {
+      events.push("graph");
+    };
+    const originalWriteArtifact = storage.writeArtifact.bind(storage);
+    storage.writeArtifact = async (...args: Parameters<typeof storage.writeArtifact>) => {
+      const id = await originalWriteArtifact(...args);
+      events.push("artifact");
+      return id;
+    };
+    orchestrator.markCatalogWrite = () => {
+      events.push("touch");
+    };
+
+    await orchestrator.persistExtraction(
+      {
+        facts: [
+          {
+            content: "The non-chunked catalog ordering fact is short.",
+            category: "fact",
+            confidence: 0.95,
+            tags: ["catalog-order"],
+          },
+        ],
+        entities: [],
+        relationships: [],
+        questions: [],
+        profileUpdates: [],
+      },
+      storage,
+      null,
+      undefined,
+      ns,
+    );
+
+    const graphIndex = events.indexOf("graph");
+    const artifactIndex = events.indexOf("artifact");
+    const touchIndex = events.indexOf("touch");
+    assert.notEqual(graphIndex, -1, "precondition: graph edge write was attempted");
+    assert.notEqual(artifactIndex, -1, "precondition: artifact write completed");
+    assert.notEqual(touchIndex, -1, "precondition: source catalog touch was recorded");
+    assert.ok(
+      touchIndex > graphIndex && touchIndex > artifactIndex,
+      `source catalog touch must follow graph and artifact writes; saw ${events.join(" -> ")}`,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── codex P2 (NZYYT): a dynamic namespace created only by a read touch has no
+// durable memory data. Maintenance must not create or keep QMD collections for
+// those absent catalog-only rows, while still including real data roots that lack
+// a historical write touch.
+test("maintenanceNamespaces skips absent catalog-only read rows but includes existing data roots", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-maintenance-catalog-read-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    const ns = "project-origin-empty-read";
+    await orchestrator.namespaceCatalog.markRead(ns, { discoveredBy: "read" });
+
+    const before = await orchestrator.maintenanceNamespaces();
+    assert.ok(
+      !before.includes(ns),
+      "catalog-only read rows without storage data must not enter maintenance fanout",
+    );
+
+    const storage = await orchestrator.getStorage(ns);
+    await storage.ensureDirectories();
+    await storage.writeMemory("fact", "A real dynamic namespace memory exists.", {
+      source: "test",
+      confidence: 0.9,
+      tags: ["maintenance"],
+    });
+    await orchestrator.namespaceCatalog.markRead(ns, {
+      discoveredBy: "read",
+      storageDir: storage.dir,
+    });
+
+    const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+    assert.ok(record, "precondition: namespace remains cataloged");
+    assert.ok(!record?.lastWriteAt, "precondition: this is still a read-only catalog row");
+
+    const after = await orchestrator.maintenanceNamespaces();
+    assert.ok(
+      after.includes(ns),
+      "read-only catalog rows with an existing data root must still enter maintenance fanout",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -547,6 +547,46 @@ test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a cano
   }
 });
 
+test("namespaceFromStorageDir preserves a CATALOGED dynamic namespace named like a canonical token", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-token-catalog-"));
+  try {
+    const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
+    const literalTokenName = tokenize("alpha");
+    const rawDir = path.join(memoryDir, "namespaces", literalTokenName);
+    await mkdir(path.join(rawDir, "facts"), { recursive: true });
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+    const seedOrchestrator = new Orchestrator(config) as any;
+    await seedOrchestrator.namespaceCatalog.markRead(literalTokenName, {
+      discoveredBy: "read",
+      storageDir: rawDir,
+    });
+
+    const freshOrchestrator = new Orchestrator(config) as any;
+    assert.equal(
+      freshOrchestrator.namespaceFromStorageDir(rawDir),
+      literalTokenName,
+      "a cataloged dynamic namespace named like a canonical token must resolve to the literal name, not its decoded identity",
+    );
+
+    assert.equal(
+      freshOrchestrator.namespaceFromStorageDir(path.join(memoryDir, "namespaces", tokenize("beta"))),
+      "beta",
+      "an uncataloged genuine tokenized dir still decodes to its identity",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDXHa): an already-ABORTED recall must not record catalog
 // read touches. The abort check runs later (Phase 1 retrieval), so without the
 // gate an already-aborted recall would still set `lastReadAt` for every recall

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -758,3 +758,95 @@ test("autoConsolidateIdentity records a catalog write for a dynamic namespace wh
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── codex P2 (NY-dK): semantic consolidation writes the canonical memory before
+// archiving the source cluster. If archival throws, the cluster catch swallows the
+// failure and continues, but the canonical write is already durable. The catalog
+// touch must still run so writtenSince/QMD maintenance sees the namespace.
+test("semantic consolidation records a catalog write when archival fails after canonical write", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-semantic-partial-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      semanticConsolidationEnabled: true,
+      semanticConsolidationModel: "fast",
+      semanticConsolidationThreshold: 0,
+      semanticConsolidationMinClusterSize: 2,
+      semanticConsolidationMaxPerRun: 10,
+      semanticConsolidationExcludeCategories: [],
+      qmdEnabled: false,
+      embeddingFallbackEnabled: false,
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const dynamicNs = "project-origin-semantic-partial";
+    const orchestrator = new Orchestrator(config) as any;
+    const dynamicStorage = await orchestrator.getStorage(dynamicNs);
+    await dynamicStorage.ensureDirectories();
+
+    for (let i = 0; i < 10; i++) {
+      await dynamicStorage.writeMemory(
+        "fact",
+        `Partial consolidation source ${i} repeats the same stable project namespace catalog detail.`,
+        {
+          source: "test",
+          confidence: 0.9,
+          tags: ["semantic-partial"],
+          created: new Date(Date.now() - i * 1000).toISOString(),
+        },
+      );
+    }
+
+    await orchestrator.namespaceCatalog.markRead(dynamicNs, {
+      discoveredBy: "read",
+      storageDir: dynamicStorage.dir,
+    });
+    const before = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
+    assert.ok(before, "precondition: dynamic namespace is cataloged before consolidation");
+    assert.ok(!before?.lastWriteAt, "precondition: lastWriteAt is unset before consolidation");
+
+    orchestrator.fastLlm = {
+      async chatCompletion() {
+        return { content: "Canonical partial consolidation memory." };
+      },
+    };
+
+    let archiveCalls = 0;
+    dynamicStorage.archiveMemory = async () => {
+      archiveCalls++;
+      throw new Error("synthetic archive failure after canonical write");
+    };
+
+    const result = await orchestrator.runSemanticConsolidation({
+      force: true,
+      storage: dynamicStorage,
+      thresholdOverride: 0,
+    });
+
+    assert.equal(result.memoriesConsolidated, 1, "precondition: canonical write completed");
+    assert.equal(result.errors, 1, "precondition: archival failure was swallowed as a cluster error");
+    assert.equal(archiveCalls, 1, "precondition: archival was attempted after the canonical write");
+
+    await orchestrator.namespaceCatalog.markRead(dynamicNs);
+
+    const after = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
+    assert.ok(
+      after?.lastWriteAt,
+      "partial semantic consolidation must record a catalog write for the durable canonical memory",
+    );
+
+    const since = new Date(Date.parse(after!.lastWriteAt!) - 1000);
+    const written = await orchestrator.namespaceCatalog.listNamespaces({ writtenSince: since });
+    assert.ok(
+      written.some((r: { namespace: string }) => r.namespace === dynamicNs),
+      "writtenSince must surface the namespace after a partial semantic consolidation write",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -1112,3 +1112,51 @@ test("maintenanceNamespaces skips absent catalog-only read rows but includes exi
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── codex P2 (Na71-): `lastWriteAt` proves a namespace was written sometime in
+// the past, not that its storage root is still live. If a dynamic tokenized root
+// is deleted before maintenance runs, the catalog row must not keep feeding that
+// stale namespace into QMD maintenance.
+test("maintenanceNamespaces skips catalog write rows whose storage root was deleted", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-maintenance-deleted-write-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    const ns = "project-origin-deleted-write";
+    const storage = await orchestrator.getStorage(ns);
+    await storage.ensureDirectories();
+    await storage.writeMemory("fact", "This dynamic namespace root will be deleted.", {
+      source: "test",
+      confidence: 0.9,
+      tags: ["maintenance"],
+    });
+    await orchestrator.namespaceCatalog.markWrite(ns, {
+      discoveredBy: "write",
+      storageDir: storage.dir,
+    });
+
+    const before = await orchestrator.maintenanceNamespaces();
+    assert.ok(before.includes(ns), "precondition: live write root enters maintenance fanout");
+
+    await rm(storage.dir, { recursive: true, force: true });
+    const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
+    assert.ok(record?.lastWriteAt, "precondition: stale catalog row still carries lastWriteAt");
+
+    const after = await orchestrator.maintenanceNamespaces();
+    assert.ok(
+      !after.includes(ns),
+      "a deleted dynamic write root must not enter maintenance fanout just because lastWriteAt is set",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -149,6 +149,127 @@ test("persistExtraction shared promotion records a shared-namespace catalog writ
   }
 });
 
+// ── Round 8 (codex P2 — NElSf): the shared-promotion HASH-DEDUP branch returns
+// early (an active matching shared fact already exists, so no NEW write happens),
+// but it first runs `applyTemporalSupersession`, which REWRITES shared-namespace
+// frontmatter to retire stale conflicting facts. That return path skips the
+// post-write `markCatalogWrite`, so a supersession-only update left the shared
+// record's `lastWriteAt` stale and `writtenSince` maintenance/QMD fanout could
+// skip the namespace. The fix touches the catalog on the dedup return path WHEN
+// any ids were actually superseded. This drives the real path: an OLD conflicting
+// active shared fact (entity E, {city: NYC}) plus a hash-indexed active shared
+// fact (content X, entity E, {city: Austin}); promoting content X (entity E,
+// {city: Austin}) hits the hash-dedup branch, supersedes the older NYC fact, and
+// must record a shared-namespace catalog write. Fails pre-fix (dedup return skips
+// markCatalogWrite); passes after.
+test("shared hash-dedup supersession-only update records a shared-namespace catalog write", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-dedup-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      autoPromoteToSharedEnabled: true,
+      autoPromoteToSharedCategories: ["fact"],
+      autoPromoteMinConfidenceTier: "implied",
+      temporalSupersessionEnabled: true,
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    const sourceStorage = await orchestrator.getStorage("default");
+    await sourceStorage.ensureDirectories();
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    const entity = "user-shared-dedup";
+    const matchedContent = "Lives in Austin.";
+
+    // 1) An OLD conflicting active shared fact (same entity, attribute city=NYC)
+    //    that a later city=Austin supersession must retire. Older timestamp so it
+    //    is the one superseded, not the incoming.
+    await sharedStorage.writeMemory("fact", "Lives in NYC.", {
+      entityRef: entity,
+      structuredAttributes: { city: "NYC" },
+      source: "seed",
+      confidence: 0.9,
+      tags: ["shared-promotion"],
+      validAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    // 2) An ACTIVE shared fact whose ENRICHED content hash is indexed, so the
+    //    incoming promotion of the SAME content + attributes takes the hash-dedup
+    //    short-circuit. We do NOT pass `contentHashSource`, so writeMemory indexes
+    //    the enriched body (`<content>\n[Attributes: city: Austin]`) — the exact
+    //    `dedupContent` the orchestrator computes for the incoming fact, so both
+    //    `hasFactContentHash(dedupContent)` AND the inner same-content match fire.
+    await sharedStorage.writeMemory("fact", matchedContent, {
+      entityRef: entity,
+      structuredAttributes: { city: "Austin" },
+      source: "seed",
+      confidence: 0.9,
+      tags: ["shared-promotion"],
+      validAt: new Date(Date.now() - 30_000).toISOString(),
+    });
+    sharedStorage.invalidateAllMemoriesCacheForDir?.();
+
+    // Rebuild the orchestrator's live content-hash index so hasFactContentHash
+    // sees the seeded shared fact (mirrors gateway_start index construction).
+    orchestrator.invalidateLiveContentHashIndex?.();
+
+    // Baseline: record the shared namespace's current lastWriteAt (set by the
+    // seed writes' router resolution, if any). We assert the dedup path ADVANCES
+    // it — i.e. a fresh write touch is recorded on the supersession-only return.
+    await orchestrator.namespaceCatalog.markMaintenance("shared", "probe");
+    const before = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    const beforeWrite = before?.lastWriteAt;
+
+    // 3) Promote the SAME content (entity, city=Austin) — hits the hash-dedup
+    //    branch (active matching fact exists), supersedes the older NYC fact, and
+    //    returns WITHOUT a new write. The fix must still record a shared catalog
+    //    write because supersession mutated the shared namespace.
+    const result = {
+      facts: [
+        {
+          content: matchedContent,
+          category: "fact",
+          confidence: 0.95,
+          tags: ["shared-promotion"],
+          entityRef: entity,
+          structuredAttributes: { city: "Austin" },
+        },
+      ],
+      entities: [],
+      questions: [],
+      profileUpdates: [],
+    };
+    await orchestrator.persistExtraction(result, sourceStorage, null, {
+      sessionKey: "s1",
+      principal: "default",
+    });
+
+    // Serialize a read to flush fire-and-forget catalog appends.
+    await orchestrator.namespaceCatalog.markRead("shared");
+    const after = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(after?.lastWriteAt, "shared record must carry a lastWriteAt after the dedup supersession");
+    if (beforeWrite) {
+      assert.ok(
+        Date.parse(after!.lastWriteAt!) > Date.parse(beforeWrite),
+        "the supersession-only dedup path must ADVANCE the shared namespace lastWriteAt",
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 3, Issue #3 (codex P2): when the planner selects no_recall, retrieval
 // is skipped — so the recall path must NOT mark every readable namespace as
 // read. A trivial prompt ("ok") classifies as no_recall; assert the catalog

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -694,6 +694,74 @@ test("namespaceFromStorageDir compacts catalog hints before choosing token-root 
   }
 });
 
+test("persistExtraction records non-fact catalog touch when a later non-fact write fails", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-nonfact-finally-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+    const orchestrator = new Orchestrator(config) as any;
+    const storage = await orchestrator.getStorage("default");
+    await storage.ensureDirectories();
+
+    const events: string[] = [];
+    const originalWriteEntity = storage.writeEntity.bind(storage);
+    storage.writeEntity = async (...args: Parameters<typeof storage.writeEntity>) => {
+      const id = await originalWriteEntity(...args);
+      events.push("entity");
+      return id;
+    };
+    storage.appendToProfile = async () => {
+      events.push("profile");
+      throw new Error("profile boom");
+    };
+    orchestrator.markCatalogWrite = () => {
+      events.push("touch");
+    };
+
+    await assert.rejects(
+      () =>
+        orchestrator.persistExtraction(
+          {
+            facts: [],
+            entities: [
+              {
+                name: "Namespace Catalog",
+                type: "system",
+                facts: ["tracks durable non-fact writes"],
+              },
+            ],
+            relationships: [],
+            questions: [],
+            profileUpdates: ["User cares about catalog recency."],
+          },
+          storage,
+          null,
+        ),
+      /profile boom/,
+    );
+
+    const entityIndex = events.indexOf("entity");
+    const touchIndex = events.indexOf("touch");
+    assert.notEqual(entityIndex, -1, "precondition: entity write succeeded");
+    assert.notEqual(touchIndex, -1, "catalog touch must run before the later write error escapes");
+    assert.ok(
+      touchIndex > entityIndex,
+      `catalog touch must follow the durable non-fact write on failure; saw ${events.join(" -> ")}`,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDXHa): an already-ABORTED recall must not record catalog
 // read touches. The abort check runs later (Phase 1 retrieval), so without the
 // gate an already-aborted recall would still set `lastReadAt` for every recall

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -285,3 +285,49 @@ test("namespaceFromStorageDir preserves a token-shaped literal raw namespace nam
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NDXHa): an already-ABORTED recall must not record catalog
+// read touches. The abort check runs later (Phase 1 retrieval), so without the
+// gate an already-aborted recall would still set `lastReadAt` for every recall
+// namespace even though it exits before any QMD/fallback read.
+test("an already-aborted recall records no catalog read touches", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-aborted-recall-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    // Pre-aborted signal: the recall should bail before any namespace read.
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      await orchestrator.recallInternal(
+        "What is the team standup schedule and who attends it?",
+        "user:test:aborted",
+        { abortSignal: controller.signal },
+      );
+    } catch {
+      // An aborted recall may throw; that's fine — we only assert no read touch.
+    }
+
+    await new Promise((r) => setTimeout(r, 20));
+    await orchestrator.namespaceCatalog.markMaintenance("default", "probe");
+    const records = await orchestrator.namespaceCatalog.listNamespaces();
+    for (const r of records) {
+      assert.ok(
+        !r.lastReadAt,
+        `an aborted recall must not record a read touch (namespace ${r.namespace} has lastReadAt)`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -149,6 +149,97 @@ test("persistExtraction shared promotion records a shared-namespace catalog writ
   }
 });
 
+test("shared promotion records catalog write after shared temporal supersession", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-order-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      autoPromoteToSharedEnabled: true,
+      autoPromoteToSharedCategories: ["fact"],
+      autoPromoteMinConfidenceTier: "implied",
+      temporalSupersessionEnabled: true,
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    const sourceStorage = await orchestrator.getStorage("default");
+    await sourceStorage.ensureDirectories();
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    const entity = "user-shared-promotion-order";
+    const oldId = await sharedStorage.writeMemory("fact", "Lives in NYC.", {
+      entityRef: entity,
+      structuredAttributes: { city: "NYC" },
+      source: "seed",
+      confidence: 0.9,
+      tags: ["shared-promotion"],
+      validAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    const sharedMutationOrder: string[] = [];
+    const originalMarkCatalogWrite = orchestrator.markCatalogWrite.bind(orchestrator);
+    orchestrator.markCatalogWrite = (namespace: string, storageDir?: string) => {
+      if (namespace === config.sharedNamespace) sharedMutationOrder.push("catalog");
+      return originalMarkCatalogWrite(namespace, storageDir);
+    };
+    const originalWriteMemoryFrontmatter = sharedStorage.writeMemoryFrontmatter.bind(sharedStorage);
+    sharedStorage.writeMemoryFrontmatter = async (...args: any[]) => {
+      sharedMutationOrder.push("frontmatter");
+      return originalWriteMemoryFrontmatter(...(args as Parameters<typeof originalWriteMemoryFrontmatter>));
+    };
+
+    const result = {
+      facts: [
+        {
+          content: "Lives in Austin.",
+          category: "fact",
+          confidence: 0.95,
+          tags: ["shared-promotion"],
+          entityRef: entity,
+          structuredAttributes: { city: "Austin" },
+        },
+      ],
+      entities: [],
+      questions: [],
+      profileUpdates: [],
+    };
+
+    await orchestrator.persistExtraction(result, sourceStorage, null, {
+      sessionKey: "s1",
+      principal: "default",
+    });
+
+    await orchestrator.namespaceCatalog.markRead("shared");
+    const oldMemory = await sharedStorage.getMemoryById(oldId);
+    const sharedRecord = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+
+    assert.equal(oldMemory?.frontmatter.status, "superseded", "precondition: shared supersession ran");
+    assert.ok(oldMemory?.frontmatter.supersededAt, "supersession must write supersededAt");
+    assert.ok(sharedRecord?.lastWriteAt, "shared promotion must record a catalog write");
+    assert.deepEqual(
+      sharedMutationOrder,
+      ["frontmatter", "catalog"],
+      "the shared catalog touch must run after shared supersession frontmatter is written",
+    );
+    assert.ok(
+      Date.parse(sharedRecord!.lastWriteAt!) >= Date.parse(oldMemory!.frontmatter.supersededAt!),
+      "shared catalog lastWriteAt must not precede supersession frontmatter mutation",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 8 (codex P2 — NElSf): the shared-promotion HASH-DEDUP branch returns
 // early (an active matching shared fact already exists, so no NEW write happens),
 // but it first runs `applyTemporalSupersession`, which REWRITES shared-namespace

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -407,6 +407,55 @@ test("namespaceFromStorageDir preserves a token-shaped literal raw namespace nam
   }
 });
 
+// ── codex P2 (NRCve): the round-trip guard is TAUTOLOGICAL for a canonical token
+// string, so a namespace literally named like a token (e.g. `ns-616c706861`,
+// the token of "alpha") served from its legacy raw root would decode to "alpha".
+// A dir name that is itself a KNOWN (configured) namespace must take precedence
+// over decoding, so routing (contradiction/QMD ownership) uses the literal name.
+test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a canonical token (NRCve)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-token-config-"));
+  try {
+    // Mirrors `namespaceIdentityToken`: ns-<lowercase hex of UTF-8>.
+    const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
+    const literalTokenName = tokenize("alpha"); // "ns-616c706861" — decodes to "alpha"
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: literalTokenName, // configured under this literal token-shaped name
+    });
+    const orchestrator = new Orchestrator(config) as any;
+    assert.equal(
+      orchestrator.namespaceFromStorageDir(path.join(memoryDir, "namespaces", literalTokenName)),
+      literalTokenName,
+      "a configured namespace named like a canonical token must resolve to the literal name, not its decoded identity",
+    );
+
+    // Control: the identical byte-shape, but NOT configured, still decodes.
+    const otherConfig = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+    const otherOrch = new Orchestrator(otherConfig) as any;
+    assert.equal(
+      otherOrch.namespaceFromStorageDir(path.join(memoryDir, "namespaces", tokenize("beta"))),
+      "beta",
+      "an unconfigured genuine tokenized dir still decodes to its identity",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDXHa): an already-ABORTED recall must not record catalog
 // read touches. The abort check runs later (Phase 1 retrieval), so without the
 // gate an already-aborted recall would still set `lastReadAt` for every recall

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 
@@ -581,6 +581,51 @@ test("namespaceFromStorageDir preserves a CATALOGED dynamic namespace named like
       freshOrchestrator.namespaceFromStorageDir(path.join(memoryDir, "namespaces", tokenize("beta"))),
       "beta",
       "an uncataloged genuine tokenized dir still decodes to its identity",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("namespaceFromStorageDir ignores catalog hints whose storageDir belongs to another namespace", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-hint-owner-"));
+  try {
+    const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
+    const betaRoot = path.join(memoryDir, "namespaces", tokenize("beta"));
+    await mkdir(path.join(betaRoot, "facts"), { recursive: true });
+    await mkdir(path.join(memoryDir, "state"), { recursive: true });
+
+    const now = new Date().toISOString();
+    await writeFile(
+      path.join(memoryDir, "state", "namespaces.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        namespace: "alpha",
+        identityToken: tokenize("alpha"),
+        kind: "project",
+        createdAt: now,
+        updatedAt: now,
+        storageDir: betaRoot,
+        discoveredBy: "write",
+      })}\n`,
+      "utf8",
+    );
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+    const freshOrchestrator = new Orchestrator(config) as any;
+
+    assert.equal(
+      freshOrchestrator.namespaceFromStorageDir(betaRoot),
+      "beta",
+      "a catalog row for alpha must not claim beta's tokenized storage root",
     );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 
@@ -497,6 +497,87 @@ test("an already-aborted recall records no catalog read touches", async () => {
         `an aborted recall must not record a read touch (namespace ${r.namespace} has lastReadAt)`,
       );
     }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── codex P2 (NRcCL): touch dynamic namespaces after identity consolidation.
+// `autoConsolidateIdentity` fans out over the catalog-union namespace set. When a
+// DYNAMIC namespace's ONLY mutation in the consolidation pass is identity
+// consolidation (it rewrites IDENTITY and clears reflections via
+// `storage.writeIdentity`/`writeIdentityReflections`), nothing recorded a catalog
+// write for it: the pass's consolidated touch only covers the DEFAULT
+// `this.storage` and only when `memoryItemMutated` was set by other work. So the
+// namespace kept a stale `lastWriteAt`, and `listNamespaces({ writtenSince })`
+// missed the write. The fix records a per-namespace `markCatalogWrite` right after
+// the identity files are updated.
+test("autoConsolidateIdentity records a catalog write for a dynamic namespace whose only mutation is consolidation (NRcCL)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-identity-consolidate-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      identityEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const dynamicNs = "project-origin-consolidate-only";
+    const orchestrator = new Orchestrator(config) as any;
+    assert.equal(orchestrator.namespaceCatalog.enabled, true, "catalog must be enabled");
+
+    // IDENTITY.<ns>.md is written under workspaceDir; it must exist for the
+    // consolidation write to land.
+    await mkdir(config.workspaceDir, { recursive: true });
+
+    // Seed the dynamic namespace's storage with enough reflections to cross the
+    // IDENTITY_CONSOLIDATE_THRESHOLD, so consolidation actually runs for it.
+    const dynamicStorage = await orchestrator.getStorage(dynamicNs);
+    await dynamicStorage.ensureDirectories();
+    const bigReflections =
+      "## Reflection\n\n" + "- synthetic reflection line filling the identity file\n".repeat(400);
+    assert.ok(bigReflections.length > 8_000, "precondition: reflections exceed the consolidate threshold");
+    await dynamicStorage.writeIdentityReflections(bigReflections);
+
+    // Register the dynamic namespace in the catalog WITHOUT a write touch (a read
+    // registration), so the catalog-union loop includes it but its lastWriteAt is
+    // unset before consolidation — isolating consolidation as the sole mutation.
+    await orchestrator.namespaceCatalog.markRead(dynamicNs, { discoveredBy: "read", storageDir: dynamicStorage.dir });
+    const before = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
+    assert.ok(before, "precondition: dynamic namespace is cataloged before consolidation");
+    assert.ok(!before?.lastWriteAt, "precondition: lastWriteAt is unset before consolidation");
+
+    // Stub the LLM consolidation so the pass produces patterns deterministically.
+    orchestrator.extraction = {
+      ...orchestrator.extraction,
+      consolidateIdentity: async () => ({
+        learnedPatterns: ["synthetic consolidated pattern"],
+        summary: "",
+      }),
+    };
+
+    await orchestrator.autoConsolidateIdentity();
+
+    // markCatalogWrite is fire-and-forget; serialize after it before reading.
+    await orchestrator.namespaceCatalog.markRead(dynamicNs);
+
+    const after = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
+    assert.ok(
+      after?.lastWriteAt,
+      "identity consolidation must record a catalog write (lastWriteAt) for the dynamic namespace",
+    );
+
+    // The consumer the bug cited now surfaces the namespace.
+    const since = new Date(Date.parse(after!.lastWriteAt!) - 1000);
+    const written = await orchestrator.namespaceCatalog.listNamespaces({ writtenSince: since });
+    assert.ok(
+      written.some((r: { namespace: string }) => r.namespace === dynamicNs),
+      "writtenSince must surface a namespace mutated only by identity consolidation",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -235,3 +235,53 @@ test("zero recall result limit (topK:0) records no catalog read touches", async 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 7 (codex P2 — NBsFz): `namespaceFromStorageDir` decodes ONLY a genuine
+// tokenized dir — one whose decoded identity round-trips back to the exact dir
+// name via `namespaceIdentityToken`. A `ns-...`-shaped dir name that does NOT
+// round-trip is treated as a literal raw name and returned verbatim, so a
+// token-shaped raw namespace name is never silently rewritten into a different
+// identity by the catalog write touch. (Regression guard for the round-trip
+// containment; the inherent same-bytes ambiguity of a raw name that is ALSO a
+// canonical token is resolved at the call site by passing the known namespace.)
+test("namespaceFromStorageDir preserves a token-shaped literal raw namespace name", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-from-dir-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+    const orchestrator = new Orchestrator(config) as any;
+
+    // Helper mirroring `namespaceIdentityToken`: ns-<lowercase hex of UTF-8>.
+    const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
+
+    // A legacy raw-name dir whose name is `ns-`-prefixed and hex-shaped but is
+    // NOT a valid canonical token (odd-length hex does not decode). Pre-fix this
+    // mangled the name via `namespaceIdentityFromToken(...) ?? name`; the
+    // round-trip guard now preserves it verbatim.
+    const literal = "ns-deadbee"; // odd-length hex after the prefix → not decodable
+    const rawDir = path.join(memoryDir, "namespaces", literal);
+    assert.equal(
+      orchestrator.namespaceFromStorageDir(rawDir),
+      literal,
+      "a token-shaped but non-canonical raw name must be preserved verbatim, not mangled",
+    );
+
+    // Control: a GENUINE tokenized dir still decodes back to its identity.
+    const realNs = "team-pi-project-origin-abc123";
+    const tokenDir = path.join(memoryDir, "namespaces", tokenize(realNs));
+    assert.equal(
+      orchestrator.namespaceFromStorageDir(tokenDir),
+      realNs,
+      "a genuine tokenized dir must still decode to its namespace identity",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -632,6 +632,68 @@ test("namespaceFromStorageDir ignores catalog hints whose storageDir belongs to 
   }
 });
 
+test("namespaceFromStorageDir compacts catalog hints before choosing token-root owner", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-hint-compact-"));
+  try {
+    const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
+    const literalTokenName = tokenize("alpha");
+    const alphaRoot = path.join(memoryDir, "namespaces", literalTokenName);
+    await mkdir(path.join(alphaRoot, "facts"), { recursive: true });
+    await mkdir(path.join(memoryDir, "state"), { recursive: true });
+
+    const now = new Date().toISOString();
+    await writeFile(
+      path.join(memoryDir, "state", "namespaces.jsonl"),
+      `${JSON.stringify({
+        version: 1,
+        namespace: literalTokenName,
+        identityToken: tokenize(literalTokenName),
+        kind: "project",
+        createdAt: now,
+        updatedAt: now,
+        storageDir: alphaRoot,
+        discoveredBy: "write",
+      })}\n${JSON.stringify({
+        version: 1,
+        namespace: "alpha",
+        identityToken: literalTokenName,
+        kind: "explicit",
+        createdAt: now,
+        updatedAt: now,
+        storageDir: alphaRoot,
+        discoveredBy: "write",
+      })}\n`,
+      "utf8",
+    );
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [
+        {
+          name: "alpha",
+          readPrincipals: [],
+          writePrincipals: [],
+        },
+      ],
+    });
+    const freshOrchestrator = new Orchestrator(config) as any;
+
+    assert.equal(
+      freshOrchestrator.namespaceFromStorageDir(alphaRoot),
+      "alpha",
+      "configured namespace alpha must own its tokenized root over a stale literal ns-* alias",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // ── Round 7 (codex P2 — NDXHa): an already-ABORTED recall must not record catalog
 // read touches. The abort check runs later (Phase 1 retrieval), so without the
 // gate an already-aborted recall would still set `lastReadAt` for every recall

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+
+// ── Round 2, Issue B (cursor[bot] Medium): a shared-namespace promotion writes
+// to the shared namespace via `sharedStorage.writeMemory`, but round 1 only
+// recorded `markCatalogWrite` for the routed SOURCE namespace. When promotion is
+// the only write the shared namespace receives, its catalog `lastWriteAt` stayed
+// stale — skewing `writtenSince` filters and maintenance fanout. The orchestrator
+// now fires `markCatalogWrite(sharedNamespace, sharedStorage.dir)` after the
+// promoted write lands. This test asserts that contract (the exact call the
+// promotion path makes) updates the SHARED record without touching the source.
+test("shared-namespace promotion updates the shared namespace lastWriteAt in the catalog", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    assert.equal(orchestrator.namespaceCatalog.enabled, true, "catalog must be enabled");
+
+    // Resolve shared storage exactly as the promotion path does (router-routed),
+    // so sharedStorage.dir matches the dir the orchestrator passes to the catalog.
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    // Before: no shared catalog write recorded yet.
+    const before = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(!before?.lastWriteAt, "shared lastWriteAt should be unset before promotion");
+
+    // Fire the exact catalog touch the promotion path now performs after a
+    // successful sharedStorage.writeMemory. markCatalogWrite is private; access
+    // via the `as any` orchestrator handle, mirroring the routing tests.
+    orchestrator.markCatalogWrite(config.sharedNamespace, sharedStorage.dir);
+
+    // markCatalogWrite is fire-and-forget; let the serialized append settle.
+    await orchestrator.namespaceCatalog.markRead("shared"); // serializes after the write
+
+    const after = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(after, "shared record must exist after promotion touch");
+    assert.equal(after?.kind, "shared");
+    assert.ok(
+      after?.lastWriteAt,
+      "shared promotion must update the shared namespace's lastWriteAt",
+    );
+    assert.equal(
+      after?.storageDir,
+      sharedStorage.dir,
+      "shared catalog storageDir must match the router-resolved shared dir",
+    );
+
+    // No double-count of the source: the default/source namespace must not have
+    // received a write touch from the shared promotion.
+    const sourceRecord = await orchestrator.namespaceCatalog.getNamespaceRecord("default");
+    assert.ok(
+      !sourceRecord?.lastWriteAt,
+      "shared promotion must not record a write on the source namespace",
+    );
+
+    // The shared record is surfaced by a writtenSince filter (the consumer the
+    // bug report cited) using a lower bound just before the touch.
+    const since = new Date(Date.parse(after!.lastWriteAt!) - 1000);
+    const written = await orchestrator.namespaceCatalog.listNamespaces({ writtenSince: since });
+    assert.ok(
+      written.some((r: { namespace: string }) => r.namespace === "shared"),
+      "writtenSince must now surface the shared namespace after promotion",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Integration guard for Issue B: drive the actual promotion path via
+// `persistExtraction` (auto-promote enabled, source namespace != shared) and
+// assert the SHARED catalog record gains lastWriteAt as a side effect of the
+// promoted write. This fails on the round-1 code (no shared markCatalogWrite in
+// promoteMemoryToShared) and passes after the fix.
+test("persistExtraction shared promotion records a shared-namespace catalog write", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-integ-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      autoPromoteToSharedEnabled: true,
+      autoPromoteToSharedCategories: ["fact"],
+      autoPromoteMinConfidenceTier: "implied",
+      // Keep the write path simple/offline: no linking, no chunking-by-size, no
+      // semantic dedup that would need an embedding backend.
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    // QMD unavailable so the write path stays offline and deterministic.
+    orchestrator.qmd = { isAvailable: () => false };
+
+    const sourceStorage = await orchestrator.getStorage("default");
+    await sourceStorage.ensureDirectories();
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    // A single high-confidence fact in a promotable category.
+    const result = {
+      facts: [
+        {
+          content: "The team standup is at 9am every weekday.",
+          category: "fact",
+          confidence: 0.95,
+          tags: ["schedule"],
+        },
+      ],
+      entities: [],
+      questions: [],
+      profileUpdates: [],
+    };
+
+    await orchestrator.persistExtraction(result, sourceStorage, null, {
+      sessionKey: "s1",
+      principal: "default",
+    });
+
+    // Let any fire-and-forget catalog appends settle by serializing a read.
+    await orchestrator.namespaceCatalog.markRead("shared");
+
+    const sharedRecord = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(sharedRecord, "shared record must exist after a promoted write");
+    assert.ok(
+      sharedRecord?.lastWriteAt,
+      "the shared promotion must record a write touch on the shared namespace",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -175,14 +175,60 @@ test("no_recall recall does not record catalog read touches", async () => {
     const out = await orchestrator.recallInternal("ok", "user:test:no-recall-catalog");
     assert.equal(out, "", "no_recall must produce no recall context");
 
-    // Allow any (incorrect) fire-and-forget read touch to settle, then assert
-    // NONE was recorded for the readable namespaces.
+    // Allow any (incorrect) fire-and-forget read touch to settle, then serialize
+    // a maintenance touch on the catalog write chain to flush pending appends
+    // before asserting NONE was recorded for the readable namespaces.
+    await new Promise((r) => setTimeout(r, 20));
     await orchestrator.namespaceCatalog.markMaintenance("default", "probe");
     const records = await orchestrator.namespaceCatalog.listNamespaces();
     for (const r of records) {
       assert.ok(
         !r.lastReadAt,
         `no_recall must not record a read touch (namespace ${r.namespace} has lastReadAt)`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ── Round 4, Issue #5 (codex P2): even when recallMode is not no_recall, a zero
+// effective result limit (topK: 0, disabled/zero `memories` section) means no
+// namespace is actually read — the QMD path returns before searching when
+// recallResultLimit <= 0. The catalog must not record read touches in that case.
+test("zero recall result limit (topK:0) records no catalog read touches", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-zero-limit-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    // Force a non-no_recall mode but a zero result limit via topK: 0.
+    await orchestrator.recallInternal(
+      "What is the team standup schedule and who attends it?",
+      "user:test:zero-limit",
+      { mode: "minimal", topK: 0 },
+    );
+
+    // Drain any fire-and-forget tails, then serialize a maintenance touch on the
+    // catalog write chain so any (incorrectly) enqueued read append is flushed
+    // before we assert its absence.
+    await new Promise((r) => setTimeout(r, 20));
+    await orchestrator.namespaceCatalog.markMaintenance("default", "probe");
+    const records = await orchestrator.namespaceCatalog.listNamespaces();
+    for (const r of records) {
+      assert.ok(
+        !r.lastReadAt,
+        `zero result limit must not record a read touch (namespace ${r.namespace} has lastReadAt)`,
       );
     }
   } finally {

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -148,3 +148,44 @@ test("persistExtraction shared promotion records a shared-namespace catalog writ
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// ── Round 3, Issue #3 (codex P2): when the planner selects no_recall, retrieval
+// is skipped — so the recall path must NOT mark every readable namespace as
+// read. A trivial prompt ("ok") classifies as no_recall; assert the catalog
+// records no lastReadAt for the recalled namespaces. Fails on the round-2 code
+// (read touch fired before the no_recall early return), passes after the gate.
+test("no_recall recall does not record catalog read touches", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-no-recall-catalog-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    assert.equal(orchestrator.namespaceCatalog.enabled, true, "catalog must be enabled");
+
+    // A trivial prompt the planner classifies as no_recall (mirrors the existing
+    // recall-no-recall-short-circuit tests).
+    const out = await orchestrator.recallInternal("ok", "user:test:no-recall-catalog");
+    assert.equal(out, "", "no_recall must produce no recall context");
+
+    // Allow any (incorrect) fire-and-forget read touch to settle, then assert
+    // NONE was recorded for the readable namespaces.
+    await orchestrator.namespaceCatalog.markMaintenance("default", "probe");
+    const records = await orchestrator.namespaceCatalog.listNamespaces();
+    for (const r of records) {
+      assert.ok(
+        !r.lastReadAt,
+        `no_recall must not record a read touch (namespace ${r.namespace} has lastReadAt)`,
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/orchestrator-threading-fail-open.test.ts
+++ b/tests/orchestrator-threading-fail-open.test.ts
@@ -156,9 +156,14 @@ test("persistExtraction includes written question IDs in persistedIds", () => {
     resolve(import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestrator.ts"),
     "utf-8",
   );
+  // The question loop tracks each written id via trackPersistedId so the thread
+  // batch append can include them. The id-tracking call lives inside the
+  // `if (id) { ... }` block alongside the durable-write catalog flag (NHZEZ
+  // sweep), so the assertion matches the tracking call within that block rather
+  // than a brittle single-line form.
   assert.match(
     source,
-    /const id = await storage\.writeQuestion\(q\.question,\s*q\.context,\s*q\.priority\);\s*if \(id\) trackPersistedId\(storage,\s*id\);/m,
+    /const id = await storage\.writeQuestion\(q\.question,\s*q\.context,\s*q\.priority\);\s*if \(id\) \{[\s\S]*?trackPersistedId\(storage,\s*id\);/m,
     "question IDs should be added to persistedIds so thread batch append can include them",
   );
 });

--- a/tests/recall-no-recall-short-circuit.test.ts
+++ b/tests/recall-no-recall-short-circuit.test.ts
@@ -179,25 +179,35 @@ test("recallInternal no_recall records last recall without blocking the response
   const cfg = baseConfig(memoryDir);
   const orchestrator = new Orchestrator(cfg);
 
-  let settled = false;
-  (orchestrator.lastRecall as any).record = () =>
-    new Promise<void>((resolve) => {
-      setTimeout(() => {
-        settled = true;
-        resolve();
-      }, 50);
-    });
+  let recordStarted = false;
+  let releaseRecord!: () => void;
+  const recordPromise = new Promise<void>((resolve) => {
+    releaseRecord = resolve;
+  });
+  (orchestrator.lastRecall as any).record = () => {
+    recordStarted = true;
+    return recordPromise;
+  };
 
-  const startedAt = Date.now();
-  const out = await (orchestrator as any).recallInternal("ok", "user:test:no-recall-record");
-  const elapsedMs = Date.now() - startedAt;
+  const recallPromise = (orchestrator as any).recallInternal(
+    "ok",
+    "user:test:no-recall-record",
+  );
+  const result = await Promise.race([
+    recallPromise.then((value: string) => ({
+      status: "returned" as const,
+      value,
+    })),
+    new Promise<{ status: "blocked" }>((resolve) =>
+      setTimeout(() => resolve({ status: "blocked" }), 250),
+    ),
+  ]);
 
-  assert.equal(out, "");
-  assert.equal(settled, false);
-  assert.ok(elapsedMs < 50);
+  releaseRecord();
+  await recordPromise;
 
-  await new Promise((resolve) => setTimeout(resolve, 70));
-  assert.equal(settled, true);
+  assert.deepEqual(result, { status: "returned", value: "" });
+  assert.equal(recordStarted, true);
 });
 
 test("artifact recall searches all readable namespaces", async () => {


### PR DESCRIPTION
## Summary

Adds a rebuildable **namespace catalog** (`NamespaceCatalog`) so Remnic can *enumerate* the configured and dynamically-created namespaces that exist or should be maintained — for maintenance fanout, QMD indexing diagnostics, dashboard listings, and `doctor`. Files remain the source of truth; the catalog is downstream metadata and is fully rebuildable from disk.

Closes #1499
Part of epic #1494

## Storage choice + rationale

`<memoryDir>/state/namespaces.jsonl` — an append-and-compact JSON-lines log. Chosen over per-namespace `.remnic-namespace.json` sidecars because:
- touches (`markRead`/`markWrite`/`markMaintenance`) are cheap single appends;
- naturally audit-friendly (raw log preserves touch history);
- a single file makes enumeration trivial (no per-call directory walk);
- last-record-wins compaction folds the log into current state on read, and `rebuildFromDisk` rewrites it atomically (temp file + `rename`).

Metadata only — the catalog never holds raw memory content or secrets.

## APIs added (`packages/remnic-core/src/namespaces/catalog.ts`)

- `listNamespaces(filter?)` — enumerate (filter by `kind` / `discoveredBy` / `writtenSince`)
- `getNamespaceRecord(namespace)`
- `markRead` / `markWrite` / `markMaintenance(ns, jobName, at?)`
- `registerConfiguredNamespaces()` / `registerResolved(ns, storageDir)`
- `rebuildFromDisk({ dryRun? })` → `{ dryRun, records, skipped }`

Record shape matches the issue (`namespace`, `identityToken`, `kind`, `principal?`, `projectId?`, `branch?`, `parentNamespace?`, timestamps, `lastMaintenanceAt`, `storageDir`, `discoveredBy`). Exported from `@remnic/core`.

## Integration points wired

- **`NamespaceStorageRouter`** — new optional `onResolve(ns, storageDir)` hook fires (defensively, never throws into the router) whenever storage is resolved/created.
- **`Orchestrator`** — owns a `namespaceCatalog`; wires `onResolve` to `registerResolved` (fire-and-forget), marks a **write** touch after each successful `writeMemory`, and marks **read** touches against the resolved recall namespaces. All touches are best-effort and failure-tolerant — a catalog write failure never crashes a memory op (CLAUDE.md gotcha #13, rule #40).
- **CLI** — `engram namespaces rebuild --dry-run | --apply [--json]`. Rejects contradictory `--dry-run`+`--apply`; defaults to non-destructive dry run.

Deferred (API exposed, wiring noted as follow-up): QMD indexing diagnostics, dashboard, and doctor can consume `listNamespaces`/`rebuildFromDisk` directly — not wired into those surfaces in this PR to keep it scoped.

## Security handling

- Catalog presence grants **no** authorization — access still flows through namespace policies; the module makes no access decisions.
- All namespace tokens validated via `isSafeRouteNamespace` (default-namespace exemption mirrors the routing layer); every storage dir is contained under `<memoryDir>/namespaces`.
- `rebuildFromDisk` rejects/reports symlinked roots and roots whose `realpath` escapes the memory root (`skipped[]` with reason `symlink`/`escape`/`unsafe`/`error`) instead of trusting or silently misclassifying them.
- Atomic writes (temp + rename, rule #54); JSONL reads validate parsed type and skip corrupt/non-object lines (rule #18); serialized keys sorted before hashing/serialization (rule #38) for byte-stable idempotent rebuilds; serialized write chain recovers from rejection (rule #40).

## Behavior when namespaces disabled

The catalog is inert: `enabled` is false unless `namespacesEnabled: true`, so it enumerates nothing and writes nothing. Existing single-namespace behavior is unchanged. Operators can also opt out via `namespaceCatalogEnabled: false`.

## Tests

`packages/remnic-core/src/namespaces/catalog.test.ts` (14 tests, all green): dynamic project namespace registers on write; configured default/shared appear; rebuild finds disk dirs and persists; dry-run writes nothing; legacy/default root compatibility preserved; symlinked roots reported; unsafe tokens rejected; mark APIs touch only metadata (memory content untouched); rebuild idempotent (byte-identical); fake maintenance scheduler consumes records; filtering; **disabled = inert/no-op**; corrupt JSONL tolerated; storage-router `onResolve` integration.

Gates: `pnpm --filter @remnic/core build` ✅, `npm run check-types` ✅, `npm run lint` ✅, `npm run check-config-contract` ✅ (schema synced), `npm run test:entity-hardening` ✅ (205), `npm run preflight:quick` ✅. configSchema added to `packages/plugin-openclaw/openclaw.plugin.json` + root synced.

## Checklist

- [x] All tests pass (catalog 14/14; entity-hardening 205/205)
- [x] New logic covered by tests
- [x] Preflight quick gates pass
- [x] No secrets or personal data committed (public repo)
- [x] Docs (`docs/namespaces.md`) + configSchema synced (`namespaceCatalogEnabled` in types/config/schema)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contradiction resolution commit/rollback ordering and multiple write entry points; mistakes could mis-schedule maintenance but catalog touches are best-effort and do not affect memory durability or auth.
> 
> **Overview**
> Adds **`namespaceCatalogEnabled`** (default on, inert unless `namespacesEnabled`) with boolean-like parsing and rejection of invalid values, plus plugin schema and **namespace catalog** documentation.
> 
> Introduces **`openclaw engram namespaces rebuild`** (`--dry-run` / `--apply` / `--json`) with stable JSON shape, non-zero exit when `--apply` does not persist (inert catalog or lock failure), and human-readable skip reporting.
> 
> **Catalog write touches** are wired for code paths that write namespace storage without the extraction pipeline: **`executeResolution`** gains `onMergedMemoryWritten`, invoked only after durable commit (or when rollback leaves mutations), for `merge` / `keep-a` / `keep-b`; HTTP, MCP, and CLI resolve handlers call **`recordCatalogWrite`** via **`AccessService`**. **Explicit capture** (accepted and queued review) records touches in a `finally` block so `lastWriteAt` / QMD **`writtenSince`** stay accurate.
> 
> Exports **`NamespaceCatalog`** types from `@remnic/core`; tests cover config coercion and catalog-touch ordering on contradiction resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25b4064c2fc241a124326ed4d37be27c54b8cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->