### PR TITLE
fix(transcript): include just-written turns at the exact "now" boundary in readRecent

### DIFF
--- a/packages/remnic-core/src/transcript.test.ts
+++ b/packages/remnic-core/src/transcript.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { TranscriptManager } from "./transcript.js";
+import type { PluginConfig, TranscriptEntry } from "./types.js";
+
+function makeConfig(memoryDir: string): PluginConfig {
+  return {
+    memoryDir,
+    transcriptSkipChannelTypes: [],
+  } as unknown as PluginConfig;
+}
+
+async function makeManager(): Promise<{ manager: TranscriptManager; memoryDir: string }> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-transcript-recent-"));
+  const manager = new TranscriptManager(makeConfig(memoryDir));
+  await manager.initialize();
+  return { manager, memoryDir };
+}
+
+function entryAt(timestamp: string, sessionKey: string, turnId: string): TranscriptEntry {
+  return { timestamp, role: "user", content: `turn ${turnId}`, sessionKey, turnId };
+}
+
+/**
+ * Freeze `new Date()` / `Date.now()` to a fixed instant for the duration of `fn`.
+ *
+ * This lets a test seed a transcript entry whose timestamp is *exactly* the
+ * instant the read observes as "now", deterministically reproducing the
+ * millisecond-collision that the recent-window boundary fix targets.
+ * Single-argument constructions (`new Date(isoString)`, `new Date(ms)`,
+ * `new Date(otherDate)`) are forwarded unchanged so timestamp parsing still works.
+ */
+async function withFrozenNow<T>(now: Date, fn: () => Promise<T>): Promise<T> {
+  const RealDate = Date;
+  const fixedMs = now.getTime();
+  class FrozenDate extends RealDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixedMs);
+      } else if (args.length === 1) {
+        super(args[0] as number);
+      } else {
+        super(
+          args[0] as number,
+          args[1] as number,
+          args[2] as number,
+          args[3] as number,
+          args[4] as number,
+          args[5] as number,
+          args[6] as number,
+        );
+      }
+    }
+    static now(): number {
+      return fixedMs;
+    }
+  }
+  (globalThis as { Date: DateConstructor }).Date = FrozenDate as unknown as DateConstructor;
+  try {
+    return await fn();
+  } finally {
+    (globalThis as { Date: DateConstructor }).Date = RealDate;
+  }
+}
+
+test("readRecent (session fast path) returns a turn written at the same instant as the read", async () => {
+  const { manager } = await makeManager();
+  const sessionKey = "agent:test-agent:main";
+  const now = new Date("2026-06-29T12:00:00.000Z");
+
+  const entries = await withFrozenNow(now, async () => {
+    // Seed an entry stamped at the exact instant the read observes as "now".
+    await manager.append(entryAt(now.toISOString(), sessionKey, "boundary"));
+    return manager.readRecent(48, sessionKey);
+  });
+
+  assert.equal(entries.length, 1, "just-written boundary entry should be included in last-N-hours read");
+  assert.equal(entries[0].turnId, "boundary");
+});
+
+test("readRecent (full scan, no sessionKey) returns a turn written at the same instant as the read", async () => {
+  const { manager } = await makeManager();
+  const sessionKey = "agent:test-agent:main";
+  const now = new Date("2026-06-29T12:00:00.000Z");
+
+  const entries = await withFrozenNow(now, async () => {
+    await manager.append(entryAt(now.toISOString(), sessionKey, "boundary"));
+    return manager.readRecent(48);
+  });
+
+  assert.equal(entries.length, 1, "just-written boundary entry should be included in full-scan recent read");
+  assert.equal(entries[0].turnId, "boundary");
+});
+
+test("readRange keeps an exclusive upper bound for caller-specified ranges", async () => {
+  const { manager } = await makeManager();
+  const sessionKey = "agent:test-agent:main";
+  const start = "2026-06-29T00:00:00.000Z";
+  const end = "2026-06-29T12:00:00.000Z";
+
+  await manager.append(entryAt("2026-06-29T11:59:59.999Z", sessionKey, "inside"));
+  await manager.append(entryAt(end, sessionKey, "at-end"));
+
+  const exclusive = await manager.readRange(start, end, sessionKey);
+  const ids = exclusive.map((e) => e.turnId);
+  assert.deepEqual(ids, ["inside"], "explicit [start, end) range must exclude the entry at exactly end (rule #35)");
+});

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -646,6 +646,12 @@ export class TranscriptManager {
    * Read transcript entries for a date range.
    * Returns entries within the time range, optionally filtered by sessionKey.
    * Reads from all channel subdirectories in the hierarchical structure.
+   *
+   * The window is half-open `[start, end)`: the upper bound is exclusive so
+   * caller-specified ranges (explicit dates, analytics buckets) don't
+   * double-count at shared boundaries (CLAUDE.md rule #35 / AGENTS.md rule 23).
+   * readRecent's inclusive-of-now behavior is handled by readRecent itself
+   * extending its end, not by relaxing this bound.
    */
   async readRange(startTime: string, endTime: string, sessionKey?: string): Promise<TranscriptEntry[]> {
     const start = new Date(startTime);
@@ -678,7 +684,7 @@ export class TranscriptManager {
               const entry = JSON.parse(line) as TranscriptEntry;
               const entryTime = new Date(entry.timestamp);
 
-              // Check if entry is within time range
+              // Check if entry is within time range (half-open: exclusive end)
               if (entryTime >= start && entryTime < end) {
                 // Filter by sessionKey if provided
                 if (!sessionKey || entry.sessionKey === sessionKey) {
@@ -714,8 +720,17 @@ export class TranscriptManager {
    * specific channel instead of scanning all 95+ transcript files across all channels.
    */
   async readRecent(hours: number, sessionKey?: string): Promise<TranscriptEntry[]> {
-    const end = new Date();
-    const start = new Date(end.getTime() - hours * 60 * 60 * 1000);
+    const now = new Date();
+    // The recent-read window is inclusive of "now": a turn that is buffered and
+    // then immediately read back can carry the same millisecond timestamp as
+    // this read, so a half-open [start, now) filter would drop it. Extend the
+    // upper bound by 1ms so the exclusive [start, end) filters in
+    // readRecentForSession / readRange (which stay half-open for
+    // caller-specified ranges, CLAUDE.md rule #35) still capture an entry
+    // stamped at exactly "now". This is the only place the "up to now" boundary
+    // is widened; explicit ranges are unaffected.
+    const end = new Date(now.getTime() + 1);
+    const start = new Date(now.getTime() - hours * 60 * 60 * 1000);
 
     if (sessionKey) {
       return this.readRecentForSession(start, end, sessionKey);
@@ -769,6 +784,9 @@ export class TranscriptManager {
           try {
             const entry = JSON.parse(line) as TranscriptEntry;
             const ts = new Date(entry.timestamp);
+            // Half-open window: exclusive end. readRecent widens its own end by
+            // 1ms so a just-written "now" entry is still captured here without
+            // relaxing this bound for direct callers (tests/transcript-boundary).
             if (ts >= start && ts < end && entry.sessionKey === sessionKey && keepRawLine(line)) {
               entries.push(entry);
             }


### PR DESCRIPTION
## Problem

`readRecent` derives `end = new Date()` ("now"), but the half-open `[start, end)` filters it delegates to (`readRecentForSession` fast path, `readRange` full-scan path) use an **exclusive** upper bound. When a turn is buffered and then immediately read back, its `timestamp` can equal `end` at **millisecond resolution**, so the just-written row is dropped. This makes "last N hours" reads intermittently return **0 entries** for very recent turns — reproduced **~70%+** in a tight write-then-read loop (**0/400** after the fix).

Pre-existing on `main`; **not** introduced by #1504.

## Fix

Confined to `readRecent` — it widens its **own** upper bound to `now + 1ms` before delegating:

```ts
const now = new Date();
const end = new Date(now.getTime() + 1); // inclusive of "now" at ms resolution
const start = new Date(now.getTime() - hours * 60 * 60 * 1000);
```

`readRecentForSession` and `readRange` keep their half-open exclusive-end semantics **unchanged** (byte-identical to `main`). Caller-specified ranges therefore stay exclusive per **CLAUDE.md rule #35 / AGENTS.md rule 23**:
- `readRange` explicit-date / today calls in `cli.ts`, `bootstrap.ts`'s `since`/`until` window,
- the summarizer's hourly fetch (`getTranscriptEntries`), whose `end` is a fixed past clock-hour (`hourEnd`), not "now",
- `tests/transcript-boundary.test.ts`, which calls `readRange` and `readRecentForSession` directly and asserts half-open exclusivity — stays green.

> The only non-comment change vs `main` in `transcript.ts` is the three lines above inside `readRecent`.

## Test

New `packages/remnic-core/src/transcript.test.ts` freezes the clock, seeds a turn stamped at exactly the read instant ("now"), and asserts:
1. `readRecent(48, sessionKey)` (fast path) returns it,
2. `readRecent(48)` (full scan) returns it,
3. explicit-range `readRange(start, end, sessionKey)` still **excludes** a boundary entry (rule #35 guard).

## Checklist
- [x] Regression test added; red before fix, green after (verified on synced `main` base)
- [x] `tests/transcript-boundary.test.ts` (the suite the first revision broke) passes — filters reverted to half-open
- [x] `@remnic/core` `tsc --noEmit`: 0 errors; `npm run lint` clean
- [x] Package suites pass: `transcript`, `transcript-session-identity`, `session-transcript-migration`, `summary-snapshot` (44 tests)
- [x] No secrets / personal data (public repo); synthetic test data only
- [x] Scoped to one subsystem (~3 logic lines + test)

> CI `quality` (full root suite) and AI re-review run against head `36b3da67`. The earlier `npm run preflight:quick` CLI `check-types` miss (`Cannot find module '@remnic/export-weclone'`) is a pre-existing un-hydrated-worktree artifact, not from this change.