### PR TITLE
feat(maintenance): fan out namespace maintenance

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1389,6 +1389,12 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `consolidationMinIntervalMs` | `600000` | `600000` |
 | `qmdMaintenanceEnabled` | `true` | `true` |
 | `qmdMaintenanceDebounceMs` | `30000` | `30000` |
+| `maintenance.namespaceFanoutEnabled` / `maintenanceNamespaceFanoutEnabled` | `true` | When namespaces are enabled, allow background jobs to use the namespace catalog to discover dynamic project/team namespaces. |
+| `maintenance.maxNamespacesPerCycle` / `maintenanceMaxNamespacesPerCycle` | `20` | Deterministic cap for each namespace-aware maintenance cycle. Default/shared/configured namespaces keep priority. |
+| `maintenance.includeProjectNamespaces` / `maintenanceIncludeProjectNamespaces` | `true` | Include project namespaces discovered from the catalog when their live roots contain memory data. |
+| `maintenance.includeBranchNamespaces` / `maintenanceIncludeBranchNamespaces` | `false` | Include branch namespaces in fanout. Off by default to avoid runaway branch maintenance. |
+| `maintenance.includeTeamProjectNamespaces` / `maintenanceIncludeTeamProjectNamespaces` | `true` | Include team-project namespaces discovered from trusted scope/profile writes. |
+| `maintenance.namespaceLockStaleMs` / `maintenanceNamespaceLockStaleMs` | `600000` | Stale threshold for per-job/per-namespace maintenance locks under `state/maintenance-locks/`. |
 | `qmdAutoEmbedEnabled` | `false` | `false` |
 | `qmdEmbedMinIntervalMs` | `3600000` | `3600000` |
 | `qmdUpdateTimeoutMs` | `90000` | `90000` |

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -216,6 +216,47 @@ Rebuild preserves known metadata (timestamps, principal hints) where safe,
 preserves the legacy/default-root compatibility case, and reports ambiguous
 roots instead of silently misclassifying them.
 
+## Namespace-Aware Maintenance Fanout (issue #1500)
+
+When `namespacesEnabled: true`, background maintenance can use the namespace
+catalog to process dynamic project and team-project namespaces that were created
+by hot writes. The first shared fanout path is QMD maintenance: update/embed runs
+per namespace through a common planner instead of only updating the configured
+default/shared/policy namespaces.
+
+The planner keeps the catalog as downstream metadata:
+
+- configured `defaultNamespace`, `sharedNamespace`, and `namespacePolicies`
+  remain eligible even if the catalog is disabled or unreadable;
+- dynamic catalog rows are eligible only when the live router root still matches
+  the catalog root and contains Remnic memory data;
+- branch namespaces are skipped by default;
+- each job+namespace gets a lock at
+  `<memoryDir>/state/maintenance-locks/<job>/<namespace-token>.lock`, so two
+  workers do not process the same namespace concurrently;
+- per-namespace status is written to
+  `<memoryDir>/state/namespace-maintenance-status/<job>/<namespace-token>.json`
+  for doctor/dashboard surfaces without rewriting other namespaces' status.
+
+Configuration:
+
+```json
+{
+  "maintenanceNamespaceFanoutEnabled": true,
+  "maintenanceMaxNamespacesPerCycle": 20,
+  "maintenanceIncludeProjectNamespaces": true,
+  "maintenanceIncludeBranchNamespaces": false,
+  "maintenanceIncludeTeamProjectNamespaces": true,
+  "maintenanceNamespaceLockStaleMs": 600000
+}
+```
+
+These flat keys are accepted by OpenClaw plugin config validation. Standalone
+Remnic config also accepts the equivalent nested `maintenance.*` shape. Default
+and shared namespaces keep priority inside the cycle budget; dynamic project/team
+namespaces are then selected deterministically by maintenance age, recent writes,
+and name.
+
 ## CLI
 
 First-class namespace commands:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3670,6 +3670,38 @@
         "default": 900000,
         "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
       },
+      "maintenanceNamespaceFanoutEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+      },
+      "maintenanceMaxNamespacesPerCycle": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+      },
+      "maintenanceIncludeProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceIncludeBranchNamespaces": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+      },
+      "maintenanceIncludeTeamProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceNamespaceLockStaleMs": {
+        "type": "number",
+        "default": 600000,
+        "minimum": 1,
+        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
+      },
       "localLlmRetry5xxCount": {
         "type": "number",
         "default": 1,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3670,6 +3670,38 @@
         "default": 900000,
         "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
       },
+      "maintenanceNamespaceFanoutEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+      },
+      "maintenanceMaxNamespacesPerCycle": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+      },
+      "maintenanceIncludeProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceIncludeBranchNamespaces": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+      },
+      "maintenanceIncludeTeamProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceNamespaceLockStaleMs": {
+        "type": "number",
+        "default": 600000,
+        "minimum": 1,
+        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
+      },
       "localLlmRetry5xxCount": {
         "type": "number",
         "default": 1,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -1331,3 +1331,72 @@ test("parseConfig namespaceCatalogEnabled present-but-unrecognized → throws (r
   assert.throws(() => parseConfig({ namespaceCatalogEnabled: "flase" }), /boolean-like value/);
   assert.throws(() => parseConfig({ namespaceCatalogEnabled: 2 }), /boolean-like value/);
 });
