### PR TITLE
fix(mcp): tolerate capsule list session keys

### DIFF
--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -371,6 +371,33 @@ test("MCP capsule tools tolerate client-injected cwd/projectTag (#1434)", async 
   }
 });
 
+test("MCP capsule list tolerates client-injected sessionKey (#1513)", async () => {
+  let received: Record<string, unknown> | undefined;
+  const service = {
+    ...makeMockService(),
+    capsuleList: async (args: Record<string, unknown>) => {
+      received = args;
+      return { capsules: [] };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.capsule_list", {
+      namespace: "team",
+      sessionKey: "pi-injected-session",
+      cwd: "/x",
+      projectTag: "t",
+    }),
+  );
+
+  assert.deepEqual(received, {
+    namespace: "team",
+    principal: undefined,
+  });
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
+});
+
 test("MCP session override is injected only into tools that accept sessionKey", async () => {
   let capsuleListArgs: Record<string, unknown> | undefined;
   let observeArgs: Record<string, unknown> | undefined;

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -398,6 +398,41 @@ test("MCP capsule list tolerates client-injected sessionKey (#1513)", async () =
   assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
 });
 
+test("MCP capsule list derives namespace principal from client-injected sessionKey (#1513)", async () => {
+  let received: Record<string, unknown> | undefined;
+  const service = {
+    ...makeMockService(),
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-mcp-capsule-list-session-principal",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      principalFromSessionKeyMode: "map",
+      principalFromSessionKeyRules: [{ match: "pi-session", principal: "pi-agent" }],
+      namespacePolicies: [
+        { name: "team", readPrincipals: ["pi-agent"], writePrincipals: [] },
+      ],
+    }),
+    capsuleList: async (args: Record<string, unknown>) => {
+      received = args;
+      return { capsules: [] };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.capsule_list", {
+      namespace: "team",
+      sessionKey: "pi-session",
+    }),
+  );
+
+  assert.deepEqual(received, {
+    namespace: "team",
+    principal: "pi-agent",
+  });
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
+});
+
 test("MCP session override is injected only into tools that accept sessionKey", async () => {
   let capsuleListArgs: Record<string, unknown> | undefined;
   let observeArgs: Record<string, unknown> | undefined;

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -438,6 +438,13 @@ test("MCP session override is injected only into tools that accept sessionKey", 
   let observeArgs: Record<string, unknown> | undefined;
   const service = {
     ...makeMockService(),
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-mcp-session-override-test",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      principalFromSessionKeyMode: "map",
+      principalFromSessionKeyRules: [{ match: "adapter-session", principal: "adapter-agent" }],
+    }),
     capsuleList: async (args: Record<string, unknown>) => {
       capsuleListArgs = args;
       return { capsules: [] };
@@ -462,7 +469,7 @@ test("MCP session override is injected only into tools that accept sessionKey", 
 
   assert.deepEqual(capsuleListArgs, {
     namespace: undefined,
-    principal: undefined,
+    principal: "adapter-agent",
   });
   assert.deepEqual(observeArgs, {
     sessionKey: "adapter-session",

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -155,7 +155,7 @@ const STRICT_MCP_SCHEMA_KEYS: Partial<Record<SchemaName, readonly string[]>> = {
     "projectTag",
   ],
   capsuleImport: ["archivePath", "namespace", "mode", "passphrase", "cwd", "projectTag"],
-  capsuleList: ["namespace", "cwd", "projectTag"],
+  capsuleList: ["namespace", "sessionKey", "cwd", "projectTag"],
 };
 
 // Shared JSON-schema fragments for the client-injected git/project context

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -853,6 +853,10 @@ export class EngramMcpServer {
           type: "object",
           properties: {
             namespace: { type: "string" },
+            sessionKey: {
+              type: "string",
+              description: "Optional session key used to derive namespace principal when no trusted transport principal is present.",
+            },
             ...MCP_GIT_CONTEXT_SCHEMA_PROPS_IGNORED,
           },
           additionalProperties: false,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -20,6 +20,7 @@ import { validateBriefingFormat } from "./briefing.js";
 import { buildCitationGuidance, type CitationMetadata } from "./citations.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
 import { expandTildePath } from "./utils/path.js";
+import { resolvePrincipal } from "./namespaces/principal.js";
 import {
   REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
@@ -2694,9 +2695,14 @@ export class EngramMcpServer {
       }
       case "engram.capsule_list": {
         const body: CapsuleListRequest = parseMcpRequest("capsuleList", args);
+        const requestPrincipal =
+          effectivePrincipal ??
+          (body.sessionKey && this.service.configRef
+            ? resolvePrincipal(body.sessionKey, this.service.configRef)
+            : undefined);
         return this.service.capsuleList({
           namespace: body.namespace,
-          principal: effectivePrincipal,
+          principal: requestPrincipal,
         });
       }
       case "engram.memory_governance_run":

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -410,6 +410,7 @@ export const capsuleImportRequestSchema = z
 export const capsuleListRequestSchema = z
   .object({
     namespace: namespaceSchema,
+    sessionKey: sessionKeySchema,
   });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow client-injected sessionKey on capsule list MCP requests
- assert capsule_list ignores injected context before dispatching to the capsule service

## Verification
- pnpm --filter @remnic/core exec tsx --test src/access-mcp.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Closes #1513

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace principal resolution for capsule listing when clients send session keys without a trusted transport principal, which can alter who can read namespace-scoped capsules.
> 
> **Overview**
> Fixes MCP clients (e.g. Pi) that auto-inject **`sessionKey`** on every tool call so **`engram.capsule_list`** no longer fails strict validation and can use that key for namespace access when there is no transport principal.
> 
> **`engram.capsule_list`** now accepts optional **`sessionKey`** in the MCP tool schema and **`capsuleListRequestSchema`**. The handler still calls **`capsuleList`** with only **`namespace`** and **`principal`**; **`sessionKey`** is not forwarded. When **`effectivePrincipal`** is missing, **`principal`** is derived via **`resolvePrincipal(sessionKey, config)`** (same pattern as other session-aware tools). **`sessionKeyOverride`** on **`capsule_list`** therefore affects listing authorization, not just **`observe`**.
> 
> Regression tests cover ignored injected context alongside **`cwd`/`projectTag`**, mapped principal from **`sessionKey`**, and updated session-override expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03e39a2078568314f7ee322e6913b9707551287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->