### PR TITLE
ci: add structural ratchets (god-file LOC, oversized-file count, scattered feature-gate reads)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Review pattern check
         run: bash scripts/check-review-patterns.sh
 
+      - name: Structural ratchets
+        run: node scripts/check-ratchets.mjs
+
       - name: Tests
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -988,6 +988,7 @@
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
+    "check:ratchets": "node scripts/check-ratchets.mjs",
     "release:bump-changed-packages": "node scripts/bump-changed-packages.mjs",
     "build": "pnpm --filter @remnic/core build && pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * Structural ratchets (issue #1529, epic #1520).
+ *
+ * Fails when structural debt grows past the committed baseline
+ * (scripts/ratchet-baseline.json):
+ *
+ *   1. watchlistLoc            — line counts of the current god files; each
+ *                                file's count may only stay equal or shrink.
+ *   2. oversizedFileCount      — number of non-test .ts files above the
+ *                                oversize threshold under packages/remnic-core/src.
+ *   3. scatteredConfigFlagReads — occurrences of `config.<flag>Enabled` reads
+ *                                outside config.ts (heuristic regex; counts
+ *                                comments/strings too, but the baseline is
+ *                                measured with the same rule, so the ratchet
+ *                                direction stays meaningful).
+ *
+ * Improvements pass and print a reminder to tighten the baseline with:
+ *   node scripts/check-ratchets.mjs --update
+ *
+ * Node stdlib only, no shell-outs — must stay cross-platform (see #1518).
+ *
+ * REMNIC_RATCHET_ROOT / REMNIC_RATCHET_BASELINE are test seams used by
+ * tests/check-ratchets.test.mjs (absolute paths); they are not user-facing
+ * configuration.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = process.env.REMNIC_RATCHET_ROOT
+  ? path.resolve(process.env.REMNIC_RATCHET_ROOT)
+  : path.resolve(SCRIPT_DIR, "..");
+const BASELINE_PATH = process.env.REMNIC_RATCHET_BASELINE
+  ? path.resolve(process.env.REMNIC_RATCHET_BASELINE)
+  : path.join(ROOT, "scripts", "ratchet-baseline.json");
+
+const CORE_SRC = path.join(ROOT, "packages", "remnic-core", "src");
+const DEFAULT_OVERSIZE_THRESHOLD_LOC = 3000;
+
+/** Repo-relative watchlist paths, always stored with forward slashes. */
+const WATCHLIST = [
+  "packages/remnic-core/src/orchestrator.ts",
+  "packages/remnic-core/src/cli.ts",
+  "packages/remnic-core/src/access-service.ts",
+  "packages/remnic-core/src/storage.ts",
+  "packages/remnic-core/src/config.ts",
+];
+
+const FLAG_READ_RE = /\bconfig\.[A-Za-z0-9_]+Enabled\b/g;
+const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".git"]);
+
+function usage() {
+  return [
+    "Usage: node scripts/check-ratchets.mjs [--update]",
+    "",
+    "  (no flags)  compare current metrics against scripts/ratchet-baseline.json;",
+    "              exit 1 if any structural metric grew",
+    "  --update    rewrite the baseline with current metrics (commit the result)",
+    "  --help      show this message",
+  ].join("\n");
+}
+
+function toPosix(relPath) {
+  return relPath.split(path.sep).join("/");
+}
+
+function countLines(filePath) {
+  return readFileSync(filePath, "utf8").split("\n").length;
+}
+
+function isCountedSourceFile(name) {
+  return (
+    name.endsWith(".ts") &&
+    !name.endsWith(".test.ts") &&
+    !name.endsWith(".d.ts")
+  );
+}
+
+/** Recursively list non-test .ts files under dir. Symlinks are skipped. */
+function walkSourceFiles(dir) {
+  const out = [];
+  if (!existsSync(dir)) {
+    return out;
+  }
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIR_NAMES.has(entry.name)) {
+        out.push(...walkSourceFiles(full));
+      }
+    } else if (entry.isFile() && isCountedSourceFile(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectMetrics(oversizeThresholdLoc) {
+  const watchlistLoc = {};
+  for (const relPath of WATCHLIST) {
+    const abs = path.join(ROOT, ...relPath.split("/"));
+    watchlistLoc[relPath] = existsSync(abs) && statSync(abs).isFile() ? countLines(abs) : 0;
+  }
+
+  const sourceFiles = walkSourceFiles(CORE_SRC).sort();
+  const oversizedFiles = [];
+  let scatteredConfigFlagReads = 0;
+  for (const file of sourceFiles) {
+    const relPosix = toPosix(path.relative(ROOT, file));
+    const content = readFileSync(file, "utf8");
+    const lines = content.split("\n").length;
+    if (lines > oversizeThresholdLoc) {
+      oversizedFiles.push({ file: relPosix, lines });
+    }
+    if (relPosix !== "packages/remnic-core/src/config.ts") {
+      const matches = content.match(FLAG_READ_RE);
+      if (matches) {
+        scatteredConfigFlagReads += matches.length;
+      }
+    }
+  }
+
+  return {
+    watchlistLoc,
+    oversizedFiles,
+    oversizedFileCount: oversizedFiles.length,
+    scatteredConfigFlagReads,
+  };
+}
+
+function readBaseline() {
+  if (!existsSync(BASELINE_PATH)) {
+    fail(
+      `baseline not found at ${BASELINE_PATH}. Generate one with ` +
+        "`node scripts/check-ratchets.mjs --update` and commit it.",
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+  } catch (error) {
+    fail(`baseline is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("baseline must be a JSON object");
+  }
+  if (parsed.version !== 1) {
+    fail(`unsupported baseline version ${JSON.stringify(parsed.version)}; expected 1`);
+  }
+  const metrics = parsed.metrics;
+  if (typeof metrics !== "object" || metrics === null) {
+    fail("baseline is missing the metrics object");
+  }
+  if (typeof metrics.watchlistLoc !== "object" || metrics.watchlistLoc === null) {
+    fail("baseline metrics.watchlistLoc must be an object");
+  }
+  for (const key of ["oversizedFileCount", "scatteredConfigFlagReads"]) {
+    if (!Number.isInteger(metrics[key]) || metrics[key] < 0) {
+      fail(`baseline metrics.${key} must be a non-negative integer`);
+    }
+  }
+  const threshold = parsed.oversizeThresholdLoc;
+  if (!Number.isInteger(threshold) || threshold <= 0) {
+    fail("baseline oversizeThresholdLoc must be a positive integer");
+  }
+  return parsed;
+}
+
+function writeBaseline(metrics, oversizeThresholdLoc) {
+  const baseline = {
+    version: 1,
+    note:
+      "Structural ratchets (issue #1529, epic #1520). Counts may only decrease. " +
+      "Regenerate with: node scripts/check-ratchets.mjs --update",
+    oversizeThresholdLoc,
+    metrics: {
+      watchlistLoc: metrics.watchlistLoc,
+      oversizedFileCount: metrics.oversizedFileCount,
+      scatteredConfigFlagReads: metrics.scatteredConfigFlagReads,
+    },
+  };
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+}
+
+function fail(message) {
+  console.error(`[ratchet] ERROR: ${message}`);
+  process.exit(1);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== "--update" && arg !== "--help");
+  if (unknown.length > 0) {
+    console.error(`[ratchet] ERROR: unknown argument(s): ${unknown.join(", ")}`);
+    console.error(usage());
+    process.exit(2);
+  }
+  if (args.includes("--help")) {
+    console.log(usage());
+    return;
+  }
+
+  if (args.includes("--update")) {
+    const metrics = collectMetrics(DEFAULT_OVERSIZE_THRESHOLD_LOC);
+    writeBaseline(metrics, DEFAULT_OVERSIZE_THRESHOLD_LOC);
+    console.log(`[ratchet] baseline written to ${BASELINE_PATH}`);
+    for (const [file, lines] of Object.entries(metrics.watchlistLoc)) {
+      console.log(`[ratchet]   watchlist ${file}: ${lines}`);
+    }
+    console.log(`[ratchet]   oversizedFileCount (> ${DEFAULT_OVERSIZE_THRESHOLD_LOC} LOC): ${metrics.oversizedFileCount}`);
+    console.log(`[ratchet]   scatteredConfigFlagReads: ${metrics.scatteredConfigFlagReads}`);
+    return;
+  }
+
+  const baseline = readBaseline();
+  const threshold = baseline.oversizeThresholdLoc;
+  const current = collectMetrics(threshold);
+  const failures = [];
+  const improvements = [];
+
+  // The baseline and the script's WATCHLIST must describe the same set of
+  // files; a silent mismatch would leave a watchlist file unchecked (or make
+  // a delisted file look like an improvement).
+  for (const file of WATCHLIST) {
+    if (!(file in baseline.metrics.watchlistLoc)) {
+      failures.push(`watchlist file ${file} is missing from the baseline — regenerate with --update`);
+    }
+  }
+  for (const [file, baseLines] of Object.entries(baseline.metrics.watchlistLoc)) {
+    if (!WATCHLIST.includes(file)) {
+      failures.push(
+        `baseline watchlist entry ${file} is no longer in the script watchlist — regenerate with --update`,
+      );
+      continue;
+    }
+    const currentLines = current.watchlistLoc[file] ?? 0;
+    if (currentLines > baseLines) {
+      failures.push(`${file} grew from ${baseLines} to ${currentLines} lines`);
+    } else if (currentLines < baseLines) {
+      improvements.push(`${file}: ${baseLines} -> ${currentLines} lines`);
+    }
+  }
+
+  if (current.oversizedFileCount > baseline.metrics.oversizedFileCount) {
+    const list = current.oversizedFiles
+      .sort((a, b) => b.lines - a.lines || a.file.localeCompare(b.file))
+      .map((entry) => `${entry.file} (${entry.lines})`)
+      .join(", ");
+    failures.push(
+      `files over ${threshold} LOC grew from ${baseline.metrics.oversizedFileCount} ` +
+        `to ${current.oversizedFileCount}: ${list}`,
+    );
+  } else if (current.oversizedFileCount < baseline.metrics.oversizedFileCount) {
+    improvements.push(
+      `oversized files: ${baseline.metrics.oversizedFileCount} -> ${current.oversizedFileCount}`,
+    );
+  }
+
+  if (current.scatteredConfigFlagReads > baseline.metrics.scatteredConfigFlagReads) {
+    failures.push(
+      `scattered config.*Enabled reads grew from ${baseline.metrics.scatteredConfigFlagReads} ` +
+        `to ${current.scatteredConfigFlagReads} (resolve gates through the shared plan instead; see #1523)`,
+    );
+  } else if (current.scatteredConfigFlagReads < baseline.metrics.scatteredConfigFlagReads) {
+    improvements.push(
+      `scattered config.*Enabled reads: ${baseline.metrics.scatteredConfigFlagReads} -> ${current.scatteredConfigFlagReads}`,
+    );
+  }
+
+  if (failures.length > 0) {
+    console.error("[ratchet] structural ratchet exceeded — this change grows debt tracked in #1520:");
+    for (const failure of failures) {
+      console.error(`[ratchet]   - ${failure}`);
+    }
+    console.error(
+      "[ratchet] reduce the metric, or — only with a reviewed justification — run " +
+        "`node scripts/check-ratchets.mjs --update` and commit the new baseline.",
+    );
+    process.exit(1);
+  }
+
+  if (improvements.length > 0) {
+    console.log("[ratchet] improvements detected — consider tightening the baseline (--update):");
+    for (const improvement of improvements) {
+      console.log(`[ratchet]   - ${improvement}`);
+    }
+  }
+  console.log("[ratchet] OK");
+}
+
+main();

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -104,10 +104,20 @@ function walkSourceFiles(dir) {
 }
 
 function collectMetrics(oversizeThresholdLoc) {
+  // `null` marks a watchlist file that is missing on disk. That is never an
+  // improvement: a rename would otherwise evade the per-file ratchet while
+  // the debt lives on under a new name. Missing files fail the check (and
+  // block --update) until the WATCHLIST is deliberately edited.
   const watchlistLoc = {};
+  const missingWatchlistFiles = [];
   for (const relPath of WATCHLIST) {
     const abs = path.join(ROOT, ...relPath.split("/"));
-    watchlistLoc[relPath] = existsSync(abs) && statSync(abs).isFile() ? countLines(abs) : 0;
+    if (existsSync(abs) && statSync(abs).isFile()) {
+      watchlistLoc[relPath] = countLines(abs);
+    } else {
+      watchlistLoc[relPath] = null;
+      missingWatchlistFiles.push(relPath);
+    }
   }
 
   const sourceFiles = walkSourceFiles(CORE_SRC).sort();
@@ -130,6 +140,7 @@ function collectMetrics(oversizeThresholdLoc) {
 
   return {
     watchlistLoc,
+    missingWatchlistFiles,
     oversizedFiles,
     oversizedFileCount: oversizedFiles.length,
     scatteredConfigFlagReads,
@@ -161,6 +172,11 @@ function readBaseline() {
   }
   if (typeof metrics.watchlistLoc !== "object" || metrics.watchlistLoc === null) {
     fail("baseline metrics.watchlistLoc must be an object");
+  }
+  for (const [file, lines] of Object.entries(metrics.watchlistLoc)) {
+    if (!Number.isInteger(lines) || lines < 0) {
+      fail(`baseline metrics.watchlistLoc entry ${file} must be a non-negative integer`);
+    }
   }
   for (const key of ["oversizedFileCount", "scatteredConfigFlagReads"]) {
     if (!Number.isInteger(metrics[key]) || metrics[key] < 0) {
@@ -210,6 +226,12 @@ function main() {
 
   if (args.includes("--update")) {
     const metrics = collectMetrics(DEFAULT_OVERSIZE_THRESHOLD_LOC);
+    if (metrics.missingWatchlistFiles.length > 0) {
+      fail(
+        `cannot write baseline: watchlist file(s) missing on disk: ${metrics.missingWatchlistFiles.join(", ")}. ` +
+          "If a god file was deliberately split or renamed, remove it from WATCHLIST in this script first, then rerun --update.",
+      );
+    }
     writeBaseline(metrics, DEFAULT_OVERSIZE_THRESHOLD_LOC);
     console.log(`[ratchet] baseline written to ${BASELINE_PATH}`);
     for (const [file, lines] of Object.entries(metrics.watchlistLoc)) {
@@ -241,8 +263,13 @@ function main() {
       );
       continue;
     }
-    const currentLines = current.watchlistLoc[file] ?? 0;
-    if (currentLines > baseLines) {
+    const currentLines = current.watchlistLoc[file];
+    if (currentLines === null || currentLines === undefined) {
+      failures.push(
+        `${file} no longer exists but is still ratcheted — if this is a deliberate split/rename, ` +
+          "remove it from WATCHLIST and regenerate the baseline with --update in the same PR",
+      );
+    } else if (currentLines > baseLines) {
       failures.push(`${file} grew from ${baseLines} to ${currentLines} lines`);
     } else if (currentLines < baseLines) {
       improvements.push(`${file}: ${baseLines} -> ${currentLines} lines`);

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -53,6 +53,7 @@ run npm run check-types
 run npm run check-config-contract
 run npm run plugin:inspect
 run bash scripts/check-review-patterns.sh
+run node scripts/check-ratchets.mjs
 run pnpm exec turbo --version
 run_quiet pnpm exec turbo run check-types --dry=json
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "note": "Structural ratchets (issue #1529, epic #1520). Counts may only decrease. Regenerate with: node scripts/check-ratchets.mjs --update",
+  "oversizeThresholdLoc": 3000,
+  "metrics": {
+    "watchlistLoc": {
+      "packages/remnic-core/src/orchestrator.ts": 19884,
+      "packages/remnic-core/src/cli.ts": 9812,
+      "packages/remnic-core/src/access-service.ts": 8277,
+      "packages/remnic-core/src/storage.ts": 7207,
+      "packages/remnic-core/src/config.ts": 4548
+    },
+    "oversizedFileCount": 10,
+    "scatteredConfigFlagReads": 559
+  }
+}

--- a/tests/check-ratchets.test.mjs
+++ b/tests/check-ratchets.test.mjs
@@ -28,7 +28,11 @@ function makeFixture() {
   const root = mkdtempSync(path.join(tmpdir(), "ratchet-test-"));
   const src = path.join(root, "packages", "remnic-core", "src");
   mkdirSync(src, { recursive: true });
+  // Every WATCHLIST file must exist — a missing one fails the check by design.
   writeFileSync(path.join(src, "orchestrator.ts"), "line\n".repeat(10));
+  writeFileSync(path.join(src, "cli.ts"), "export {};\n");
+  writeFileSync(path.join(src, "access-service.ts"), "export {};\n");
+  writeFileSync(path.join(src, "storage.ts"), "export {};\n");
   writeFileSync(path.join(src, "config.ts"), "export const parsed = { fooEnabled: true };\n");
   writeFileSync(
     path.join(src, "widget.ts"),
@@ -130,6 +134,35 @@ test("missing and invalid baselines are rejected with clear errors", () => {
     const invalid = runRatchets([], fixture);
     assert.equal(invalid.status, 1);
     assert.match(invalid.stderr, /not valid JSON/);
+  });
+});
+
+test("a missing watchlist file fails the check instead of counting as improvement", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    rmSync(path.join(fixture.src, "orchestrator.ts"));
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /orchestrator\.ts no longer exists but is still ratcheted/);
+
+    // --update must also refuse until WATCHLIST itself is edited.
+    const update = runRatchets(["--update"], fixture);
+    assert.equal(update.status, 1);
+    assert.match(update.stderr, /remove it from WATCHLIST in this script first/);
+  });
+});
+
+test("non-integer baseline watchlist entries are rejected", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    const baseline = JSON.parse(readFileSync(fixture.baseline, "utf8"));
+    baseline.metrics.watchlistLoc["packages/remnic-core/src/orchestrator.ts"] = "many";
+    writeFileSync(fixture.baseline, JSON.stringify(baseline));
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /must be a non-negative integer/);
   });
 });
 

--- a/tests/check-ratchets.test.mjs
+++ b/tests/check-ratchets.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "scripts",
+  "check-ratchets.mjs",
+);
+
+function runRatchets(args, fixture) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      REMNIC_RATCHET_ROOT: fixture.root,
+      REMNIC_RATCHET_BASELINE: fixture.baseline,
+    },
+  });
+}
+
+function makeFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "ratchet-test-"));
+  const src = path.join(root, "packages", "remnic-core", "src");
+  mkdirSync(src, { recursive: true });
+  writeFileSync(path.join(src, "orchestrator.ts"), "line\n".repeat(10));
+  writeFileSync(path.join(src, "config.ts"), "export const parsed = { fooEnabled: true };\n");
+  writeFileSync(
+    path.join(src, "widget.ts"),
+    "if (config.fooEnabled) {}\nif (config.barEnabled) {}\n",
+  );
+  // Test files must not count toward the flag-read metric.
+  writeFileSync(path.join(src, "widget.test.ts"), "if (config.bazEnabled) {}\n");
+  return { root, src, baseline: path.join(root, "ratchet-baseline.json") };
+}
+
+function withFixture(fn) {
+  const fixture = makeFixture();
+  try {
+    fn(fixture);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+test("--update writes a baseline the check then passes against", () => {
+  withFixture((fixture) => {
+    const update = runRatchets(["--update"], fixture);
+    assert.equal(update.status, 0, update.stderr);
+
+    const baseline = JSON.parse(readFileSync(fixture.baseline, "utf8"));
+    assert.equal(baseline.version, 1);
+    assert.equal(
+      baseline.metrics.watchlistLoc["packages/remnic-core/src/orchestrator.ts"],
+      11,
+    );
+    // widget.ts has 2 reads; widget.test.ts and config.ts are excluded.
+    assert.equal(baseline.metrics.scatteredConfigFlagReads, 2);
+    assert.equal(baseline.metrics.oversizedFileCount, 0);
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 0, check.stderr);
+    assert.match(check.stdout, /\[ratchet\] OK/);
+  });
+});
+
+test("watchlist file growth fails the check", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    appendFileSync(path.join(fixture.src, "orchestrator.ts"), "more\nlines\n");
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /orchestrator\.ts grew from 11 to 13/);
+  });
+});
+
+test("new scattered config flag reads fail the check", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    appendFileSync(path.join(fixture.src, "widget.ts"), "if (config.quxEnabled) {}\n");
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /scattered config\.\*Enabled reads grew from 2 to 3/);
+  });
+});
+
+test("a new oversized file fails the check", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    writeFileSync(path.join(fixture.src, "big.ts"), "pad\n".repeat(3100));
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /files over 3000 LOC grew from 0 to 1/);
+    assert.match(check.stderr, /big\.ts/);
+  });
+});
+
+test("improvements pass and suggest tightening the baseline", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    writeFileSync(path.join(fixture.src, "orchestrator.ts"), "line\n".repeat(5));
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 0, check.stderr);
+    assert.match(check.stdout, /improvements detected/);
+    assert.match(check.stdout, /--update/);
+  });
+});
+
+test("missing and invalid baselines are rejected with clear errors", () => {
+  withFixture((fixture) => {
+    const missing = runRatchets([], fixture);
+    assert.equal(missing.status, 1);
+    assert.match(missing.stderr, /baseline not found/);
+
+    writeFileSync(fixture.baseline, "null\n");
+    const nullBaseline = runRatchets([], fixture);
+    assert.equal(nullBaseline.status, 1);
+    assert.match(nullBaseline.stderr, /baseline must be a JSON object/);
+
+    writeFileSync(fixture.baseline, "{ not json\n");
+    const invalid = runRatchets([], fixture);
+    assert.equal(invalid.status, 1);
+    assert.match(invalid.stderr, /not valid JSON/);
+  });
+});
+
+test("watchlist/baseline drift fails in both directions", () => {
+  withFixture((fixture) => {
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+    const baseline = JSON.parse(readFileSync(fixture.baseline, "utf8"));
+
+    // Baseline entry the script no longer watches.
+    const extra = structuredClone(baseline);
+    extra.metrics.watchlistLoc["packages/remnic-core/src/ghost.ts"] = 5;
+    writeFileSync(fixture.baseline, JSON.stringify(extra));
+    const extraCheck = runRatchets([], fixture);
+    assert.equal(extraCheck.status, 1);
+    assert.match(extraCheck.stderr, /no longer in the script watchlist/);
+
+    // Watchlist file missing from the baseline.
+    const missing = structuredClone(baseline);
+    delete missing.metrics.watchlistLoc["packages/remnic-core/src/orchestrator.ts"];
+    writeFileSync(fixture.baseline, JSON.stringify(missing));
+    const missingCheck = runRatchets([], fixture);
+    assert.equal(missingCheck.status, 1);
+    assert.match(missingCheck.stderr, /missing from the baseline/);
+  });
+});
+
+test("unknown arguments are rejected with usage", () => {
+  withFixture((fixture) => {
+    const result = runRatchets(["--bogus"], fixture);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /unknown argument/);
+    assert.match(result.stderr, /--update/);
+  });
+});


