### PR TITLE
fix(transcript): include final second of day in CLI day-view range

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 import type { Orchestrator } from "./orchestrator.js";
 import { ThreadingManager } from "./threading.js";
+import { utcDayRange } from "./transcript.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
 import type {
   BehaviorSignalEvent,
@@ -8630,12 +8631,11 @@ export function registerCli(
           }
 
           if (date) {
-            // Read specific date
-            const entries = await orchestrator.transcript.readRange(
-              `${date}T00:00:00Z`,
-              `${date}T23:59:59Z`,
-              channel,
-            );
+            // Read specific date. Use a half-open [start, next-day-00:00:00Z)
+            // window so `readRange`'s exclusive upper bound still covers the
+            // final second of the day (rule #35).
+            const { start, end } = utcDayRange(date);
+            const entries = await orchestrator.transcript.readRange(start, end, channel);
             console.log(formatTranscript(entries));
           } else if (recent) {
             // Parse duration (e.g., "12h", "30m")
@@ -8643,13 +8643,11 @@ export function registerCli(
             const entries = await orchestrator.transcript.readRecent(hours, channel);
             console.log(formatTranscript(entries));
           } else {
-            // Default: show today's transcript
+            // Default: show today's transcript. Same half-open day window as
+            // the --date branch so the final second of the day is included.
             const today = new Date().toISOString().slice(0, 10);
-            const entries = await orchestrator.transcript.readRange(
-              `${today}T00:00:00Z`,
-              `${today}T23:59:59Z`,
-              channel,
-            );
+            const { start, end } = utcDayRange(today);
+            const entries = await orchestrator.transcript.readRange(start, end, channel);
             console.log(formatTranscript(entries));
           }
         });

