### PR TITLE
fix(briefing): parse fenced followup JSON

### DIFF
--- a/packages/remnic-core/src/briefing.test.ts
+++ b/packages/remnic-core/src/briefing.test.ts
@@ -16,6 +16,7 @@ import {
   focusMatchesMemory,
   buildActiveThreads,
   buildBriefing,
+  buildChainFollowupGenerator,
   BRIEFING_FOLLOWUP_DEFAULT_MODEL,
 } from "./briefing.js";
 import type {
@@ -974,6 +975,40 @@ test("buildBriefing: unrelated LLM errors still produce generic message (no fals
     !result.followupsUnavailableReason!.includes("not available"),
     "unrelated errors must NOT produce model-not-available message",
   );
+});
+
+test("buildChainFollowupGenerator accepts markdown-fenced followup JSON", async () => {
+  const generator = buildChainFollowupGenerator({
+    chatCompletion: async () => ({
+      content: [
+        "```json",
+        "{",
+        '  "followups": [',
+        '    { "text": "Check the launch plan", "rationale": "Open commitment found" }',
+        "  ]",
+        "}",
+        "```",
+      ].join("\n"),
+    }),
+  });
+
+  const followups = await generator({
+    sections: {
+      activeThreads: [],
+      recentEntities: [],
+      openCommitments: [{ id: "commit-1", kind: "commitment", text: "Finish launch plan" }],
+      suggestedFollowups: [],
+    },
+    windowLabel: "today",
+    maxFollowups: 3,
+  });
+
+  assert.deepEqual(followups, [
+    {
+      text: "Check the launch plan",
+      rationale: "Open commitment found",
+    },
+  ]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/briefing.test.ts
+++ b/packages/remnic-core/src/briefing.test.ts
@@ -1011,6 +1011,41 @@ test("buildChainFollowupGenerator accepts markdown-fenced followup JSON", async 
   ]);
 });
 
+test("buildChainFollowupGenerator skips parseable non-followup JSON candidates", async () => {
+  const generator = buildChainFollowupGenerator({
+    chatCompletion: async () => ({
+      content: [
+        '{ "metadata": "not followups" }',
+        "```json",
+        "{",
+        '  "followups": [',
+        '    { "text": "Review the launch plan", "rationale": "Actual follow-up block" }',
+        "  ]",
+        "}",
+        "```",
+      ].join("\n"),
+    }),
+  });
+
+  const followups = await generator({
+    sections: {
+      activeThreads: [],
+      recentEntities: [],
+      openCommitments: [{ id: "commit-1", kind: "commitment", text: "Finish launch plan" }],
+      suggestedFollowups: [],
+    },
+    windowLabel: "today",
+    maxFollowups: 3,
+  });
+
+  assert.deepEqual(followups, [
+    {
+      text: "Review the launch plan",
+      rationale: "Actual follow-up block",
+    },
+  ]);
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // Round 8 Finding UXE4: buildActiveThreads must recompute reason from newer memory
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -1298,7 +1298,22 @@ function parseFollowupResponse(raw: string, max: number): BriefingFollowup[] {
   // JSON.parse throws on invalid JSON — let the caller catch it so the outer
   // try/catch in buildBriefing can set followupsUnavailableReason rather than
   // silently returning an empty array that masks the parse failure.
-  const parsed = JSON.parse(raw) as unknown;
+  const candidates = extractJsonCandidates(raw);
+  let parsed: unknown;
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    try {
+      parsed = JSON.parse(candidate) as unknown;
+      lastError = undefined;
+      break;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  if (lastError) throw lastError;
+  if (parsed === undefined) {
+    throw new Error("LLM response contained no JSON candidates");
+  }
   if (!parsed || typeof parsed !== "object") {
     throw new Error(`LLM returned non-object JSON: ${typeof parsed}`);
   }

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -1299,41 +1299,36 @@ function parseFollowupResponse(raw: string, max: number): BriefingFollowup[] {
   // try/catch in buildBriefing can set followupsUnavailableReason rather than
   // silently returning an empty array that masks the parse failure.
   const candidates = extractJsonCandidates(raw);
-  let parsed: unknown;
   let lastError: unknown;
   for (const candidate of candidates) {
     try {
-      parsed = JSON.parse(candidate) as unknown;
-      lastError = undefined;
-      break;
+      const parsed = JSON.parse(candidate) as unknown;
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error(`LLM returned non-object JSON: ${typeof parsed}`);
+      }
+      const arr = (parsed as { followups?: unknown }).followups;
+      if (!Array.isArray(arr)) {
+        throw new Error(`LLM response missing "followups" array`);
+      }
+      const out: BriefingFollowup[] = [];
+      for (const entry of arr) {
+        if (!entry || typeof entry !== "object") continue;
+        const text = (entry as Record<string, unknown>).text;
+        if (typeof text !== "string" || text.trim().length === 0) continue;
+        const rationale = (entry as Record<string, unknown>).rationale;
+        out.push({
+          text: text.trim(),
+          rationale: typeof rationale === "string" ? rationale.trim() : undefined,
+        });
+        if (out.length >= max) break;
+      }
+      return out;
     } catch (err) {
       lastError = err;
     }
   }
   if (lastError) throw lastError;
-  if (parsed === undefined) {
-    throw new Error("LLM response contained no JSON candidates");
-  }
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error(`LLM returned non-object JSON: ${typeof parsed}`);
-  }
-  const arr = (parsed as { followups?: unknown }).followups;
-  if (!Array.isArray(arr)) {
-    throw new Error(`LLM response missing "followups" array`);
-  }
-  const out: BriefingFollowup[] = [];
-  for (const entry of arr) {
-    if (!entry || typeof entry !== "object") continue;
-    const text = (entry as Record<string, unknown>).text;
-    if (typeof text !== "string" || text.trim().length === 0) continue;
-    const rationale = (entry as Record<string, unknown>).rationale;
-    out.push({
-      text: text.trim(),
-      rationale: typeof rationale === "string" ? rationale.trim() : undefined,
-    });
-    if (out.length >= max) break;
-  }
-  return out;
+  throw new Error("LLM response contained no JSON candidates");
 }
 
 function stringifyError(err: unknown): string {


### PR DESCRIPTION
## Summary
- parse follow-up LLM output through the shared JSON candidate extractor
- cover markdown-fenced follow-up JSON returned from the chain generator path

## Verification
- pnpm --filter @remnic/core exec tsx --test src/briefing.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Closes #1514

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to LLM response parsing for optional briefing follow-ups; failures still surface via existing error handling.
> 
> **Overview**
> **Briefing follow-up parsing** now runs LLM output through `extractJsonCandidates` before validating the `{ followups: [...] }` shape, instead of requiring the whole response to be bare JSON.
> 
> That matches the chain follow-up path and fixes failures when models return markdown code fences or extra prose. Candidates without a `followups` array are skipped until a valid block is found.
> 
> Regression tests cover fenced JSON and responses that lead with unrelated parseable JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655297519112e22dd585820e59143018a17f4bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->