### PR TITLE
Expose QMD health diagnostics for Docker deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Health responses now include structured QMD diagnostics (`qmd.active`,
+  `qmd.mode`, version support, collection state, and degraded fallback status)
+  so Docker/standalone deployments can tell whether QMD is actually active
+  instead of inferring it from recall behavior.
+
 ## [v9.3.648] — 2026-06-29
 
 ### Added

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -66,7 +66,13 @@ curl -s http://localhost:4318/engram/v1/health \
   -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" | jq .
 ```
 
-You should see a JSON response with `status: "ok"` and details about search availability. The API path remains `/engram/v1/...` during the v1.x compatibility window.
+You should see a JSON response with `ok: true` and a `qmd` object. In a full
+standalone or Docker image, `qmd.active` should be true and `qmd.mode` should be
+`"cli"` or `"daemon"`. If `qmd.active` is false while `qmd.enabled` is true,
+Remnic is in degraded filesystem fallback mode; use `qmd.debugStatus`,
+`qmd.installedVersion`, and `qmd.collectionState` to diagnose the missing
+binary, unsupported version, or collection probe problem. The API path remains
+`/engram/v1/...` during the v1.x compatibility window.
 
 To bind to all interfaces (e.g., for LAN access from other machines), use `--host 0.0.0.0`. Only do this on trusted networks or behind a reverse proxy.
 

--- a/docs/integration/deployment-topologies.md
+++ b/docs/integration/deployment-topologies.md
@@ -111,22 +111,26 @@ The standalone topology supports all the same endpoints and MCP tools as the Ope
 ## 5. Containerized (Docker)
 
 Run Remnic in Docker, either standalone or as a sidecar alongside other services.
+The default Dockerfile builds a full local-first image with `@tobilu/qmd@2.5.3`
+installed and available as `qmd` for the non-root runtime user. Persist `/data`
+so Remnic memory files and QMD index state survive container restarts.
 
 ```yaml
 # docker-compose.yml
 version: "3.8"
 services:
-  engram:
-    image: node:22-slim
-    working_dir: /app
-    command: ["node", "dist/access-cli.js", "http-serve", "--host", "0.0.0.0", "--port", "4318"]
+  remnic:
+    build: .
     ports:
       - "4318:4318"
     environment:
-      OPENCLAW_ENGRAM_ACCESS_TOKEN: ${ENGRAM_TOKEN}
+      REMNIC_AUTH_TOKEN: ${REMNIC_AUTH_TOKEN}
       NODE_ENV: production
     volumes:
-      - ./engram-data:/root/.openclaw/workspace/memory
+      - remnic-data:/data
+
+volumes:
+  remnic-data:
 ```
 
 ## Port Selection
@@ -192,7 +196,27 @@ Returns:
   "defaultNamespace": "default",
   "searchBackend": "qmd",
   "qmdEnabled": true,
+  "qmd": {
+    "enabled": true,
+    "active": true,
+    "degraded": false,
+    "mode": "cli",
+    "collection": "remnic-memory",
+    "collectionState": "present",
+    "installedVersion": "qmd 2.5.3",
+    "supportedVersion": "2.5.3",
+    "supported": true,
+    "upgradeAvailable": false,
+    "doctorAvailable": true,
+    "debugStatus": "cli=true daemon=false ..."
+  },
   "nativeKnowledgeEnabled": false,
   "projectionAvailable": true
 }
 ```
+
+If `qmdEnabled` is true but `qmd.active` is false, the server is running in
+degraded filesystem fallback mode. Check `qmd.debugStatus` and
+`qmd.collectionState`; the default Docker image should report an installed
+QMD version and an active `present` or fail-open `unknown` collection state
+after startup.

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -299,6 +299,59 @@ test("health reports namespace-scoped QMD backend state", async () => {
   }
 });
 