### PR DESCRIPTION
Part of #1520. Closes #1529.

## What

Structural ratchets that fail CI when architectural debt grows. Counts may only stay equal or decrease against a committed baseline:

1. **Watchlist file LOC** — `orchestrator.ts` (19,884), `cli.ts` (9,812), `access-service.ts` (8,277), `storage.ts` (7,207), `config.ts` (4,548)
2. **Oversized-file count** — non-test `.ts` files > 3,000 LOC under `packages/remnic-core/src` (currently 10)
3. **Scattered feature-gate reads** — `config.<flag>Enabled` occurrences outside `config.ts` (currently 559)

## How

- `scripts/check-ratchets.mjs` — Node stdlib only, no shell-outs, cross-platform (cf. #1518); symlinks skipped during the walk; baseline keys stored with forward slashes so the file is OS-stable
- `scripts/ratchet-baseline.json` — committed baseline (`--update` regenerates; growth requires a reviewed justification to touch it)
- Blocking in `scripts/pr-preflight.sh` (quick + full, mandatory gate section) and the CI `quality` job; also exposed as `npm run check:ratchets`
- Regressions exit 1 naming the metric and pointing at #1520; improvements pass with a tighten hint; watchlist/baseline drift fails in both directions; missing/invalid baselines and unknown flags are rejected with explicit errors (CLAUDE.md rules 18/51)

## Tests

`tests/check-ratchets.test.mjs` (8 cases): update-then-pass round trip, watchlist growth fails, new scattered flag read fails, new oversized file fails, improvement passes with tighten hint, missing/null/malformed baseline rejected, watchlist↔baseline drift fails both directions, unknown args rejected with usage.

## Checklist

- [x] All tests pass (new suite 8/8; `preflight:quick`)
- [x] New logic covered by tests
- [x] Pre-commit gates pass locally
- [x] No secrets or personal data
- [x] Diff ≤ 400 LOC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI/preflight tooling and a JSON baseline only; no runtime or product behavior changes.
> 
> **Overview**
> Adds **structural ratchets** that block CI when architectural debt grows past a committed baseline (`scripts/ratchet-baseline.json`). `scripts/check-ratchets.mjs` compares current metrics to that baseline and exits non-zero if any metric increases; `--update` refreshes the baseline after reviewed shrinkage.
> 
> Tracked metrics: **watchlist LOC** for five core god files (may only stay flat or shrink), **count of non-test `.ts` files over 3k LOC** under `packages/remnic-core/src`, and **heuristic `config.*Enabled` reads** outside `config.ts`. Improvements still pass but log a hint to tighten the baseline; watchlist/baseline drift and missing watchlist files are explicit failures.
> 
> Wired into the CI **quality** job, `scripts/pr-preflight.sh`, and `npm run check:ratchets`. `tests/check-ratchets.test.mjs` covers pass/fail paths, baseline validation, and drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29dadec93473f13bda9e3837a8ac461a33830576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->