+
+test("parseConfig maintenance namespace fanout defaults match hosted-safe policy", () => {
+  const cfg = parseConfig({});
+  assert.equal(cfg.maintenanceNamespaceFanoutEnabled, true);
+  assert.equal(cfg.maintenanceMaxNamespacesPerCycle, 20);
+  assert.equal(cfg.maintenanceIncludeProjectNamespaces, true);
+  assert.equal(cfg.maintenanceIncludeBranchNamespaces, false);
+  assert.equal(cfg.maintenanceIncludeTeamProjectNamespaces, true);
+  assert.equal(cfg.maintenanceNamespaceLockStaleMs, 10 * 60_000);
+});
+
+test("parseConfig accepts nested maintenance namespace fanout config", () => {
+  const cfg = parseConfig({
+    maintenance: {
+      namespaceFanoutEnabled: "false",
+      maxNamespacesPerCycle: "7",
+      includeProjectNamespaces: "off",
+      includeBranchNamespaces: "on",
+      includeTeamProjectNamespaces: "0",
+      namespaceLockStaleMs: "120000",
+    },
+  });
+  assert.equal(cfg.maintenanceNamespaceFanoutEnabled, false);
+  assert.equal(cfg.maintenanceMaxNamespacesPerCycle, 7);
+  assert.equal(cfg.maintenanceIncludeProjectNamespaces, false);
+  assert.equal(cfg.maintenanceIncludeBranchNamespaces, true);
+  assert.equal(cfg.maintenanceIncludeTeamProjectNamespaces, false);
+  assert.equal(cfg.maintenanceNamespaceLockStaleMs, 120_000);
+});
+
+test("parseConfig flat maintenance namespace fanout fields override nested config", () => {
+  const cfg = parseConfig({
+    maintenance: {
+      namespaceFanoutEnabled: false,
+      maxNamespacesPerCycle: 5,
+    },
+    maintenanceNamespaceFanoutEnabled: true,
+    maintenanceMaxNamespacesPerCycle: 8,
+  });
+  assert.equal(cfg.maintenanceNamespaceFanoutEnabled, true);
+  assert.equal(cfg.maintenanceMaxNamespacesPerCycle, 8);
+});
+
+test("parseConfig rejects invalid maintenance namespace fanout values", () => {
+  assert.throws(
+    () => parseConfig({ maintenance: [] }),
+    /maintenance must be a plain object/,
+  );
+  assert.throws(
+    () => parseConfig({ maintenance: "off" }),
+    /maintenance must be a plain object/,
+  );
+  assert.throws(
+    () => parseConfig({ maintenance: [], maintenanceNamespaceFanoutEnabled: false }),
+    /maintenance must be a plain object/,
+  );
+  assert.throws(
+    () => parseConfig({ maintenance: { namespaceFanoutEnabled: "flase" } }),
+    /maintenance\.namespaceFanoutEnabled must be a boolean-like value/,
+  );
+  assert.throws(
+    () => parseConfig({ maintenance: { maxNamespacesPerCycle: 0 } }),
+    /maintenance\.maxNamespacesPerCycle must be a positive integer/,
+  );
+  assert.throws(
+    () => parseConfig({ maintenance: { namespaceLockStaleMs: 1.5 } }),
+    /maintenance\.namespaceLockStaleMs must be a positive integer/,
+  );
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -405,6 +405,74 @@ function resolveNamespaceCatalogEnabled(configValue: unknown): boolean {
   return true;
 }
 
+function readNestedConfig(
+  cfg: Record<string, unknown>,
+  blockName: string,
+  key: string,
+): unknown {
+  const block = validateNestedConfigBlock(cfg, blockName);
+  if (!block) return undefined;
+  return block[key];
+}
+
+function validateNestedConfigBlock(
+  cfg: Record<string, unknown>,
+  blockName: string,
+): Record<string, unknown> | undefined {
+  const block = cfg[blockName];
+  if (block === undefined || block === null) return undefined;
+  if (typeof block !== "object" || Array.isArray(block)) {
+    throw new Error(`${blockName} must be a plain object`);
+  }
+  return block as Record<string, unknown>;
+}
+
+function readFlatOrNestedConfig(
+  cfg: Record<string, unknown>,
+  flatKey: string,
+  blockName: string,
+  nestedKey: string,
+): unknown {
+  return cfg[flatKey] !== undefined
+    ? cfg[flatKey]
+    : readNestedConfig(cfg, blockName, nestedKey);
+}
+
+function resolveBooleanConfig(
+  value: unknown,
+  defaultValue: boolean,
+  keyName: string,
+): boolean {
+  if (value === undefined || value === null) return defaultValue;
+  const coerced = coerceBool(value);
+  if (coerced === undefined) {
+    throw new Error(
+      `${keyName} must be a boolean-like value (true/false/1/0/yes/no/on/off); got ${JSON.stringify(value)}`,
+    );
+  }
+  return coerced;
+}
+
+function resolvePositiveIntegerConfig(
+  value: unknown,
+  defaultValue: number,
+  keyName: string,
+): number {
+  if (value === undefined || value === null) return defaultValue;
+  const coerced = coerceNumber(value);
+  if (
+    coerced === undefined ||
+    !Number.isFinite(coerced) ||
+    !Number.isInteger(coerced) ||
+    coerced < 1
+  ) {
+    throw new Error(
+      `${keyName} must be a positive integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return coerced;
+}
+
 export function isOpenaiApiKeyDisabled(value: unknown): boolean {
   return value === false || (typeof value === "string" && value.trim().toLowerCase() === "false");
 }
@@ -768,6 +836,7 @@ export function parseConfig(raw: unknown): PluginConfig {
   } else {
     cfg = baseCfg;
   }
+  validateNestedConfigBlock(cfg, "maintenance");
 
   const modelSource =
     cfg.modelSource === "gateway" ? "gateway" : "plugin";
@@ -1482,6 +1551,66 @@ export function parseConfig(raw: unknown): PluginConfig {
         ? Math.max(1, Math.floor(cfg.crossSignalsSemanticTimeoutMs))
         : 4000;
   const recallPipelineConfig = buildRecallPipelineConfig(cfg);
+  const maintenanceNamespaceFanoutEnabled = resolveBooleanConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceNamespaceFanoutEnabled",
+      "maintenance",
+      "namespaceFanoutEnabled",
+    ),
+    true,
+    "maintenance.namespaceFanoutEnabled",
+  );
+  const maintenanceMaxNamespacesPerCycle = resolvePositiveIntegerConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceMaxNamespacesPerCycle",
+      "maintenance",
+      "maxNamespacesPerCycle",
+    ),
+    20,
+    "maintenance.maxNamespacesPerCycle",
+  );
+  const maintenanceIncludeProjectNamespaces = resolveBooleanConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceIncludeProjectNamespaces",
+      "maintenance",
+      "includeProjectNamespaces",
+    ),
+    true,
+    "maintenance.includeProjectNamespaces",
+  );
+  const maintenanceIncludeBranchNamespaces = resolveBooleanConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceIncludeBranchNamespaces",
+      "maintenance",
+      "includeBranchNamespaces",
+    ),
+    false,
+    "maintenance.includeBranchNamespaces",
+  );
+  const maintenanceIncludeTeamProjectNamespaces = resolveBooleanConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceIncludeTeamProjectNamespaces",
+      "maintenance",
+      "includeTeamProjectNamespaces",
+    ),
+    true,
+    "maintenance.includeTeamProjectNamespaces",
+  );
+  const maintenanceNamespaceLockStaleMs = resolvePositiveIntegerConfig(
+    readFlatOrNestedConfig(
+      cfg,
+      "maintenanceNamespaceLockStaleMs",
+      "maintenance",
+      "namespaceLockStaleMs",
+    ),
+    10 * 60_000,
+    "maintenance.namespaceLockStaleMs",
+  );
 
   return {
     openaiApiKey: apiKey,
@@ -2546,6 +2675,12 @@ export function parseConfig(raw: unknown): PluginConfig {
     qmdMaintenanceEnabled: cfg.qmdMaintenanceEnabled !== false,
     qmdMaintenanceDebounceMs:
       typeof cfg.qmdMaintenanceDebounceMs === "number" ? cfg.qmdMaintenanceDebounceMs : 30_000,
+    maintenanceNamespaceFanoutEnabled,
+    maintenanceMaxNamespacesPerCycle,
+    maintenanceIncludeProjectNamespaces,
+    maintenanceIncludeBranchNamespaces,
+    maintenanceIncludeTeamProjectNamespaces,
+    maintenanceNamespaceLockStaleMs,
     qmdAutoEmbedEnabled: cfg.qmdAutoEmbedEnabled === true,
     qmdEmbedMinIntervalMs:
       typeof cfg.qmdEmbedMinIntervalMs === "number" ? cfg.qmdEmbedMinIntervalMs : 60 * 60_000,

--- a/packages/remnic-core/src/maintenance/namespace-planner.test.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.test.ts
@@ -1,0 +1,1120 @@
+import assert from "node:assert/strict";
+import { lutimes, mkdir, mkdtemp, open as openFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { NamespaceCatalog, NamespaceRecord } from "../namespaces/catalog.js";
+import { namespaceIdentityToken } from "../namespaces/identity.js";
+import type { PluginConfig } from "../types.js";
+import {
+  __setNamespaceMaintenanceFsForTest,
+  type NamespaceMaintenanceCandidate,
+  planNamespaceMaintenance,
+  readNamespaceMaintenanceStatuses,
+  runNamespaceMaintenanceBatchPlan,
+  runNamespaceMaintenancePlan,
+} from "./namespace-planner.js";
+
+function makeConfig(memoryDir: string, overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    memoryDir,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    maintenanceNamespaceFanoutEnabled: true,
+    maintenanceMaxNamespacesPerCycle: 20,
+    maintenanceIncludeProjectNamespaces: true,
+    maintenanceIncludeBranchNamespaces: false,
+    maintenanceIncludeTeamProjectNamespaces: true,
+    maintenanceNamespaceLockStaleMs: 10 * 60_000,
+    qmdCollection: "remnic",
+    entitySchemas: {},
+    inlineSourceAttributionFormat: undefined,
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+async function mkMemoryDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "remnic-maintenance-planner-"));
+}
+
+async function createNamespaceData(memoryDir: string, namespace: string): Promise<string> {
+  const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(namespace));
+  await mkdir(path.join(storageDir, "facts"), { recursive: true });
+  await writeFile(path.join(storageDir, "facts", "sample.md"), "# sample\n", "utf8");
+  return storageDir;
+}
+
+function fakeCatalog(records: NamespaceRecord[]): NamespaceCatalog {
+  return {
+    enabled: true,
+    async listNamespaces() {
+      return records;
+    },
+    async markMaintenance() {},
+  } as unknown as NamespaceCatalog;
+}
+
+function record(
+  memoryDir: string,
+  namespace: string,
+  kind: NamespaceRecord["kind"],
+  lastWriteAt: string
+): NamespaceRecord {
+  return {
+    namespace,
+    identityToken: namespaceIdentityToken(namespace),
+    kind,
+    createdAt: "2026-06-30T00:00:00.000Z",
+    lastWriteAt,
+    storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(namespace)),
+    discoveredBy: "write",
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function writeStatus(
+  memoryDir: string,
+  status: {
+    namespace: string;
+    jobName?: string;
+    state?: "ran" | "skipped" | "failed";
+    reason?: string;
+    completedAt: string;
+  }
+): Promise<void> {
+  const jobName = status.jobName ?? "qmd";
+  const statusDir = path.join(memoryDir, "state", "namespace-maintenance-status", jobName);
+  await mkdir(statusDir, { recursive: true });
+  await writeFile(
+    path.join(statusDir, `${namespaceIdentityToken(status.namespace)}.json`),
+    `${JSON.stringify({
+      version: 1,
+      namespace: status.namespace,
+      jobName,
+      state: status.state ?? "ran",
+      reason: status.reason,
+      startedAt: status.completedAt,
+      completedAt: status.completedAt,
+    })}\n`,
+    "utf8"
+  );
+}
+
+test("planner fans out to live cataloged project and team namespaces while skipping branches by default", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha");
+    await createNamespaceData(memoryDir, "team-pi-project-alpha");
+    await createNamespaceData(memoryDir, "project-alpha-branch-main");
+
+    const plan = await planNamespaceMaintenance(makeConfig(memoryDir), {
+      jobName: "qmd",
+      catalog: fakeCatalog([
+        record(memoryDir, "project-alpha", "project", "2026-06-30T10:00:00.000Z"),
+        record(memoryDir, "team-pi-project-alpha", "team-project", "2026-06-30T11:00:00.000Z"),
+        record(memoryDir, "project-alpha-branch-main", "branch", "2026-06-30T12:00:00.000Z"),
+      ]),
+    });
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "team-pi-project-alpha", "project-alpha"]
+    );
+    assert.ok(
+      plan.skipped.some(
+        (skipped) => skipped.namespace === "project-alpha-branch-main" && skipped.reason === "branch_disabled"
+      )
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner includes branch namespaces only when branch maintenance is enabled", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha-branch-main");
+
+    const plan = await planNamespaceMaintenance(makeConfig(memoryDir, { maintenanceIncludeBranchNamespaces: true }), {
+      jobName: "qmd",
+      catalog: fakeCatalog([record(memoryDir, "project-alpha-branch-main", "branch", "2026-06-30T12:00:00.000Z")]),
+    });
+
+    assert.ok(
+      plan.namespaces.some((candidate) => candidate.namespace === "project-alpha-branch-main"),
+      "branch namespace should be selected when explicitly enabled"
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner applies maxNamespacesPerCycle deterministically after default and shared", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-a");
+    await createNamespaceData(memoryDir, "project-b");
+
+    const plan = await planNamespaceMaintenance(makeConfig(memoryDir, { maintenanceMaxNamespacesPerCycle: 3 }), {
+      jobName: "qmd",
+      catalog: fakeCatalog([
+        record(memoryDir, "project-a", "project", "2026-06-30T10:00:00.000Z"),
+        record(memoryDir, "project-b", "project", "2026-06-30T11:00:00.000Z"),
+      ]),
+    });
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-b"]
+    );
+    assert.ok(
+      plan.skipped.some((skipped) => skipped.namespace === "project-a" && skipped.reason === "budget_exhausted")
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner preserves configured default priority when catalog metadata disagrees", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const defaultRecord = record(memoryDir, "default", "project", "2026-06-30T08:00:00.000Z");
+    defaultRecord.lastMaintenanceAt = { qmd: "2026-06-30T12:00:00.000Z" };
+
+    const plan = await planNamespaceMaintenance(
+      makeConfig(memoryDir, {
+        maintenanceMaxNamespacesPerCycle: 2,
+        namespacePolicies: [
+          {
+            name: "project-explicit",
+            readPrincipals: ["*"],
+            writePrincipals: ["*"],
+          },
+        ],
+      }),
+      {
+        jobName: "qmd",
+        catalog: fakeCatalog([defaultRecord]),
+      },
+    );
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => [candidate.namespace, candidate.kind]),
+      [
+        ["default", "default"],
+        ["shared", "shared"],
+      ],
+    );
+    assert.ok(
+      plan.skipped.some(
+        (skipped) => skipped.namespace === "project-explicit" && skipped.reason === "budget_exhausted"
+      ),
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner can return the full safe namespace union without applying the cycle budget", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-a");
+    await createNamespaceData(memoryDir, "project-b");
+
+    const plan = await planNamespaceMaintenance(makeConfig(memoryDir, { maintenanceMaxNamespacesPerCycle: 3 }), {
+      jobName: "qmd",
+      budgetMode: "unbounded",
+      catalog: fakeCatalog([
+        record(memoryDir, "project-a", "project", "2026-06-30T10:00:00.000Z"),
+        record(memoryDir, "project-b", "project", "2026-06-30T11:00:00.000Z"),
+      ]),
+    });
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-b", "project-a"]
+    );
+    assert.ok(
+      !plan.skipped.some((skipped) => skipped.reason === "budget_exhausted"),
+      "startup/recovery namespace discovery must not drop safe namespaces because of the maintenance cycle budget"
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner rotates budgeted dynamic namespaces by maintenance age before write recency", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-old-maintenance");
+    await createNamespaceData(memoryDir, "project-new-maintenance");
+    await createNamespaceData(memoryDir, "project-never-maintained");
+
+    const oldMaintenance = record(memoryDir, "project-old-maintenance", "project", "2026-06-30T10:00:00.000Z");
+    oldMaintenance.lastMaintenanceAt = { qmd: "2026-06-30T10:30:00.000Z" };
+    const newMaintenance = record(memoryDir, "project-new-maintenance", "project", "2026-06-30T12:00:00.000Z");
+    newMaintenance.lastMaintenanceAt = { qmd: "2026-06-30T12:30:00.000Z" };
+    const neverMaintained = record(memoryDir, "project-never-maintained", "project", "2026-06-30T09:00:00.000Z");
+
+    const plan = await planNamespaceMaintenance(makeConfig(memoryDir, { maintenanceMaxNamespacesPerCycle: 4 }), {
+      jobName: "qmd",
+      catalog: fakeCatalog([newMaintenance, oldMaintenance, neverMaintained]),
+    });
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-never-maintained", "project-old-maintenance"]
+    );
+    assert.ok(
+      plan.skipped.some(
+        (skipped) => skipped.namespace === "project-new-maintenance" && skipped.reason === "budget_exhausted"
+      ),
+      "recently maintained dynamic namespaces should yield the cycle budget to never/older-maintained namespaces"
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner rotates configured namespaces from status history when catalog metadata is unavailable", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    for (const [namespace, completedAt] of [
+      ["project-a", "2026-06-30T12:00:00.000Z"],
+      ["project-b", "2026-06-30T10:00:00.000Z"],
+      ["project-c", "2026-06-30T11:00:00.000Z"],
+    ] as const) {
+      await writeStatus(memoryDir, { namespace, completedAt });
+    }
+
+    const plan = await planNamespaceMaintenance(
+      makeConfig(memoryDir, {
+        namespaceCatalogEnabled: false,
+        maintenanceMaxNamespacesPerCycle: 3,
+        namespacePolicies: [
+          { name: "project-a", readPrincipals: ["*"], writePrincipals: ["*"] },
+          { name: "project-b", readPrincipals: ["*"], writePrincipals: ["*"] },
+          { name: "project-c", readPrincipals: ["*"], writePrincipals: ["*"] },
+        ],
+      }),
+      {
+        jobName: "qmd",
+      }
+    );
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-b"]
+    );
+    assert.ok(plan.skipped.some((skipped) => skipped.namespace === "project-a" && skipped.reason === "budget_exhausted"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner ignores unsuccessful status history when rotating configured namespaces", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await writeStatus(memoryDir, {
+      namespace: "project-a",
+      state: "failed",
+      completedAt: "2026-06-30T12:00:00.000Z",
+    });
+    await writeStatus(memoryDir, {
+      namespace: "project-b",
+      state: "skipped",
+      reason: "lock_held",
+      completedAt: "2026-06-30T11:00:00.000Z",
+    });
+    await writeStatus(memoryDir, {
+      namespace: "project-c",
+      completedAt: "2026-06-30T10:00:00.000Z",
+    });
+
+    const plan = await planNamespaceMaintenance(
+      makeConfig(memoryDir, {
+        namespaceCatalogEnabled: false,
+        maintenanceMaxNamespacesPerCycle: 3,
+        namespacePolicies: [
+          { name: "project-a", readPrincipals: ["*"], writePrincipals: ["*"] },
+          { name: "project-b", readPrincipals: ["*"], writePrincipals: ["*"] },
+          { name: "project-c", readPrincipals: ["*"], writePrincipals: ["*"] },
+        ],
+      }),
+      {
+        jobName: "qmd",
+      }
+    );
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-a"]
+    );
+    assert.ok(plan.skipped.some((skipped) => skipped.namespace === "project-c" && skipped.reason === "budget_exhausted"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("planner preserves successful rotation history when later skips overwrite latest status", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, {
+      namespaceCatalogEnabled: false,
+      maintenanceMaxNamespacesPerCycle: 3,
+      namespacePolicies: [
+        { name: "project-a", readPrincipals: ["*"], writePrincipals: ["*"] },
+        { name: "project-b", readPrincipals: ["*"], writePrincipals: ["*"] },
+        { name: "project-c", readPrincipals: ["*"], writePrincipals: ["*"] },
+      ],
+    });
+
+    await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [{ namespace: "project-a", kind: "explicit", source: "configured" }],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 3, selected: 1 },
+      },
+      async () => ({ itemCount: 1 }),
+    );
+    await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:01.000Z",
+        namespaces: [],
+        skipped: [{ namespace: "project-a", kind: "explicit", reason: "budget_exhausted" }],
+        budget: { maxNamespacesPerCycle: 3, selected: 0 },
+      },
+      async () => {
+        throw new Error("skipped plans must not run namespace work");
+      },
+    );
+
+    const statuses = await readNamespaceMaintenanceStatuses(config);
+    assert.deepEqual(
+      statuses
+        .filter((status) => status.namespace === "project-a")
+        .map((status) => `${status.state}:${status.reason ?? ""}`),
+      ["skipped:budget_exhausted"],
+      "public maintenance status should still report the latest observed state",
+    );
+
+    const plan = await planNamespaceMaintenance(config, { jobName: "qmd" });
+
+    assert.deepEqual(
+      plan.namespaces.map((candidate) => candidate.namespace),
+      ["default", "shared", "project-b"],
+      "a skipped latest status must not erase the last successful rotation timestamp",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner honors sub-minute configured stale lock thresholds", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, { maintenanceNamespaceLockStaleMs: 100_000 });
+    const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+    const lockFile = path.join(lockDir, `${namespaceIdentityToken("project-stale")}.lock`);
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(lockFile, "stale\n", "utf8");
+    const staleTime = new Date(Date.now() - 200_000);
+    await utimes(lockFile, staleTime, staleTime);
+
+    let ran = false;
+    const summary = await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          {
+            namespace: "project-stale",
+            kind: "project",
+            source: "catalog",
+          },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 1 },
+      },
+      async () => {
+        ran = true;
+        return { itemCount: 1 };
+      }
+    );
+
+    assert.equal(ran, true);
+    assert.equal(summary.ran, 1);
+    assert.equal(summary.skipped, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner cleans up partial lock files after acquisition setup failures", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockFile = path.join(
+      memoryDir,
+      "state",
+      "maintenance-locks",
+      "qmd",
+      `${namespaceIdentityToken("project-a")}.lock`,
+    );
+    const probe = await openFile(path.join(memoryDir, "probe.tmp"), "w");
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      writeFile: (data: string, encoding: BufferEncoding) => Promise<void>;
+    };
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    await probe.close();
+    let injectedFailure = false;
+    fileHandlePrototype.writeFile = async function patchedWriteFile(
+      this: unknown,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      await originalWriteFile.call(this, data, encoding);
+      if (!injectedFailure) {
+        injectedFailure = true;
+        throw Object.assign(new Error("simulated lock write failure"), { code: "EIO" });
+      }
+    };
+
+    try {
+      await assert.rejects(
+        () =>
+          runNamespaceMaintenancePlan(
+            config,
+            {
+              jobName: "qmd",
+              generatedAt: "2026-06-30T00:00:00.000Z",
+              namespaces: [{ namespace: "project-a", kind: "project", source: "catalog" }],
+              skipped: [],
+              budget: { maxNamespacesPerCycle: 20, selected: 1 },
+            },
+            async () => ({ itemCount: 1 }),
+          ),
+        /simulated lock write failure/,
+      );
+    } finally {
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    assert.equal(injectedFailure, true);
+    await assert.rejects(() => stat(lockFile), "partial setup failures must unlink the created lock file");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner cleans up lock directories after owner-file open failures", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockFile = path.join(
+      memoryDir,
+      "state",
+      "maintenance-locks",
+      "qmd",
+      `${namespaceIdentityToken("project-a")}.lock`,
+    );
+    let injectedFailure = false;
+    const restoreFs = __setNamespaceMaintenanceFsForTest({
+      async open(target, flags) {
+        if (target.toString().startsWith(lockFile) && flags === "wx" && !injectedFailure) {
+          injectedFailure = true;
+          throw Object.assign(new Error("simulated owner open failure"), { code: "ENOSPC" });
+        }
+        return openFile(target, flags);
+      },
+    });
+
+    try {
+      await assert.rejects(
+        () =>
+          runNamespaceMaintenancePlan(
+            config,
+            {
+              jobName: "qmd",
+              generatedAt: "2026-06-30T00:00:00.000Z",
+              namespaces: [{ namespace: "project-a", kind: "project", source: "catalog" }],
+              skipped: [],
+              budget: { maxNamespacesPerCycle: 20, selected: 1 },
+            },
+            async () => ({ itemCount: 1 }),
+          ),
+        /simulated owner open failure/,
+      );
+    } finally {
+      restoreFs();
+    }
+
+    assert.equal(injectedFailure, true);
+    await assert.rejects(() => stat(lockFile), "owner open failures must remove the empty lock directory");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner does not recursively retry persistent stale lock removal failures", async () => {
+  const memoryDir = await mkMemoryDir();
+  const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+  try {
+    const config = makeConfig(memoryDir, { maintenanceNamespaceLockStaleMs: 1 });
+    const lockFile = path.join(lockDir, `${namespaceIdentityToken("project-a")}.lock`);
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(lockFile, "stale\n", "utf8");
+    const staleTime = new Date(Date.now() - 5_000);
+    await utimes(lockFile, staleTime, staleTime);
+    const restoreFs = __setNamespaceMaintenanceFsForTest({
+      async rm(target, options) {
+        if (target.toString() === lockFile) {
+          throw Object.assign(new Error("simulated stale lock removal failure"), { code: "EACCES" });
+        }
+        return rm(target, options);
+      },
+    });
+
+    try {
+      await assert.rejects(
+        () =>
+          runNamespaceMaintenancePlan(
+            config,
+            {
+              jobName: "qmd",
+              generatedAt: "2026-06-30T00:00:00.000Z",
+              namespaces: [{ namespace: "project-a", kind: "project", source: "catalog" }],
+              skipped: [],
+              budget: { maxNamespacesPerCycle: 20, selected: 1 },
+            },
+            async () => ({ itemCount: 1 }),
+          ),
+        (error: unknown) => {
+          const code =
+            typeof error === "object" && error !== null && "code" in error
+              ? (error as { code?: string }).code
+              : undefined;
+          return code === "EACCES";
+        },
+      );
+    } finally {
+      restoreFs();
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner treats symlinked stale lock directories as held without traversing them", async () => {
+  const memoryDir = await mkMemoryDir();
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lock-symlink-target-"));
+  const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+  const sentinelPath = path.join(outsideDir, "sentinel.txt");
+  try {
+    const config = makeConfig(memoryDir, { maintenanceNamespaceLockStaleMs: 1 });
+    const lockFile = path.join(lockDir, `${namespaceIdentityToken("project-a")}.lock`);
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(sentinelPath, "keep\n", "utf8");
+    await symlink(outsideDir, lockFile, "dir");
+    const staleTime = new Date(Date.now() - 5_000);
+    await lutimes(lockFile, staleTime, staleTime);
+
+    const summary = await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [{ namespace: "project-a", kind: "project", source: "catalog" }],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 1 },
+      },
+      async () => {
+        throw new Error("symlinked lock paths must not be acquired");
+      },
+    );
+
+    assert.equal(summary.ran, 0);
+    assert.equal(summary.skipped, 1);
+    assert.ok(
+      summary.statuses.some(
+        (status) =>
+          status.namespace === "project-a" &&
+          status.state === "skipped" &&
+          status.reason === "lock_held",
+      ),
+      "symlinked lock paths should be treated as held/corrupt locks",
+    );
+    await assert.doesNotReject(
+      () => stat(sentinelPath),
+      "stale lock cleanup must not traverse a symlink and remove files outside memoryDir",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("runner release does not clear a replacement worker lock after stale takeover", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, { maintenanceNamespaceLockStaleMs: 1 });
+    const lockFile = path.join(
+      memoryDir,
+      "state",
+      "maintenance-locks",
+      "qmd",
+      `${namespaceIdentityToken("project-stale")}.lock`
+    );
+    const plan = {
+      jobName: "qmd",
+      generatedAt: "2026-06-30T00:00:00.000Z",
+      namespaces: [
+        {
+          namespace: "project-stale",
+          kind: "project" as const,
+          source: "catalog" as const,
+        },
+      ],
+      skipped: [],
+      budget: { maxNamespacesPerCycle: 20, selected: 1 },
+    };
+
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const secondEntered = deferred();
+    const releaseSecond = deferred();
+
+    const firstRun = runNamespaceMaintenancePlan(config, plan, async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      return { itemCount: 1 };
+    });
+    await firstEntered.promise;
+
+    const staleTime = new Date(Date.now() - 5_000);
+    await utimes(lockFile, staleTime, staleTime);
+
+    const secondRun = runNamespaceMaintenancePlan(config, plan, async () => {
+      secondEntered.resolve();
+      await releaseSecond.promise;
+      return { itemCount: 1 };
+    });
+    await secondEntered.promise;
+
+    releaseFirst.resolve();
+    await firstRun;
+    await assert.doesNotReject(
+      () => stat(lockFile),
+      "first worker release must not delete a newer replacement lock"
+    );
+
+    releaseSecond.resolve();
+    await secondRun;
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner records sanitized failure details without raw filesystem paths", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const rawPath = path.join(memoryDir, "state", "maintenance-locks", "secret.json");
+    const error = Object.assign(new Error(`failed to open ${rawPath}`), { code: "EACCES" });
+
+    const summary = await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          {
+            namespace: "project-failed",
+            kind: "project",
+            source: "catalog",
+          },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 1 },
+      },
+      async () => {
+        throw error;
+      }
+    );
+
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.statuses[0]?.error, "Error (EACCES)");
+    assert.ok(!summary.statuses[0]?.error?.includes(memoryDir), "raw failure status must not leak filesystem paths");
+
+    const statuses = await readNamespaceMaintenanceStatuses(config);
+    const persisted = statuses.find((status) => status.namespace === "project-failed");
+    assert.equal(persisted?.error, "Error (EACCES)");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner records lock-held skips without running duplicate namespace work", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(path.join(lockDir, `${namespaceIdentityToken("project-a")}.lock`), "held\n", "utf8");
+
+    const summary = await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          {
+            namespace: "project-a",
+            kind: "project",
+            source: "catalog",
+          },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 1 },
+      },
+      async () => {
+        throw new Error("runner should not execute when lock is held");
+      }
+    );
+
+    assert.equal(summary.ran, 0);
+    assert.equal(summary.skipped, 1);
+    assert.equal(summary.statuses[0]?.reason, "lock_held");
+
+    const statuses = await readNamespaceMaintenanceStatuses(config);
+    assert.ok(
+      statuses.some(
+        (status) =>
+          status.namespace === "project-a" &&
+          status.jobName === "qmd" &&
+          status.state === "skipped" &&
+          status.reason === "lock_held"
+      ),
+      "lock-held status should be persisted for doctor/dashboard consumers"
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runner refreshes live locks during long namespace work", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, { maintenanceNamespaceLockStaleMs: 30 });
+    const lockFile = path.join(
+      memoryDir,
+      "state",
+      "maintenance-locks",
+      "qmd",
+      `${namespaceIdentityToken("project-a")}.lock`
+    );
+
+    await runNamespaceMaintenancePlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          {
+            namespace: "project-a",
+            kind: "project",
+            source: "catalog",
+          },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 1 },
+      },
+      async () => {
+        const before = (await stat(lockFile)).mtimeMs;
+        await sleep(90);
+        const after = (await stat(lockFile)).mtimeMs;
+        assert.ok(after > before, "live maintenance locks should be touched before they become stale");
+        return { itemCount: 1 };
+      }
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner locks selected namespaces and runs one shared job", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const runnerInputs: string[][] = [];
+
+    const summary = await runNamespaceMaintenanceBatchPlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          { namespace: "default", kind: "default", source: "configured" },
+          { namespace: "project-a", kind: "project", source: "catalog" },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 2 },
+      },
+      async (candidates) => {
+        runnerInputs.push(candidates.map((candidate) => candidate.namespace));
+        return { itemCount: 1 };
+      }
+    );
+
+    assert.equal(summary.ran, 2);
+    assert.deepEqual(runnerInputs, [["default", "project-a"]]);
+    assert.ok(summary.statuses.every((status) => status.state === "ran"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner can require every selected namespace lock before running shared work", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+    const defaultLock = path.join(lockDir, `${namespaceIdentityToken("default")}.lock`);
+    const projectLock = path.join(lockDir, `${namespaceIdentityToken("project-a")}.lock`);
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(projectLock, "held\n", "utf8");
+    let runnerCalls = 0;
+
+    const summary = await runNamespaceMaintenanceBatchPlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          { namespace: "default", kind: "default", source: "configured" },
+          { namespace: "project-a", kind: "project", source: "catalog" },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 2 },
+      },
+      async () => {
+        runnerCalls += 1;
+        return { itemCount: 1 };
+      },
+      undefined,
+      { requireAllLocks: true }
+    );
+
+    assert.equal(runnerCalls, 0);
+    assert.equal(summary.ran, 0);
+    assert.equal(summary.skipped, 2);
+    assert.ok(summary.statuses.every((status) => status.state === "skipped"));
+    assert.deepEqual(
+      Object.fromEntries(summary.statuses.map((status) => [status.namespace, status.reason])),
+      {
+        default: "batch_lock_incomplete",
+        "project-a": "lock_held",
+      }
+    );
+    await assert.rejects(() => stat(defaultLock), "partial acquired locks must be released");
+    await assert.doesNotReject(() => stat(projectLock), "externally held locks must be left alone");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner skips locked namespaces without blocking acquired batch work by default", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+    const defaultLock = path.join(lockDir, `${namespaceIdentityToken("default")}.lock`);
+    const projectLock = path.join(lockDir, `${namespaceIdentityToken("project-a")}.lock`);
+    await mkdir(lockDir, { recursive: true });
+    await writeFile(projectLock, "held\n", "utf8");
+    const runnerInputs: string[][] = [];
+
+    const summary = await runNamespaceMaintenanceBatchPlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          { namespace: "default", kind: "default", source: "configured" },
+          { namespace: "project-a", kind: "project", source: "catalog" },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 2 },
+      },
+      async (candidates) => {
+        runnerInputs.push(candidates.map((candidate) => candidate.namespace));
+        return { itemCount: 1 };
+      }
+    );
+
+    assert.deepEqual(runnerInputs, [["default"]]);
+    assert.equal(summary.ran, 1);
+    assert.equal(summary.skipped, 1);
+    assert.deepEqual(
+      Object.fromEntries(summary.statuses.map((status) => [status.namespace, status.state])),
+      {
+        default: "ran",
+        "project-a": "skipped",
+      }
+    );
+    assert.deepEqual(
+      Object.fromEntries(summary.statuses.map((status) => [status.namespace, status.reason])),
+      {
+        default: undefined,
+        "project-a": "lock_held",
+      }
+    );
+    await assert.rejects(() => stat(defaultLock), "acquired locks must be released after the batch run");
+    await assert.doesNotReject(() => stat(projectLock), "externally held locks must be left alone");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner releases acquired locks when later lock acquisition throws", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const lockDir = path.join(memoryDir, "state", "maintenance-locks", "qmd");
+    const defaultLock = path.join(lockDir, `${namespaceIdentityToken("default")}.lock`);
+    const throwingCandidate = {
+      kind: "project",
+      source: "catalog",
+    } as unknown as NamespaceMaintenanceCandidate;
+    Object.defineProperty(throwingCandidate, "namespace", {
+      get() {
+        throw new Error("namespace unavailable");
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        runNamespaceMaintenanceBatchPlan(
+          config,
+          {
+            jobName: "qmd",
+            generatedAt: "2026-06-30T00:00:00.000Z",
+            namespaces: [
+              { namespace: "default", kind: "default", source: "configured" },
+              throwingCandidate,
+            ],
+            skipped: [],
+            budget: { maxNamespacesPerCycle: 20, selected: 2 },
+          },
+          async () => ({ itemCount: 1 }),
+        ),
+      /namespace unavailable/,
+    );
+
+    await assert.rejects(() => stat(defaultLock), "acquired locks must be released on acquisition errors");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner records every locked namespace as failed when the shared job fails", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+
+    const summary = await runNamespaceMaintenanceBatchPlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          { namespace: "default", kind: "default", source: "configured" },
+          { namespace: "project-a", kind: "project", source: "catalog" },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 2 },
+      },
+      async () => {
+        throw Object.assign(new Error("qmd failed"), { code: "EIO" });
+      }
+    );
+
+    assert.equal(summary.failed, 2);
+    assert.ok(summary.statuses.every((status) => status.state === "failed"));
+    assert.ok(summary.statuses.every((status) => status.error === "Error (EIO)"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("batch runner can record classified shared-job errors as skipped", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    let markMaintenanceCalls = 0;
+    const catalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    } as unknown as NamespaceCatalog;
+
+    const summary = await runNamespaceMaintenanceBatchPlan(
+      config,
+      {
+        jobName: "qmd",
+        generatedAt: "2026-06-30T00:00:00.000Z",
+        namespaces: [
+          { namespace: "default", kind: "default", source: "configured" },
+          { namespace: "project-a", kind: "project", source: "catalog" },
+        ],
+        skipped: [],
+        budget: { maxNamespacesPerCycle: 20, selected: 2 },
+      },
+      async () => {
+        throw new Error("QMD update skipped by global min-interval gate");
+      },
+      catalog,
+      {
+        skipReasonForError(error) {
+          return error instanceof Error && error.message.includes("min-interval")
+            ? "throttled"
+            : null;
+        },
+      },
+    );
+
+    assert.equal(summary.ran, 0);
+    assert.equal(summary.skipped, 2);
+    assert.equal(summary.failed, 0);
+    assert.ok(summary.statuses.every((status) => status.state === "skipped"));
+    assert.ok(summary.statuses.every((status) => status.reason === "throttled"));
+    assert.equal(markMaintenanceCalls, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/maintenance/namespace-planner.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.ts
@@ -1,0 +1,893 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { lstat, mkdir, open, readFile, readdir, rename, rm, rmdir, stat, utimes, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { NamespaceCatalog, NamespaceKind, NamespaceRecord } from "../namespaces/catalog.js";
+import { hasMemoryData } from "../namespaces/catalog.js";
+import { namespaceIdentityToken } from "../namespaces/identity.js";
+import { resolveNamespaceStorageRoot } from "../namespaces/storage.js";
+import { displayErrorDetail } from "../runtime/better-sqlite.js";
+import type { PluginConfig } from "../types.js";
+
+export type NamespaceMaintenanceJobName = string;
+
+export type NamespaceMaintenanceSkipReason =
+  | "fanout_disabled"
+  | "empty_root"
+  | "branch_disabled"
+  | "project_disabled"
+  | "team_project_disabled"
+  | "catalog_read_failed"
+  | "unsafe_or_stale_root"
+  | "budget_exhausted"
+  | "lock_held"
+  | "batch_lock_incomplete"
+  | "throttled"
+  | "job_failed";
+
+export interface NamespaceMaintenancePlannerOptions {
+  jobName: NamespaceMaintenanceJobName;
+  catalog?: NamespaceCatalog;
+  now?: Date;
+  budgetMode?: "cycle" | "unbounded";
+}
+
+export interface NamespaceMaintenanceCandidate {
+  namespace: string;
+  kind: NamespaceKind;
+  storageDir?: string;
+  source: "configured" | "catalog";
+  lastWriteAt?: string;
+  lastMaintenanceAt?: string;
+}
+
+export interface NamespaceMaintenancePlan {
+  jobName: NamespaceMaintenanceJobName;
+  generatedAt: string;
+  namespaces: NamespaceMaintenanceCandidate[];
+  skipped: NamespaceMaintenanceSkippedNamespace[];
+  budget: {
+    maxNamespacesPerCycle: number;
+    selected: number;
+  };
+}
+
+export interface NamespaceMaintenanceSkippedNamespace {
+  namespace: string;
+  kind?: NamespaceKind;
+  reason: NamespaceMaintenanceSkipReason;
+  detail?: string;
+}
+
+export interface NamespaceMaintenanceRunStatus {
+  namespace: string;
+  jobName: NamespaceMaintenanceJobName;
+  state: "ran" | "skipped" | "failed";
+  reason?: NamespaceMaintenanceSkipReason;
+  startedAt: string;
+  completedAt: string;
+  itemCount?: number;
+  error?: string;
+}
+
+export interface NamespaceMaintenanceSummary {
+  jobName: NamespaceMaintenanceJobName;
+  generatedAt: string;
+  ran: number;
+  skipped: number;
+  failed: number;
+  statuses: NamespaceMaintenanceRunStatus[];
+}
+
+export interface NamespaceMaintenanceBatchRunResult {
+  itemCount?: number;
+  itemCounts?: Record<string, number> | Map<string, number>;
+}
+
+export interface NamespaceMaintenanceBatchRunOptions {
+  requireAllLocks?: boolean;
+  skipReasonForError?: (error: unknown) => NamespaceMaintenanceSkipReason | null | undefined;
+}
+
+interface LockHandle {
+  path: string;
+  touch(): Promise<void>;
+  release(): Promise<void>;
+}
+
+const DEFAULT_MAX_NAMESPACES_PER_CYCLE = 20;
+const DEFAULT_LOCK_STALE_MS = 10 * 60_000;
+const LOCK_BASE = "maintenance-locks";
+const STATUS_BASE = "namespace-maintenance-status";
+const namespaceMaintenanceFs = { open, rm };
+
+export function __setNamespaceMaintenanceFsForTest(overrides: Partial<typeof namespaceMaintenanceFs>): () => void {
+  const previous = { ...namespaceMaintenanceFs };
+  Object.assign(namespaceMaintenanceFs, overrides);
+  return () => {
+    Object.assign(namespaceMaintenanceFs, previous);
+  };
+}
+
+function configuredNamespaces(config: PluginConfig): string[] {
+  return Array.from(
+    new Set(
+      [config.defaultNamespace, config.sharedNamespace, ...config.namespacePolicies.map((policy) => policy.name)]
+        .map((value) => value.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+function inferConfiguredKind(config: PluginConfig, namespace: string): NamespaceKind {
+  if (namespace === config.defaultNamespace.trim()) return "default";
+  if (namespace === config.sharedNamespace.trim()) return "shared";
+  return "explicit";
+}
+
+function maxNamespacesPerCycle(config: PluginConfig): number {
+  return Math.max(
+    1,
+    Math.floor(
+      typeof config.maintenanceMaxNamespacesPerCycle === "number" &&
+        Number.isFinite(config.maintenanceMaxNamespacesPerCycle)
+        ? config.maintenanceMaxNamespacesPerCycle
+        : DEFAULT_MAX_NAMESPACES_PER_CYCLE
+    )
+  );
+}
+
+function namespaceKindAllowed(config: PluginConfig, kind: NamespaceKind): boolean {
+  switch (kind) {
+    case "branch":
+      return config.maintenanceIncludeBranchNamespaces === true;
+    case "project":
+      return config.maintenanceIncludeProjectNamespaces !== false;
+    case "team-project":
+      return config.maintenanceIncludeTeamProjectNamespaces !== false;
+    default:
+      return true;
+  }
+}
+
+function disabledReasonForKind(kind: NamespaceKind): NamespaceMaintenanceSkipReason {
+  if (kind === "branch") return "branch_disabled";
+  if (kind === "project") return "project_disabled";
+  if (kind === "team-project") return "team_project_disabled";
+  return "fanout_disabled";
+}
+
+async function catalogRootIsLive(config: PluginConfig, record: NamespaceRecord): Promise<boolean> {
+  if (typeof record.storageDir !== "string" || record.storageDir.length === 0) {
+    return false;
+  }
+  try {
+    const liveRoot = await resolveNamespaceStorageRoot(config, record.namespace);
+    if (path.resolve(liveRoot) !== path.resolve(record.storageDir)) return false;
+    return hasMemoryData(liveRoot);
+  } catch {
+    return false;
+  }
+}
+
+function candidateSortKey(candidate: NamespaceMaintenanceCandidate): string {
+  const write = candidate.lastWriteAt ?? "";
+  return `${write}\u0000${candidate.namespace}`;
+}
+
+function candidatePriority(candidate: NamespaceMaintenanceCandidate): number {
+  if (candidate.kind === "default") return 0;
+  if (candidate.kind === "shared") return 1;
+  if (candidate.source === "configured") return 2;
+  if (candidate.kind === "team-project") return 3;
+  if (candidate.kind === "project") return 4;
+  if (candidate.kind === "self") return 5;
+  if (candidate.kind === "legacy") return 6;
+  if (candidate.kind === "branch") return 8;
+  return 7;
+}
+
+function sortCandidates(a: NamespaceMaintenanceCandidate, b: NamespaceMaintenanceCandidate): number {
+  const priority = candidatePriority(a) - candidatePriority(b);
+  if (priority !== 0) return priority;
+  const am = Date.parse(a.lastMaintenanceAt ?? "");
+  const bm = Date.parse(b.lastMaintenanceAt ?? "");
+  const aMaintained = Number.isFinite(am);
+  const bMaintained = Number.isFinite(bm);
+  if (aMaintained && bMaintained && am !== bm) return am - bm;
+  if (aMaintained !== bMaintained) return aMaintained ? 1 : -1;
+  const aw = Date.parse(a.lastWriteAt ?? "");
+  const bw = Date.parse(b.lastWriteAt ?? "");
+  const aValid = Number.isFinite(aw);
+  const bValid = Number.isFinite(bw);
+  if (aValid && bValid && aw !== bw) return bw - aw;
+  if (aValid !== bValid) return aValid ? -1 : 1;
+  const byKey = candidateSortKey(a).localeCompare(candidateSortKey(b));
+  if (byKey !== 0) return byKey;
+  return a.namespace.localeCompare(b.namespace);
+}
+
+export async function planNamespaceMaintenance(
+  config: PluginConfig,
+  options: NamespaceMaintenancePlannerOptions
+): Promise<NamespaceMaintenancePlan> {
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const configured = configuredNamespaces(config);
+  const byNamespace = new Map<string, NamespaceMaintenanceCandidate>();
+  const skipped: NamespaceMaintenanceSkippedNamespace[] = [];
+
+  for (const namespace of configured) {
+    const kind = inferConfiguredKind(config, namespace);
+    byNamespace.set(namespace, {
+      namespace,
+      kind,
+      source: "configured",
+    });
+  }
+
+  if (config.namespacesEnabled && config.maintenanceNamespaceFanoutEnabled !== false) {
+    const configuredSet = new Set(configured);
+    try {
+      const records = options.catalog?.enabled ? await options.catalog.listNamespaces() : [];
+      for (const record of records) {
+        const namespace = record.namespace.trim();
+        if (!namespace) continue;
+        const isConfigured = configuredSet.has(namespace);
+        const kind = isConfigured ? inferConfiguredKind(config, namespace) : record.kind;
+        if (!namespaceKindAllowed(config, kind)) {
+          skipped.push({
+            namespace,
+            kind,
+            reason: disabledReasonForKind(kind),
+          });
+          continue;
+        }
+        if (!isConfigured && !(await catalogRootIsLive(config, record))) {
+          skipped.push({
+            namespace,
+            kind,
+            reason: "unsafe_or_stale_root",
+          });
+          continue;
+        }
+        byNamespace.set(namespace, {
+          namespace,
+          kind,
+          storageDir: record.storageDir,
+          source: isConfigured ? "configured" : "catalog",
+          lastWriteAt: record.lastWriteAt,
+          lastMaintenanceAt: record.lastMaintenanceAt?.[options.jobName],
+        });
+      }
+    } catch (error) {
+      skipped.push({
+        namespace: "*",
+        reason: "catalog_read_failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  } else if (config.namespacesEnabled) {
+    skipped.push({
+      namespace: "*",
+      reason: "fanout_disabled",
+    });
+  }
+
+  if (options.budgetMode !== "unbounded") {
+    const latestStatusAtByNamespace = await readLatestStatusAtByNamespace(config, options.jobName);
+    for (const candidate of byNamespace.values()) {
+      if (!candidate.lastMaintenanceAt) {
+        candidate.lastMaintenanceAt = latestStatusAtByNamespace.get(candidate.namespace);
+      }
+    }
+  }
+
+  const candidates = [...byNamespace.values()]
+    .filter((candidate) => namespaceKindAllowed(config, candidate.kind))
+    .sort(sortCandidates);
+
+  const max = maxNamespacesPerCycle(config);
+  const applyCycleBudget = options.budgetMode !== "unbounded";
+  const selected = applyCycleBudget ? candidates.slice(0, max) : candidates;
+  if (applyCycleBudget) {
+    for (const candidate of candidates.slice(max)) {
+      skipped.push({
+        namespace: candidate.namespace,
+        kind: candidate.kind,
+        reason: "budget_exhausted",
+      });
+    }
+  }
+
+  return {
+    jobName: options.jobName,
+    generatedAt,
+    namespaces: selected,
+    skipped,
+    budget: {
+      maxNamespacesPerCycle: max,
+      selected: selected.length,
+    },
+  };
+}
+
+function stablePathSegment(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 128) || "unnamed";
+  if (sanitized.length <= 128 && sanitized === value) return sanitized;
+  return `${sanitized.slice(0, 80)}-${createHash("sha256").update(value).digest("hex").slice(0, 16)}`;
+}
+
+function namespacePathSegment(namespace: string): string {
+  const token = namespaceIdentityToken(namespace);
+  if (token.length <= 160) return token;
+  return `ns-${createHash("sha256").update(namespace).digest("hex")}`;
+}
+
+function lockPath(config: PluginConfig, jobName: string, namespace: string): string {
+  return path.join(
+    config.memoryDir,
+    "state",
+    LOCK_BASE,
+    stablePathSegment(jobName),
+    `${namespacePathSegment(namespace)}.lock`
+  );
+}
+
+function namespaceMaintenanceLockStaleMs(config: PluginConfig): number {
+  if (
+    typeof config.maintenanceNamespaceLockStaleMs === "number" &&
+    Number.isFinite(config.maintenanceNamespaceLockStaleMs) &&
+    config.maintenanceNamespaceLockStaleMs > 0
+  ) {
+    return Math.floor(config.maintenanceNamespaceLockStaleMs);
+  }
+  return DEFAULT_LOCK_STALE_MS;
+}
+
+function namespaceMaintenanceLockHeartbeatMs(config: PluginConfig): number {
+  const staleMs = namespaceMaintenanceLockStaleMs(config);
+  return Math.max(1, Math.min(30_000, Math.floor(staleMs / 3) || 1));
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? (error as { code?: string }).code
+    : undefined;
+}
+
+async function withNamespaceMaintenanceLockHeartbeat<T>(
+  config: PluginConfig,
+  locks: LockHandle | LockHandle[],
+  task: () => Promise<T>,
+): Promise<T> {
+  const activeLocks = Array.isArray(locks) ? locks : [locks];
+  const interval = setInterval(() => {
+    for (const lock of activeLocks) {
+      void lock.touch().catch(() => undefined);
+    }
+  }, namespaceMaintenanceLockHeartbeatMs(config));
+  interval.unref?.();
+  try {
+    return await task();
+  } finally {
+    clearInterval(interval);
+  }
+}
+
+async function removeStaleLockDirectory(filePath: string): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(filePath, { withFileTypes: true });
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return;
+    throw error;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    await namespaceMaintenanceFs.rm(path.join(filePath, entry.name), { force: true });
+  }
+  try {
+    await rmdir(filePath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return;
+    throw error;
+  }
+}
+
+async function tryAcquireNamespaceMaintenanceLock(
+  config: PluginConfig,
+  jobName: string,
+  namespace: string
+): Promise<LockHandle | null> {
+  const filePath = lockPath(config, jobName, namespace);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    const lockId = randomUUID();
+    await mkdir(filePath);
+    const ownerPath = path.join(filePath, `${lockId}.json`);
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    try {
+      handle = await namespaceMaintenanceFs.open(ownerPath, "wx");
+      await handle.writeFile(
+        `${JSON.stringify({
+          lockId,
+          pid: process.pid,
+          jobName,
+          namespace,
+          acquiredAt: new Date().toISOString(),
+        })}\n`,
+        "utf8"
+      );
+      await handle.close();
+    } catch (setupError) {
+      await handle?.close().catch(() => undefined);
+      await namespaceMaintenanceFs.rm(ownerPath, { force: true }).catch(() => undefined);
+      await rmdir(filePath).catch(() => undefined);
+      throw setupError;
+    }
+    return {
+      path: filePath,
+      async touch() {
+        try {
+          const parsed = JSON.parse(await readFile(ownerPath, "utf8")) as { lockId?: unknown };
+          if (parsed.lockId === lockId) {
+            const now = new Date();
+            await utimes(ownerPath, now, now);
+            await utimes(filePath, now, now);
+          }
+        } catch {}
+      },
+      async release() {
+        try {
+          const parsed = JSON.parse(await readFile(ownerPath, "utf8")) as { lockId?: unknown };
+          if (parsed.lockId === lockId) {
+            await namespaceMaintenanceFs.rm(ownerPath, { force: true });
+            await rmdir(filePath).catch(() => undefined);
+          }
+        } catch {}
+      },
+    };
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") {
+      const staleMs =
+        namespaceMaintenanceLockStaleMs(config);
+      try {
+        const s = await lstat(filePath);
+        if (s.isSymbolicLink()) {
+          return null;
+        }
+        if ((s.isFile() || s.isDirectory()) && Date.now() - s.mtimeMs > staleMs) {
+          try {
+            if (s.isDirectory()) {
+              await removeStaleLockDirectory(filePath);
+            } else {
+              await namespaceMaintenanceFs.rm(filePath, { force: true });
+            }
+          } catch (removeError) {
+            if (errorCode(removeError) === "ENOENT") {
+              return tryAcquireNamespaceMaintenanceLock(config, jobName, namespace);
+            }
+            if (errorCode(removeError) === "ENOTEMPTY") {
+              return null;
+            }
+            throw removeError;
+          }
+          return tryAcquireNamespaceMaintenanceLock(config, jobName, namespace);
+        }
+      } catch (statError) {
+        if (errorCode(statError) === "ENOENT") {
+          return tryAcquireNamespaceMaintenanceLock(config, jobName, namespace);
+        }
+        throw statError;
+      }
+      return null;
+    }
+    throw error;
+  }
+}
+
+function statusBasePath(config: PluginConfig): string {
+  return path.join(config.memoryDir, "state", STATUS_BASE);
+}
+
+function statusPath(config: PluginConfig, jobName: string, namespace: string): string {
+  return path.join(statusBasePath(config), stablePathSegment(jobName), `${namespacePathSegment(namespace)}.json`);
+}
+
+function lastRanStatusPath(config: PluginConfig, jobName: string, namespace: string): string {
+  return path.join(statusBasePath(config), stablePathSegment(jobName), `${namespacePathSegment(namespace)}.last-ran.json`);
+}
+
+function parseStatus(value: unknown): NamespaceMaintenanceRunStatus | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const v = value as Partial<NamespaceMaintenanceRunStatus>;
+  if (
+    typeof v.namespace === "string" &&
+    typeof v.jobName === "string" &&
+    (v.state === "ran" || v.state === "skipped" || v.state === "failed") &&
+    typeof v.startedAt === "string" &&
+    typeof v.completedAt === "string"
+  ) {
+    return v as NamespaceMaintenanceRunStatus;
+  }
+  return null;
+}
+
+async function readLatestStatusAtByNamespace(config: PluginConfig, jobName: string): Promise<Map<string, string>> {
+  const latest = new Map<string, string>();
+  const latestMs = new Map<string, number>();
+  for (const status of [...(await readStatusFiles(config)), ...(await readLastRanStatusFiles(config))]) {
+    if (status.state !== "ran") continue;
+    if (status.jobName !== jobName) continue;
+    const completedAtMs = Date.parse(status.completedAt);
+    if (!Number.isFinite(completedAtMs)) continue;
+    const previousMs = latestMs.get(status.namespace);
+    if (previousMs !== undefined && previousMs >= completedAtMs) continue;
+    latestMs.set(status.namespace, completedAtMs);
+    latest.set(status.namespace, status.completedAt);
+  }
+  return latest;
+}
+
+async function readStatusFile(filePath: string): Promise<NamespaceMaintenanceRunStatus | null> {
+  try {
+    const parsed = JSON.parse(await readFile(filePath, "utf8")) as unknown;
+    return parseStatus(parsed);
+  } catch {
+    return null;
+  }
+}
+
+async function readStatusFiles(config: PluginConfig): Promise<NamespaceMaintenanceRunStatus[]> {
+  if (typeof config.memoryDir !== "string" || config.memoryDir.length === 0) {
+    return [];
+  }
+  const root = statusBasePath(config);
+  const statuses: NamespaceMaintenanceRunStatus[] = [];
+  let jobDirs: Dirent[];
+  try {
+    jobDirs = await readdir(root, { withFileTypes: true });
+  } catch {
+    return statuses;
+  }
+  for (const jobDir of jobDirs) {
+    if (!jobDir.isDirectory()) continue;
+    let files: Dirent[];
+    try {
+      files = await readdir(path.join(root, jobDir.name), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith(".json")) continue;
+      if (file.name.endsWith(".last-ran.json")) continue;
+      const status = await readStatusFile(path.join(root, jobDir.name, file.name));
+      if (status) statuses.push(status);
+    }
+  }
+  return statuses;
+}
+
+async function readLastRanStatusFiles(config: PluginConfig): Promise<NamespaceMaintenanceRunStatus[]> {
+  if (typeof config.memoryDir !== "string" || config.memoryDir.length === 0) {
+    return [];
+  }
+  const root = statusBasePath(config);
+  const statuses: NamespaceMaintenanceRunStatus[] = [];
+  let jobDirs: Dirent[];
+  try {
+    jobDirs = await readdir(root, { withFileTypes: true });
+  } catch {
+    return statuses;
+  }
+  for (const jobDir of jobDirs) {
+    if (!jobDir.isDirectory()) continue;
+    let files: Dirent[];
+    try {
+      files = await readdir(path.join(root, jobDir.name), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.isFile() || !file.name.endsWith(".last-ran.json")) continue;
+      const status = await readStatusFile(path.join(root, jobDir.name, file.name));
+      if (status) statuses.push(status);
+    }
+  }
+  return statuses;
+}
+
+async function writeStatusPayload(target: string, status: NamespaceMaintenanceRunStatus): Promise<void> {
+  const dir = path.dirname(target);
+  await mkdir(dir, { recursive: true });
+  const temp = `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  const payload = {
+    version: 1,
+    ...status,
+  };
+  await writeFile(temp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await rename(temp, target);
+}
+
+async function writeStatusFile(config: PluginConfig, status: NamespaceMaintenanceRunStatus): Promise<void> {
+  await writeStatusPayload(statusPath(config, status.jobName, status.namespace), status);
+  if (status.state === "ran") {
+    await writeStatusPayload(lastRanStatusPath(config, status.jobName, status.namespace), status);
+  }
+}
+
+async function recordNamespaceMaintenanceStatusSafely(
+  config: PluginConfig,
+  status: NamespaceMaintenanceRunStatus
+): Promise<void> {
+  try {
+    await writeStatusFile(config, status);
+  } catch {
+    // Observability must not fail the maintenance operation.
+  }
+}
+
+function maintenanceErrorDetail(error: unknown): string {
+  return displayErrorDetail(error) || "Error";
+}
+
+export async function readNamespaceMaintenanceStatuses(config: PluginConfig): Promise<NamespaceMaintenanceRunStatus[]> {
+  return (await readStatusFiles(config)).sort((a, b) => {
+    const byJob = a.jobName.localeCompare(b.jobName);
+    if (byJob !== 0) return byJob;
+    return a.namespace.localeCompare(b.namespace);
+  });
+}
+
+export async function runNamespaceMaintenancePlan(
+  config: PluginConfig,
+  plan: NamespaceMaintenancePlan,
+  runner: (candidate: NamespaceMaintenanceCandidate) => Promise<{ itemCount?: number } | undefined>,
+  catalog?: NamespaceCatalog
+): Promise<NamespaceMaintenanceSummary> {
+  const statuses: NamespaceMaintenanceRunStatus[] = [];
+
+  for (const skipped of plan.skipped) {
+    if (skipped.namespace === "*") continue;
+    const now = new Date().toISOString();
+    const status: NamespaceMaintenanceRunStatus = {
+      namespace: skipped.namespace,
+      jobName: plan.jobName,
+      state: "skipped",
+      reason: skipped.reason,
+      startedAt: now,
+      completedAt: now,
+    };
+    statuses.push(status);
+    await recordNamespaceMaintenanceStatusSafely(config, status);
+  }
+
+  for (const candidate of plan.namespaces) {
+    const startedAt = new Date().toISOString();
+    const lock = await tryAcquireNamespaceMaintenanceLock(config, plan.jobName, candidate.namespace);
+    if (!lock) {
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = {
+        namespace: candidate.namespace,
+        jobName: plan.jobName,
+        state: "skipped",
+        reason: "lock_held",
+        startedAt,
+        completedAt,
+      };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+      continue;
+    }
+    try {
+      const result = await withNamespaceMaintenanceLockHeartbeat(config, lock, () => runner(candidate));
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = {
+        namespace: candidate.namespace,
+        jobName: plan.jobName,
+        state: "ran",
+        startedAt,
+        completedAt,
+        itemCount: result?.itemCount,
+      };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+      try {
+        await catalog?.markMaintenance(candidate.namespace, plan.jobName, new Date(completedAt));
+      } catch {
+        // Catalog maintenance touches are best-effort status metadata.
+      }
+    } catch (error) {
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = {
+        namespace: candidate.namespace,
+        jobName: plan.jobName,
+        state: "failed",
+        reason: "job_failed",
+        startedAt,
+        completedAt,
+        error: maintenanceErrorDetail(error),
+      };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+    } finally {
+      await lock.release().catch(() => undefined);
+    }
+  }
+
+  return {
+    jobName: plan.jobName,
+    generatedAt: new Date().toISOString(),
+    ran: statuses.filter((s) => s.state === "ran").length,
+    skipped: statuses.filter((s) => s.state === "skipped").length,
+    failed: statuses.filter((s) => s.state === "failed").length,
+    statuses,
+  };
+}
+
+export async function runNamespaceMaintenanceBatchPlan(
+  config: PluginConfig,
+  plan: NamespaceMaintenancePlan,
+  runner: (candidates: NamespaceMaintenanceCandidate[]) => Promise<NamespaceMaintenanceBatchRunResult | undefined>,
+  catalog?: NamespaceCatalog,
+  options: NamespaceMaintenanceBatchRunOptions = {}
+): Promise<NamespaceMaintenanceSummary> {
+  const statuses: NamespaceMaintenanceRunStatus[] = [];
+
+  for (const skipped of plan.skipped) {
+    if (skipped.namespace === "*") continue;
+    const now = new Date().toISOString();
+    const status: NamespaceMaintenanceRunStatus = {
+      namespace: skipped.namespace,
+      jobName: plan.jobName,
+      state: "skipped",
+      reason: skipped.reason,
+      startedAt: now,
+      completedAt: now,
+    };
+    statuses.push(status);
+    await recordNamespaceMaintenanceStatusSafely(config, status);
+  }
+
+  const acquired: Array<{
+    candidate: NamespaceMaintenanceCandidate;
+    lock: LockHandle;
+    startedAt: string;
+  }> = [];
+
+  try {
+    for (const candidate of plan.namespaces) {
+      const startedAt = new Date().toISOString();
+      const lock = await tryAcquireNamespaceMaintenanceLock(config, plan.jobName, candidate.namespace);
+      if (!lock) {
+        const completedAt = new Date().toISOString();
+        const status: NamespaceMaintenanceRunStatus = {
+          namespace: candidate.namespace,
+          jobName: plan.jobName,
+          state: "skipped",
+          reason: "lock_held",
+          startedAt,
+          completedAt,
+        };
+        statuses.push(status);
+        await recordNamespaceMaintenanceStatusSafely(config, status);
+        continue;
+      }
+      acquired.push({ candidate, lock, startedAt });
+    }
+  } catch (error) {
+    await Promise.all(acquired.map(({ lock }) => lock.release().catch(() => undefined)));
+    throw error;
+  }
+
+  if (options.requireAllLocks && acquired.length > 0 && acquired.length < plan.namespaces.length) {
+    for (const { candidate, startedAt } of acquired) {
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = {
+        namespace: candidate.namespace,
+        jobName: plan.jobName,
+        state: "skipped",
+        reason: "batch_lock_incomplete",
+        startedAt,
+        completedAt,
+      };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+    }
+    await Promise.all(acquired.map(({ lock }) => lock.release().catch(() => undefined)));
+    return {
+      jobName: plan.jobName,
+      generatedAt: new Date().toISOString(),
+      ran: statuses.filter((s) => s.state === "ran").length,
+      skipped: statuses.filter((s) => s.state === "skipped").length,
+      failed: statuses.filter((s) => s.state === "failed").length,
+      statuses,
+    };
+  }
+
+  if (acquired.length === 0) {
+    return {
+      jobName: plan.jobName,
+      generatedAt: new Date().toISOString(),
+      ran: statuses.filter((s) => s.state === "ran").length,
+      skipped: statuses.filter((s) => s.state === "skipped").length,
+      failed: statuses.filter((s) => s.state === "failed").length,
+      statuses,
+    };
+  }
+
+  try {
+    const result = await withNamespaceMaintenanceLockHeartbeat(
+      config,
+      acquired.map(({ lock }) => lock),
+      () => runner(acquired.map(({ candidate }) => candidate)),
+    );
+    for (const { candidate, startedAt } of acquired) {
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = {
+        namespace: candidate.namespace,
+        jobName: plan.jobName,
+        state: "ran",
+        startedAt,
+        completedAt,
+        itemCount: itemCountForNamespace(result, candidate.namespace),
+      };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+      try {
+        await catalog?.markMaintenance(candidate.namespace, plan.jobName, new Date(completedAt));
+      } catch {
+        // Catalog maintenance touches are best-effort status metadata.
+      }
+    }
+  } catch (error) {
+    const skipReason = options.skipReasonForError?.(error);
+    for (const { candidate, startedAt } of acquired) {
+      const completedAt = new Date().toISOString();
+      const status: NamespaceMaintenanceRunStatus = skipReason
+        ? {
+            namespace: candidate.namespace,
+            jobName: plan.jobName,
+            state: "skipped",
+            reason: skipReason,
+            startedAt,
+            completedAt,
+          }
+        : {
+            namespace: candidate.namespace,
+            jobName: plan.jobName,
+            state: "failed",
+            reason: "job_failed",
+            startedAt,
+            completedAt,
+            error: maintenanceErrorDetail(error),
+          };
+      statuses.push(status);
+      await recordNamespaceMaintenanceStatusSafely(config, status);
+    }
+  } finally {
+    await Promise.all(acquired.map(({ lock }) => lock.release().catch(() => undefined)));
+  }
+
+  return {
+    jobName: plan.jobName,
+    generatedAt: new Date().toISOString(),
+    ran: statuses.filter((s) => s.state === "ran").length,
+    skipped: statuses.filter((s) => s.state === "skipped").length,
+    failed: statuses.filter((s) => s.state === "failed").length,
+    statuses,
+  };
+}
+
+function itemCountForNamespace(
+  result: NamespaceMaintenanceBatchRunResult | undefined,
+  namespace: string,
+): number | undefined {
+  const itemCounts = result?.itemCounts;
+  if (itemCounts instanceof Map) return itemCounts.get(namespace);
+  if (itemCounts && Object.prototype.hasOwnProperty.call(itemCounts, namespace)) {
+    return itemCounts[namespace];
+  }
+  return result?.itemCount;
+}

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -13,6 +13,12 @@ type CollectionState = "present" | "missing" | "unknown" | "skipped";
 
 class FakeBackend implements SearchBackend {
   updates = 0;
+  strictUpdates = 0;
+  strictCollectionUpdates: string[] = [];
+  embeds = 0;
+  collectionEmbeds: string[] = [];
+  strictEmbeds = 0;
+  strictCollectionEmbeds: string[] = [];
   disposed = 0;
   available = true;
   calls: Array<{
@@ -130,15 +136,35 @@ class FakeBackend implements SearchBackend {
     this.updates += 1;
   }
 
+  async updateStrict(): Promise<void> {
+    this.strictUpdates += 1;
+  }
+
   async updateCollection(): Promise<void> {}
+
+  async updateCollectionStrict(collection: string): Promise<void> {
+    this.strictCollectionUpdates.push(collection);
+  }
 
   updatesAllCollections(): boolean {
     return this.globalUpdate;
   }
 
-  async embed(): Promise<void> {}
+  async embed(): Promise<void> {
+    this.embeds += 1;
+  }
 
-  async embedCollection(): Promise<void> {}
+  async embedStrict(): Promise<void> {
+    this.strictEmbeds += 1;
+  }
+
+  async embedCollection(collection: string): Promise<void> {
+    this.collectionEmbeds.push(collection);
+  }
+
+  async embedCollectionStrict(collection: string): Promise<void> {
+    this.strictCollectionEmbeds.push(collection);
+  }
 
   async ensureCollection(
     _memoryDir?: string,
@@ -251,6 +277,108 @@ test("updateNamespaces still updates every namespace for scoped backends", async
 
   assert.equal(updated, 3);
   assert.equal(created.reduce((sum, backend) => sum + backend.updates, 0), 3);
+});
+
+test("updateNamespaces uses strict global update when requested", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(true);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const updated = await router.updateNamespaces(
+    ["main", "shared", "main", "project"],
+    undefined,
+    { strict: true },
+  );
+
+  assert.equal(updated, 1);
+  assert.equal(created.reduce((sum, backend) => sum + backend.strictUpdates, 0), 1);
+  assert.equal(created.reduce((sum, backend) => sum + backend.updates, 0), 0);
+});
+
+test("updateNamespaces uses strict collection updates for scoped backends when requested", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(false);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const updated = await router.updateNamespaces(
+    ["main", "shared", "main", "project"],
+    undefined,
+    { strict: true },
+  );
+
+  assert.equal(updated, 3);
+  assert.equal(created.reduce((sum, backend) => sum + backend.strictCollectionUpdates.length, 0), 3);
+  assert.equal(created.reduce((sum, backend) => sum + backend.updates, 0), 0);
+});
+
+test("embedNamespaces uses strict collection embeds when requested", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(false);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  await router.embedNamespaces(["main", "shared", "main", "project"], { strict: true });
+
+  assert.equal(created.reduce((sum, backend) => sum + backend.strictCollectionEmbeds.length, 0), 3);
+  assert.equal(created.reduce((sum, backend) => sum + backend.collectionEmbeds.length, 0), 0);
+  assert.equal(created.reduce((sum, backend) => sum + backend.embeds, 0), 0);
+});
+
+test("embedNamespaces propagates strict embed failures", async () => {
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(false);
+      backend.embedCollectionStrict = async () => {
+        throw new Error("embed failed");
+      };
+      return backend;
+    },
+  );
+
+  await assert.rejects(
+    () => router.embedNamespaces(["main"], { strict: true }),
+    /embed failed/,
+  );
+});
+
+test("updateNamespacesDetailed reports only eligible namespaces", async () => {
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    (scopedConfig) => {
+      const backend = new FakeBackend(false, [], {
+        ensure: scopedConfig.memoryDir.endsWith("/missing") ? "missing" : "present",
+      });
+      return backend;
+    },
+  );
+
+  const result = await router.updateNamespacesDetailed(["main", "missing", "shared"]);
+
+  assert.equal(result.backendCount, 2);
+  assert.deepEqual(result.eligibleNamespaces.sort(), ["main", "shared"]);
 });
 
 test("searchAcrossNamespaces preserves same path results from distinct namespaces", async () => {

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -44,6 +44,11 @@ type NamespaceBackendRecord = {
   filtersNestedNamespaces: boolean;
 };
 
+export interface NamespaceUpdateResult {
+  backendCount: number;
+  eligibleNamespaces: string[];
+}
+
 export type CollectionState = "present" | "missing" | "unknown" | "skipped";
 
 export interface NamespaceSearchHealth {
@@ -161,37 +166,51 @@ export class NamespaceSearchRouter {
   async updateNamespaces(
     namespaces: string[],
     execution?: SearchExecutionOptions,
+    options?: { strict?: boolean },
   ): Promise<number> {
+    return (await this.updateNamespacesDetailed(namespaces, execution, options)).backendCount;
+  }
+
+  async updateNamespacesDetailed(
+    namespaces: string[],
+    execution?: SearchExecutionOptions,
+    options?: { strict?: boolean },
+  ): Promise<NamespaceUpdateResult> {
     const unique = Array.from(new Set(namespaces.map((value) => value.trim()).filter(Boolean)));
     const eligible = (await Promise.all(
       unique.map(async (namespace) => {
         const record = await this.backendRecordFor(namespace);
         return record.available && record.collectionState !== "missing"
-          ? record
+          ? { namespace, record }
           : null;
       }),
-    )).filter((record): record is NamespaceBackendRecord => record !== null);
+    )).filter((entry): entry is { namespace: string; record: NamespaceBackendRecord } => entry !== null);
 
-    const globalRecord = eligible.find((record) => record.backend.updatesAllCollections?.() === true);
-    const scopedRecords = globalRecord
-      ? eligible.filter((record) => record.backend.updatesAllCollections?.() !== true)
+    const globalEntry = eligible.find(({ record }) => record.backend.updatesAllCollections?.() === true);
+    const scopedEntries = globalEntry
+      ? eligible.filter(({ record }) => record.backend.updatesAllCollections?.() !== true)
       : eligible;
 
     await Promise.all([
-      globalRecord ? globalRecord.backend.update(execution) : Promise.resolve(),
-      ...scopedRecords.map((record) => record.backend.update(execution)),
+      globalEntry
+        ? updateBackendRecord(globalEntry.record, execution, options)
+        : Promise.resolve(),
+      ...scopedEntries.map(({ record }) => updateBackendRecord(record, execution, options)),
     ]);
 
-    return (globalRecord ? 1 : 0) + scopedRecords.length;
+    return {
+      backendCount: (globalEntry ? 1 : 0) + scopedEntries.length,
+      eligibleNamespaces: eligible.map(({ namespace }) => namespace),
+    };
   }
 
-  async embedNamespaces(namespaces: string[]): Promise<void> {
+  async embedNamespaces(namespaces: string[], options?: { strict?: boolean }): Promise<void> {
     const unique = Array.from(new Set(namespaces.map((value) => value.trim()).filter(Boolean)));
     await Promise.all(
       unique.map(async (namespace) => {
         const record = await this.backendRecordFor(namespace);
         if (!record.available || record.collectionState === "missing") return;
-        await record.backend.embed();
+        await embedBackendRecord(record, options);
       }),
     );
   }
@@ -440,6 +459,48 @@ function backendSearchLimit(
     maxResults * NESTED_NAMESPACE_FILTER_OVERFETCH_FACTOR,
     NESTED_NAMESPACE_FILTER_OVERFETCH_MIN,
   );
+}
+
+async function updateBackendRecord(
+  record: NamespaceBackendRecord,
+  execution?: SearchExecutionOptions,
+  options?: { strict?: boolean },
+): Promise<void> {
+  if (options?.strict === true) {
+    if (
+      record.backend.updatesAllCollections?.() === true &&
+      typeof record.backend.updateStrict === "function"
+    ) {
+      await record.backend.updateStrict(execution);
+      return;
+    }
+    if (typeof record.backend.updateCollectionStrict === "function") {
+      await record.backend.updateCollectionStrict(record.collection, execution);
+      return;
+    }
+  }
+  await record.backend.update(execution);
+}
+
+async function embedBackendRecord(
+  record: NamespaceBackendRecord,
+  options?: { strict?: boolean },
+): Promise<void> {
+  if (options?.strict === true) {
+    if (typeof record.backend.embedCollectionStrict === "function") {
+      await record.backend.embedCollectionStrict(record.collection);
+      return;
+    }
+    if (typeof record.backend.embedStrict === "function") {
+      await record.backend.embedStrict();
+      return;
+    }
+  }
+  if (typeof record.backend.embedCollection === "function") {
+    await record.backend.embedCollection(record.collection);
+    return;
+  }
+  await record.backend.embed();
 }
 
 function daemonModeForBackend(backend: SearchBackend): boolean | null {

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -11,6 +11,7 @@ import { parseConfig } from "./config.js";
 import type { BufferTurn } from "./types.js";
 import type { ImportTurn } from "./bulk-import/types.js";
 import { namespaceIdentityToken } from "./namespaces/identity.js";
+import { readNamespaceMaintenanceStatuses } from "./maintenance/namespace-planner.js";
 
 function makeTurn(sessionKey: string, content: string): BufferTurn {
   return {
@@ -1780,8 +1781,10 @@ test("runExtraction still clears the session buffer after persistence even if re
 // cataloged namespaces.
 test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)", async () => {
   const orchestrator = Object.create(Orchestrator.prototype) as any;
-  let updateArg: string[] | undefined;
-  let embedArg: string[] | undefined;
+  const updateArgs: string[] = [];
+  const updateCalls: Array<{ namespaces: string[]; strict: boolean | undefined }> = [];
+  const embedArgs: string[] = [];
+  const embedCalls: string[][] = [];
   const memoryDir = path.join(os.tmpdir(), "remnic-qmd-maintenance-ngnei");
   const dynamicNamespace = "project-origin-dynamic";
   const dynamicStorageDir = path.join(
@@ -1797,6 +1800,7 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
     defaultNamespace: "default",
     sharedNamespace: "shared",
     namespacePolicies: [],
+    maintenanceNamespaceLockStaleMs: 100,
     qmdAutoEmbedEnabled: true,
     qmdEmbedMinIntervalMs: 0,
   };
@@ -1820,35 +1824,98 @@ test("runQmdMaintenance updates and embeds cataloged dynamic namespaces (NGnei)"
     },
   };
   orchestrator.namespaceSearchRouter = {
-    async updateNamespaces(ns: string[]) {
-      updateArg = ns;
-      return ns.length;
+    async updateNamespacesDetailed(ns: string[], _execution?: unknown, options?: { strict?: boolean }) {
+      updateCalls.push({ namespaces: [...ns], strict: options?.strict });
+      updateArgs.push(...ns);
+      return { backendCount: ns.length, eligibleNamespaces: ns };
     },
     async embedNamespaces(ns: string[]) {
-      embedArg = ns;
+      embedCalls.push([...ns]);
+      embedArgs.push(...ns);
     },
   };
 
   await orchestrator.runQmdMaintenance();
 
-  assert.ok(updateArg, "updateNamespaces must be called");
+  assert.ok(updateArgs.length > 0, "updateNamespaces must be called");
+  assert.equal(updateCalls.length, 1, "global QMD maintenance must batch selected namespaces into one update call");
+  assert.equal(updateCalls[0]?.strict, true, "recurring QMD maintenance must use strict update semantics");
   assert.ok(
-    updateArg!.includes(dynamicNamespace),
+    updateArgs.includes(dynamicNamespace),
     "QMD update must cover the cataloged dynamic namespace, not just configured ones",
   );
   assert.ok(
-    updateArg!.includes("default") && updateArg!.includes("shared"),
+    updateArgs.includes("default") && updateArgs.includes("shared"),
     "configured namespaces remain covered",
   );
   assert.ok(
-    embedArg && embedArg.includes(dynamicNamespace),
+    embedArgs.includes(dynamicNamespace),
     "QMD embed must cover the cataloged dynamic namespace",
   );
+  assert.equal(embedCalls.length, 1, "QMD embed must batch all selected namespaces into one router call");
+  assert.deepEqual(new Set(embedCalls[0]), new Set(["default", "shared", dynamicNamespace]));
+});
+
+test("runQmdMaintenance tracks namespace embed cadence across budget rotation", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-namespace-embed-cadence-"));
+  const updateCalls: string[][] = [];
+  const embedCalls: string[][] = [];
+
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [{ name: "project-a" }, { name: "project-b" }],
+      maintenanceMaxNamespacesPerCycle: 3,
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: true,
+      qmdEmbedMinIntervalMs: 60_000,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.lastQmdEmbedAtMsByNamespace = new Map();
+    orchestrator.namespaceCatalog = {
+      enabled: false,
+      async listNamespaces() {
+        throw new Error("catalog disabled - must not be read");
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(ns: string[]) {
+        updateCalls.push([...ns]);
+        return { backendCount: ns.length, eligibleNamespaces: ns };
+      },
+      async embedNamespaces(ns: string[]) {
+        embedCalls.push([...ns]);
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+    orchestrator.qmdMaintenancePending = true;
+    await orchestrator.runQmdMaintenance();
+
+    assert.deepEqual(updateCalls, [
+      ["default", "shared", "project-a"],
+      ["default", "shared", "project-b"],
+    ]);
+    assert.deepEqual(
+      embedCalls,
+      [["default", "shared", "project-a"], ["project-b"]],
+      "a global embed timestamp must not suppress embeddings for newly budgeted namespaces",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 test("runQmdMaintenance skips cataloged dynamic namespaces whose live root is unsafe", async () => {
   const orchestrator = Object.create(Orchestrator.prototype) as any;
-  let updateArg: string[] | undefined;
+  const updateArgs: string[] = [];
+  const updateCalls: string[][] = [];
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-unsafe-root-"));
   const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-unsafe-target-"));
   try {
@@ -1868,6 +1935,7 @@ test("runQmdMaintenance skips cataloged dynamic namespaces whose live root is un
       defaultNamespace: "default",
       sharedNamespace: "shared",
       namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
       qmdAutoEmbedEnabled: false,
       qmdEmbedMinIntervalMs: 0,
     };
@@ -1890,18 +1958,20 @@ test("runQmdMaintenance skips cataloged dynamic namespaces whose live root is un
       },
     };
     orchestrator.namespaceSearchRouter = {
-      async updateNamespaces(ns: string[]) {
-        updateArg = ns;
-        return ns.length;
+      async updateNamespacesDetailed(ns: string[]) {
+        updateCalls.push([...ns]);
+        updateArgs.push(...ns);
+        return { backendCount: ns.length, eligibleNamespaces: ns };
       },
       async embedNamespaces() {},
     };
 
     await orchestrator.runQmdMaintenance();
 
-    assert.ok(updateArg, "updateNamespaces must be called");
+    assert.ok(updateArgs.length > 0, "updateNamespaces must be called");
+    assert.equal(updateCalls.length, 1, "global QMD maintenance must update once for the locked namespace set");
     assert.deepEqual(
-      [...updateArg!].sort(),
+      [...updateArgs].sort(),
       ["default", "shared"],
       "cataloged dynamic namespaces are skipped when the live router root differs from the catalog-sanitized root",
     );
@@ -1911,46 +1981,395 @@ test("runQmdMaintenance skips cataloged dynamic namespaces whose live root is un
   }
 });
 
+test("runQmdMaintenance treats zero namespace updates as failed maintenance", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-zero-update-"));
+  let markMaintenanceCalls = 0;
+  let embedCalls = 0;
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: false,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed() {
+        return { backendCount: 0, eligibleNamespaces: [] };
+      },
+      async embedNamespaces() {
+        embedCalls += 1;
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.ok(
+      statuses.some((status) => status.namespace === "default" && status.state === "failed"),
+      "zero updates should be recorded as failed maintenance, not a successful run",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.equal(embedCalls, 0);
+    assert.equal(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runQmdMaintenance treats partial namespace update eligibility as failed maintenance", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-partial-update-"));
+  let markMaintenanceCalls = 0;
+  let embedCalls = 0;
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: false,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(ns: string[]) {
+        assert.ok(ns.includes("default") && ns.includes("shared"));
+        return { backendCount: 1, eligibleNamespaces: ["default"] };
+      },
+      async embedNamespaces() {
+        embedCalls += 1;
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.ok(
+      statuses.some((status) => status.namespace === "default" && status.state === "failed"),
+      "partial update eligibility should not be recorded as successful maintenance",
+    );
+    assert.ok(
+      statuses.some((status) => status.namespace === "shared" && status.state === "failed"),
+      "ineligible selected namespaces should not be rotated as maintained",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.equal(embedCalls, 0);
+    assert.equal(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runQmdMaintenance treats namespace embed errors as failed maintenance", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-embed-failure-"));
+  let markMaintenanceCalls = 0;
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: true,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(ns: string[]) {
+        return { backendCount: 1, eligibleNamespaces: ns };
+      },
+      async embedNamespaces() {
+        throw Object.assign(new Error("embed failed"), { code: "EQMD" });
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.ok(
+      statuses.some((status) => status.namespace === "default" && status.state === "failed"),
+      "embed failures should not be recorded as successful namespace maintenance",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.equal(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runQmdMaintenance records QMD min-interval throttles as skipped maintenance", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-throttled-update-"));
+  let markMaintenanceCalls = 0;
+  let embedCalls = 0;
+  let updateCalls = 0;
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: false,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(_ns: string[], _execution?: unknown, options?: { strict?: boolean }) {
+        updateCalls += 1;
+        assert.equal(options?.strict, true, "recurring maintenance must use strict QMD updates");
+        throw new Error("QMD update skipped by global min-interval gate");
+      },
+      async embedNamespaces() {
+        embedCalls += 1;
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.equal(updateCalls, 1, "strict global QMD maintenance should be attempted once");
+    assert.ok(
+      statuses.some(
+        (status) =>
+          status.namespace === "default" &&
+          status.state === "skipped" &&
+          status.reason === "throttled",
+      ),
+      "QMD min-interval throttles should be recorded as skipped maintenance",
+    );
+    assert.ok(
+      statuses.some(
+        (status) =>
+          status.namespace === "shared" &&
+          status.state === "skipped" &&
+          status.reason === "throttled",
+      ),
+      "every selected namespace should receive the throttled skip status",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.equal(embedCalls, 0);
+    assert.equal(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runQmdMaintenance still embeds when due update is throttled", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-throttled-update-embed-"));
+  let markMaintenanceCalls = 0;
+  let updateCalls = 0;
+  const embedCalls: string[][] = [];
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: true,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(_ns: string[], _execution?: unknown, options?: { strict?: boolean }) {
+        updateCalls += 1;
+        assert.equal(options?.strict, true, "recurring maintenance must use strict QMD updates");
+        throw new Error("QMD update skipped by global min-interval gate");
+      },
+      async embedNamespaces(ns: string[], options?: { strict?: boolean }) {
+        assert.equal(options?.strict, true, "due embed retries must surface embed failures");
+        embedCalls.push([...ns]);
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.equal(updateCalls, 1, "strict global QMD maintenance should be attempted once");
+    assert.deepEqual(embedCalls, [["default", "shared"]]);
+    assert.ok(
+      statuses.every((status) => status.state === "skipped" && status.reason === "throttled"),
+      "a throttled update should still be recorded as skipped after the due embed retry",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.notEqual(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("runQmdMaintenance treats strict namespace update errors as failed maintenance", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-update-failure-"));
+  let markMaintenanceCalls = 0;
+  let embedCalls = 0;
+  let updateCalls = 0;
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      maintenanceNamespaceLockStaleMs: 100,
+      qmdAutoEmbedEnabled: true,
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [{ namespace: "default" }];
+      },
+      async markMaintenance() {
+        markMaintenanceCalls += 1;
+      },
+    };
+    orchestrator.namespaceSearchRouter = {
+      async updateNamespacesDetailed(_ns: string[], _execution?: unknown, options?: { strict?: boolean }) {
+        updateCalls += 1;
+        assert.equal(options?.strict, true, "recurring maintenance must require strict update failure propagation");
+        throw new Error("qmd exploded");
+      },
+      async embedNamespaces() {
+        embedCalls += 1;
+      },
+    };
+
+    await orchestrator.runQmdMaintenance();
+
+    const statuses = await readNamespaceMaintenanceStatuses(orchestrator.config);
+    assert.equal(updateCalls, 1, "strict global QMD maintenance should be attempted once");
+    assert.ok(
+      statuses.some((status) => status.namespace === "default" && status.state === "failed"),
+      "strict update errors should be recorded as failed maintenance",
+    );
+    assert.equal(markMaintenanceCalls, 0);
+    assert.equal(embedCalls, 0);
+    assert.equal(orchestrator.lastQmdEmbedAtMs, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 // NGnei fallback: when the catalog is disabled, maintenance covers exactly the
 // configured set (no catalog read), and a catalog read failure degrades to the
 // configured set rather than breaking maintenance.
 test("runQmdMaintenance falls back to configured namespaces when the catalog is disabled (NGnei)", async () => {
   const orchestrator = Object.create(Orchestrator.prototype) as any;
-  let updateArg: string[] | undefined;
+  const updateArgs: string[] = [];
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-disabled-catalog-"));
 
-  orchestrator.config = {
-    namespacesEnabled: true,
-    defaultNamespace: "default",
-    sharedNamespace: "shared",
+  try {
+    orchestrator.config = {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
     namespacePolicies: [],
+    maintenanceNamespaceLockStaleMs: 100,
     qmdAutoEmbedEnabled: false,
-    qmdEmbedMinIntervalMs: 0,
-  };
-  orchestrator.qmdMaintenanceInFlight = false;
-  orchestrator.qmdMaintenancePending = true;
-  orchestrator.lastQmdEmbedAtMs = 0;
-  orchestrator.namespaceCatalog = {
-    enabled: false,
-    async listNamespaces() {
-      throw new Error("catalog disabled — must not be read");
-    },
+      qmdEmbedMinIntervalMs: 0,
+    };
+    orchestrator.qmdMaintenanceInFlight = false;
+    orchestrator.qmdMaintenancePending = true;
+    orchestrator.lastQmdEmbedAtMs = 0;
+    orchestrator.namespaceCatalog = {
+      enabled: false,
+      async listNamespaces() {
+        throw new Error("catalog disabled — must not be read");
+      },
   };
   orchestrator.namespaceSearchRouter = {
-    async updateNamespaces(ns: string[]) {
-      updateArg = ns;
-      return ns.length;
+    async updateNamespacesDetailed(ns: string[]) {
+      updateArgs.push(...ns);
+      return { backendCount: ns.length, eligibleNamespaces: ns };
     },
-    async embedNamespaces() {},
-  };
+      async embedNamespaces() {},
+    };
 
-  await orchestrator.runQmdMaintenance();
+    await orchestrator.runQmdMaintenance();
 
-  assert.ok(updateArg, "updateNamespaces must be called");
-  assert.deepEqual(
-    [...updateArg!].sort(),
-    ["default", "shared"],
-    "a disabled catalog covers exactly the configured set",
-  );
+    assert.ok(updateArgs.length > 0, "updateNamespaces must be called");
+    assert.deepEqual(
+      [...updateArgs].sort(),
+      ["default", "shared"],
+      "a disabled catalog covers exactly the configured set",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 // ── NHZEV (codex P2): the QMD STARTUP sync in deferredInitialize() must cover
@@ -1981,6 +2400,7 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
     sharedNamespace: "shared",
     namespacePolicies: [],
     qmdMaintenanceEnabled: true,
+    maintenanceMaxNamespacesPerCycle: 2,
   };
   orchestrator.qmd = {
     isAvailable: () => true,
@@ -2017,7 +2437,7 @@ test("deferredInitialize startup sync covers cataloged dynamic namespaces (NHZEV
   assert.ok(updateArg, "startup updateNamespaces must be called");
   assert.ok(
     updateArg!.includes(dynamicNamespace),
-    "startup sync must cover the cataloged dynamic namespace (NHZEV), not just configured ones",
+    "startup sync must cover the cataloged dynamic namespace even when it exceeds the recurring maintenance cycle budget",
   );
   assert.ok(
     updateArg!.includes("default") && updateArg!.includes("shared"),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -299,13 +299,16 @@ import {
 } from "./conversation-index/backend.js";
 import {
   NamespaceStorageRouter,
-  resolveNamespaceStorageRoot,
 } from "./namespaces/storage.js";
 import {
   NamespaceCatalog,
-  hasMemoryData,
-  type NamespaceRecord,
 } from "./namespaces/catalog.js";
+import {
+  planNamespaceMaintenance,
+  runNamespaceMaintenanceBatchPlan,
+  type NamespaceMaintenancePlan,
+  type NamespaceMaintenanceSkipReason,
+} from "./maintenance/namespace-planner.js";
 import {
   namespaceIdentityFromToken,
   namespaceIdentityToken,
@@ -1767,6 +1770,13 @@ export function resolvePersistedMemoryRelativePath(options: {
   return path.join(subtree, `${options.memoryId}.md`);
 }
 
+function qmdMaintenanceSkipReasonForError(error: unknown): NamespaceMaintenanceSkipReason | null {
+  const message = error instanceof Error ? error.message : String(error);
+  return /^QMD (?:update|embed) skipped by .*min-interval gate$/.test(message)
+    ? "throttled"
+    : null;
+}
+
 export class Orchestrator {
   readonly storage: StorageManager;
   private readonly storageRouter: NamespaceStorageRouter;
@@ -1914,6 +1924,7 @@ export class Orchestrator {
   private qmdMaintenancePending = false;
   private qmdMaintenanceInFlight = false;
   private lastQmdEmbedAtMs = 0;
+  private lastQmdEmbedAtMsByNamespace = new Map<string, number>();
   private lastQmdReprobeAtMs = 0;
   private tierMigrationInFlight = false;
   private lastTierMigrationRunAtMs = 0;
@@ -2417,63 +2428,31 @@ export class Orchestrator {
   }
 
   /**
-   * Namespaces that QMD maintenance (update/embed) must cover: the CONFIGURED set
-   * PLUS every dynamic namespace recorded in the catalog (NGnei, codex P2). An
-   * extraction that writes to a coding-scoped/dynamic namespace (not in
-   * defaultNamespace/sharedNamespace/namespacePolicies) is only made discoverable
-   * via the catalog; if maintenance embeds only `configuredNamespaces()`, that
-   * namespace's QMD collection is never updated/embedded after writes and
-   * recall/search stays stale or empty until it is manually configured. We union in
-   * the catalog's namespaces so maintenance keeps dynamic namespaces fresh.
-   * `updateNamespaces`/`embedNamespaces` already trim, dedup, and skip
-   * unavailable/missing collections, so extra names are filtered safely. A catalog
-   * read failure must never break maintenance — fall back to the configured set.
+   * Shared namespace maintenance planner (issue #1500). This extends the
+   * #1499 catalog-union QMD helper into a reusable contract: configured
+   * namespaces are always considered, dynamic catalog namespaces are admitted
+   * only when their live router root still matches real memory data, and branch
+   * namespaces are opt-in. Recurring jobs use the per-cycle budget; startup and
+   * recovery discovery paths use the same safety filters without that cycle
+   * budget so every live namespace is ensured/synced.
    */
-  private async maintenanceNamespaces(): Promise<string[]> {
-    const configured = this.configuredNamespaces();
-    if (!this.namespaceCatalog.enabled) return configured;
-    const configuredSet = new Set(configured);
-    let cataloged: string[] = [];
-    try {
-      const records = await this.namespaceCatalog.listNamespaces();
-      const safeRecords = await Promise.all(
-        records.map(async (record) => {
-          const namespace = record.namespace.trim();
-          if (!namespace || configuredSet.has(namespace)) return null;
-          return (await this.isCatalogedMaintenanceRootLive(record))
-            ? namespace
-            : null;
-        }),
-      );
-      cataloged = safeRecords.filter(
-        (namespace): namespace is string => namespace !== null,
-      );
-    } catch {
-      // Best-effort: a catalog read failure must not break QMD maintenance.
-      cataloged = [];
-    }
-    return Array.from(
-      new Set(
-        [...configured, ...cataloged].map((value) => value.trim()).filter(Boolean),
-      ),
-    );
+  private async namespaceMaintenancePlan(jobName: string): Promise<NamespaceMaintenancePlan> {
+    return planNamespaceMaintenance(this.config, {
+      jobName,
+      catalog: this.namespaceCatalog,
+    });
   }
 
-  private async isCatalogedMaintenanceRootLive(
-    record: NamespaceRecord,
-  ): Promise<boolean> {
-    if (typeof record.storageDir !== "string" || record.storageDir.length === 0) {
-      return false;
-    }
-    try {
-      const liveRoot = await resolveNamespaceStorageRoot(this.config, record.namespace);
-      if (path.resolve(liveRoot) !== path.resolve(record.storageDir)) {
-        return false;
-      }
-      return hasMemoryData(liveRoot);
-    } catch {
-      return false;
-    }
+  private async maintenanceNamespaces(
+    jobName = "qmd",
+    budgetMode: "cycle" | "unbounded" = "unbounded",
+  ): Promise<string[]> {
+    const plan = await planNamespaceMaintenance(this.config, {
+      jobName,
+      catalog: this.namespaceCatalog,
+      budgetMode,
+    });
+    return plan.namespaces.map((candidate) => candidate.namespace);
   }
 
   private buildConfiguredQmdSearchOptions(
@@ -13337,17 +13316,69 @@ export class Orchestrator {
     try {
       if (this.config.namespacesEnabled) {
         // Include cataloged dynamic namespaces, not just the configured set
-        // (NGnei) — resolve once and reuse for both update and embed.
-        const maintenanceNamespaces = await this.maintenanceNamespaces();
-        await this.namespaceSearchRouter.updateNamespaces(maintenanceNamespaces);
+        // (NGnei), but run through the namespace-aware maintenance planner so
+        // each namespace is budgeted, lock-protected, and status-recorded
+        // independently (issue #1500).
+        const plan = await this.namespaceMaintenancePlan("qmd");
         const now = Date.now();
-        if (
-          this.config.qmdAutoEmbedEnabled &&
-          now - this.lastQmdEmbedAtMs >= this.config.qmdEmbedMinIntervalMs
-        ) {
-          await this.namespaceSearchRouter.embedNamespaces(maintenanceNamespaces);
+        const lastEmbedAtByNamespace =
+          this.lastQmdEmbedAtMsByNamespace ?? (this.lastQmdEmbedAtMsByNamespace = new Map());
+        const dueEmbedNamespaces = (namespaces: string[]): string[] => {
+          if (!this.config.qmdAutoEmbedEnabled) return [];
+          return namespaces.filter(
+            (namespace) =>
+              now - (lastEmbedAtByNamespace.get(namespace) ?? 0) >= this.config.qmdEmbedMinIntervalMs,
+          );
+        };
+        const markEmbedded = (namespaces: string[]): void => {
+          if (namespaces.length === 0) return;
+          for (const namespace of namespaces) {
+            lastEmbedAtByNamespace.set(namespace, now);
+          }
           this.lastQmdEmbedAtMs = now;
-        }
+        };
+        await runNamespaceMaintenanceBatchPlan(
+          this.config,
+          plan,
+          async (candidates) => {
+            const namespaces = candidates.map((candidate) => candidate.namespace);
+            const embedNamespaces = dueEmbedNamespaces(namespaces);
+            let result: Awaited<ReturnType<NamespaceSearchRouter["updateNamespacesDetailed"]>>;
+            try {
+              result = await this.namespaceSearchRouter.updateNamespacesDetailed(
+                namespaces,
+                undefined,
+                { strict: true },
+              );
+            } catch (error) {
+              if (
+                embedNamespaces.length > 0 &&
+                qmdMaintenanceSkipReasonForError(error) === "throttled"
+              ) {
+                await this.namespaceSearchRouter.embedNamespaces(embedNamespaces, { strict: true });
+                markEmbedded(embedNamespaces);
+              }
+              throw error;
+            }
+            if (result.backendCount <= 0) {
+              throw new Error("no eligible QMD backend for selected namespaces");
+            }
+            if (result.eligibleNamespaces.length !== namespaces.length) {
+              const eligible = new Set(result.eligibleNamespaces);
+              const missing = namespaces.filter((namespace) => !eligible.has(namespace));
+              throw new Error(`QMD backend ineligible for selected namespaces (${missing.length})`);
+            }
+            if (embedNamespaces.length > 0) {
+              await this.namespaceSearchRouter.embedNamespaces(embedNamespaces, { strict: true });
+              markEmbedded(embedNamespaces);
+            }
+            return { itemCount: result.backendCount };
+          },
+          this.namespaceCatalog,
+          {
+            skipReasonForError: qmdMaintenanceSkipReasonForError,
+          },
+        );
       } else {
         await this.qmd.update();
         const now = Date.now();

--- a/packages/remnic-core/src/qmd-client.test.ts
+++ b/packages/remnic-core/src/qmd-client.test.ts
@@ -70,6 +70,65 @@ function captureSubprocessArgs(client: QmdClient): string[][] {
   return calls;
 }
 
+test("updateStrict respects QMD update min-interval throttles", async () => {
+  const client = new QmdClient("memories", 3, { updateMinIntervalMs: 60_000 });
+  client.resetUpdateThrottles();
+  const calls = captureSubprocessArgs(client);
+
+  try {
+    await client.updateStrict();
+    await assert.rejects(
+      () => client.updateStrict(),
+      /QMD update skipped by min-interval gate|QMD update skipped by global min-interval gate/,
+    );
+  } finally {
+    client.resetUpdateThrottles();
+  }
+
+  assert.equal(calls.length, 1);
+});
+
+test("embedCollectionStrict rejects QMD embed subprocess failures", async () => {
+  const client = new QmdClient("memories", 3, { updateMinIntervalMs: 60_000 });
+  client.resetUpdateThrottles();
+  const internals = client as unknown as SubprocessInternals;
+  const calls: string[][] = [];
+  internals.available = true;
+  internals.runQmdCommand = async (args: string[]) => {
+    calls.push(args);
+    throw new Error("embed subprocess failed");
+  };
+
+  try {
+    await assert.rejects(
+      () => client.embedCollectionStrict("memories--project"),
+      /embed subprocess failed/,
+    );
+  } finally {
+    client.resetUpdateThrottles();
+  }
+
+  assert.deepEqual(calls, [["embed", "-c", "memories--project"]]);
+});
+
+test("embedCollectionStrict respects QMD embed min-interval throttles", async () => {
+  const client = new QmdClient("memories", 3, { updateMinIntervalMs: 60_000 });
+  client.resetUpdateThrottles();
+  const calls = captureSubprocessArgs(client);
+
+  try {
+    await client.embedCollectionStrict("memories--project");
+    await assert.rejects(
+      () => client.embedCollectionStrict("memories--project"),
+      /QMD embed skipped by per-collection min-interval gate/,
+    );
+  } finally {
+    client.resetUpdateThrottles();
+  }
+
+  assert.equal(calls.length, 1);
+});
+
 test("ensureCollection treats cancelled auto-create as unknown", async () => {
   const client = new QmdClient("memories", 3, {});
   const internals = client as unknown as SubprocessInternals & {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1232,9 +1232,14 @@ export class QmdClient implements SearchBackend {
   resetUpdateThrottles(): void {
     this._lastUpdateFailAtMs = null;
     this.lastUpdateRunAtMs = null;
+    this.lastEmbedFailAtMs = null;
     const gs = getGlobalQmdState();
     gs.lastGlobalUpdateRunAtMs = null;
     gs.lastGlobalUpdateFailAtMs = null;
+    gs.lastGlobalEmbedRunAtMs = null;
+    gs.lastGlobalEmbedFailAtMs = null;
+    gs.lastEmbedByCollectionMs = {};
+    gs.lastEmbedFailByCollectionMs = {};
   }
 
   private readonly updateTimeoutMs: number;
@@ -2493,6 +2498,14 @@ export class QmdClient implements SearchBackend {
     );
   }
 
+  async updateStrict(execution?: SearchExecutionOptions): Promise<void> {
+    await this.runUpdateForCollection(
+      this.collection,
+      { perCollectionThrottle: false, strict: true },
+      execution?.signal,
+    );
+  }
+
   async updateCollection(
     collection: string,
     execution?: SearchExecutionOptions,
@@ -2510,7 +2523,7 @@ export class QmdClient implements SearchBackend {
   ): Promise<void> {
     await this.runUpdateForCollection(
       collection,
-      { perCollectionThrottle: true, strict: true },
+      { perCollectionThrottle: true, strict: true, force: true },
       execution?.signal,
     );
   }
@@ -2521,7 +2534,7 @@ export class QmdClient implements SearchBackend {
 
   private async runUpdateForCollection(
     collection: string,
-    options: { perCollectionThrottle: boolean; strict?: boolean },
+    options: { perCollectionThrottle: boolean; strict?: boolean; force?: boolean },
     signal?: AbortSignal,
   ): Promise<void> {
     if (this.available === false) {
@@ -2539,12 +2552,13 @@ export class QmdClient implements SearchBackend {
     }
     const globalState = getGlobalQmdState();
     const now = Date.now();
-    if (!options.strict && options.perCollectionThrottle) {
+    if (!options.force && options.perCollectionThrottle) {
       if (
         globalState.lastGlobalUpdateFailAtMs &&
         now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
       ) {
         log.debug("QMD update: suppressed by global failure backoff");
+        if (options.strict) throw new Error("QMD update skipped by global failure backoff");
         return;
       }
       const lastCollectionRun = globalState.lastUpdateByCollectionMs[name];
@@ -2553,6 +2567,7 @@ export class QmdClient implements SearchBackend {
         now - lastCollectionRun < this.updateMinIntervalMs
       ) {
         log.debug(`QMD update: suppressed by per-collection min-interval gate (${name})`);
+        if (options.strict) throw new Error("QMD update skipped by per-collection min-interval gate");
         return;
       }
       const lastCollectionFail = globalState.lastUpdateFailByCollectionMs[name];
@@ -2561,14 +2576,16 @@ export class QmdClient implements SearchBackend {
         now - lastCollectionFail < QMD_UPDATE_BACKOFF_MS
       ) {
         log.debug(`QMD update: suppressed by per-collection failure backoff (${name})`);
+        if (options.strict) throw new Error("QMD update skipped by per-collection failure backoff");
         return;
       }
-    } else if (!options.strict) {
+    } else if (!options.force) {
       if (
         this.lastUpdateRunAtMs &&
         now - this.lastUpdateRunAtMs < this.updateMinIntervalMs
       ) {
         log.debug("QMD update: suppressed due to min-interval gate");
+        if (options.strict) throw new Error("QMD update skipped by min-interval gate");
         return;
       }
       if (
@@ -2576,6 +2593,7 @@ export class QmdClient implements SearchBackend {
         now - this._lastUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
       ) {
         log.debug("QMD update: suppressed due to recent failures (backoff)");
+        if (options.strict) throw new Error("QMD update skipped by recent failure backoff");
         return;
       }
       if (
@@ -2583,6 +2601,7 @@ export class QmdClient implements SearchBackend {
         now - globalState.lastGlobalUpdateRunAtMs < this.updateMinIntervalMs
       ) {
         log.debug("QMD update: suppressed by global min-interval gate");
+        if (options.strict) throw new Error("QMD update skipped by global min-interval gate");
         return;
       }
       if (
@@ -2590,6 +2609,7 @@ export class QmdClient implements SearchBackend {
         now - globalState.lastGlobalUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
       ) {
         log.debug("QMD update: suppressed by global failure backoff");
+        if (options.strict) throw new Error("QMD update skipped by global failure backoff");
         return;
       }
     }
@@ -2633,117 +2653,137 @@ export class QmdClient implements SearchBackend {
   }
 
   async embed(): Promise<void> {
-    if (this.available === false) return;
+    await this.runEmbedForCollection(this.collection, { perCollectionThrottle: false });
+  }
+
+  async embedStrict(): Promise<void> {
+    await this.runEmbedForCollection(this.collection, { perCollectionThrottle: false, strict: true });
+  }
+
+  async embedCollection(collection: string): Promise<void> {
+    await this.runEmbedForCollection(collection, { perCollectionThrottle: true });
+  }
+
+  async embedCollectionStrict(collection: string): Promise<void> {
+    await this.runEmbedForCollection(collection, { perCollectionThrottle: true, strict: true });
+  }
+
+  private async runEmbedForCollection(
+    collection: string,
+    options: { perCollectionThrottle: boolean; strict?: boolean },
+  ): Promise<void> {
+    if (this.available === false) {
+      if (options.strict) throw new Error("QMD unavailable");
+      return;
+    }
+    const name = collection.trim();
+    if (!name) {
+      if (options.strict) throw new Error("QMD collection name is required");
+      return;
+    }
     const globalState = getGlobalQmdState();
-    if (
-      this.lastEmbedFailAtMs &&
-      Date.now() - this.lastEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-    ) {
-      log.debug("QMD embed: suppressed due to recent failures (backoff)");
-      return;
-    }
-    if (
-      globalState.lastGlobalEmbedRunAtMs &&
-      Date.now() - globalState.lastGlobalEmbedRunAtMs < this.updateMinIntervalMs
-    ) {
-      log.debug("QMD embed: suppressed by global min-interval gate");
-      return;
-    }
-    if (
-      globalState.lastGlobalEmbedFailAtMs &&
-      Date.now() - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-    ) {
-      log.debug("QMD embed: suppressed by global failure backoff");
-      return;
+    const now = Date.now();
+    if (options.perCollectionThrottle) {
+      if (
+        globalState.lastGlobalEmbedFailAtMs &&
+        now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
+      ) {
+        log.debug(`QMD embed: suppressed by global failure backoff (${name})`);
+        if (options.strict) throw new Error("QMD embed skipped by global failure backoff");
+        return;
+      }
+      const lastCollectionRun = globalState.lastEmbedByCollectionMs[name];
+      if (
+        Number.isFinite(lastCollectionRun) &&
+        now - lastCollectionRun < this.updateMinIntervalMs
+      ) {
+        log.debug(`QMD embed: suppressed by per-collection min-interval gate (${name})`);
+        if (options.strict) throw new Error("QMD embed skipped by per-collection min-interval gate");
+        return;
+      }
+      const lastCollectionFail = globalState.lastEmbedFailByCollectionMs[name];
+      if (
+        Number.isFinite(lastCollectionFail) &&
+        now - lastCollectionFail < QMD_EMBED_BACKOFF_MS
+      ) {
+        log.debug(`QMD embed: suppressed by per-collection failure backoff (${name})`);
+        if (options.strict) throw new Error("QMD embed skipped by per-collection failure backoff");
+        return;
+      }
+    } else {
+      if (
+        this.lastEmbedFailAtMs &&
+        now - this.lastEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
+      ) {
+        log.debug("QMD embed: suppressed due to recent failures (backoff)");
+        if (options.strict) throw new Error("QMD embed skipped by recent failure backoff");
+        return;
+      }
+      if (
+        globalState.lastGlobalEmbedRunAtMs &&
+        now - globalState.lastGlobalEmbedRunAtMs < this.updateMinIntervalMs
+      ) {
+        log.debug("QMD embed: suppressed by global min-interval gate");
+        if (options.strict) throw new Error("QMD embed skipped by global min-interval gate");
+        return;
+      }
+      if (
+        globalState.lastGlobalEmbedFailAtMs &&
+        now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
+      ) {
+        log.debug("QMD embed: suppressed by global failure backoff");
+        if (options.strict) throw new Error("QMD embed skipped by global failure backoff");
+        return;
+      }
     }
     try {
       const startedAtMs = Date.now();
-      await this.runQmdCommand(this.buildEmbedArgs(this.collection), 300_000);
+      await this.runQmdCommand(this.buildEmbedArgs(name), 300_000);
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(`SLOW QMD embed: durationMs=${durationMs}`);
       }
-      globalState.lastGlobalEmbedRunAtMs = Date.now();
-      log.debug("QMD embed completed");
-    } catch (err) {
-      if (isVectorDimensionMismatchError(err)) {
-        try {
-          log.warn("QMD embed hit a vector dimension mismatch; retrying with force re-embed");
-          await this.runQmdCommand(this.buildEmbedArgs(this.collection, true), 300_000);
-          globalState.lastGlobalEmbedRunAtMs = Date.now();
-          this.lastEmbedFailAtMs = null;
-          globalState.lastGlobalEmbedFailAtMs = null;
-          log.warn("QMD embed recovered by forcing a full vector rebuild");
-          return;
-        } catch (retryErr) {
-          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-          log.warn(`QMD force re-embed failed after dimension mismatch: ${retryMsg}`);
-        }
-      }
-      const now = Date.now();
-      this.lastEmbedFailAtMs = now;
-      globalState.lastGlobalEmbedFailAtMs = now;
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(`QMD embed failed: ${msg}`);
-    }
-  }
-
-  async embedCollection(collection: string): Promise<void> {
-    if (this.available === false) return;
-    const name = collection.trim();
-    if (!name) return;
-    const globalState = getGlobalQmdState();
-    const now = Date.now();
-    if (
-      globalState.lastGlobalEmbedFailAtMs &&
-      now - globalState.lastGlobalEmbedFailAtMs < QMD_EMBED_BACKOFF_MS
-    ) {
-      log.debug(`QMD embed: suppressed by global failure backoff (${name})`);
-      return;
-    }
-    const lastCollectionRun = globalState.lastEmbedByCollectionMs[name];
-    if (
-      Number.isFinite(lastCollectionRun) &&
-      now - lastCollectionRun < this.updateMinIntervalMs
-    ) {
-      log.debug(`QMD embed: suppressed by per-collection min-interval gate (${name})`);
-      return;
-    }
-    const lastCollectionFail = globalState.lastEmbedFailByCollectionMs[name];
-    if (
-      Number.isFinite(lastCollectionFail) &&
-      now - lastCollectionFail < QMD_EMBED_BACKOFF_MS
-    ) {
-      log.debug(`QMD embed: suppressed by per-collection failure backoff (${name})`);
-      return;
-    }
-    try {
-      await this.runQmdCommand(this.buildEmbedArgs(name), 300_000);
       const at = Date.now();
-      globalState.lastEmbedByCollectionMs[name] = at;
+      if (options.perCollectionThrottle) {
+        globalState.lastEmbedByCollectionMs[name] = at;
+      }
       globalState.lastGlobalEmbedRunAtMs = at;
+      log.debug(`QMD embed completed for collection=${name}`);
     } catch (err) {
+      let failure: unknown = err;
       if (isVectorDimensionMismatchError(err)) {
         try {
           log.warn(`QMD embed for collection ${name} hit a vector dimension mismatch; retrying with force re-embed`);
           await this.runQmdCommand(this.buildEmbedArgs(name, true), 300_000);
           const recoveredAt = Date.now();
-          globalState.lastEmbedByCollectionMs[name] = recoveredAt;
+          if (options.perCollectionThrottle) {
+            globalState.lastEmbedByCollectionMs[name] = recoveredAt;
+            delete globalState.lastEmbedFailByCollectionMs[name];
+          } else {
+            this.lastEmbedFailAtMs = null;
+          }
           globalState.lastGlobalEmbedRunAtMs = recoveredAt;
-          delete globalState.lastEmbedFailByCollectionMs[name];
           globalState.lastGlobalEmbedFailAtMs = null;
           log.warn(`QMD embed for collection ${name} recovered by forcing a full vector rebuild`);
           return;
         } catch (retryErr) {
+          failure = retryErr;
           const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
           log.warn(`QMD force re-embed failed for collection ${name}: ${retryMsg}`);
         }
       }
       const at = Date.now();
-      globalState.lastEmbedFailByCollectionMs[name] = at;
+      if (options.perCollectionThrottle) {
+        globalState.lastEmbedFailByCollectionMs[name] = at;
+      } else {
+        this.lastEmbedFailAtMs = at;
+      }
       globalState.lastGlobalEmbedFailAtMs = at;
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = failure instanceof Error ? failure.message : String(failure);
       log.warn(`QMD embed failed for collection ${name}: ${msg}`);
+      if (options.strict) {
+        throw failure;
+      }
     }
   }
 

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -81,6 +81,12 @@ export interface SearchBackend {
 
   // ── Maintenance ──
   update(execution?: SearchExecutionOptions): Promise<void>;
+  /**
+   * Optional strict refresh used by callers that must know whether the backend
+   * was actually refreshed before writing success markers. Ordinary update
+   * calls remain fail-open for migration/maintenance resilience.
+   */
+  updateStrict?(execution?: SearchExecutionOptions): Promise<void>;
   updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void>;
   updateCollectionFromDir?(collection: string, memoryDir: string, execution?: SearchExecutionOptions): Promise<void>;
   /**
@@ -96,7 +102,17 @@ export interface SearchBackend {
    */
   updateCollectionStrict?(collection: string, execution?: SearchExecutionOptions): Promise<void>;
   embed(): Promise<void>;
+  /**
+   * Optional strict embed used by callers that must know vectors were actually
+   * refreshed before writing success markers.
+   */
+  embedStrict?(): Promise<void>;
   embedCollection(collection: string): Promise<void>;
+  /**
+   * Optional strict collection embed used by callers that must know vectors were
+   * actually refreshed before writing success markers.
+   */
+  embedCollectionStrict?(collection: string): Promise<void>;
 
   // ── Collection management ──
   /**

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1216,6 +1216,18 @@ export interface PluginConfig {
   // QMD maintenance (debounced singleflight)
   qmdMaintenanceEnabled: boolean;
   qmdMaintenanceDebounceMs: number;
+  /**
+   * Namespace-aware maintenance fanout (issue #1500). When namespaces are
+   * enabled, background maintenance jobs use the rebuildable namespace catalog
+   * to discover dynamic project/team namespaces rather than only processing the
+   * configured default/shared/policy set.
+   */
+  maintenanceNamespaceFanoutEnabled: boolean;
+  maintenanceMaxNamespacesPerCycle: number;
+  maintenanceIncludeProjectNamespaces: boolean;
+  maintenanceIncludeBranchNamespaces: boolean;
+  maintenanceIncludeTeamProjectNamespaces: boolean;
+  maintenanceNamespaceLockStaleMs: number;
   qmdAutoEmbedEnabled: boolean;
   qmdEmbedMinIntervalMs: number;
   qmdUpdateTimeoutMs: number;

--- a/tests/namespace-search-router.test.ts
+++ b/tests/namespace-search-router.test.ts
@@ -510,7 +510,7 @@ test("NamespaceSearchRouter runs maintenance only for present namespace collecti
   await router.updateNamespaces(["default", "shared"]);
   await router.embedNamespaces(["default", "shared"]);
 
-  assert.deepEqual(backends.get("openclaw-engram")?.calls, ["update", "embed"]);
+  assert.deepEqual(backends.get("openclaw-engram")?.calls, ["update", "embedCollection"]);
   assert.deepEqual(backends.get("openclaw-engram--ns-736861726564")?.calls ?? [], []);
 });
 

--- a/tests/qmd-sync-after-store.test.ts
+++ b/tests/qmd-sync-after-store.test.ts
@@ -35,11 +35,17 @@ test("QmdClient.update() passes collection flag to qmd subprocess", async () => 
     "runUpdateForCollection() should pass -c name to scope updates to the target collection",
   );
 
-  // embed() must pass -c collection
+  // embed() must route through the collection-aware helper.
   assert.match(
     qmdSource,
-    /runQmd(?:Command)?\(this\.buildEmbedArgs\(this\.collection\)/,
-    "embed() should pass -c this.collection to scope embedding to the remnic collection",
+    /async embed\(\): Promise<void>\s*\{\s*await this\.runEmbedForCollection\(this\.collection,\s*\{\s*perCollectionThrottle:\s*false\s*\}\);/s,
+    "embed() should route through runEmbedForCollection(this.collection)",
+  );
+
+  assert.match(
+    qmdSource,
+    /await this\.runQmdCommand\(this\.buildEmbedArgs\(name\),\s*300_000\);/,
+    "runEmbedForCollection() should build embed args from the target collection name",
   );
 
   assert.match(


### PR DESCRIPTION
## Summary
- add a shared namespace maintenance planner that combines configured namespaces with live namespace-catalog records
- wire QMD maintenance/startup sync through the planner with per-job/per-namespace locks and per-namespace status files
- add maintenance fanout config parsing, plugin schema entries, docs, and focused tests

Refs #1500
Refs #1494

## Verification
- npm run preflight:quick
- npm run check-config-contract
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/maintenance/namespace-planner.test.ts
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/config.test.ts
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test --test-name-pattern "runQmdMaintenance updates and embeds cataloged dynamic namespaces|runQmdMaintenance skips cataloged dynamic namespaces whose live root is unsafe|runQmdMaintenance falls back to configured namespaces|deferredInitialize startup sync covers cataloged dynamic namespaces|deferredInitialize startup sync falls back to configured set" packages/remnic-core/src/orchestrator-flush.test.ts
- pnpm exec biome check --diagnostic-level=error packages/remnic-core/src/maintenance/namespace-planner.ts packages/remnic-core/src/maintenance/namespace-planner.test.ts
- npm run review:cursor (skipped: agent/cursor-agent not installed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recurring background QMD behavior, filesystem locking, and success/failure semantics across many namespaces; mitigated by cycle caps, defaults that skip branches, and extensive tests.
> 
> **Overview**
> Adds **namespace-aware maintenance fanout** so background QMD work can target dynamic catalog namespaces—not only default/shared/policy—under a per-cycle budget, with per-job/per-namespace locks and status files for doctor/dashboard surfaces.
> 
> A new **`namespace-planner`** module selects namespaces (configured always eligible; catalog rows only when live roots match and hold memory data; branches off by default), runs batch maintenance with lock heartbeats and sanitized failure reporting, and records per-namespace outcomes under `state/namespace-maintenance-status/`.
> 
> **`runQmdMaintenance`** now plans via that module, acquires locks through **`runNamespaceMaintenanceBatchPlan`**, uses **strict** `updateNamespacesDetailed` / `embedNamespaces`, tracks **per-namespace embed cadence**, classifies min-interval throttles as skipped maintenance, and treats partial/zero backend eligibility as failure instead of silent success. Startup discovery still uses an **unbounded** budget so all safe namespaces can sync.
> 
> Config adds flat/nested **`maintenance.*`** keys (fanout toggle, max namespaces per cycle, project/branch/team inclusion, lock stale ms), mirrored in plugin JSON and docs. QMD/search layers gain **`updateStrict` / `embedStrict`** (and collection variants) plus **`updateNamespacesDetailed`** eligibility reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea2d367dd9931ec583c1ab2d39f28ae85cd39de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->