+test("health marks namespace QMD unknown collection state degraded", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-unknown-"));
+  try {
+    const teamDir = path.join(rootDir, "namespaces", "team");
+    const config = parseConfig({
+      memoryDir: rootDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+      namespacePolicies: [{ name: "team", readPrincipals: [], writePrincipals: [] }],
+    });
+    const expectedCollection = namespaceCollectionName("remnic-memory", "team", {
+      defaultNamespace: "default",
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({}),
+      async getStorage(namespace: string) {
+        return { dir: namespace === "team" ? teamDir : rootDir };
+      },
+      async searchHealthForNamespace(namespace: string, execution?: { signal?: AbortSignal }) {
+        assert.equal(namespace, "team");
+        assert.ok(execution?.signal instanceof AbortSignal);
+        return {
+          collection: expectedCollection,
+          available: true,
+          collectionState: "unknown",
+          debugStatus: "cli=true collection=unknown",
+          installedVersion: "qmd 2.5.3",
+          supportedVersion: "2.5.3",
+          supported: true,
+          upgradeAvailable: false,
+          doctorAvailable: true,
+          daemonMode: false,
+        };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health("team");
+
+    assert.equal(health.memoryDir, teamDir);
+    assert.equal(health.qmd.active, true);
+    assert.equal(health.qmd.degraded, true);
+    assert.equal(health.qmd.collection, expectedCollection);
+    assert.equal(health.qmd.collectionState, "unknown");
+    assert.equal(health.qmd.mode, "cli");
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("health keeps namespace QMD failures scoped to the namespace", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-fail-"));
   try {

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -168,7 +168,7 @@ test("health marks QMD as degraded when the checked collection is missing", asyn
   }
 });
 
-test("health re-probes root QMD before reporting it active", async () => {
+test("health reports degraded diagnostics when read-only root QMD probe fails", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-stale-probe-"));
   try {
     const config = parseConfig({
@@ -193,9 +193,9 @@ test("health re-probes root QMD before reporting it active", async () => {
 
     const health = await service.health();
 
-    assert.equal(health.qmd.active, false);
+    assert.equal(health.qmd.active, true);
     assert.equal(health.qmd.degraded, true);
-    assert.equal(health.qmd.mode, "fallback");
+    assert.equal(health.qmd.mode, "cli");
     assert.equal(health.qmd.collectionState, "unknown");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -57,6 +57,7 @@ test("health reports active QMD version and collection state", async () => {
       qmdCollection: "remnic-memory",
     });
     const qmd = makeQmd({
+      probe: async () => true,
       isAvailable: () => true,
       debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
       checkCollection: async (collection, execution) => {
@@ -145,6 +146,7 @@ test("health marks QMD as degraded when the checked collection is missing", asyn
     const service = new EngramAccessService({
       config,
       qmd: makeQmd({
+        probe: async () => true,
         isAvailable: () => true,
         debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
         checkCollection: async () => "missing",
@@ -161,6 +163,40 @@ test("health marks QMD as degraded when the checked collection is missing", asyn
     assert.equal(health.qmd.active, false);
     assert.equal(health.qmd.degraded, true);
     assert.equal(health.qmd.mode, "fallback");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health re-probes root QMD before reporting it active", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-stale-probe-"));
+  try {
+    const config = parseConfig({
+      memoryDir,
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({
+        probe: async () => false,
+        isAvailable: () => true,
+        debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+        checkCollection: async () => "present",
+        isDaemonMode: () => false,
+      }),
+      async getStorage() {
+        return { dir: memoryDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health();
+
+    assert.equal(health.qmd.active, false);
+    assert.equal(health.qmd.degraded, true);
+    assert.equal(health.qmd.mode, "fallback");
+    assert.equal(health.qmd.collectionState, "unknown");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { parseConfig } from "./config.js";
+import { namespaceCollectionName } from "./namespaces/search.js";
+import type { Orchestrator } from "./orchestrator.js";
+import type { SearchBackend } from "./search/port.js";
+
+function makeQmd(overrides: Partial<SearchBackend> & Record<string, unknown>): SearchBackend {
+  return {
+    async probe() {
+      return false;
+    },
+    isAvailable() {
+      return false;
+    },
+    debugStatus() {
+      return "backend=noop";
+    },
+    async search() {
+      return [];
+    },
+    async searchGlobal() {
+      return [];
+    },
+    async bm25Search() {
+      return [];
+    },
+    async vectorSearch() {
+      return [];
+    },
+    async hybridSearch() {
+      return [];
+    },
+    async update() {},
+    async updateCollection() {},
+    async embed() {},
+    async embedCollection() {},
+    async ensureCollection() {
+      return "skipped";
+    },
+    ...overrides,
+  } as SearchBackend;
+}
+
+test("health reports active QMD version and collection state", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-"));
+  try {
+    const config = parseConfig({
+      memoryDir,
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+    });
+    const qmd = makeQmd({
+      isAvailable: () => true,
+      debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+      checkCollection: async (collection, execution) => {
+        assert.equal(collection, "remnic-memory");
+        assert.ok(execution?.signal instanceof AbortSignal);
+        return "present";
+      },
+      getVersionStatus: () => ({
+        installedVersion: "qmd 2.5.3",
+        supportedVersion: "2.5.3",
+        supported: true,
+        newerThanSupported: false,
+        upgradeAvailable: false,
+        capabilities: { doctor: true },
+      }),
+      isDaemonMode: () => false,
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd,
+      async getStorage() {
+        return { dir: memoryDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health();
+
+    assert.equal(health.qmdEnabled, true);
+    assert.deepEqual(health.qmd, {
+      enabled: true,
+      active: true,
+      degraded: false,
+      mode: "cli",
+      collection: "remnic-memory",
+      collectionState: "present",
+      installedVersion: "qmd 2.5.3",
+      supportedVersion: "2.5.3",
+      supported: true,
+      upgradeAvailable: false,
+      doctorAvailable: true,
+      debugStatus: "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+    });
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health marks QMD as degraded when configured search falls back to noop", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-degraded-"));
+  try {
+    const config = parseConfig({
+      memoryDir,
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({}),
+      async getStorage() {
+        return { dir: memoryDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health();
+
+    assert.equal(health.qmd.active, false);
+    assert.equal(health.qmd.degraded, true);
+    assert.equal(health.qmd.mode, "fallback");
+    assert.equal(health.qmd.collectionState, "unknown");
+    assert.equal(health.qmd.debugStatus, "backend=noop");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health reports namespace-scoped QMD collection names", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-"));
+  try {
+    const teamDir = path.join(rootDir, "namespaces", "team");
+    const config = parseConfig({
+      memoryDir: rootDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+      namespacePolicies: [{ name: "team", readPrincipals: [], writePrincipals: [] }],
+    });
+    const expectedCollection = namespaceCollectionName("remnic-memory", "team", {
+      defaultNamespace: "default",
+    });
+    const qmd = makeQmd({
+      isAvailable: () => true,
+      debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+      checkCollection: async (collection) => {
+        assert.equal(collection, expectedCollection);
+        return "present";
+      },
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd,
+      async getStorage(namespace: string) {
+        return { dir: namespace === "team" ? teamDir : rootDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health("team");
+
+    assert.equal(health.memoryDir, teamDir);
+    assert.equal(health.qmd.collection, expectedCollection);
+    assert.equal(health.qmd.collectionState, "present");
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -380,7 +380,7 @@ test("health keeps namespace QMD failures scoped to the namespace", async () => 
         return { dir: namespace === "team" ? teamDir : rootDir };
       },
       async searchHealthForNamespace() {
-        throw new Error("namespace probe timed out");
+        throw new Error(`namespace probe timed out at ${teamDir}/qmd/index.sqlite`);
       },
     } as unknown as Orchestrator);
 
@@ -392,8 +392,10 @@ test("health keeps namespace QMD failures scoped to the namespace", async () => 
     assert.equal(health.qmd.degraded, true);
     assert.equal(health.qmd.collectionState, "unknown");
     assert.equal(health.qmd.mode, "fallback");
-    assert.match(health.qmd.debugStatus, /backend=namespace-unavailable/);
+    assert.equal(health.qmd.debugStatus, "backend=namespace-unavailable error=Error");
     assert.doesNotMatch(health.qmd.debugStatus, /root-qmd-should-not-leak/);
+    assert.doesNotMatch(health.qmd.debugStatus, /index\.sqlite/);
+    assert.doesNotMatch(health.qmd.debugStatus, /remnic-health-qmd-ns-fail/);
   } finally {
     await rm(rootDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -298,3 +298,50 @@ test("health reports namespace-scoped QMD backend state", async () => {
     await rm(rootDir, { recursive: true, force: true });
   }
 });
+
+test("health keeps namespace QMD failures scoped to the namespace", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-fail-"));
+  try {
+    const teamDir = path.join(rootDir, "namespaces", "team");
+    const config = parseConfig({
+      memoryDir: rootDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+      namespacePolicies: [{ name: "team", readPrincipals: [], writePrincipals: [] }],
+    });
+    const expectedCollection = namespaceCollectionName("remnic-memory", "team", {
+      defaultNamespace: "default",
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({
+        probe: async () => true,
+        isAvailable: () => true,
+        debugStatus: () => "root-qmd-should-not-leak",
+        checkCollection: async () => "present",
+      }),
+      async getStorage(namespace: string) {
+        return { dir: namespace === "team" ? teamDir : rootDir };
+      },
+      async searchHealthForNamespace() {
+        throw new Error("namespace probe timed out");
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health("team");
+
+    assert.equal(health.memoryDir, teamDir);
+    assert.equal(health.qmd.collection, expectedCollection);
+    assert.equal(health.qmd.active, false);
+    assert.equal(health.qmd.degraded, true);
+    assert.equal(health.qmd.collectionState, "unknown");
+    assert.equal(health.qmd.mode, "fallback");
+    assert.match(health.qmd.debugStatus, /backend=namespace-unavailable/);
+    assert.doesNotMatch(health.qmd.debugStatus, /root-qmd-should-not-leak/);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -202,6 +202,50 @@ test("health re-probes root QMD before reporting it active", async () => {
   }
 });
 
+test("health uses read-only root QMD availability checks", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-readonly-"));
+  try {
+    const config = parseConfig({
+      memoryDir,
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+    });
+    let checkAvailabilityCalled = false;
+    let probeCalled = false;
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({
+        probe: async () => {
+          probeCalled = true;
+          return true;
+        },
+        checkAvailability: async (execution) => {
+          checkAvailabilityCalled = true;
+          assert.ok(execution?.signal instanceof AbortSignal);
+          return true;
+        },
+        isAvailable: () => true,
+        debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+        checkCollection: async () => "present",
+        isDaemonMode: () => false,
+      }),
+      async getStorage() {
+        return { dir: memoryDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health();
+
+    assert.equal(checkAvailabilityCalled, true);
+    assert.equal(probeCalled, false);
+    assert.equal(health.qmd.active, true);
+    assert.equal(health.qmd.degraded, false);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("health reports namespace-scoped QMD backend state", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-"));
   try {

--- a/packages/remnic-core/src/access-service-health.test.ts
+++ b/packages/remnic-core/src/access-service-health.test.ts
@@ -133,7 +133,40 @@ test("health marks QMD as degraded when configured search falls back to noop", a
   }
 });
 
-test("health reports namespace-scoped QMD collection names", async () => {
+test("health marks QMD as degraded when the checked collection is missing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-missing-"));
+  try {
+    const config = parseConfig({
+      memoryDir,
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      qmdCollection: "remnic-memory",
+    });
+    const service = new EngramAccessService({
+      config,
+      qmd: makeQmd({
+        isAvailable: () => true,
+        debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+        checkCollection: async () => "missing",
+        isDaemonMode: () => false,
+      }),
+      async getStorage() {
+        return { dir: memoryDir };
+      },
+    } as unknown as Orchestrator);
+
+    const health = await service.health();
+
+    assert.equal(health.qmd.collectionState, "missing");
+    assert.equal(health.qmd.active, false);
+    assert.equal(health.qmd.degraded, true);
+    assert.equal(health.qmd.mode, "fallback");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health reports namespace-scoped QMD backend state", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "remnic-health-qmd-ns-"));
   try {
     const teamDir = path.join(rootDir, "namespaces", "team");
@@ -149,27 +182,38 @@ test("health reports namespace-scoped QMD collection names", async () => {
     const expectedCollection = namespaceCollectionName("remnic-memory", "team", {
       defaultNamespace: "default",
     });
-    const qmd = makeQmd({
-      isAvailable: () => true,
-      debugStatus: () => "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
-      checkCollection: async (collection) => {
-        assert.equal(collection, expectedCollection);
-        return "present";
-      },
-    });
     const service = new EngramAccessService({
       config,
-      qmd,
+      qmd: makeQmd({}),
       async getStorage(namespace: string) {
         return { dir: namespace === "team" ? teamDir : rootDir };
+      },
+      async searchHealthForNamespace(namespace: string, execution?: { signal?: AbortSignal }) {
+        assert.equal(namespace, "team");
+        assert.ok(execution?.signal instanceof AbortSignal);
+        return {
+          collection: expectedCollection,
+          available: true,
+          collectionState: "present",
+          debugStatus: "cli=true daemon=false cliPath=qmd cliVersion=qmd 2.5.3",
+          installedVersion: "qmd 2.5.3",
+          supportedVersion: "2.5.3",
+          supported: true,
+          upgradeAvailable: false,
+          doctorAvailable: true,
+          daemonMode: false,
+        };
       },
     } as unknown as Orchestrator);
 
     const health = await service.health("team");
 
     assert.equal(health.memoryDir, teamDir);
+    assert.equal(health.qmd.active, true);
+    assert.equal(health.qmd.degraded, false);
     assert.equal(health.qmd.collection, expectedCollection);
     assert.equal(health.qmd.collectionState, "present");
+    assert.equal(health.qmd.installedVersion, "qmd 2.5.3");
   } finally {
     await rm(rootDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2521,8 +2521,10 @@ export class EngramAccessService {
         debugStatus: "backend=unavailable",
       };
     }
-    const collectionState = await this.qmdCollectionState(searchBackend, qmdEnabled, collection);
-    const binaryAvailable = searchBackend === "qmd" && qmdEnabled && qmd.isAvailable();
+    const binaryAvailable = await this.qmdProbeAvailable(searchBackend, qmdEnabled);
+    const collectionState = binaryAvailable
+      ? await this.qmdCollectionState(searchBackend, qmdEnabled, collection)
+      : "unknown";
     const active = binaryAvailable && collectionState !== "missing";
     const debugStatus = qmd.debugStatus();
     const versionStatus =
@@ -2643,6 +2645,35 @@ export class EngramAccessService {
       });
     } catch {
       return "unknown";
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async qmdProbeAvailable(
+    searchBackend: string,
+    qmdEnabled: boolean,
+  ): Promise<boolean> {
+    if (searchBackend !== "qmd" || !qmdEnabled) return false;
+    const qmd = this.orchestrator.qmd;
+    if (!qmd) return false;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2_000);
+    timer.unref?.();
+    try {
+      return await new Promise<boolean>((resolve) => {
+        const onAbort = () => {
+          controller.signal.removeEventListener("abort", onAbort);
+          resolve(false);
+        };
+        controller.signal.addEventListener("abort", onAbort, { once: true });
+        qmd.probe()
+          .then(resolve, () => resolve(false))
+          .finally(() => {
+            controller.signal.removeEventListener("abort", onAbort);
+          });
+      });
     } finally {
       clearTimeout(timer);
     }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2624,8 +2624,22 @@ export class EngramAccessService {
         doctorAvailable: health.doctorAvailable,
         debugStatus: health.debugStatus,
       };
-    } catch {
-      return null;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        enabled: true,
+        active: false,
+        degraded: true,
+        mode: "fallback",
+        collection: fallbackCollection,
+        collectionState: "unknown",
+        installedVersion: null,
+        supportedVersion: null,
+        supported: null,
+        upgradeAvailable: null,
+        doctorAvailable: null,
+        debugStatus: `backend=namespace-unavailable error=${message.slice(0, 160)}`,
+      };
     } finally {
       clearTimeout(timer);
     }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -38,6 +38,7 @@ import {
   runMemoryGovernance,
 } from "./maintenance/memory-governance.js";
 import { runProcedureMining } from "./procedural/procedure-miner.js";
+import { displayErrorDetail } from "./runtime/better-sqlite.js";
 import type { PatternReinforcementResult } from "./maintenance/pattern-reinforcement.js";
 import type { LiveConnectorsRunSummary } from "./live-connectors-runner.js";
 import type { WearablesService } from "./wearables/service.js";
@@ -2626,7 +2627,7 @@ export class EngramAccessService {
         debugStatus: health.debugStatus,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const detail = displayErrorDetail(error) || "unknown";
       return {
         enabled: true,
         active: false,
@@ -2639,7 +2640,7 @@ export class EngramAccessService {
         supported: null,
         upgradeAvailable: null,
         doctorAvailable: null,
-        debugStatus: `backend=namespace-unavailable error=${message.slice(0, 160)}`,
+        debugStatus: `backend=namespace-unavailable error=${detail}`,
       };
     } finally {
       clearTimeout(timer);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2603,6 +2603,7 @@ export class EngramAccessService {
         signal: controller.signal,
       });
       const active = health.available && health.collectionState !== "missing";
+      const degraded = !active || health.collectionState === "unknown";
       const mode =
         !active
           ? "fallback"
@@ -2613,7 +2614,7 @@ export class EngramAccessService {
       return {
         enabled: true,
         active,
-        degraded: !active,
+        degraded,
         mode,
         collection: health.collection || fallbackCollection,
         collectionState: health.collectionState,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2454,6 +2454,7 @@ export class EngramAccessService {
       qmd: await this.qmdHealth(
         searchBackend,
         qmdEnabled,
+        resolvedNamespace,
         this.qmdCollectionForHealth(resolvedNamespace, storage.dir),
       ),
       nativeKnowledgeEnabled: this.orchestrator.config.nativeKnowledge?.enabled === true,
@@ -2478,10 +2479,51 @@ export class EngramAccessService {
   private async qmdHealth(
     searchBackend: string,
     qmdEnabled: boolean,
+    namespace: string,
     collection: string,
   ): Promise<EngramAccessQmdHealthResponse> {
+    if (searchBackend !== "qmd" || !qmdEnabled) {
+      return {
+        enabled: qmdEnabled,
+        active: false,
+        degraded: false,
+        mode: searchBackend !== "qmd" ? "not-selected" : "disabled",
+        collection,
+        collectionState: "skipped",
+        installedVersion: null,
+        supportedVersion: null,
+        supported: null,
+        upgradeAvailable: null,
+        doctorAvailable: null,
+        debugStatus: searchBackend !== "qmd" ? `backend=${searchBackend}` : "backend=disabled",
+      };
+    }
+
+    if (this.orchestrator.config.namespacesEnabled === true) {
+      const namespaceHealth = await this.namespaceQmdHealth(searchBackend, qmdEnabled, namespace, collection);
+      if (namespaceHealth) return namespaceHealth;
+    }
+
     const qmd = this.orchestrator.qmd;
-    const active = searchBackend === "qmd" && qmdEnabled && qmd.isAvailable();
+    if (!qmd) {
+      return {
+        enabled: true,
+        active: false,
+        degraded: true,
+        mode: "fallback",
+        collection,
+        collectionState: "unknown",
+        installedVersion: null,
+        supportedVersion: null,
+        supported: null,
+        upgradeAvailable: null,
+        doctorAvailable: null,
+        debugStatus: "backend=unavailable",
+      };
+    }
+    const collectionState = await this.qmdCollectionState(searchBackend, qmdEnabled, collection);
+    const binaryAvailable = searchBackend === "qmd" && qmdEnabled && qmd.isAvailable();
+    const active = binaryAvailable && collectionState !== "missing";
     const debugStatus = qmd.debugStatus();
     const versionStatus =
       "getVersionStatus" in qmd && typeof qmd.getVersionStatus === "function"
@@ -2508,7 +2550,7 @@ export class EngramAccessService {
       degraded: searchBackend === "qmd" && qmdEnabled && !active,
       mode,
       collection,
-      collectionState: await this.qmdCollectionState(searchBackend, qmdEnabled, collection),
+      collectionState,
       installedVersion: versionStatus?.installedVersion ?? null,
       supportedVersion: versionStatus?.supportedVersion ?? null,
       supported: versionStatus?.supported ?? null,
@@ -2516,6 +2558,70 @@ export class EngramAccessService {
       doctorAvailable: versionStatus?.capabilities?.doctor ?? null,
       debugStatus,
     };
+  }
+
+  private async namespaceQmdHealth(
+    searchBackend: string,
+    qmdEnabled: boolean,
+    namespace: string,
+    fallbackCollection: string,
+  ): Promise<EngramAccessQmdHealthResponse | null> {
+    if (searchBackend !== "qmd" || !qmdEnabled) return null;
+    const searchHealthForNamespace = (
+      this.orchestrator as Orchestrator & {
+        searchHealthForNamespace?: (
+          namespace: string,
+          execution?: { signal?: AbortSignal },
+        ) => Promise<{
+          collection: string;
+          available: boolean;
+          collectionState: EngramAccessQmdCollectionState;
+          debugStatus: string;
+          installedVersion: string | null;
+          supportedVersion: string | null;
+          supported: boolean | null;
+          upgradeAvailable: boolean | null;
+          doctorAvailable: boolean | null;
+          daemonMode: boolean | null;
+        }>;
+      }
+    ).searchHealthForNamespace;
+    if (typeof searchHealthForNamespace !== "function") return null;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2_000);
+    timer.unref?.();
+    try {
+      const health = await searchHealthForNamespace.call(this.orchestrator, namespace, {
+        signal: controller.signal,
+      });
+      const active = health.available && health.collectionState !== "missing";
+      const mode =
+        !active
+          ? "fallback"
+          : health.daemonMode === true
+          ? "daemon"
+          : "cli";
+
+      return {
+        enabled: true,
+        active,
+        degraded: !active,
+        mode,
+        collection: health.collection || fallbackCollection,
+        collectionState: health.collectionState,
+        installedVersion: health.installedVersion,
+        supportedVersion: health.supportedVersion,
+        supported: health.supported,
+        upgradeAvailable: health.upgradeAvailable,
+        doctorAvailable: health.doctorAvailable,
+        debugStatus: health.debugStatus,
+      };
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async qmdCollectionState(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -279,8 +279,30 @@ export interface EngramAccessHealthResponse {
   defaultNamespace: string;
   searchBackend: string;
   qmdEnabled: boolean;
+  qmd: EngramAccessQmdHealthResponse;
   nativeKnowledgeEnabled: boolean;
   projectionAvailable: boolean;
+}
+
+export type EngramAccessQmdCollectionState =
+  | "present"
+  | "missing"
+  | "unknown"
+  | "skipped";
+
+export interface EngramAccessQmdHealthResponse {
+  enabled: boolean;
+  active: boolean;
+  degraded: boolean;
+  mode: "cli" | "daemon" | "fallback" | "disabled" | "not-selected";
+  collection: string;
+  collectionState: EngramAccessQmdCollectionState;
+  installedVersion: string | null;
+  supportedVersion: string | null;
+  supported: boolean | null;
+  upgradeAvailable: boolean | null;
+  doctorAvailable: boolean | null;
+  debugStatus: string;
 }
 
 export interface EngramAccessRecallRequest {
@@ -2412,6 +2434,8 @@ export class EngramAccessService {
   async health(namespace?: string): Promise<EngramAccessHealthResponse> {
     const resolvedNamespace = this.resolveNamespace(namespace);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const searchBackend = this.orchestrator.config.searchBackend ?? "qmd";
+    const qmdEnabled = this.orchestrator.config.qmdEnabled === true;
     let projectionAvailable = false;
     try {
       await stat(getMemoryProjectionPath(storage.dir));
@@ -2425,11 +2449,97 @@ export class EngramAccessService {
       memoryDir: storage.dir,
       namespacesEnabled: this.orchestrator.config.namespacesEnabled === true,
       defaultNamespace: this.orchestrator.config.defaultNamespace,
-      searchBackend: this.orchestrator.config.searchBackend ?? "qmd",
-      qmdEnabled: this.orchestrator.config.qmdEnabled === true,
+      searchBackend,
+      qmdEnabled,
+      qmd: await this.qmdHealth(
+        searchBackend,
+        qmdEnabled,
+        this.qmdCollectionForHealth(resolvedNamespace, storage.dir),
+      ),
       nativeKnowledgeEnabled: this.orchestrator.config.nativeKnowledge?.enabled === true,
       projectionAvailable,
     };
+  }
+
+  private qmdCollectionForHealth(namespace: string, storageDir: string): string {
+    if (this.orchestrator.config.namespacesEnabled !== true) {
+      return this.orchestrator.config.qmdCollection;
+    }
+
+    const useLegacyDefaultCollection =
+      namespace === this.orchestrator.config.defaultNamespace &&
+      storageDir === this.orchestrator.config.memoryDir;
+    return namespaceCollectionName(this.orchestrator.config.qmdCollection, namespace, {
+      defaultNamespace: this.orchestrator.config.defaultNamespace,
+      useLegacyDefaultCollection,
+    });
+  }
+
+  private async qmdHealth(
+    searchBackend: string,
+    qmdEnabled: boolean,
+    collection: string,
+  ): Promise<EngramAccessQmdHealthResponse> {
+    const qmd = this.orchestrator.qmd;
+    const active = searchBackend === "qmd" && qmdEnabled && qmd.isAvailable();
+    const debugStatus = qmd.debugStatus();
+    const versionStatus =
+      "getVersionStatus" in qmd && typeof qmd.getVersionStatus === "function"
+        ? qmd.getVersionStatus()
+        : null;
+    const daemonMode =
+      "isDaemonMode" in qmd && typeof qmd.isDaemonMode === "function"
+        ? qmd.isDaemonMode() === true
+        : false;
+    const mode =
+      searchBackend !== "qmd"
+        ? "not-selected"
+        : !qmdEnabled
+        ? "disabled"
+        : !active
+        ? "fallback"
+        : daemonMode
+        ? "daemon"
+        : "cli";
+
+    return {
+      enabled: qmdEnabled,
+      active,
+      degraded: searchBackend === "qmd" && qmdEnabled && !active,
+      mode,
+      collection,
+      collectionState: await this.qmdCollectionState(searchBackend, qmdEnabled, collection),
+      installedVersion: versionStatus?.installedVersion ?? null,
+      supportedVersion: versionStatus?.supportedVersion ?? null,
+      supported: versionStatus?.supported ?? null,
+      upgradeAvailable: versionStatus?.upgradeAvailable ?? null,
+      doctorAvailable: versionStatus?.capabilities?.doctor ?? null,
+      debugStatus,
+    };
+  }
+
+  private async qmdCollectionState(
+    searchBackend: string,
+    qmdEnabled: boolean,
+    collection: string,
+  ): Promise<EngramAccessQmdCollectionState> {
+    if (searchBackend !== "qmd" || !qmdEnabled) return "skipped";
+    const qmd = this.orchestrator.qmd;
+    if (!qmd.isAvailable()) return "unknown";
+    if (!qmd.checkCollection) return "skipped";
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2_000);
+    timer.unref?.();
+    try {
+      return await qmd.checkCollection(collection, {
+        signal: controller.signal,
+      });
+    } catch {
+      return "unknown";
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   async actionConfidence(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2668,7 +2668,11 @@ export class EngramAccessService {
           resolve(false);
         };
         controller.signal.addEventListener("abort", onAbort, { once: true });
-        qmd.probe()
+        const probe =
+          typeof qmd.checkAvailability === "function"
+            ? qmd.checkAvailability({ signal: controller.signal })
+            : qmd.probe();
+        probe
           .then(resolve, () => resolve(false))
           .finally(() => {
             controller.signal.removeEventListener("abort", onAbort);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2521,11 +2521,16 @@ export class EngramAccessService {
         debugStatus: "backend=unavailable",
       };
     }
-    const binaryAvailable = await this.qmdProbeAvailable(searchBackend, qmdEnabled);
-    const collectionState = binaryAvailable
+    const diagnosticAvailable = await this.qmdProbeAvailable(searchBackend, qmdEnabled);
+    const operationalAvailable = diagnosticAvailable || qmd.isAvailable();
+    const collectionState = diagnosticAvailable
       ? await this.qmdCollectionState(searchBackend, qmdEnabled, collection)
       : "unknown";
-    const active = binaryAvailable && collectionState !== "missing";
+    const active = operationalAvailable && collectionState !== "missing";
+    const degraded =
+      searchBackend === "qmd" &&
+      qmdEnabled &&
+      (!active || !diagnosticAvailable || collectionState === "unknown");
     const debugStatus = qmd.debugStatus();
     const versionStatus =
       "getVersionStatus" in qmd && typeof qmd.getVersionStatus === "function"
@@ -2549,7 +2554,7 @@ export class EngramAccessService {
     return {
       enabled: qmdEnabled,
       active,
-      degraded: searchBackend === "qmd" && qmdEnabled && !active,
+      degraded,
       mode,
       collection,
       collectionState,

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -363,6 +363,42 @@ test("healthForNamespace stops waiting when namespace backend probe aborts", asy
   assert.equal(backend.disposed, 1);
 });
 
+test("ensureNamespaceCollection does not cache aborted namespace backend probes", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = created.length === 0
+        ? new class extends FakeBackend {
+          override async probe(): Promise<boolean> {
+            return await new Promise<boolean>(() => {});
+          }
+        }(false)
+        : new FakeBackend(false, [], { ensure: "present" });
+      created.push(backend);
+      return backend;
+    },
+  );
+  const controller = new AbortController();
+  controller.abort();
+
+  await assert.rejects(
+    () => router.ensureNamespaceCollection("shared", { signal: controller.signal }),
+    /operation aborted/,
+  );
+
+  assert.equal(created[0]?.disposed, 1);
+  assert.deepEqual(created[0]?.checkCollections, []);
+  assert.deepEqual(created[0]?.ensureCollections, []);
+
+  const ensured = await router.ensureNamespaceCollection("shared");
+
+  assert.equal(ensured, "present");
+  assert.equal(created.length, 2);
+  assert.deepEqual(created[1]?.ensureCollections, ["openclaw-engram--ns-736861726564"]);
+});
+
 test("legacy default namespace root filters nested namespace search results", async () => {
   const router = new NamespaceSearchRouter(
     config(),

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -338,6 +338,31 @@ test("healthForNamespace checks namespace collection without auto-creating or ca
   assert.deepEqual(created[1]?.ensureCollections, ["openclaw-engram--ns-736861726564"]);
 });
 
+test("healthForNamespace stops waiting when namespace backend probe aborts", async () => {
+  const backend = new class extends FakeBackend {
+    override async probe(): Promise<boolean> {
+      return await new Promise<boolean>(() => {});
+    }
+  }(false);
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => backend,
+  );
+  const controller = new AbortController();
+  controller.abort();
+
+  const health = await router.healthForNamespace("shared", {
+    signal: controller.signal,
+  });
+
+  assert.equal(health.available, false);
+  assert.equal(health.collectionState, "unknown");
+  assert.deepEqual(backend.checkCollections, []);
+  assert.deepEqual(backend.ensureCollections, []);
+  assert.equal(backend.disposed, 1);
+});
+
 test("legacy default namespace root filters nested namespace search results", async () => {
   const router = new NamespaceSearchRouter(
     config(),

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -32,6 +32,7 @@ class FakeBackend implements SearchBackend {
       check?: CollectionState;
       ensure?: CollectionState;
     } = {},
+    private readonly daemonMode = false,
   ) {}
 
   private limitedResults(maxResults: number | undefined): QmdSearchResult[] {
@@ -56,6 +57,10 @@ class FakeBackend implements SearchBackend {
 
   debugStatus(): string {
     return "fake";
+  }
+
+  isDaemonMode(): boolean {
+    return this.daemonMode;
   }
 
   async dispose(): Promise<void> {
@@ -346,6 +351,42 @@ test("healthForNamespace checks namespace collection without auto-creating or ca
   assert.equal(ensured, "present");
   assert.equal(created.length, 2);
   assert.deepEqual(created[1]?.ensureCollections, ["openclaw-engram--ns-736861726564"]);
+});
+
+test("healthForNamespace reports daemon mode from live cached namespace backend", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = created.length === 0
+        ? new FakeBackend(false, [
+          {
+            path: "facts/a.md",
+            docid: "a",
+            score: 1,
+            snippet: "a",
+          },
+        ], { ensure: "present" }, true)
+        : new FakeBackend(false, [], { check: "present" }, false);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  await router.searchAcrossNamespaces({
+    query: "a",
+    namespaces: ["shared"],
+    maxResults: 1,
+  });
+  const health = await router.healthForNamespace("shared");
+
+  assert.equal(health.daemonMode, true);
+  assert.equal(health.collectionState, "present");
+  assert.equal(created.length, 2);
+  assert.equal(created[0]?.disposed, 0);
+  assert.equal(created[1]?.disposed, 1);
+  assert.deepEqual(created[1]?.checkCollections, ["openclaw-engram--ns-736861726564"]);
 });
 
 test("healthForNamespace stops waiting when namespace availability probe aborts", async () => {

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -394,6 +394,37 @@ test("healthForNamespace reports daemon mode from live cached namespace backend"
   assert.deepEqual(created[1]?.checkCollections, []);
 });
 
+test("healthForNamespace preserves cached missing collection state", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = created.length === 0
+        ? new FakeBackend(false, [], { ensure: "missing" }, true)
+        : new FakeBackend(false, [], { check: "present" }, false);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  assert.deepEqual(
+    await router.searchAcrossNamespaces({
+      query: "a",
+      namespaces: ["shared"],
+      maxResults: 1,
+    }),
+    [],
+  );
+  const health = await router.healthForNamespace("shared");
+
+  assert.equal(health.available, true);
+  assert.equal(health.daemonMode, true);
+  assert.equal(health.collectionState, "missing");
+  assert.equal(created.length, 2);
+  assert.deepEqual(created[1]?.checkCollections, ["openclaw-engram--ns-736861726564"]);
+});
+
 test("healthForNamespace stops waiting when namespace availability probe aborts", async () => {
   const backend = new class extends FakeBackend {
     override async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -6,6 +6,7 @@ import type {
   SearchExecutionOptions,
   SearchQueryOptions,
 } from "../search/port.js";
+import type { QmdCapabilities, QmdVersionStatus } from "../qmd.js";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
 
 type CollectionState = "present" | "missing" | "unknown" | "skipped";
@@ -34,6 +35,10 @@ class FakeBackend implements SearchBackend {
       ensure?: CollectionState;
     } = {},
     private readonly daemonMode = false,
+    private readonly diagnostics: {
+      debugStatus?: string;
+      versionStatus?: QmdVersionStatus;
+    } = {},
   ) {}
 
   private limitedResults(maxResults: number | undefined): QmdSearchResult[] {
@@ -57,11 +62,15 @@ class FakeBackend implements SearchBackend {
   }
 
   debugStatus(): string {
-    return "fake";
+    return this.diagnostics.debugStatus ?? "fake";
   }
 
   isDaemonMode(): boolean {
     return this.daemonMode;
+  }
+
+  getVersionStatus(): QmdVersionStatus | null {
+    return this.diagnostics.versionStatus ?? null;
   }
 
   async dispose(): Promise<void> {
@@ -171,6 +180,41 @@ function config(): PluginConfig {
     defaultNamespace: "main",
     qmdMaxResults: 10,
   } as PluginConfig;
+}
+
+function qmdCapabilities(enabled: boolean): QmdCapabilities {
+  return {
+    version: enabled ? "2.5.3" : null,
+    parsedVersion: enabled ? [2, 5, 3] : null,
+    stableSdk: enabled,
+    unifiedSearch: enabled,
+    getDocumentBody: enabled,
+    maintenanceApi: enabled,
+    legacySkillInstall: enabled,
+    intentHints: enabled,
+    explainTraces: enabled,
+    candidateLimit: enabled,
+    v2McpQueryTool: enabled,
+    structuredSearches: enabled,
+    queryRerankToggle: enabled,
+    chunkStrategy: enabled,
+    qmdBench: enabled,
+    perCollectionModels: enabled,
+    jsonLineNumbers: enabled,
+    editorLinks: enabled,
+    doctor: enabled,
+    versionedSkills: enabled,
+    absoluteSnippetLines: enabled,
+    fullQueryOutput: enabled,
+    forceCpu: enabled,
+    gpuBackendOverride: enabled,
+    embedParallelism: enabled,
+    modelEnvConsistency: enabled,
+    scopedEmbed: enabled,
+    safeStatusDeviceProbe: enabled,
+    mcpIndexSelection: enabled,
+    outputFormatFlag: enabled,
+  };
 }
 
 test("updateNamespaces runs a global-update backend only once", async () => {
@@ -368,8 +412,28 @@ test("healthForNamespace reports daemon mode from live cached namespace backend"
             score: 1,
             snippet: "a",
           },
-        ], { ensure: "present" }, true)
-        : new FakeBackend(false, [], { check: "present" }, false);
+        ], { ensure: "present" }, true, {
+          debugStatus: "live-daemon",
+          versionStatus: {
+            installedVersion: "qmd 2.5.3",
+            supportedVersion: "2.5.3",
+            supported: true,
+            newerThanSupported: false,
+            upgradeAvailable: false,
+            capabilities: qmdCapabilities(true),
+          },
+        })
+        : new FakeBackend(false, [], { check: "present" }, false, {
+          debugStatus: "probe-unavailable",
+          versionStatus: {
+            installedVersion: null,
+            supportedVersion: "2.5.3",
+            supported: false,
+            newerThanSupported: false,
+            upgradeAvailable: false,
+            capabilities: qmdCapabilities(false),
+          },
+        });
       if (created.length === 1) {
         backend.available = false;
       }
@@ -387,6 +451,12 @@ test("healthForNamespace reports daemon mode from live cached namespace backend"
 
   assert.equal(health.available, true);
   assert.equal(health.daemonMode, true);
+  assert.equal(health.debugStatus, "live-daemon");
+  assert.equal(health.installedVersion, "qmd 2.5.3");
+  assert.equal(health.supportedVersion, "2.5.3");
+  assert.equal(health.supported, true);
+  assert.equal(health.upgradeAvailable, false);
+  assert.equal(health.doctorAvailable, true);
   assert.equal(health.collectionState, "unknown");
   assert.equal(created.length, 2);
   assert.equal(created[0]?.disposed, 0);

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -18,6 +18,8 @@ class FakeBackend implements SearchBackend {
     collection: string | undefined;
     maxResults: number | undefined;
   }> = [];
+  availabilitySignals: Array<AbortSignal | undefined> = [];
+  probeCalls = 0;
   ensureSignals: Array<AbortSignal | undefined> = [];
   ensureCollections: Array<string | undefined> = [];
   checkSignals: Array<AbortSignal | undefined> = [];
@@ -39,6 +41,12 @@ class FakeBackend implements SearchBackend {
   }
 
   async probe(): Promise<boolean> {
+    this.probeCalls += 1;
+    return true;
+  }
+
+  async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
+    this.availabilitySignals.push(execution?.signal);
     return true;
   }
 
@@ -329,6 +337,8 @@ test("healthForNamespace checks namespace collection without auto-creating or ca
   assert.equal(health.collection, "openclaw-engram--ns-736861726564");
   assert.deepEqual(created[0]?.checkCollections, ["openclaw-engram--ns-736861726564"]);
   assert.deepEqual(created[0]?.ensureCollections, []);
+  assert.equal(created[0]?.probeCalls, 0);
+  assert.equal(created[0]?.availabilitySignals.length, 1);
   assert.equal(created[0]?.disposed, 1);
 
   const ensured = await router.ensureNamespaceCollection("shared");
@@ -338,9 +348,10 @@ test("healthForNamespace checks namespace collection without auto-creating or ca
   assert.deepEqual(created[1]?.ensureCollections, ["openclaw-engram--ns-736861726564"]);
 });
 
-test("healthForNamespace stops waiting when namespace backend probe aborts", async () => {
+test("healthForNamespace stops waiting when namespace availability probe aborts", async () => {
   const backend = new class extends FakeBackend {
-    override async probe(): Promise<boolean> {
+    override async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
+      this.availabilitySignals.push(execution?.signal);
       return await new Promise<boolean>(() => {});
     }
   }(false);
@@ -358,6 +369,8 @@ test("healthForNamespace stops waiting when namespace backend probe aborts", asy
 
   assert.equal(health.available, false);
   assert.equal(health.collectionState, "unknown");
+  assert.equal(backend.probeCalls, 0);
+  assert.equal(backend.availabilitySignals[0], controller.signal);
   assert.deepEqual(backend.checkCollections, []);
   assert.deepEqual(backend.ensureCollections, []);
   assert.equal(backend.disposed, 1);

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -13,6 +13,7 @@ type CollectionState = "present" | "missing" | "unknown" | "skipped";
 class FakeBackend implements SearchBackend {
   updates = 0;
   disposed = 0;
+  available = true;
   calls: Array<{
     method: string;
     collection: string | undefined;
@@ -43,16 +44,16 @@ class FakeBackend implements SearchBackend {
 
   async probe(): Promise<boolean> {
     this.probeCalls += 1;
-    return true;
+    return this.available;
   }
 
   async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
     this.availabilitySignals.push(execution?.signal);
-    return true;
+    return this.available;
   }
 
   isAvailable(): boolean {
-    return true;
+    return this.available;
   }
 
   debugStatus(): string {
@@ -369,6 +370,9 @@ test("healthForNamespace reports daemon mode from live cached namespace backend"
           },
         ], { ensure: "present" }, true)
         : new FakeBackend(false, [], { check: "present" }, false);
+      if (created.length === 1) {
+        backend.available = false;
+      }
       created.push(backend);
       return backend;
     },
@@ -381,12 +385,13 @@ test("healthForNamespace reports daemon mode from live cached namespace backend"
   });
   const health = await router.healthForNamespace("shared");
 
+  assert.equal(health.available, true);
   assert.equal(health.daemonMode, true);
-  assert.equal(health.collectionState, "present");
+  assert.equal(health.collectionState, "unknown");
   assert.equal(created.length, 2);
   assert.equal(created[0]?.disposed, 0);
   assert.equal(created[1]?.disposed, 1);
-  assert.deepEqual(created[1]?.checkCollections, ["openclaw-engram--ns-736861726564"]);
+  assert.deepEqual(created[1]?.checkCollections, []);
 });
 
 test("healthForNamespace stops waiting when namespace availability probe aborts", async () => {

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -12,6 +12,7 @@ type CollectionState = "present" | "missing" | "unknown" | "skipped";
 
 class FakeBackend implements SearchBackend {
   updates = 0;
+  disposed = 0;
   calls: Array<{
     method: string;
     collection: string | undefined;
@@ -47,6 +48,10 @@ class FakeBackend implements SearchBackend {
 
   debugStatus(): string {
     return "fake";
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed += 1;
   }
 
   async search(
@@ -302,6 +307,35 @@ test("legacy default namespace root fail-opens missing guarded collections", asy
   assert.equal(state, "unknown");
   assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
   assert.deepEqual(backend.ensureCollections, []);
+});
+
+test("healthForNamespace checks namespace collection without auto-creating or caching state", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(false, [], created.length === 0
+        ? { check: "missing" }
+        : { ensure: "present" });
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const health = await router.healthForNamespace("shared");
+
+  assert.equal(health.collectionState, "missing");
+  assert.equal(health.collection, "openclaw-engram--ns-736861726564");
+  assert.deepEqual(created[0]?.checkCollections, ["openclaw-engram--ns-736861726564"]);
+  assert.deepEqual(created[0]?.ensureCollections, []);
+  assert.equal(created[0]?.disposed, 1);
+
+  const ensured = await router.ensureNamespaceCollection("shared");
+
+  assert.equal(ensured, "present");
+  assert.equal(created.length, 2);
+  assert.deepEqual(created[1]?.ensureCollections, ["openclaw-engram--ns-736861726564"]);
 });
 
 test("legacy default namespace root filters nested namespace search results", async () => {

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -226,12 +226,16 @@ export class NamespaceSearchRouter {
           : null;
       const liveRecord = await this.liveCachedRecordForHealth(key, record, execution);
       const daemonMode = daemonModeForBackend(liveRecord?.backend ?? record.backend);
+      const collectionState =
+        liveRecord?.collectionState === "missing"
+          ? "missing"
+          : record.collectionState;
 
       return {
         collection: record.collection,
         memoryDir: record.memoryDir,
         available: liveRecord?.available ?? record.available,
-        collectionState: record.collectionState,
+        collectionState,
         debugStatus: record.backend.debugStatus(),
         installedVersion: versionStatus?.installedVersion ?? null,
         supportedVersion: versionStatus?.supportedVersion ?? null,

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -66,6 +66,7 @@ type NamespaceScopedSearchConfig = PluginConfig & {
 
 type BackendRecordOptions = {
   autoCreateCollection: boolean;
+  abortAsUnavailable: boolean;
   failOpenMissingGuardedCollection: boolean;
 };
 
@@ -212,6 +213,7 @@ export class NamespaceSearchRouter {
       execution,
       {
         autoCreateCollection: false,
+        abortAsUnavailable: true,
         failOpenMissingGuardedCollection: false,
       },
     );
@@ -275,7 +277,11 @@ export class NamespaceSearchRouter {
 
     const pending = this.createBackendRecordFor(key, execution, {
       autoCreateCollection: true,
+      abortAsUnavailable: false,
       failOpenMissingGuardedCollection: true,
+    }).catch((error) => {
+      this.cache.delete(key);
+      throw error;
     });
 
     this.cache.set(key, pending);
@@ -307,26 +313,44 @@ export class NamespaceSearchRouter {
     };
 
     const backend = this.createBackend(scopedConfig);
-    const available = await awaitWithAbort(backend.probe(), execution?.signal).catch(() => false);
-    const collectionState = available
-      ? await awaitWithAbort(
-        this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
-          autoCreate: options.autoCreateCollection,
-          failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
-          skipAutoCreate: filtersNestedNamespaces,
-          execution,
-        }),
-        execution?.signal,
-      ).catch(() => "unknown" as const)
-      : "unknown";
-    return {
-      backend,
-      collection: scopedConfig.qmdCollection,
-      memoryDir: storage.dir,
-      available,
-      collectionState,
-      filtersNestedNamespaces,
-    };
+    try {
+      const available = await awaitWithAbort(backend.probe(), execution?.signal).catch((error) => {
+        if (error instanceof NamespaceSearchAbortError && !options.abortAsUnavailable) {
+          throw error;
+        }
+        return false;
+      });
+      const collectionState = available
+        ? await awaitWithAbort(
+          this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
+            autoCreate: options.autoCreateCollection,
+            failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
+            skipAutoCreate: filtersNestedNamespaces,
+            execution,
+          }),
+          execution?.signal,
+        ).catch((error) => {
+          if (error instanceof NamespaceSearchAbortError && !options.abortAsUnavailable) {
+            throw error;
+          }
+          return "unknown" as const;
+        })
+        : "unknown";
+      return {
+        backend,
+        collection: scopedConfig.qmdCollection,
+        memoryDir: storage.dir,
+        available,
+        collectionState,
+        filtersNestedNamespaces,
+      };
+    } catch (error) {
+      const dispose = (backend as { dispose?: () => void | Promise<void> }).dispose;
+      if (dispose) {
+        await Promise.resolve(dispose.call(backend)).catch(() => {});
+      }
+      throw error;
+    }
   }
 
   private async collectionStateForBackend(
@@ -353,12 +377,21 @@ export class NamespaceSearchRouter {
   }
 }
 
+class NamespaceSearchAbortError extends Error {
+  constructor() {
+    super("operation aborted");
+  }
+}
+
 function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) return operation;
-  if (signal.aborted) return Promise.reject(new Error("operation aborted"));
+  if (signal.aborted) return Promise.reject(new NamespaceSearchAbortError());
 
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(new Error("operation aborted"));
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new NamespaceSearchAbortError());
+    };
     signal.addEventListener("abort", onAbort, { once: true });
     operation.then(resolve, reject).finally(() => {
       signal.removeEventListener("abort", onAbort);

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -44,7 +44,21 @@ type NamespaceBackendRecord = {
   filtersNestedNamespaces: boolean;
 };
 
-type CollectionState = "present" | "missing" | "unknown" | "skipped";
+export type CollectionState = "present" | "missing" | "unknown" | "skipped";
+
+export interface NamespaceSearchHealth {
+  collection: string;
+  memoryDir: string;
+  available: boolean;
+  collectionState: CollectionState;
+  debugStatus: string;
+  installedVersion: string | null;
+  supportedVersion: string | null;
+  supported: boolean | null;
+  upgradeAvailable: boolean | null;
+  doctorAvailable: boolean | null;
+  daemonMode: boolean | null;
+}
 
 type NamespaceScopedSearchConfig = PluginConfig & {
   hostEmbeddingProviderScope?: string;
@@ -182,6 +196,37 @@ export class NamespaceSearchRouter {
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
     const record = await this.backendRecordFor(namespace, execution);
     return record.collectionState;
+  }
+
+  async healthForNamespace(
+    namespace: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<NamespaceSearchHealth> {
+    const record = await this.backendRecordFor(namespace, execution);
+    const versionStatus =
+      "getVersionStatus" in record.backend &&
+      typeof record.backend.getVersionStatus === "function"
+        ? record.backend.getVersionStatus()
+        : null;
+    const daemonMode =
+      "isDaemonMode" in record.backend &&
+      typeof record.backend.isDaemonMode === "function"
+        ? record.backend.isDaemonMode() === true
+        : null;
+
+    return {
+      collection: record.collection,
+      memoryDir: record.memoryDir,
+      available: record.available,
+      collectionState: record.collectionState,
+      debugStatus: record.backend.debugStatus(),
+      installedVersion: versionStatus?.installedVersion ?? null,
+      supportedVersion: versionStatus?.supportedVersion ?? null,
+      supported: versionStatus?.supported ?? null,
+      upgradeAvailable: versionStatus?.upgradeAvailable ?? null,
+      doctorAvailable: versionStatus?.capabilities?.doctor ?? null,
+      daemonMode,
+    };
   }
 
   /** Clear cached backend records so the next access re-probes availability. */

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -208,8 +208,9 @@ export class NamespaceSearchRouter {
     namespace: string,
     execution?: SearchExecutionOptions,
   ): Promise<NamespaceSearchHealth> {
+    const key = namespace.trim() || this.config.defaultNamespace;
     const record = await this.createBackendRecordFor(
-      namespace.trim() || this.config.defaultNamespace,
+      key,
       execution,
       {
         autoCreateCollection: false,
@@ -223,11 +224,8 @@ export class NamespaceSearchRouter {
         typeof record.backend.getVersionStatus === "function"
           ? record.backend.getVersionStatus()
           : null;
-      const daemonMode =
-        "isDaemonMode" in record.backend &&
-        typeof record.backend.isDaemonMode === "function"
-          ? record.backend.isDaemonMode() === true
-          : null;
+      const liveRecord = await this.liveCachedRecordForHealth(key, record, execution);
+      const daemonMode = daemonModeForBackend(liveRecord?.backend ?? record.backend);
 
       return {
         collection: record.collection,
@@ -246,6 +244,20 @@ export class NamespaceSearchRouter {
       const dispose = (record.backend as { dispose?: () => void | Promise<void> }).dispose;
       await dispose?.call(record.backend);
     }
+  }
+
+  private async liveCachedRecordForHealth(
+    key: string,
+    disposableRecord: NamespaceBackendRecord,
+    execution?: SearchExecutionOptions,
+  ): Promise<NamespaceBackendRecord | null> {
+    const pending = this.cache.get(key);
+    if (!pending) return null;
+    const cachedRecord = await awaitWithAbort(pending, execution?.signal).catch(() => null);
+    if (!cachedRecord) return null;
+    if (cachedRecord.collection !== disposableRecord.collection) return null;
+    if (cachedRecord.memoryDir !== disposableRecord.memoryDir) return null;
+    return cachedRecord;
   }
 
   /** Clear cached backend records so the next access re-probes availability. */
@@ -423,6 +435,12 @@ function backendSearchLimit(
     maxResults * NESTED_NAMESPACE_FILTER_OVERFETCH_FACTOR,
     NESTED_NAMESPACE_FILTER_OVERFETCH_MIN,
   );
+}
+
+function daemonModeForBackend(backend: SearchBackend): boolean | null {
+  return "isDaemonMode" in backend && typeof backend.isDaemonMode === "function"
+    ? backend.isDaemonMode() === true
+    : null;
 }
 
 function pathIsInsideNamespaceSubtree(

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -307,14 +307,17 @@ export class NamespaceSearchRouter {
     };
 
     const backend = this.createBackend(scopedConfig);
-    const available = await backend.probe().catch(() => false);
+    const available = await awaitWithAbort(backend.probe(), execution?.signal).catch(() => false);
     const collectionState = available
-      ? await this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
-        autoCreate: options.autoCreateCollection,
-        failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
-        skipAutoCreate: filtersNestedNamespaces,
-        execution,
-      })
+      ? await awaitWithAbort(
+        this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
+          autoCreate: options.autoCreateCollection,
+          failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
+          skipAutoCreate: filtersNestedNamespaces,
+          execution,
+        }),
+        execution?.signal,
+      ).catch(() => "unknown" as const)
       : "unknown";
     return {
       backend,
@@ -348,6 +351,19 @@ export class NamespaceSearchRouter {
     }
     return await backend.ensureCollection(memoryDir, collection, options.execution).catch(() => "unknown" as const);
   }
+}
+
+function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) return Promise.reject(new Error("operation aborted"));
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error("operation aborted"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
 }
 
 function filterNamespaceSubtreeResults(

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -230,7 +230,7 @@ export class NamespaceSearchRouter {
       return {
         collection: record.collection,
         memoryDir: record.memoryDir,
-        available: record.available,
+        available: liveRecord?.available ?? record.available,
         collectionState: record.collectionState,
         debugStatus: record.backend.debugStatus(),
         installedVersion: versionStatus?.installedVersion ?? null,

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -219,13 +219,14 @@ export class NamespaceSearchRouter {
       },
     );
     try {
-      const versionStatus =
-        "getVersionStatus" in record.backend &&
-        typeof record.backend.getVersionStatus === "function"
-          ? record.backend.getVersionStatus()
-          : null;
       const liveRecord = await this.liveCachedRecordForHealth(key, record, execution);
-      const daemonMode = daemonModeForBackend(liveRecord?.backend ?? record.backend);
+      const diagnosticBackend = liveRecord?.backend ?? record.backend;
+      const versionStatus =
+        "getVersionStatus" in diagnosticBackend &&
+        typeof diagnosticBackend.getVersionStatus === "function"
+          ? diagnosticBackend.getVersionStatus()
+          : null;
+      const daemonMode = daemonModeForBackend(diagnosticBackend);
       const collectionState =
         liveRecord?.collectionState === "missing"
           ? "missing"
@@ -236,7 +237,7 @@ export class NamespaceSearchRouter {
         memoryDir: record.memoryDir,
         available: liveRecord?.available ?? record.available,
         collectionState,
-        debugStatus: record.backend.debugStatus(),
+        debugStatus: diagnosticBackend.debugStatus(),
         installedVersion: versionStatus?.installedVersion ?? null,
         supportedVersion: versionStatus?.supportedVersion ?? null,
         supported: versionStatus?.supported ?? null,

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -314,7 +314,11 @@ export class NamespaceSearchRouter {
 
     const backend = this.createBackend(scopedConfig);
     try {
-      const available = await awaitWithAbort(backend.probe(), execution?.signal).catch((error) => {
+      const availabilityProbe =
+        options.autoCreateCollection || typeof backend.checkAvailability !== "function"
+          ? backend.probe()
+          : backend.checkAvailability({ signal: execution?.signal });
+      const available = await awaitWithAbort(availabilityProbe, execution?.signal).catch((error) => {
         if (error instanceof NamespaceSearchAbortError && !options.abortAsUnavailable) {
           throw error;
         }

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -64,6 +64,11 @@ type NamespaceScopedSearchConfig = PluginConfig & {
   hostEmbeddingProviderScope?: string;
 };
 
+type BackendRecordOptions = {
+  autoCreateCollection: boolean;
+  failOpenMissingGuardedCollection: boolean;
+};
+
 export class NamespaceSearchRouter {
   private readonly cache = new Map<string, Promise<NamespaceBackendRecord>>();
 
@@ -202,31 +207,43 @@ export class NamespaceSearchRouter {
     namespace: string,
     execution?: SearchExecutionOptions,
   ): Promise<NamespaceSearchHealth> {
-    const record = await this.backendRecordFor(namespace, execution);
-    const versionStatus =
-      "getVersionStatus" in record.backend &&
-      typeof record.backend.getVersionStatus === "function"
-        ? record.backend.getVersionStatus()
-        : null;
-    const daemonMode =
-      "isDaemonMode" in record.backend &&
-      typeof record.backend.isDaemonMode === "function"
-        ? record.backend.isDaemonMode() === true
-        : null;
+    const record = await this.createBackendRecordFor(
+      namespace.trim() || this.config.defaultNamespace,
+      execution,
+      {
+        autoCreateCollection: false,
+        failOpenMissingGuardedCollection: false,
+      },
+    );
+    try {
+      const versionStatus =
+        "getVersionStatus" in record.backend &&
+        typeof record.backend.getVersionStatus === "function"
+          ? record.backend.getVersionStatus()
+          : null;
+      const daemonMode =
+        "isDaemonMode" in record.backend &&
+        typeof record.backend.isDaemonMode === "function"
+          ? record.backend.isDaemonMode() === true
+          : null;
 
-    return {
-      collection: record.collection,
-      memoryDir: record.memoryDir,
-      available: record.available,
-      collectionState: record.collectionState,
-      debugStatus: record.backend.debugStatus(),
-      installedVersion: versionStatus?.installedVersion ?? null,
-      supportedVersion: versionStatus?.supportedVersion ?? null,
-      supported: versionStatus?.supported ?? null,
-      upgradeAvailable: versionStatus?.upgradeAvailable ?? null,
-      doctorAvailable: versionStatus?.capabilities?.doctor ?? null,
-      daemonMode,
-    };
+      return {
+        collection: record.collection,
+        memoryDir: record.memoryDir,
+        available: record.available,
+        collectionState: record.collectionState,
+        debugStatus: record.backend.debugStatus(),
+        installedVersion: versionStatus?.installedVersion ?? null,
+        supportedVersion: versionStatus?.supportedVersion ?? null,
+        supported: versionStatus?.supported ?? null,
+        upgradeAvailable: versionStatus?.upgradeAvailable ?? null,
+        doctorAvailable: versionStatus?.capabilities?.doctor ?? null,
+        daemonMode,
+      };
+    } finally {
+      const dispose = (record.backend as { dispose?: () => void | Promise<void> }).dispose;
+      await dispose?.call(record.backend);
+    }
   }
 
   /** Clear cached backend records so the next access re-probes availability. */
@@ -256,45 +273,57 @@ export class NamespaceSearchRouter {
     const existing = this.cache.get(key);
     if (existing) return await existing;
 
-    const pending = (async (): Promise<NamespaceBackendRecord> => {
-      const storage = await this.storageRouter.storageFor(key);
-      const useLegacyDefaultCollection =
-        key === this.config.defaultNamespace && storage.dir === this.config.memoryDir;
-      const filtersNestedNamespaces =
-        this.config.namespacesEnabled === true && useLegacyDefaultCollection;
-      const rootHostEmbeddingScope =
-        (this.config as NamespaceScopedSearchConfig).hostEmbeddingProviderScope ??
-        this.config.memoryDir;
-      const scopedConfig: NamespaceScopedSearchConfig = {
-        ...this.config,
-        memoryDir: storage.dir,
-        hostEmbeddingProviderScope: rootHostEmbeddingScope,
-        qmdCollection: namespaceCollectionName(this.config.qmdCollection, key, {
-          defaultNamespace: this.config.defaultNamespace,
-          useLegacyDefaultCollection,
-        }),
-      };
-
-      const backend = this.createBackend(scopedConfig);
-      const available = await backend.probe().catch(() => false);
-      const collectionState = available
-        ? await this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
-          skipAutoCreate: filtersNestedNamespaces,
-          execution,
-        })
-        : "unknown";
-      return {
-        backend,
-        collection: scopedConfig.qmdCollection,
-        memoryDir: storage.dir,
-        available,
-        collectionState,
-        filtersNestedNamespaces,
-      };
-    })();
+    const pending = this.createBackendRecordFor(key, execution, {
+      autoCreateCollection: true,
+      failOpenMissingGuardedCollection: true,
+    });
 
     this.cache.set(key, pending);
     return await pending;
+  }
+
+  private async createBackendRecordFor(
+    namespace: string,
+    execution: SearchExecutionOptions | undefined,
+    options: BackendRecordOptions,
+  ): Promise<NamespaceBackendRecord> {
+    const key = namespace.trim() || this.config.defaultNamespace;
+    const storage = await this.storageRouter.storageFor(key);
+    const useLegacyDefaultCollection =
+      key === this.config.defaultNamespace && storage.dir === this.config.memoryDir;
+    const filtersNestedNamespaces =
+      this.config.namespacesEnabled === true && useLegacyDefaultCollection;
+    const rootHostEmbeddingScope =
+      (this.config as NamespaceScopedSearchConfig).hostEmbeddingProviderScope ??
+      this.config.memoryDir;
+    const scopedConfig: NamespaceScopedSearchConfig = {
+      ...this.config,
+      memoryDir: storage.dir,
+      hostEmbeddingProviderScope: rootHostEmbeddingScope,
+      qmdCollection: namespaceCollectionName(this.config.qmdCollection, key, {
+        defaultNamespace: this.config.defaultNamespace,
+        useLegacyDefaultCollection,
+      }),
+    };
+
+    const backend = this.createBackend(scopedConfig);
+    const available = await backend.probe().catch(() => false);
+    const collectionState = available
+      ? await this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
+        autoCreate: options.autoCreateCollection,
+        failOpenMissingGuardedCollection: options.failOpenMissingGuardedCollection,
+        skipAutoCreate: filtersNestedNamespaces,
+        execution,
+      })
+      : "unknown";
+    return {
+      backend,
+      collection: scopedConfig.qmdCollection,
+      memoryDir: storage.dir,
+      available,
+      collectionState,
+      filtersNestedNamespaces,
+    };
   }
 
   private async collectionStateForBackend(
@@ -302,16 +331,20 @@ export class NamespaceSearchRouter {
     memoryDir: string,
     collection: string,
     options: {
+      autoCreate: boolean;
+      failOpenMissingGuardedCollection: boolean;
       skipAutoCreate: boolean;
       execution?: SearchExecutionOptions;
     },
   ): Promise<CollectionState> {
-    if (options.skipAutoCreate) {
+    if (!options.autoCreate || options.skipAutoCreate) {
       if (!backend.checkCollection) return "unknown";
       const collectionState = await backend
         .checkCollection(collection, options.execution)
         .catch(() => "unknown" as const);
-      return collectionState === "missing" ? "unknown" : collectionState;
+      return options.failOpenMissingGuardedCollection && collectionState === "missing"
+        ? "unknown"
+        : collectionState;
     }
     return await backend.ensureCollection(memoryDir, collection, options.execution).catch(() => "unknown" as const);
   }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -311,7 +311,10 @@ import {
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
 import type { CodingContext } from "./types.js";
-import { NamespaceSearchRouter } from "./namespaces/search.js";
+import {
+  NamespaceSearchRouter,
+  type NamespaceSearchHealth,
+} from "./namespaces/search.js";
 import { SharedContextManager } from "./shared-context/manager.js";
 import {
   CompoundingEngine,
@@ -2322,6 +2325,13 @@ export class Orchestrator {
       searchOptions: options.searchOptions,
       execution: options.execution,
     });
+  }
+
+  async searchHealthForNamespace(
+    namespace: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<NamespaceSearchHealth> {
+    return await this.namespaceSearchRouter.healthForNamespace(namespace, execution);
   }
 
   private isSearchAvailableForNamespaceRouting(): boolean {

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -183,6 +183,45 @@ test("QmdClient preserves configured qmdPath diagnostics when all probes fail", 
   }
 });
 
+test("QmdClient read-only availability failures preserve operational state", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const originalPath = process.env.PATH;
+  const originalWindowsPath = process.env.Path;
+  const missingQmdPath = path.join(
+    os.tmpdir(),
+    `remnic-missing-readonly-qmd-${process.pid}-${Date.now()}`,
+    "qmd.cmd",
+  );
+
+  process.env.PATH = "";
+  process.env.Path = "";
+  try {
+    const client = new QmdClient("test-collection", 10, {
+      qmdPath: missingQmdPath,
+      qmdFallbackPaths: [],
+    });
+    (client as any).available = true;
+    (client as any).qmdPath = "qmd";
+    (client as any).qmdPathSource = "auto-path";
+    (client as any).cliVersion = "qmd 2.5.3";
+    (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.3");
+    (client as any).lastCliProbeError = null;
+
+    assert.equal(await client.checkAvailability(), false);
+
+    assert.equal(client.isAvailable(), true);
+    assert.equal((client as any).qmdPath, "qmd");
+    assert.equal((client as any).qmdPathSource, "auto-path");
+    assert.equal((client as any).cliVersion, "qmd 2.5.3");
+    assert.equal((client as any).lastCliProbeError, null);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalWindowsPath === undefined) delete process.env.Path;
+    else process.env.Path = originalWindowsPath;
+  }
+});
+
 test("QmdClient applies chunk strategy to normal and forced embed args", async () => {
   const { QmdClient } = await import("./qmd.js");
   const client = new QmdClient("test", 5, {

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -240,9 +240,41 @@ test("QmdClient read-only availability preserves live daemon availability", asyn
       qmdFallbackPaths: [],
     });
     (client as any).daemonAvailable = true;
+    (client as any).daemonSession = { isActive: () => true };
 
     assert.equal(await client.checkAvailability(), true);
     assert.equal(client.isAvailable(), true);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalWindowsPath === undefined) delete process.env.Path;
+    else process.env.Path = originalWindowsPath;
+  }
+});
+
+test("QmdClient read-only availability clears stale daemon availability", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const originalPath = process.env.PATH;
+  const originalWindowsPath = process.env.Path;
+  const missingQmdPath = path.join(
+    os.tmpdir(),
+    `remnic-missing-stale-daemon-qmd-${process.pid}-${Date.now()}`,
+    "qmd.cmd",
+  );
+
+  process.env.PATH = "";
+  process.env.Path = "";
+  try {
+    const client = new QmdClient("test-collection", 10, {
+      qmdPath: missingQmdPath,
+      qmdFallbackPaths: [],
+    });
+    (client as any).daemonAvailable = true;
+    (client as any).daemonSession = { isActive: () => false };
+
+    assert.equal(await client.checkAvailability(), false);
+    assert.equal(client.isAvailable(), false);
+    assert.equal((client as any).daemonAvailable, false);
   } finally {
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -222,6 +222,35 @@ test("QmdClient read-only availability failures preserve operational state", asy
   }
 });
 
+test("QmdClient read-only availability preserves live daemon availability", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const originalPath = process.env.PATH;
+  const originalWindowsPath = process.env.Path;
+  const missingQmdPath = path.join(
+    os.tmpdir(),
+    `remnic-missing-daemon-qmd-${process.pid}-${Date.now()}`,
+    "qmd.cmd",
+  );
+
+  process.env.PATH = "";
+  process.env.Path = "";
+  try {
+    const client = new QmdClient("test-collection", 10, {
+      qmdPath: missingQmdPath,
+      qmdFallbackPaths: [],
+    });
+    (client as any).daemonAvailable = true;
+
+    assert.equal(await client.checkAvailability(), true);
+    assert.equal(client.isAvailable(), true);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalWindowsPath === undefined) delete process.env.Path;
+    else process.env.Path = originalWindowsPath;
+  }
+});
+
 test("QmdClient applies chunk strategy to normal and forced embed args", async () => {
   const { QmdClient } = await import("./qmd.js");
   const client = new QmdClient("test", 5, {

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -271,10 +271,12 @@ test("QmdClient read-only availability clears stale daemon availability", async 
     });
     (client as any).daemonAvailable = true;
     (client as any).daemonSession = { isActive: () => false };
+    (client as any).lastDaemonCheckAtMs = Date.now();
 
     assert.equal(await client.checkAvailability(), false);
     assert.equal(client.isAvailable(), false);
     assert.equal((client as any).daemonAvailable, false);
+    assert.equal((client as any).lastDaemonCheckAtMs, 0);
   } finally {
     if (originalPath === undefined) delete process.env.PATH;
     else process.env.PATH = originalPath;

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1373,6 +1373,7 @@ export class QmdClient implements SearchBackend {
     }
     if (this.daemonAvailable) {
       this.daemonAvailable = false;
+      this.lastDaemonCheckAtMs = 0;
     }
     return cliAvailable;
   }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1368,7 +1368,13 @@ export class QmdClient implements SearchBackend {
       preserveStateOnFailure: true,
       signal: execution?.signal,
     });
-    return cliAvailable || this.daemonAvailable;
+    if (this.daemonAvailable && this.daemonSession?.isActive()) {
+      return true;
+    }
+    if (this.daemonAvailable) {
+      this.daemonAvailable = false;
+    }
+    return cliAvailable;
   }
 
   private async probeDaemon(): Promise<boolean> {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1362,6 +1362,13 @@ export class QmdClient implements SearchBackend {
     return cliOk || this.daemonAvailable;
   }
 
+  async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
+    return this.probeCli({
+      allowAutoUpgrade: false,
+      signal: execution?.signal,
+    });
+  }
+
   private async probeDaemon(): Promise<boolean> {
     this.lastDaemonCheckAtMs = Date.now();
     const normalizedPath = this.qmdPath.trim() || "qmd";
@@ -1409,7 +1416,7 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  private async probeCli(): Promise<boolean> {
+  private async probeCli(options: { allowAutoUpgrade?: boolean; signal?: AbortSignal } = {}): Promise<boolean> {
     let configuredProbeFailure: string | null = null;
     const markProbeFailure = (err: unknown): void => {
       this.lastCliProbeError = err instanceof Error ? err.message : String(err);
@@ -1431,12 +1438,14 @@ export class QmdClient implements SearchBackend {
       this.cliVersion = parseQmdVersionOutput(result.stdout, result.stderr);
       this.qmdCapabilities = resolveQmdCapabilities(this.cliVersion);
       this.lastCliProbeError = null;
-      await this.maybeAutoUpgradeQmd();
+      if (options.allowAutoUpgrade !== false) {
+        await this.maybeAutoUpgradeQmd();
+      }
     };
 
     if (this.configuredQmdPath) {
       try {
-        const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, this.configuredQmdPath, undefined, this.qmdRuntimeEnv);
+        const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, this.configuredQmdPath, options.signal, this.qmdRuntimeEnv);
         await recordProbeSuccess(result, this.configuredQmdPath, "configured");
         return true;
       } catch (err) {
@@ -1452,7 +1461,7 @@ export class QmdClient implements SearchBackend {
 
     // Try PATH first
     try {
-      const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, "qmd", undefined, this.qmdRuntimeEnv);
+      const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, "qmd", options.signal, this.qmdRuntimeEnv);
       await recordProbeSuccess(result, "qmd", "auto-path");
       return true;
     } catch (err) {
@@ -1460,7 +1469,7 @@ export class QmdClient implements SearchBackend {
       // Try fallback paths
       for (const fallbackPath of this.qmdFallbackPaths) {
         try {
-          const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, fallbackPath, undefined, this.qmdRuntimeEnv);
+          const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, fallbackPath, options.signal, this.qmdRuntimeEnv);
           await recordProbeSuccess(result, fallbackPath, "auto-fallback");
           log.info(`QMD: found at ${fallbackPath}`);
           return true;

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1363,11 +1363,12 @@ export class QmdClient implements SearchBackend {
   }
 
   async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
-    return this.probeCli({
+    const cliAvailable = await this.probeCli({
       allowAutoUpgrade: false,
       preserveStateOnFailure: true,
       signal: execution?.signal,
     });
+    return cliAvailable || this.daemonAvailable;
   }
 
   private async probeDaemon(): Promise<boolean> {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1365,6 +1365,7 @@ export class QmdClient implements SearchBackend {
   async checkAvailability(execution?: SearchExecutionOptions): Promise<boolean> {
     return this.probeCli({
       allowAutoUpgrade: false,
+      preserveStateOnFailure: true,
       signal: execution?.signal,
     });
   }
@@ -1416,7 +1417,32 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  private async probeCli(options: { allowAutoUpgrade?: boolean; signal?: AbortSignal } = {}): Promise<boolean> {
+  private async probeCli(
+    options: {
+      allowAutoUpgrade?: boolean;
+      preserveStateOnFailure?: boolean;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<boolean> {
+    const priorState = options.preserveStateOnFailure === true
+      ? {
+        available: this.available,
+        qmdPath: this.qmdPath,
+        qmdPathSource: this.qmdPathSource,
+        cliVersion: this.cliVersion,
+        lastCliProbeError: this.lastCliProbeError,
+        qmdCapabilities: this.qmdCapabilities,
+      }
+      : null;
+    const restorePriorState = (): void => {
+      if (!priorState) return;
+      this.available = priorState.available;
+      this.qmdPath = priorState.qmdPath;
+      this.qmdPathSource = priorState.qmdPathSource;
+      this.cliVersion = priorState.cliVersion;
+      this.lastCliProbeError = priorState.lastCliProbeError;
+      this.qmdCapabilities = priorState.qmdCapabilities;
+    };
     let configuredProbeFailure: string | null = null;
     const markProbeFailure = (err: unknown): void => {
       this.lastCliProbeError = err instanceof Error ? err.message : String(err);
@@ -1478,8 +1504,12 @@ export class QmdClient implements SearchBackend {
           // Continue to next fallback
         }
       }
-      this.available = false;
-      restoreConfiguredProbeFailure();
+      if (priorState) {
+        restorePriorState();
+      } else {
+        this.available = false;
+        restoreConfiguredProbeFailure();
+      }
       return false;
     }
   }

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -42,6 +42,12 @@ export function resolveEnsureCollectionArgs(
 export interface SearchBackend {
   // ── Lifecycle ──
   probe(): Promise<boolean>;
+  /**
+   * Optional non-mutating availability probe for health/readiness checks.
+   * Implementations must avoid auto-upgrades, collection creation, daemon
+   * startup, or any other runtime-modifying side effects.
+   */
+  checkAvailability?(execution?: SearchExecutionOptions): Promise<boolean>;
   isAvailable(): boolean;
   debugStatus(): string;
 


### PR DESCRIPTION
## Summary

- Reviewed issue #1498 against merged PR #1493: #1493 installed QMD in the Docker image and added collection auto-create/probe behavior, but health/docs still did not make active-vs-fallback QMD state visible.
- Add structured `qmd` diagnostics to `/engram/v1/health`, including active/degraded mode, version support, doctor availability, debug status, and non-mutating collection state.
- Report namespace-scoped QMD collection names in health responses and update Docker/standalone docs to describe the full-image strategy and degraded fallback signal.

Closes #1498

## Verification

- `pnpm --filter @remnic/core exec tsx --test src/access-service-health.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall health and namespace QMD probing paths; behavior is mostly additive observability, but degraded/active flags affect how operators interpret search readiness.
> 
> **Overview**
> Adds a structured **`qmd`** object to `/engram/v1/health` so operators can see whether QMD search is actually active or running in degraded filesystem fallback, without inferring from recall behavior.
> 
> Health now reports **`active`**, **`degraded`**, **`mode`** (`cli` / `daemon` / `fallback`), version support, **`collectionState`**, and **`debugStatus`**. Probes use a new read-only **`checkAvailability`** path on `QmdClient` (no auto-upgrade or collection creation) with 2s timeouts; namespace deployments route through **`healthForNamespace`** / **`searchHealthForNamespace`** so collection names and failures stay scoped per namespace.
> 
> **`NamespaceSearchRouter`** gains **`healthForNamespace`** (check-only, disposable backends, abort-aware). Docs and changelog describe interpreting **`qmd.active`** vs **`qmd.enabled`**, plus updated Docker compose examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8318d3f95c72ec068913caec78df4dc87576f027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->