--- a/packages/remnic-core/src/transcript-day-range.test.ts
+++ b/packages/remnic-core/src/transcript-day-range.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the CLI transcript day-view window helper `utcDayRange`.
+ *
+ * The `transcript --date <day>` and default "today" CLI views read a single
+ * calendar day via {@link TranscriptManager.readRange}, which uses a half-open
+ * `[start, end)` interval (`entryTime < end`, CLAUDE.md rule #35). The day end
+ * must therefore be the NEXT day's `00:00:00Z`, not `${date}T23:59:59Z`:
+ * a literal `23:59:59Z` end (== `.000Z`) silently drops any entry stamped in
+ * the final second of the day (`23:59:59.000Z`–`23:59:59.999Z`).
+ *
+ * (Pre-existing boundary gap flagged as a P2 on PR #1507, fixed out of band.)
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { TranscriptManager, utcDayRange } from "./transcript.js";
+import type { PluginConfig, TranscriptEntry } from "./types.js";
+
+function makeConfig(memoryDir: string): PluginConfig {
+  // TranscriptManager only reads memoryDir + transcriptSkipChannelTypes.
+  return {
+    memoryDir,
+    transcriptSkipChannelTypes: [],
+  } as unknown as PluginConfig;
+}
+
+// On macOS `os.tmpdir()` is a `/var/folders/...` symlink to `/private/var/...`.
+// Canonicalize the test root upfront (issue #691 symlink convention).
+async function makeMemoryDir(): Promise<string> {
+  return realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-tx-dayrange-")));
+}
+
+function entryAt(timestamp: string, turnId: string): TranscriptEntry {
+  return {
+    sessionKey: "agent:generalist:main",
+    turnId,
+    role: "user",
+    content: `content-${turnId}`,
+    timestamp,
+  } as TranscriptEntry;
+}
+
+// ── utcDayRange: half-open [start, next-day-00:00:00Z) ───────────────────────
+
+test("utcDayRange end is the next day's 00:00:00Z (half-open day window)", () => {
+  assert.deepEqual(utcDayRange("2025-03-15"), {
+    start: "2025-03-15T00:00:00Z",
+    end: "2025-03-16T00:00:00Z",
+  });
+});
+
+test("utcDayRange rolls over month boundaries", () => {
+  assert.deepEqual(utcDayRange("2025-01-31"), {
+    start: "2025-01-31T00:00:00Z",
+    end: "2025-02-01T00:00:00Z",
+  });
+});
+
+test("utcDayRange rolls over leap-day and year boundaries", () => {
+  assert.deepEqual(utcDayRange("2024-02-28"), {
+    start: "2024-02-28T00:00:00Z",
+    end: "2024-02-29T00:00:00Z",
+  });
+  assert.deepEqual(utcDayRange("2025-12-31"), {
+    start: "2025-12-31T00:00:00Z",
+    end: "2026-01-01T00:00:00Z",
+  });
+});
+
+// ── Day-view range includes the final second of the day (the bug fix) ────────
+
+test("day-view range returns an entry stamped at 23:59:59.500Z of the queried day", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    const date = "2025-03-15";
+    const channel = "agent:generalist:main";
+
+    // Entry in the final second of the day — dropped by the old
+    // `${date}T23:59:59Z` (== `.000Z`) exclusive upper bound.
+    await tm.append(entryAt(`${date}T23:59:59.500Z`, "final-second"));
+    // Midday control entry, comfortably inside the window.
+    await tm.append(entryAt(`${date}T12:00:00.000Z`, "midday"));
+    // Start-of-next-day entry must stay OUT — the upper bound is exclusive
+    // (`[start, end)`, rule #35), so `nextDate T00:00:00.000Z` is not the
+    // queried day.
+    await tm.append(entryAt("2025-03-16T00:00:00.000Z", "next-day"));
+
+    const { start, end } = utcDayRange(date);
+    const entries = await tm.readRange(start, end, channel);
+    const ids = entries.map((e) => e.turnId).sort();
+
+    assert.deepEqual(ids, ["final-second", "midday"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -34,6 +34,32 @@ function makeRawLineDeduper(): (rawLine: string) => boolean {
 }
 
 /**
+ * Compute the half-open UTC instant range `[start, end)` that covers an entire
+ * calendar day, suitable for {@link TranscriptManager.readRange}.
+ *
+ * `readRange` filters with an EXCLUSIVE upper bound (`entryTime < end`, CLAUDE.md
+ * rule #35 / AGENTS.md rule 23). The end is therefore the NEXT day's
+ * `00:00:00Z`, not `${date}T23:59:59Z`: a literal `23:59:59Z` end (== `.000Z`)
+ * would drop any entry stamped in the final second of the day
+ * (`23:59:59.000Z`–`23:59:59.999Z`). Using the next day's midnight keeps the
+ * `[start, end)` semantics intact while including the whole day.
+ *
+ * @param date - A `YYYY-MM-DD` calendar day (UTC).
+ */
+export function utcDayRange(date: string): { start: string; end: string } {
+  const start = `${date}T00:00:00Z`;
+  const startMs = Date.parse(start);
+  if (Number.isNaN(startMs)) {
+    // Malformed date: preserve the pre-existing "empty range" behavior (an
+    // unparseable bound makes `readRange` match nothing) rather than throwing.
+    return { start, end: start };
+  }
+  const next = new Date(startMs);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return { start, end: `${next.toISOString().slice(0, 10)}T00:00:00Z` };
+}
+
+/**
  * Manages conversation transcript storage, checkpointing, and recall formatting.
  *
  * Transcripts are stored as JSONL files in a hierarchical structure:


### PR DESCRIPTION
## Summary

The `remnic transcript --date <day>` and default "today" CLI views read a single calendar day via `TranscriptManager.readRange`, which filters with an **exclusive** upper bound (`entryTime < end`, CLAUDE.md rule #35 / AGENTS.md rule 23). The end was the literal `${date}T23:59:59Z` — i.e. `23:59:59.000Z` — so any transcript entry stamped in the **final second** of the day (`23:59:59.000Z`–`23:59:59.999Z`) was silently omitted from these day views.

This is a **pre-existing** boundary gap. It predates #1507 (which only changed `readRecent`'s "now" boundary and left `readRange` untouched). It was flagged as a **P2 by `chatgpt-codex-connector`** on #1507 but was out of scope there.

## Change

- Add a shared `utcDayRange(date)` helper in `transcript.ts`, co-located with `readRange` whose half-open `[start, end)` contract it documents. It returns the day window with the end set to the **next day's `00:00:00Z`**, computed via `setUTCDate(+1)` so month / leap-day / year rollovers stay correct. Malformed dates fall back to an empty range rather than throwing (preserves prior behavior).
- Wire it into **both** the `--date` branch and the default "today" branch in `cli.ts`, keeping the exclusive-upper-bound semantics intact.

`bootstrap.ts` (the only other `readRange` caller) uses arbitrary `Date`-based bounds, not a day literal — correctly unaffected.

## Tests

New `transcript-day-range.test.ts`:
- Asserts an entry at **`23:59:59.500Z`** on the queried day **is returned** (the bug fix).
- Asserts a next-day `00:00:00.000Z` entry **stays excluded** (exclusive upper bound preserved, rule #35).
- `utcDayRange` unit cases: normal day, month rollover, leap-day, year rollover.

## Verification

- `@remnic/core` typecheck clean (`tsc --noEmit`, exit 0)
- `npm run preflight:quick` → `[preflight] OK (quick)`
- `transcript-day-range.test.ts` + `transcript-session-identity.test.ts`: 17/17 pass

## PR checklist
- [x] All tests pass
- [x] New logic covered by tests
- [x] Pre-commit / preflight gates pass locally
- [x] Docs/comments updated (helper JSDoc documents the half-open contract)
- [x] No secrets or personal data committed (public repo)
- [x] Diff well under 400 LOC, single subsystem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI read-path fix with no changes to storage, auth, or other `readRange` callers; behavior is covered by new boundary tests.
> 
> **Overview**
> Fixes **silent omission** of transcript entries stamped in the last second of a UTC day when using `remnic transcript --date` or the default “today” view.
> 
> Those paths used `readRange` with an upper bound of `${date}T23:59:59Z` (midnight of the last second). Because `readRange` treats the end as **exclusive** (`entryTime < end`), anything after `23:59:59.000Z` was dropped. The change introduces **`utcDayRange`**, which returns a half-open `[start, next-day 00:00:00Z)` window (with correct month/leap/year rollover), and wires it into both CLI day-view branches.
> 
> Adds **`transcript-day-range.test.ts`** covering boundary math and an integration case that entries at `23:59:59.500Z` are included while next-day midnight stays excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10710f1c8a05baaaceab7ebded40d5058447300d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->