### PR TITLE
feat(scopes): add hosted scope profiles

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1492,6 +1492,9 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `namespacePolicies[].writePrincipals` | (unset) | (unset) |
 | `namespacePolicies[].includeInRecallByDefault` | (unset) | (unset) |
 | `defaultRecallNamespaces` | `["self","shared"]` | `["self","shared"]` |
+| `scopeProfiles` | `{}` | unset unless running a hosted multi-user/project-aware deployment |
+| `defaultScopeProfile` | (unset) | unset unless a `scopeProfiles` entry should control implicit reads/writes |
+| `teams` | `{}` | trusted team membership for `teamProject` scope profile layers |
 | `cronRecallMode` | `all` | `all` |
 | `cronRecallAllowlist` | `[]` | `[]` |
 | `cronRecallPolicyEnabled` | `true` | `true` |

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -11,6 +11,8 @@ Namespaces allow multiple agents to share one Engram installation while keeping 
 - `namespacePolicies`: list of namespaces and read/write principals
 - `principalFromSessionKeyMode` + `principalFromSessionKeyRules`: derive a principal from `sessionKey`
 - `defaultRecallNamespaces`: typically `["self", "shared"]`
+- `scopeProfiles` + `defaultScopeProfile`: optional hosted-team layered scope profiles
+- `teams`: trusted team membership and team-project namespace templates used by scope profiles
 
 ## Cross-Agent Memory Access
 
@@ -29,6 +31,57 @@ If this directory is empty or missing, non-generalist agents may have limited cr
 **Categories eligible for promotion:** The `autoPromoteToSharedCategories` setting controls which memory categories are promoted. The default is `["fact", "correction", "decision", "preference"]`. The `"fact"` category was added in v9.0.67 — prior versions defaulted to `["correction", "decision", "preference"]` only.
 
 **Cross-agent recall:** The primary mechanism for cross-agent memory sharing is shared namespace promotion. When promotion is configured, memories extracted by any agent are copied to the shared namespace and become available to all agents during recall.
+
+## Scope Profiles
+
+`scopeProfiles` are optional. When absent, Remnic keeps the existing `defaultRecallNamespaces` behavior. When `defaultScopeProfile` points to a profile, implicit recall and write-producing access paths resolve the profile through the same core scope planner used for observe diagnostics.
+
+Example hosted coding profile:
+
+```json
+{
+  "scopeProfiles": {
+    "teamCoding": {
+      "readOrder": ["userProject", "teamProject", "userGlobal", "serverShared"],
+      "writeDefault": "userProject",
+      "promotionTargets": ["teamProject", "serverShared"],
+      "teamProject": {
+        "namespaceTemplate": "team-{teamId}-project-{projectHash}"
+      },
+      "autoPromote": {
+        "enabled": false,
+        "targets": ["teamProject"],
+        "categories": ["decision", "rule", "procedure", "correction"],
+        "minConfidenceTier": "explicit"
+      }
+    }
+  },
+  "defaultScopeProfile": "teamCoding",
+  "teams": {
+    "pi": {
+      "principals": ["pi-geek", "pi-friend"],
+      "read": ["pi-geek", "pi-friend"],
+      "write": ["pi-geek", "pi-friend"],
+      "promote": ["pi-geek", "pi-friend"]
+    }
+  }
+}
+```
+
+Layer meanings:
+
+- `userProject`: the caller principal's self namespace overlaid with the resolved project or branch context.
+- `teamProject`: a trusted team/project namespace derived from `teams` plus the resolved project context.
+- `userGlobal`: the caller principal's self namespace without a project overlay.
+- `serverShared`: the configured `sharedNamespace`.
+
+Security rules:
+
+- Explicit `namespace` overrides still use the existing namespace policy checks.
+- Team-project namespaces are derived from trusted config, not accepted from caller-supplied namespace strings.
+- User-project namespaces remain principal-isolated by default; `pi-geek` and `pi-friend` in the same repo get different `userProject` namespaces.
+- Automatic profile promotion remains off unless `autoPromote.enabled` is true. The initial core contract exposes authorized promotion targets for surfaces; it does not make automatic cross-user sharing the default.
+- If project context is missing, Remnic skips project layers and falls back to the next authorized configured layer instead of inventing a project namespace.
 
 ## QMD Collections for Namespaces
 

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -40,6 +40,7 @@ Example hosted coding profile:
 
 ```json
 {
+  "namespacesEnabled": true,
   "scopeProfiles": {
     "teamCoding": {
       "readOrder": ["userProject", "teamProject", "userGlobal", "serverShared"],

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4276,6 +4276,136 @@
           "shared"
         ]
       },
+      "scopeProfiles": {
+        "type": "object",
+        "default": {},
+        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "readOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "writeDefault": {
+              "type": "string",
+              "enum": [
+                "userProject",
+                "teamProject",
+                "userGlobal",
+                "serverShared"
+              ]
+            },
+            "promotionTargets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "teamProject": {
+              "type": "object",
+              "properties": {
+                "namespaceTemplate": {
+                  "type": "string"
+                },
+                "teamId": {
+                  "type": "string"
+                }
+              }
+            },
+            "autoPromote": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "targets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "teamProject",
+                      "serverShared",
+                      "userGlobal",
+                      "userProject"
+                    ]
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "minConfidenceTier": {
+                  "type": "string",
+                  "enum": [
+                    "explicit",
+                    "implied",
+                    "inferred",
+                    "speculative"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "defaultScopeProfile": {
+        "type": "string",
+        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+      },
+      "teams": {
+        "type": "object",
+        "default": {},
+        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "principals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "projectNamespaceTemplate": {
+              "type": "string"
+            },
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "promote": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "cronRecallMode": {
         "type": "string",
         "enum": [

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -4276,6 +4276,136 @@
           "shared"
         ]
       },
+      "scopeProfiles": {
+        "type": "object",
+        "default": {},
+        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "readOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "writeDefault": {
+              "type": "string",
+              "enum": [
+                "userProject",
+                "teamProject",
+                "userGlobal",
+                "serverShared"
+              ]
+            },
+            "promotionTargets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "teamProject": {
+              "type": "object",
+              "properties": {
+                "namespaceTemplate": {
+                  "type": "string"
+                },
+                "teamId": {
+                  "type": "string"
+                }
+              }
+            },
+            "autoPromote": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "targets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "teamProject",
+                      "serverShared",
+                      "userGlobal",
+                      "userProject"
+                    ]
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "minConfidenceTier": {
+                  "type": "string",
+                  "enum": [
+                    "explicit",
+                    "implied",
+                    "inferred",
+                    "speculative"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "defaultScopeProfile": {
+        "type": "string",
+        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+      },
+      "teams": {
+        "type": "object",
+        "default": {},
+        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "principals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "projectNamespaceTemplate": {
+              "type": "string"
+            },
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "promote": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "cronRecallMode": {
         "type": "string",
         "enum": [

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -661,6 +661,7 @@ test("#1501 scope profile lcmSearch reads the team-project profile key", async (
         readOrder: ["teamProject"],
         writeDefault: "teamProject",
         promotionTargets: ["teamProject"],
+        autoPromote: false,
         teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
       },
     },

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -652,6 +652,43 @@ test("#1505 thread 2 compaction regression: flush/record overlay-derived key mat
   );
 });
 
+test("#1501 scope profile lcmSearch fans out prefix-only reads across profile namespaces", async () => {
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-observer"),
+    namespacePolicies: [
+      { name: "pi-observer", readPrincipals: ["pi-observer"], writePrincipals: ["pi-observer"] },
+      { name: "shared", readPrincipals: ["pi-observer"], writePrincipals: [] },
+    ],
+    defaultScopeProfile: "profilePrefix",
+    scopeProfiles: {
+      profilePrefix: {
+        readOrder: ["userGlobal", "serverShared"],
+        writeDefault: "userGlobal",
+        promotionTargets: [],
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.lcmSearch({
+    query: "database",
+    sessionPrefix: "pi-observer:",
+    authenticatedPrincipal: "pi-observer",
+  });
+
+  assert.deepEqual(probe.searchSessionIds, [undefined, undefined]);
+  assert.deepEqual(probe.searchSessionPrefixes, [
+    encodeNs("pi-observer", "pi-observer:"),
+    encodeNs("shared", "pi-observer:"),
+  ]);
+});
+
 test("#1501 scope profile lcmSearch reads the team-project profile key", async () => {
   const probe = makeParityProbe({
     ...withSelfPolicyPrefix("pi-observer"),

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -38,7 +38,7 @@ import {
   projectNamespaceName,
   projectTagProjectId,
 } from "./coding/coding-namespace.js";
-import { resolveGitContext } from "./coding/git-context.js";
+import { resolveGitContext, stableHash } from "./coding/git-context.js";
 import { defaultNamespaceForPrincipal } from "./namespaces/principal.js";
 import type { CodingContext, PluginConfig } from "./types.js";
 
@@ -649,6 +649,48 @@ test("#1505 thread 2 compaction regression: flush/record overlay-derived key mat
     probe.compactionFlushKeys[0],
     observedWriteKey,
     "compaction flush must target the overlay key, not the base",
+  );
+});
+
+test("#1501 scope profile lcmSearch reads the team-project profile key", async () => {
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-observer"),
+    defaultScopeProfile: "teamCoding",
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: ["pi-observer"],
+        promote: ["pi-observer"],
+      },
+    },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({ sessionKey: "pi-observer:abc123", projectTag: "Remnic" }),
+  );
+  const expectedTeamProject = `team-pi-project-${stableHash(projectTagProjectId("Remnic"))}`;
+  const expectedKey = encodeNs(expectedTeamProject, "pi-observer:abc123");
+  assert.equal(probe.lcmWriteKeys[0], expectedKey);
+
+  await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "pi-observer:abc123",
+  });
+
+  assert.equal(
+    probe.searchSessionIds[0],
+    expectedKey,
+    "lcmSearch must read the same team-project key the scope-profile observe wrote",
   );
 });
 

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -661,7 +661,12 @@ test("#1501 scope profile lcmSearch reads the team-project profile key", async (
         readOrder: ["teamProject"],
         writeDefault: "teamProject",
         promotionTargets: ["teamProject"],
-        autoPromote: false,
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
         teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
       },
     },

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -748,7 +748,7 @@ test("#1501 team-project profile observe reports the profile write namespace as 
     }),
   );
 
-  assert.equal(res.scopeDebug?.baseNamespace, "default");
+  assert.equal(res.scopeDebug?.baseNamespace, "pi-observer");
   assert.equal(res.scopeDebug?.writeLayer, "teamProject");
   assert.equal(res.scopeDebug?.codingOverlayApplied, true);
   assert.equal(res.namespace, expectedTeamProject);

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -701,6 +701,62 @@ test("#1501 profile write auth rejects memory_store when no profile layer is wri
   );
 });
 
+test("#1501 team-project profile observe reports the profile write namespace as legacy namespace", async () => {
+  const projectId = projectTagProjectId("Remnic");
+  const expectedTeamProject = `team-pi-project-${stableHash(projectId)}`;
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      {
+        name: expectedTeamProject,
+        readPrincipals: ["pi-observer"],
+        writePrincipals: ["pi-observer"],
+      },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-observer:", principal: "pi-observer" }],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject", "serverShared"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: ["pi-observer"],
+        promote: ["pi-observer"],
+      },
+    },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({
+      sessionKey: "pi-observer:abc123",
+      authenticatedPrincipal: "pi-observer",
+      projectTag: "Remnic",
+    }),
+  );
+
+  assert.equal(res.scopeDebug?.baseNamespace, "default");
+  assert.equal(res.scopeDebug?.writeLayer, "teamProject");
+  assert.equal(res.scopeDebug?.codingOverlayApplied, true);
+  assert.equal(res.namespace, expectedTeamProject);
+  assert.equal(res.effectiveNamespace, expectedTeamProject);
+  assert.equal(probe.lcmCalls[0]?.sessionKey, encodeNs(expectedTeamProject, "pi-observer:abc123"));
+  assert.equal(probe.extractionCalls[0]?.writeNamespaceOverride, expectedTeamProject);
+});
+
 test("#1495 skipExtraction does not enqueue extraction but still archives LCM under the effective namespace", async () => {
   const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
   const service = new EngramAccessService(probe.orch);

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -643,6 +643,64 @@ test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteName
   }
 });
 
+test("#1501 profile write auth rejects memory_store when no profile layer is writable", async () => {
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      { name: "pi-observer", readPrincipals: ["pi-observer"], writePrincipals: [] },
+      { name: "shared", readPrincipals: ["pi-observer"], writePrincipals: [] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-observer:", principal: "pi-observer" }],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "teamProject", "serverShared"],
+        writeDefault: "userProject",
+        promotionTargets: ["teamProject", "serverShared"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: [],
+        promote: [],
+      },
+    },
+  } as Partial<PluginConfig>);
+  probe.contexts.set("pi-observer:abc123", {
+    projectId: projectTagProjectId("Remnic"),
+    branch: null,
+    rootPath: projectTagProjectId("Remnic"),
+    defaultBranch: null,
+  });
+  const service = new EngramAccessService(probe.orch);
+  const internals = service as unknown as {
+    resolveMemoryScopePlan: (r: unknown) => Promise<{ writeNamespace: string }>;
+    resolveCodingScopedWriteNamespace: (r: unknown) => Promise<string>;
+  };
+  const req = {
+    sessionKey: "pi-observer:abc123",
+    authenticatedPrincipal: "pi-observer",
+  };
+
+  await assert.rejects(
+    () => internals.resolveMemoryScopePlan.call(service, req),
+    /scope profile teamCoding has no writable layer/,
+  );
+  await assert.rejects(
+    () => internals.resolveCodingScopedWriteNamespace.call(service, req),
+    /scope profile teamCoding has no writable layer/,
+  );
+});
+
 test("#1495 skipExtraction does not enqueue extraction but still archives LCM under the effective namespace", async () => {
   const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
   const service = new EngramAccessService(probe.orch);

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -78,7 +78,6 @@ function makeObserveProbe(overrides: Partial<PluginConfig> = {}): ObserveProbe {
 
   const config = {
     namespacesEnabled: true,
-    memoryDir: "/synthetic/remnic-memory-search",
     defaultNamespace: "default",
     sharedNamespace: "shared",
     namespacePolicies: [],

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -78,6 +78,7 @@ function makeObserveProbe(overrides: Partial<PluginConfig> = {}): ObserveProbe {
 
   const config = {
     namespacesEnabled: true,
+    memoryDir: "/synthetic/remnic-memory-search",
     defaultNamespace: "default",
     sharedNamespace: "shared",
     namespacePolicies: [],

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -42,6 +42,7 @@ import {
   projectTagProjectId,
 } from "./coding/coding-namespace.js";
 import { resolveGitContext, stableHash } from "./coding/git-context.js";
+import { namespaceCollectionName } from "./namespaces/search.js";
 import type { CodingContext, PluginConfig } from "./types.js";
 
 /**
@@ -784,6 +785,7 @@ test("#1501 implicit memorySearch honors active scope profile readOrder", async 
     namespacesEnabled: true,
     defaultNamespace: "default",
     sharedNamespace: "shared",
+    memoryDir: "/synthetic/remnic-memory-search",
     namespacePolicies: [
       { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
       { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
@@ -826,4 +828,54 @@ test("#1501 implicit memorySearch honors active scope profile readOrder", async 
     null,
     "userProject-only profiles without project context must not fall back to shared/global search",
   );
+});
+
+test("#1501 memorySearch collection names stay constrained to active scope profile namespaces", async () => {
+  let searchedNamespaces: string[] | null = null;
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    memoryDir: "/synthetic/remnic-memory-search-collection",
+    qmdCollection: "memories",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    defaultRecallNamespaces: ["self", "shared"],
+    defaultScopeProfile: "privateOnly",
+    scopeProfiles: {
+      privateOnly: {
+        readOrder: ["userGlobal"],
+        writeDefault: "userGlobal",
+        promotionTargets: [],
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    codingMode: { projectScope: true },
+  } as unknown as PluginConfig;
+  const orch = {
+    config,
+    qmd: { isAvailable: () => true },
+    searchAcrossNamespaces: async (options: { namespaces: string[] }) => {
+      searchedNamespaces = options.namespaces;
+      return [];
+    },
+  } as unknown as Orchestrator;
+  const service = new EngramAccessService(orch);
+  const sharedCollection = namespaceCollectionName(config.qmdCollection, "shared", {
+    defaultNamespace: config.defaultNamespace,
+    useLegacyDefaultCollection: false,
+  });
+
+  await assert.rejects(
+    () => service.memorySearch({ query: "deployment", principal: "pi-geek", collection: sharedCollection }),
+    /collection is not namespace-scoped/,
+  );
+  assert.equal(searchedNamespaces, null);
 });

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -41,7 +41,7 @@ import {
   projectNamespaceName,
   projectTagProjectId,
 } from "./coding/coding-namespace.js";
-import { resolveGitContext } from "./coding/git-context.js";
+import { resolveGitContext, stableHash } from "./coding/git-context.js";
 import type { CodingContext, PluginConfig } from "./types.js";
 
 /**
@@ -210,6 +210,72 @@ test("#1495 projectTag: LCM, extraction, objective-state, and response all agree
     probe.objectiveStateNamespaces.every((ns) => ns === expected),
     `objective-state target must be the effective namespace, got ${JSON.stringify(probe.objectiveStateNamespaces)}`,
   );
+});
+
+test("#1501 scope profile exposes layered read/write/promotion diagnostics without changing user-project write default", async () => {
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "teamProject", "userGlobal", "serverShared"],
+        writeDefault: "userProject",
+        promotionTargets: ["teamProject", "serverShared"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-geek", "pi-friend"],
+        read: ["pi-geek", "pi-friend"],
+        write: ["pi-geek", "pi-friend"],
+        promote: ["pi-geek", "pi-friend"],
+      },
+    },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Remnic" }),
+  );
+  const expectedUserProject = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Remnic")),
+  );
+  const expectedTeamProject = `team-pi-project-${stableHash(projectTagProjectId("Remnic"))}`;
+
+  assert.equal(res.effectiveNamespace, expectedUserProject);
+  assert.equal(res.scopeDebug?.scopeProfile, "teamCoding");
+  assert.equal(res.scopeDebug?.writeLayer, "userProject");
+  assert.deepEqual(res.scopeDebug?.readNamespaces, [
+    expectedUserProject,
+    expectedTeamProject,
+    "pi-geek",
+    "shared",
+  ]);
+  assert.deepEqual(
+    res.scopeDebug?.promotionTargets?.map((target) => [
+      target.target,
+      target.namespace,
+      target.authorized,
+    ]),
+    [
+      ["teamProject", expectedTeamProject, true],
+      ["serverShared", "shared", true],
+    ],
+  );
+  assert.equal(probe.extractionCalls[0]?.writeNamespaceOverride, expectedUserProject);
 });
 
 test("#1495 cwd (git repo): every observe side effect agrees on the effective namespace", async () => {

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -777,3 +777,53 @@ test("#1495 skipExtraction does not enqueue extraction but still archives LCM un
   assert.equal(probe.extractionCalls.length, 0);
   assert.equal(probe.lcmCalls[0].sessionKey, encodeNs(expected, "pi-geek:abc123"));
 });
+
+test("#1501 implicit memorySearch honors active scope profile readOrder", async () => {
+  let searchedNamespaces: string[] | null = null;
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    defaultRecallNamespaces: ["self", "shared"],
+    defaultScopeProfile: "projectOnly",
+    scopeProfiles: {
+      projectOnly: {
+        readOrder: ["userProject"],
+        writeDefault: "userProject",
+        promotionTargets: [],
+        autoPromote: {
+          enabled: false,
+          targets: [],
+          categories: ["fact", "correction", "decision", "preference"],
+          minConfidenceTier: "explicit",
+        },
+      },
+    },
+    codingMode: { projectScope: true },
+  } as unknown as PluginConfig;
+  const orch = {
+    config,
+    qmd: { isAvailable: () => true },
+    searchAcrossNamespaces: async (options: { namespaces: string[] }) => {
+      searchedNamespaces = options.namespaces;
+      return [];
+    },
+  } as unknown as Orchestrator;
+  const service = new EngramAccessService(orch);
+
+  const result = await service.memorySearch({
+    query: "deployment",
+    principal: "pi-geek",
+  });
+
+  assert.equal(result.count, 0);
+  assert.equal(
+    searchedNamespaces,
+    null,
+    "userProject-only profiles without project context must not fall back to shared/global search",
+  );
+});

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -165,6 +165,13 @@ type ExecuteRecallInternals = {
   executeRecall: (request: unknown) => Promise<unknown>;
 };
 
+type RawExcerptInternals = {
+  fetchRawExcerpts: (
+    disclosure: "raw",
+    context: { query: string; sessionKey: string; lcmSessionIds: string[] },
+  ) => Promise<Array<{ turnIndex: number; role: string; content: string; sessionId: string }> | null>;
+};
+
 const SESSION_KEY = "pi-geek:abc123";
 const PROJECT_TAG = "Blend/Supply";
 
@@ -440,4 +447,50 @@ test("#1505 thread 2f7 (single-store regression): namespaces disabled ⇒ raw ex
 
   assert.equal(probe.searchSessionIds.length, 1);
   assert.equal(probe.searchSessionIds[0], SESSION_KEY);
+});
+
+test("scope-profile raw excerpts preserve successful sibling LCM keys when one key fails", async () => {
+  const probe = makeRawExcerptProbe({
+    config: {},
+    snapshotNamespace: "default",
+    sessionKey: SESSION_KEY,
+  });
+  const orchestrator = (probe.service as unknown as { orchestrator: Orchestrator }).orchestrator as unknown as {
+    lcmEngine: {
+      enabled: boolean;
+      searchContextFull: (query: string, limit: number, sessionId?: string) => Promise<Array<{
+        session_id: string;
+        turn_index: number;
+        role: string;
+        content: string;
+      }>>;
+    };
+  };
+  orchestrator.lcmEngine.searchContextFull = async (_query, _limit, sessionId) => {
+    probe.searchSessionIds.push(sessionId);
+    if (sessionId === "bad") throw new Error("synthetic LCM failure");
+    return [
+      {
+        session_id: sessionId ?? "default",
+        turn_index: sessionId === "good" ? 1 : 2,
+        role: "user",
+        content: `raw row from ${sessionId}`,
+      },
+    ];
+  };
+
+  const excerpts = await (probe.service as unknown as RawExcerptInternals).fetchRawExcerpts("raw", {
+    query: "what happened?",
+    sessionKey: SESSION_KEY,
+    lcmSessionIds: ["good", "bad", "later"],
+  });
+
+  assert.deepEqual(probe.searchSessionIds, ["good", "bad", "later"]);
+  assert.deepEqual(
+    excerpts?.map((excerpt) => [excerpt.sessionId, excerpt.turnIndex, excerpt.content]),
+    [
+      ["good", 1, "raw row from good"],
+      ["later", 2, "raw row from later"],
+    ],
+  );
 });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1643,7 +1643,13 @@ export class EngramAccessService {
       const readNamespaces = expandedReadNamespaces;
       const profileCodingOverlayApplied = Boolean(
         codingOverlay &&
-          profilePlan.layers.some((layer) => layer.id === "userProject" && layer.readable && layer.namespace),
+          profilePlan.layers.some(
+            (layer) =>
+              (layer.id === "userProject" || layer.id === "teamProject") &&
+              layer.readable &&
+              layer.namespace &&
+              readNamespaces.includes(layer.namespace),
+          ),
       );
       return {
         principal,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1636,7 +1636,7 @@ export class EngramAccessService {
         : [];
       const expandedReadNamespaces = expandScopeProfileReadNamespaces({
         profilePlan,
-        principalSelfNamespace: baseNamespace,
+        principalSelfNamespace: profilePlan.baseNamespace,
         codingOverlay,
         legacyRecallNamespaces,
       });
@@ -3185,7 +3185,7 @@ export class EngramAccessService {
       : profilePlan
         ? expandScopeProfileReadNamespaces({
             profilePlan,
-            principalSelfNamespace: principalNamespace,
+            principalSelfNamespace: profilePlan.baseNamespace,
             codingOverlay: profileCodingOverlay,
             legacyRecallNamespaces,
           })
@@ -5989,7 +5989,7 @@ export class EngramAccessService {
       : [];
     return expandScopeProfileReadNamespaces({
       profilePlan,
-      principalSelfNamespace,
+      principalSelfNamespace: profilePlan.baseNamespace,
       codingOverlay,
       legacyRecallNamespaces,
     });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -56,7 +56,12 @@ import {
 } from "./memory-lifecycle-ledger-utils.js";
 import { getMemoryProjectionPath } from "./memory-projection-store.js";
 import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
-import { resolveScopeProfilePlan, type ScopeProfileLayerResolution, type ScopeProfilePromotionResolution } from "./namespaces/scope-profiles.js";
+import {
+  expandScopeProfileReadNamespaces,
+  resolveScopeProfilePlan,
+  type ScopeProfileLayerResolution,
+  type ScopeProfilePromotionResolution,
+} from "./namespaces/scope-profiles.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -1439,6 +1444,12 @@ export class EngramAccessService {
       codingOverlay: overlay,
     });
     if (profilePlan) {
+      const selectedLayer = profilePlan.layers.find((layer) => layer.id === profilePlan.writeLayer);
+      if (!selectedLayer?.writable) {
+        throw new EngramAccessInputError(
+          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
+        );
+      }
       return profilePlan.writeNamespace;
     }
     if (!overlay) {
@@ -1614,8 +1625,17 @@ export class EngramAccessService {
           `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
         );
       }
