### PR TITLE
fix(access): correct scopeDebug.baseNamespace on implicit no-overlay path (#1505 cursor hAp)

### DIFF
--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -490,6 +490,42 @@ test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () =>
   assert.equal(res.scopeDebug!.codingOverlayApplied, true);
 });
 
+test("#1505 (cursor hAp) scopeDebug.baseNamespace reports the principal self base on the implicit no-overlay path", async () => {
+  // Regression for the round-4 cursor "Wrong scopeDebug base namespace" thread.
+  // Implicit (no explicit namespace) + projectScope OFF ⇒ the no-overlay branch
+  // of resolveMemoryScopePlan runs: the general write namespace collapses to
+  // config.defaultNamespace ("default") for memory_store parity (rule 39), but
+  // the plan's diagnostic baseNamespace must report the principal SELF base
+  // ("pi-geek" via defaultNamespaceForPrincipal) — the same base
+  // objectiveStateNamespace already targets — NOT the write namespace. Before the
+  // fix, scopeDebug.baseNamespace misstated the self base as "default".
+  const probe = makeObserveProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123" }),
+  );
+
+  assert.ok(res.scopeDebug, "scopeDebug must be present");
+  assert.equal(
+    res.scopeDebug!.codingOverlayApplied,
+    false,
+    "no overlay on this path",
+  );
+  // Write/effective namespace collapses to the default store (memory_store parity)…
+  assert.equal(res.scopeDebug!.writeNamespace, "default");
+  assert.equal(res.effectiveNamespace, "default");
+  // …but the diagnostic base must be the principal SELF base, not the write ns.
+  assert.equal(
+    res.scopeDebug!.baseNamespace,
+    "pi-geek",
+    "scopeDebug.baseNamespace must be the principal self base on the implicit no-overlay path",
+  );
+});
+
 test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteNamespace (memory_store / suggestion_submit parity, rule 39)", async () => {
   // Regression guard: observe's effective scope MUST be identical to what the
   // explicit-write tools (memory_store / suggestion_submit) resolve via

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1584,7 +1584,12 @@ export class EngramAccessService {
       }
       return {
         principal,
-        baseNamespace: writeNamespace,
+        // scopeDebug.baseNamespace must report the principal SELF base
+        // (`defaultNamespaceForPrincipal`), NOT the general write namespace —
+        // which collapses to config.defaultNamespace on this implicit no-overlay
+        // path (#1505 cursor "Wrong scopeDebug base namespace"). It already
+        // matches `objectiveStateNamespace` below; `writeNamespace` is unchanged.
+        baseNamespace,
         writeNamespace,
         // Implicit objective-state stays on the principal self base, NOT the
         // (possibly default) general write namespace — preserving the #928


### PR DESCRIPTION
## What

Follow-up to PR #1505. Fixes the round-4 cursor **"Wrong scopeDebug base namespace"** thread (hAp), a pre-existing observe scope-plan concern from the #1495 work — not the LCM read/write gate.

In `resolveMemoryScopePlan`, the **implicit no-overlay** branch set the plan's `baseNamespace` field to `writeNamespace` (which collapses to `config.defaultNamespace` for `memory_store` parity) instead of the principal self base from `defaultNamespaceForPrincipal`. The observe response's `scopeDebug.baseNamespace` then **misstated the self base**, even though `objectiveStateNamespace` already targeted that self namespace correctly.

## Fix

One line in the no-overlay branch: `baseNamespace: writeNamespace,` → `baseNamespace,` (the principal self base const).

- `writeNamespace` and `objectiveStateNamespace` are **unchanged**.
- `scope.baseNamespace` is consumed **only** by `scopeDebug` (diagnostic-only — never gates authorization), so nothing else is affected.
- The **explicit-namespace** branch is intentionally left as `base == explicit namespace` (the cursor thread's authoritative location was the implicit no-overlay path / L1586–1587 only).

## Test

Adds a fail-before/pass-after test in `access-service-observe-scope.test.ts` asserting `scopeDebug.baseNamespace` is the principal self base (`pi-geek`) on the implicit no-overlay path while `writeNamespace`/`effectiveNamespace` stay `default`.

- Fail-before: `actual: 'default'` vs `expected: 'pi-geek'`.
- Pass-after: green.

## Gates (node 22)

- `access-service-observe-scope.test.ts` — 13/13
- `tests/access-service-observe.test.ts` + `tests/access-service-objective-state.test.ts` — 17/17
- `test:entity-hardening` — 205/205
- `pnpm --filter @remnic/core build` — clean
- `preflight:quick` — OK

## Checklist
- [x] All tests pass
- [x] New logic covered by a fail-before/pass-after test
- [x] No secrets/personal data (public repo)
- [x] Diff ≤ 400 LOC (1-line code change + 1 test)

> Note: the GitHub thread for this concern (`hAp`) was already auto-resolved, but the underlying code defect persisted; this PR closes the actual gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line diagnostic field correction with no change to write routing or auth; covered by a targeted regression test.
> 
> **Overview**
> On **implicit observe** with **no coding overlay** (`projectScope: false`), `resolveMemoryScopePlan` was setting the plan’s `baseNamespace` to the **general write namespace** (`config.defaultNamespace`, e.g. `"default"`) instead of the principal **self base** from `defaultNamespaceForPrincipal` (e.g. `"pi-geek"`). **`writeNamespace`**, **`effectiveNamespace`**, and **`objectiveStateNamespace`** were already correct; only the diagnostic **`scopeDebug.baseNamespace`** was wrong.
> 
> The fix is a single assignment in the no-overlay branch: return the existing `baseNamespace` const instead of `writeNamespace`. **`scope.baseNamespace` is only surfaced in `scopeDebug`** (not used for authorization), so routing behavior is unchanged.
> 
> Adds a fail-before/pass-after test in `access-service-observe-scope.test.ts` for implicit no-overlay: `writeNamespace` / `effectiveNamespace` stay `"default"` while `scopeDebug.baseNamespace` is the principal self base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f745a07657ee0d99320f38c29e1839ec492cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->