### PR TITLE
fix(recall): merge LCM fallback reads across keys instead of short-circuiting (#1505 codex P2)

### DIFF
--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -1,6 +1,9 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
-import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
+import {
+  gatherAcrossReadSessions,
+  resolveLcmReadSessionIds,
+} from "./lcm-fallback-read.js";
 
 export interface EventOrderRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
@@ -72,11 +75,14 @@ export async function buildEventOrderRecallSection(
 
   // UNION per-key candidates into the existing rank/select/budget pass so a
   // stronger project-fallback turn is not masked by a weak primary-key hit.
+  // `gatherAcrossReadSessions` isolates a per-key read failure so a
+  // corrupt/locked fallback index can't discard the primary key's turns; the
+  // single-key path runs one collect and propagates a failure as before.
   const items: EvidencePackItem[] = [];
-  for (const sessionId of readSessionIds) {
-    if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+  await gatherAcrossReadSessions(readSessionIds, async (sessionId) => {
+    if (typeof sessionId !== "string" || sessionId.length === 0) return;
     items.push(...(await collectEventOrderItems({ ...options, sessionId })));
-  }
+  });
   const ranked = rankAndSelectEventOrderItems(items, options, maxItems);
   if (ranked.length === 0) {
     return "";

--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -1,9 +1,18 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
 
 export interface EventOrderRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
+  /**
+   * Ordered, read-authorized LCM read key set (primary overlay → project/root
+   * fallbacks). When present, chronological evidence is gathered across EVERY
+   * key and merged under this section's budget (#1505 codex P2). Falls back to
+   * `sessionId`. Sessionless (`undefined`) keys are skipped — event-order
+   * evidence is inherently per-session.
+   */
+  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -42,7 +51,16 @@ export async function buildEventOrderRecallSection(
 ): Promise<string> {
   const budget = normalizePositiveInteger(options.maxChars);
   const maxItems = normalizePositiveInteger(options.maxItems ?? DEFAULT_MAX_ITEMS);
-  if (!options.engine || !options.sessionId || budget <= 0) {
+  // #1505 codex P2: gather chronological evidence across the ordered LCM read key
+  // set (primary overlay → project/root fallbacks). event-order evidence is
+  // inherently per-session, so sessionless keys are skipped; the section runs
+  // when at least one real read key is authorized. A single real sessionId is
+  // byte-for-byte the pre-#1505 behavior.
+  const readSessionIds = resolveLcmReadSessionIds(options);
+  const hasReadKey = readSessionIds.some(
+    (sessionId) => typeof sessionId === "string" && sessionId.length > 0,
+  );
+  if (!options.engine || !hasReadKey || budget <= 0) {
     return "";
   }
   if (maxItems <= 0) {
@@ -52,7 +70,13 @@ export async function buildEventOrderRecallSection(
     return "";
   }
 
-  const items = await collectEventOrderItems(options);
+  // UNION per-key candidates into the existing rank/select/budget pass so a
+  // stronger project-fallback turn is not masked by a weak primary-key hit.
+  const items: EvidencePackItem[] = [];
+  for (const sessionId of readSessionIds) {
+    if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+    items.push(...(await collectEventOrderItems({ ...options, sessionId })));
+  }
   const ranked = rankAndSelectEventOrderItems(items, options, maxItems);
   if (ranked.length === 0) {
     return "";

--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -1,21 +1,14 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
-import {
-  gatherAcrossReadSessions,
-  resolveLcmReadSessionIds,
-} from "./lcm-fallback-read.js";
 
 export interface EventOrderRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
+  // event-order reads a SINGLE LCM session key. Unlike the relevance-ranked
+  // sections, its evidence must not be merged across the #1505 fallback key set:
+  // `turn_index` is local to each LCM `session_id`, so interleaving keys would
+  // misstate chronology. The orchestrator reads the ordered key set via
+  // first-non-empty instead (see the event-order call site).
   sessionId?: string;
-  /**
-   * Ordered, read-authorized LCM read key set (primary overlay → project/root
-   * fallbacks). When present, chronological evidence is gathered across EVERY
-   * key and merged under this section's budget (#1505 codex P2). Falls back to
-   * `sessionId`. Sessionless (`undefined`) keys are skipped — event-order
-   * evidence is inherently per-session.
-   */
-  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -54,16 +47,10 @@ export async function buildEventOrderRecallSection(
 ): Promise<string> {
   const budget = normalizePositiveInteger(options.maxChars);
   const maxItems = normalizePositiveInteger(options.maxItems ?? DEFAULT_MAX_ITEMS);
-  // #1505 codex P2: gather chronological evidence across the ordered LCM read key
-  // set (primary overlay → project/root fallbacks). event-order evidence is
-  // inherently per-session, so sessionless keys are skipped; the section runs
-  // when at least one real read key is authorized. A single real sessionId is
-  // byte-for-byte the pre-#1505 behavior.
-  const readSessionIds = resolveLcmReadSessionIds(options);
-  const hasReadKey = readSessionIds.some(
-    (sessionId) => typeof sessionId === "string" && sessionId.length > 0,
-  );
-  if (!options.engine || !hasReadKey || budget <= 0) {
+  // event-order reads a SINGLE session key (`turn_index` is local to each LCM
+  // `session_id`, so chronology can't be merged across the #1505 fallback set —
+  // the orchestrator drives the ordered key set via first-non-empty instead).
+  if (!options.engine || !options.sessionId || budget <= 0) {
     return "";
   }
   if (maxItems <= 0) {
@@ -73,16 +60,7 @@ export async function buildEventOrderRecallSection(
     return "";
   }
 
-  // UNION per-key candidates into the existing rank/select/budget pass so a
-  // stronger project-fallback turn is not masked by a weak primary-key hit.
-  // `gatherAcrossReadSessions` isolates a per-key read failure so a
-  // corrupt/locked fallback index can't discard the primary key's turns; the
-  // single-key path runs one collect and propagates a failure as before.
-  const items: EvidencePackItem[] = [];
-  await gatherAcrossReadSessions(readSessionIds, async (sessionId) => {
-    if (typeof sessionId !== "string" || sessionId.length === 0) return;
-    items.push(...(await collectEventOrderItems({ ...options, sessionId })));
-  });
+  const items = await collectEventOrderItems(options);
   const ranked = rankAndSelectEventOrderItems(items, options, maxItems);
   if (ranked.length === 0) {
     return "";

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -334,12 +334,24 @@ export async function buildExplicitCueRecallSection(
 
   // #1505 codex P2: gather cue evidence across the ordered LCM read key set
   // (primary overlay → project/root fallbacks) into ONE shared accumulator
-  // (`evidenceItems` / `seenTurns`), so a stronger project-fallback cue is not
-  // masked by a weak primary-key hit. `seenTurns` dedupes across keys by
+  // (`evidenceItems` / `seenTurns`), so a branch-scoped session's project/root
+  // fallback cues are RECOVERED instead of being skipped by the old
+  // first-non-empty short-circuit. `seenTurns` dedupes across keys by
   // `session_id`+`turn_index`; the budget is applied exactly once in the
-  // `buildEvidencePack` call below. A single key (or a single sessionless
-  // `undefined`) runs the gather once — byte-for-byte the pre-#1505 behavior.
-  for (const sessionId of resolveLcmReadSessionIds(options)) {
+  // `buildEvidencePack` call below.
+  //
+  // Ordering note: unlike the other LCM sections, explicit-cue does NOT
+  // relevance-rank before budgeting — `buildEvidencePack` consumes
+  // `evidenceItems` in insertion order. To keep a lower-value evidence TYPE from
+  // one key from crowding out a higher-value type from another key under a tight
+  // budget, gather is ordered by evidence TYPE first (turn references → content
+  // cues → lexical cues), then by read-key priority (primary overlay first)
+  // WITHIN each type. So a tight budget still prefers the primary key within a
+  // type, but a fallback key's turn references outrank the primary key's lexical
+  // cues. A single key (or a single sessionless `undefined`) runs each collector
+  // exactly once, in the original order — byte-for-byte the pre-#1505 behavior.
+  const readSessionIds = resolveLcmReadSessionIds(options);
+  for (const sessionId of readSessionIds) {
     await collectTurnReferenceEvidence({
       engine,
       sessionId,
@@ -348,8 +360,10 @@ export async function buildExplicitCueRecallSection(
       evidenceItems,
       seenTurns,
     });
+  }
 
-    if (options.includeContentLexicalCues) {
+  if (options.includeContentLexicalCues) {
+    for (const sessionId of readSessionIds) {
       await collectNamedMeetingFactEvidence({
         engine,
         sessionId,
@@ -358,7 +372,9 @@ export async function buildExplicitCueRecallSection(
         evidenceItems,
         seenTurns,
       });
+    }
 
+    for (const sessionId of readSessionIds) {
       await collectFocusedTranscriptCueEvidence({
         engine,
         sessionId,
@@ -367,7 +383,9 @@ export async function buildExplicitCueRecallSection(
         seenTurns,
       });
     }
+  }
 
+  for (const sessionId of readSessionIds) {
     await collectLexicalCueEvidence({
       engine,
       sessionId,

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -1,4 +1,5 @@
 import { buildEvidencePack } from "./evidence-pack.js";
+import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
 
 export interface ExplicitCueRecallEngine {
   expandContext(
@@ -29,6 +30,13 @@ export interface ExplicitCueRecallEngine {
 export interface ExplicitCueRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
+  /**
+   * Ordered, read-authorized LCM read key set (primary overlay → project/root
+   * fallbacks). When present, cue evidence is gathered across EVERY key into one
+   * shared accumulator and merged under this section's budget (#1505 codex P2).
+   * Falls back to `sessionId`.
+   */
+  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -324,45 +332,54 @@ export async function buildExplicitCueRecallSection(
   }> = [];
   const seenTurns = new Set<string>();
 
-  await collectTurnReferenceEvidence({
-    engine,
-    sessionId: options.sessionId,
-    query,
-    maxReferences,
-    evidenceItems,
-    seenTurns,
-  });
-
-  if (options.includeContentLexicalCues) {
-    await collectNamedMeetingFactEvidence({
+  // #1505 codex P2: gather cue evidence across the ordered LCM read key set
+  // (primary overlay → project/root fallbacks) into ONE shared accumulator
+  // (`evidenceItems` / `seenTurns`), so a stronger project-fallback cue is not
+  // masked by a weak primary-key hit. `seenTurns` dedupes across keys by
+  // `session_id`+`turn_index`; the budget is applied exactly once in the
+  // `buildEvidencePack` call below. A single key (or a single sessionless
+  // `undefined`) runs the gather once — byte-for-byte the pre-#1505 behavior.
+  for (const sessionId of resolveLcmReadSessionIds(options)) {
+    await collectTurnReferenceEvidence({
       engine,
-      sessionId: options.sessionId,
+      sessionId,
       query,
       maxReferences,
       evidenceItems,
       seenTurns,
     });
 
-    await collectFocusedTranscriptCueEvidence({
+    if (options.includeContentLexicalCues) {
+      await collectNamedMeetingFactEvidence({
+        engine,
+        sessionId,
+        query,
+        maxReferences,
+        evidenceItems,
+        seenTurns,
+      });
+
+      await collectFocusedTranscriptCueEvidence({
+        engine,
+        sessionId,
+        query,
+        evidenceItems,
+        seenTurns,
+      });
+    }
+
+    await collectLexicalCueEvidence({
       engine,
-      sessionId: options.sessionId,
+      sessionId,
       query,
+      maxReferences,
+      includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,
+      includeContentLexicalCues: options.includeContentLexicalCues,
+      includeStructuredPlanCues: options.includeStructuredPlanCues,
       evidenceItems,
       seenTurns,
     });
   }
-
-  await collectLexicalCueEvidence({
-    engine,
-    sessionId: options.sessionId,
-    query,
-    maxReferences,
-    includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,
-    includeContentLexicalCues: options.includeContentLexicalCues,
-    includeStructuredPlanCues: options.includeStructuredPlanCues,
-    evidenceItems,
-    seenTurns,
-  });
 
   const evidenceFocusQuery = buildEvidenceFocusQuery(query, {
     includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -346,9 +346,16 @@ export async function buildExplicitCueRecallSection(
   // other keys' cues); single-key recall runs each collector directly, so a
   // failure propagates exactly as before.
   //
-  // Gather is ordered by evidence TYPE first (turn references → content cues →
-  // lexical cues), then by read-key priority within each type, so an unscored
-  // fallback cue keeps a sensible position relative to other unscored cues.
+  // Ordering: gather by evidence TYPE first (turn references → content cues →
+  // lexical cues), then by read-key priority within each type. This is the
+  // section's deliberate value order, and it carries across keys — so a fallback
+  // key's high-value turn references precede the primary key's lower-value
+  // lexical cues under a tight budget, while a single key is byte-for-byte the
+  // pre-#1505 insertion order. We intentionally do NOT score-sort the merged set:
+  // explicit-cue's highest-value cues (turn references / content cues) are
+  // deliberately UNSCORED while lexical search hits carry numeric scores, so a
+  // score-DESC sort would invert the priority and demote turn references below
+  // weak lexical hits (cursor[bot] / codex P2 on this PR).
   const readSessionIds = resolveLcmReadSessionIds(options);
   await gatherAcrossReadSessions(readSessionIds, (sessionId) =>
     collectTurnReferenceEvidence({
@@ -397,18 +404,6 @@ export async function buildExplicitCueRecallSection(
       seenTurns,
     }),
   );
-
-  // #1505 codex P2 (review follow-up): explicit-cue does NOT relevance-rank
-  // before budgeting — `buildEvidencePack` consumes `evidenceItems` in order. So
-  // when MORE than one read key contributed, stable-sort by score DESC so the
-  // strongest cues win a tight budget regardless of which key produced them
-  // (otherwise the primary key's low-score cues, gathered first, could crowd out
-  // a fallback key's stronger cues). Search-scored cues rise; unscored cues
-  // (score `undefined` → 0) keep their relative gather order. Single-key recall
-  // skips the sort, so its output is byte-for-byte the pre-#1505 insertion order.
-  if (readSessionIds.length > 1) {
-    evidenceItems.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
-  }
 
   const evidenceFocusQuery = buildEvidenceFocusQuery(query, {
     includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -1,5 +1,8 @@
 import { buildEvidencePack } from "./evidence-pack.js";
-import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
+import {
+  gatherAcrossReadSessions,
+  resolveLcmReadSessionIds,
+} from "./lcm-fallback-read.js";
 
 export interface ExplicitCueRecallEngine {
   expandContext(
@@ -338,55 +341,51 @@ export async function buildExplicitCueRecallSection(
   // fallback cues are RECOVERED instead of being skipped by the old
   // first-non-empty short-circuit. `seenTurns` dedupes across keys by
   // `session_id`+`turn_index`; the budget is applied exactly once in the
-  // `buildEvidencePack` call below.
+  // `buildEvidencePack` call below. `gatherAcrossReadSessions` isolates a
+  // per-key read failure (a corrupt/locked fallback index must not discard the
+  // other keys' cues); single-key recall runs each collector directly, so a
+  // failure propagates exactly as before.
   //
-  // Ordering note: unlike the other LCM sections, explicit-cue does NOT
-  // relevance-rank before budgeting — `buildEvidencePack` consumes
-  // `evidenceItems` in insertion order. To keep a lower-value evidence TYPE from
-  // one key from crowding out a higher-value type from another key under a tight
-  // budget, gather is ordered by evidence TYPE first (turn references → content
-  // cues → lexical cues), then by read-key priority (primary overlay first)
-  // WITHIN each type. So a tight budget still prefers the primary key within a
-  // type, but a fallback key's turn references outrank the primary key's lexical
-  // cues. A single key (or a single sessionless `undefined`) runs each collector
-  // exactly once, in the original order — byte-for-byte the pre-#1505 behavior.
+  // Gather is ordered by evidence TYPE first (turn references → content cues →
+  // lexical cues), then by read-key priority within each type, so an unscored
+  // fallback cue keeps a sensible position relative to other unscored cues.
   const readSessionIds = resolveLcmReadSessionIds(options);
-  for (const sessionId of readSessionIds) {
-    await collectTurnReferenceEvidence({
+  await gatherAcrossReadSessions(readSessionIds, (sessionId) =>
+    collectTurnReferenceEvidence({
       engine,
       sessionId,
       query,
       maxReferences,
       evidenceItems,
       seenTurns,
-    });
-  }
+    }),
+  );
 
   if (options.includeContentLexicalCues) {
-    for (const sessionId of readSessionIds) {
-      await collectNamedMeetingFactEvidence({
+    await gatherAcrossReadSessions(readSessionIds, (sessionId) =>
+      collectNamedMeetingFactEvidence({
         engine,
         sessionId,
         query,
         maxReferences,
         evidenceItems,
         seenTurns,
-      });
-    }
+      }),
+    );
 
-    for (const sessionId of readSessionIds) {
-      await collectFocusedTranscriptCueEvidence({
+    await gatherAcrossReadSessions(readSessionIds, (sessionId) =>
+      collectFocusedTranscriptCueEvidence({
         engine,
         sessionId,
         query,
         evidenceItems,
         seenTurns,
-      });
-    }
+      }),
+    );
   }
 
-  for (const sessionId of readSessionIds) {
-    await collectLexicalCueEvidence({
+  await gatherAcrossReadSessions(readSessionIds, (sessionId) =>
+    collectLexicalCueEvidence({
       engine,
       sessionId,
       query,
@@ -396,7 +395,19 @@ export async function buildExplicitCueRecallSection(
       includeStructuredPlanCues: options.includeStructuredPlanCues,
       evidenceItems,
       seenTurns,
-    });
+    }),
+  );
+
+  // #1505 codex P2 (review follow-up): explicit-cue does NOT relevance-rank
+  // before budgeting — `buildEvidencePack` consumes `evidenceItems` in order. So
+  // when MORE than one read key contributed, stable-sort by score DESC so the
+  // strongest cues win a tight budget regardless of which key produced them
+  // (otherwise the primary key's low-score cues, gathered first, could crowd out
+  // a fallback key's stronger cues). Search-scored cues rise; unscored cues
+  // (score `undefined` → 0) keep their relative gather order. Single-key recall
+  // skips the sort, so its output is byte-for-byte the pre-#1505 insertion order.
+  if (readSessionIds.length > 1) {
+    evidenceItems.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
   }
 
   const evidenceFocusQuery = buildEvidenceFocusQuery(query, {

--- a/packages/remnic-core/src/focused-list-recall.ts
+++ b/packages/remnic-core/src/focused-list-recall.ts
@@ -4,7 +4,10 @@ import {
   type EvidencePackItem,
 } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
-import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
+import {
+  gatherAcrossReadSessions,
+  resolveLcmReadSessionIds,
+} from "./lcm-fallback-read.js";
 
 export interface FocusedListRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
@@ -63,13 +66,15 @@ export async function buildFocusedListRecallSection(
   // (primary overlay → project/root fallbacks) and UNION them into the existing
   // rank/dedupe/budget pass, so a stronger project-fallback candidate is not
   // masked by a weak primary-key hit. `rankAndDedupeFocusedListItems` applies
-  // the section-appropriate dedupe; the budget is applied exactly once below.
-  // The single-key path runs exactly one collect — byte-for-byte the pre-#1505
-  // behavior.
+  // the section-appropriate dedupe and relevance rank; the budget is applied
+  // exactly once below. `gatherAcrossReadSessions` isolates a per-key read
+  // failure so a corrupt/locked fallback index can't discard the primary key's
+  // candidates; the single-key path runs exactly one collect and propagates a
+  // failure as before — byte-for-byte the pre-#1505 behavior.
   const items: EvidencePackItem[] = [];
-  for (const sessionId of resolveLcmReadSessionIds(options)) {
+  await gatherAcrossReadSessions(resolveLcmReadSessionIds(options), async (sessionId) => {
     items.push(...(await collectFocusedListItems({ ...options, sessionId }, intent)));
-  }
+  });
   const ranked = rankAndDedupeFocusedListItems(items, options.query, intent)
     .slice(0, maxResults);
   if (ranked.length === 0) {

--- a/packages/remnic-core/src/focused-list-recall.ts
+++ b/packages/remnic-core/src/focused-list-recall.ts
@@ -4,10 +4,17 @@ import {
   type EvidencePackItem,
 } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
 
 export interface FocusedListRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
+  /**
+   * Ordered, read-authorized LCM read key set (primary overlay → project/root
+   * fallbacks). When present, evidence is gathered across EVERY key and merged
+   * under this section's budget (#1505 codex P2). Falls back to `sessionId`.
+   */
+  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -52,7 +59,17 @@ export async function buildFocusedListRecallSection(
     return "";
   }
 
-  const items = await collectFocusedListItems(options, intent);
+  // #1505 codex P2: gather candidates across the ordered LCM read key set
+  // (primary overlay → project/root fallbacks) and UNION them into the existing
+  // rank/dedupe/budget pass, so a stronger project-fallback candidate is not
+  // masked by a weak primary-key hit. `rankAndDedupeFocusedListItems` applies
+  // the section-appropriate dedupe; the budget is applied exactly once below.
+  // The single-key path runs exactly one collect — byte-for-byte the pre-#1505
+  // behavior.
+  const items: EvidencePackItem[] = [];
+  for (const sessionId of resolveLcmReadSessionIds(options)) {
+    items.push(...(await collectFocusedListItems({ ...options, sessionId }, intent)));
+  }
   const ranked = rankAndDedupeFocusedListItems(items, options.query, intent)
     .slice(0, maxResults);
   if (ranked.length === 0) {

--- a/packages/remnic-core/src/lcm-fallback-read.ts
+++ b/packages/remnic-core/src/lcm-fallback-read.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared helper for reading LCM-backed recall sections across the ordered,
+ * read-authorized fallback key set (#1505 codex P2 "Merge LCM fallback reads
+ * instead of short-circuiting").
+ *
+ * Background: a branch-scoped session archives its LCM rows under whichever
+ * coding-overlay namespace was effective at write time, so its evidence can be
+ * split across the primary overlay key AND the project / root fallback keys.
+ * Normal QMD/file recall already searches the primary namespace PLUS
+ * `codingOverlay.readFallbacks` and MERGES the rows. The LCM read path must do
+ * the same: query EVERY authorized read key and merge the candidate evidence
+ * into each section's existing dedupe + rank + budget pass, instead of stopping
+ * at the first key that happens to yield a (possibly weak) hit.
+ *
+ * Each section already owns a section-appropriate dedupe (a `seen` set or a
+ * `rankAndDedupe…` step), so the fan-out only needs to resolve the ordered,
+ * deduped read-key set and UNION the per-key candidates into that existing
+ * pipeline — the budget is then applied exactly once to the union. Centralizing
+ * the key-set resolution here (rather than re-implementing per builder) follows
+ * CLAUDE.md rule 22 (scope resolution must be deduplicated).
+ */
+
+/** A recall section's LCM read target: either a single key or an ordered set. */
+export interface LcmReadSessionTarget {
+  /**
+   * The single LCM read `session_id` (pre-#1505 behavior). `undefined` means a
+   * sessionless, archive-wide read with no `session_id` filter.
+   */
+  sessionId?: string;
+  /**
+   * The ordered, read-authorized LCM read key set (primary overlay key first,
+   * then project / root fallbacks) the orchestrator derived from the same
+   * readable namespace set normal recall searches. When present and non-empty,
+   * it supersedes `sessionId`.
+   */
+  sessionIds?: readonly (string | undefined)[];
+}
+
+// `undefined` (a sessionless, archive-wide read) is a distinct, legitimate read
+// target, so it needs a non-string sentinel in the dedupe set. A leading space
+// keeps it disjoint from every real session key / namespaced LCM key (which are
+// `[A-Za-z0-9._-]` plus the U+001F namespace sentinel, never leading-space).
+const UNDEFINED_SESSION_SENTINEL = " <lcm-sessionless>";
+
+/**
+ * Resolve the ordered, deduped set of LCM read `session_id`s a recall section
+ * must query.
+ *
+ * When `sessionIds` is provided (the #1505 fallback unification), it is used
+ * verbatim, deduped while preserving first-seen order so the caller queries
+ * keys in priority order (primary overlay → fallbacks) without re-querying an
+ * identical key (e.g. when two namespaces both collapse to the default store).
+ * Otherwise the section reads under the single `sessionId`, so the result is
+ * `[sessionId]` — byte-for-byte the pre-#1505 single-key behavior, including a
+ * single `undefined` for a sessionless archive-wide read.
+ */
+export function resolveLcmReadSessionIds(
+  target: LcmReadSessionTarget,
+): Array<string | undefined> {
+  const source =
+    target.sessionIds && target.sessionIds.length > 0
+      ? target.sessionIds
+      : [target.sessionId];
+  const seen = new Set<string>();
+  const out: Array<string | undefined> = [];
+  for (const sessionId of source) {
+    const key = sessionId === undefined ? UNDEFINED_SESSION_SENTINEL : sessionId;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(sessionId);
+  }
+  // Defensive: an all-empty `sessionIds` still collapses to the single-key path.
+  return out.length > 0 ? out : [target.sessionId];
+}

--- a/packages/remnic-core/src/lcm-fallback-read.ts
+++ b/packages/remnic-core/src/lcm-fallback-read.ts
@@ -72,3 +72,42 @@ export function resolveLcmReadSessionIds(
   // Defensive: an all-empty `sessionIds` still collapses to the single-key path.
   return out.length > 0 ? out : [target.sessionId];
 }
+
+/**
+ * Run a per-key LCM `gather` across the resolved read-key set with FAULT
+ * ISOLATION across keys (#1505 codex P2 review follow-up).
+ *
+ * A recall section that reads every key in a bare `for…await` loop loses the
+ * WHOLE section if any one key throws (e.g. a `SqliteError` from a corrupt or
+ * locked fallback index) — even when the primary overlay key already gathered
+ * evidence. The pre-#1505 first-non-empty read never had this problem: it
+ * returned the primary key's non-empty result without ever touching a failing
+ * fallback. This helper restores that resilience for the merged path: when more
+ * than one key is read, a per-key failure is contained so the other keys'
+ * evidence survives (best-effort recall — a total failure degrades to an empty
+ * section, which the orchestrator already treats as "no evidence").
+ *
+ * SINGLE-KEY is byte-for-byte the pre-#1505 behavior: the gather runs directly,
+ * so a failure PROPAGATES exactly as before (the caller / orchestrator catch
+ * still logs it). Fault isolation only engages once there is a fallback key that
+ * could fail independently of the primary.
+ */
+export async function gatherAcrossReadSessions(
+  sessionIds: ReadonlyArray<string | undefined>,
+  gather: (sessionId: string | undefined) => Promise<void>,
+): Promise<void> {
+  if (sessionIds.length <= 1) {
+    for (const sessionId of sessionIds) {
+      await gather(sessionId);
+    }
+    return;
+  }
+  for (const sessionId of sessionIds) {
+    try {
+      await gather(sessionId);
+    } catch {
+      // One read key failed; keep the evidence already gathered from the other
+      // keys instead of discarding the whole section.
+    }
+  }
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9955,7 +9955,13 @@ export class Orchestrator {
           // `formatStructuredRecall` — otherwise weak primary-key parts could crowd
           // out stronger fallback parts. Stable sort: a single key is already in
           // this order, so it stays byte-for-byte the pre-#1505 behavior.
-          .sort((a, b) => b.score - a.score || b.turn_index - a.turn_index);
+          // `?? 0` is defensive: `LcmStructuredRecallMatch.score` is always a
+          // number here, but a bare `b.score - a.score` would yield NaN (falsy)
+          // for any future unscored match and silently fall through to turn order.
+          .sort(
+            (a, b) =>
+              (b.score ?? 0) - (a.score ?? 0) || b.turn_index - a.turn_index,
+          );
         const structuredSection = this.lcmEngine.formatStructuredRecall(
           structuredMatches,
           Math.ceil(this.config.recallBudgetChars * 0.08),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9921,18 +9921,35 @@ export class Orchestrator {
         // below. A sessionless key (`undefined`) normalizes to "" → no matches
         // (structured parts are inherently per-session; pre-#1505 behavior, codex
         // P2).
-        const structuredBatches = await Promise.all(
+        // FAULT ISOLATION (allSettled, not all): the pre-#1505 first-non-empty read
+        // short-circuited, so a fallback key was often never queried and its latent
+        // search failure never surfaced. Querying every key eagerly must NOT let one
+        // key's failure (e.g. a SqliteError from a corrupt/locked fallback index)
+        // reject the batch and discard the OTHER keys' parts — or, since this and
+        // the compressed-history read below share one try block, silently drop the
+        // compressed-history section a healthy primary key would still produce. So
+        // read each key independently and keep the fulfilled batches.
+        const structuredSettled = await Promise.allSettled(
           lcmReadSessionIds.map((lcmSessionId) =>
             this.lcmEngine!.searchStructuredParts(lcmSessionId ?? "", retrievalQuery),
           ),
         );
+        for (const settled of structuredSettled) {
+          if (settled.status === "rejected") {
+            log.debug(
+              `LCM structured-parts read failed for one key: ${settled.reason}`,
+            );
+          }
+        }
         const seenStructuredParts = new Set<string>();
-        const structuredMatches = structuredBatches.flat().filter((match) => {
-          const key = `${match.session_id} ${match.turn_index} ${match.part_id}`;
-          if (seenStructuredParts.has(key)) return false;
-          seenStructuredParts.add(key);
-          return true;
-        })
+        const structuredMatches = structuredSettled
+          .flatMap((settled) => (settled.status === "fulfilled" ? settled.value : []))
+          .filter((match) => {
+            const key = `${match.session_id} ${match.turn_index} ${match.part_id}`;
+            if (seenStructuredParts.has(key)) return false;
+            seenStructuredParts.add(key);
+            return true;
+          })
           // Restore the archive's per-key ordering (score DESC, then turn DESC)
           // across the MERGED set so the strongest parts win the shared budget in
           // `formatStructuredRecall` — otherwise weak primary-key parts could crowd

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9717,25 +9717,38 @@ export class Orchestrator {
       shouldRecallEventOrderEvidence(retrievalQuery)
     ) {
       try {
-        const eventOrderSection = await buildEventOrderRecallSection({
-          engine: this.lcmEngine,
-          // #1495 thread 3 + #1505 fallback unification: read across the ordered
-          // LCM read key set so a branch-scoped session reads its own
-          // chronological event-order evidence even at project/root scope. #1505
-          // codex P2: the builder MERGES per-key turns under its single budget.
-          sessionIds: lcmReadSessionIds,
-          query: retrievalQuery,
-          maxChars: eventOrderMaxChars,
-          maxItems:
-            this.getRecallSectionNumber("event-order", "maxResults") ??
-            this.config.eventOrderRecallMaxResults,
-          maxScanWindowTurns:
-            this.getRecallSectionNumber("event-order", "maxTurns") ??
-            this.config.eventOrderRecallScanWindowTurns,
-          maxScanWindowTokens:
-            this.getRecallSectionNumber("event-order", "maxTokens") ??
-            this.config.eventOrderRecallScanWindowTokens,
-        });
+        // #1495 thread 3 + #1505 fallback unification: read across the ordered LCM
+        // read key set so a branch-scoped session reads its own chronological
+        // event-order evidence even at project/root scope. UNLIKE the relevance-
+        // ranked sections, event-order must NOT merge across keys: `turn_index` is
+        // LOCAL to each LCM `session_id` (`observe` numbers turns per session via
+        // `getMaxTurnIndex`), so interleaving two keys and sorting by `turn_index`
+        // would place an older project-scope turn after a newer branch-scope turn
+        // and misstate the chronology (#1505 codex P2). Like compressed-history,
+        // event-order is an inherently per-session ORDERED artifact, so it takes
+        // the highest-priority authorized key (primary overlay → project/root)
+        // that actually has chronological evidence — each key's timeline is
+        // internally consistent.
+        const eventOrderSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildEventOrderRecallSection({
+              engine: this.lcmEngine,
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: eventOrderMaxChars,
+              maxItems:
+                this.getRecallSectionNumber("event-order", "maxResults") ??
+                this.config.eventOrderRecallMaxResults,
+              maxScanWindowTurns:
+                this.getRecallSectionNumber("event-order", "maxTurns") ??
+                this.config.eventOrderRecallScanWindowTurns,
+              maxScanWindowTokens:
+                this.getRecallSectionNumber("event-order", "maxTokens") ??
+                this.config.eventOrderRecallScanWindowTokens,
+            }),
+          (s) => !s,
+          "",
+        );
         if (eventOrderSection) {
           this.appendRecallSection(
             sectionBuckets,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7243,16 +7243,24 @@ export class Orchestrator {
     );
     // Query an LCM-backed read across the ordered read key set and return the
     // FIRST non-empty result (#1505 fallback-namespace unification). The primary
-    // overlay key is tried first; if a branch-scoped session has no rows under
-    // its branch key, the project / root fallback keys are tried in order. Each
-    // builder applies its own per-session budget/limit, so taking the first hit
-    // (rather than concatenating across keys) preserves existing budgets while
-    // recovering fallback evidence. When the set is a single key (single-user /
-    // no-overlay / explicit-namespace), this is exactly one call — unchanged.
-    // `lcmSessionId` is `string | undefined`: a SESSIONLESS recall yields the
-    // single `undefined` key so the LCM builders run ONE archive-wide read with
-    // no `session_id` filter (pre-#1505 behavior; the builders accept an optional
-    // `sessionId`). NEVER the literal "default" session id (codex P2).
+    // overlay key is tried first; if a branch-scoped session has no rows under its
+    // branch key, the project / root fallback keys are tried in order.
+    //
+    // #1505 codex P2 ("Merge LCM fallback reads instead of short-circuiting"): the
+    // query-SCORED sections (explicit-cue, targeted-facts, focused-list,
+    // response-guidance, event-order, structured message-parts) no longer use this
+    // helper — they MERGE candidates across EVERY authorized key under their single
+    // budget (a weak primary-key hit must not mask stronger fallback evidence; the
+    // section builders take `sessionIds`, structured-parts merges inline below).
+    // This first-non-empty helper now serves ONLY the compressed-history section,
+    // which is a per-session HOLISTIC DAG narrative with no per-item id to merge or
+    // dedupe on — see its call site for the rationale.
+    //
+    // When the set is a single key (single-user / no-overlay / explicit-namespace),
+    // this is exactly one call — unchanged. `lcmSessionId` is `string | undefined`:
+    // a SESSIONLESS recall yields the single `undefined` key so the read runs ONE
+    // archive-wide read with no `session_id` filter (pre-#1505 behavior). NEVER the
+    // literal "default" session id (codex P2).
     const firstNonEmptyLcmRead = async <T>(
       read: (lcmSessionId: string | undefined) => Promise<T>,
       isEmpty: (value: T) => boolean,
@@ -9513,24 +9521,21 @@ export class Orchestrator {
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
       try {
-        const explicitCueSection = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            buildExplicitCueRecallSection({
-              engine: this.lcmEngine,
-              // #1495 thread 3 + #1505 fallback unification: read across the
-              // ordered LCM read key set (primary overlay → coding fallbacks)
-              // so a branch-scoped session finds its own explicit-cue evidence
-              // even when archived at project/root scope (rule 39).
-              sessionId: lcmSessionId,
-              query: retrievalQuery,
-              maxChars: explicitCueMaxChars,
-              maxReferences:
-                this.getRecallSectionNumber("explicit-cue", "maxResults") ??
-                this.config.explicitCueRecallMaxReferences,
-            }),
-          (s) => !s,
-          "",
-        );
+        const explicitCueSection = await buildExplicitCueRecallSection({
+          engine: this.lcmEngine,
+          // #1495 thread 3 + #1505 fallback unification: read across the ordered
+          // LCM read key set (primary overlay → coding fallbacks) so a
+          // branch-scoped session finds its own explicit-cue evidence even when
+          // archived at project/root scope (rule 39). #1505 codex P2: the builder
+          // MERGES candidates across every key under its single budget instead of
+          // short-circuiting on the first non-empty key.
+          sessionIds: lcmReadSessionIds,
+          query: retrievalQuery,
+          maxChars: explicitCueMaxChars,
+          maxReferences:
+            this.getRecallSectionNumber("explicit-cue", "maxResults") ??
+            this.config.explicitCueRecallMaxReferences,
+        });
         if (explicitCueSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9560,29 +9565,25 @@ export class Orchestrator {
       shouldRecallTargetedFactEvidence(retrievalQuery)
     ) {
       try {
-        const targetedFactSection = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            buildTargetedFactRecallSection({
-              engine: this.lcmEngine,
-              // #1495 + #1505 fallback unification: read across the ordered LCM
-              // read key set so a branch-scoped session finds its own
-              // targeted-fact evidence even when archived at project/root scope.
-              sessionId: lcmSessionId,
-              query: retrievalQuery,
-              maxChars: targetedFactMaxChars,
-              maxSearchResults:
-                this.getRecallSectionNumber("targeted-facts", "maxResults") ??
-                this.config.targetedFactRecallMaxResults,
-              maxScanWindowTurns:
-                this.getRecallSectionNumber("targeted-facts", "maxTurns") ??
-                this.config.targetedFactRecallScanWindowTurns,
-              maxScanWindowTokens:
-                this.getRecallSectionNumber("targeted-facts", "maxTokens") ??
-                this.config.targetedFactRecallScanWindowTokens,
-            }),
-          (s) => !s,
-          "",
-        );
+        const targetedFactSection = await buildTargetedFactRecallSection({
+          engine: this.lcmEngine,
+          // #1495 + #1505 fallback unification: read across the ordered LCM read
+          // key set so a branch-scoped session finds its own targeted-fact
+          // evidence even when archived at project/root scope. #1505 codex P2: the
+          // builder MERGES candidates across every key under its single budget.
+          sessionIds: lcmReadSessionIds,
+          query: retrievalQuery,
+          maxChars: targetedFactMaxChars,
+          maxSearchResults:
+            this.getRecallSectionNumber("targeted-facts", "maxResults") ??
+            this.config.targetedFactRecallMaxResults,
+          maxScanWindowTurns:
+            this.getRecallSectionNumber("targeted-facts", "maxTurns") ??
+            this.config.targetedFactRecallScanWindowTurns,
+          maxScanWindowTokens:
+            this.getRecallSectionNumber("targeted-facts", "maxTokens") ??
+            this.config.targetedFactRecallScanWindowTokens,
+        });
         if (targetedFactSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9613,29 +9614,26 @@ export class Orchestrator {
       shouldRecallFocusedListEvidence(retrievalQuery)
     ) {
       try {
-        const focusedListSection = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            buildFocusedListRecallSection({
-              engine: this.lcmEngine,
-              // #1495 thread 3 + #1505 fallback unification: read across the
-              // ordered LCM read key set so a branch-scoped session reads its own
-              // focused-list/count evidence even at project/root scope (rule 39).
-              sessionId: lcmSessionId,
-              query: retrievalQuery,
-              maxChars: focusedListMaxChars,
-              maxSearchResults:
-                this.getRecallSectionNumber("focused-list", "maxResults") ??
-                this.config.focusedListRecallMaxResults,
-              maxScanWindowTurns:
-                this.getRecallSectionNumber("focused-list", "maxTurns") ??
-                this.config.focusedListRecallScanWindowTurns,
-              maxScanWindowTokens:
-                this.getRecallSectionNumber("focused-list", "maxTokens") ??
-                this.config.focusedListRecallScanWindowTokens,
-            }),
-          (s) => !s,
-          "",
-        );
+        const focusedListSection = await buildFocusedListRecallSection({
+          engine: this.lcmEngine,
+          // #1495 thread 3 + #1505 fallback unification: read across the ordered
+          // LCM read key set so a branch-scoped session reads its own
+          // focused-list/count evidence even at project/root scope (rule 39).
+          // #1505 codex P2: the builder MERGES candidates across every key under
+          // its single budget.
+          sessionIds: lcmReadSessionIds,
+          query: retrievalQuery,
+          maxChars: focusedListMaxChars,
+          maxSearchResults:
+            this.getRecallSectionNumber("focused-list", "maxResults") ??
+            this.config.focusedListRecallMaxResults,
+          maxScanWindowTurns:
+            this.getRecallSectionNumber("focused-list", "maxTurns") ??
+            this.config.focusedListRecallScanWindowTurns,
+          maxScanWindowTokens:
+            this.getRecallSectionNumber("focused-list", "maxTokens") ??
+            this.config.focusedListRecallScanWindowTokens,
+        });
         if (focusedListSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9670,30 +9668,27 @@ export class Orchestrator {
       (responseGuidanceMatchesQuery || responseGuidanceForcedByPipeline)
     ) {
       try {
-        const responseGuidanceSection = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            buildResponseGuidanceRecallSection({
-              engine: this.lcmEngine,
-              // #1495 thread 3 + #1505 fallback unification: read across the
-              // ordered LCM read key set so a branch-scoped session reads its own
-              // response-guidance evidence even at project/root scope (rule 39).
-              sessionId: lcmSessionId,
-              query: retrievalQuery,
-              maxChars: responseGuidanceMaxChars,
-              maxSearchResults:
-                this.getRecallSectionNumber("response-guidance", "maxResults") ??
-                this.config.responseGuidanceRecallMaxResults,
-              maxScanWindowTurns:
-                this.getRecallSectionNumber("response-guidance", "maxTurns") ??
-                this.config.responseGuidanceRecallScanWindowTurns,
-              maxScanWindowTokens:
-                this.getRecallSectionNumber("response-guidance", "maxTokens") ??
-                this.config.responseGuidanceRecallScanWindowTokens,
-              forceGeneric: responseGuidanceForcedByPipeline,
-            }),
-          (s) => !s,
-          "",
-        );
+        const responseGuidanceSection = await buildResponseGuidanceRecallSection({
+          engine: this.lcmEngine,
+          // #1495 thread 3 + #1505 fallback unification: read across the ordered
+          // LCM read key set so a branch-scoped session reads its own
+          // response-guidance evidence even at project/root scope (rule 39).
+          // #1505 codex P2: the builder MERGES candidates across every key under
+          // its single budget.
+          sessionIds: lcmReadSessionIds,
+          query: retrievalQuery,
+          maxChars: responseGuidanceMaxChars,
+          maxSearchResults:
+            this.getRecallSectionNumber("response-guidance", "maxResults") ??
+            this.config.responseGuidanceRecallMaxResults,
+          maxScanWindowTurns:
+            this.getRecallSectionNumber("response-guidance", "maxTurns") ??
+            this.config.responseGuidanceRecallScanWindowTurns,
+          maxScanWindowTokens:
+            this.getRecallSectionNumber("response-guidance", "maxTokens") ??
+            this.config.responseGuidanceRecallScanWindowTokens,
+          forceGeneric: responseGuidanceForcedByPipeline,
+        });
         if (responseGuidanceSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9722,29 +9717,25 @@ export class Orchestrator {
       shouldRecallEventOrderEvidence(retrievalQuery)
     ) {
       try {
-        const eventOrderSection = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            buildEventOrderRecallSection({
-              engine: this.lcmEngine,
-              // #1495 thread 3 + #1505 fallback unification: read across the
-              // ordered LCM read key set so a branch-scoped session reads its own
-              // chronological event-order evidence even at project/root scope.
-              sessionId: lcmSessionId,
-              query: retrievalQuery,
-              maxChars: eventOrderMaxChars,
-              maxItems:
-                this.getRecallSectionNumber("event-order", "maxResults") ??
-                this.config.eventOrderRecallMaxResults,
-              maxScanWindowTurns:
-                this.getRecallSectionNumber("event-order", "maxTurns") ??
-                this.config.eventOrderRecallScanWindowTurns,
-              maxScanWindowTokens:
-                this.getRecallSectionNumber("event-order", "maxTokens") ??
-                this.config.eventOrderRecallScanWindowTokens,
-            }),
-          (s) => !s,
-          "",
-        );
+        const eventOrderSection = await buildEventOrderRecallSection({
+          engine: this.lcmEngine,
+          // #1495 thread 3 + #1505 fallback unification: read across the ordered
+          // LCM read key set so a branch-scoped session reads its own
+          // chronological event-order evidence even at project/root scope. #1505
+          // codex P2: the builder MERGES per-key turns under its single budget.
+          sessionIds: lcmReadSessionIds,
+          query: retrievalQuery,
+          maxChars: eventOrderMaxChars,
+          maxItems:
+            this.getRecallSectionNumber("event-order", "maxResults") ??
+            this.config.eventOrderRecallMaxResults,
+          maxScanWindowTurns:
+            this.getRecallSectionNumber("event-order", "maxTurns") ??
+            this.config.eventOrderRecallScanWindowTurns,
+          maxScanWindowTokens:
+            this.getRecallSectionNumber("event-order", "maxTokens") ??
+            this.config.eventOrderRecallScanWindowTokens,
+        });
         if (eventOrderSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9918,21 +9909,36 @@ export class Orchestrator {
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
       try {
-        const structuredMatches = await firstNonEmptyLcmRead(
-          (lcmSessionId) =>
-            this.lcmEngine!.searchStructuredParts(
-              // #1495 + #1505 fallback unification: read across the ordered LCM
-              // read key set so a branch-scoped session reads its own structured
-              // message-part evidence even when archived at project/root scope.
-              // Structured parts are inherently per-session (the DAG is keyed by
-              // session_id), so a SESSIONLESS read (`undefined`) normalizes to
-              // empty → no section, the correct pre-#1505 behavior (codex P2).
-              lcmSessionId ?? "",
-              retrievalQuery,
-            ),
-          (matches) => matches.length === 0,
-          [],
+        // #1495 + #1505 fallback unification: read across the ordered LCM read
+        // key set so a branch-scoped session reads its own structured
+        // message-part evidence even when archived at project/root scope.
+        // #1505 codex P2: structured matches are query-SCORED evidence, so MERGE
+        // across EVERY key (primary overlay → project/root fallbacks) instead of
+        // short-circuiting on the first non-empty key — a weak branch-key hit must
+        // not mask stronger project-fallback parts. Keys are queried in priority
+        // order; dedupe by session_id+turn_index+part_id keeps the primary key's
+        // row on collision. `formatStructuredRecall` applies the single budget
+        // below. A sessionless key (`undefined`) normalizes to "" → no matches
+        // (structured parts are inherently per-session; pre-#1505 behavior, codex
+        // P2).
+        const structuredBatches = await Promise.all(
+          lcmReadSessionIds.map((lcmSessionId) =>
+            this.lcmEngine!.searchStructuredParts(lcmSessionId ?? "", retrievalQuery),
+          ),
         );
+        const seenStructuredParts = new Set<string>();
+        const structuredMatches = structuredBatches.flat().filter((match) => {
+          const key = `${match.session_id} ${match.turn_index} ${match.part_id}`;
+          if (seenStructuredParts.has(key)) return false;
+          seenStructuredParts.add(key);
+          return true;
+        })
+          // Restore the archive's per-key ordering (score DESC, then turn DESC)
+          // across the MERGED set so the strongest parts win the shared budget in
+          // `formatStructuredRecall` — otherwise weak primary-key parts could crowd
+          // out stronger fallback parts. Stable sort: a single key is already in
+          // this order, so it stays byte-for-byte the pre-#1505 behavior.
+          .sort((a, b) => b.score - a.score || b.turn_index - a.turn_index);
         const structuredSection = this.lcmEngine.formatStructuredRecall(
           structuredMatches,
           Math.ceil(this.config.recallBudgetChars * 0.08),
@@ -9955,15 +9961,20 @@ export class Orchestrator {
             }
           }
         }
+        // #1495 + #1505 fallback unification: read across the ordered LCM read key
+        // set so a branch-scoped session reads its own compressed-history evidence
+        // even at project/root scope. UNLIKE the query-scored sections above, the
+        // compressed history is a per-session HOLISTIC DAG narrative, not a set of
+        // independently-rankable evidence items — concatenating two sessions'
+        // summaries would double-count the conversation and blow the budget, and
+        // there is no per-item id to dedupe on. So this section deliberately keeps
+        // first-non-empty semantics (#1505 codex P2 scope: "merge the query-matched
+        // sections"): the highest-priority authorized key (primary overlay →
+        // project/root) that actually has a compressed history wins. A sessionless
+        // key (`undefined`) normalizes to empty → no section (pre-#1505 behavior).
         const lcmSection = await firstNonEmptyLcmRead(
           (lcmSessionId) =>
             this.lcmEngine!.assembleRecall(
-              // #1495 + #1505 fallback unification: read across the ordered LCM
-              // read key set so a branch-scoped session reads its own
-              // compressed-history evidence even at project/root scope.
-              // Compressed history is inherently per-session (a per-session DAG),
-              // so a SESSIONLESS read (`undefined`) normalizes to empty → no
-              // section, the correct pre-#1505 behavior (codex P2).
               lcmSessionId ?? "",
               this.config.recallBudgetChars,
             ),

--- a/packages/remnic-core/src/response-guidance-recall.ts
+++ b/packages/remnic-core/src/response-guidance-recall.ts
@@ -1,9 +1,16 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
 
 export interface ResponseGuidanceRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
+  /**
+   * Ordered, read-authorized LCM read key set (primary overlay → project/root
+   * fallbacks). When present, evidence is gathered across EVERY key and merged
+   * under this section's budget (#1505 codex P2). Falls back to `sessionId`.
+   */
+  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -157,7 +164,15 @@ export async function buildResponseGuidanceRecallSection(
   ) {
     return "";
   }
-  const items = await collectGuidanceItems(options, intents);
+  // #1505 codex P2: gather candidates across the ordered LCM read key set
+  // (primary overlay → project/root fallbacks) and UNION them into the existing
+  // rank/dedupe/budget pass, so stronger project-fallback guidance is not masked
+  // by a weak primary-key hit. The single-key path collects exactly once —
+  // byte-for-byte the pre-#1505 behavior.
+  const items: EvidencePackItem[] = [];
+  for (const sessionId of resolveLcmReadSessionIds(options)) {
+    items.push(...(await collectGuidanceItems({ ...options, sessionId }, intents)));
+  }
   const ranked = rankAndDedupeGuidanceItems(items, options.query, intents)
     .slice(0, maxResults);
   if (ranked.length === 0) {

--- a/packages/remnic-core/src/response-guidance-recall.ts
+++ b/packages/remnic-core/src/response-guidance-recall.ts
@@ -1,6 +1,9 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
-import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
+import {
+  gatherAcrossReadSessions,
+  resolveLcmReadSessionIds,
+} from "./lcm-fallback-read.js";
 
 export interface ResponseGuidanceRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
@@ -167,12 +170,14 @@ export async function buildResponseGuidanceRecallSection(
   // #1505 codex P2: gather candidates across the ordered LCM read key set
   // (primary overlay → project/root fallbacks) and UNION them into the existing
   // rank/dedupe/budget pass, so stronger project-fallback guidance is not masked
-  // by a weak primary-key hit. The single-key path collects exactly once —
-  // byte-for-byte the pre-#1505 behavior.
+  // by a weak primary-key hit. `gatherAcrossReadSessions` isolates a per-key read
+  // failure so a corrupt/locked fallback index can't discard the primary key's
+  // guidance; the single-key path collects exactly once and propagates a failure
+  // as before — byte-for-byte the pre-#1505 behavior.
   const items: EvidencePackItem[] = [];
-  for (const sessionId of resolveLcmReadSessionIds(options)) {
+  await gatherAcrossReadSessions(resolveLcmReadSessionIds(options), async (sessionId) => {
     items.push(...(await collectGuidanceItems({ ...options, sessionId }, intents)));
-  }
+  });
   const ranked = rankAndDedupeGuidanceItems(items, options.query, intents)
     .slice(0, maxResults);
   if (ranked.length === 0) {

--- a/packages/remnic-core/src/targeted-fact-recall.ts
+++ b/packages/remnic-core/src/targeted-fact-recall.ts
@@ -4,7 +4,10 @@ import {
   type EvidencePackItem,
 } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
-import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
+import {
+  gatherAcrossReadSessions,
+  resolveLcmReadSessionIds,
+} from "./lcm-fallback-read.js";
 
 export interface TargetedFactRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
@@ -53,14 +56,16 @@ export async function buildTargetedFactRecallSection(
   // #1505 codex P2: gather candidates across the ordered LCM read key set
   // (primary overlay → project/root fallbacks) and UNION them into the existing
   // rank/dedupe/budget pass, so stronger project-fallback evidence is not masked
-  // by a weak primary-key hit. The single-key path collects exactly one
-  // search+scan pair — byte-for-byte the pre-#1505 behavior.
+  // by a weak primary-key hit. `gatherAcrossReadSessions` isolates a per-key read
+  // failure so a corrupt/locked fallback index can't discard the primary key's
+  // evidence; the single-key path collects exactly one search+scan pair and
+  // propagates a failure as before — byte-for-byte the pre-#1505 behavior.
   const collected: EvidencePackItem[] = [];
-  for (const sessionId of resolveLcmReadSessionIds(options)) {
+  await gatherAcrossReadSessions(resolveLcmReadSessionIds(options), async (sessionId) => {
     const scoped = { ...options, sessionId };
     collected.push(...(await collectTargetedFactSearchItems(scoped)));
     collected.push(...(await collectTargetedFactScanItems(scoped)));
-  }
+  });
   const ranked = rankAndDedupeTargetedFactItems(
     collected,
     options.query,

--- a/packages/remnic-core/src/targeted-fact-recall.ts
+++ b/packages/remnic-core/src/targeted-fact-recall.ts
@@ -4,10 +4,17 @@ import {
   type EvidencePackItem,
 } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
+import { resolveLcmReadSessionIds } from "./lcm-fallback-read.js";
 
 export interface TargetedFactRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
+  /**
+   * Ordered, read-authorized LCM read key set (primary overlay → project/root
+   * fallbacks). When present, evidence is gathered across EVERY key and merged
+   * under this section's budget (#1505 codex P2). Falls back to `sessionId`.
+   */
+  sessionIds?: readonly (string | undefined)[];
   query: string;
   maxChars: number;
   maxItemChars?: number;
@@ -43,10 +50,19 @@ export async function buildTargetedFactRecallSection(
     return "";
   }
 
-  const searchItems = await collectTargetedFactSearchItems(options);
-  const scannedItems = await collectTargetedFactScanItems(options);
+  // #1505 codex P2: gather candidates across the ordered LCM read key set
+  // (primary overlay → project/root fallbacks) and UNION them into the existing
+  // rank/dedupe/budget pass, so stronger project-fallback evidence is not masked
+  // by a weak primary-key hit. The single-key path collects exactly one
+  // search+scan pair — byte-for-byte the pre-#1505 behavior.
+  const collected: EvidencePackItem[] = [];
+  for (const sessionId of resolveLcmReadSessionIds(options)) {
+    const scoped = { ...options, sessionId };
+    collected.push(...(await collectTargetedFactSearchItems(scoped)));
+    collected.push(...(await collectTargetedFactScanItems(scoped)));
+  }
   const ranked = rankAndDedupeTargetedFactItems(
-    [...searchItems, ...scannedItems],
+    collected,
     options.query,
   ).slice(0, maxResults);
 

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -773,3 +773,310 @@ test("#1505 fallback read-auth: an unreadable principal self/overlay namespace i
     );
   }
 });
+
+test("#1505 codex P2: a WEAK branch-key hit must NOT mask stronger project-fallback LCM evidence (merge, don't short-circuit)", async () => {
+  // Round 6 read the ordered LCM key set but STOPPED at the first non-empty key
+  // (`firstNonEmptyLcmRead`). So if the primary BRANCH overlay key has ANY
+  // matching evidence — even a single weak hit — the project/root fallback keys
+  // are NEVER queried, and stronger project-scope evidence is silently dropped.
+  // This diverges from QMD/file recall, which searches the primary namespace PLUS
+  // `codingOverlay.readFallbacks` and MERGES. This pins the merge: each
+  // query-matched LCM section must query EVERY authorized read key and merge +
+  // dedupe results under its existing budget, so the project-fallback evidence
+  // surfaces even when the branch key already returned a (weaker) hit.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-merge-"));
+  const sessionId = "alice:branch-session";
+  const projectId = "origin:proj7777";
+
+  const lcmQueriedSessionIds: string[] = [];
+  let branchOverlayKey = "";
+  let projectFallbackKey = "";
+  // The BRANCH key returns a non-empty but WEAK hit (turn 5, low score); the
+  // PROJECT fallback key returns STRONGER, distinct evidence (turn 7, high
+  // score). first-non-empty surfaces ONLY the weak branch hit (fail-before);
+  // merging across the readable set surfaces BOTH (pass-after).
+  const branchHit = {
+    turn_index: 5,
+    role: "user",
+    content:
+      "WEAK_BRANCH_EVIDENCE: my culinary journey jotted a quick note about Thai food.",
+  };
+  const projectHit = {
+    turn_index: 7,
+    role: "user",
+    content:
+      "STRONG_PROJECT_EVIDENCE: my culinary journey started with Turkish, Greek, and Lebanese cuisines.",
+  };
+  const evidenceFor = (requestedSessionId?: string, limit = 8) => {
+    lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+    if (requestedSessionId === branchOverlayKey) {
+      return [
+        {
+          id: 0,
+          session_id: branchOverlayKey,
+          turn_index: branchHit.turn_index,
+          role: branchHit.role,
+          content: branchHit.content,
+          score: 10,
+        },
+      ].slice(0, limit);
+    }
+    if (requestedSessionId === projectFallbackKey) {
+      return [
+        {
+          id: 1,
+          session_id: projectFallbackKey,
+          turn_index: projectHit.turn_index,
+          role: projectHit.role,
+          content: projectHit.content,
+          score: 100,
+        },
+      ].slice(0, limit);
+    }
+    return [] as Array<{
+      id: number;
+      session_id: string;
+      turn_index: number;
+      role: string;
+      content: string;
+      score: number;
+    }>;
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    codingMode: { projectScope: true, branchScope: true },
+    explicitCueRecallEnabled: true,
+    focusedListRecallEnabled: true,
+    eventOrderRecallEnabled: true,
+    recallPipeline: [
+      { id: "event-order", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "focused-list", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "explicit-cue", enabled: true, maxChars: 2_400, maxResults: 8 },
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/cuisines",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  assert.notEqual(branchOverlayNs, "alice", "branch overlay must change the namespace");
+  const projectFallbackNs = projectFallbackNamespace(orchestrator, "alice", projectId);
+  assert.notEqual(
+    projectFallbackNs,
+    branchOverlayNs,
+    "project fallback namespace must differ from the branch overlay namespace",
+  );
+  branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  projectFallbackKey = encodeNs(projectFallbackNs, sessionId);
+
+  const expandFor = (requestedSessionId: string) => {
+    if (requestedSessionId === branchOverlayKey) return [branchHit];
+    if (requestedSessionId === projectFallbackKey) return [projectHit];
+    return [] as Array<{ turn_index: number; role: string; content: string }>;
+  };
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async (_q: string, limit: number, requestedSessionId?: string) =>
+      evidenceFor(requestedSessionId, limit),
+    expandContext: async (
+      requestedSessionId: string,
+      fromTurn: number,
+      toTurn: number,
+    ) =>
+      expandFor(requestedSessionId).filter(
+        (m) => m.turn_index >= fromTurn && m.turn_index <= toTurn,
+      ),
+    getStats: async (requestedSessionId?: string) => {
+      lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+      if (requestedSessionId === branchOverlayKey) {
+        return { totalMessages: 6, maxTurnIndex: branchHit.turn_index };
+      }
+      if (requestedSessionId === projectFallbackKey) {
+        return { totalMessages: 8, maxTurnIndex: projectHit.turn_index };
+      }
+      return { totalMessages: 0, maxTurnIndex: -1 };
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "Remember when you told me to list, in chronological order, the cuisines I started my culinary journey with?",
+    sessionId,
+  );
+
+  // Both the primary branch key AND the project fallback key must be queried —
+  // the merge must NOT short-circuit on the weak branch hit.
+  assert.ok(
+    lcmQueriedSessionIds.includes(branchOverlayKey),
+    `expected the branch overlay key ${branchOverlayKey} to be queried; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  assert.ok(
+    lcmQueriedSessionIds.includes(projectFallbackKey),
+    `expected the project fallback key ${projectFallbackKey} to ALSO be queried (merge, not short-circuit); queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  // The stronger project-fallback evidence must surface even though the branch
+  // key already returned a (weaker) hit — this is the codex P2 fix.
+  assert.match(
+    context,
+    /STRONG_PROJECT_EVIDENCE/,
+    "merged recall must surface project-fallback evidence even when the branch key has a weak hit",
+  );
+  // The weak branch hit is still included (the merge unions, it does not drop the
+  // primary key's evidence).
+  assert.match(
+    context,
+    /WEAK_BRANCH_EVIDENCE/,
+    "merged recall must still include the primary branch-key evidence",
+  );
+});
+
+test("#1505 codex P2: structured message-parts merge across branch + project fallback keys (dedupe by part)", async () => {
+  // The structured message-parts section is query-SCORED evidence, so it too must
+  // MERGE across the ordered LCM read key set instead of short-circuiting on the
+  // first non-empty key. A weak branch-key part must not mask stronger
+  // project-fallback parts; parts are deduped by session_id+turn_index+part_id.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-parts-"));
+  const sessionId = "alice:branch-session";
+  const projectId = "origin:proj5555";
+
+  const partsQueriedSessionIds: string[] = [];
+  let branchOverlayKey = "";
+  let projectFallbackKey = "";
+  const partsFor = (requestedSessionId: string) => {
+    partsQueriedSessionIds.push(requestedSessionId);
+    if (requestedSessionId === branchOverlayKey) {
+      return [
+        {
+          part_id: 1,
+          session_id: branchOverlayKey,
+          turn_index: 5,
+          role: "user",
+          kind: "text",
+          content: "WEAK_BRANCH_PART",
+          score: 10,
+        },
+      ];
+    }
+    if (requestedSessionId === projectFallbackKey) {
+      return [
+        {
+          part_id: 2,
+          session_id: projectFallbackKey,
+          turn_index: 7,
+          role: "user",
+          kind: "text",
+          content: "STRONG_PROJECT_PART",
+          score: 100,
+        },
+      ];
+    }
+    return [];
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    codingMode: { projectScope: true, branchScope: true },
+    recallPipeline: [
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/cuisines",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  projectFallbackKey = encodeNs(projectFallbackNamespace(orchestrator, "alice", projectId), sessionId);
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async () => [],
+    expandContext: async () => [],
+    getStats: async () => ({ totalMessages: 0, maxTurnIndex: -1 }),
+    searchStructuredParts: async (requestedSessionId: string) =>
+      partsFor(requestedSessionId),
+    // Render the matches it receives so the test can assert on merged content.
+    formatStructuredRecall: (matches: Array<{ content: string }>) =>
+      matches.length > 0
+        ? `## Structured Session Matches\n\n${matches.map((m) => m.content).join("\n")}`
+        : "",
+    assembleRecall: async () => "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "What did we cover earlier?",
+    sessionId,
+  );
+
+  assert.ok(
+    partsQueriedSessionIds.includes(branchOverlayKey),
+    `expected structured parts to query the branch overlay key; queried: ${JSON.stringify(partsQueriedSessionIds)}`,
+  );
+  assert.ok(
+    partsQueriedSessionIds.includes(projectFallbackKey),
+    `expected structured parts to ALSO query the project fallback key (merge, not short-circuit); queried: ${JSON.stringify(partsQueriedSessionIds)}`,
+  );
+  assert.match(context, /STRONG_PROJECT_PART/);
+  assert.match(context, /WEAK_BRANCH_PART/);
+});

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -1191,3 +1191,128 @@ test("#1505 codex P2: a failing fallback structured-parts read must NOT discard 
     "a structured-parts failure must not discard the sibling compressed-history section",
   );
 });
+
+test("#1505 codex review: a fallback read-key failure must NOT discard the PRIMARY key's section evidence", async () => {
+  // cursor[bot] Medium: the merged builders read every key in one call. If the
+  // PRIMARY overlay key already gathered evidence but a later FALLBACK key throws
+  // (e.g. a corrupt/locked fallback index), a bare `for...await` loop would
+  // propagate and lose the whole section — discarding the primary's evidence the
+  // old first-non-empty read would have returned. This pins per-key fault
+  // isolation: the primary key's evidence still surfaces when a fallback read
+  // throws.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-keyfail-"));
+  const sessionId = "alice:branch-session";
+  const projectId = "origin:proj3131";
+
+  let branchOverlayKey = "";
+  let projectFallbackKey = "";
+  const primaryEvidence = {
+    turn_index: 9,
+    role: "user",
+    content:
+      "PRIMARY_SURVIVES: my culinary journey started with Turkish, Greek, and Lebanese cuisines.",
+  };
+  // The PRIMARY (branch) key returns evidence; every read for the FALLBACK
+  // (project) key throws, simulating a corrupt/locked fallback index.
+  const failIfFallback = (requestedSessionId?: string) => {
+    if (requestedSessionId === projectFallbackKey) {
+      throw new Error("simulated corrupt fallback index");
+    }
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    codingMode: { projectScope: true, branchScope: true },
+    explicitCueRecallEnabled: true,
+    focusedListRecallEnabled: true,
+    eventOrderRecallEnabled: true,
+    recallPipeline: [
+      { id: "event-order", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "focused-list", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "explicit-cue", enabled: true, maxChars: 2_400, maxResults: 8 },
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/cuisines",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  projectFallbackKey = encodeNs(projectFallbackNamespace(orchestrator, "alice", projectId), sessionId);
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async (_q: string, limit: number, requestedSessionId?: string) => {
+      failIfFallback(requestedSessionId);
+      return requestedSessionId === branchOverlayKey
+        ? [
+            {
+              id: 0,
+              session_id: branchOverlayKey,
+              turn_index: primaryEvidence.turn_index,
+              role: primaryEvidence.role,
+              content: primaryEvidence.content,
+              score: 100,
+            },
+          ].slice(0, limit)
+        : [];
+    },
+    expandContext: async (requestedSessionId: string, fromTurn: number, toTurn: number) => {
+      failIfFallback(requestedSessionId);
+      return requestedSessionId === branchOverlayKey &&
+        primaryEvidence.turn_index >= fromTurn &&
+        primaryEvidence.turn_index <= toTurn
+        ? [primaryEvidence]
+        : [];
+    },
+    getStats: async (requestedSessionId?: string) => {
+      failIfFallback(requestedSessionId);
+      return requestedSessionId === branchOverlayKey
+        ? { totalMessages: 10, maxTurnIndex: primaryEvidence.turn_index }
+        : { totalMessages: 0, maxTurnIndex: -1 };
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "Remember when you told me to list, in chronological order, the cuisines I started my culinary journey with?",
+    sessionId,
+  );
+
+  assert.match(
+    context,
+    /PRIMARY_SURVIVES/,
+    "a fallback read-key failure must not discard the primary key's already-gathered evidence",
+  );
+});

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -1080,3 +1080,114 @@ test("#1505 codex P2: structured message-parts merge across branch + project fal
   assert.match(context, /STRONG_PROJECT_PART/);
   assert.match(context, /WEAK_BRANCH_PART/);
 });
+
+test("#1505 codex P2: a failing fallback structured-parts read must NOT discard the other key's parts or the compressed-history section", async () => {
+  // Fault isolation: the structured-parts merge reads every key, but one key's
+  // search throwing (e.g. a SqliteError on a corrupt/locked fallback index) must
+  // not reject the whole batch. With `Promise.all` it would, and — because the
+  // structured-parts read and the compressed-history read share one try block —
+  // BOTH sections would be silently dropped even though the primary key is
+  // healthy. This pins `Promise.allSettled` semantics: the surviving key's parts
+  // AND the compressed-history section still appear.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-parts-fail-"));
+  const sessionId = "alice:branch-session";
+  const projectId = "origin:proj4242";
+
+  let branchOverlayKey = "";
+  let projectFallbackKey = "";
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    codingMode: { projectScope: true, branchScope: true },
+    recallPipeline: [
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/cuisines",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  projectFallbackKey = encodeNs(projectFallbackNamespace(orchestrator, "alice", projectId), sessionId);
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async () => [],
+    expandContext: async () => [],
+    getStats: async () => ({ totalMessages: 0, maxTurnIndex: -1 }),
+    // The PRIMARY (branch) key's structured read throws; the project fallback
+    // key returns a healthy part.
+    searchStructuredParts: async (requestedSessionId: string) => {
+      if (requestedSessionId === branchOverlayKey) {
+        throw new Error("simulated SqliteError on branch index");
+      }
+      if (requestedSessionId === projectFallbackKey) {
+        return [
+          {
+            part_id: 7,
+            session_id: projectFallbackKey,
+            turn_index: 3,
+            role: "user",
+            kind: "text",
+            content: "SURVIVING_PROJECT_PART",
+            score: 100,
+          },
+        ];
+      }
+      return [];
+    },
+    formatStructuredRecall: (matches: Array<{ content: string }>) =>
+      matches.length > 0
+        ? `## Structured Session Matches\n\n${matches.map((m) => m.content).join("\n")}`
+        : "",
+    // Compressed history is healthy for the primary key — it must survive a
+    // structured-parts failure on a fallback key.
+    assembleRecall: async (requestedSessionId: string) =>
+      requestedSessionId ? "## Compressed History\n\nCOMPRESSED_HISTORY_BODY" : "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "What did we cover earlier?",
+    sessionId,
+  );
+
+  assert.match(
+    context,
+    /SURVIVING_PROJECT_PART/,
+    "a fallback key's structured read failure must not discard the other key's parts",
+  );
+  assert.match(
+    context,
+    /COMPRESSED_HISTORY_BODY/,
+    "a structured-parts failure must not discard the sibling compressed-history section",
+  );
+});


### PR DESCRIPTION
## Summary

Follow-up to the now-merged **#1505**, addressing its codex **P2** review thread
*"Merge LCM fallback reads instead of short-circuiting"*.

Round 6's `firstNonEmptyLcmRead` queried the ordered, read-authorized LCM read
key set (primary coding-overlay key → project → root fallbacks) but **stopped at
the first non-empty key**. So a branch-scoped session whose branch key returned
even a *weak* hit masked stronger project/root fallback evidence — diverging from
the QMD/file recall path, which searches the same `codingOverlay.readFallbacks`
set and **merges**.

This makes the six **query-scored** LCM recall sections query **every** authorized
read key and **merge candidates under each section's existing budget**, matching
QMD/file recall.

## What changed

- **New** `packages/remnic-core/src/lcm-fallback-read.ts` — `resolveLcmReadSessionIds()`
  resolves the ordered, deduped read-key set, collapsing to `[sessionId]` for
  single-key / no-overlay / explicit-namespace / sessionless flows (byte-for-byte
  unchanged).
- **5 section builders** (`explicit-cue`, `targeted-fact`, `focused-list`,
  `response-guidance`, `event-order`) gained an optional `sessionIds`; each gather
  step now **unions per-key candidates into its existing dedupe + rank + budget
  pass**, so the per-section char/result budget is still applied exactly once and
  the section-appropriate dedupe handles identity. `event-order`'s `!sessionId`
  guard was widened so the merged path isn't blocked.
- **Structured message-parts** merge across keys in the orchestrator, deduped by
  `session_id`+`turn_index`+`part_id` and **stably re-sorted by score** (then turn)
  so stronger fallback parts win the shared `formatStructuredRecall` budget.
- **Compressed-history** (`assembleRecall`) deliberately **keeps first-non-empty**:
  it's a per-session *holistic DAG narrative* with no per-item id to merge/dedupe,
  and concatenating two sessions' summaries would double-count the conversation and
  blow the budget. `firstNonEmptyLcmRead` now serves only that one section
  (documented at its definition and call site).

### Invariants preserved
- **Read-authorization** — unreadable overlay keys are never in the read set, so
  they're never queried (no cross-tenant leak). Unchanged from round 6.
- **Ordering** — primary overlay first, then project → root.
- **Single-key / single-store / no-overlay / sessionless** — exactly one read,
  byte-for-byte the prior behavior.

## Tests (`tests/recall-pipeline-assembly.test.ts`)
- **Fail-before / pass-after**: a branch-scoped session with a *weak* branch-key
  hit **and** stronger project-fallback evidence now surfaces the project evidence
  and queries the fallback key (the old first-non-empty short-circuited and missed
  it).
- Structured message-parts merge across branch + project keys, deduped by part.

## Verification
- `tests/recall-pipeline-assembly.test.ts` **10/10** · `tests/recall-hardening.test.ts` **90** · 5 builder suites **275/275**
- `npm run test:entity-hardening` **205/205** · `npm run preflight:quick` **OK** · full `npm run check-types` **OK**

## PR checklist
- [x] All tests pass (targeted suites + entity-hardening + preflight:quick + check-types)
- [x] New logic covered by fail-before/pass-after tests
- [x] Pre-commit / preflight gates pass locally
- [x] Docs/comments updated (call-site + helper rationale)
- [x] No secrets or personal data (synthetic test data only)
- [x] Single subsystem (recall LCM read path); ~655 LOC incl. tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core recall assembly and evidence selection for branch-scoped sessions; behavior shifts when multiple LCM keys have data, though single-key paths and read-authorization are preserved.
> 
> **Overview**
> Fixes **#1505 codex P2**: branch-scoped LCM recall no longer **short-circuits** on the first non-empty overlay key, which could hide stronger evidence on project/root fallback keys while QMD/file recall already merges those namespaces.
> 
> Adds **`lcm-fallback-read.ts`** with `resolveLcmReadSessionIds` and `gatherAcrossReadSessions`. **Explicit-cue**, **targeted-fact**, **focused-list**, and **response-guidance** take optional `sessionIds`, union candidates from every authorized key, then run their existing dedupe/rank/budget once (explicit-cue keeps type-first ordering across keys, not score-sort). The orchestrator passes `lcmReadSessionIds` directly instead of wrapping those builders in `firstNonEmptyLcmRead`.
> 
> **Structured message-parts** merges via `Promise.allSettled`, dedupes by `session_id`+`turn_index`+`part_id`, and re-sorts by score so fallback hits can win the shared budget. **Event-order** and **compressed-history** stay **first-non-empty** only—`turn_index` is per-session (merging would break chronology) and compressed history is a single holistic narrative with nothing to dedupe.
> 
> Multi-key reads **swallow per-key failures** so a bad fallback index does not drop primary evidence or the sibling compressed-history section; single-key behavior still propagates errors. New **recall-pipeline-assembly** tests cover weak-primary vs strong-fallback merge, structured-parts merge, and fault isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a351b06137fec5c8823f8770be537d7c287f5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->