### PR TITLE
fix(security): make LCM session IDs unforgeable across namespaces (#1505)

### DIFF
--- a/packages/remnic-core/src/access-service-lcm-session-forgery.test.ts
+++ b/packages/remnic-core/src/access-service-lcm-session-forgery.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Cross-namespace LCM read-leak hardening (issue #1505, Codex P1 —
+ * "Make LCM session IDs unforgeable across namespaces").
+ *
+ * Overlay (coding-scope) namespaces archive LCM turns under
+ * `${overlayNamespace}:${sessionKey}`, while the DEFAULT store passes the raw,
+ * caller-controlled `sessionKey` through VERBATIM as the LCM `session_id`.
+ * Namespace names are sanitized to `[A-Za-z0-9._-]` (never contain `:`) and the
+ * overlay names are predictable + surfaced via `effectiveNamespace`, so a caller
+ * authorized only for the DEFAULT store could forge a raw key shaped like
+ * `<other-overlay-ns>:<victim-session>` and read another scope's transcript rows
+ * through `lcmSearch` and the raw-disclosure excerpt path.
+ *
+ * These tests prove, against the real EngramAccessService read surfaces:
+ *  - a forged `<overlay-ns>:<victim>` sessionKey / sessionPrefix yields EMPTY
+ *    (no LCM query is even issued — no leak);
+ *  - a legitimate principal-encoded self key (`pi-geek:abc123`) still reads its
+ *    own default-store session (no false positive — the round-3 regression);
+ *  - a non-default (overlay) store and namespaces-disabled are UNCHANGED.
+ *
+ * All fixtures synthetic.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { PluginConfig } from "./types.js";
+
+type LcmCall = { sessionId?: string; sessionPrefix?: string };
+
+const VICTIM_ROW = {
+  id: 1,
+  turn_index: 0,
+  role: "user",
+  content: "alice's project-scoped secret transcript",
+  session_id: "alice-project-tag-foo:victim-session",
+  score: 0.9,
+};
+
+function makeService(
+  overrides: Partial<PluginConfig> = {},
+): { service: EngramAccessService; calls: LcmCall[] } {
+  const calls: LcmCall[] = [];
+  const orch = Object.create(Orchestrator.prototype) as Orchestrator;
+  const internals = orch as unknown as {
+    config: PluginConfig;
+    lcmEngine: unknown;
+  };
+  internals.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    memoryDir: "/synthetic/remnic-lcm-forgery",
+    recallCrossNamespaceBudgetEnabled: false,
+    recallCrossNamespaceBudgetWindowMs: 60_000,
+    recallCrossNamespaceBudgetSoftLimit: 10,
+    recallCrossNamespaceBudgetHardLimit: 30,
+    ...overrides,
+  } as unknown as PluginConfig;
+  // Minimal LCM engine stub: records every read and ALWAYS returns the victim
+  // row, so any non-empty result means the read reached another scope's data.
+  internals.lcmEngine = {
+    enabled: true,
+    async searchContextFull(
+      _query: string,
+      _limit: number,
+      sessionId?: string,
+      sessionPrefix?: string,
+    ) {
+      calls.push({ sessionId, sessionPrefix });
+      return [VICTIM_ROW];
+    },
+  };
+  return { service: new EngramAccessService(orch), calls };
+}
+
+// ── lcmSearch ──────────────────────────────────────────────────────────────
+
+test("lcmSearch: forged overlay-encoded sessionKey on the default store returns EMPTY (no leak)", async () => {
+  const { service, calls } = makeService();
+  const res = await service.lcmSearch({
+    query: "secret",
+    sessionKey: "alice-project-tag-foo:victim-session",
+  });
+  assert.deepEqual(res.results, [], "forged key must not surface another scope's rows");
+  assert.equal(res.count, 0);
+  assert.equal(res.lcmEnabled, true);
+  assert.equal(
+    calls.length,
+    0,
+    "the LCM archive must never be queried with the forged verbatim key",
+  );
+});
+
+test("lcmSearch: forged overlay-encoded sessionPrefix on the default store returns EMPTY (no leak)", async () => {
+  // An authenticated default-store caller pairs a benign sessionKey with a
+  // forged LIKE-prefix to enumerate another scope's sessions — the prefix arm
+  // of the guard must still suppress it even when the sessionKey is clean.
+  const { service, calls } = makeService();
+  const res = await service.lcmSearch({
+    query: "secret",
+    sessionKey: "bob-own-session",
+    sessionPrefix: "alice-project-tag-foo",
+  });
+  assert.deepEqual(res.results, []);
+  assert.equal(res.count, 0);
+  assert.equal(calls.length, 0, "forged LIKE-prefix must not reach the archive");
+});
+
+test("lcmSearch: legitimate principal-encoded self key still reads its own default-store session", async () => {
+  // Regression guard (round-3): a principal's own default-store key naturally
+  // begins with `<principal>:`. It must pass through verbatim and return rows.
+  const { service, calls } = makeService();
+  const res = await service.lcmSearch({
+    query: "secret",
+    sessionKey: "pi-geek:abc123",
+  });
+  assert.equal(res.count, 1, "the principal must still read its own session");
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0]!.sessionId,
+    "pi-geek:abc123",
+    "the verbatim self key must reach the archive unchanged",
+  );
+});
+
+test("lcmSearch: a plain bare sessionKey on the default store is unaffected", async () => {
+  const { service, calls } = makeService();
+  const res = await service.lcmSearch({ query: "secret", sessionKey: "plain-session" });
+  assert.equal(res.count, 1);
+  assert.equal(calls[0]!.sessionId, "plain-session");
+});
+
+test("lcmSearch: namespaces disabled — overlay-shaped key passes through verbatim (single-store unchanged)", async () => {
+  // With namespaces disabled there is no overlay encoding: every row lives in
+  // the single store under its verbatim sessionKey. The guard must NOT fire.
+  const { service, calls } = makeService({ namespacesEnabled: false } as Partial<PluginConfig>);
+  const res = await service.lcmSearch({
+    query: "secret",
+    sessionKey: "alice-project-tag-foo:victim-session",
+  });
+  assert.equal(res.count, 1, "single-store deployments must be unchanged");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionId, "alice-project-tag-foo:victim-session");
+});
+
+test("lcmSearch: explicit readable overlay namespace + overlay-looking sessionKey is NOT suppressed (prefix isolates it)", async () => {
+  // When the caller passes an authorized non-default namespace, the read key is
+  // `${namespace}:${sessionKey}` — already non-colliding — so the default-store
+  // forgery guard must not fire and break legitimate overlay reads.
+  const { service, calls } = makeService({
+    namespacePolicies: [
+      { name: "alice-project-tag-foo", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  } as Partial<PluginConfig>);
+  const res = await service.lcmSearch({
+    query: "secret",
+    sessionKey: "victim-session",
+    namespace: "alice-project-tag-foo",
+  });
+  assert.equal(res.count, 1, "an authorized overlay-namespace read must still work");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionId, "alice-project-tag-foo:victim-session");
+});
+
+// ── raw-disclosure excerpt path (what recall({disclosure:"raw"}) uses) ───────
+
+function fetchRawExcerpts(
+  service: EngramAccessService,
+  context: { query: string; sessionKey?: string; namespace?: string; selfBase?: string },
+): Promise<Array<{ sessionId: string }> | null> {
+  return (
+    service as unknown as {
+      fetchRawExcerpts: (
+        disclosure: "raw",
+        ctx: typeof context,
+      ) => Promise<Array<{ sessionId: string }> | null>;
+    }
+  ).fetchRawExcerpts("raw", context);
+}
+
+test("recall raw excerpts: forged overlay-encoded sessionKey on the default store returns EMPTY (no leak)", async () => {
+  const { service, calls } = makeService();
+  const rows = await fetchRawExcerpts(service, {
+    query: "secret",
+    sessionKey: "alice-project-tag-foo:victim-session",
+    namespace: "default",
+    selfBase: "default",
+  });
+  assert.deepEqual(rows, [], "raw-disclosure excerpts must not leak another scope's transcript");
+  assert.equal(calls.length, 0, "the LCM archive must never be queried with the forged key");
+});
+
+test("recall raw excerpts: legitimate self key still returns its own excerpts (no false positive)", async () => {
+  const { service, calls } = makeService();
+  const rows = await fetchRawExcerpts(service, {
+    query: "secret",
+    sessionKey: "pi-geek:abc123",
+    namespace: "default",
+    selfBase: "pi-geek",
+  });
+  assert.equal(rows?.length, 1, "the principal must still see its own raw excerpts");
+  assert.equal(calls[0]!.sessionId, "pi-geek:abc123");
+});
+
+test("recall raw excerpts: namespaces disabled — overlay-shaped key passes through (single-store unchanged)", async () => {
+  const { service, calls } = makeService({ namespacesEnabled: false } as Partial<PluginConfig>);
+  const rows = await fetchRawExcerpts(service, {
+    query: "secret",
+    sessionKey: "alice-project-tag-foo:victim-session",
+    namespace: "default",
+    selfBase: "default",
+  });
+  assert.equal(rows?.length, 1, "single-store deployments must be unchanged");
+  assert.equal(calls.length, 1);
+});

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -9,6 +9,7 @@ import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
 import {
   combineNamespaces,
+  isForgedDefaultStoreLcmSessionKey,
   projectTagProjectId,
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
@@ -1510,6 +1511,12 @@ export class EngramAccessService {
       {
         query: options.query,
         ...(options.sessionKey ? { sessionKey: options.sessionKey } : {}),
+        // selfBase exempts the principal's own self namespace from the
+        // raw-excerpt forgery guard (#1505).
+        selfBase: defaultNamespaceForPrincipal(
+          resolvePrincipal(options.sessionKey, this.orchestrator.config),
+          this.orchestrator.config,
+        ),
       },
     );
     const context = results
@@ -1545,7 +1552,7 @@ export class EngramAccessService {
   private async serializeRecallResults(
     snapshot: LastRecallSnapshot | null,
     disclosure: RecallDisclosure,
-    rawContext: { query: string; sessionKey?: string } | null = null,
+    rawContext: { query: string; sessionKey?: string; selfBase?: string } | null = null,
   ): Promise<EngramAccessMemorySummary[]> {
     if (!snapshot) return [];
     const namespace = snapshot.namespace ? this.resolveNamespace(snapshot.namespace) : this.orchestrator.config.defaultNamespace;
@@ -1787,7 +1794,9 @@ export class EngramAccessService {
    */
   private async fetchRawExcerpts(
     disclosure: RecallDisclosure,
-    context: { query: string; sessionKey?: string; namespace?: string } | null,
+    context:
+      | { query: string; sessionKey?: string; namespace?: string; selfBase?: string }
+      | null,
   ): Promise<EngramAccessMemorySummary["rawExcerpts"] | null> {
     if (disclosure !== "raw") return null;
     if (!context || !context.query) return [];
@@ -1799,6 +1808,23 @@ export class EngramAccessService {
     // missing sessionKey as "no excerpts" — callers asking for raw
     // disclosure outside a session get an empty list, not a leak.
     if (!context.sessionKey) return [];
+    // Cross-namespace forgery guard (issue #1505, Codex P1): mirror lcmSearch.
+    // On the DEFAULT store the LCM key below is the verbatim sessionKey, so a
+    // raw key shaped like an overlay-encoded id (`<overlayNamespace>:<victim>`)
+    // would surface another scope's transcript rows here too. Refuse it (empty
+    // excerpts — the safe failure mode). `selfBase` is exempt; gated to the
+    // default store with namespaces enabled, identical to the lcmSearch gate
+    // (CLAUDE.md rule 39 — the same gate on every read path).
+    const onDefaultStore =
+      !context.namespace ||
+      context.namespace === this.orchestrator.config.defaultNamespace;
+    if (
+      this.orchestrator.config.namespacesEnabled === true &&
+      onDefaultStore &&
+      isForgedDefaultStoreLcmSessionKey(context.sessionKey, context.selfBase)
+    ) {
+      return [];
+    }
     const lcm = this.orchestrator.lcmEngine;
     if (!lcm || !lcm.enabled) return [];
     try {
@@ -2536,6 +2562,9 @@ export class EngramAccessService {
     let results = await this.serializeRecallResults(snapshot, disclosure, {
       query,
       sessionKey: request.sessionKey,
+      // selfBase exempts the principal's own (possibly overlay-shaped) self
+      // namespace from the raw-excerpt forgery guard (#1505).
+      selfBase: principalNamespace,
     });
 
     // Tag filter (issue #689). Applied post-recall, post-serialization so
@@ -3034,6 +3063,12 @@ export class EngramAccessService {
                   query,
                   ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
                   namespace,
+                  // selfBase exempts the principal's own self namespace from the
+                  // raw-excerpt forgery guard (#1505).
+                  selfBase: defaultNamespaceForPrincipal(
+                    principal,
+                    this.orchestrator.config,
+                  ),
                 })
               : null;
           const rawExcerptText =
@@ -4449,6 +4484,33 @@ export class EngramAccessService {
         count: 0,
         lcmEnabled: false,
       };
+    }
+
+    // Cross-namespace forgery guard (issue #1505, Codex P1): on the DEFAULT
+    // store the LCM `session_id` is the caller's raw sessionKey/prefix, used
+    // verbatim. Overlay (coding-scope) namespaces archive under
+    // `${overlayNamespace}:${sessionKey}`, so a raw key shaped like an
+    // overlay-encoded id would surface another scope's rows. Refuse it — the
+    // safe failure mode is empty results. Gated to the default store with
+    // namespaces enabled: a non-default store's `${namespace}:` prefix already
+    // isolates the key, and namespaces-disabled has no overlay encoding at all.
+    if (
+      this.orchestrator.config.namespacesEnabled === true &&
+      namespace === this.orchestrator.config.defaultNamespace
+    ) {
+      const selfBase = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+      if (
+        isForgedDefaultStoreLcmSessionKey(request.sessionKey, selfBase) ||
+        isForgedDefaultStoreLcmSessionKey(request.sessionPrefix, selfBase)
+      ) {
+        return {
+          query: request.query,
+          namespace,
+          results: [],
+          count: 0,
+          lcmEnabled: true,
+        };
+      }
     }
 
     const limit = Math.max(1, Math.min(request.limit ?? 10, 100));

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -12,6 +12,8 @@ import test from "node:test";
 import {
   branchNamespaceName,
   combineNamespaces,
+  isCodingOverlayNamespaceToken,
+  isForgedDefaultStoreLcmSessionKey,
   projectTagProjectId,
   projectNamespaceName,
   resolveCodingNamespaceOverlay,
@@ -364,4 +366,126 @@ test("resolveCodingNamespaceOverlay: read path and write path see identical name
   const readOverlay = resolveCodingNamespaceOverlay(input[0], input[1]);
   const writeOverlay = resolveCodingNamespaceOverlay(input[0], input[1]);
   assert.deepEqual(readOverlay, writeOverlay);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Unforgeable LCM session keys across namespaces (issue #1505, Codex P1)
+//
+// Overlay (coding-scope) namespaces archive LCM turns under
+// `${overlayNamespace}:${sessionKey}`; the default store passes the raw
+// caller-controlled `sessionKey` through VERBATIM. Because overlay namespace
+// names are predictable, surfaced via `effectiveNamespace`, and sanitization
+// never yields `:`, a default-store-authorized caller could otherwise forge a
+// raw key shaped like `<overlayNamespace>:<victim-session>` and read another
+// scope's transcript rows. These helpers restore injectivity by detecting the
+// overlay shape on the default read path.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("isCodingOverlayNamespaceToken: recognizes bare project/branch overlay names", () => {
+  // Produced by projectNamespaceName / branchNamespaceName when the base is
+  // empty/collapsed (combineNamespaces('', overlay)).
+  assert.equal(isCodingOverlayNamespaceToken("project-origin-abcd1234"), true);
+  assert.equal(isCodingOverlayNamespaceToken("branch-main"), true);
+  assert.equal(
+    isCodingOverlayNamespaceToken("project-origin-abcd1234-branch-main"),
+    true,
+  );
+});
+
+test("isCodingOverlayNamespaceToken: recognizes base-prefixed overlay names", () => {
+  // combineNamespaces(base, overlay) → `<base>-project-…` / `<base>-branch-…`.
+  assert.equal(
+    isCodingOverlayNamespaceToken("alice-project-origin-abcd1234"),
+    true,
+  );
+  assert.equal(
+    isCodingOverlayNamespaceToken("alice-project-tag-foo"),
+    true,
+  );
+  assert.equal(
+    isCodingOverlayNamespaceToken(
+      "alice-project-origin-ab12-branch-main",
+    ),
+    true,
+  );
+});
+
+test("isCodingOverlayNamespaceToken: rejects plain namespaces and principal ids", () => {
+  // The default store, shared store, principal self-namespaces, and bare
+  // principal ids are NEVER overlay-shaped.
+  assert.equal(isCodingOverlayNamespaceToken("default"), false);
+  assert.equal(isCodingOverlayNamespaceToken("shared"), false);
+  assert.equal(isCodingOverlayNamespaceToken("alice"), false);
+  assert.equal(isCodingOverlayNamespaceToken("pi-geek"), false);
+  assert.equal(isCodingOverlayNamespaceToken("agent"), false);
+  assert.equal(isCodingOverlayNamespaceToken(""), false);
+  // "project"/"branch" without the trailing `-` are not overlay markers.
+  assert.equal(isCodingOverlayNamespaceToken("project"), false);
+  assert.equal(isCodingOverlayNamespaceToken("branchwork"), false);
+});
+
+test("isForgedDefaultStoreLcmSessionKey: forged overlay-encoded exact key is rejected", () => {
+  // The core attack: a default-store caller passes another scope's encoded id.
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey(
+      "alice-project-tag-foo:victim-session",
+      "default",
+    ),
+    true,
+  );
+});
+
+test("isForgedDefaultStoreLcmSessionKey: forged branch-overlay key is rejected", () => {
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey(
+      "alice-project-origin-ab12-branch-main:victim-session",
+      "default",
+    ),
+    true,
+  );
+});
+
+test("isForgedDefaultStoreLcmSessionKey: colon-less overlay-shaped LIKE-prefix is rejected", () => {
+  // `searchContextFull(..., sessionPrefix)` is a LIKE-prefix match, so a
+  // colon-less overlay namespace prefixes `alice-project-tag-foo:<victim>`.
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey("alice-project-tag-foo", "default"),
+    true,
+  );
+});
+
+test("isForgedDefaultStoreLcmSessionKey: legitimate principal-encoded self key is allowed", () => {
+  // Regression guard: a principal's OWN default-store key naturally begins with
+  // `<principal>:` (e.g. `pi-geek:abc123`). Blindly rejecting `<token>:` keys
+  // would break a principal reading its own session — it must still pass.
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey("pi-geek:abc123", "pi-geek"),
+    false,
+  );
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey("pi-geek:abc123", "default"),
+    false,
+  );
+});
+
+test("isForgedDefaultStoreLcmSessionKey: principal's own overlay-shaped self base is exempt", () => {
+  // If a principal's self namespace is itself overlay-shaped, that one token is
+  // legitimately theirs to address.
+  assert.equal(
+    isForgedDefaultStoreLcmSessionKey(
+      "alice-project-tag-foo:victim-session",
+      "alice-project-tag-foo",
+    ),
+    false,
+  );
+});
+
+test("isForgedDefaultStoreLcmSessionKey: plain/bare keys and empty inputs are allowed", () => {
+  assert.equal(isForgedDefaultStoreLcmSessionKey("victim-session", "default"), false);
+  assert.equal(isForgedDefaultStoreLcmSessionKey("agent:foo:slack:1", "default"), false);
+  assert.equal(isForgedDefaultStoreLcmSessionKey(undefined, "default"), false);
+  assert.equal(isForgedDefaultStoreLcmSessionKey("", "default"), false);
+  assert.equal(isForgedDefaultStoreLcmSessionKey(null, "default"), false);
+  // Leading colon → empty token → not overlay-shaped.
+  assert.equal(isForgedDefaultStoreLcmSessionKey(":foo", "default"), false);
 });

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -250,6 +250,85 @@ export function branchNamespaceName(projectId: string, branch: string): string {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// Unforgeable LCM session keys across namespaces (issue #1505, Codex P1)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * True when `token` has the structural shape of a coding-agent overlay
+ * namespace — the form produced by `combineNamespaces` /
+ * `projectNamespaceName` / `branchNamespaceName`: `project-…`, `branch-…`, or
+ * `<base>-project-…` / `<base>-branch-…`.
+ *
+ * The global default store NEVER legitimately holds a namespace of this shape
+ * (overlay namespaces only ever exist when project/branch scope is active and
+ * namespaces are enabled), so an LCM `session_id` whose leading namespace
+ * segment matches this shape, encountered on the DEFAULT read path, is a
+ * cross-namespace forgery rather than a key the default store could own.
+ *
+ * Pure and allocation-light: four substring checks, no regex — keeping this
+ * module's no-polynomial-backtracking posture (CodeQL).
+ */
+export function isCodingOverlayNamespaceToken(token: string): boolean {
+  if (typeof token !== "string" || token.length === 0) return false;
+  return (
+    token.startsWith("project-") ||
+    token.startsWith("branch-") ||
+    token.includes("-project-") ||
+    token.includes("-branch-")
+  );
+}
+
+/**
+ * Decide whether a raw LCM `sessionKey` / `sessionPrefix` — one used VERBATIM
+ * as an LCM `session_id` (exact match) or LIKE-prefix on the DEFAULT store — is
+ * forging another namespace's overlay-encoded id.
+ *
+ * Why this is needed (the P1 read leak): overlay (non-default) namespaces
+ * archive turns under `${overlayNamespace}:${sessionKey}` (see
+ * `EngramAccessService.observe`), while the default store passes the
+ * caller-controlled `sessionKey` through verbatim. That encoding is therefore
+ * NOT injective: a caller authorized only for the default store could pass a
+ * raw key shaped like `<overlayNamespace>:<victim-session>` and `lcmSearch` /
+ * the raw-disclosure excerpt path would query that exact `session_id` and
+ * surface another scope's transcript rows. Namespace names are sanitized to
+ * `[A-Za-z0-9._-]` (never contain `:`) and overlay names are predictable and
+ * surfaced via `effectiveNamespace`, so the forge is trivial to construct. This
+ * predicate restores injectivity by refusing such keys on the default path.
+ *
+ * Returns true (⇒ the caller MUST suppress the read; the safe failure mode is
+ * EMPTY results, never a leak) when the candidate's leading namespace segment —
+ * the part before the first `:`, or the whole value when there is none, so a
+ * colon-less overlay-shaped LIKE-prefix is caught too — has the overlay shape
+ * and is NOT the principal's own self base.
+ *
+ * A value whose leading segment is not overlay-shaped is never treated as
+ * forged. In particular a legitimate principal-encoded key such as
+ * `pi-geek:abc123` (leading token `pi-geek`) passes, so a principal reading its
+ * OWN default-store session is unaffected — blindly rejecting every `<token>:`
+ * key would regress that legitimate self-read.
+ *
+ * NOTE for callers: gate this only when namespaces are enabled AND the read is
+ * on the default store. With namespaces disabled no overlay encoding ever
+ * happens (every row is a verbatim sessionKey in the single store), and on a
+ * non-default store the `${namespace}:` prefix already makes the key
+ * non-colliding — applying the guard there would be a false-positive.
+ *
+ * @param rawKey   the verbatim `sessionKey` or `sessionPrefix` (nullish ⇒ false)
+ * @param selfBase `defaultNamespaceForPrincipal(principal)` — the one
+ *                 overlay-shaped segment the principal may legitimately address
+ */
+export function isForgedDefaultStoreLcmSessionKey(
+  rawKey: string | undefined | null,
+  selfBase?: string,
+): boolean {
+  if (typeof rawKey !== "string" || rawKey.length === 0) return false;
+  const colon = rawKey.indexOf(":");
+  const token = colon >= 0 ? rawKey.slice(0, colon) : rawKey;
+  if (selfBase && token === selfBase) return false;
+  return isCodingOverlayNamespaceToken(token);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Overlay resolver
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -307,6 +307,7 @@ import {
 } from "./namespaces/principal.js";
 import {
   combineNamespaces,
+  isForgedDefaultStoreLcmSessionKey,
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
 import type { CodingContext } from "./types.js";
@@ -9352,6 +9353,24 @@ export class Orchestrator {
     // --- Phase 2: Assemble sections in correct order ---
     this.profiler.startSpan("assembly", profileTraceId);
 
+    // Cross-namespace forgery guard (issue #1505, Codex P1): the in-prompt LCM
+    // sections below read the archive keyed VERBATIM by `sessionKey`. Overlay
+    // (coding-scope) namespaces archive turns under `${overlayNamespace}:${sk}`,
+    // so a caller-controlled `sessionKey` shaped like `<overlayNamespace>:<victim>`
+    // would surface another scope's transcript rows directly into the prompt.
+    // Refuse such forged keys here exactly as the access-service LCM read
+    // surfaces do (CLAUDE.md rule 39 — identical gate on every read path). The
+    // principal's own self base is exempt; namespaces-disabled is a no-op.
+    const lcmSessionForged =
+      this.config.namespacesEnabled === true &&
+      isForgedDefaultStoreLcmSessionKey(
+        sessionKey,
+        defaultNamespaceForPrincipal(
+          resolvePrincipal(sessionKey, this.config),
+          this.config,
+        ),
+      );
+
     // 0. Shared context
     if (sharedCtx)
       this.appendRecallSection(sectionBuckets, "shared-context", sharedCtx);
@@ -9365,6 +9384,7 @@ export class Orchestrator {
       this.isRecallSectionEnabled("explicit-cue") &&
       explicitCueMaxChars !== 0 &&
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
       try {
@@ -9402,6 +9422,7 @@ export class Orchestrator {
       ) &&
       targetedFactMaxChars !== 0 &&
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       (recallMode as RecallPlanMode) !== "no_recall" &&
       shouldRecallTargetedFactEvidence(retrievalQuery)
     ) {
@@ -9447,6 +9468,7 @@ export class Orchestrator {
       ) &&
       focusedListMaxChars !== 0 &&
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       (recallMode as RecallPlanMode) !== "no_recall" &&
       shouldRecallFocusedListEvidence(retrievalQuery)
     ) {
@@ -9496,6 +9518,7 @@ export class Orchestrator {
       ) &&
       responseGuidanceMaxChars !== 0 &&
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       (recallMode as RecallPlanMode) !== "no_recall" &&
       (responseGuidanceMatchesQuery || responseGuidanceForcedByPipeline)
     ) {
@@ -9540,6 +9563,7 @@ export class Orchestrator {
       ) &&
       eventOrderMaxChars !== 0 &&
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       (recallMode as RecallPlanMode) !== "no_recall" &&
       shouldRecallEventOrderEvidence(retrievalQuery)
     ) {
@@ -9728,6 +9752,7 @@ export class Orchestrator {
     // LCM compressed history section
     if (
       this.lcmEngine?.enabled &&
+      !lcmSessionForged &&
       recallMode !== "minimal" &&
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Security fix for unauthorized cross-namespace transcript disclosure; behavior changes only for forged keys on the default path when namespaces are enabled, with broad test coverage for false positives.
> 
> **Overview**
> Closes a **cross-namespace LCM read leak** where default-store callers could pass `sessionKey` / `sessionPrefix` values shaped like overlay-encoded ids (`<overlay-ns>:<victim>`) and read another coding scope’s archived transcripts, because the default store uses those strings verbatim as LCM `session_id`.
> 
> Adds **`isCodingOverlayNamespaceToken`** and **`isForgedDefaultStoreLcmSessionKey`** in `coding-namespace.ts` to detect overlay-shaped leading segments, with a **`selfBase`** exemption so principals can still use their own keys (e.g. `pi-geek:abc123`). The guard runs only when **namespaces are enabled** and the read is on the **default store**; overlay-namespace reads and single-store (`namespacesEnabled: false`) behavior stay unchanged.
> 
> Applies the same gate on every LCM read path: **`lcmSearch`**, **`fetchRawExcerpts`** (raw recall), and **orchestrator** in-prompt LCM sections (explicit cues, targeted facts, compressed history, etc.) — forged keys yield **empty results** and **no LCM query** where applicable.
> 
> New integration tests in `access-service-lcm-session-forgery.test.ts` and unit tests in `coding-namespace.test.ts` cover forgery, prefix enumeration, regressions, and exempt paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1856fde2f0df3786f17462196e52eed9302d620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->