-      const readNamespaces = profilePlan.readNamespaces.length > 0
-        ? profilePlan.readNamespaces
+      const legacyRecallNamespaces = Array.isArray(this.orchestrator.config.defaultRecallNamespaces)
+        ? recallNamespacesForPrincipal(principal, this.orchestrator.config)
+        : [];
+      const expandedReadNamespaces = expandScopeProfileReadNamespaces({
+        profilePlan,
+        principalSelfNamespace: baseNamespace,
+        codingOverlay,
+        legacyRecallNamespaces,
+      });
+      const readNamespaces = expandedReadNamespaces.length > 0
+        ? expandedReadNamespaces
         : [profilePlan.writeNamespace];
       return {
         principal,
@@ -3139,11 +3159,19 @@ export class EngramAccessService {
     // against every cross-namespace entry in the effective set so that omitting
     // `namespace` cannot bypass the limiter (Cursor/Codex review feedback).
     //
+    const legacyRecallNamespaces = Array.isArray(this.orchestrator.config.defaultRecallNamespaces)
+      ? recallNamespacesForPrincipal(principal, this.orchestrator.config)
+      : [];
     const effectiveNamespaces = namespaceOverride
       ? [namespaceOverride]
       : profilePlan?.readNamespaces.length
-        ? profilePlan.readNamespaces
-        : recallNamespacesForPrincipal(principal, this.orchestrator.config);
+        ? expandScopeProfileReadNamespaces({
+            profilePlan,
+            principalSelfNamespace: principalNamespace,
+            codingOverlay: profileCodingOverlay,
+            legacyRecallNamespaces,
+          })
+        : legacyRecallNamespaces;
     let budgetDecision: BudgetDecision;
     let recordBudgetAfterSuccess = false;
     if (modeSkipsBudget) {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -56,6 +56,7 @@ import {
 } from "./memory-lifecycle-ledger-utils.js";
 import { getMemoryProjectionPath } from "./memory-projection-store.js";
 import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
+import { resolveScopeProfilePlan, type ScopeProfileLayerResolution, type ScopeProfilePromotionResolution } from "./namespaces/scope-profiles.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -888,6 +889,14 @@ export interface MemoryScopePlan {
   objectiveStateNamespace: string;
   /** Namespaces a same-session recall would read (cheap subset). */
   readNamespaces: string[];
+  /** Active scope profile id, when `defaultScopeProfile` is configured. */
+  scopeProfile?: string;
+  /** Resolved profile layer that supplied `writeNamespace`. */
+  writeLayer?: string;
+  /** Resolved profile layers in the active profile contract. */
+  layers?: ScopeProfileLayerResolution[];
+  /** Authorized promotion targets from the active profile contract. */
+  promotionTargets?: ScopeProfilePromotionResolution[];
   /** Whether the coding overlay changed the base namespace. */
   codingOverlayApplied: boolean;
   /** Non-fatal diagnostics surfaced during resolution. */
@@ -966,6 +975,10 @@ export interface EngramAccessScopeDebug {
   codingOverlayApplied: boolean;
   /** Namespaces a same-session recall would read, when cheap to compute. */
   readNamespaces?: string[];
+  scopeProfile?: string;
+  writeLayer?: string;
+  layers?: ScopeProfileLayerResolution[];
+  promotionTargets?: ScopeProfilePromotionResolution[];
 }
 
 export interface EngramAccessObserveResponse {
@@ -1398,17 +1411,36 @@ export class EngramAccessService {
     // `default-project-*` that its own recall never searches (Codex review).
     const hasSession =
       typeof request.sessionKey === "string" && request.sessionKey.length > 0;
+    const codingContext =
+      hasSession &&
+      this.orchestrator.config.namespacesEnabled &&
+      this.orchestrator.config.codingMode?.projectScope
+        ? this.orchestrator.getCodingContextForSession(request.sessionKey) ??
+          (await this.resolveCodingContextFromOptions(request))
+        : null;
     const overlay =
       hasSession &&
       this.orchestrator.config.namespacesEnabled &&
       this.orchestrator.config.codingMode?.projectScope
         ? resolveCodingNamespaceOverlay(
-            this.orchestrator.getCodingContextForSession(request.sessionKey) ??
-              (await this.resolveCodingContextFromOptions(request)),
+            codingContext,
             this.orchestrator.config.codingMode,
             this.orchestrator.config.defaultNamespace,
           )
         : null;
+    const principal = this.resolveRequestPrincipal(
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
+    const profilePlan = resolveScopeProfilePlan({
+      config: this.orchestrator.config,
+      principal,
+      codingContext,
+      codingOverlay: overlay,
+    });
+    if (profilePlan) {
+      return profilePlan.writeNamespace;
+    }
     if (!overlay) {
       // No coding overlay → unqualified write stays on config.defaultNamespace,
       // exactly the pre-#1434 behavior (auth-checked, like the legacy path).
@@ -1422,10 +1454,6 @@ export class EngramAccessService {
     // recall/observe/buffer-flush use. The result is a principal-owned
     // `project-*` sub-namespace derived from this authorized base, so it needs
     // no separate write policy.
-    const principal = this.resolveRequestPrincipal(
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
     const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     if (!canWriteNamespace(principal, base, this.orchestrator.config)) {
       throw new EngramAccessInputError(`namespace is not writable: ${base}`);
@@ -1565,6 +1593,44 @@ export class EngramAccessService {
       baseNamespace,
     );
     const codingOverlayApplied = overlaidBase !== baseNamespace;
+    const codingOverlay = overlayEligible
+      ? resolveCodingNamespaceOverlay(
+          attachedContext,
+          this.orchestrator.config.codingMode,
+          this.orchestrator.config.defaultNamespace,
+        )
+      : null;
+    const profilePlan = resolveScopeProfilePlan({
+      config: this.orchestrator.config,
+      principal,
+      codingContext: attachedContext,
+      codingOverlay,
+    });
+    if (profilePlan) {
+      const selectedLayer = profilePlan.layers.find((layer) => layer.id === profilePlan.writeLayer);
+      if (!selectedLayer?.writable) {
+        clearSeededContext();
+        throw new EngramAccessInputError(
+          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
+        );
+      }
+      const readNamespaces = profilePlan.readNamespaces.length > 0
+        ? profilePlan.readNamespaces
+        : [profilePlan.writeNamespace];
+      return {
+        principal,
+        baseNamespace,
+        writeNamespace: profilePlan.writeNamespace,
+        objectiveStateNamespace: profilePlan.writeNamespace,
+        readNamespaces,
+        scopeProfile: profilePlan.profileId,
+        writeLayer: profilePlan.writeLayer,
+        layers: profilePlan.layers,
+        promotionTargets: profilePlan.promotionTargets,
+        codingOverlayApplied: codingOverlayApplied || profilePlan.writeLayer === "userProject" || profilePlan.writeLayer === "teamProject",
+        warnings: [...warnings, ...profilePlan.warnings],
+      };
+    }
 
     if (!codingOverlayApplied) {
       // No overlay → the LCM/extraction/response write namespace mirrors the
@@ -1640,12 +1706,7 @@ export class EngramAccessService {
     // matches what a same-session recall searches. Resolved through the pure
     // overlay helper to enumerate fallbacks; the write namespace itself already
     // came from `applyCodingNamespaceOverlay` so the two agree.
-    const overlay = resolveCodingNamespaceOverlay(
-      attachedContext,
-      this.orchestrator.config.codingMode,
-      this.orchestrator.config.defaultNamespace,
-    );
-    for (const fallback of overlay?.readFallbacks ?? []) {
+    for (const fallback of codingOverlay?.readFallbacks ?? []) {
       const ns = combineNamespaces(baseNamespace, fallback);
       if (!readNamespaces.includes(ns)) readNamespaces.push(ns);
     }
@@ -3048,6 +3109,28 @@ export class EngramAccessService {
     }
     const principal = maybePrincipal ?? "default";
     const principalNamespace = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+    const profileCodingContext = request.sessionKey
+      ? this.orchestrator.getCodingContextForSession(request.sessionKey)
+      : null;
+    const profileCodingOverlay =
+      !namespaceOverride &&
+      profileCodingContext &&
+      this.orchestrator.config.namespacesEnabled &&
+      this.orchestrator.config.codingMode?.projectScope
+        ? resolveCodingNamespaceOverlay(
+            profileCodingContext,
+            this.orchestrator.config.codingMode,
+            this.orchestrator.config.defaultNamespace,
+          )
+        : null;
+    const profilePlan = namespaceOverride
+      ? null
+      : resolveScopeProfilePlan({
+          config: this.orchestrator.config,
+          principal,
+          codingContext: profileCodingContext,
+          codingOverlay: profileCodingOverlay,
+        });
     // Skip budget checks for modes that never perform a cross-namespace read.
     const modeSkipsBudget = mode === "no_recall";
     // Derive the full set of namespaces the orchestrator will actually search.
@@ -3056,14 +3139,11 @@ export class EngramAccessService {
     // against every cross-namespace entry in the effective set so that omitting
     // `namespace` cannot bypass the limiter (Cursor/Codex review feedback).
     //
-    // NOTE: coding overlays (branch/project scope) are resolved inside
-    // orchestrator.recall() AFTER this check.  The access-service does not
-    // duplicate that resolution here to avoid tight coupling.  Coding-overlay
-    // namespaces are a second-layer defense covered by the anomaly detector
-    // (PR 5/5 of issue #565).
     const effectiveNamespaces = namespaceOverride
       ? [namespaceOverride]
-      : recallNamespacesForPrincipal(principal, this.orchestrator.config);
+      : profilePlan?.readNamespaces.length
+        ? profilePlan.readNamespaces
+        : recallNamespacesForPrincipal(principal, this.orchestrator.config);
     let budgetDecision: BudgetDecision;
     let recordBudgetAfterSuccess = false;
     if (modeSkipsBudget) {
@@ -5339,6 +5419,10 @@ export class EngramAccessService {
         writeNamespace: scope.writeNamespace,
         codingOverlayApplied: scope.codingOverlayApplied,
         readNamespaces: scope.readNamespaces,
+        scopeProfile: scope.scopeProfile,
+        writeLayer: scope.writeLayer,
+        layers: scope.layers,
+        promotionTargets: scope.promotionTargets,
       },
       lcmArchived,
       extractionQueued,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1884,9 +1884,19 @@ export class EngramAccessService {
       return namespaces;
     }
 
+    const activeScopeProfilePlan = collectionPrincipal
+      ? resolveScopeProfilePlan({
+          config: this.orchestrator.config,
+          principal: collectionPrincipal,
+          codingContext: null,
+          codingOverlay: null,
+        })
+      : null;
     const allowedNamespaces = new Set(namespaces);
     const candidates = collectionPrincipal
-      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal).filter((ns) => allowedNamespaces.has(ns))
+      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal).filter((ns) =>
+          activeScopeProfilePlan ? allowedNamespaces.has(ns) : true,
+        )
       : namespaces;
     const matchedNamespaces = candidates.filter((namespace) => {
       const canonical = namespaceCollectionName(baseCollection, namespace, {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5804,10 +5804,21 @@ export class EngramAccessService {
         "read",
       );
     }
-    // IMPLICIT raw recall: derive the read fallback from the ALREADY
-    // read-authorized recall namespace set — NEVER pre-authorize `default`
-    // (#1505 thread NBHWz). When namespaces are disabled the default store is the
-    // only namespace and is always readable (byte-for-byte single-user path).
+    // IMPLICIT raw recall: an active scope profile owns the same LCM read
+    // namespace set used by recall and lcmSearch. Return the first profile
+    // namespace as the legacy raw-excerpt namespace hint; the concrete ordered
+    // key set is still produced by resolveLcmReadSessionIds(), which also treats
+    // an empty profile read set as authoritative.
+    const profileReadNamespaces = this.resolveScopeProfileLcmReadNamespaces(
+      sessionKey,
+      authenticatedPrincipal,
+    );
+    if (profileReadNamespaces !== null) return profileReadNamespaces[0];
+
+    // Otherwise derive the read fallback from the ALREADY read-authorized recall
+    // namespace set — NEVER pre-authorize `default` (#1505 thread NBHWz). When
+    // namespaces are disabled the default store is the only namespace and is
+    // always readable (byte-for-byte single-user path).
     const fallbackNamespace =
       this.resolveImplicitLcmReadFallbackNamespace(principal);
     // No readable LCM namespace at all ⇒ no excerpts (caller short-circuits).

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1647,7 +1647,7 @@ export class EngramAccessService {
         writeLayer: profilePlan.writeLayer,
         layers: profilePlan.layers,
         promotionTargets: profilePlan.promotionTargets,
-        codingOverlayApplied: codingOverlayApplied || profilePlan.writeLayer === "userProject" || profilePlan.writeLayer === "teamProject",
+        codingOverlayApplied,
         warnings: [...warnings, ...profilePlan.warnings],
       };
     }
@@ -1739,6 +1739,19 @@ export class EngramAccessService {
       codingOverlayApplied: true,
       warnings,
     };
+  }
+
+  private legacyResponseNamespaceForScope(scope: MemoryScopePlan): string {
+    if (scope.explicitNamespace) return scope.writeNamespace;
+    // Legacy overlay compatibility only applies to the principal-owned
+    // user-project layer. Hosted profile layers such as teamProject are not the
+    // old overlay response shape; reporting default there hides the real write.
+    if (scope.scopeProfile && scope.writeLayer !== "userProject") {
+      return scope.writeNamespace;
+    }
+    return scope.codingOverlayApplied
+      ? this.orchestrator.config.defaultNamespace
+      : scope.writeNamespace;
   }
 
   private async objectiveStateStoreLocationForNamespace(namespace: string): Promise<{
@@ -5273,15 +5286,11 @@ export class EngramAccessService {
     // the single authorization point (rule 22 / 39); the legacy field must reuse it
     // and never re-authorize. Pre-#1495 semantics were exactly
     // `resolveWritableNamespace(request.namespace)` (overlay-agnostic): the explicit
-    // namespace when supplied, else `config.defaultNamespace`. `scope.explicitNamespace`
-    // carries the authorized explicit value; the no-overlay implicit
-    // `scope.writeNamespace` IS `config.defaultNamespace`, so an unqualified observe
-    // stays byte-for-byte identical to the legacy response.
-    const namespace = scope.explicitNamespace
-      ? scope.writeNamespace
-      : scope.codingOverlayApplied
-        ? this.orchestrator.config.defaultNamespace
-        : scope.writeNamespace;
+    // namespace when supplied, else `config.defaultNamespace` for user-project
+    // coding overlays. Hosted scope-profile layers such as `teamProject` report
+    // their effective profile write namespace because there is no legacy
+    // overlay-compatible base namespace for those writes.
+    const namespace = this.legacyResponseNamespaceForScope(scope);
     const shouldWriteObjectiveState =
       this.orchestrator.config.objectiveStateMemoryEnabled === true &&
       this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
@@ -5995,13 +6004,10 @@ export class EngramAccessService {
     // `resolveWritableNamespace(request.namespace)` (overlay-agnostic) — the
     // authorized explicit namespace when supplied, else `config.defaultNamespace`.
     // DERIVED from the scope plan (NOT a second auth pass, #1505 thread jvO):
-    // explicit ⇒ writeNamespace; coding overlay ⇒ defaultNamespace; no overlay ⇒
-    // writeNamespace (== defaultNamespace). Identical to observe's legacy field.
-    const namespace = scope.explicitNamespace
-      ? scope.writeNamespace
-      : scope.codingOverlayApplied
-        ? this.orchestrator.config.defaultNamespace
-        : scope.writeNamespace;
+    // explicit ⇒ writeNamespace; user-project coding overlay ⇒ defaultNamespace;
+    // non-user scope-profile layer/no overlay ⇒ writeNamespace. Identical to
+    // observe's legacy field.
+    const namespace = this.legacyResponseNamespaceForScope(scope);
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
         enabled: false,
@@ -6060,11 +6066,7 @@ export class EngramAccessService {
     // overlay write and never throws `not writable: default` for a validly scoped
     // observe's queue.
     const scope = await this.resolveMemoryScopePlan(request);
-    const namespace = scope.explicitNamespace
-      ? scope.writeNamespace
-      : scope.codingOverlayApplied
-        ? this.orchestrator.config.defaultNamespace
-        : scope.writeNamespace;
+    const namespace = this.legacyResponseNamespaceForScope(scope);
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
         enabled: false,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1831,8 +1831,27 @@ export class EngramAccessService {
       );
     }
 
-    return recallNamespacesForPrincipal(principal, this.orchestrator.config)
-      .filter((ns) => canReadNamespace(principal, ns, this.orchestrator.config));
+    const legacyRecallNamespaces = recallNamespacesForPrincipal(
+      principal,
+      this.orchestrator.config,
+    );
+    const profilePlan = resolveScopeProfilePlan({
+      config: this.orchestrator.config,
+      principal,
+      codingContext: null,
+      codingOverlay: null,
+    });
+    const namespaces = profilePlan
+      ? expandScopeProfileReadNamespaces({
+          profilePlan,
+          principalSelfNamespace: profilePlan.baseNamespace,
+          codingOverlay: null,
+          legacyRecallNamespaces,
+        })
+      : legacyRecallNamespaces;
+    return namespaces.filter((ns) =>
+      canReadNamespace(principal, ns, this.orchestrator.config),
+    );
   }
 
   private resolveAllReadableConfiguredNamespaces(principal: string): string[] {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2380,14 +2380,15 @@ export class EngramAccessService {
       const limit = 5;
       const seenRows = new Set<string>();
       const excerpts: NonNullable<EngramAccessMemorySummary["rawExcerpts"]> = [];
-      for (const lcmSessionKey of lcmSessionIds) {
+      const settledRows = await Promise.allSettled(
+        lcmSessionIds.map(async (lcmSessionKey) =>
+          lcm.searchContextFull(context.query, limit, lcmSessionKey),
+        ),
+      );
+      for (const result of settledRows) {
         if (excerpts.length >= limit) break;
-        const rows = await lcm.searchContextFull(
-          context.query,
-          limit,
-          lcmSessionKey,
-        );
-        for (const r of rows) {
+        if (result.status !== "fulfilled") continue;
+        for (const r of result.value) {
           const dedupeKey = `${r.session_id} ${r.turn_index}`;
           if (seenRows.has(dedupeKey)) continue;
           seenRows.add(dedupeKey);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1445,9 +1445,12 @@ export class EngramAccessService {
     });
     if (profilePlan) {
       const selectedLayer = profilePlan.layers.find((layer) => layer.id === profilePlan.writeLayer);
-      if (!selectedLayer?.writable) {
+      const writeNamespaceReadable =
+        profilePlan.writeNamespace.length > 0 &&
+        profilePlan.readNamespaces.includes(profilePlan.writeNamespace);
+      if (!selectedLayer?.writable || !writeNamespaceReadable) {
         throw new EngramAccessInputError(
-          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
+          `scope profile ${profilePlan.profileId} has no writable layer inside the profile read stack for principal ${principal ?? "anonymous"}`,
         );
       }
       return profilePlan.writeNamespace;
@@ -1619,10 +1622,13 @@ export class EngramAccessService {
     });
     if (profilePlan) {
       const selectedLayer = profilePlan.layers.find((layer) => layer.id === profilePlan.writeLayer);
-      if (!selectedLayer?.writable) {
+      const writeNamespaceReadable =
+        profilePlan.writeNamespace.length > 0 &&
+        profilePlan.readNamespaces.includes(profilePlan.writeNamespace);
+      if (!selectedLayer?.writable || !writeNamespaceReadable) {
         clearSeededContext();
         throw new EngramAccessInputError(
-          `scope profile ${profilePlan.profileId} has no writable layer for principal ${principal ?? "anonymous"}`,
+          `scope profile ${profilePlan.profileId} has no writable layer inside the profile read stack for principal ${principal ?? "anonymous"}`,
         );
       }
       const legacyRecallNamespaces = Array.isArray(this.orchestrator.config.defaultRecallNamespaces)

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5568,13 +5568,20 @@ export class EngramAccessService {
             request.authenticatedPrincipal,
           )
       : [undefined];
-    const lcmSessionPrefix = request.sessionPrefix
-      ? lcmSessionKeyForNamespace(
-          lcmReadNamespace,
-          request.sessionPrefix,
-          this.orchestrator.config.defaultNamespace,
-        ) ?? request.sessionPrefix
-      : request.sessionPrefix;
+    const lcmSessionPrefixes = request.sessionPrefix
+      ? profileLcmReadNamespaces !== null && !request.sessionKey
+        ? this.lcmSessionIdsForNamespaces(
+            profileLcmReadNamespaces,
+            request.sessionPrefix,
+          )
+        : [
+            lcmSessionKeyForNamespace(
+              lcmReadNamespace,
+              request.sessionPrefix,
+              this.orchestrator.config.defaultNamespace,
+            ) ?? request.sessionPrefix,
+          ]
+      : [undefined];
     // SECURITY (#1495 P1 + codex P1 r2 "Require a scoped LCM filter before
     // archive searches"): a sessionless, prefixless `lcmSearch` issues
     // `searchContextFull(query, limit, undefined, undefined)`, an archive-wide
@@ -5596,7 +5603,7 @@ export class EngramAccessService {
     const hasScopedSession =
       (typeof request.sessionKey === "string" &&
         request.sessionKey.length > 0) ||
-      (typeof lcmSessionPrefix === "string" && lcmSessionPrefix.length > 0);
+      lcmSessionPrefixes.some((prefix) => typeof prefix === "string" && prefix.length > 0);
     if (!hasScopedSession && this.orchestrator.config.namespacesEnabled === true) {
       return {
         query: request.query,
@@ -5612,22 +5619,25 @@ export class EngramAccessService {
     const results: Array<{ sessionId: string; content: string; turnIndex: number }> = [];
     for (const lcmSessionKey of lcmSessionKeyIds) {
       if (results.length >= limit) break;
-      const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
-        request.query,
-        limit,
-        lcmSessionKey,
-        lcmSessionPrefix,
-      );
-      for (const r of rawResults as Array<{ session_id: string; content: string; turn_index: number }>) {
-        const dedupeKey = `${r.session_id} ${r.turn_index}`;
-        if (seenRows.has(dedupeKey)) continue;
-        seenRows.add(dedupeKey);
-        results.push({
-          sessionId: r.session_id,
-          content: r.content,
-          turnIndex: r.turn_index,
-        });
+      for (const lcmSessionPrefix of lcmSessionPrefixes) {
         if (results.length >= limit) break;
+        const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
+          request.query,
+          limit,
+          lcmSessionKey,
+          lcmSessionPrefix,
+        );
+        for (const r of rawResults as Array<{ session_id: string; content: string; turn_index: number }>) {
+          const dedupeKey = `${r.session_id} ${r.turn_index}`;
+          if (seenRows.has(dedupeKey)) continue;
+          seenRows.add(dedupeKey);
+          results.push({
+            sessionId: r.session_id,
+            content: r.content,
+            turnIndex: r.turn_index,
+          });
+          if (results.length >= limit) break;
+        }
       }
     }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3194,6 +3194,7 @@ export class EngramAccessService {
             legacyRecallNamespaces,
           })
         : legacyRecallNamespaces;
+    const budgetPrincipalNamespace = profilePlan?.baseNamespace ?? principalNamespace;
     let budgetDecision: BudgetDecision;
     let recordBudgetAfterSuccess = false;
     if (modeSkipsBudget) {
@@ -3221,7 +3222,7 @@ export class EngramAccessService {
       for (const ns of effectiveNamespaces) {
         const peek = this.budget.peek({
           principal,
-          principalNamespace,
+          principalNamespace: budgetPrincipalNamespace,
           queryNamespace: ns,
         });
         if (peek.reason !== "allowed-same-namespace") {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1641,9 +1641,13 @@ export class EngramAccessService {
         legacyRecallNamespaces,
       });
       const readNamespaces = expandedReadNamespaces;
+      const profileCodingOverlayApplied = Boolean(
+        codingOverlay &&
+          profilePlan.layers.some((layer) => layer.id === "userProject" && layer.readable && layer.namespace),
+      );
       return {
         principal,
-        baseNamespace,
+        baseNamespace: profilePlan.baseNamespace,
         writeNamespace: profilePlan.writeNamespace,
         objectiveStateNamespace: profilePlan.writeNamespace,
         readNamespaces,
@@ -1651,7 +1655,7 @@ export class EngramAccessService {
         writeLayer: profilePlan.writeLayer,
         layers: profilePlan.layers,
         promotionTargets: profilePlan.promotionTargets,
-        codingOverlayApplied,
+        codingOverlayApplied: profileCodingOverlayApplied,
         warnings: [...warnings, ...profilePlan.warnings],
       };
     }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1637,6 +1637,8 @@ export class EngramAccessService {
       const expandedReadNamespaces = expandScopeProfileReadNamespaces({
         profilePlan,
         principalSelfNamespace: profilePlan.baseNamespace,
+        config: this.orchestrator.config,
+        principal,
         codingOverlay,
         legacyRecallNamespaces,
       });
@@ -1845,6 +1847,8 @@ export class EngramAccessService {
       ? expandScopeProfileReadNamespaces({
           profilePlan,
           principalSelfNamespace: profilePlan.baseNamespace,
+          config: this.orchestrator.config,
+          principal,
           codingOverlay: null,
           legacyRecallNamespaces,
         })
@@ -1880,8 +1884,9 @@ export class EngramAccessService {
       return namespaces;
     }
 
+    const allowedNamespaces = new Set(namespaces);
     const candidates = collectionPrincipal
-      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal)
+      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal).filter((ns) => allowedNamespaces.has(ns))
       : namespaces;
     const matchedNamespaces = candidates.filter((namespace) => {
       const canonical = namespaceCollectionName(baseCollection, namespace, {
@@ -3217,6 +3222,8 @@ export class EngramAccessService {
         ? expandScopeProfileReadNamespaces({
             profilePlan,
             principalSelfNamespace: profilePlan.baseNamespace,
+            config: this.orchestrator.config,
+            principal,
             codingOverlay: profileCodingOverlay,
             legacyRecallNamespaces,
           })
@@ -6045,6 +6052,8 @@ export class EngramAccessService {
     return expandScopeProfileReadNamespaces({
       profilePlan,
       principalSelfNamespace: profilePlan.baseNamespace,
+      config,
+      principal,
       codingOverlay,
       legacyRecallNamespaces,
     });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5633,29 +5633,52 @@ export class EngramAccessService {
     }
     // Query each LCM read key in order, merging + deduping rows (by
     // sessionId+turnIndex) and preserving first-seen order, capped at `limit`.
+    // Use allSettled so one corrupt/failed namespace key cannot discard sibling
+    // results from other authorized profile namespaces.
     const seenRows = new Set<string>();
     const results: Array<{ sessionId: string; content: string; turnIndex: number }> = [];
+    const lcmSearches: Array<{
+      key: string | undefined;
+      prefix: string | undefined;
+      promise: Promise<Array<{ session_id: string; content: string; turn_index: number }>>;
+    }> = [];
     for (const lcmSessionKey of lcmSessionKeyIds) {
-      if (results.length >= limit) break;
       for (const lcmSessionPrefix of lcmSessionPrefixes) {
-        if (results.length >= limit) break;
-        const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
-          request.query,
-          limit,
-          lcmSessionKey,
-          lcmSessionPrefix,
+        lcmSearches.push({
+          key: lcmSessionKey,
+          prefix: lcmSessionPrefix,
+          promise: this.orchestrator.lcmEngine.searchContextFull(
+            request.query,
+            limit,
+            lcmSessionKey,
+            lcmSessionPrefix,
+          ) as Promise<Array<{ session_id: string; content: string; turn_index: number }>>,
+        });
+      }
+    }
+    const settledSearches = await Promise.allSettled(
+      lcmSearches.map((search) => search.promise),
+    );
+    for (let i = 0; i < settledSearches.length; i += 1) {
+      if (results.length >= limit) break;
+      const settled = settledSearches[i];
+      if (!settled || settled.status === "rejected") {
+        const failed = lcmSearches[i];
+        log.warn(
+          `lcmSearch: failed for key=${failed?.key ?? "<none>"} prefix=${failed?.prefix ?? "<none>"}: ${settled?.status === "rejected" ? settled.reason : "missing result"}`,
         );
-        for (const r of rawResults as Array<{ session_id: string; content: string; turn_index: number }>) {
-          const dedupeKey = `${r.session_id} ${r.turn_index}`;
-          if (seenRows.has(dedupeKey)) continue;
-          seenRows.add(dedupeKey);
-          results.push({
-            sessionId: r.session_id,
-            content: r.content,
-            turnIndex: r.turn_index,
-          });
-          if (results.length >= limit) break;
-        }
+        continue;
+      }
+      for (const r of settled.value) {
+        const dedupeKey = `${r.session_id}\0${r.turn_index}`;
+        if (seenRows.has(dedupeKey)) continue;
+        seenRows.add(dedupeKey);
+        results.push({
+          sessionId: r.session_id,
+          content: r.content,
+          turnIndex: r.turn_index,
+        });
+        if (results.length >= limit) break;
       }
     }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1892,11 +1892,10 @@ export class EngramAccessService {
           codingOverlay: null,
         })
       : null;
-    const allowedNamespaces = new Set(namespaces);
     const candidates = collectionPrincipal
-      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal).filter((ns) =>
-          activeScopeProfilePlan ? allowedNamespaces.has(ns) : true,
-        )
+      ? activeScopeProfilePlan
+        ? namespaces
+        : this.resolveAllReadableConfiguredNamespaces(collectionPrincipal)
       : namespaces;
     const matchedNamespaces = candidates.filter((namespace) => {
       const canonical = namespaceCollectionName(baseCollection, namespace, {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1849,6 +1849,7 @@ export class EngramAccessService {
           legacyRecallNamespaces,
         })
       : legacyRecallNamespaces;
+    if (profilePlan) return namespaces;
     return namespaces.filter((ns) =>
       canReadNamespace(principal, ns, this.orchestrator.config),
     );

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3140,9 +3140,10 @@ export class EngramAccessService {
     }
     const principal = maybePrincipal ?? "default";
     const principalNamespace = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
-    const profileCodingContext = request.sessionKey
-      ? this.orchestrator.getCodingContextForSession(request.sessionKey)
-      : null;
+    const profileCodingContext =
+      request.sessionKey && typeof this.orchestrator.getCodingContextForSession === "function"
+        ? this.orchestrator.getCodingContextForSession(request.sessionKey)
+        : null;
     const profileCodingOverlay =
       !namespaceOverride &&
       profileCodingContext &&

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1634,9 +1634,7 @@ export class EngramAccessService {
         codingOverlay,
         legacyRecallNamespaces,
       });
-      const readNamespaces = expandedReadNamespaces.length > 0
-        ? expandedReadNamespaces
-        : [profilePlan.writeNamespace];
+      const readNamespaces = expandedReadNamespaces;
       return {
         principal,
         baseNamespace,
@@ -1961,7 +1959,7 @@ export class EngramAccessService {
         ...(options.rawExcerptNamespace
           ? { rawExcerptNamespace: options.rawExcerptNamespace }
           : {}),
-        ...(options.rawExcerptSessionIds
+        ...(options.rawExcerptSessionIds !== undefined
           ? { rawExcerptSessionIds: options.rawExcerptSessionIds }
           : {}),
         ...(options.rawExcerptsSuppressed
@@ -2187,7 +2185,7 @@ export class EngramAccessService {
                     ? { sessionKey: rawContext.sessionKey }
                     : {}),
                   namespace: rawContext.rawExcerptNamespace ?? namespace,
-                  ...(rawContext.rawExcerptSessionIds
+                  ...(rawContext.rawExcerptSessionIds !== undefined
                     ? { lcmSessionIds: rawContext.rawExcerptSessionIds }
                     : {}),
                 }
@@ -2335,7 +2333,7 @@ export class EngramAccessService {
           ? `${context.namespace}:${context.sessionKey}`
           : context.sessionKey;
       const lcmSessionIds =
-        context.lcmSessionIds && context.lcmSessionIds.length > 0
+        context.lcmSessionIds !== undefined
           ? context.lcmSessionIds
           : [legacyKey];
       // Cap the excerpt fanout so recall responses stay bounded.  Five matches
@@ -3177,7 +3175,7 @@ export class EngramAccessService {
       : [];
     const effectiveNamespaces = namespaceOverride
       ? [namespaceOverride]
-      : profilePlan?.readNamespaces.length
+      : profilePlan
         ? expandScopeProfileReadNamespaces({
             profilePlan,
             principalSelfNamespace: principalNamespace,
@@ -3407,7 +3405,7 @@ export class EngramAccessService {
       query,
       sessionKey: trimmedSessionKey,
       ...(rawExcerptNamespace ? { rawExcerptNamespace } : {}),
-      ...(rawExcerptSessionIds ? { rawExcerptSessionIds } : {}),
+      ...(rawExcerptSessionIds !== undefined ? { rawExcerptSessionIds } : {}),
       ...(rawExcerptsSuppressed ? { rawExcerptsSuppressed } : {}),
     });
 
@@ -3950,7 +3948,7 @@ export class EngramAccessService {
                   ...(rawExcerptNamespace
                     ? { namespace: rawExcerptNamespace }
                     : {}),
-                  ...(rawExcerptSessionIds
+                  ...(rawExcerptSessionIds !== undefined
                     ? { lcmSessionIds: rawExcerptSessionIds }
                     : {}),
                 })
@@ -4102,7 +4100,7 @@ export class EngramAccessService {
           ...(xrayRawExcerptNamespace
             ? { rawExcerptNamespace: xrayRawExcerptNamespace }
             : {}),
-          ...(xrayRawExcerptSessionIds
+          ...(xrayRawExcerptSessionIds !== undefined
             ? { rawExcerptSessionIds: xrayRawExcerptSessionIds }
             : {}),
           ...(xrayRawExcerptsSuppressed
@@ -5485,9 +5483,17 @@ export class EngramAccessService {
     // still succeeds via `recallNamespacesForPrincipal`, so `lcmSearch` must too
     // (the same defect class the raw-excerpt path fixes). `undefined` ⇒ no
     // readable LCM namespace exists, so return NO rows rather than throwing.
+    const profileLcmReadNamespaces = hasExplicitNamespace
+      ? null
+      : this.resolveScopeProfileLcmReadNamespaces(
+          request.sessionKey,
+          request.authenticatedPrincipal,
+        );
     const namespace = hasExplicitNamespace
       ? this.resolveReadableNamespace(request.namespace, principal)
-      : this.resolveImplicitLcmReadFallbackNamespace(principal);
+      : profileLcmReadNamespaces !== null
+        ? profileLcmReadNamespaces[0]
+        : this.resolveImplicitLcmReadFallbackNamespace(principal);
 
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
@@ -5496,6 +5502,18 @@ export class EngramAccessService {
         results: [],
         count: 0,
         lcmEnabled: false,
+      };
+    }
+
+    // An active scope profile with no readable layers is authoritative: search
+    // no legacy/default LCM keys instead of falling back around the profile.
+    if (profileLcmReadNamespaces !== null && profileLcmReadNamespaces.length === 0) {
+      return {
+        query: request.query,
+        namespace: this.orchestrator.config.defaultNamespace,
+        results: [],
+        count: 0,
+        lcmEnabled: true,
       };
     }
 
@@ -5523,26 +5541,32 @@ export class EngramAccessService {
     // (`request.sessionKey`) — the prefix is a search fragment with no bound
     // coding context, so it inherits the same namespace. Collapses to the raw key
     // for single-store / no-overlay / explicit-default flows (existing behavior).
-    const lcmReadNamespace = this.resolveLcmReadNamespace(
-      request.namespace,
-      namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
-    // Ordered, read-authorized LCM read key SET for a concrete `sessionKey`
-    // (#1505 fallback unification). A branch-scoped session whose rows were
-    // archived at project/root scope is found by querying the primary overlay key
-    // first, then each coding read fallback — exactly as the orchestrator recall
-    // path does. Collapses to a single key for explicit-namespace / no-overlay /
-    // unreadable-self flows. The `sessionPrefix` search fragment stays on the
-    // primary overlay namespace (its own coding context can't be looked up).
-    const lcmSessionKeyIds = request.sessionKey
-      ? this.resolveLcmReadSessionIds(
+    const lcmReadNamespace = profileLcmReadNamespaces !== null
+      ? profileLcmReadNamespaces[0] ?? this.orchestrator.config.defaultNamespace
+      : this.resolveLcmReadNamespace(
           request.namespace,
           namespace,
           request.sessionKey,
           request.authenticatedPrincipal,
-        )
+        );
+    // Ordered, read-authorized LCM read key SET for a concrete `sessionKey`
+    // (#1505 fallback unification + #1501 scope profiles). A branch-scoped
+    // session whose rows were archived at project/root scope is found by querying
+    // the primary overlay key first, then each fallback. When a scope profile is
+    // active, the profile's expanded read namespace set is authoritative,
+    // including the empty set.
+    const lcmSessionKeyIds = request.sessionKey
+      ? profileLcmReadNamespaces !== null
+        ? this.lcmSessionIdsForNamespaces(
+            profileLcmReadNamespaces,
+            request.sessionKey,
+          )
+        : this.resolveLcmReadSessionIds(
+            request.namespace,
+            namespace,
+            request.sessionKey,
+            request.authenticatedPrincipal,
+          )
       : [undefined];
     const lcmSessionPrefix = request.sessionPrefix
       ? lcmSessionKeyForNamespace(
@@ -5910,6 +5934,57 @@ export class EngramAccessService {
    * `<principal>-project-*` key is ever searched for an unauthorized reader (no
    * cross-tenant read leak).
    */
+  private resolveScopeProfileLcmReadNamespaces(
+    sessionKey: string | undefined,
+    authenticatedPrincipal: string | undefined,
+  ): string[] | null {
+    const config = this.orchestrator.config;
+    const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
+    const codingContext = sessionKey
+      ? this.orchestrator.getCodingContextForSession(sessionKey)
+      : null;
+    const codingOverlay = resolveCodingNamespaceOverlay(
+      codingContext,
+      config.codingMode,
+      config.defaultNamespace,
+    );
+    const profilePlan = resolveScopeProfilePlan({
+      config,
+      principal,
+      codingContext,
+      codingOverlay,
+    });
+    if (!profilePlan) return null;
+    const principalSelfNamespace = defaultNamespaceForPrincipal(principal, config);
+    const legacyRecallNamespaces = Array.isArray(config.defaultRecallNamespaces)
+      ? recallNamespacesForPrincipal(principal, config)
+      : [];
+    return expandScopeProfileReadNamespaces({
+      profilePlan,
+      principalSelfNamespace,
+      codingOverlay,
+      legacyRecallNamespaces,
+    });
+  }
+
+  private lcmSessionIdsForNamespaces(namespaces: string[], sessionKey: string): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const namespace of namespaces) {
+      const key =
+        lcmSessionKeyForNamespace(
+          namespace,
+          sessionKey,
+          this.orchestrator.config.defaultNamespace,
+        ) ?? sessionKey;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(key);
+      }
+    }
+    return out;
+  }
+
   private resolveLcmReadSessionIds(
     explicitNamespace: string | undefined,
     resolvedNamespace: string,
@@ -5929,6 +6004,14 @@ export class EngramAccessService {
     // Explicit namespace → no overlay fallbacks (the overlay never applies to an
     // explicit read). Single key, unchanged.
     if (hasExplicitNamespace) return [primary];
+
+    const profileReadNamespaces = this.resolveScopeProfileLcmReadNamespaces(
+      sessionKey,
+      authenticatedPrincipal,
+    );
+    if (profileReadNamespaces !== null) {
+      return this.lcmSessionIdsForNamespaces(profileReadNamespaces, sessionKey);
+    }
 
     const principal = this.resolveRequestPrincipal(
       sessionKey,

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -576,8 +576,5 @@ export function lcmReadSessionIdsForNamespaces(
       out.push(key);
     }
   }
-  if (out.length === 0) {
-    out.push(sessionKey);
-  }
   return out;
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -179,18 +179,33 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
     ) {
       throw new Error("scopeProfiles." + profileId + ".teamProject must be an object");
     }
-    const teamProject = isRecord(rawProfile.teamProject)
-      ? {
-          ...(typeof rawProfile.teamProject.namespaceTemplate === "string" &&
-          rawProfile.teamProject.namespaceTemplate.length > 0
-            ? { namespaceTemplate: rawProfile.teamProject.namespaceTemplate }
-            : {}),
-          ...(typeof rawProfile.teamProject.teamId === "string" &&
-          rawProfile.teamProject.teamId.length > 0
-            ? { teamId: rawProfile.teamProject.teamId }
-            : {}),
+    const teamProject = (() => {
+      if (!isRecord(rawProfile.teamProject)) return undefined;
+      const out: NonNullable<ScopeProfileConfig["teamProject"]> = {};
+      if (rawProfile.teamProject.namespaceTemplate !== undefined) {
+        if (
+          typeof rawProfile.teamProject.namespaceTemplate !== "string" ||
+          rawProfile.teamProject.namespaceTemplate.length === 0
+        ) {
+          throw new Error(
+            `scopeProfiles.${profileId}.teamProject.namespaceTemplate must be a non-empty string`,
+          );
         }
-      : undefined;
+        out.namespaceTemplate = rawProfile.teamProject.namespaceTemplate;
+      }
+      if (rawProfile.teamProject.teamId !== undefined) {
+        if (
+          typeof rawProfile.teamProject.teamId !== "string" ||
+          rawProfile.teamProject.teamId.length === 0
+        ) {
+          throw new Error(
+            `scopeProfiles.${profileId}.teamProject.teamId must be a non-empty string`,
+          );
+        }
+        out.teamId = rawProfile.teamProject.teamId;
+      }
+      return out;
+    })();
     const rawAutoPromote = isRecord(rawProfile.autoPromote) ? rawProfile.autoPromote : {};
     const autoPromoteEnabled = coerceBool(rawAutoPromote.enabled);
     const minConfidenceTier = (() => {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -172,6 +172,13 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
     if (!SCOPE_PROFILE_LAYER_IDS.includes(writeDefault as ScopeProfileLayerId)) {
       throw new Error(`scopeProfiles.${profileId}.writeDefault contains unsupported layer: ${String(writeDefault)}`);
     }
+    if (
+      rawProfile.teamProject !== undefined &&
+      rawProfile.teamProject !== null &&
+      !isRecord(rawProfile.teamProject)
+    ) {
+      throw new Error("scopeProfiles." + profileId + ".teamProject must be an object");
+    }
     const teamProject = isRecord(rawProfile.teamProject)
       ? {
           ...(typeof rawProfile.teamProject.namespaceTemplate === "string" &&

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -268,6 +268,20 @@ function parseScopeTeams(value: unknown): Record<string, ScopeTeamConfig> {
   return teams;
 }
 
+function validateScopeProfileTeamReferences(
+  profiles: Record<string, ScopeProfileConfig>,
+  teams: Record<string, ScopeTeamConfig>,
+): void {
+  for (const [profileId, profile] of Object.entries(profiles)) {
+    const teamId = profile.teamProject?.teamId;
+    if (teamId && !Object.prototype.hasOwnProperty.call(teams, teamId)) {
+      throw new Error(
+        `scopeProfiles.${profileId}.teamProject.teamId references unknown team: ${teamId}`,
+      );
+    }
+  }
+}
+
 function parseBoundedIntegerMs(
   value: unknown,
   fallback: number,
@@ -1490,6 +1504,8 @@ export function parseConfig(raw: unknown): PluginConfig {
       ? expandTildePath(cfg.memoryDir)
       : DEFAULT_MEMORY_DIR;
   const scopeProfiles = parseScopeProfiles(cfg.scopeProfiles);
+  const teams = parseScopeTeams(cfg.teams);
+  validateScopeProfileTeamReferences(scopeProfiles, teams);
   const defaultScopeProfile =
     typeof cfg.defaultScopeProfile === "string" && cfg.defaultScopeProfile.trim().length > 0
       ? cfg.defaultScopeProfile.trim()
@@ -1500,7 +1516,6 @@ export function parseConfig(raw: unknown): PluginConfig {
   ) {
     throw new Error(`defaultScopeProfile references unknown scope profile: ${defaultScopeProfile}`);
   }
-  const teams = parseScopeTeams(cfg.teams);
   const rawIdentityInjectionMode = cfg.identityInjectionMode as string | undefined;
   const identityInjectionMode: IdentityInjectionMode =
     rawIdentityInjectionMode

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -214,7 +214,16 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
       throw new Error(`scopeProfiles.${profileId}.autoPromote must be an object`);
     }
     const rawAutoPromote = isRecord(rawProfile.autoPromote) ? rawProfile.autoPromote : {};
+    const hasAutoPromoteEnabled = Object.prototype.hasOwnProperty.call(
+      rawAutoPromote,
+      "enabled",
+    );
     const autoPromoteEnabled = coerceBool(rawAutoPromote.enabled);
+    if (hasAutoPromoteEnabled && autoPromoteEnabled === undefined) {
+      throw new Error(
+        `scopeProfiles.${profileId}.autoPromote.enabled must be a boolean or boolean-like string`,
+      );
+    }
     const minConfidenceTier = (() => {
       const rawTier = rawAutoPromote.minConfidenceTier;
       if (rawTier === undefined || rawTier === null) return "explicit";

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -235,8 +235,13 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
       return rawTier as typeof CONFIDENCE_TIERS[number];
     })();
     const autoPromoteCategories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = (() => {
-      if (!Array.isArray(rawAutoPromote.categories)) {
+      if (rawAutoPromote.categories === undefined || rawAutoPromote.categories === null) {
         return ["fact", "correction", "decision", "preference"];
+      }
+      if (!Array.isArray(rawAutoPromote.categories)) {
+        throw new Error(
+          `scopeProfiles.${profileId}.autoPromote.categories must be an array`,
+        );
       }
       const categories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = [];
       for (const entry of rawAutoPromote.categories) {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1524,10 +1524,15 @@ export function parseConfig(raw: unknown): PluginConfig {
   const scopeProfiles = parseScopeProfiles(cfg.scopeProfiles);
   const teams = parseScopeTeams(cfg.teams);
   validateScopeProfileTeamReferences(scopeProfiles, teams);
-  const defaultScopeProfile =
-    typeof cfg.defaultScopeProfile === "string" && cfg.defaultScopeProfile.trim().length > 0
-      ? cfg.defaultScopeProfile.trim()
-      : undefined;
+  const defaultScopeProfile = (() => {
+    if (cfg.defaultScopeProfile === undefined || cfg.defaultScopeProfile === null) {
+      return undefined;
+    }
+    if (typeof cfg.defaultScopeProfile !== "string" || cfg.defaultScopeProfile.trim().length === 0) {
+      throw new Error("defaultScopeProfile must be a non-empty string");
+    }
+    return cfg.defaultScopeProfile.trim();
+  })();
   if (
     defaultScopeProfile !== undefined &&
     scopeProfiles[defaultScopeProfile] === undefined

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -269,12 +269,15 @@ function parseScopeTeams(value: unknown): Record<string, ScopeTeamConfig> {
     if (!isRecord(rawTeam)) {
       throw new Error(`teams.${teamId} must be an object`);
     }
+    const projectNamespaceTemplate = rawTeam.projectNamespaceTemplate;
+    if (projectNamespaceTemplate !== undefined) {
+      if (typeof projectNamespaceTemplate !== "string" || projectNamespaceTemplate.length === 0) {
+        throw new Error(`teams.${teamId}.projectNamespaceTemplate must be a non-empty string`);
+      }
+    }
     teams[teamId] = {
       principals: parseStringList(rawTeam.principals, `teams.${teamId}.principals`),
-      ...(typeof rawTeam.projectNamespaceTemplate === "string" &&
-      rawTeam.projectNamespaceTemplate.length > 0
-        ? { projectNamespaceTemplate: rawTeam.projectNamespaceTemplate }
-        : {}),
+      ...(projectNamespaceTemplate !== undefined ? { projectNamespaceTemplate } : {}),
       read: parseStringList(rawTeam.read, `teams.${teamId}.read`),
       write: parseStringList(rawTeam.write, `teams.${teamId}.write`),
       promote: parseStringList(rawTeam.promote, `teams.${teamId}.promote`),

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -177,11 +177,16 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
       : undefined;
     const rawAutoPromote = isRecord(rawProfile.autoPromote) ? rawProfile.autoPromote : {};
     const autoPromoteEnabled = coerceBool(rawAutoPromote.enabled);
-    const minConfidenceTier =
-      typeof rawAutoPromote.minConfidenceTier === "string" &&
-      CONFIDENCE_TIERS.includes(rawAutoPromote.minConfidenceTier as any)
-        ? (rawAutoPromote.minConfidenceTier as typeof CONFIDENCE_TIERS[number])
-        : "explicit";
+    const minConfidenceTier = (() => {
+      const rawTier = rawAutoPromote.minConfidenceTier;
+      if (rawTier === undefined || rawTier === null) return "explicit";
+      if (typeof rawTier !== "string" || !CONFIDENCE_TIERS.includes(rawTier as any)) {
+        throw new Error(
+          `scopeProfiles.${profileId}.autoPromote.minConfidenceTier must be one of: ${CONFIDENCE_TIERS.join(", ")}`,
+        );
+      }
+      return rawTier as typeof CONFIDENCE_TIERS[number];
+    })();
     const autoPromoteCategories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = Array.isArray(rawAutoPromote.categories)
       ? rawAutoPromote.categories.filter((entry): entry is typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number] =>
           SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES.includes(entry as any),

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -206,6 +206,13 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
       }
       return out;
     })();
+    if (
+      rawProfile.autoPromote !== undefined &&
+      rawProfile.autoPromote !== null &&
+      !isRecord(rawProfile.autoPromote)
+    ) {
+      throw new Error(`scopeProfiles.${profileId}.autoPromote must be an object`);
+    }
     const rawAutoPromote = isRecord(rawProfile.autoPromote) ? rawProfile.autoPromote : {};
     const autoPromoteEnabled = coerceBool(rawAutoPromote.enabled);
     const minConfidenceTier = (() => {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -91,10 +91,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseStringList(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
-    : [];
+function parseStringList(value: unknown, keyName: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(keyName + " must be an array");
+  }
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(keyName + " must contain only non-empty strings");
+    }
+    out.push(entry);
+  }
+  return out;
 }
 
 function parseScopeProfileLayerList(
@@ -239,14 +248,14 @@ function parseScopeTeams(value: unknown): Record<string, ScopeTeamConfig> {
       throw new Error(`teams.${teamId} must be an object`);
     }
     teams[teamId] = {
-      principals: parseStringList(rawTeam.principals),
+      principals: parseStringList(rawTeam.principals, `teams.${teamId}.principals`),
       ...(typeof rawTeam.projectNamespaceTemplate === "string" &&
       rawTeam.projectNamespaceTemplate.length > 0
         ? { projectNamespaceTemplate: rawTeam.projectNamespaceTemplate }
         : {}),
-      read: parseStringList(rawTeam.read),
-      write: parseStringList(rawTeam.write),
-      promote: parseStringList(rawTeam.promote),
+      read: parseStringList(rawTeam.read, `teams.${teamId}.read`),
+      write: parseStringList(rawTeam.write, `teams.${teamId}.write`),
+      promote: parseStringList(rawTeam.promote, `teams.${teamId}.promote`),
     };
   }
   return teams;

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -19,6 +19,10 @@ import type {
   RecallPipelineConfig,
   RecallSectionConfig,
   ReasoningEffort,
+  ScopeProfileConfig,
+  ScopeProfileLayerId,
+  ScopeProfilePromotionTarget,
+  ScopeTeamConfig,
   SemanticChunkingConfigShape,
   SessionObserverBandConfig,
   SlotBehaviorConfig,
@@ -59,6 +63,178 @@ const LEGACY_ACTIVE_RECALL_CUSTOM_FIELD = [
   "Prompt",
   "Override",
 ].join("") as "activeRecallPromptOverride";
+const SCOPE_PROFILE_LAYER_IDS = [
+  "userProject",
+  "teamProject",
+  "userGlobal",
+  "serverShared",
+] as const satisfies readonly ScopeProfileLayerId[];
+const SCOPE_PROFILE_PROMOTION_TARGETS = [
+  ...SCOPE_PROFILE_LAYER_IDS,
+] as const satisfies readonly ScopeProfilePromotionTarget[];
+const SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES = [
+  "fact",
+  "correction",
+  "decision",
+  "preference",
+  "rule",
+  "procedure",
+] as const;
+const CONFIDENCE_TIERS = [
+  "explicit",
+  "implied",
+  "inferred",
+  "speculative",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+}
+
+function parseScopeProfileLayerList(
+  value: unknown,
+  keyName: string,
+  fallback: ScopeProfileLayerId[],
+): ScopeProfileLayerId[] {
+  if (value === undefined || value === null) return [...fallback];
+  if (!Array.isArray(value)) {
+    throw new Error(`${keyName} must be an array`);
+  }
+  const out: ScopeProfileLayerId[] = [];
+  for (const entry of value) {
+    if (!SCOPE_PROFILE_LAYER_IDS.includes(entry as ScopeProfileLayerId)) {
+      throw new Error(`${keyName} contains unsupported layer: ${String(entry)}`);
+    }
+    if (!out.includes(entry as ScopeProfileLayerId)) {
+      out.push(entry as ScopeProfileLayerId);
+    }
+  }
+  return out;
+}
+
+function parseScopeProfilePromotionTargets(
+  value: unknown,
+  keyName: string,
+): ScopeProfilePromotionTarget[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`${keyName} must be an array`);
+  }
+  const out: ScopeProfilePromotionTarget[] = [];
+  for (const entry of value) {
+    if (!SCOPE_PROFILE_PROMOTION_TARGETS.includes(entry as ScopeProfilePromotionTarget)) {
+      throw new Error(`${keyName} contains unsupported target: ${String(entry)}`);
+    }
+    if (!out.includes(entry as ScopeProfilePromotionTarget)) {
+      out.push(entry as ScopeProfilePromotionTarget);
+    }
+  }
+  return out;
+}
+
+function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> {
+  if (value === undefined || value === null) return {};
+  if (!isRecord(value)) {
+    throw new Error("scopeProfiles must be an object");
+  }
+  const profiles: Record<string, ScopeProfileConfig> = {};
+  for (const [profileId, rawProfile] of Object.entries(value)) {
+    if (profileId.trim().length === 0) {
+      throw new Error("scopeProfiles keys must not be empty");
+    }
+    if (!isRecord(rawProfile)) {
+      throw new Error(`scopeProfiles.${profileId} must be an object`);
+    }
+    const readOrder = parseScopeProfileLayerList(
+      rawProfile.readOrder,
+      `scopeProfiles.${profileId}.readOrder`,
+      ["userProject", "userGlobal", "serverShared"],
+    );
+    const writeDefault =
+      rawProfile.writeDefault === undefined || rawProfile.writeDefault === null
+        ? "userProject"
+        : rawProfile.writeDefault;
+    if (!SCOPE_PROFILE_LAYER_IDS.includes(writeDefault as ScopeProfileLayerId)) {
+      throw new Error(`scopeProfiles.${profileId}.writeDefault contains unsupported layer: ${String(writeDefault)}`);
+    }
+    const teamProject = isRecord(rawProfile.teamProject)
+      ? {
+          ...(typeof rawProfile.teamProject.namespaceTemplate === "string" &&
+          rawProfile.teamProject.namespaceTemplate.length > 0
+            ? { namespaceTemplate: rawProfile.teamProject.namespaceTemplate }
+            : {}),
+          ...(typeof rawProfile.teamProject.teamId === "string" &&
+          rawProfile.teamProject.teamId.length > 0
+            ? { teamId: rawProfile.teamProject.teamId }
+            : {}),
+        }
+      : undefined;
+    const rawAutoPromote = isRecord(rawProfile.autoPromote) ? rawProfile.autoPromote : {};
+    const autoPromoteEnabled = coerceBool(rawAutoPromote.enabled);
+    const minConfidenceTier =
+      typeof rawAutoPromote.minConfidenceTier === "string" &&
+      CONFIDENCE_TIERS.includes(rawAutoPromote.minConfidenceTier as any)
+        ? (rawAutoPromote.minConfidenceTier as typeof CONFIDENCE_TIERS[number])
+        : "explicit";
+    const autoPromoteCategories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = Array.isArray(rawAutoPromote.categories)
+      ? rawAutoPromote.categories.filter((entry): entry is typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number] =>
+          SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES.includes(entry as any),
+        )
+      : ["fact", "correction", "decision", "preference"];
+    profiles[profileId] = {
+      readOrder,
+      writeDefault: writeDefault as ScopeProfileLayerId,
+      promotionTargets: parseScopeProfilePromotionTargets(
+        rawProfile.promotionTargets,
+        `scopeProfiles.${profileId}.promotionTargets`,
+      ),
+      ...(teamProject && Object.keys(teamProject).length > 0 ? { teamProject } : {}),
+      autoPromote: {
+        enabled: autoPromoteEnabled === true,
+        targets: parseScopeProfilePromotionTargets(
+          rawAutoPromote.targets,
+          `scopeProfiles.${profileId}.autoPromote.targets`,
+        ),
+        categories: autoPromoteCategories,
+        minConfidenceTier,
+      },
+    };
+  }
+  return profiles;
+}
+
+function parseScopeTeams(value: unknown): Record<string, ScopeTeamConfig> {
+  if (value === undefined || value === null) return {};
+  if (!isRecord(value)) {
+    throw new Error("teams must be an object");
+  }
+  const teams: Record<string, ScopeTeamConfig> = {};
+  for (const [teamId, rawTeam] of Object.entries(value)) {
+    if (teamId.trim().length === 0) {
+      throw new Error("teams keys must not be empty");
+    }
+    if (!isRecord(rawTeam)) {
+      throw new Error(`teams.${teamId} must be an object`);
+    }
+    teams[teamId] = {
+      principals: parseStringList(rawTeam.principals),
+      ...(typeof rawTeam.projectNamespaceTemplate === "string" &&
+      rawTeam.projectNamespaceTemplate.length > 0
+        ? { projectNamespaceTemplate: rawTeam.projectNamespaceTemplate }
+        : {}),
+      read: parseStringList(rawTeam.read),
+      write: parseStringList(rawTeam.write),
+      promote: parseStringList(rawTeam.promote),
+    };
+  }
+  return teams;
+}
 
 function parseBoundedIntegerMs(
   value: unknown,
@@ -1281,6 +1457,18 @@ export function parseConfig(raw: unknown): PluginConfig {
     typeof cfg.memoryDir === "string" && cfg.memoryDir.length > 0
       ? expandTildePath(cfg.memoryDir)
       : DEFAULT_MEMORY_DIR;
+  const scopeProfiles = parseScopeProfiles(cfg.scopeProfiles);
+  const defaultScopeProfile =
+    typeof cfg.defaultScopeProfile === "string" && cfg.defaultScopeProfile.trim().length > 0
+      ? cfg.defaultScopeProfile.trim()
+      : undefined;
+  if (
+    defaultScopeProfile !== undefined &&
+    scopeProfiles[defaultScopeProfile] === undefined
+  ) {
+    throw new Error(`defaultScopeProfile references unknown scope profile: ${defaultScopeProfile}`);
+  }
+  const teams = parseScopeTeams(cfg.teams);
   const rawIdentityInjectionMode = cfg.identityInjectionMode as string | undefined;
   const identityInjectionMode: IdentityInjectionMode =
     rawIdentityInjectionMode
@@ -2777,6 +2965,9 @@ export function parseConfig(raw: unknown): PluginConfig {
         })).filter((p) => p.name.length > 0)
       : [],
     defaultRecallNamespaces: Array.isArray(cfg.defaultRecallNamespaces) ? ["self", "shared"].filter((x) => (cfg.defaultRecallNamespaces as any[]).includes(x)) as any : ["self", "shared"],
+    scopeProfiles,
+    defaultScopeProfile,
+    teams,
     cronRecallMode:
       cfg.cronRecallMode === "none"
         ? "none"

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -187,11 +187,22 @@ function parseScopeProfiles(value: unknown): Record<string, ScopeProfileConfig> 
       }
       return rawTier as typeof CONFIDENCE_TIERS[number];
     })();
-    const autoPromoteCategories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = Array.isArray(rawAutoPromote.categories)
-      ? rawAutoPromote.categories.filter((entry): entry is typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number] =>
-          SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES.includes(entry as any),
-        )
-      : ["fact", "correction", "decision", "preference"];
+    const autoPromoteCategories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = (() => {
+      if (!Array.isArray(rawAutoPromote.categories)) {
+        return ["fact", "correction", "decision", "preference"];
+      }
+      const categories: Array<typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]> = [];
+      for (const entry of rawAutoPromote.categories) {
+        if (typeof entry !== "string" || !SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES.includes(entry as any)) {
+          throw new Error(
+            "scopeProfiles." + profileId + ".autoPromote.categories must contain only: " +
+              SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES.join(", "),
+          );
+        }
+        categories.push(entry as typeof SCOPE_PROFILE_AUTO_PROMOTE_CATEGORIES[number]);
+      }
+      return categories;
+    })();
     profiles[profileId] = {
       readOrder,
       writeDefault: writeDefault as ScopeProfileLayerId,

--- a/packages/remnic-core/src/lcm-fallback-read.ts
+++ b/packages/remnic-core/src/lcm-fallback-read.ts
@@ -57,10 +57,7 @@ const UNDEFINED_SESSION_SENTINEL = " <lcm-sessionless>";
 export function resolveLcmReadSessionIds(
   target: LcmReadSessionTarget,
 ): Array<string | undefined> {
-  const source =
-    target.sessionIds && target.sessionIds.length > 0
-      ? target.sessionIds
-      : [target.sessionId];
+  const source = target.sessionIds !== undefined ? target.sessionIds : [target.sessionId];
   const seen = new Set<string>();
   const out: Array<string | undefined> = [];
   for (const sessionId of source) {
@@ -69,8 +66,7 @@ export function resolveLcmReadSessionIds(
     seen.add(key);
     out.push(sessionId);
   }
-  // Defensive: an all-empty `sessionIds` still collapses to the single-key path.
-  return out.length > 0 ? out : [target.sessionId];
+  return out;
 }
 
 /**

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -512,6 +512,37 @@ test("scope profile requires namespace policy access when team-project templates
 
 
 
+
+
+test("scope profile derives isolated safe namespace for unsafe principal ids", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    scopeProfiles: {
+      hosted: {
+        readOrder: ["userGlobal"],
+        writeDefault: "userGlobal",
+      },
+    },
+    defaultScopeProfile: "hosted",
+  });
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "alice@example.com",
+    codingContext: null,
+    codingOverlay: null,
+  });
+
+  const expected = "principal-" + stableHash("alice@example.com");
+  assert.ok(plan);
+  assert.equal(plan.baseNamespace, expected);
+  assert.deepEqual(plan.readNamespaces, [expected]);
+  assert.equal(plan.writeNamespace, expected);
+});
+
 test("scope profile explicit self namespace policy overrides implicit self access", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -862,6 +862,17 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
   assert.throws(
     () =>
       parseConfig({
+        scopeProfiles: {
+          bad: {
+            autoPromote: { categories: "rule" },
+          },
+        },
+      }),
+    /autoPromote.categories must be an array/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
         teams: {
           core: {
             read: "alice",

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -269,6 +269,8 @@ test("scope profile effective reads retain coding fallbacks without omitted lega
     expandScopeProfileReadNamespaces({
       profilePlan: plan,
       principalSelfNamespace: "pi-geek",
+      config,
+      principal: "pi-geek",
       codingOverlay: overlay,
       legacyRecallNamespaces: ["pi-geek", "shared", "team-extra"],
     }),
@@ -278,6 +280,58 @@ test("scope profile effective reads retain coding fallbacks without omitted lega
       combineNamespaces("pi-geek", overlay.readFallbacks[0]!),
     ],
   );
+});
+
+test("scope profile expansion respects explicit policies on user-project fallbacks", () => {
+  const branchContext: CodingContext = {
+    projectId: "origin:aaaa0000",
+    branch: "feat/x",
+    rootPath: "origin:aaaa0000",
+    defaultBranch: "main",
+  };
+  const initialConfig = parseConfig({
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    codingMode: { projectScope: true, branchScope: true },
+  });
+  const overlay = resolveCodingNamespaceOverlay(branchContext, initialConfig.codingMode, initialConfig.defaultNamespace);
+  assert.ok(overlay);
+  const deniedProjectFallback = combineNamespaces("pi-geek", overlay.readFallbacks[0]!);
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    codingMode: { projectScope: true, branchScope: true },
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: deniedProjectFallback, readPrincipals: [], writePrincipals: [] },
+    ],
+    scopeProfiles: {
+      projectOnly: {
+        readOrder: ["userProject"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "projectOnly",
+  });
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: branchContext,
+    codingOverlay: overlay,
+  });
+  assert.ok(plan);
+
+  const expanded = expandScopeProfileReadNamespaces({
+    profilePlan: plan,
+    principalSelfNamespace: "pi-geek",
+    config,
+    principal: "pi-geek",
+    codingOverlay: overlay,
+    legacyRecallNamespaces: ["pi-geek"],
+  });
+
+  assert.ok(!expanded.includes(deniedProjectFallback));
 });
 
 test("scope profile expansion does not add user-project fallbacks when userProject is omitted from readOrder", () => {
@@ -328,6 +382,8 @@ test("scope profile expansion does not add user-project fallbacks when userProje
     expandScopeProfileReadNamespaces({
       profilePlan: plan,
       principalSelfNamespace: "pi-geek",
+      config,
+      principal: "pi-geek",
       codingOverlay: overlay,
       legacyRecallNamespaces: ["pi-geek", "shared"],
     }),
@@ -371,6 +427,8 @@ test("scope profile expansion does not add global fallback when userGlobal is om
   const expanded = expandScopeProfileReadNamespaces({
     profilePlan: plan,
     principalSelfNamespace: "pi-geek",
+    config,
+    principal: "pi-geek",
     codingOverlay: overlay,
     legacyRecallNamespaces: ["pi-geek", "shared"],
   });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -510,6 +510,41 @@ test("scope profile requires namespace policy access when team-project templates
   assert.match(teamProject?.reason ?? "", /team-project namespace collides with a protected namespace policy/);
 });
 
+
+
+test("scope profile explicit self namespace policy overrides implicit self access", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: [], writePrincipals: [] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userGlobal"],
+        writeDefault: "userGlobal",
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+  });
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: null,
+    codingOverlay: null,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.baseNamespace, "pi-geek");
+  assert.deepEqual(plan.readNamespaces, []);
+  assert.equal(plan.writeNamespace, "");
+  const userGlobal = plan.layers.find((layer) => layer.id === "userGlobal");
+  assert.equal(userGlobal?.readable, false);
+  assert.equal(userGlobal?.writable, false);
+});
+
 test("scope profile auto-promotion is disabled by default", () => {
   const config = parseConfig({
     scopeProfiles: {

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -134,7 +134,7 @@ test("teamCoding profile resolves user-project, team-project, user-global, and s
   );
 });
 
-test("scope profile effective reads retain coding fallbacks and legacy policy namespaces", () => {
+test("scope profile effective reads retain coding fallbacks without omitted legacy namespaces", () => {
   const config = parseConfig({
     namespacesEnabled: true,
     defaultNamespace: "default",
@@ -206,9 +206,6 @@ test("scope profile effective reads retain coding fallbacks and legacy policy na
       combineNamespaces("pi-geek", overlay.namespace),
       teamProjectNamespace,
       combineNamespaces("pi-geek", overlay.readFallbacks[0]!),
-      "pi-geek",
-      "shared",
-      "team-extra",
     ],
   );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -528,4 +528,15 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
       }),
     /unsupported target/,
   );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            autoPromote: { minConfidenceTier: "implide" },
+          },
+        },
+      }),
+    /minConfidenceTier must be one of/,
+  );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -667,4 +667,15 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
       }),
     /teams.core.read must contain only non-empty strings/,
   );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            teamProject: "pi",
+          },
+        },
+      }),
+    /scopeProfiles.bad.teamProject must be an object/,
+  );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -685,6 +685,32 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
           bad: {
             readOrder: ["teamProject", "userGlobal"],
             writeDefault: "teamProject",
+            teamProject: { teamId: 42 },
+          },
+        },
+      }),
+    /scopeProfiles.bad.teamProject.teamId must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            readOrder: ["teamProject", "userGlobal"],
+            writeDefault: "teamProject",
+            teamProject: { namespaceTemplate: "" },
+          },
+        },
+      }),
+    /scopeProfiles.bad.teamProject.namespaceTemplate must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            readOrder: ["teamProject", "userGlobal"],
+            writeDefault: "teamProject",
             teamProject: { teamId: "missing" },
           },
         },

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { combineNamespaces, resolveCodingNamespaceOverlay } from "../coding/coding-namespace.js";
+import { parseConfig } from "../config.js";
+import type { CodingContext } from "../types.js";
+import { resolveScopeProfilePlan } from "./scope-profiles.js";
+
+function teamCodingConfig() {
+  return parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: "pi-geek",
+        readPrincipals: ["pi-geek"],
+        writePrincipals: ["pi-geek"],
+      },
+      {
+        name: "pi-friend",
+        readPrincipals: ["pi-friend"],
+        writePrincipals: ["pi-friend"],
+      },
+      {
+        name: "shared",
+        readPrincipals: ["pi-geek", "pi-friend"],
+        writePrincipals: ["pi-geek", "pi-friend"],
+      },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "teamProject", "userGlobal", "serverShared"],
+        writeDefault: "userProject",
+        promotionTargets: ["teamProject", "serverShared"],
+        teamProject: {
+          namespaceTemplate: "team-{teamId}-project-{projectHash}",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-geek", "pi-friend"],
+        read: ["pi-geek", "pi-friend"],
+        write: ["pi-geek", "pi-friend"],
+        promote: ["pi-geek", "pi-friend"],
+      },
+    },
+  });
+}
+
+const codingContext: CodingContext = {
+  projectId: "tag:remnic",
+  branch: null,
+  rootPath: "tag:remnic",
+  defaultBranch: null,
+};
+
+test("scope profile absent preserves legacy caller behavior by resolving to null", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+  });
+  assert.equal(
+    resolveScopeProfilePlan({
+      config,
+      principal: "pi-geek",
+      codingContext,
+      codingOverlay: resolveCodingNamespaceOverlay(
+        codingContext,
+        config.codingMode,
+        config.defaultNamespace,
+      ),
+    }),
+    null,
+  );
+});
+
+test("teamCoding profile resolves user-project, team-project, user-global, and shared layers in order", () => {
+  const config = teamCodingConfig();
+  const overlay = resolveCodingNamespaceOverlay(
+    codingContext,
+    config.codingMode,
+    config.defaultNamespace,
+  );
+  assert.ok(overlay);
+
+  const geek = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext,
+    codingOverlay: overlay,
+  });
+  const friend = resolveScopeProfilePlan({
+    config,
+    principal: "pi-friend",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(geek);
+  assert.ok(friend);
+  const geekProject = combineNamespaces("pi-geek", overlay.namespace);
+  const friendProject = combineNamespaces("pi-friend", overlay.namespace);
+  assert.equal(geek.writeNamespace, geekProject);
+  assert.equal(friend.writeNamespace, friendProject);
+  assert.notEqual(geekProject, friendProject);
+  assert.deepEqual(geek.readNamespaces, [
+    geekProject,
+    "team-pi-project-2d7ea3c1",
+    "pi-geek",
+    "shared",
+  ]);
+  assert.deepEqual(friend.readNamespaces, [
+    friendProject,
+    "team-pi-project-2d7ea3c1",
+    "pi-friend",
+    "shared",
+  ]);
+  assert.ok(!geek.readNamespaces.includes(friendProject));
+  assert.ok(!friend.readNamespaces.includes(geekProject));
+  assert.deepEqual(
+    geek.promotionTargets.map((target) => [target.target, target.namespace, target.authorized]),
+    [
+      ["teamProject", "team-pi-project-2d7ea3c1", true],
+      ["serverShared", "shared", true],
+    ],
+  );
+});
+
+test("scope profile denies unauthorized team-project promotion while preserving readable layers", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: "pi-observer",
+        readPrincipals: ["pi-observer"],
+        writePrincipals: ["pi-observer"],
+      },
+      {
+        name: "shared",
+        readPrincipals: ["pi-observer"],
+        writePrincipals: ["pi-maintainer"],
+      },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject", "userGlobal", "serverShared"],
+        writeDefault: "userGlobal",
+        promotionTargets: ["teamProject", "serverShared"],
+        teamProject: {
+          namespaceTemplate: "team-{teamId}-project-{projectHash}",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: [],
+        promote: [],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(
+    codingContext,
+    config.codingMode,
+    config.defaultNamespace,
+  );
+  assert.ok(overlay);
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-observer",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(plan);
+  assert.deepEqual(plan.readNamespaces, ["team-pi-project-2d7ea3c1", "pi-observer", "shared"]);
+  assert.deepEqual(
+    plan.promotionTargets.map((target) => [target.target, target.namespace, target.authorized]),
+    [
+      ["teamProject", "team-pi-project-2d7ea3c1", false],
+      ["serverShared", "shared", false],
+    ],
+  );
+});
+
+test("scope profile missing project context falls back without inventing project namespaces", () => {
+  const config = teamCodingConfig();
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: null,
+    codingOverlay: null,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeNamespace, "pi-geek");
+  assert.equal(plan.writeLayer, "userGlobal");
+  assert.deepEqual(plan.readNamespaces, ["pi-geek", "shared"]);
+  assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
+});
+
+test("scope profile missing project context prefers user-global over shared fallback", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "serverShared"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+  });
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: null,
+    codingOverlay: null,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeLayer, "userGlobal");
+  assert.equal(plan.writeNamespace, "pi-geek");
+  assert.deepEqual(plan.readNamespaces, ["shared"]);
+  assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
+});
+
+test("scope profile auto-promotion is disabled by default", () => {
+  const config = parseConfig({
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "teamProject", "userGlobal", "serverShared"],
+        writeDefault: "userProject",
+        promotionTargets: ["teamProject", "serverShared"],
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+  });
+
+  assert.equal(config.scopeProfiles.teamCoding.autoPromote.enabled, false);
+  assert.deepEqual(config.scopeProfiles.teamCoding.autoPromote.targets, []);
+  assert.deepEqual(config.scopeProfiles.teamCoding.autoPromote.categories, [
+    "fact",
+    "correction",
+    "decision",
+    "preference",
+  ]);
+});
+
+test("parseConfig rejects unsupported scope profile layers and targets", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            readOrder: ["userProject", "otherUserProject"],
+          },
+        },
+      }),
+    /unsupported layer/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            promotionTargets: ["../../shared"],
+          },
+        },
+      }),
+    /unsupported target/,
+  );
+});

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -831,6 +831,17 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
       parseConfig({
         scopeProfiles: {
           bad: {
+            autoPromote: { enabled: "treu" },
+          },
+        },
+      }),
+    /autoPromote.enabled must be a boolean or boolean-like string/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
             autoPromote: { minConfidenceTier: "implide" },
           },
         },

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -134,6 +134,49 @@ test("teamCoding profile resolves user-project, team-project, user-global, and s
   );
 });
 
+test("explicit user-project namespace policies override base self access", () => {
+  const baseConfig = teamCodingConfig();
+  const overlay = resolveCodingNamespaceOverlay(
+    codingContext,
+    baseConfig.codingMode,
+    baseConfig.defaultNamespace,
+  );
+  assert.ok(overlay);
+  const deniedProject = combineNamespaces("pi-geek", overlay.namespace);
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: deniedProject, readPrincipals: [], writePrincipals: [] },
+    ],
+    scopeProfiles: {
+      projectOnly: {
+        readOrder: ["userProject", "userGlobal"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "projectOnly",
+  });
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeLayer, "userGlobal");
+  assert.equal(plan.writeNamespace, "pi-geek");
+  assert.deepEqual(plan.readNamespaces, ["pi-geek"]);
+  const projectLayer = plan.layers.find((layer) => layer.id === "userProject");
+  assert.equal(projectLayer?.namespace, deniedProject);
+  assert.equal(projectLayer?.readable, false);
+  assert.equal(projectLayer?.writable, false);
+});
+
 test("userProject profile namespaces stay principal-specific without namespace policies", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -343,6 +343,38 @@ test("scope profile missing project context falls back without inventing project
   assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
 });
 
+test("scope profile unavailable write default does not fall back to shared writes", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: [] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "serverShared"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+  });
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: null,
+    codingOverlay: null,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeLayer, "userGlobal");
+  assert.equal(plan.writeNamespace, "pi-geek");
+  assert.ok(plan.warnings.some((warning) => warning.includes("has no writable layer")));
+  assert.deepEqual(plan.readNamespaces, ["shared"]);
+});
+
 test("scope profile missing project context prefers user-global over shared fallback", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -316,7 +316,7 @@ test("scope profile missing project context prefers user-global over shared fall
   assert.ok(plan);
   assert.equal(plan.writeLayer, "userGlobal");
   assert.equal(plan.writeNamespace, "pi-geek");
-  assert.deepEqual(plan.readNamespaces, ["shared"]);
+  assert.deepEqual(plan.readNamespaces, ["shared", "pi-geek"]);
   assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
 });
 

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -343,7 +343,7 @@ test("scope profile missing project context falls back without inventing project
   assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
 });
 
-test("scope profile unavailable write default does not fall back to shared writes", () => {
+test("scope profile unavailable write default uses next readable writable layer", () => {
   const config = parseConfig({
     namespacesEnabled: true,
     defaultNamespace: "default",
@@ -369,9 +369,9 @@ test("scope profile unavailable write default does not fall back to shared write
   });
 
   assert.ok(plan);
-  assert.equal(plan.writeLayer, "userProject");
-  assert.equal(plan.writeNamespace, "");
-  assert.ok(plan.warnings.some((warning) => warning.includes("has no writable layer")));
+  assert.equal(plan.writeLayer, "serverShared");
+  assert.equal(plan.writeNamespace, "shared");
+  assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
   assert.deepEqual(plan.readNamespaces, ["shared"]);
 });
 
@@ -401,10 +401,10 @@ test("scope profile missing project context does not write outside readable laye
   });
 
   assert.ok(plan);
-  assert.equal(plan.writeLayer, "userProject");
-  assert.equal(plan.writeNamespace, "");
+  assert.equal(plan.writeLayer, "serverShared");
+  assert.equal(plan.writeNamespace, "shared");
   assert.deepEqual(plan.readNamespaces, ["shared"]);
-  assert.ok(plan.warnings.some((warning) => warning.includes("has no writable layer")));
+  assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
 });
 
 test("scope profile rejects unknown team-project namespace template placeholders", () => {

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -134,6 +134,33 @@ test("teamCoding profile resolves user-project, team-project, user-global, and s
   );
 });
 
+test("userProject profile namespaces stay principal-specific without namespace policies", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    codingMode: { projectScope: true },
+    scopeProfiles: {
+      hosted: {
+        readOrder: ["userProject"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "hosted",
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+
+  const geek = resolveScopeProfilePlan({ config, principal: "pi-geek", codingContext, codingOverlay: overlay });
+  const friend = resolveScopeProfilePlan({ config, principal: "pi-friend", codingContext, codingOverlay: overlay });
+
+  assert.ok(geek);
+  assert.ok(friend);
+  assert.equal(geek.writeNamespace, combineNamespaces("pi-geek", overlay.namespace));
+  assert.equal(friend.writeNamespace, combineNamespaces("pi-friend", overlay.namespace));
+  assert.notEqual(geek.writeNamespace, friend.writeNamespace);
+});
+
 test("scope profile effective reads retain coding fallbacks without omitted legacy namespaces", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -292,6 +292,53 @@ test("scope profile expansion does not add user-project fallbacks when userProje
   );
 });
 
+test("scope profile expansion does not add global fallback when userGlobal is omitted from readOrder", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    codingMode: { projectScope: true, branchScope: true, globalFallback: true },
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    scopeProfiles: {
+      projectOnly: {
+        readOrder: ["userProject"],
+        writeDefault: "userProject",
+      },
+    },
+    defaultScopeProfile: "projectOnly",
+  });
+  const branchContext: CodingContext = {
+    projectId: "origin:aaaa0000",
+    branch: "feat/x",
+    rootPath: "origin:aaaa0000",
+    defaultBranch: "main",
+  };
+  const overlay = resolveCodingNamespaceOverlay(branchContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: branchContext,
+    codingOverlay: overlay,
+  });
+  assert.ok(plan);
+
+  const expanded = expandScopeProfileReadNamespaces({
+    profilePlan: plan,
+    principalSelfNamespace: "pi-geek",
+    codingOverlay: overlay,
+    legacyRecallNamespaces: ["pi-geek", "shared"],
+  });
+
+  assert.deepEqual(expanded, [
+    combineNamespaces("pi-geek", overlay.namespace),
+    combineNamespaces("pi-geek", overlay.readFallbacks[0]!),
+  ]);
+  assert.ok(!expanded.includes("pi-geek"));
+});
+
 test("scope profile denies unauthorized team-project promotion while preserving readable layers", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -339,6 +339,52 @@ test("scope profile expansion does not add global fallback when userGlobal is om
   assert.ok(!expanded.includes("pi-geek"));
 });
 
+test("scope profile chooses a readable implicit team mapping before promote-only memberships", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    scopeProfiles: {
+      hosted: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    defaultScopeProfile: "hosted",
+    teams: {
+      ops: {
+        principals: [],
+        read: [],
+        write: [],
+        promote: ["alice"],
+      },
+      core: {
+        principals: ["alice"],
+        read: ["alice"],
+        write: ["alice"],
+        promote: ["alice"],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "alice",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeNamespace, "team-core-project-2d7ea3c1");
+  assert.deepEqual(plan.readNamespaces, ["team-core-project-2d7ea3c1"]);
+});
+
 test("scope profile denies unauthorized team-project promotion while preserving readable layers", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -515,7 +515,7 @@ test("scope profile rejects unknown team-project namespace template placeholders
   assert.equal(teamProject?.readable, false);
   assert.equal(teamProject?.writable, false);
   assert.deepEqual(plan.readNamespaces, []);
-  assert.match(teamProject?.reason ?? "", /unknown team-project namespace template placeholder(s): projecthash/);
+  assert.equal(teamProject?.reason, "unknown team-project namespace template placeholder(s): projecthash");
 });
 
 test("scope profile requires namespace policy access when team-project templates collide with protected namespaces", () => {
@@ -713,6 +713,17 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
         },
       }),
     /teams.core.read must contain only non-empty strings/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        teams: {
+          core: {
+            projectNamespaceTemplate: 42,
+          },
+        },
+      }),
+    /teams.core.projectNamespaceTemplate must be a non-empty string/,
   );
   assert.throws(
     () =>

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -601,4 +601,15 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
       }),
     /minConfidenceTier must be one of/,
   );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            autoPromote: { categories: ["decison"] },
+          },
+        },
+      }),
+    /autoPromote.categories must contain only/,
+  );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -339,6 +339,52 @@ test("scope profile expansion does not add global fallback when userGlobal is om
   assert.ok(!expanded.includes("pi-geek"));
 });
 
+test("scope profile prefers writable implicit team mapping when teamProject is the write layer", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    scopeProfiles: {
+      hosted: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    defaultScopeProfile: "hosted",
+    teams: {
+      ops: {
+        principals: ["alice"],
+        read: ["alice"],
+        write: [],
+        promote: [],
+      },
+      core: {
+        principals: ["alice"],
+        read: ["alice"],
+        write: ["alice"],
+        promote: ["alice"],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "alice",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeNamespace, "team-core-project-2d7ea3c1");
+  assert.deepEqual(plan.readNamespaces, ["team-core-project-2d7ea3c1"]);
+});
+
 test("scope profile chooses a readable implicit team mapping before promote-only memberships", () => {
   const config = parseConfig({
     namespacesEnabled: true,
@@ -725,6 +771,17 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
         },
       }),
     /defaultScopeProfile must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            autoPromote: true,
+          },
+        },
+      }),
+    /scopeProfiles.bad.autoPromote must be an object/,
   );
   assert.throws(
     () =>

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -210,6 +210,61 @@ test("scope profile effective reads retain coding fallbacks without omitted lega
   );
 });
 
+test("scope profile expansion does not add user-project fallbacks when userProject is omitted from readOrder", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: true, branchScope: true },
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    scopeProfiles: {
+      teamOnly: {
+        readOrder: ["teamProject"],
+        writeDefault: "userProject",
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    defaultScopeProfile: "teamOnly",
+    teams: {
+      pi: {
+        principals: ["pi-geek"],
+        read: ["pi-geek"],
+        write: ["pi-geek"],
+        promote: ["pi-geek"],
+      },
+    },
+  });
+  const branchContext: CodingContext = {
+    projectId: "origin:aaaa0000",
+    branch: "feat/x",
+    rootPath: "origin:aaaa0000",
+    defaultBranch: "main",
+  };
+  const overlay = resolveCodingNamespaceOverlay(branchContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: branchContext,
+    codingOverlay: overlay,
+  });
+  assert.ok(plan);
+  const teamProjectNamespace = `team-pi-project-${stableHash(branchContext.projectId)}`;
+
+  assert.deepEqual(
+    expandScopeProfileReadNamespaces({
+      profilePlan: plan,
+      principalSelfNamespace: "pi-geek",
+      codingOverlay: overlay,
+      legacyRecallNamespaces: ["pi-geek", "shared"],
+    }),
+    [teamProjectNamespace],
+  );
+});
+
 test("scope profile denies unauthorized team-project promotion while preserving readable layers", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -369,13 +369,13 @@ test("scope profile unavailable write default does not fall back to shared write
   });
 
   assert.ok(plan);
-  assert.equal(plan.writeLayer, "userGlobal");
-  assert.equal(plan.writeNamespace, "pi-geek");
+  assert.equal(plan.writeLayer, "userProject");
+  assert.equal(plan.writeNamespace, "");
   assert.ok(plan.warnings.some((warning) => warning.includes("has no writable layer")));
   assert.deepEqual(plan.readNamespaces, ["shared"]);
 });
 
-test("scope profile missing project context prefers user-global over shared fallback", () => {
+test("scope profile missing project context does not write outside readable layers", () => {
   const config = parseConfig({
     namespacesEnabled: true,
     defaultNamespace: "default",
@@ -401,10 +401,10 @@ test("scope profile missing project context prefers user-global over shared fall
   });
 
   assert.ok(plan);
-  assert.equal(plan.writeLayer, "userGlobal");
-  assert.equal(plan.writeNamespace, "pi-geek");
-  assert.deepEqual(plan.readNamespaces, ["shared", "pi-geek"]);
-  assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
+  assert.equal(plan.writeLayer, "userProject");
+  assert.equal(plan.writeNamespace, "");
+  assert.deepEqual(plan.readNamespaces, ["shared"]);
+  assert.ok(plan.warnings.some((warning) => warning.includes("has no writable layer")));
 });
 
 test("scope profile rejects unknown team-project namespace template placeholders", () => {

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -678,4 +678,25 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
       }),
     /scopeProfiles.bad.teamProject must be an object/,
   );
+  assert.throws(
+    () =>
+      parseConfig({
+        scopeProfiles: {
+          bad: {
+            readOrder: ["teamProject", "userGlobal"],
+            writeDefault: "teamProject",
+            teamProject: { teamId: "missing" },
+          },
+        },
+        teams: {
+          core: {
+            principals: ["alice"],
+            read: ["alice"],
+            write: ["alice"],
+            promote: ["alice"],
+          },
+        },
+      }),
+    /scopeProfiles.bad.teamProject.teamId references unknown team: missing/,
+  );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -2,9 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { combineNamespaces, resolveCodingNamespaceOverlay } from "../coding/coding-namespace.js";
+import { stableHash } from "../coding/git-context.js";
 import { parseConfig } from "../config.js";
 import type { CodingContext } from "../types.js";
-import { resolveScopeProfilePlan } from "./scope-profiles.js";
+import {
+  expandScopeProfileReadNamespaces,
+  resolveScopeProfilePlan,
+} from "./scope-profiles.js";
 
 function teamCodingConfig() {
   return parseConfig({
@@ -126,6 +130,85 @@ test("teamCoding profile resolves user-project, team-project, user-global, and s
     [
       ["teamProject", "team-pi-project-2d7ea3c1", true],
       ["serverShared", "shared", true],
+    ],
+  );
+});
+
+test("scope profile effective reads retain coding fallbacks and legacy policy namespaces", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: true, branchScope: true },
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      {
+        name: "team-extra",
+        readPrincipals: ["pi-geek"],
+        writePrincipals: [],
+        includeInRecallByDefault: true,
+      },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["userProject", "teamProject"],
+        writeDefault: "userProject",
+        teamProject: {
+          namespaceTemplate: "team-{teamId}-project-{projectHash}",
+        },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-geek"],
+        read: ["pi-geek"],
+        write: ["pi-geek"],
+        promote: ["pi-geek"],
+      },
+    },
+  });
+  const branchContext: CodingContext = {
+    projectId: "origin:aaaa0000",
+    branch: "feat/x",
+    rootPath: "origin:aaaa0000",
+    defaultBranch: "main",
+  };
+  const overlay = resolveCodingNamespaceOverlay(
+    branchContext,
+    config.codingMode,
+    config.defaultNamespace,
+  );
+  assert.ok(overlay);
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "pi-geek",
+    codingContext: branchContext,
+    codingOverlay: overlay,
+  });
+  assert.ok(plan);
+  const teamProjectNamespace = `team-pi-project-${stableHash(branchContext.projectId)}`;
+
+  assert.deepEqual(plan.readNamespaces, [
+    combineNamespaces("pi-geek", overlay.namespace),
+    teamProjectNamespace,
+  ]);
+  assert.deepEqual(
+    expandScopeProfileReadNamespaces({
+      profilePlan: plan,
+      principalSelfNamespace: "pi-geek",
+      codingOverlay: overlay,
+      legacyRecallNamespaces: ["pi-geek", "shared", "team-extra"],
+    }),
+    [
+      combineNamespaces("pi-geek", overlay.namespace),
+      teamProjectNamespace,
+      combineNamespaces("pi-geek", overlay.readFallbacks[0]!),
+      "pi-geek",
+      "shared",
+      "team-extra",
     ],
   );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -323,6 +323,82 @@ test("scope profile missing project context prefers user-global over shared fall
   assert.ok(plan.warnings.some((warning) => warning.includes("writeDefault userProject unavailable")));
 });
 
+test("scope profile rejects unknown team-project namespace template placeholders", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projecthash}" },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-geek"],
+        read: ["pi-geek"],
+        write: ["pi-geek"],
+        promote: ["pi-geek"],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  const plan = resolveScopeProfilePlan({ config, principal: "pi-geek", codingContext, codingOverlay: overlay });
+  assert.ok(plan);
+  const teamProject = plan.layers.find((layer) => layer.id === "teamProject");
+
+  assert.equal(teamProject?.readable, false);
+  assert.equal(teamProject?.writable, false);
+  assert.deepEqual(plan.readNamespaces, []);
+  assert.match(teamProject?.reason ?? "", /unknown team-project namespace template placeholder(s): projecthash/);
+});
+
+test("scope profile requires namespace policy access when team-project templates collide with protected namespaces", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      { name: "shared", readPrincipals: ["pi-maintainer"], writePrincipals: ["pi-maintainer"] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "shared" },
+      },
+    },
+    defaultScopeProfile: "teamCoding",
+    teams: {
+      pi: {
+        principals: ["pi-geek"],
+        read: ["pi-geek"],
+        write: ["pi-geek"],
+        promote: ["pi-geek"],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  const plan = resolveScopeProfilePlan({ config, principal: "pi-geek", codingContext, codingOverlay: overlay });
+  assert.ok(plan);
+  const teamProject = plan.layers.find((layer) => layer.id === "teamProject");
+
+  assert.equal(teamProject?.namespace, "shared");
+  assert.equal(teamProject?.readable, false);
+  assert.equal(teamProject?.writable, false);
+  assert.deepEqual(plan.readNamespaces, []);
+  assert.match(teamProject?.reason ?? "", /team-project namespace collides with a protected namespace policy/);
+});
+
 test("scope profile auto-promotion is disabled by default", () => {
   const config = parseConfig({
     scopeProfiles: {

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -536,9 +536,10 @@ test("scope profile derives isolated safe namespace for unsafe principal ids", (
     codingOverlay: null,
   });
 
-  const expected = "principal-" + stableHash("alice@example.com");
   assert.ok(plan);
-  assert.equal(plan.baseNamespace, expected);
+  assert.match(plan.baseNamespace, /^principal-[a-f0-9]{64}$/);
+  assert.notEqual(plan.baseNamespace, "principal-" + stableHash("alice@example.com"));
+  const expected = plan.baseNamespace;
   assert.deepEqual(plan.readNamespaces, [expected]);
   assert.equal(plan.writeNamespace, expected);
 });
@@ -642,5 +643,27 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
         },
       }),
     /autoPromote.categories must contain only/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        teams: {
+          core: {
+            read: "alice",
+          },
+        },
+      }),
+    /teams.core.read must be an array/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        teams: {
+          core: {
+            read: ["alice", 42],
+          },
+        },
+      }),
+    /teams.core.read must contain only non-empty strings/,
   );
 });

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -474,6 +474,58 @@ test("scope profile chooses a readable implicit team mapping before promote-only
   assert.deepEqual(plan.readNamespaces, ["team-core-project-2d7ea3c1"]);
 });
 
+test("scope profile prefers promotable implicit team mapping for promotion-only team targets", () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    scopeProfiles: {
+      hosted: {
+        readOrder: ["userGlobal"],
+        writeDefault: "userGlobal",
+        promotionTargets: ["teamProject"],
+        autoPromote: { enabled: true, targets: ["teamProject"] },
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    defaultScopeProfile: "hosted",
+    teams: {
+      ops: {
+        principals: ["alice"],
+        read: ["alice"],
+        write: [],
+        promote: [],
+      },
+      core: {
+        principals: ["alice"],
+        read: ["alice"],
+        write: [],
+        promote: ["alice"],
+      },
+    },
+  });
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config.codingMode, config.defaultNamespace);
+  assert.ok(overlay);
+
+  const plan = resolveScopeProfilePlan({
+    config,
+    principal: "alice",
+    codingContext,
+    codingOverlay: overlay,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.writeNamespace, "alice");
+  assert.deepEqual(plan.readNamespaces, ["alice"]);
+  assert.deepEqual(
+    plan.promotionTargets.map((target) => [target.target, target.namespace, target.authorized]),
+    [["teamProject", "team-core-project-2d7ea3c1", true]],
+  );
+});
+
 test("scope profile denies unauthorized team-project promotion while preserving readable layers", () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -537,7 +537,8 @@ test("scope profile derives isolated safe namespace for unsafe principal ids", (
   });
 
   assert.ok(plan);
-  assert.match(plan.baseNamespace, /^principal-[a-f0-9]{64}$/);
+  assert.match(plan.baseNamespace, /^principal-[a-f0-9]{54}$/);
+  assert.equal(plan.baseNamespace.length, 64);
   assert.notEqual(plan.baseNamespace, "principal-" + stableHash("alice@example.com"));
   const expected = plan.baseNamespace;
   assert.deepEqual(plan.readNamespaces, [expected]);

--- a/packages/remnic-core/src/namespaces/scope-profiles.test.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.test.ts
@@ -673,6 +673,16 @@ test("parseConfig rejects unsupported scope profile layers and targets", () => {
   assert.throws(
     () =>
       parseConfig({
+        defaultScopeProfile: 42,
+        scopeProfiles: {
+          hosted: { readOrder: ["userProject"], writeDefault: "userProject" },
+        },
+      }),
+    /defaultScopeProfile must be a non-empty string/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
         scopeProfiles: {
           bad: {
             autoPromote: { minConfidenceTier: "implide" },

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -353,8 +353,5 @@ export function expandScopeProfileReadNamespaces(options: {
       add(combineNamespaces(options.principalSelfNamespace, fallback));
     }
   }
-  for (const namespace of options.legacyRecallNamespaces ?? []) {
-    add(namespace);
-  }
   return out;
 }

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -292,7 +292,7 @@ export function resolveScopeProfilePlan(
       ? preferredWriteLayer
       : userGlobalWriteLayer?.writable && userGlobalWriteLayer.namespace
         ? userGlobalWriteLayer
-      : [...layerMap.values()].find((layer) => layer.writable && layer.namespace);
+        : undefined;
   if (
     fallbackWriteLayer?.id !== active.profile.writeDefault &&
     fallbackWriteLayer?.readable &&

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -124,9 +124,18 @@ function resolveTeam(
   const readableTeams = Object.entries(config.teams ?? {}).filter(([, team]) =>
     principalListed(team.principals, principal) || principalListed(team.read, principal),
   );
-  if (profile.writeDefault === "teamProject" || profile.readOrder.includes("teamProject")) {
+  const needsWritableTeam = profile.writeDefault === "teamProject" || profile.readOrder.includes("teamProject");
+  if (needsWritableTeam) {
     const writableTeam = readableTeams.find(([, team]) => principalListed(team.write, principal));
     if (writableTeam) return { teamId: writableTeam[0], team: writableTeam[1] };
+  }
+  const needsPromotableTeam =
+    profile.promotionTargets.includes("teamProject") || profile.autoPromote.targets.includes("teamProject");
+  if (needsPromotableTeam) {
+    const promotableTeam = readableTeams.find(
+      ([, team]) => principalListed(team.promote, principal) || principalListed(team.write, principal),
+    );
+    if (promotableTeam) return { teamId: promotableTeam[0], team: promotableTeam[1] };
   }
   const firstReadableTeam = readableTeams[0];
   return firstReadableTeam

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -1,0 +1,304 @@
+import { combineNamespaces, type CodingNamespaceOverlay } from "../coding/coding-namespace.js";
+import { stableHash } from "../coding/git-context.js";
+import { isSafeRouteNamespace } from "../routing/engine.js";
+import type {
+  CodingContext,
+  PluginConfig,
+  ScopeProfileConfig,
+  ScopeProfileLayerId,
+  ScopeProfilePromotionTarget,
+  ScopeTeamConfig,
+} from "../types.js";
+import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal } from "./principal.js";
+
+type ScopeProfileCodingOverlay = Pick<CodingNamespaceOverlay, "namespace" | "readFallbacks">;
+
+export interface ScopeProfileLayerResolution {
+  id: ScopeProfileLayerId;
+  kind: "user-project" | "team-project" | "user-global" | "server-shared";
+  namespace?: string;
+  readable: boolean;
+  writable: boolean;
+  promotable: boolean;
+  reason: string;
+}
+
+export interface ScopeProfilePromotionResolution {
+  target: ScopeProfilePromotionTarget;
+  namespace?: string;
+  authorized: boolean;
+  reason: string;
+}
+
+export interface ResolvedScopeProfilePlan {
+  profileId: string;
+  profile: ScopeProfileConfig;
+  baseNamespace: string;
+  writeLayer: ScopeProfileLayerId;
+  writeNamespace: string;
+  readNamespaces: string[];
+  layers: ScopeProfileLayerResolution[];
+  promotionTargets: ScopeProfilePromotionResolution[];
+  warnings: string[];
+}
+
+export interface ResolveScopeProfilePlanOptions {
+  config: PluginConfig;
+  principal?: string;
+  codingContext?: CodingContext | null;
+  codingOverlay?: ScopeProfileCodingOverlay | null;
+}
+
+function activeScopeProfile(config: PluginConfig): { profileId: string; profile: ScopeProfileConfig } | null {
+  const profileId = config.defaultScopeProfile;
+  if (!profileId) return null;
+  const profile = (config.scopeProfiles ?? {})[profileId];
+  return profile ? { profileId, profile } : null;
+}
+
+function principalListed(list: string[], principal: string | undefined): boolean {
+  if (!principal) return false;
+  return list.includes(principal) || list.includes("*");
+}
+
+function resolveTeam(
+  config: PluginConfig,
+  profile: ScopeProfileConfig,
+  principal: string | undefined,
+): { teamId: string; team: ScopeTeamConfig } | null {
+  const configuredTeamId = profile.teamProject?.teamId;
+  if (configuredTeamId) {
+    const configured = (config.teams ?? {})[configuredTeamId];
+    return configured ? { teamId: configuredTeamId, team: configured } : null;
+  }
+  for (const [teamId, team] of Object.entries(config.teams ?? {})) {
+    if (
+      principalListed(team.principals, principal) ||
+      principalListed(team.read, principal) ||
+      principalListed(team.write, principal) ||
+      principalListed(team.promote, principal)
+    ) {
+      return { teamId, team };
+    }
+  }
+  return null;
+}
+
+function renderTeamProjectNamespace(params: {
+  template: string;
+  teamId: string;
+  principal: string | undefined;
+  codingContext: CodingContext;
+  codingOverlay: ScopeProfileCodingOverlay;
+}): string {
+  const replacements: Record<string, string> = {
+    teamId: params.teamId,
+    principal: params.principal ?? "anonymous",
+    projectId: params.codingContext.projectId,
+    projectHash: stableHash(params.codingContext.projectId),
+    projectNamespace: params.codingOverlay.namespace,
+  };
+  return params.template.replace(/\{([A-Za-z][A-Za-z0-9]*)\}/g, (_match, key: string) =>
+    replacements[key] ?? "",
+  );
+}
+
+function resolveLayer(params: {
+  id: ScopeProfileLayerId;
+  config: PluginConfig;
+  profile: ScopeProfileConfig;
+  principal: string | undefined;
+  baseNamespace: string;
+  codingContext: CodingContext | null | undefined;
+  codingOverlay: ScopeProfileCodingOverlay | null | undefined;
+}): ScopeProfileLayerResolution {
+  const { id, config, profile, principal, baseNamespace, codingContext, codingOverlay } = params;
+  if (id === "userGlobal") {
+    return {
+      id,
+      kind: "user-global",
+      namespace: baseNamespace,
+      readable: canReadNamespace(principal, baseNamespace, config),
+      writable: canWriteNamespace(principal, baseNamespace, config),
+      promotable: canWriteNamespace(principal, baseNamespace, config),
+      reason: "principal self/global namespace",
+    };
+  }
+  if (id === "serverShared") {
+    return {
+      id,
+      kind: "server-shared",
+      namespace: config.sharedNamespace,
+      readable: canReadNamespace(principal, config.sharedNamespace, config),
+      writable: canWriteNamespace(principal, config.sharedNamespace, config),
+      promotable: canWriteNamespace(principal, config.sharedNamespace, config),
+      reason: "configured shared namespace",
+    };
+  }
+  if (id === "userProject") {
+    if (!codingContext || !codingOverlay) {
+      return {
+        id,
+        kind: "user-project",
+        readable: false,
+        writable: false,
+        promotable: false,
+        reason: "missing project context",
+      };
+    }
+    const namespace = combineNamespaces(baseNamespace, codingOverlay.namespace);
+    const baseReadable = canReadNamespace(principal, baseNamespace, config);
+    const baseWritable = canWriteNamespace(principal, baseNamespace, config);
+    return {
+      id,
+      kind: "user-project",
+      namespace,
+      readable: baseReadable,
+      writable: baseWritable,
+      promotable: baseWritable,
+      reason: baseReadable || baseWritable
+        ? "principal project namespace derived from coding context"
+        : "principal base namespace is not authorized",
+    };
+  }
+  const team = resolveTeam(config, profile, principal);
+  if (!team) {
+    return {
+      id,
+      kind: "team-project",
+      readable: false,
+      writable: false,
+      promotable: false,
+      reason: "no authorized team mapping",
+    };
+  }
+  if (!codingContext || !codingOverlay) {
+    return {
+      id,
+      kind: "team-project",
+      readable: false,
+      writable: false,
+      promotable: false,
+      reason: "missing project context",
+    };
+  }
+  const template =
+    profile.teamProject?.namespaceTemplate ??
+    team.team.projectNamespaceTemplate ??
+    "team-{teamId}-project-{projectHash}";
+  const namespace = renderTeamProjectNamespace({
+    template,
+    teamId: team.teamId,
+    principal,
+    codingContext,
+    codingOverlay,
+  }).trim();
+  if (!namespace || !isSafeRouteNamespace(namespace)) {
+    return {
+      id,
+      kind: "team-project",
+      namespace,
+      readable: false,
+      writable: false,
+      promotable: false,
+      reason: "team-project namespace template resolved to an unsafe namespace",
+    };
+  }
+  return {
+    id,
+    kind: "team-project",
+    namespace,
+    readable: principalListed(team.team.read, principal) || principalListed(team.team.principals, principal),
+    writable: principalListed(team.team.write, principal),
+    promotable: principalListed(team.team.promote, principal) || principalListed(team.team.write, principal),
+    reason: "trusted team-project namespace derived from team and project config",
+  };
+}
+
+export function resolveScopeProfilePlan(
+  options: ResolveScopeProfilePlanOptions,
+): ResolvedScopeProfilePlan | null {
+  const active = activeScopeProfile(options.config);
+  if (!active || !options.config.namespacesEnabled) return null;
+
+  const baseNamespace = defaultNamespaceForPrincipal(options.principal, options.config);
+  const layerIds = Array.from(
+    new Set<ScopeProfileLayerId>([
+      ...active.profile.readOrder,
+      active.profile.writeDefault,
+      "userGlobal",
+      ...active.profile.promotionTargets.filter((target): target is ScopeProfileLayerId =>
+        ["userProject", "teamProject", "userGlobal", "serverShared"].includes(target),
+      ),
+    ]),
+  );
+  const layerMap = new Map<ScopeProfileLayerId, ScopeProfileLayerResolution>();
+  for (const id of layerIds) {
+    layerMap.set(
+      id,
+      resolveLayer({
+        id,
+        config: options.config,
+        profile: active.profile,
+        principal: options.principal,
+        baseNamespace,
+        codingContext: options.codingContext,
+        codingOverlay: options.codingOverlay,
+      }),
+    );
+  }
+
+  const readNamespaces: string[] = [];
+  for (const id of active.profile.readOrder) {
+    const layer = layerMap.get(id);
+    if (layer?.readable && layer.namespace && !readNamespaces.includes(layer.namespace)) {
+      readNamespaces.push(layer.namespace);
+    }
+  }
+
+  const preferredWriteLayer = layerMap.get(active.profile.writeDefault);
+  const userGlobalWriteLayer = layerMap.get("userGlobal");
+  const fallbackWriteLayer =
+    preferredWriteLayer?.writable && preferredWriteLayer.namespace
+      ? preferredWriteLayer
+      : userGlobalWriteLayer?.writable && userGlobalWriteLayer.namespace
+        ? userGlobalWriteLayer
+      : [...layerMap.values()].find((layer) => layer.writable && layer.namespace);
+  const warnings: string[] = [];
+  if (!fallbackWriteLayer?.namespace) {
+    warnings.push(`scope profile ${active.profileId} has no writable layer; falling back to ${baseNamespace}`);
+  } else if (fallbackWriteLayer.id !== active.profile.writeDefault) {
+    warnings.push(
+      `scope profile ${active.profileId} writeDefault ${active.profile.writeDefault} unavailable: ${preferredWriteLayer?.reason ?? "not resolved"}`,
+    );
+  }
+
+  const promotionTargets = active.profile.promotionTargets.map((target) => {
+    const layer = layerMap.get(target as ScopeProfileLayerId);
+    if (!layer) {
+      return {
+        target,
+        authorized: false,
+        reason: "promotion target did not resolve to a profile layer",
+      };
+    }
+    return {
+      target,
+      namespace: layer.namespace,
+      authorized: layer.promotable && Boolean(layer.namespace),
+      reason: layer.reason,
+    };
+  });
+
+  return {
+    profileId: active.profileId,
+    profile: active.profile,
+    baseNamespace,
+    writeLayer: fallbackWriteLayer?.id ?? "userGlobal",
+    writeNamespace: fallbackWriteLayer?.namespace ?? baseNamespace,
+    readNamespaces,
+    layers: [...layerMap.values()],
+    promotionTargets,
+    warnings,
+  };
+}

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -293,6 +293,15 @@ export function resolveScopeProfilePlan(
       : userGlobalWriteLayer?.writable && userGlobalWriteLayer.namespace
         ? userGlobalWriteLayer
       : [...layerMap.values()].find((layer) => layer.writable && layer.namespace);
+  if (
+    fallbackWriteLayer?.id !== active.profile.writeDefault &&
+    fallbackWriteLayer?.readable &&
+    fallbackWriteLayer.namespace &&
+    !readNamespaces.includes(fallbackWriteLayer.namespace)
+  ) {
+    readNamespaces.push(fallbackWriteLayer.namespace);
+  }
+
   const warnings: string[] = [];
   if (!fallbackWriteLayer?.namespace) {
     warnings.push(`scope profile ${active.profileId} has no writable layer; falling back to ${baseNamespace}`);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -61,18 +61,16 @@ function principalListed(list: string[], principal: string | undefined): boolean
   return list.includes(principal) || list.includes("*");
 }
 
+function derivedScopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string | null {
+  if (!principal || principal === config.defaultNamespace || principal === config.sharedNamespace) return null;
+  if (isSafeRouteNamespace(principal)) return principal;
+  return "principal-" + stableHash(principal);
+}
+
 function scopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string {
   const existing = defaultNamespaceForPrincipal(principal, config);
   if (existing !== config.defaultNamespace) return existing;
-  if (
-    principal &&
-    principal !== config.defaultNamespace &&
-    principal !== config.sharedNamespace &&
-    isSafeRouteNamespace(principal)
-  ) {
-    return principal;
-  }
-  return existing;
+  return derivedScopeProfileSelfNamespace(principal, config) ?? existing;
 }
 
 function hasExplicitNamespacePolicy(namespace: string, config: PluginConfig): boolean {
@@ -84,9 +82,10 @@ function isScopeProfileImplicitSelfNamespace(
   namespace: string,
   config: PluginConfig,
 ): boolean {
+  const derived = derivedScopeProfileSelfNamespace(principal, config);
   return Boolean(
-    principal &&
-      namespace === principal &&
+    derived &&
+      namespace === derived &&
       namespace !== config.defaultNamespace &&
       namespace !== config.sharedNamespace &&
       isSafeRouteNamespace(namespace) &&

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -415,8 +415,14 @@ export function expandScopeProfileReadNamespaces(options: {
     options.profilePlan.layers.some(
       (layer) => layer.id === "userProject" && layer.readable && layer.namespace,
     );
+  const userGlobalReadable =
+    options.profilePlan.profile.readOrder.includes("userGlobal") &&
+    options.profilePlan.layers.some(
+      (layer) => layer.id === "userGlobal" && layer.readable && layer.namespace,
+    );
   if (userProjectReadable) {
     for (const fallback of options.codingOverlay?.readFallbacks ?? []) {
+      if (fallback === "" && !userGlobalReadable) continue;
       add(combineNamespaces(options.principalSelfNamespace, fallback));
     }
   }

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -418,6 +418,8 @@ export function resolveScopeProfilePlan(
 export function expandScopeProfileReadNamespaces(options: {
   profilePlan: ResolvedScopeProfilePlan;
   principalSelfNamespace: string;
+  config: PluginConfig;
+  principal?: string;
   codingOverlay?: ScopeProfileCodingOverlay | null;
   legacyRecallNamespaces?: string[];
 }): string[] {
@@ -441,7 +443,10 @@ export function expandScopeProfileReadNamespaces(options: {
   if (userProjectReadable) {
     for (const fallback of options.codingOverlay?.readFallbacks ?? []) {
       if (fallback === "" && !userGlobalReadable) continue;
-      add(combineNamespaces(options.principalSelfNamespace, fallback));
+      const fallbackNamespace = combineNamespaces(options.principalSelfNamespace, fallback);
+      if (canReadScopeProfileNamespace(options.principal, fallbackNamespace, options.config)) {
+        add(fallbackNamespace);
+      }
     }
   }
   return out;

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -296,13 +296,18 @@ export function resolveScopeProfilePlan(
   }
 
   const preferredWriteLayer = layerMap.get(active.profile.writeDefault);
-  const userGlobalWriteLayer = layerMap.get("userGlobal");
+  const readableWriteLayers = active.profile.readOrder
+    .map((id) => layerMap.get(id))
+    .filter(
+      (layer): layer is ScopeProfileLayerResolution =>
+        Boolean(layer?.writable && layer.namespace && readNamespaces.includes(layer.namespace)),
+    );
   const fallbackWriteLayer =
-    preferredWriteLayer?.writable && preferredWriteLayer.namespace
+    preferredWriteLayer?.writable &&
+    preferredWriteLayer.namespace &&
+    readNamespaces.includes(preferredWriteLayer.namespace)
       ? preferredWriteLayer
-      : userGlobalWriteLayer?.writable && userGlobalWriteLayer.namespace
-        ? userGlobalWriteLayer
-        : undefined;
+      : readableWriteLayers[0];
   const warnings: string[] = [];
   if (!fallbackWriteLayer?.namespace) {
     warnings.push(`scope profile ${active.profileId} has no writable layer; falling back to ${baseNamespace}`);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -90,7 +90,7 @@ function renderTeamProjectNamespace(params: {
   principal: string | undefined;
   codingContext: CodingContext;
   codingOverlay: ScopeProfileCodingOverlay;
-}): string {
+}): { namespace: string; unknownPlaceholders: string[] } {
   const replacements: Record<string, string> = {
     teamId: params.teamId,
     principal: params.principal ?? "anonymous",
@@ -98,9 +98,14 @@ function renderTeamProjectNamespace(params: {
     projectHash: stableHash(params.codingContext.projectId),
     projectNamespace: params.codingOverlay.namespace,
   };
-  return params.template.replace(/\{([A-Za-z][A-Za-z0-9]*)\}/g, (_match, key: string) =>
-    replacements[key] ?? "",
-  );
+  const unknownPlaceholders: string[] = [];
+  const namespace = params.template.replace(/\{([A-Za-z][A-Za-z0-9]*)\}/g, (match, key: string) => {
+    const replacement = replacements[key];
+    if (replacement !== undefined) return replacement;
+    if (!unknownPlaceholders.includes(key)) unknownPlaceholders.push(key);
+    return match;
+  });
+  return { namespace, unknownPlaceholders };
 }
 
 function resolveLayer(params: {
@@ -186,13 +191,25 @@ function resolveLayer(params: {
     profile.teamProject?.namespaceTemplate ??
     team.team.projectNamespaceTemplate ??
     "team-{teamId}-project-{projectHash}";
-  const namespace = renderTeamProjectNamespace({
+  const renderedNamespace = renderTeamProjectNamespace({
     template,
     teamId: team.teamId,
     principal,
     codingContext,
     codingOverlay,
-  }).trim();
+  });
+  const namespace = renderedNamespace.namespace.trim();
+  if (renderedNamespace.unknownPlaceholders.length > 0) {
+    return {
+      id,
+      kind: "team-project",
+      namespace,
+      readable: false,
+      writable: false,
+      promotable: false,
+      reason: `unknown team-project namespace template placeholder(s): ${renderedNamespace.unknownPlaceholders.join(", ")}`,
+    };
+  }
   if (!namespace || !isSafeRouteNamespace(namespace)) {
     return {
       id,
@@ -204,14 +221,26 @@ function resolveLayer(params: {
       reason: "team-project namespace template resolved to an unsafe namespace",
     };
   }
+  const teamReadable = principalListed(team.team.read, principal) || principalListed(team.team.principals, principal);
+  const teamWritable = principalListed(team.team.write, principal);
+  const teamPromotable = principalListed(team.team.promote, principal) || principalListed(team.team.write, principal);
+  const protectedNamespace =
+    namespace === config.defaultNamespace ||
+    namespace === config.sharedNamespace ||
+    (config.namespacePolicies ?? []).some((policy) => policy.name === namespace);
+  const policyReadable = !protectedNamespace || canReadNamespace(principal, namespace, config);
+  const policyWritable = !protectedNamespace || canWriteNamespace(principal, namespace, config);
+  const policyBlocked = protectedNamespace && (!policyReadable || !policyWritable);
   return {
     id,
     kind: "team-project",
     namespace,
-    readable: principalListed(team.team.read, principal) || principalListed(team.team.principals, principal),
-    writable: principalListed(team.team.write, principal),
-    promotable: principalListed(team.team.promote, principal) || principalListed(team.team.write, principal),
-    reason: "trusted team-project namespace derived from team and project config",
+    readable: teamReadable && policyReadable,
+    writable: teamWritable && policyWritable,
+    promotable: teamPromotable && policyWritable,
+    reason: policyBlocked
+      ? "team-project namespace collides with a protected namespace policy"
+      : "trusted team-project namespace derived from team and project config",
   };
 }
 
@@ -309,6 +338,9 @@ export function expandScopeProfileReadNamespaces(options: {
   codingOverlay?: ScopeProfileCodingOverlay | null;
   legacyRecallNamespaces?: string[];
 }): string[] {
+  if (options.profilePlan.readNamespaces.length === 0) {
+    return [];
+  }
   const out = [...options.profilePlan.readNamespaces];
   const add = (namespace: string | undefined): void => {
     if (namespace && !out.includes(namespace)) out.push(namespace);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -121,12 +121,17 @@ function resolveTeam(
     const configured = (config.teams ?? {})[configuredTeamId];
     return configured ? { teamId: configuredTeamId, team: configured } : null;
   }
-  for (const [teamId, team] of Object.entries(config.teams ?? {})) {
-    if (principalListed(team.principals, principal) || principalListed(team.read, principal)) {
-      return { teamId, team };
-    }
+  const readableTeams = Object.entries(config.teams ?? {}).filter(([, team]) =>
+    principalListed(team.principals, principal) || principalListed(team.read, principal),
+  );
+  if (profile.writeDefault === "teamProject") {
+    const writableTeam = readableTeams.find(([, team]) => principalListed(team.write, principal));
+    if (writableTeam) return { teamId: writableTeam[0], team: writableTeam[1] };
   }
-  return null;
+  const firstReadableTeam = readableTeams[0];
+  return firstReadableTeam
+    ? { teamId: firstReadableTeam[0], team: firstReadableTeam[1] }
+    : null;
 }
 
 function renderTeamProjectNamespace(params: {

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -202,18 +202,27 @@ function resolveLayer(params: {
       };
     }
     const namespace = combineNamespaces(baseNamespace, codingOverlay.namespace);
+    const explicitProjectPolicy = hasExplicitNamespacePolicy(namespace, config);
     const baseReadable = canReadScopeProfileNamespace(principal, baseNamespace, config);
     const baseWritable = canWriteScopeProfileNamespace(principal, baseNamespace, config);
+    const projectReadable = explicitProjectPolicy
+      ? canReadNamespace(principal, namespace, config)
+      : baseReadable;
+    const projectWritable = explicitProjectPolicy
+      ? canWriteNamespace(principal, namespace, config)
+      : baseWritable;
     return {
       id,
       kind: "user-project",
       namespace,
-      readable: baseReadable,
-      writable: baseWritable,
-      promotable: baseWritable,
-      reason: baseReadable || baseWritable
-        ? "principal project namespace derived from coding context"
-        : "principal base namespace is not authorized",
+      readable: projectReadable,
+      writable: projectWritable,
+      promotable: projectWritable,
+      reason: explicitProjectPolicy
+        ? "explicit user-project namespace policy"
+        : baseReadable || baseWritable
+          ? "principal project namespace derived from coding context"
+          : "principal base namespace is not authorized",
     };
   }
   const team = resolveTeam(config, profile, principal);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -75,6 +75,10 @@ function scopeProfileSelfNamespace(principal: string | undefined, config: Plugin
   return existing;
 }
 
+function hasExplicitNamespacePolicy(namespace: string, config: PluginConfig): boolean {
+  return (config.namespacePolicies ?? []).some((policy) => policy.name === namespace);
+}
+
 function isScopeProfileImplicitSelfNamespace(
   principal: string | undefined,
   namespace: string,
@@ -85,7 +89,8 @@ function isScopeProfileImplicitSelfNamespace(
       namespace === principal &&
       namespace !== config.defaultNamespace &&
       namespace !== config.sharedNamespace &&
-      isSafeRouteNamespace(namespace),
+      isSafeRouteNamespace(namespace) &&
+      !hasExplicitNamespacePolicy(namespace, config),
   );
 }
 

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -61,6 +61,50 @@ function principalListed(list: string[], principal: string | undefined): boolean
   return list.includes(principal) || list.includes("*");
 }
 
+function scopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string {
+  const existing = defaultNamespaceForPrincipal(principal, config);
+  if (existing !== config.defaultNamespace) return existing;
+  if (
+    principal &&
+    principal !== config.defaultNamespace &&
+    principal !== config.sharedNamespace &&
+    isSafeRouteNamespace(principal)
+  ) {
+    return principal;
+  }
+  return existing;
+}
+
+function isScopeProfileImplicitSelfNamespace(
+  principal: string | undefined,
+  namespace: string,
+  config: PluginConfig,
+): boolean {
+  return Boolean(
+    principal &&
+      namespace === principal &&
+      namespace !== config.defaultNamespace &&
+      namespace !== config.sharedNamespace &&
+      isSafeRouteNamespace(namespace),
+  );
+}
+
+function canReadScopeProfileNamespace(
+  principal: string | undefined,
+  namespace: string,
+  config: PluginConfig,
+): boolean {
+  return isScopeProfileImplicitSelfNamespace(principal, namespace, config) || canReadNamespace(principal, namespace, config);
+}
+
+function canWriteScopeProfileNamespace(
+  principal: string | undefined,
+  namespace: string,
+  config: PluginConfig,
+): boolean {
+  return isScopeProfileImplicitSelfNamespace(principal, namespace, config) || canWriteNamespace(principal, namespace, config);
+}
+
 function resolveTeam(
   config: PluginConfig,
   profile: ScopeProfileConfig,
@@ -123,9 +167,9 @@ function resolveLayer(params: {
       id,
       kind: "user-global",
       namespace: baseNamespace,
-      readable: canReadNamespace(principal, baseNamespace, config),
-      writable: canWriteNamespace(principal, baseNamespace, config),
-      promotable: canWriteNamespace(principal, baseNamespace, config),
+      readable: canReadScopeProfileNamespace(principal, baseNamespace, config),
+      writable: canWriteScopeProfileNamespace(principal, baseNamespace, config),
+      promotable: canWriteScopeProfileNamespace(principal, baseNamespace, config),
       reason: "principal self/global namespace",
     };
   }
@@ -152,8 +196,8 @@ function resolveLayer(params: {
       };
     }
     const namespace = combineNamespaces(baseNamespace, codingOverlay.namespace);
-    const baseReadable = canReadNamespace(principal, baseNamespace, config);
-    const baseWritable = canWriteNamespace(principal, baseNamespace, config);
+    const baseReadable = canReadScopeProfileNamespace(principal, baseNamespace, config);
+    const baseWritable = canWriteScopeProfileNamespace(principal, baseNamespace, config);
     return {
       id,
       kind: "user-project",
@@ -260,7 +304,7 @@ export function resolveScopeProfilePlan(
   const active = activeScopeProfile(options.config);
   if (!active || !options.config.namespacesEnabled) return null;
 
-  const baseNamespace = defaultNamespaceForPrincipal(options.principal, options.config);
+  const baseNamespace = scopeProfileSelfNamespace(options.principal, options.config);
   const layerIds = Array.from(
     new Set<ScopeProfileLayerId>([
       ...active.profile.readOrder,

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -303,15 +303,6 @@ export function resolveScopeProfilePlan(
       : userGlobalWriteLayer?.writable && userGlobalWriteLayer.namespace
         ? userGlobalWriteLayer
         : undefined;
-  if (
-    fallbackWriteLayer?.id !== active.profile.writeDefault &&
-    fallbackWriteLayer?.readable &&
-    fallbackWriteLayer.namespace &&
-    !readNamespaces.includes(fallbackWriteLayer.namespace)
-  ) {
-    readNamespaces.push(fallbackWriteLayer.namespace);
-  }
-
   const warnings: string[] = [];
   if (!fallbackWriteLayer?.namespace) {
     warnings.push(`scope profile ${active.profileId} has no writable layer; falling back to ${baseNamespace}`);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -124,7 +124,7 @@ function resolveTeam(
   const readableTeams = Object.entries(config.teams ?? {}).filter(([, team]) =>
     principalListed(team.principals, principal) || principalListed(team.read, principal),
   );
-  if (profile.writeDefault === "teamProject") {
+  if (profile.writeDefault === "teamProject" || profile.readOrder.includes("teamProject")) {
     const writableTeam = readableTeams.find(([, team]) => principalListed(team.write, principal));
     if (writableTeam) return { teamId: writableTeam[0], team: writableTeam[1] };
   }

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { combineNamespaces, type CodingNamespaceOverlay } from "../coding/coding-namespace.js";
 import { stableHash } from "../coding/git-context.js";
 import { isSafeRouteNamespace } from "../routing/engine.js";
@@ -64,7 +66,7 @@ function principalListed(list: string[], principal: string | undefined): boolean
 function derivedScopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string | null {
   if (!principal || principal === config.defaultNamespace || principal === config.sharedNamespace) return null;
   if (isSafeRouteNamespace(principal)) return principal;
-  return "principal-" + stableHash(principal);
+  return "principal-" + createHash("sha256").update(principal).digest("hex");
 }
 
 function scopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string {

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -354,9 +354,11 @@ export function expandScopeProfileReadNamespaces(options: {
   const add = (namespace: string | undefined): void => {
     if (namespace && !out.includes(namespace)) out.push(namespace);
   };
-  const userProjectReadable = options.profilePlan.layers.some(
-    (layer) => layer.id === "userProject" && layer.readable && layer.namespace,
-  );
+  const userProjectReadable =
+    options.profilePlan.profile.readOrder.includes("userProject") &&
+    options.profilePlan.layers.some(
+      (layer) => layer.id === "userProject" && layer.readable && layer.namespace,
+    );
   if (userProjectReadable) {
     for (const fallback of options.codingOverlay?.readFallbacks ?? []) {
       add(combineNamespaces(options.principalSelfNamespace, fallback));

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -224,9 +224,19 @@ function resolveLayer(params: {
   const teamReadable = principalListed(team.team.read, principal) || principalListed(team.team.principals, principal);
   const teamWritable = principalListed(team.team.write, principal);
   const teamPromotable = principalListed(team.team.promote, principal) || principalListed(team.team.write, principal);
+  const userProjectSuffix = `-${codingOverlay.namespace}`;
+  const userProjectBase = namespace.endsWith(userProjectSuffix)
+    ? namespace.slice(0, -userProjectSuffix.length)
+    : "";
+  const dynamicUserProjectCollision =
+    userProjectBase.length > 0 &&
+    (userProjectBase === config.defaultNamespace ||
+      userProjectBase === config.sharedNamespace ||
+      (config.namespacePolicies ?? []).some((policy) => policy.name === userProjectBase));
   const protectedNamespace =
     namespace === config.defaultNamespace ||
     namespace === config.sharedNamespace ||
+    dynamicUserProjectCollision ||
     (config.namespacePolicies ?? []).some((policy) => policy.name === namespace);
   const policyReadable = !protectedNamespace || canReadNamespace(principal, namespace, config);
   const policyWritable = !protectedNamespace || canWriteNamespace(principal, namespace, config);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -122,12 +122,7 @@ function resolveTeam(
     return configured ? { teamId: configuredTeamId, team: configured } : null;
   }
   for (const [teamId, team] of Object.entries(config.teams ?? {})) {
-    if (
-      principalListed(team.principals, principal) ||
-      principalListed(team.read, principal) ||
-      principalListed(team.write, principal) ||
-      principalListed(team.promote, principal)
-    ) {
+    if (principalListed(team.principals, principal) || principalListed(team.read, principal)) {
       return { teamId, team };
     }
   }

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -444,7 +444,10 @@ export function expandScopeProfileReadNamespaces(options: {
     for (const fallback of options.codingOverlay?.readFallbacks ?? []) {
       if (fallback === "" && !userGlobalReadable) continue;
       const fallbackNamespace = combineNamespaces(options.principalSelfNamespace, fallback);
-      if (canReadScopeProfileNamespace(options.principal, fallbackNamespace, options.config)) {
+      if (
+        !hasExplicitNamespacePolicy(fallbackNamespace, options.config) ||
+        canReadScopeProfileNamespace(options.principal, fallbackNamespace, options.config)
+      ) {
         add(fallbackNamespace);
       }
     }

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -296,17 +296,18 @@ export function resolveScopeProfilePlan(
   }
 
   const preferredWriteLayer = layerMap.get(active.profile.writeDefault);
-  const userGlobalWriteLayer = layerMap.get("userGlobal");
+  const readableWriteLayers = active.profile.readOrder
+    .map((id) => layerMap.get(id))
+    .filter(
+      (layer): layer is ScopeProfileLayerResolution =>
+        Boolean(layer?.writable && layer.namespace && readNamespaces.includes(layer.namespace)),
+    );
   const fallbackWriteLayer =
     preferredWriteLayer?.writable &&
     preferredWriteLayer.namespace &&
     readNamespaces.includes(preferredWriteLayer.namespace)
       ? preferredWriteLayer
-      : userGlobalWriteLayer?.writable &&
-          userGlobalWriteLayer.namespace &&
-          readNamespaces.includes(userGlobalWriteLayer.namespace)
-        ? userGlobalWriteLayer
-        : undefined;
+      : readableWriteLayers[0];
   const warnings: string[] = [];
   if (!fallbackWriteLayer?.namespace) {
     warnings.push(`scope profile ${active.profileId} has no writable layer inside the profile read stack; writes disabled`);

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -302,3 +302,27 @@ export function resolveScopeProfilePlan(
     warnings,
   };
 }
+
+export function expandScopeProfileReadNamespaces(options: {
+  profilePlan: ResolvedScopeProfilePlan;
+  principalSelfNamespace: string;
+  codingOverlay?: ScopeProfileCodingOverlay | null;
+  legacyRecallNamespaces?: string[];
+}): string[] {
+  const out = [...options.profilePlan.readNamespaces];
+  const add = (namespace: string | undefined): void => {
+    if (namespace && !out.includes(namespace)) out.push(namespace);
+  };
+  const userProjectReadable = options.profilePlan.layers.some(
+    (layer) => layer.id === "userProject" && layer.readable && layer.namespace,
+  );
+  if (userProjectReadable) {
+    for (const fallback of options.codingOverlay?.readFallbacks ?? []) {
+      add(combineNamespaces(options.principalSelfNamespace, fallback));
+    }
+  }
+  for (const namespace of options.legacyRecallNamespaces ?? []) {
+    add(namespace);
+  }
+  return out;
+}

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -66,7 +66,7 @@ function principalListed(list: string[], principal: string | undefined): boolean
 function derivedScopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string | null {
   if (!principal || principal === config.defaultNamespace || principal === config.sharedNamespace) return null;
   if (isSafeRouteNamespace(principal)) return principal;
-  return "principal-" + createHash("sha256").update(principal).digest("hex");
+  return "principal-" + createHash("sha256").update(principal).digest("hex").slice(0, 54);
 }
 
 function scopeProfileSelfNamespace(principal: string | undefined, config: PluginConfig): string {

--- a/packages/remnic-core/src/namespaces/scope-profiles.ts
+++ b/packages/remnic-core/src/namespaces/scope-profiles.ts
@@ -296,21 +296,20 @@ export function resolveScopeProfilePlan(
   }
 
   const preferredWriteLayer = layerMap.get(active.profile.writeDefault);
-  const readableWriteLayers = active.profile.readOrder
-    .map((id) => layerMap.get(id))
-    .filter(
-      (layer): layer is ScopeProfileLayerResolution =>
-        Boolean(layer?.writable && layer.namespace && readNamespaces.includes(layer.namespace)),
-    );
+  const userGlobalWriteLayer = layerMap.get("userGlobal");
   const fallbackWriteLayer =
     preferredWriteLayer?.writable &&
     preferredWriteLayer.namespace &&
     readNamespaces.includes(preferredWriteLayer.namespace)
       ? preferredWriteLayer
-      : readableWriteLayers[0];
+      : userGlobalWriteLayer?.writable &&
+          userGlobalWriteLayer.namespace &&
+          readNamespaces.includes(userGlobalWriteLayer.namespace)
+        ? userGlobalWriteLayer
+        : undefined;
   const warnings: string[] = [];
   if (!fallbackWriteLayer?.namespace) {
-    warnings.push(`scope profile ${active.profileId} has no writable layer; falling back to ${baseNamespace}`);
+    warnings.push(`scope profile ${active.profileId} has no writable layer inside the profile read stack; writes disabled`);
   } else if (fallbackWriteLayer.id !== active.profile.writeDefault) {
     warnings.push(
       `scope profile ${active.profileId} writeDefault ${active.profile.writeDefault} unavailable: ${preferredWriteLayer?.reason ?? "not resolved"}`,
@@ -338,8 +337,8 @@ export function resolveScopeProfilePlan(
     profileId: active.profileId,
     profile: active.profile,
     baseNamespace,
-    writeLayer: fallbackWriteLayer?.id ?? "userGlobal",
-    writeNamespace: fallbackWriteLayer?.namespace ?? baseNamespace,
+    writeLayer: fallbackWriteLayer?.id ?? active.profile.writeDefault,
+    writeNamespace: fallbackWriteLayer?.namespace ?? "",
     readNamespaces,
     layers: [...layerMap.values()],
     promotionTargets,

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -636,6 +636,68 @@ test("flushSession drains every discovered buffer for the session", async () => 
   ]);
 });
 
+test("runExtraction skips active scope profile writes when no layer is writable", async () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    defaultScopeProfile: "teamCoding",
+    codingMode: { projectScope: true },
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-observer:", principal: "pi-observer" }],
+    namespacePolicies: [
+      { name: "pi-observer", readPrincipals: ["pi-observer"], writePrincipals: [] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: [],
+        promote: [],
+      },
+    },
+  });
+  config.extractionMinChars = 0;
+  config.extractionMinUserTurns = 1;
+
+  let clearCalls = 0;
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  orchestrator.config = config;
+  orchestrator.buffer = {
+    clearAfterExtraction: async () => {
+      clearCalls += 1;
+    },
+  };
+  orchestrator.getCodingContextForSession = () => ({
+    projectId: "tag:remnic",
+    branch: null,
+    rootPath: "tag:remnic",
+    defaultBranch: "main",
+  });
+  orchestrator.storageRouter = {
+    storageFor: async () => {
+      throw new Error("unauthorized profile write must not choose fallback storage");
+    },
+  };
+
+  const result = await orchestrator.runExtraction(
+    [makeTurn("pi-observer:abc123", "remember unauthorized profile target")],
+    { bufferKey: "pi-observer:abc123" },
+  );
+
+  assert.equal(result.status, "skipped");
+  assert.equal(result.reason, "scope_profile_no_writable_layer");
+  assert.equal(clearCalls, 1);
+});
+
 test("runExtraction writes buffered turns to active scope profile write layer", async () => {
   const config = parseConfig({
     namespacesEnabled: true,

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -8,6 +8,7 @@ import {
   Orchestrator,
 } from "./orchestrator.js";
 import { parseConfig } from "./config.js";
+import { stableHash } from "./coding/git-context.js";
 import type { BufferTurn } from "./types.js";
 import type { ImportTurn } from "./bulk-import/types.js";
 import { namespaceIdentityToken } from "./namespaces/identity.js";
@@ -633,6 +634,85 @@ test("flushSession drains every discovered buffer for the session", async () => 
     "session-z",
     "codex-thread:thread-11::principal:cli",
   ]);
+});
+
+test("runExtraction writes buffered turns to active scope profile write layer", async () => {
+  const config = parseConfig({
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    defaultScopeProfile: "teamCoding",
+    codingMode: { projectScope: true },
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-observer:", principal: "pi-observer" }],
+    namespacePolicies: [
+      { name: "pi-observer", readPrincipals: ["pi-observer"], writePrincipals: ["pi-observer"] },
+    ],
+    scopeProfiles: {
+      teamCoding: {
+        readOrder: ["teamProject"],
+        writeDefault: "teamProject",
+        promotionTargets: ["teamProject"],
+        teamProject: { namespaceTemplate: "team-{teamId}-project-{projectHash}" },
+      },
+    },
+    teams: {
+      pi: {
+        principals: ["pi-observer"],
+        read: ["pi-observer"],
+        write: ["pi-observer"],
+        promote: ["pi-observer"],
+      },
+    },
+  });
+  config.extractionMinChars = 0;
+  config.extractionMinUserTurns = 1;
+
+  const turn = {
+    ...makeTurn("pi-observer:abc123", "remember the team profile target"),
+    persistProcessedFingerprint: true,
+  };
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  orchestrator.config = config;
+  orchestrator.buffer = { clearAfterExtraction: async () => undefined };
+  orchestrator.getCodingContextForSession = () => ({
+    projectId: "tag:remnic",
+    branch: null,
+    rootPath: "tag:remnic",
+    defaultBranch: "main",
+  });
+  let requestedNamespace: string | undefined;
+  orchestrator.storageRouter = {
+    storageFor: async (namespace: string) => {
+      requestedNamespace = namespace;
+      return {
+        listEntityNames: async () => [],
+        loadMeta: async () => ({
+          extractionCount: 0,
+          lastExtractionAt: null,
+          lastConsolidationAt: null,
+          totalMemories: 0,
+          totalEntities: 0,
+          processedExtractionFingerprints: [
+            {
+              fingerprint: orchestrator.buildExtractionFingerprint([turn], "pi-observer:abc123"),
+              observedAt: "2026-04-15T00:00:00.000Z",
+            },
+          ],
+        }),
+        saveMeta: async () => undefined,
+      };
+    },
+  };
+  orchestrator.extraction = {
+    extract: async () => {
+      throw new Error("extraction should be skipped by processed fingerprint");
+    },
+  };
+
+  await orchestrator.runExtraction([turn], { bufferKey: "pi-observer:abc123" });
+
+  assert.equal(requestedNamespace, `team-pi-project-${stableHash("tag:remnic")}`);
 });
 
 test("runExtraction skips batches whose persisted fingerprint already exists in storage meta", async () => {

--- a/packages/remnic-core/src/orchestrator-source-attribution.test.ts
+++ b/packages/remnic-core/src/orchestrator-source-attribution.test.ts
@@ -699,3 +699,76 @@ test("dedup: pre-tagged fact is not re-persisted when canonical body is already 
     "only one copy of the fact must be stored",
   );
 });
+
+
+test("dedup: exact matches are scoped to the target namespace storage", async () => {
+  const { orchestrator, storage, memoryDir } = await makeOrchestrator({
+    factDeduplicationEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+  });
+
+  const stateDir = path.join(memoryDir, "state");
+  await mkdir(stateDir, { recursive: true });
+  const hashIndex = new ContentHashIndex(stateDir);
+  await hashIndex.load();
+  (orchestrator as any).contentHashIndex = hashIndex;
+
+  const tenantStorage = await orchestrator.getStorage("alice-project");
+  await tenantStorage.ensureDirectories();
+
+  const rawBody = "The Helios tenant keeps staging feature flags isolated.";
+  const firstIds = await orchestrator.persistExtraction(
+    {
+      facts: [makeFact(rawBody)],
+      entities: [],
+      relationships: [],
+      questions: [],
+      profileUpdates: [],
+    } as ExtractionResult,
+    storage,
+    null,
+    { sessionKey: "agent:alice:default", principal: "alice" },
+  );
+  assert.equal(firstIds.length, 1, "default namespace write must succeed");
+
+  const tenantIds = await orchestrator.persistExtraction(
+    {
+      facts: [makeFact(rawBody)],
+      entities: [],
+      relationships: [],
+      questions: [],
+      profileUpdates: [],
+    } as ExtractionResult,
+    tenantStorage,
+    null,
+    { sessionKey: "agent:alice:project", principal: "alice" },
+  );
+  assert.equal(
+    tenantIds.length,
+    1,
+    "a duplicate in another namespace must not be suppressed by the default hash index",
+  );
+
+  const tenantDuplicateIds = await orchestrator.persistExtraction(
+    {
+      facts: [makeFact(rawBody)],
+      entities: [],
+      relationships: [],
+      questions: [],
+      profileUpdates: [],
+    } as ExtractionResult,
+    tenantStorage,
+    null,
+    { sessionKey: "agent:alice:project", principal: "alice" },
+  );
+  assert.equal(
+    tenantDuplicateIds.length,
+    0,
+    "the same namespace storage must still exact-dedup repeated facts",
+  );
+
+  assert.equal((await storage.readAllMemories()).length, 1);
+  assert.equal((await tenantStorage.readAllMemories()).length, 1);
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7814,23 +7814,70 @@ export class Orchestrator {
       return "";
     }
 
-    const selfNamespaceReadableForProfileSections =
-      !scopeProfilePlan || recallNamespaces.includes(selfNamespace);
-    const profileStorageNamespace = selfNamespaceReadableForProfileSections
-      ? selfNamespace
-      : recallNamespaces[0];
+    const profileStorageNamespaces = scopeProfilePlan ? recallNamespaces : [selfNamespace];
+    const profileStorages = await Promise.all(
+      profileStorageNamespaces.map((namespace) => this.storageRouter.storageFor(namespace)),
+    );
     const emptyProfileStorage = new Proxy({ dir: "" } as any, {
       get(target, prop: string | symbol) {
-        if (prop in target) return target[prop as keyof typeof target];
+        if (prop in target) return target[prop];
         if (prop === "readProfile") return async () => "";
         if (prop === "readQuestions" || prop === "listEntityNames") return async () => [];
         if (prop === "readEntity" || prop === "readMemoryByPath") return async () => null;
         return async () => [];
       },
     });
-    const profileStorage = profileStorageNamespace
-      ? await this.storageRouter.storageFor(profileStorageNamespace)
-      : emptyProfileStorage;
+    const profileStorage =
+      profileStorages.length <= 1
+        ? profileStorages[0] ?? emptyProfileStorage
+        : new Proxy(profileStorages[0] as any, {
+            get(target, prop: string | symbol) {
+              if (prop === "readProfile") {
+                return async () => {
+                  for (const storage of profileStorages) {
+                    const profile = await storage.readProfile();
+                    if (profile.trim().length > 0) return profile;
+                  }
+                  return "";
+                };
+              }
+              if (prop === "readQuestions") {
+                return async (...args: any[]) => {
+                  const merged: any[] = [];
+                  const seen = new Set<string>();
+                  for (const storage of profileStorages) {
+                    const questions = await storage.readQuestions(...args);
+                    for (const question of questions) {
+                      const key = typeof question === "string" ? question : JSON.stringify(question);
+                      if (seen.has(key)) continue;
+                      seen.add(key);
+                      merged.push(question);
+                    }
+                  }
+                  return merged;
+                };
+              }
+              if (prop === "listEntityNames") {
+                return async (...args: any[]) => {
+                  const names = new Set<string>();
+                  for (const storage of profileStorages) {
+                    for (const name of await storage.listEntityNames(...args)) names.add(name);
+                  }
+                  return [...names];
+                };
+              }
+              if (prop === "readEntity" || prop === "readMemoryByPath") {
+                return async (...args: any[]) => {
+                  for (const storage of profileStorages) {
+                    const value = await storage[prop](...args);
+                    if (value) return value;
+                  }
+                  return null;
+                };
+              }
+              return target[prop];
+            },
+          });
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
     throwIfRecallAborted(options.abortSignal);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7831,16 +7831,19 @@ export class Orchestrator {
     const profileStorages = await Promise.all(
       profileStorageNamespaces.map((namespace) => this.storageRouter.storageFor(namespace)),
     );
-    const emptyProfileStorage = new Proxy({ dir: "" } as any, {
+    const emptyProfileStorage = new Proxy(
+      { dir: path.join(this.config.memoryDir, ".empty-scope-profile") } as any,
+      {
       get(target, prop: string | symbol) {
         if (prop in target) return target[prop];
         if (prop === "readProfile") return async () => "";
         if (prop === "readQuestions" || prop === "listEntityNames" || prop === "readContinuityIncidents") return async () => [];
         if (prop === "readIdentityAnchor" || prop === "readIdentityImprovementLoops") return async () => "";
         if (prop === "readEntity" || prop === "readMemoryByPath") return async () => null;
-        return async () => [];
+          return async () => [];
+        },
       },
-    });
+    );
     const profileStorage =
       profileStorages.length <= 1
         ? profileStorages[0] ?? emptyProfileStorage
@@ -8292,17 +8295,18 @@ export class Orchestrator {
         const knowledgeIndexMaxChars =
           this.getRecallSectionNumber("knowledge-index", "maxChars") ??
           this.config.knowledgeIndexMaxChars;
+        const knowledgeIndexMaxEntities =
+          this.getRecallSectionNumber("knowledge-index", "maxEntities") ??
+          this.config.knowledgeIndexMaxEntities;
         const knowledgeIndexOptions = {
-          maxEntities: this.getRecallSectionNumber(
-            "knowledge-index",
-            "maxEntities",
-          ),
+          maxEntities: knowledgeIndexMaxEntities,
           maxChars: knowledgeIndexMaxChars,
         };
         const ki = scopeProfilePlan
           ? await (async () => {
               const perLayerOptions = {
                 ...knowledgeIndexOptions,
+                maxEntities: Number.MAX_SAFE_INTEGER,
                 maxChars: Number.MAX_SAFE_INTEGER,
               };
               const results = await Promise.all(
@@ -8313,7 +8317,30 @@ export class Orchestrator {
               const sections = results
                 .map((result) => result.result.trim())
                 .filter((section) => section.length > 0);
-              const merged = sections.join("\n\n");
+              const maxRows = Math.max(0, Math.floor(knowledgeIndexMaxEntities));
+              const rows: string[] = [];
+              let header: string[] | null = null;
+              for (const section of sections) {
+                const lines = section
+                  .split("\n")
+                  .map((line) => line.trimEnd())
+                  .filter((line) => line.length > 0);
+                const tableHeaderIndex = lines.findIndex((line) =>
+                  line.startsWith("| Entity |"),
+                );
+                if (tableHeaderIndex === -1) continue;
+                header ??= lines.slice(0, tableHeaderIndex + 2);
+                for (const row of lines.slice(tableHeaderIndex + 2)) {
+                  if (!row.startsWith("|")) continue;
+                  if (rows.length >= maxRows) break;
+                  rows.push(row);
+                }
+                if (rows.length >= maxRows) break;
+              }
+              const merged =
+                header && rows.length > 0
+                  ? `${header.join("\n")}\n${rows.join("\n")}\n`
+                  : "";
               return {
                 result: this.truncateRecallSectionToBudget(
                   merged,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -320,7 +320,10 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
-import { resolveScopeProfilePlan } from "./namespaces/scope-profiles.js";
+import {
+  expandScopeProfileReadNamespaces,
+  resolveScopeProfilePlan,
+} from "./namespaces/scope-profiles.js";
 import {
   combineNamespaces,
   lcmReadSessionIdsForNamespaces,
@@ -5846,7 +5849,12 @@ export class Orchestrator {
     if (namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)) {
       observationNamespaces = [namespaceOverride];
     } else if (observationScopeProfilePlan?.readNamespaces.length) {
-      observationNamespaces = observationScopeProfilePlan.readNamespaces;
+      observationNamespaces = expandScopeProfileReadNamespaces({
+        profilePlan: observationScopeProfilePlan,
+        principalSelfNamespace: observationPrincipalSelf,
+        codingOverlay: observationCodingOverlay,
+        legacyRecallNamespaces: recallNamespacesForPrincipal(principal, this.config),
+      });
     } else if (observationCodingOverlay && observationCodingSelf) {
       // Rule 42 / parity with the main recall path: substitute the self
       // namespace within the principal's recall list rather than
@@ -7481,7 +7489,12 @@ export class Orchestrator {
     if (namespaceOverride) {
       recallNamespaces = [namespaceOverride];
     } else if (scopeProfilePlan?.readNamespaces.length) {
-      recallNamespaces = scopeProfilePlan.readNamespaces;
+      recallNamespaces = expandScopeProfileReadNamespaces({
+        profilePlan: scopeProfilePlan,
+        principalSelfNamespace,
+        codingOverlay,
+        legacyRecallNamespaces: readableRecallNamespaces,
+      });
     } else if (codingOverlay && codingSelfNamespace) {
       // Substitute the principal's self namespace with the coding-scoped
       // one, and append any read fallbacks (branch→project, PR 3) combined
@@ -7548,6 +7561,11 @@ export class Orchestrator {
     if (namespaceOverride) {
       // Explicit namespace already read-authorized above (canReadNamespace gate).
       lcmReadNamespaces = [namespaceOverride];
+    } else if (scopeProfilePlan?.readNamespaces.length) {
+      // Scope profiles define a layered read stack; LCM-backed evidence uses the
+      // same namespace set as QMD/file recall so team/global/shared observations
+      // are not silently skipped.
+      lcmReadNamespaces = recallNamespaces;
     } else if (codingOverlay && codingSelfNamespace && codingOverlaySelfReadable) {
       // Self base readable → overlay rows authorized. Read the primary overlay
       // key first, then each coding read fallback (project → root), combined with

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5848,7 +5848,7 @@ export class Orchestrator {
     let observationNamespaces: string[];
     if (namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)) {
       observationNamespaces = [namespaceOverride];
-    } else if (observationScopeProfilePlan?.readNamespaces.length) {
+    } else if (observationScopeProfilePlan) {
       observationNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: observationScopeProfilePlan,
         principalSelfNamespace: observationPrincipalSelf,
@@ -7488,7 +7488,7 @@ export class Orchestrator {
     let recallNamespaces: string[];
     if (namespaceOverride) {
       recallNamespaces = [namespaceOverride];
-    } else if (scopeProfilePlan?.readNamespaces.length) {
+    } else if (scopeProfilePlan) {
       recallNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: scopeProfilePlan,
         principalSelfNamespace,
@@ -7561,7 +7561,7 @@ export class Orchestrator {
     if (namespaceOverride) {
       // Explicit namespace already read-authorized above (canReadNamespace gate).
       lcmReadNamespaces = [namespaceOverride];
-    } else if (scopeProfilePlan?.readNamespaces.length) {
+    } else if (scopeProfilePlan) {
       // Scope profiles define a layered read stack; LCM-backed evidence uses the
       // same namespace set as QMD/file recall so team/global/shared observations
       // are not silently skipped.

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7888,6 +7888,11 @@ export class Orchestrator {
                   const limit = typeof args[0] === "number" && Number.isFinite(args[0]) ? Math.max(0, args[0]) : undefined;
                   const incidents: any[] = [];
                   const seen = new Set<string>();
+                  const incidentTime = (incident: any): number => {
+                    const raw = incident?.updatedAt ?? incident?.openedAt ?? incident?.createdAt;
+                    const parsed = typeof raw === "string" ? Date.parse(raw) : Number.NaN;
+                    return Number.isFinite(parsed) ? parsed : 0;
+                  };
                   for (const storage of profileStorages) {
                     for (const incident of await (storage.readContinuityIncidents as any)(...args)) {
                       const key = JSON.stringify(incident);
@@ -7896,6 +7901,11 @@ export class Orchestrator {
                       incidents.push(incident);
                     }
                   }
+                  incidents.sort(
+                    (left, right) =>
+                      incidentTime(right) - incidentTime(left) ||
+                      String(left?.id ?? "").localeCompare(String(right?.id ?? "")),
+                  );
                   return limit === undefined ? incidents : incidents.slice(0, limit);
                 };
               }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -254,6 +254,7 @@ import {
   type VerifiedEpisodeResult,
 } from "./verified-recall.js";
 import {
+  compareVerifiedSemanticRuleResults,
   searchVerifiedSemanticRules,
   type VerifiedSemanticRuleResult,
 } from "./semantic-rule-verifier.js";
@@ -8868,10 +8869,27 @@ export class Orchestrator {
       const VERIFIED_RULES_TIMEOUT_MS = 15_000;
       let rulesTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
       const results = await Promise.race([
-        searchVerifiedSemanticRules({
-          memoryDir: this.config.memoryDir,
-          query: retrievalQuery,
-          maxResults,
+        Promise.all(
+          profileStorageDirs.map((memoryDir) =>
+            searchVerifiedSemanticRules({
+              memoryDir,
+              query: retrievalQuery,
+              maxResults,
+            }).catch((err) => {
+              log.debug(`verified rules directory scan failed: ${err}`);
+              return [] as VerifiedSemanticRuleResult[];
+            }),
+          ),
+        ).then((groups) => {
+          const merged: VerifiedSemanticRuleResult[] = [];
+          const seen = new Set<string>();
+          for (const result of groups.flat()) {
+            const key = result.rule.frontmatter.id || result.rule.path || JSON.stringify(result);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            merged.push(result);
+          }
+          return merged.sort(compareVerifiedSemanticRuleResults).slice(0, maxResults);
         }),
         new Promise<[]>((resolve) => {
           rulesTimeoutHandle = setTimeout(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8717,15 +8717,36 @@ export class Orchestrator {
           return null;
         }
 
-        const results = await searchHarmonicRetrieval({
-          memoryDir: this.config.memoryDir,
-          abstractionNodeStoreDir: this.config.abstractionNodeStoreDir,
-          query: retrievalQuery,
-          maxResults,
-          sessionKey,
-          anchorsEnabled: this.config.abstractionAnchorsEnabled,
-          abortSignal: harmonicRetrievalAbort.signal,
-        });
+        const harmonicSearchDirs = scopeProfilePlan ? profileStorageDirs : [this.config.memoryDir];
+        const harmonicResultsByDir = await Promise.all(
+          harmonicSearchDirs.map((memoryDir) =>
+            searchHarmonicRetrieval({
+              memoryDir,
+              abstractionNodeStoreDir: scopeProfilePlan ? undefined : this.config.abstractionNodeStoreDir,
+              query: retrievalQuery,
+              maxResults,
+              sessionKey,
+              anchorsEnabled: this.config.abstractionAnchorsEnabled,
+              abortSignal: harmonicRetrievalAbort.signal,
+            }),
+          ),
+        );
+        const harmonicByNodeId = new Map<string, HarmonicRetrievalResult>();
+        for (const result of harmonicResultsByDir.flat()) {
+          const existing = harmonicByNodeId.get(result.node.nodeId);
+          if (!existing || result.score > existing.score) {
+            harmonicByNodeId.set(result.node.nodeId, result);
+          }
+        }
+        const results = [...harmonicByNodeId.values()]
+          .sort(
+            (left, right) =>
+              right.score - left.score ||
+              right.anchorScore - left.anchorScore ||
+              right.node.recordedAt.localeCompare(left.node.recordedAt) ||
+              left.node.nodeId.localeCompare(right.node.nodeId),
+          )
+          .slice(0, maxResults);
 
         recordRecallSectionMetric({
           section: "harmonicRetrieval",
@@ -8962,13 +8983,33 @@ export class Orchestrator {
         return null;
       }
 
-      const results = await searchWorkProductLedgerEntries({
-        memoryDir: this.config.memoryDir,
-        workProductLedgerDir: this.config.workProductLedgerDir,
-        query: retrievalQuery,
-        maxResults,
-        sessionKey,
-      });
+      const workProductSearchDirs = scopeProfilePlan ? profileStorageDirs : [this.config.memoryDir];
+      const workProductResultsByDir = await Promise.all(
+        workProductSearchDirs.map((memoryDir) =>
+          searchWorkProductLedgerEntries({
+            memoryDir,
+            workProductLedgerDir: scopeProfilePlan ? undefined : this.config.workProductLedgerDir,
+            query: retrievalQuery,
+            maxResults,
+            sessionKey,
+          }),
+        ),
+      );
+      const workProductByEntryId = new Map<string, WorkProductLedgerSearchResult>();
+      for (const result of workProductResultsByDir.flat()) {
+        const existing = workProductByEntryId.get(result.entry.entryId);
+        if (!existing || result.score > existing.score) {
+          workProductByEntryId.set(result.entry.entryId, result);
+        }
+      }
+      const results = [...workProductByEntryId.values()]
+        .sort(
+          (left, right) =>
+            right.score - left.score ||
+            right.entry.recordedAt.localeCompare(left.entry.recordedAt) ||
+            left.entry.entryId.localeCompare(right.entry.entryId),
+        )
+        .slice(0, maxResults);
 
       recordRecallSectionMetric({
         section: "workProducts",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5757,6 +5757,7 @@ export class Orchestrator {
             prompt,
             sessionKey,
             options.namespace?.trim() || undefined,
+            options.principalOverride,
           );
         } catch (err) {
           log.debug(`direct-answer observation setup failed: ${err}`);
@@ -5824,6 +5825,7 @@ export class Orchestrator {
     prompt: string,
     sessionKey: string,
     namespaceOverride: string | undefined,
+    principalOverride: string | undefined,
   ): void {
     const expectedSnapshot = this.lastRecall.get(sessionKey);
     if (expectedSnapshot === null) return;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7807,6 +7807,8 @@ export class Orchestrator {
       return "";
     }
 
+    const selfNamespaceReadableForProfileSections =
+      !scopeProfilePlan || recallNamespaces.includes(selfNamespace);
     const profileStorage = await this.storageRouter.storageFor(selfNamespace);
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
@@ -7905,6 +7907,7 @@ export class Orchestrator {
     // 1. Profile
     const profilePromise = (async (): Promise<string | null> => {
       if (!this.isRecallSectionEnabled("profile")) return null;
+      if (!selfNamespaceReadableForProfileSections) return null;
       const t0 = Date.now();
       const profile = await profileStorage.readProfile();
       recordRecallSectionMetric({

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12809,9 +12809,12 @@ export class Orchestrator {
       const selectedLayer = scopeProfileWritePlan.layers.find(
         (layer) => layer.id === scopeProfileWritePlan.writeLayer,
       );
-      if (!selectedLayer?.writable) {
+      const writeNamespaceReadable = scopeProfileWritePlan.readNamespaces.includes(
+        scopeProfileWritePlan.writeNamespace,
+      );
+      if (!selectedLayer?.writable || !writeNamespaceReadable) {
         log.warn(
-          `runExtraction: skipping scope profile ${scopeProfileWritePlan.profileId} because write layer ${scopeProfileWritePlan.writeLayer} is not writable`,
+          `runExtraction: skipping scope profile ${scopeProfileWritePlan.profileId} because write layer ${scopeProfileWritePlan.writeLayer} is not writable inside the profile read stack`,
         );
         await clearBuffer();
         return {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9200,30 +9200,14 @@ export class Orchestrator {
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
                 shouldRunAgent("temporal", retrievalQuery, 0)
-                  ? Promise.all(
-                      profileStorageDirs.map((memoryDir) =>
-                        runTemporalAgent(
-                          retrievalQuery,
-                          memoryDir,
-                          maxPerAgent,
-                          queryAwarePrefilter.candidatePaths,
-                        ).catch((err) => {
-                          log.debug(`TemporalAgent pre-start failed: ${err}`);
-                          return [] as ParallelSearchResult[];
-                        }),
-                      ),
-                    ).then((groups) => {
-                      const merged: ParallelSearchResult[] = [];
-                      const seen = new Set<string>();
-                      for (const result of groups.flat()) {
-                        const key = (result as any).path ?? JSON.stringify(result);
-                        if (seen.has(key)) continue;
-                        seen.add(key);
-                        merged.push(result);
-                      }
-                      return merged
-                        .sort((a, b) => b.score - a.score)
-                        .slice(0, maxPerAgent);
+                  ? runTemporalAgent(
+                      retrievalQuery,
+                      this.config.memoryDir,
+                      maxPerAgent,
+                      queryAwarePrefilter.candidatePaths,
+                    ).catch((err) => {
+                      log.debug(`TemporalAgent pre-start failed: ${err}`);
+                      return [] as ParallelSearchResult[];
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
               ])

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8289,13 +8289,29 @@ export class Orchestrator {
       if (!this.config.knowledgeIndexEnabled) return null;
       const t0 = Date.now();
       try {
-        const ki = await this.storage.buildKnowledgeIndex(this.config, {
+        const knowledgeIndexOptions = {
           maxEntities: this.getRecallSectionNumber(
             "knowledge-index",
             "maxEntities",
           ),
           maxChars: this.getRecallSectionNumber("knowledge-index", "maxChars"),
-        });
+        };
+        const ki = scopeProfilePlan
+          ? await (async () => {
+              const results = await Promise.all(
+                profileStorages.map((storage) =>
+                  storage.buildKnowledgeIndex(this.config, knowledgeIndexOptions),
+                ),
+              );
+              const sections = results
+                .map((result) => result.result.trim())
+                .filter((section) => section.length > 0);
+              return {
+                result: sections.join("\n\n"),
+                cached: results.every((result) => result.cached),
+              };
+            })()
+          : await this.storage.buildKnowledgeIndex(this.config, knowledgeIndexOptions);
         recordRecallSectionMetric({
           section: "ki",
           priority: "core",
@@ -12972,23 +12988,21 @@ export class Orchestrator {
       options.writeNamespaceOverride.length > 0
         ? options.writeNamespaceOverride
         : undefined;
-    const codingOverlayForWrite = explicitWriteNamespace
-      ? null
-      : resolveCodingNamespaceOverlay(
-          this.getCodingContextForSession(sessionKey),
-          this.config.codingMode,
-          this.config.defaultNamespace,
-        );
-    const scopeProfileWritePlan = explicitWriteNamespace
-      ? null
-      : resolveScopeProfilePlan({
-          config: this.config,
-          principal,
-          codingContext: sessionKey
-            ? this.getCodingContextForSession(sessionKey)
-            : null,
-          codingOverlay: codingOverlayForWrite,
-        });
+    const codingContextForWrite = sessionKey
+      ? this.getCodingContextForSession(sessionKey)
+      : null;
+    const codingOverlayForWrite = resolveCodingNamespaceOverlay(
+      codingContextForWrite,
+      this.config.codingMode,
+      this.config.defaultNamespace,
+    );
+    const scopeProfileGatePlan = resolveScopeProfilePlan({
+      config: this.config,
+      principal,
+      codingContext: codingContextForWrite,
+      codingOverlay: codingOverlayForWrite,
+    });
+    const scopeProfileWritePlan = explicitWriteNamespace ? null : scopeProfileGatePlan;
     if (scopeProfileWritePlan) {
       const selectedLayer = scopeProfileWritePlan.layers.find(
         (layer) => layer.id === scopeProfileWritePlan.writeLayer,
@@ -13175,7 +13189,7 @@ export class Orchestrator {
       // Pass the KNOWN base namespace (NHIdx) so the catalog write touch records the
       // real namespace rather than a guess decoded from the storage dir.
       selfNamespace,
-      scopeProfileWritePlan,
+      scopeProfileGatePlan,
     );
     let postPersistMetadataFailed = false;
     meta ??= await storage.loadMeta();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -325,6 +325,7 @@ import {
 import {
   expandScopeProfileReadNamespaces,
   resolveScopeProfilePlan,
+  type ResolvedScopeProfilePlan,
 } from "./namespaces/scope-profiles.js";
 import {
   combineNamespaces,
@@ -13127,6 +13128,7 @@ export class Orchestrator {
       // Pass the KNOWN base namespace (NHIdx) so the catalog write touch records the
       // real namespace rather than a guess decoded from the storage dir.
       selfNamespace,
+      scopeProfileWritePlan,
     );
     let postPersistMetadataFailed = false;
     meta ??= await storage.loadMeta();
@@ -13697,6 +13699,7 @@ export class Orchestrator {
     threadIdForExtraction?: string | null,
     sourceContext?: { sessionKey?: string; principal?: string; validAt?: string },
     baseNamespace?: string,
+    scopeProfileWritePlan?: ResolvedScopeProfilePlan | null,
   ): Promise<string[]> {
     // Inline source attribution (issue #369). When enabled, every extracted
     // fact is rewritten to carry a compact provenance tag inside its body so
@@ -14514,8 +14517,21 @@ export class Orchestrator {
         fact.scope === "global" &&
         !routedNamespaceExplicit
       ) {
+        const sharedProfileLayer = scopeProfileWritePlan?.layers.find(
+          (layer) =>
+            layer.id === "serverShared" &&
+            layer.namespace === this.config.sharedNamespace,
+        );
+        const profileAllowsSharedScopeRouting =
+          !scopeProfileWritePlan ||
+          Boolean(
+            scopeProfileWritePlan.profile.readOrder.includes("serverShared") &&
+              scopeProfileWritePlan.readNamespaces.includes(this.config.sharedNamespace) &&
+              sharedProfileLayer?.readable &&
+              sharedProfileLayer.writable,
+          );
         const currentNs = this.namespaceFromStorageDir(targetStorage.dir);
-        if (currentNs !== this.config.sharedNamespace) {
+        if (currentNs !== this.config.sharedNamespace && profileAllowsSharedScopeRouting) {
           try {
             targetStorage = await this.storageRouter.storageFor(
               this.config.sharedNamespace,
@@ -14529,6 +14545,10 @@ export class Orchestrator {
               `scope-routing: failed to resolve shared namespace storage; writing to session namespace (fail-open): ${scopeRouteErr}`,
             );
           }
+        } else if (currentNs !== this.config.sharedNamespace) {
+          log.debug(
+            `scope-routing: skipped shared namespace for global fact because active scope profile ${scopeProfileWritePlan?.profileId ?? "none"} does not authorize serverShared writes`,
+          );
         }
       }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7879,7 +7879,7 @@ export class Orchestrator {
             },
           });
     const profileStorageDirs = Array.from(
-      new Set(profileStorages.map((storage) => storage.dir).filter((dir): dir is string => dir.length > 0)),
+      new Set(profileStorages.map((storage) => storage.dir).filter((dir): dir is string => typeof dir === "string" && dir.length > 0)),
     );
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
@@ -9107,7 +9107,7 @@ export class Orchestrator {
                       const merged: ParallelSearchResult[] = [];
                       const seen = new Set<string>();
                       for (const result of groups.flat()) {
-                        const key = result.path ?? JSON.stringify(result);
+                        const key = (result as any).path ?? JSON.stringify(result);
                         if (seen.has(key)) continue;
                         seen.add(key);
                         merged.push(result);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7993,6 +7993,14 @@ export class Orchestrator {
       )
         return null;
       if (!this.sharedContext) return null;
+      if (
+        scopeProfilePlan &&
+        !(
+          scopeProfilePlan.profile.readOrder.includes("serverShared") &&
+          scopeProfilePlan.readNamespaces.includes(this.config.sharedNamespace)
+        )
+      )
+        return null;
       const t0 = Date.now();
       const [priorities, roundtable, crossSignals] = await Promise.all([
         this.sharedContext.readPriorities(),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5829,7 +5829,7 @@ export class Orchestrator {
     if (expectedSnapshot === null) return;
     if (expectedSnapshot.plannerMode === "no_recall") return;
 
-    const principal = resolvePrincipal(sessionKey, this.config);
+    const principal = principalOverride ?? resolvePrincipal(sessionKey, this.config);
     // Coding-agent overlay (issue #569) is applied when the session has a
     // coding context and there is no explicit namespaceOverride — mirrors
     // the main recall path above.
@@ -9720,9 +9720,23 @@ export class Orchestrator {
       ) &&
         this.config.memoryBoxesEnabled &&
         this.config.boxRecallDays > 0
-        ? this.boxBuilderFor(profileStorage)
-            .readRecentBoxes(this.config.boxRecallDays)
-            .catch(() => [] as BoxFrontmatter[])
+        ? Promise.all(
+            profileStorages.map((storage) =>
+              this.boxBuilderFor(storage)
+                .readRecentBoxes(this.config.boxRecallDays)
+                .catch(() => [] as BoxFrontmatter[]),
+            ),
+          ).then((groups) => {
+            const boxes: BoxFrontmatter[] = [];
+            const seen = new Set<string>();
+            for (const box of groups.flat()) {
+              const key = JSON.stringify(box);
+              if (seen.has(key)) continue;
+              seen.add(key);
+              boxes.push(box);
+            }
+            return boxes;
+          })
         : Promise.resolve([] as BoxFrontmatter[]),
     );
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12735,6 +12735,23 @@ export class Orchestrator {
             : null,
           codingOverlay: codingOverlayForWrite,
         });
+    if (scopeProfileWritePlan) {
+      const selectedLayer = scopeProfileWritePlan.layers.find(
+        (layer) => layer.id === scopeProfileWritePlan.writeLayer,
+      );
+      if (!selectedLayer?.writable) {
+        log.warn(
+          `runExtraction: skipping scope profile ${scopeProfileWritePlan.profileId} because write layer ${scopeProfileWritePlan.writeLayer} is not writable`,
+        );
+        await clearBuffer();
+        return {
+          status: "skipped",
+          reason: "scope_profile_no_writable_layer",
+          persistedCount: 0,
+          durableOutputCount: 0,
+        };
+      }
+    }
     const selfNamespace =
       explicitWriteNamespace ??
       scopeProfileWritePlan?.writeNamespace ??

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8724,6 +8724,9 @@ export class Orchestrator {
               query: retrievalQuery,
               maxResults,
               boxRecallDays: this.config.boxRecallDays,
+            }).catch((err) => {
+              log.debug(`verified recall directory scan failed: ${err}`);
+              return [] as VerifiedEpisodeResult[];
             }),
           ),
         ).then((groups) => {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13868,19 +13868,28 @@ export class Orchestrator {
           sharedProfileLayer?.readable &&
           sharedProfileLayer.writable,
       );
-    const profileAllowsSharedAutoPromotion = (
+    const sharedAutoPromotionAllows = (
       category: string,
       confidence: number,
     ): boolean => {
-      if (!scopeProfileWritePlan) return true;
+      const actualTier = confidenceTier(confidence);
+      const actualRank = confidenceTierOrder.indexOf(actualTier);
+      if (actualRank === -1) return false;
+      if (!scopeProfileWritePlan) {
+        if (!this.config.autoPromoteToSharedEnabled) return false;
+        if (!this.config.autoPromoteToSharedCategories.includes(category as any))
+          return false;
+        const minimumRank = confidenceTierOrder.indexOf(
+          this.config.autoPromoteMinConfidenceTier,
+        );
+        return minimumRank !== -1 && actualRank <= minimumRank;
+      }
       const autoPromote = scopeProfileWritePlan.profile.autoPromote;
       if (!autoPromote.enabled) return false;
       if (!autoPromote.targets.includes("serverShared")) return false;
       if (!autoPromote.categories.includes(category as any)) return false;
-      const actualTier = confidenceTier(confidence);
-      const actualRank = confidenceTierOrder.indexOf(actualTier);
       const minimumRank = confidenceTierOrder.indexOf(autoPromote.minConfidenceTier);
-      return actualRank !== -1 && minimumRank !== -1 && actualRank <= minimumRank;
+      return minimumRank !== -1 && actualRank <= minimumRank;
     };
     const shouldPromoteToShared = (
       targetStorage: StorageManager,
@@ -13889,9 +13898,8 @@ export class Orchestrator {
     ): boolean => {
       if (
         !this.config.namespacesEnabled ||
-        !this.config.autoPromoteToSharedEnabled ||
         !profileAllowsSharedWrites ||
-        !profileAllowsSharedAutoPromotion(category, confidence)
+        !sharedAutoPromotionAllows(category, confidence)
       )
         return false;
       if (
@@ -13899,15 +13907,7 @@ export class Orchestrator {
         this.config.sharedNamespace
       )
         return false;
-      if (!scopeProfileWritePlan && !this.config.autoPromoteToSharedCategories.includes(category as any))
-        return false;
-      const actualTier = confidenceTier(confidence);
-      const actualRank = confidenceTierOrder.indexOf(actualTier);
-      const minimumRank = confidenceTierOrder.indexOf(
-        this.config.autoPromoteMinConfidenceTier,
-      );
-      if (actualRank === -1 || minimumRank === -1) return false;
-      return actualRank <= minimumRank;
+      return true;
     };
     const promoteMemoryToShared = async (options: {
       sourceStorage: StorageManager;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12709,18 +12709,39 @@ export class Orchestrator {
       options.principalOverride.length > 0
         ? options.principalOverride
         : resolvePrincipal(sessionKey, this.config);
-    // Write path — overlay the coding-agent namespace (issue #569) when the
-    // session has a codingContext and `codingMode.projectScope` is true.
-    // Explicit `writeNamespaceOverride` from callers still wins, matching
-    // pre-#569 semantics.
-    const selfNamespace =
+    // Write path — explicit callers still win. Otherwise, an active hosted
+    // scope profile owns the extraction write target so hook-captured turns land
+    // in the same layer that profile recall searches. Without a profile, preserve
+    // the existing coding-agent overlay behavior (issue #569).
+    const explicitWriteNamespace =
       typeof options.writeNamespaceOverride === "string" &&
       options.writeNamespaceOverride.length > 0
         ? options.writeNamespaceOverride
-        : this.applyCodingNamespaceOverlay(
-            sessionKey,
-            defaultNamespaceForPrincipal(principal, this.config),
-          );
+        : undefined;
+    const codingOverlayForWrite = explicitWriteNamespace
+      ? null
+      : resolveCodingNamespaceOverlay(
+          this.getCodingContextForSession(sessionKey),
+          this.config.codingMode,
+          this.config.defaultNamespace,
+        );
+    const scopeProfileWritePlan = explicitWriteNamespace
+      ? null
+      : resolveScopeProfilePlan({
+          config: this.config,
+          principal,
+          codingContext: sessionKey
+            ? this.getCodingContextForSession(sessionKey)
+            : null,
+          codingOverlay: codingOverlayForWrite,
+        });
+    const selfNamespace =
+      explicitWriteNamespace ??
+      scopeProfileWritePlan?.writeNamespace ??
+      this.applyCodingNamespaceOverlay(
+        sessionKey,
+        defaultNamespaceForPrincipal(principal, this.config),
+      );
     const storage = await this.storageRouter.storageFor(selfNamespace);
     const shouldPersistProcessedFingerprint = targetTurns.some(
       (turn) => turn.persistProcessedFingerprint === true,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8289,10 +8289,9 @@ export class Orchestrator {
       if (!this.config.knowledgeIndexEnabled) return null;
       const t0 = Date.now();
       try {
-        const knowledgeIndexMaxChars = this.getRecallSectionNumber(
-          "knowledge-index",
-          "maxChars",
-        );
+        const knowledgeIndexMaxChars =
+          this.getRecallSectionNumber("knowledge-index", "maxChars") ??
+          this.config.knowledgeIndexMaxChars;
         const knowledgeIndexOptions = {
           maxEntities: this.getRecallSectionNumber(
             "knowledge-index",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9396,14 +9396,30 @@ export class Orchestrator {
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
                 shouldRunAgent("temporal", retrievalQuery, 0)
-                  ? runTemporalAgent(
-                      retrievalQuery,
-                      this.config.memoryDir,
-                      maxPerAgent,
-                      queryAwarePrefilter.candidatePaths,
-                    ).catch((err) => {
-                      log.debug(`TemporalAgent pre-start failed: ${err}`);
-                      return [] as ParallelSearchResult[];
+                  ? Promise.all(
+                      profileStorageDirs.map((memoryDir) =>
+                        runTemporalAgent(
+                          retrievalQuery,
+                          memoryDir,
+                          maxPerAgent,
+                          queryAwarePrefilter.candidatePaths,
+                        ).catch((err) => {
+                          log.debug(`TemporalAgent pre-start failed for ${memoryDir}: ${err}`);
+                          return [] as ParallelSearchResult[];
+                        }),
+                      ),
+                    ).then((groups) => {
+                      const merged: ParallelSearchResult[] = [];
+                      const seen = new Set<string>();
+                      for (const result of groups.flat()) {
+                        const key = (result as any).path ?? JSON.stringify(result);
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        merged.push(result);
+                      }
+                      return merged
+                        .sort((a, b) => b.score - a.score)
+                        .slice(0, maxPerAgent);
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
               ])

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7491,8 +7491,10 @@ export class Orchestrator {
             : null,
           codingOverlay,
         });
+    const profileEffectiveNamespace = scopeProfilePlan?.writeNamespace || scopeProfilePlan?.readNamespaces[0];
     const selfNamespace =
       namespaceOverride ??
+      profileEffectiveNamespace ??
       codingSelfNamespace ??
       principalSelfNamespace;
     let recallNamespaces: string[];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5860,7 +5860,7 @@ export class Orchestrator {
     } else if (observationScopeProfilePlan) {
       observationNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: observationScopeProfilePlan,
-        principalSelfNamespace: observationPrincipalSelf,
+        principalSelfNamespace: observationScopeProfilePlan.baseNamespace,
         codingOverlay: observationCodingOverlay,
         legacyRecallNamespaces: recallNamespacesForPrincipal(principal, this.config),
       });
@@ -7500,7 +7500,7 @@ export class Orchestrator {
     } else if (scopeProfilePlan) {
       recallNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: scopeProfilePlan,
-        principalSelfNamespace,
+        principalSelfNamespace: scopeProfilePlan.baseNamespace,
         codingOverlay,
         legacyRecallNamespaces: readableRecallNamespaces,
       });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7958,6 +7958,21 @@ export class Orchestrator {
                   return null;
                 };
               }
+              if (prop === "readAllMemories") {
+                return async (...args: any[]) => {
+                  const memories: any[] = [];
+                  const seen = new Set<string>();
+                  for (const storage of profileStorages) {
+                    for (const memory of await (storage.readAllMemories as any)(...args)) {
+                      const key = String(memory?.path ?? memory?.frontmatter?.id ?? JSON.stringify(memory));
+                      if (seen.has(key)) continue;
+                      seen.add(key);
+                      memories.push(memory);
+                    }
+                  }
+                  return memories;
+                };
+              }
               return target[prop];
             },
           });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7824,7 +7824,8 @@ export class Orchestrator {
       get(target, prop: string | symbol) {
         if (prop in target) return target[prop];
         if (prop === "readProfile") return async () => "";
-        if (prop === "readQuestions" || prop === "listEntityNames") return async () => [];
+        if (prop === "readQuestions" || prop === "listEntityNames" || prop === "readContinuityIncidents") return async () => [];
+        if (prop === "readIdentityAnchor" || prop === "readIdentityImprovementLoops") return async () => "";
         if (prop === "readEntity" || prop === "readMemoryByPath") return async () => null;
         return async () => [];
       },
@@ -7857,6 +7858,44 @@ export class Orchestrator {
                     }
                   }
                   return merged;
+                };
+              }
+              if (prop === "readIdentityAnchor") {
+                return async () => {
+                  for (const storage of profileStorages) {
+                    const anchor = await storage.readIdentityAnchor();
+                    if (anchor.trim().length > 0) return anchor;
+                  }
+                  return "";
+                };
+              }
+              if (prop === "readIdentityImprovementLoops") {
+                return async () => {
+                  const sections: string[] = [];
+                  const seen = new Set<string>();
+                  for (const storage of profileStorages) {
+                    const loops = (await storage.readIdentityImprovementLoops()).trim();
+                    if (!loops || seen.has(loops)) continue;
+                    seen.add(loops);
+                    sections.push(loops);
+                  }
+                  return sections.join("\n\n");
+                };
+              }
+              if (prop === "readContinuityIncidents") {
+                return async (...args: any[]) => {
+                  const limit = typeof args[0] === "number" && Number.isFinite(args[0]) ? Math.max(0, args[0]) : undefined;
+                  const incidents: any[] = [];
+                  const seen = new Set<string>();
+                  for (const storage of profileStorages) {
+                    for (const incident of await (storage.readContinuityIncidents as any)(...args)) {
+                      const key = JSON.stringify(incident);
+                      if (seen.has(key)) continue;
+                      seen.add(key);
+                      incidents.push(incident);
+                    }
+                  }
+                  return limit === undefined ? incidents : incidents.slice(0, limit);
                 };
               }
               if (prop === "listEntityNames") {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13841,6 +13841,19 @@ export class Orchestrator {
       "inferred",
       "speculative",
     ] as const;
+    const sharedProfileLayer = scopeProfileWritePlan?.layers.find(
+      (layer) =>
+        layer.id === "serverShared" &&
+        layer.namespace === this.config.sharedNamespace,
+    );
+    const profileAllowsSharedWrites =
+      !scopeProfileWritePlan ||
+      Boolean(
+        scopeProfileWritePlan.profile.readOrder.includes("serverShared") &&
+          scopeProfileWritePlan.readNamespaces.includes(this.config.sharedNamespace) &&
+          sharedProfileLayer?.readable &&
+          sharedProfileLayer.writable,
+      );
     const shouldPromoteToShared = (
       targetStorage: StorageManager,
       category: string,
@@ -13848,7 +13861,8 @@ export class Orchestrator {
     ): boolean => {
       if (
         !this.config.namespacesEnabled ||
-        !this.config.autoPromoteToSharedEnabled
+        !this.config.autoPromoteToSharedEnabled ||
+        !profileAllowsSharedWrites
       )
         return false;
       if (
@@ -14564,21 +14578,8 @@ export class Orchestrator {
         fact.scope === "global" &&
         !routedNamespaceExplicit
       ) {
-        const sharedProfileLayer = scopeProfileWritePlan?.layers.find(
-          (layer) =>
-            layer.id === "serverShared" &&
-            layer.namespace === this.config.sharedNamespace,
-        );
-        const profileAllowsSharedScopeRouting =
-          !scopeProfileWritePlan ||
-          Boolean(
-            scopeProfileWritePlan.profile.readOrder.includes("serverShared") &&
-              scopeProfileWritePlan.readNamespaces.includes(this.config.sharedNamespace) &&
-              sharedProfileLayer?.readable &&
-              sharedProfileLayer.writable,
-          );
         const currentNs = this.namespaceFromStorageDir(targetStorage.dir);
-        if (currentNs !== this.config.sharedNamespace && profileAllowsSharedScopeRouting) {
+        if (currentNs !== this.config.sharedNamespace && profileAllowsSharedWrites) {
           try {
             targetStorage = await this.storageRouter.storageFor(
               this.config.sharedNamespace,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7834,12 +7834,22 @@ export class Orchestrator {
     const emptyProfileStorage = new Proxy(
       { dir: path.join(this.config.memoryDir, ".empty-scope-profile") } as any,
       {
-      get(target, prop: string | symbol) {
-        if (prop in target) return target[prop];
-        if (prop === "readProfile") return async () => "";
-        if (prop === "readQuestions" || prop === "listEntityNames" || prop === "readContinuityIncidents") return async () => [];
-        if (prop === "readIdentityAnchor" || prop === "readIdentityImprovementLoops") return async () => "";
-        if (prop === "readEntity" || prop === "readMemoryByPath") return async () => null;
+        get(target, prop: string | symbol) {
+          if (prop in target) return target[prop];
+          if (prop === "readProfile") return async () => "";
+          if (
+            prop === "readQuestions" ||
+            prop === "listEntityNames" ||
+            prop === "readContinuityIncidents"
+          )
+            return async () => [];
+          if (
+            prop === "readIdentityAnchor" ||
+            prop === "readIdentityImprovementLoops"
+          )
+            return async () => "";
+          if (prop === "readEntity" || prop === "readMemoryByPath")
+            return async () => null;
           return async () => [];
         },
       },

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9116,9 +9116,10 @@ export class Orchestrator {
                         if (seen.has(key)) continue;
                         seen.add(key);
                         merged.push(result);
-                        if (merged.length >= maxPerAgent) break;
                       }
-                      return merged;
+                      return merged
+                        .sort((a, b) => b.score - a.score)
+                        .slice(0, maxPerAgent);
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
                 shouldRunAgent("temporal", retrievalQuery, 0)
@@ -9737,7 +9738,13 @@ export class Orchestrator {
               seen.add(key);
               boxes.push(box);
             }
-            return boxes;
+            return boxes.sort((a, b) => {
+              const aTime = Date.parse(a.sealedAt ?? "");
+              const bTime = Date.parse(b.sealedAt ?? "");
+              const aRank = Number.isFinite(aTime) ? aTime : 0;
+              const bRank = Number.isFinite(bTime) ? bTime : 0;
+              return bRank - aRank;
+            });
           })
         : Promise.resolve([] as BoxFrontmatter[]),
     );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7851,6 +7851,10 @@ export class Orchestrator {
                 return async (...args: any[]) => {
                   const merged: any[] = [];
                   const seen = new Set<string>();
+                  const priorityOf = (question: any): number => {
+                    const priority = Number(question?.priority ?? 0);
+                    return Number.isFinite(priority) ? priority : 0;
+                  };
                   for (const storage of profileStorages) {
                     const questions = await (storage.readQuestions as any)(...args);
                     for (const question of questions) {
@@ -7860,7 +7864,11 @@ export class Orchestrator {
                       merged.push(question);
                     }
                   }
-                  return merged;
+                  return merged.sort(
+                    (left, right) =>
+                      priorityOf(right) - priorityOf(left) ||
+                      String(left?.id ?? "").localeCompare(String(right?.id ?? "")),
+                  );
                 };
               }
               if (prop === "readIdentityAnchor") {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13868,6 +13868,20 @@ export class Orchestrator {
           sharedProfileLayer?.readable &&
           sharedProfileLayer.writable,
       );
+    const profileAllowsSharedAutoPromotion = (
+      category: string,
+      confidence: number,
+    ): boolean => {
+      if (!scopeProfileWritePlan) return true;
+      const autoPromote = scopeProfileWritePlan.profile.autoPromote;
+      if (!autoPromote.enabled) return false;
+      if (!autoPromote.targets.includes("serverShared")) return false;
+      if (!autoPromote.categories.includes(category as any)) return false;
+      const actualTier = confidenceTier(confidence);
+      const actualRank = confidenceTierOrder.indexOf(actualTier);
+      const minimumRank = confidenceTierOrder.indexOf(autoPromote.minConfidenceTier);
+      return actualRank !== -1 && minimumRank !== -1 && actualRank <= minimumRank;
+    };
     const shouldPromoteToShared = (
       targetStorage: StorageManager,
       category: string,
@@ -13876,7 +13890,8 @@ export class Orchestrator {
       if (
         !this.config.namespacesEnabled ||
         !this.config.autoPromoteToSharedEnabled ||
-        !profileAllowsSharedWrites
+        !profileAllowsSharedWrites ||
+        !profileAllowsSharedAutoPromotion(category, confidence)
       )
         return false;
       if (
@@ -13884,7 +13899,7 @@ export class Orchestrator {
         this.config.sharedNamespace
       )
         return false;
-      if (!this.config.autoPromoteToSharedCategories.includes(category as any))
+      if (!scopeProfileWritePlan && !this.config.autoPromoteToSharedCategories.includes(category as any))
         return false;
       const actualTier = confidenceTier(confidence);
       const actualRank = confidenceTierOrder.indexOf(actualTier);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -320,6 +320,7 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
+import { resolveScopeProfilePlan } from "./namespaces/scope-profiles.js";
 import {
   combineNamespaces,
   lcmReadSessionIdsForNamespaces,
@@ -5830,9 +5831,22 @@ export class Orchestrator {
     const observationCodingSelf = observationCodingOverlay
       ? combineNamespaces(observationPrincipalSelf, observationCodingOverlay.namespace)
       : null;
+    const observationScopeProfilePlan =
+      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
+        ? null
+        : resolveScopeProfilePlan({
+            config: this.config,
+            principal,
+            codingContext: sessionKey
+              ? this.getCodingContextForSession(sessionKey)
+              : null,
+            codingOverlay: observationCodingOverlay,
+          });
     let observationNamespaces: string[];
     if (namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)) {
       observationNamespaces = [namespaceOverride];
+    } else if (observationScopeProfilePlan?.readNamespaces.length) {
+      observationNamespaces = observationScopeProfilePlan.readNamespaces;
     } else if (observationCodingOverlay && observationCodingSelf) {
       // Rule 42 / parity with the main recall path: substitute the self
       // namespace within the principal's recall list rather than
@@ -7449,6 +7463,16 @@ export class Orchestrator {
     const codingSelfNamespace = codingOverlay
       ? combineNamespaces(principalSelfNamespace, codingOverlay.namespace)
       : null;
+    const scopeProfilePlan = namespaceOverride
+      ? null
+      : resolveScopeProfilePlan({
+          config: this.config,
+          principal,
+          codingContext: sessionKey
+            ? this.getCodingContextForSession(sessionKey)
+            : null,
+          codingOverlay,
+        });
     const selfNamespace =
       namespaceOverride ??
       codingSelfNamespace ??
@@ -7456,6 +7480,8 @@ export class Orchestrator {
     let recallNamespaces: string[];
     if (namespaceOverride) {
       recallNamespaces = [namespaceOverride];
+    } else if (scopeProfilePlan?.readNamespaces.length) {
+      recallNamespaces = scopeProfilePlan.readNamespaces;
     } else if (codingOverlay && codingSelfNamespace) {
       // Substitute the principal's self namespace with the coding-scoped
       // one, and append any read fallbacks (branch→project, PR 3) combined
@@ -7515,7 +7541,9 @@ export class Orchestrator {
     // so the prior round's authorization invariant is preserved.
     const codingOverlaySelfReadable =
       codingOverlay !== null &&
-      readableRecallNamespaces.includes(principalSelfNamespace);
+      (scopeProfilePlan
+        ? scopeProfilePlan.layers.some((layer) => layer.id === "userProject" && layer.readable)
+        : readableRecallNamespaces.includes(principalSelfNamespace));
     let lcmReadNamespaces: string[];
     if (namespaceOverride) {
       // Explicit namespace already read-authorized above (canReadNamespace gate).

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7816,7 +7816,10 @@ export class Orchestrator {
 
     const selfNamespaceReadableForProfileSections =
       !scopeProfilePlan || recallNamespaces.includes(selfNamespace);
-    const profileStorage = await this.storageRouter.storageFor(selfNamespace);
+    const profileStorageNamespace = selfNamespaceReadableForProfileSections
+      ? selfNamespace
+      : recallNamespaces[0] ?? "scope-profile-no-readable-layer";
+    const profileStorage = await this.storageRouter.storageFor(profileStorageNamespace);
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
     throwIfRecallAborted(options.abortSignal);
@@ -7914,7 +7917,6 @@ export class Orchestrator {
     // 1. Profile
     const profilePromise = (async (): Promise<string | null> => {
       if (!this.isRecallSectionEnabled("profile")) return null;
-      if (!selfNamespaceReadableForProfileSections) return null;
       const t0 = Date.now();
       const profile = await profileStorage.readProfile();
       recordRecallSectionMetric({

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13916,14 +13916,28 @@ export class Orchestrator {
           sharedProfileLayer?.readable &&
           sharedProfileLayer.writable,
       );
+    const profileAutoPromotionAllows = (
+      category: string,
+      confidence: number,
+    ): boolean => {
+      if (!scopeProfileWritePlan) return false;
+      const actualTier = confidenceTier(confidence);
+      const actualRank = confidenceTierOrder.indexOf(actualTier);
+      if (actualRank === -1) return false;
+      const autoPromote = scopeProfileWritePlan.profile.autoPromote;
+      if (!autoPromote.enabled) return false;
+      if (!autoPromote.categories.includes(category as any)) return false;
+      const minimumRank = confidenceTierOrder.indexOf(autoPromote.minConfidenceTier);
+      return minimumRank !== -1 && actualRank <= minimumRank;
+    };
     const sharedAutoPromotionAllows = (
       category: string,
       confidence: number,
     ): boolean => {
-      const actualTier = confidenceTier(confidence);
-      const actualRank = confidenceTierOrder.indexOf(actualTier);
-      if (actualRank === -1) return false;
       if (!scopeProfileWritePlan) {
+        const actualTier = confidenceTier(confidence);
+        const actualRank = confidenceTierOrder.indexOf(actualTier);
+        if (actualRank === -1) return false;
         if (!this.config.autoPromoteToSharedEnabled) return false;
         if (!this.config.autoPromoteToSharedCategories.includes(category as any))
           return false;
@@ -13932,12 +13946,10 @@ export class Orchestrator {
         );
         return minimumRank !== -1 && actualRank <= minimumRank;
       }
-      const autoPromote = scopeProfileWritePlan.profile.autoPromote;
-      if (!autoPromote.enabled) return false;
-      if (!autoPromote.targets.includes("serverShared")) return false;
-      if (!autoPromote.categories.includes(category as any)) return false;
-      const minimumRank = confidenceTierOrder.indexOf(autoPromote.minConfidenceTier);
-      return minimumRank !== -1 && actualRank <= minimumRank;
+      return (
+        scopeProfileWritePlan.profile.autoPromote.targets.includes("serverShared") &&
+        profileAutoPromotionAllows(category, confidence)
+      );
     };
     const shouldPromoteToShared = (
       targetStorage: StorageManager,
@@ -13957,6 +13969,101 @@ export class Orchestrator {
         return false;
       return true;
     };
+    const promoteMemoryToProfileTargets = async (options: {
+      sourceStorage: StorageManager;
+      category: string;
+      content: string;
+      confidence: number;
+      tags: string[];
+      entityRef?: string;
+      structuredAttributes?: Record<string, string>;
+      sourceMemoryId: string;
+      importance?: ReturnType<typeof scoreImportance>;
+      intentGoal?: string;
+      intentActionType?: string;
+      intentEntityTypes?: string[];
+      memoryKind?: MemoryFrontmatter["memoryKind"];
+      validAt?: string;
+      source: string;
+    }): Promise<void> => {
+      if (
+        !scopeProfileWritePlan ||
+        !profileAutoPromotionAllows(options.category, options.confidence)
+      )
+        return;
+      const autoTargets = new Set(scopeProfileWritePlan.profile.autoPromote.targets);
+      const targets = scopeProfileWritePlan.promotionTargets.filter(
+        (target) =>
+          target.target !== "serverShared" &&
+          autoTargets.has(target.target) &&
+          target.authorized &&
+          target.namespace,
+      );
+      if (targets.length === 0) return;
+      const rawContent =
+        citationEnabled && hasCitationForTemplate(options.content, citationTemplate)
+          ? stripCitationForTemplate(options.content, citationTemplate)
+          : options.content;
+      const citedContent = applyInlineCitation(rawContent);
+      const sanitizedBase = sanitizeMemoryContent(rawContent);
+      const dedupContent =
+        options.category === "fact" &&
+        options.structuredAttributes &&
+        Object.keys(options.structuredAttributes).length > 0
+          ? `${sanitizedBase.text}\n[Attributes: ${normalizeAttributePairs(options.structuredAttributes)}]`
+          : sanitizedBase.text;
+      for (const target of targets) {
+        if (!target.namespace) continue;
+        try {
+          const targetStorage = await this.storageRouter.storageFor(target.namespace);
+          if (targetStorage.dir === options.sourceStorage.dir) continue;
+          if (
+            options.category === "fact" &&
+            (await targetStorage.hasFactContentHash(dedupContent))
+          ) {
+            continue;
+          }
+          const promotedId = await targetStorage.writeMemory(
+            options.category as any,
+            citedContent,
+            {
+              confidence: options.confidence,
+              tags: [...options.tags, `${target.target}-promotion`],
+              entityRef: options.entityRef,
+              structuredAttributes: options.structuredAttributes,
+              source: `${options.source}-${target.target}-promotion`,
+              importance: options.importance,
+              lineage: [options.sourceMemoryId],
+              sourceMemoryId: options.sourceMemoryId,
+              intentGoal: options.intentGoal,
+              intentActionType: options.intentActionType,
+              intentEntityTypes: options.intentEntityTypes,
+              memoryKind: options.memoryKind,
+              validAt: options.validAt,
+              contentHashSource: rawContent,
+            },
+          );
+          this.markCatalogWrite(target.namespace, targetStorage.dir);
+          trackPersistedId(targetStorage, promotedId, { includeReturnedIds: false });
+          await this.indexPersistedMemory(targetStorage, promotedId);
+          trackBehaviorSignals(
+            targetStorage,
+            buildBehaviorSignalsForMemory({
+              memoryId: promotedId,
+              category: options.category as any,
+              content: options.content,
+              namespace: target.namespace,
+              confidence: options.confidence,
+              source: "extraction",
+            }),
+          );
+        } catch (err) {
+          log.warn(
+            `persistExtraction: ${target.target} promotion failed open for ${options.sourceMemoryId}: ${err}`,
+          );
+        }
+      }
+    };
     const promoteMemoryToShared = async (options: {
       sourceStorage: StorageManager;
       category: string;
@@ -13974,6 +14081,7 @@ export class Orchestrator {
       validAt?: string;
       source: string;
     }): Promise<void> => {
+      await promoteMemoryToProfileTargets(options);
       if (
         !shouldPromoteToShared(
           options.sourceStorage,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8289,25 +8289,37 @@ export class Orchestrator {
       if (!this.config.knowledgeIndexEnabled) return null;
       const t0 = Date.now();
       try {
+        const knowledgeIndexMaxChars = this.getRecallSectionNumber(
+          "knowledge-index",
+          "maxChars",
+        );
         const knowledgeIndexOptions = {
           maxEntities: this.getRecallSectionNumber(
             "knowledge-index",
             "maxEntities",
           ),
-          maxChars: this.getRecallSectionNumber("knowledge-index", "maxChars"),
+          maxChars: knowledgeIndexMaxChars,
         };
         const ki = scopeProfilePlan
           ? await (async () => {
+              const perLayerOptions = {
+                ...knowledgeIndexOptions,
+                maxChars: Number.MAX_SAFE_INTEGER,
+              };
               const results = await Promise.all(
                 profileStorages.map((storage) =>
-                  storage.buildKnowledgeIndex(this.config, knowledgeIndexOptions),
+                  storage.buildKnowledgeIndex(this.config, perLayerOptions),
                 ),
               );
               const sections = results
                 .map((result) => result.result.trim())
                 .filter((section) => section.length > 0);
+              const merged = sections.join("\n\n");
               return {
-                result: sections.join("\n\n"),
+                result: this.truncateRecallSectionToBudget(
+                  merged,
+                  knowledgeIndexMaxChars,
+                ),
                 cached: results.every((result) => result.cached),
               };
             })()

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9200,14 +9200,30 @@ export class Orchestrator {
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
                 shouldRunAgent("temporal", retrievalQuery, 0)
-                  ? runTemporalAgent(
-                      retrievalQuery,
-                      this.config.memoryDir,
-                      maxPerAgent,
-                      queryAwarePrefilter.candidatePaths,
-                    ).catch((err) => {
-                      log.debug(`TemporalAgent pre-start failed: ${err}`);
-                      return [] as ParallelSearchResult[];
+                  ? Promise.all(
+                      profileStorageDirs.map((memoryDir) =>
+                        runTemporalAgent(
+                          retrievalQuery,
+                          memoryDir,
+                          maxPerAgent,
+                          queryAwarePrefilter.candidatePaths,
+                        ).catch((err) => {
+                          log.debug(`TemporalAgent pre-start failed: ${err}`);
+                          return [] as ParallelSearchResult[];
+                        }),
+                      ),
+                    ).then((groups) => {
+                      const merged: ParallelSearchResult[] = [];
+                      const seen = new Set<string>();
+                      for (const result of groups.flat()) {
+                        const key = (result as any).path ?? JSON.stringify(result);
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        merged.push(result);
+                      }
+                      return merged
+                        .sort((a, b) => b.score - a.score)
+                        .slice(0, maxPerAgent);
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
               ])

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2484,6 +2484,13 @@ export class Orchestrator {
     searchOptions?: SearchQueryOptions;
     execution?: SearchExecutionOptions;
   }): Promise<QmdSearchResult[]> {
+    if (
+      this.config.namespacesEnabled &&
+      options.namespaces !== undefined &&
+      options.namespaces.length === 0
+    ) {
+      return [];
+    }
     const namespaces = this.config.namespacesEnabled
       ? Array.from(
           new Set(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1896,6 +1896,7 @@ export class Orchestrator {
   private readonly _peerIdBySession = new Map<string, string>();
   private routingRulesStore: RoutingRulesStore | null = null;
   private contentHashIndex: ContentHashIndex | null = null;
+  private readonly contentHashIndexesByStorageDir = new Map<string, ContentHashIndex>();
   private readonly artifactSourceStatusCache = new WeakMap<
     StorageManager,
     {
@@ -2565,6 +2566,79 @@ export class Orchestrator {
 
   invalidateLiveContentHashIndex(): void {
     this.contentHashIndex = null;
+    this.contentHashIndexesByStorageDir.clear();
+  }
+
+  private async contentHashIndexForStorage(
+    targetStorage: StorageManager,
+  ): Promise<ContentHashIndex | null> {
+    if (!this.config.factDeduplicationEnabled) return null;
+
+    if (targetStorage.dir === this.storage.dir) {
+      if (!this.contentHashIndex) {
+        this.contentHashIndex = this.storage.createContentHashIndex();
+        await this.contentHashIndex.load();
+      }
+      return this.contentHashIndex;
+    }
+
+    const cached = this.contentHashIndexesByStorageDir.get(targetStorage.dir);
+    if (cached) return cached;
+
+    const index = targetStorage.createContentHashIndex();
+    await index.load();
+    this.contentHashIndexesByStorageDir.set(targetStorage.dir, index);
+    log.info(
+      `content-hash dedup: loaded ${index.size} hashes for storage ${targetStorage.dir}`,
+    );
+    return index;
+  }
+
+  private async hasContentHashDedup(
+    targetStorage: StorageManager,
+    content: string,
+  ): Promise<boolean> {
+    const index = await this.contentHashIndexForStorage(targetStorage);
+    return index ? index.has(content) : false;
+  }
+
+  private async addContentHashDedup(
+    targetStorage: StorageManager,
+    content: string,
+  ): Promise<void> {
+    const index = await this.contentHashIndexForStorage(targetStorage);
+    if (!index) return;
+    index.add(content);
+  }
+
+  private async removeContentHashForMemory(
+    targetStorage: StorageManager,
+    memory: MemoryFile,
+    context: string,
+  ): Promise<void> {
+    const index = await this.contentHashIndexForStorage(targetStorage);
+    if (!index) return;
+
+    if (memory.frontmatter.contentHash) {
+      index.removeByHash(memory.frontmatter.contentHash);
+      return;
+    }
+
+    log.warn(
+      `[${context}] removing hash for legacy memory ${memory.frontmatter.id ?? "(unknown)"} via content fallback - no contentHash in frontmatter`,
+    );
+    index.remove(memory.content);
+  }
+
+  private async saveContentHashIndexes(): Promise<void> {
+    const indexes = new Set<ContentHashIndex>();
+    if (this.contentHashIndex) indexes.add(this.contentHashIndex);
+    for (const index of this.contentHashIndexesByStorageDir.values()) {
+      indexes.add(index);
+    }
+    for (const index of indexes) {
+      await index.save();
+    }
   }
 
   constructor(config: PluginConfig) {
@@ -4334,28 +4408,13 @@ export class Orchestrator {
             relatedMemoryIds: [canonicalId],
           });
           if (archiveResult) {
-            // Remove from content-hash index.
-            // Use the raw-content hash stored on the frontmatter at write
-            // time (contentHash) — it is format-agnostic and survives any
-            // citation template.  Legacy memories without contentHash are
-            // skipped (see Finding 2 — Urgw).
-            if (this.contentHashIndex) {
-              if (m.frontmatter.contentHash) {
-                // Modern memory: frontmatter.contentHash is already a SHA-256
-                // hex string — use removeByHash to avoid double-hashing.
-                this.contentHashIndex.removeByHash(m.frontmatter.contentHash);
-              } else {
-                // Legacy memory written before contentHash was stored on the
-                // frontmatter.  Pre-#369 facts were stored without inline
-                // citations, so m.content is the raw fact text and we can
-                // remove the hash directly from the content.  This clears
-                // stale dedup entries so the fact can be re-extracted.
-                log.warn(
-                  `[semantic-consolidation] removing hash for legacy memory ${m.frontmatter.id ?? "(unknown)"} via content fallback — no contentHash in frontmatter`,
-                );
-                this.contentHashIndex.remove(m.content);
-              }
-            }
+            // Remove from the same storage-scoped content-hash index that
+            // originally deduped this memory.
+            await this.removeContentHashForMemory(
+              targetStorage,
+              m,
+              "semantic-consolidation",
+            );
             // Best-effort index cleanup: a failure here (e.g. on-disk index save
             // under disk-full) must NOT abort the archival loop and thereby skip
             // the catalog write touch below for an already-durable canonical write
@@ -4409,15 +4468,13 @@ export class Orchestrator {
       }
     }
 
-    // Save hash index if we modified it
-    if (result.memoriesArchived > 0 && this.contentHashIndex) {
-      await this.contentHashIndex
-        .save()
-        .catch((err) =>
-          log.warn(
-            `[semantic-consolidation] content-hash index save failed: ${err}`,
-          ),
-        );
+    // Save hash indexes if we modified them.
+    if (result.memoriesArchived > 0) {
+      await this.saveContentHashIndexes().catch((err) =>
+        log.warn(
+          `[semantic-consolidation] content-hash index save failed: ${err}`,
+        ),
+      );
     }
 
     log.info(
@@ -14823,9 +14880,20 @@ export class Orchestrator {
         writeCategory === "procedure"
           ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
           : canonicalContentForHash;
-      if (this.contentHashIndex && this.contentHashIndex.has(contentHashDedupKey)) {
+      let exactDuplicate = false;
+      try {
+        exactDuplicate = await this.hasContentHashDedup(
+          targetStorage,
+          contentHashDedupKey,
+        );
+      } catch (err) {
+        log.warn(
+          `content-hash dedup lookup failed for storage ${targetStorage.dir}; writing fact fail-open: ${err}`,
+        );
+      }
+      if (exactDuplicate) {
         log.debug(
-          `dedup: skipping duplicate fact "${fact.content.slice(0, 60)}…"`,
+          `dedup: skipping duplicate fact "${fact.content.slice(0, 60)}…" in storage ${targetStorage.dir}`,
         );
         dedupedCount++;
         continue;
@@ -15273,17 +15341,20 @@ export class Orchestrator {
             validAt: sourceContext?.validAt,
             source: extractionWriteSource,
           });
-          // Register chunked content in hash index too.
+          // Register chunked content in the target storage hash index too.
           // Thread 3 fix: canonicalize by stripping any pre-existing citation
-          // so the stored hash matches what the dedup check computes via
-          // stripCitationForTemplate before calling contentHashIndex.has().
-          if (this.contentHashIndex) {
+          // so the stored hash matches what the dedup check computes.
+          try {
             const canonicalChunkedContent =
               citationEnabled &&
               hasCitationForTemplate(fact.content, citationTemplate)
                 ? stripCitationForTemplate(fact.content, citationTemplate)
                 : fact.content;
-            this.contentHashIndex.add(canonicalChunkedContent);
+            await this.addContentHashDedup(targetStorage, canonicalChunkedContent);
+          } catch (err) {
+            log.warn(
+              `content-hash dedup registration failed for chunked memory ${parentId}: ${err}`,
+            );
           }
 
           for (const chunk of chunkResult.chunks) {
@@ -15561,11 +15632,10 @@ export class Orchestrator {
             intentEntityTypes: inferredIntent?.entityTypes,
           });
         }
-        // Register in content-hash index after successful write.
-        // Thread 3 fix: canonicalize by stripping any pre-existing citation so
-        // the stored hash matches what the dedup check computes via
-        // stripCitationForTemplate before calling contentHashIndex.has().
-        if (this.contentHashIndex) {
+        // Register in the target storage content-hash index after successful
+        // write. Thread 3 fix: canonicalize by stripping any pre-existing
+        // citation so the stored hash matches what the dedup check computes.
+        try {
           const canonicalFactContent =
             citationEnabled &&
             hasCitationForTemplate(fact.content, citationTemplate)
@@ -15575,7 +15645,11 @@ export class Orchestrator {
             writeCategory === "procedure"
               ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
               : canonicalFactContent;
-          this.contentHashIndex.add(hashRegisterKey);
+          await this.addContentHashDedup(targetStorage, hashRegisterKey);
+        } catch (err) {
+          log.warn(
+            `content-hash dedup registration failed for memory ${memoryId}: ${err}`,
+          );
         }
       } finally {
         // Catalog touch (issue #1499): record AFTER every synchronous
@@ -15731,12 +15805,10 @@ export class Orchestrator {
       touchBaseNonFactNamespace();
     }
 
-    // Save content-hash index after batch
-    if (this.contentHashIndex) {
-      await this.contentHashIndex
-        .save()
-        .catch((err) => log.warn(`content-hash index save failed: ${err}`));
-    }
+    // Save any content-hash indexes touched during the batch.
+    await this.saveContentHashIndexes().catch((err) =>
+      log.warn(`content-hash index save failed: ${err}`),
+    );
 
     for (const {
       storage: targetStorage,
@@ -17074,27 +17146,13 @@ export class Orchestrator {
       // All criteria met — archive
       const result = await this.storage.archiveMemory(memory);
       if (result) {
-        // Remove from content-hash index since it's no longer in hot search.
-        // Prefer the raw-content hash stored on the frontmatter at write
-        // time (contentHash) — it is format-agnostic and survives any
-        // citation template.
-        if (this.contentHashIndex) {
-          if (memory.frontmatter.contentHash) {
-            // Modern memory: frontmatter.contentHash is already a SHA-256
-            // hex string — use removeByHash to avoid double-hashing.
-            this.contentHashIndex.removeByHash(memory.frontmatter.contentHash);
-          } else {
-            // Legacy memory written before contentHash was stored on the
-            // frontmatter.  Pre-#369 facts were stored without inline
-            // citations, so memory.content is the raw fact text and we can
-            // remove the hash directly from the content.  This clears
-            // stale dedup entries so the fact can be re-extracted.
-            log.warn(
-              `[fact-archival] removing hash for legacy memory ${memory.frontmatter.id ?? "(unknown)"} via content fallback — no contentHash in frontmatter`,
-            );
-            this.contentHashIndex.remove(memory.content);
-          }
-        }
+        // Remove from the same storage-scoped content-hash index since it is
+        // no longer in hot search.
+        await this.removeContentHashForMemory(
+          this.storage,
+          memory,
+          "fact-archival",
+        );
         await this.embeddingFallback.removeFromIndex(memory.frontmatter.id);
         if (
           this.config.queryAwareIndexingEnabled &&
@@ -17112,13 +17170,11 @@ export class Orchestrator {
       }
     }
 
-    // Save hash index if we removed any entries
-    if (archivedCount > 0 && this.contentHashIndex) {
-      await this.contentHashIndex
-        .save()
-        .catch((err) =>
-          log.warn(`content-hash index save failed during archival: ${err}`),
-        );
+    // Save hash indexes if we removed any entries.
+    if (archivedCount > 0) {
+      await this.saveContentHashIndexes().catch((err) =>
+        log.warn(`content-hash index save failed during archival: ${err}`),
+      );
     }
 
     return archivedCount;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7863,7 +7863,7 @@ export class Orchestrator {
               if (prop === "readIdentityAnchor") {
                 return async () => {
                   for (const storage of profileStorages) {
-                    const anchor = await storage.readIdentityAnchor();
+                    const anchor = (await storage.readIdentityAnchor()) ?? "";
                     if (anchor.trim().length > 0) return anchor;
                   }
                   return "";
@@ -7874,7 +7874,7 @@ export class Orchestrator {
                   const sections: string[] = [];
                   const seen = new Set<string>();
                   for (const storage of profileStorages) {
-                    const loops = (await storage.readIdentityImprovementLoops()).trim();
+                    const loops = ((await storage.readIdentityImprovementLoops()) ?? "").trim();
                     if (!loops || seen.has(loops)) continue;
                     seen.add(loops);
                     sections.push(loops);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7869,7 +7869,7 @@ export class Orchestrator {
               if (prop === "readEntity" || prop === "readMemoryByPath") {
                 return async (...args: any[]) => {
                   for (const storage of profileStorages) {
-                    const value = await storage[prop](...args);
+                    const value = await (storage as any)[prop](...args);
                     if (value) return value;
                   }
                   return null;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -249,6 +249,7 @@ import {
   type HarmonicRetrievalResult,
 } from "./harmonic-retrieval.js";
 import {
+  compareVerifiedEpisodeResults,
   searchVerifiedEpisodes,
   type VerifiedEpisodeResult,
 } from "./verified-recall.js";
@@ -8774,13 +8775,12 @@ export class Orchestrator {
           const merged: VerifiedEpisodeResult[] = [];
           const seen = new Set<string>();
           for (const result of groups.flat()) {
-            const key = JSON.stringify(result);
+            const key = result.box.id || JSON.stringify(result);
             if (seen.has(key)) continue;
             seen.add(key);
             merged.push(result);
-            if (merged.length >= maxResults) break;
           }
-          return merged;
+          return merged.sort(compareVerifiedEpisodeResults).slice(0, maxResults);
         }),
         new Promise<[]>((resolve) => {
           timeoutHandle = setTimeout(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7846,7 +7846,7 @@ export class Orchestrator {
                   const merged: any[] = [];
                   const seen = new Set<string>();
                   for (const storage of profileStorages) {
-                    const questions = await storage.readQuestions(...args);
+                    const questions = await (storage.readQuestions as any)(...args);
                     for (const question of questions) {
                       const key = typeof question === "string" ? question : JSON.stringify(question);
                       if (seen.has(key)) continue;
@@ -7861,7 +7861,7 @@ export class Orchestrator {
                 return async (...args: any[]) => {
                   const names = new Set<string>();
                   for (const storage of profileStorages) {
-                    for (const name of await storage.listEntityNames(...args)) names.add(name);
+                    for (const name of await (storage.listEntityNames as any)(...args)) names.add(name);
                   }
                   return [...names];
                 };

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13992,13 +13992,19 @@ export class Orchestrator {
         layer.id === "serverShared" &&
         layer.namespace === this.config.sharedNamespace,
     );
+    const sharedPromotionTarget = scopeProfileWritePlan?.promotionTargets.find(
+      (target) =>
+        target.target === "serverShared" &&
+        target.namespace === this.config.sharedNamespace,
+    );
     const profileAllowsSharedWrites =
       !scopeProfileWritePlan ||
       Boolean(
         scopeProfileWritePlan.profile.readOrder.includes("serverShared") &&
           scopeProfileWritePlan.readNamespaces.includes(this.config.sharedNamespace) &&
           sharedProfileLayer?.readable &&
-          sharedProfileLayer.writable,
+          sharedProfileLayer.writable &&
+          sharedPromotionTarget?.authorized,
       );
     const profileAutoPromotionAllows = (
       category: string,
@@ -14124,9 +14130,31 @@ export class Orchestrator {
               intentEntityTypes: options.intentEntityTypes,
               memoryKind: options.memoryKind,
               validAt: options.validAt,
-              contentHashSource: rawContent,
+              contentHashSource: options.category === "fact" ? dedupContent : rawContent,
             },
           );
+          if (
+            this.config.temporalSupersessionEnabled &&
+            options.category === "fact" &&
+            options.entityRef &&
+            options.structuredAttributes &&
+            Object.keys(options.structuredAttributes).length > 0
+          ) {
+            try {
+              await applyTemporalSupersession({
+                storage: targetStorage,
+                newMemoryId: promotedId,
+                entityRef: options.entityRef,
+                structuredAttributes: options.structuredAttributes,
+                createdAt: supersessionOrderingAt(options.validAt),
+                enabled: true,
+              });
+            } catch (profileSupersessionErr) {
+              log.warn(
+                `persistExtraction: ${target.target} promotion temporal supersession failed open for promoted ${promotedId}: ${profileSupersessionErr}`,
+              );
+            }
+          }
           this.markCatalogWrite(target.namespace, targetStorage.dir);
           trackPersistedId(targetStorage, promotedId, { includeReturnedIds: false });
           await this.indexPersistedMemory(targetStorage, promotedId);
@@ -14390,11 +14418,10 @@ export class Orchestrator {
             intentEntityTypes: options.intentEntityTypes,
             memoryKind: options.memoryKind,
             validAt: options.validAt,
-            // Index the RAW content hash so hasFactContentHash(rawContent)
-            // returns true on subsequent extractions. Without this, the index
-            // would record the hash of citedContent (which changes every call
-            // due to an updated timestamp), causing duplicate promotions.
-            contentHashSource: rawContent,
+            // Index the same canonical body used by hasFactContentHash above.
+            // For structured facts this includes the normalized Attributes
+            // suffix, matching StorageManager.writeMemory enrichment.
+            contentHashSource: options.category === "fact" ? dedupContent : rawContent,
           },
         );
         // PR #402 Finding 3 fix: run temporal supersession against the shared

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7599,11 +7599,14 @@ export class Orchestrator {
     // session_id set. Single-user / no-overlay recall passes a single-namespace
     // set that collapses to the raw `sessionKey`, so this is `[sessionKey]` —
     // byte-for-byte the pre-#1495 single-key behavior.
-    const lcmReadSessionIds = lcmReadSessionIdsForNamespaces(
-      lcmReadNamespaces,
-      sessionKey,
-      this.config.defaultNamespace,
-    );
+    const lcmReadSessionIds =
+      scopeProfilePlan && !sessionKey
+        ? []
+        : lcmReadSessionIdsForNamespaces(
+            lcmReadNamespaces,
+            sessionKey,
+            this.config.defaultNamespace,
+          );
     // Query an LCM-backed read across the ordered read key set and return the
     // FIRST non-empty result (#1505 fallback-namespace unification). The primary
     // overlay key is tried first; if a branch-scoped session has no rows under its
@@ -7621,9 +7624,12 @@ export class Orchestrator {
     //
     // When the set is a single key (single-user / no-overlay / explicit-namespace),
     // this is exactly one call — unchanged. `lcmSessionId` is `string | undefined`:
-    // a SESSIONLESS recall yields the single `undefined` key so the read runs ONE
-    // archive-wide read with no `session_id` filter (pre-#1505 behavior). NEVER the
-    // literal "default" session id (codex P2).
+    // a legacy SESSIONLESS recall yields the single `undefined` key so the read
+    // runs ONE archive-wide read with no `session_id` filter (pre-#1505 behavior).
+    // Hosted scope profiles are stricter: without a session key there is no
+    // namespace-scoped LCM key to query, so the key set stays empty and LCM cannot
+    // bypass the profile read stack via an archive-wide read. NEVER the literal
+    // "default" session id (codex P2).
     const firstNonEmptyLcmRead = async <T>(
       read: (lcmSessionId: string | undefined) => Promise<T>,
       isEmpty: (value: T) => boolean,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7878,6 +7878,9 @@ export class Orchestrator {
               return target[prop];
             },
           });
+    const profileStorageDirs = Array.from(
+      new Set(profileStorages.map((storage) => storage.dir).filter((dir): dir is string => dir.length > 0)),
+    );
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
     throwIfRecallAborted(options.abortSignal);
@@ -8714,11 +8717,26 @@ export class Orchestrator {
       const VERIFIED_RECALL_TIMEOUT_MS = 15_000;
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       const results = await Promise.race([
-        searchVerifiedEpisodes({
-          memoryDir: profileStorage.dir,
-          query: retrievalQuery,
-          maxResults,
-          boxRecallDays: this.config.boxRecallDays,
+        Promise.all(
+          profileStorageDirs.map((memoryDir) =>
+            searchVerifiedEpisodes({
+              memoryDir,
+              query: retrievalQuery,
+              maxResults,
+              boxRecallDays: this.config.boxRecallDays,
+            }),
+          ),
+        ).then((groups) => {
+          const merged: VerifiedEpisodeResult[] = [];
+          const seen = new Set<string>();
+          for (const result of groups.flat()) {
+            const key = JSON.stringify(result);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            merged.push(result);
+            if (merged.length >= maxResults) break;
+          }
+          return merged;
         }),
         new Promise<[]>((resolve) => {
           timeoutHandle = setTimeout(
@@ -9074,13 +9092,28 @@ export class Orchestrator {
           this.config.parallelRetrievalEnabled && maxPerAgent > 0
             ? Promise.all([
                 shouldRunAgent("direct", retrievalQuery, 0)
-                  ? runDirectAgent(
-                      retrievalQuery,
-                      profileStorage.dir,
-                      maxPerAgent,
-                    ).catch((err) => {
-                      log.debug(`DirectAgent pre-start failed: ${err}`);
-                      return [] as ParallelSearchResult[];
+                  ? Promise.all(
+                      profileStorageDirs.map((memoryDir) =>
+                        runDirectAgent(
+                          retrievalQuery,
+                          memoryDir,
+                          maxPerAgent,
+                        ).catch((err) => {
+                          log.debug(`DirectAgent pre-start failed: ${err}`);
+                          return [] as ParallelSearchResult[];
+                        }),
+                      ),
+                    ).then((groups) => {
+                      const merged: ParallelSearchResult[] = [];
+                      const seen = new Set<string>();
+                      for (const result of groups.flat()) {
+                        const key = result.path ?? JSON.stringify(result);
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        merged.push(result);
+                        if (merged.length >= maxPerAgent) break;
+                      }
+                      return merged;
                     })
                   : Promise.resolve([] as ParallelSearchResult[]),
                 shouldRunAgent("temporal", retrievalQuery, 0)

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5864,6 +5864,8 @@ export class Orchestrator {
       observationNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: observationScopeProfilePlan,
         principalSelfNamespace: observationScopeProfilePlan.baseNamespace,
+        config: this.config,
+        principal,
         codingOverlay: observationCodingOverlay,
         legacyRecallNamespaces: recallNamespacesForPrincipal(principal, this.config),
       });
@@ -7506,6 +7508,8 @@ export class Orchestrator {
       recallNamespaces = expandScopeProfileReadNamespaces({
         profilePlan: scopeProfilePlan,
         principalSelfNamespace: scopeProfilePlan.baseNamespace,
+        config: this.config,
+        principal,
         codingOverlay,
         legacyRecallNamespaces: readableRecallNamespaces,
       });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7818,8 +7818,19 @@ export class Orchestrator {
       !scopeProfilePlan || recallNamespaces.includes(selfNamespace);
     const profileStorageNamespace = selfNamespaceReadableForProfileSections
       ? selfNamespace
-      : recallNamespaces[0] ?? "scope-profile-no-readable-layer";
-    const profileStorage = await this.storageRouter.storageFor(profileStorageNamespace);
+      : recallNamespaces[0];
+    const emptyProfileStorage = new Proxy({ dir: "" } as any, {
+      get(target, prop: string | symbol) {
+        if (prop in target) return target[prop as keyof typeof target];
+        if (prop === "readProfile") return async () => "";
+        if (prop === "readQuestions" || prop === "listEntityNames") return async () => [];
+        if (prop === "readEntity" || prop === "readMemoryByPath") return async () => null;
+        return async () => [];
+      },
+    });
+    const profileStorage = profileStorageNamespace
+      ? await this.storageRouter.storageFor(profileStorageNamespace)
+      : emptyProfileStorage;
 
     // --- Phase 1: Launch ALL independent data fetches in parallel ---
     throwIfRecallAborted(options.abortSignal);

--- a/packages/remnic-core/src/semantic-rule-verifier.ts
+++ b/packages/remnic-core/src/semantic-rule-verifier.ts
@@ -99,6 +99,18 @@ function scoreVerifiedSemanticRuleCandidate(
   return { score, matchedFields };
 }
 
+export function compareVerifiedSemanticRuleResults(
+  left: VerifiedSemanticRuleResult,
+  right: VerifiedSemanticRuleResult,
+): number {
+  return (
+    right.score - left.score ||
+    right.effectiveConfidence - left.effectiveConfidence ||
+    right.rule.frontmatter.updated.localeCompare(left.rule.frontmatter.updated) ||
+    left.rule.frontmatter.id.localeCompare(right.rule.frontmatter.id)
+  );
+}
+
 export async function searchVerifiedSemanticRules(options: {
   memoryDir: string;
   query: string;
@@ -150,11 +162,6 @@ export async function searchVerifiedSemanticRules(options: {
   }
 
   return candidates
-    .sort(
-      (left, right) =>
-        right.score - left.score
-        || right.effectiveConfidence - left.effectiveConfidence
-        || right.rule.frontmatter.updated.localeCompare(left.rule.frontmatter.updated),
-    )
+    .sort(compareVerifiedSemanticRuleResults)
     .slice(0, options.maxResults);
 }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -442,6 +442,55 @@ export interface CodingContext {
   defaultBranch: string | null;
 }
 
+export type ScopeProfileLayerId =
+  | "userProject"
+  | "teamProject"
+  | "userGlobal"
+  | "serverShared";
+
+export type ScopeProfilePromotionTarget =
+  | ScopeProfileLayerId
+  | "serverShared"
+  | "teamProject"
+  | "userGlobal";
+
+export interface ScopeProfileTeamProjectConfig {
+  /**
+   * Namespace template for team-project layers. Supported placeholders:
+   * `{teamId}`, `{principal}`, `{projectId}`, `{projectHash}`, and
+   * `{projectNamespace}`. The resolved namespace is validated at use time.
+   */
+  namespaceTemplate?: string;
+  /**
+   * Optional trusted team id for this profile. When omitted, the resolver uses
+   * the first configured team whose principal lists include the caller.
+   */
+  teamId?: string;
+}
+
+export interface ScopeProfileAutoPromoteConfig {
+  enabled: boolean;
+  targets: ScopeProfilePromotionTarget[];
+  categories: Array<"fact" | "correction" | "decision" | "preference" | "rule" | "procedure">;
+  minConfidenceTier: ConfidenceTier;
+}
+
+export interface ScopeProfileConfig {
+  readOrder: ScopeProfileLayerId[];
+  writeDefault: ScopeProfileLayerId;
+  promotionTargets: ScopeProfilePromotionTarget[];
+  teamProject?: ScopeProfileTeamProjectConfig;
+  autoPromote: ScopeProfileAutoPromoteConfig;
+}
+
+export interface ScopeTeamConfig {
+  principals: string[];
+  projectNamespaceTemplate?: string;
+  read: string[];
+  write: string[];
+  promote: string[];
+}
+
 /** Configuration for the nightly contradiction-scan cron (issue #520). */
 export interface ContradictionScanConfig {
   /** Master switch for the contradiction scan cron. Default true. */
@@ -1321,6 +1370,9 @@ export interface PluginConfig {
   principalFromSessionKeyRules: PrincipalRule[];
   namespacePolicies: NamespacePolicy[];
   defaultRecallNamespaces: Array<"self" | "shared">;
+  scopeProfiles: Record<string, ScopeProfileConfig>;
+  defaultScopeProfile: string | undefined;
+  teams: Record<string, ScopeTeamConfig>;
   cronRecallMode: CronRecallMode;
   cronRecallAllowlist: string[];
   cronRecallPolicyEnabled: boolean;

--- a/packages/remnic-core/src/verified-recall.ts
+++ b/packages/remnic-core/src/verified-recall.ts
@@ -84,6 +84,15 @@ function resolveVerifiedEpisodeMemoriesFromMap(
   return verified;
 }
 
+export function compareVerifiedEpisodeResults(left: VerifiedEpisodeResult, right: VerifiedEpisodeResult): number {
+  return (
+    right.score - left.score ||
+    right.verifiedEpisodeCount - left.verifiedEpisodeCount ||
+    right.box.sealedAt.localeCompare(left.box.sealedAt) ||
+    left.box.id.localeCompare(right.box.id)
+  );
+}
+
 export async function searchVerifiedEpisodes(options: {
   memoryDir: string;
   query: string;
@@ -128,11 +137,6 @@ export async function searchVerifiedEpisodes(options: {
       verifiedMemoryIds: candidate.verifiedMemories.map((memory) => memory.frontmatter.id),
       matchedFields: [...candidate.matchedFields].sort(),
     }))
-    .sort(
-      (left, right) =>
-        right.score - left.score
-        || right.verifiedEpisodeCount - left.verifiedEpisodeCount
-        || right.box.sealedAt.localeCompare(left.box.sealedAt),
-    )
+    .sort(compareVerifiedEpisodeResults)
     .slice(0, options.maxResults);
 }

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "openclaw-engram",
+  "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
   "version": "9.3.654",
   "kind": "memory",
@@ -23,14 +23,14 @@
       "provider": "openai",
       "method": "api-key",
       "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "OpenAI API key for Remnic memory extraction",
-      "choiceHint": "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
+      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
       "groupId": "remnic-memory",
       "groupLabel": "Remnic memory",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",
-      "cliDescription": "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
       "onboardingScopes": [
         "text-inference"
       ]
@@ -3391,8 +3391,8 @@
           "plugin",
           "gateway"
         ],
-        "default": "plugin",
-        "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -3669,6 +3669,38 @@
         "type": "number",
         "default": 900000,
         "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
+      },
+      "maintenanceNamespaceFanoutEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+      },
+      "maintenanceMaxNamespacesPerCycle": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+      },
+      "maintenanceIncludeProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceIncludeBranchNamespaces": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+      },
+      "maintenanceIncludeTeamProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceNamespaceLockStaleMs": {
+        "type": "number",
+        "default": 600000,
+        "minimum": 1,
+        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
       },
       "localLlmRetry5xxCount": {
         "type": "number",
@@ -4243,6 +4275,136 @@
           "self",
           "shared"
         ]
+      },
+      "scopeProfiles": {
+        "type": "object",
+        "default": {},
+        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "readOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "writeDefault": {
+              "type": "string",
+              "enum": [
+                "userProject",
+                "teamProject",
+                "userGlobal",
+                "serverShared"
+              ]
+            },
+            "promotionTargets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "teamProject": {
+              "type": "object",
+              "properties": {
+                "namespaceTemplate": {
+                  "type": "string"
+                },
+                "teamId": {
+                  "type": "string"
+                }
+              }
+            },
+            "autoPromote": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "targets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "teamProject",
+                      "serverShared",
+                      "userGlobal",
+                      "userProject"
+                    ]
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "minConfidenceTier": {
+                  "type": "string",
+                  "enum": [
+                    "explicit",
+                    "implied",
+                    "inferred",
+                    "speculative"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "defaultScopeProfile": {
+        "type": "string",
+        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+      },
+      "teams": {
+        "type": "object",
+        "default": {},
+        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "principals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "projectNamespaceTemplate": {
+              "type": "string"
+            },
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "promote": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
       },
       "cronRecallMode": {
         "type": "string",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "openclaw-remnic",
+  "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
   "version": "9.3.654",
   "kind": "memory",

--- a/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
+++ b/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
@@ -17,27 +17,4 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 const manifest = JSON.parse(raw);
 manifest.id = "openclaw-engram";
 manifest.version = packageJson.version;
-manifest.providerAuthChoices = [
-  {
-    provider: "openai",
-    method: "api-key",
-    choiceId: "remnic-openai-api-key",
-    choiceLabel: "OpenAI API key for Remnic memory extraction",
-    choiceHint:
-      "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
-    groupId: "remnic-memory",
-    groupLabel: "Remnic memory",
-    optionKey: "openaiApiKey",
-    cliFlag: "--openai-api-key",
-    cliOption: "--openai-api-key <key>",
-    cliDescription:
-      "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
-    onboardingScopes: ["text-inference"],
-  },
-];
-if (manifest.configSchema?.properties?.modelSource) {
-  manifest.configSchema.properties.modelSource.default = "plugin";
-  manifest.configSchema.properties.modelSource.description =
-    "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[]).";
-}
 await writeFile(target, JSON.stringify(manifest, null, 2) + "\n");

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3896,6 +3896,65 @@ test("access service recall surfaces budgetWarning when over soft limit", async 
   assert.equal(res2.budgetWarning!.reason, "warn-over-soft");
 });
 
+
+
+test("access service recall treats profile self namespace as own namespace for budget", async () => {
+  let recallCalls = 0;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["self"],
+      scopeProfiles: {
+        hosted: {
+          readOrder: ["userGlobal"],
+          writeDefault: "userGlobal",
+          promotionTargets: [],
+        },
+      },
+      defaultScopeProfile: "hosted",
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: true,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 0,
+      recallCrossNamespaceBudgetHardLimit: 2,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => {
+      recallCalls += 1;
+      return "ctx";
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getCodingContextForSession: () => null,
+    getStorage: async () => ({
+      dir: "/tmp/engram",
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  } as any);
+
+  for (let i = 0; i < 3; i += 1) {
+    const response = await service.recall({
+      query: "profile self recall " + i,
+      sessionKey: "agent:pi-geek:chat",
+      authenticatedPrincipal: "pi-geek",
+    });
+    assert.equal(response.context, "ctx");
+    assert.equal(response.budgetWarning, undefined);
+  }
+  assert.equal(recallCalls, 3);
+});
+
 test("access service liveConnectorsRun enforces write ACL before ingestion", async () => {
   let runCount = 0;
   const orchestrator = {

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -221,39 +221,22 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
         openai: ["OPENAI_API_KEY"],
       },
     );
-    const expectedAuthChoice = manifest.id === "openclaw-engram"
-      ? {
-          provider: "openai",
-          method: "api-key",
-          choiceId: "remnic-openai-api-key",
-          choiceLabel: "OpenAI API key for Remnic memory extraction",
-          choiceHint:
-            "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
-          groupId: "remnic-memory",
-          groupLabel: "Remnic memory",
-          optionKey: "openaiApiKey",
-          cliFlag: "--openai-api-key",
-          cliOption: "--openai-api-key <key>",
-          cliDescription:
-            "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
-          onboardingScopes: ["text-inference"],
-        }
-      : {
-          provider: "openai",
-          method: "api-key",
-          choiceId: "remnic-openai-api-key",
-          choiceLabel: "Optional OpenAI API key for Remnic plugin-mode extraction",
-          choiceHint:
-            "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
-          groupId: "remnic-memory",
-          groupLabel: "Remnic memory",
-          optionKey: "openaiApiKey",
-          cliFlag: "--openai-api-key",
-          cliOption: "--openai-api-key <key>",
-          cliDescription:
-            "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
-          onboardingScopes: ["text-inference"],
-        };
+    const expectedAuthChoice = {
+      provider: "openai",
+      method: "api-key",
+      choiceId: "remnic-openai-api-key",
+      choiceLabel: "Optional OpenAI API key for Remnic plugin-mode extraction",
+      choiceHint:
+        "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
+      groupId: "remnic-memory",
+      groupLabel: "Remnic memory",
+      optionKey: "openaiApiKey",
+      cliFlag: "--openai-api-key",
+      cliOption: "--openai-api-key <key>",
+      cliDescription:
+        "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
+      onboardingScopes: ["text-inference"],
+    };
     assert.deepEqual(manifest.providerAuthChoices, [
       expectedAuthChoice,
     ]);

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -219,6 +219,79 @@ test("scope profile shared reads do not imply automatic shared promotion", async
   }
 });
 
+test("scope profile auto-promotion does not require legacy global promotion", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-scope-profile-promo-enabled-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [
+        { name: "default", read: ["default"], write: ["default"] },
+        { name: "shared", read: ["default"], write: ["default"] },
+      ],
+      defaultScopeProfile: "hosted",
+      scopeProfiles: {
+        hosted: {
+          readOrder: ["userGlobal", "serverShared"],
+          writeDefault: "userGlobal",
+          promotionTargets: ["serverShared"],
+          autoPromote: {
+            enabled: true,
+            targets: ["serverShared"],
+            categories: ["fact"],
+            minConfidenceTier: "implied",
+          },
+        },
+      },
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+    assert.equal(config.autoPromoteToSharedEnabled, false, "legacy promotion remains disabled");
+
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    const sourceStorage = await orchestrator.getStorage("default");
+    await sourceStorage.ensureDirectories();
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    await orchestrator.persistExtraction(
+      {
+        facts: [
+          {
+            content: "Profile-native promotion should reach shared.",
+            category: "fact",
+            confidence: 0.95,
+            tags: ["scope-profile"],
+          },
+        ],
+        entities: [],
+        questions: [],
+        profileUpdates: [],
+      },
+      sourceStorage,
+      null,
+      { sessionKey: "s1", principal: "default" },
+    );
+
+    await orchestrator.namespaceCatalog.markRead("shared");
+
+    const sharedRecord = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(
+      sharedRecord?.lastWriteAt,
+      "active scope profile autoPromote.enabled should promote without the legacy global flag",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("shared promotion records catalog write after shared temporal supersession", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-order-"));
   try {

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -149,6 +149,76 @@ test("persistExtraction shared promotion records a shared-namespace catalog writ
   }
 });
 
+test("scope profile shared reads do not imply automatic shared promotion", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-scope-profile-promo-gate-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      namespaceCatalogEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      autoPromoteToSharedEnabled: true,
+      autoPromoteToSharedCategories: ["fact"],
+      autoPromoteMinConfidenceTier: "implied",
+      namespacePolicies: [
+        { name: "default", read: ["default"], write: ["default"] },
+        { name: "shared", read: ["default"], write: ["default"] },
+      ],
+      defaultScopeProfile: "hosted",
+      scopeProfiles: {
+        hosted: {
+          readOrder: ["userGlobal", "serverShared"],
+          writeDefault: "userGlobal",
+          promotionTargets: ["serverShared"],
+          autoPromote: { enabled: false, targets: ["serverShared"] },
+        },
+      },
+      memoryLinkingEnabled: false,
+      inlineSourceAttributionEnabled: false,
+    });
+
+    const orchestrator = new Orchestrator(config) as any;
+    orchestrator.qmd = { isAvailable: () => false };
+
+    const sourceStorage = await orchestrator.getStorage("default");
+    await sourceStorage.ensureDirectories();
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+
+    await orchestrator.persistExtraction(
+      {
+        facts: [
+          {
+            content: "Profile-gated promotion should stay private.",
+            category: "fact",
+            confidence: 0.95,
+            tags: ["scope-profile"],
+          },
+        ],
+        entities: [],
+        questions: [],
+        profileUpdates: [],
+      },
+      sourceStorage,
+      null,
+      { sessionKey: "s1", principal: "default" },
+    );
+
+    await orchestrator.namespaceCatalog.markRead("shared");
+
+    const sharedRecord = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
+    assert.ok(
+      !sharedRecord?.lastWriteAt,
+      "shared read/write access must not bypass the active profile autoPromote gate",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("shared promotion records catalog write after shared temporal supersession", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-order-"));
   try {

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
+import { resolveScopeProfilePlan } from "../src/namespaces/scope-profiles.js";
 
 // ── Round 2, Issue B (cursor[bot] Medium): a shared-namespace promotion writes
 // to the shared namespace via `sharedStorage.writeMemory`, but round 1 only
@@ -188,6 +189,14 @@ test("scope profile shared reads do not imply automatic shared promotion", async
     const sharedStorage = await orchestrator.getStorage("shared");
     await sharedStorage.ensureDirectories();
 
+    const scopeProfileWritePlan = resolveScopeProfilePlan({
+      config,
+      principal: "default",
+      codingContext: null,
+      codingOverlay: null,
+    });
+    assert.ok(scopeProfileWritePlan);
+
     await orchestrator.persistExtraction(
       {
         facts: [
@@ -205,6 +214,8 @@ test("scope profile shared reads do not imply automatic shared promotion", async
       sourceStorage,
       null,
       { sessionKey: "s1", principal: "default" },
+      scopeProfileWritePlan.baseNamespace,
+      scopeProfileWritePlan,
     );
 
     await orchestrator.namespaceCatalog.markRead("shared");
@@ -261,6 +272,14 @@ test("scope profile auto-promotion does not require legacy global promotion", as
     const sharedStorage = await orchestrator.getStorage("shared");
     await sharedStorage.ensureDirectories();
 
+    const scopeProfileWritePlan = resolveScopeProfilePlan({
+      config,
+      principal: "default",
+      codingContext: null,
+      codingOverlay: null,
+    });
+    assert.ok(scopeProfileWritePlan);
+
     await orchestrator.persistExtraction(
       {
         facts: [
@@ -278,6 +297,8 @@ test("scope profile auto-promotion does not require legacy global promotion", as
       sourceStorage,
       null,
       { sessionKey: "s1", principal: "default" },
+      scopeProfileWritePlan.baseNamespace,
+      scopeProfileWritePlan,
     );
 
     await orchestrator.namespaceCatalog.markRead("shared");

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
-import { resolveScopeProfilePlan } from "../src/namespaces/scope-profiles.js";
+import { resolveScopeProfilePlan } from "../packages/remnic-core/src/namespaces/scope-profiles.js";
 
 // ── Round 2, Issue B (cursor[bot] Medium): a shared-namespace promotion writes
 // to the shared namespace via `sharedStorage.writeMemory`, but round 1 only

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -165,8 +165,8 @@ test("scope profile shared reads do not imply automatic shared promotion", async
       autoPromoteToSharedCategories: ["fact"],
       autoPromoteMinConfidenceTier: "implied",
       namespacePolicies: [
-        { name: "default", read: ["default"], write: ["default"] },
-        { name: "shared", read: ["default"], write: ["default"] },
+        { name: "default", readPrincipals: ["default"], writePrincipals: ["default"] },
+        { name: "shared", readPrincipals: ["default"], writePrincipals: ["default"] },
       ],
       defaultScopeProfile: "hosted",
       scopeProfiles: {
@@ -242,8 +242,8 @@ test("scope profile auto-promotion does not require legacy global promotion", as
       defaultNamespace: "default",
       sharedNamespace: "shared",
       namespacePolicies: [
-        { name: "default", read: ["default"], write: ["default"] },
-        { name: "shared", read: ["default"], write: ["default"] },
+        { name: "default", readPrincipals: ["default"], writePrincipals: ["default"] },
+        { name: "shared", readPrincipals: ["default"], writePrincipals: ["default"] },
       ],
       defaultScopeProfile: "hosted",
       scopeProfiles: {

--- a/tests/procedure-recall.test.ts
+++ b/tests/procedure-recall.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
+import { Orchestrator } from "../src/orchestrator.js";
 import { StorageManager } from "../src/storage.ts";
 import { parseConfig } from "../packages/remnic-core/src/config.ts";
 import { buildProcedureRecallSection } from "../packages/remnic-core/src/procedural/procedure-recall.ts";
@@ -57,5 +58,63 @@ test("buildProcedureRecallSection returns null when procedural.enabled is false"
     assert.equal(section, null);
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("scope profile procedure recall merges procedures from later readable layers", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-profile-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [
+        { name: "default", readPrincipals: ["default"], writePrincipals: ["default"] },
+        { name: "shared", readPrincipals: ["default"], writePrincipals: ["default"] },
+      ],
+      defaultScopeProfile: "hosted",
+      scopeProfiles: {
+        hosted: {
+          readOrder: ["userGlobal", "serverShared"],
+          writeDefault: "userGlobal",
+        },
+      },
+      procedural: { enabled: true, recallMaxProcedures: 2 },
+      qmdEnabled: false,
+      knowledgeIndexEnabled: false,
+      identityContinuityEnabled: false,
+      transcriptEnabled: false,
+      injectQuestions: false,
+      hourlySummariesEnabled: false,
+      compoundingEnabled: false,
+      recallPipeline: [
+        { id: "procedure-recall", enabled: true },
+      ],
+    });
+    const orchestrator = new Orchestrator(config) as any;
+    const sharedStorage = await orchestrator.getStorage("shared");
+    await sharedStorage.ensureDirectories();
+    const body = buildProcedureMarkdownBody([
+      { order: 1, intent: "Run deploy checks for production gateway" },
+      { order: 2, intent: "Push the release tag" },
+    ]);
+    const id = await sharedStorage.writeMemory(
+      "procedure",
+      `When you deploy the gateway\n\n${body}`,
+      { source: "test", tags: ["deploy", "gateway"] },
+    );
+
+    const context = await orchestrator.recallInternal(
+      "Let's deploy the gateway to production today",
+      "default",
+    );
+
+    assert.match(context, /## Relevant procedures/);
+    assert.match(context, new RegExp(id));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/tests/procedure-recall.test.ts
+++ b/tests/procedure-recall.test.ts
@@ -115,6 +115,6 @@ test("scope profile procedure recall merges procedures from later readable layer
     assert.match(context, /## Relevant procedures/);
     assert.match(context, new RegExp(id));
   } finally {
-    await rm(memoryDir, { recursive: true, force: true });
+    await rm(memoryDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   }
 });

--- a/tests/shared-context-recall.test.ts
+++ b/tests/shared-context-recall.test.ts
@@ -71,3 +71,61 @@ test("shared context recall injects latest cross-signals summary when available"
     await rm(sharedDir, { recursive: true, force: true });
   }
 });
+
+test("scope profile recall omits shared context when serverShared is not readable", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-profile-memory-"));
+  const sharedDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-profile-shared-"));
+
+  try {
+    const cfg = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [
+        { name: "default", readPrincipals: ["*"], writePrincipals: ["*"] },
+        { name: "shared", readPrincipals: ["*"], writePrincipals: ["*"] },
+      ],
+      defaultScopeProfile: "privateOnly",
+      scopeProfiles: {
+        privateOnly: {
+          readOrder: ["userGlobal"],
+          writeDefault: "userGlobal",
+        },
+      },
+      qmdEnabled: false,
+      sharedContextEnabled: true,
+      sharedContextDir: sharedDir,
+      sharedContextMaxInjectChars: 2400,
+      knowledgeIndexEnabled: false,
+      identityContinuityEnabled: false,
+      transcriptEnabled: false,
+      injectQuestions: false,
+      hourlySummariesEnabled: false,
+      compoundingEnabled: false,
+      recallPipeline: [
+        { id: "shared-context", enabled: true },
+      ],
+    });
+    const orchestrator = new Orchestrator(cfg);
+    assert.ok(orchestrator.sharedContext);
+    await orchestrator.sharedContext!.ensureStructure();
+    await orchestrator.sharedContext!.appendPrioritiesInbox({
+      agentId: "generalist",
+      text: "- Shared priority that a private-only profile must not inject.",
+    });
+
+    const context = await (orchestrator as any).recallInternal(
+      "What shared priority is active?",
+      "default",
+    );
+
+    assert.doesNotMatch(context, /## Shared Context/);
+    assert.doesNotMatch(context, /private-only profile must not inject/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(sharedDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add first-class `scopeProfiles`, `defaultScopeProfile`, and trusted `teams` config for hosted layered memory scopes
- route implicit observe/write and recall planning through a shared scope-profile resolver while preserving legacy behavior when profiles are absent
- expose profile layer diagnostics and promotion target authorization in scope debug output
- document hosted scope profile configuration and add OpenClaw manifest schema entries

Closes #1501
Refs #1494

## Verification

- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/namespaces/scope-profiles.test.ts packages/remnic-core/src/access-service-observe-scope.test.ts`
- `npm run preflight:quick`
- `npm run test:entity-hardening`

Cursor CLI was not available on this host, so `npm run review:cursor` could not be run locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how principals resolve read/write namespaces, recall, LCM, and extraction across team and project layers—core multi-tenant isolation and authorization boundaries.
> 
> **Overview**
> Adds optional **hosted scope profiles** (`scopeProfiles`, `defaultScopeProfile`, `teams`) so multi-user deployments can define ordered read layers (`userProject`, `teamProject`, `userGlobal`, `serverShared`), default write targets, and authorized promotion aliases. When no profile is active, behavior stays on `defaultRecallNamespaces`.
> 
> **Core routing** goes through a new `resolveScopeProfilePlan` / `expandScopeProfileReadNamespaces` path in `access-service` and the orchestrator: implicit observe/write scope, recall budget namespaces, `memorySearch`, `lcmSearch`, and raw LCM excerpts all honor the profile read stack. Observe responses expose richer `scopeDebug` (profile id, write layer, layers, promotion targets). Writes fail closed when the profile has no writable layer inside the read stack; team-project namespaces are derived from trusted config/templates, not caller-supplied strings.
> 
> **Related hardening:** multi-key LCM reads use `Promise.allSettled` so one bad key does not drop sibling profile namespaces; explicit empty `lcmSessionIds` / `sessionIds` no longer collapse to an unscoped session key; legacy `namespace` response fields distinguish user-project coding overlays from hosted layers like `teamProject`; extraction dedup tests assert exact-match dedup is per-namespace storage.
> 
> Docs and OpenClaw plugin JSON schema document the new settings and a hosted coding example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1d5269ac3f2a16184117541f2f633511849598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->