### PR TITLE
test-infra: self-healing root test runner with honest native-binding signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,10 @@ jobs:
 
       - name: Tests
         run: pnpm test
+        env:
+          # CI rebuilds the native binding above; skipping native-dependent
+          # suites here would silently drop coverage (#1538).
+          REMNIC_REQUIRE_NATIVE_TESTS: "1"
 
       - name: Build
         run: pnpm run build

--- a/scripts/native-dependent-tests.json
+++ b/scripts/native-dependent-tests.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "issue": "#1538",
+  "reason": "These test files require the better-sqlite3 native binding (LCM engine, memory projection store, sqlite import/export, AMB integration). When the binding is unavailable and cannot be rebuilt, the root test runner excludes them with a loud per-file [SKIP] instead of producing ~160 guaranteed failures. CI sets REMNIC_REQUIRE_NATIVE_TESTS=1, which forbids exclusion entirely.",
+  "files": [
+    "integrations/amb/install-remnic-provider.test.mjs",
+    "integrations/amb/run-remnic-amb.test.mjs",
+    "packages/bench/src/adapters/remnic-adapter.test.ts",
+    "packages/import-lossless-claw/src/importer.test.ts",
+    "packages/import-lossless-claw/src/source.test.ts",
+    "packages/remnic-core/src/lcm-engine.test.ts",
+    "packages/remnic-core/src/lcm-recall.test.ts",
+    "packages/remnic-core/src/runtime/better-sqlite.test.ts",
+    "tests/amb-integration.test.ts",
+    "tests/export-import-sqlite.test.ts",
+    "tests/lcm-gateway-summarizer.test.ts",
+    "tests/lcm.test.ts",
+    "tests/memory-projection.test.ts"
+  ]
+}

--- a/scripts/root-test-runner-lib.mjs
+++ b/scripts/root-test-runner-lib.mjs
@@ -128,6 +128,34 @@ export function partitionNativeDependent(files, manifestFiles) {
 }
 
 /**
+ * Greedily chunk argument lists so each spawn's combined argv stays under a
+ * conservative character budget — Windows builds one command line with a low
+ * length limit, so hundreds of explicit file paths cannot go into a single
+ * spawn (cursor review on #1542). A single oversized argument still gets its
+ * own chunk rather than being dropped.
+ */
+export function chunkArgsByLength(args, budgetChars) {
+  if (!Number.isInteger(budgetChars) || budgetChars <= 0) {
+    throw new Error(`chunkArgsByLength: budgetChars must be a positive integer, got ${budgetChars}`);
+  }
+  const chunks = [];
+  let current = [];
+  let currentLength = 0;
+  for (const arg of args) {
+    const cost = arg.length + 1;
+    if (current.length > 0 && currentLength + cost > budgetChars) {
+      chunks.push(current);
+      current = [];
+      currentLength = 0;
+    }
+    current.push(arg);
+    currentLength += cost;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+/**
  * Parse the trailing TAP summary from a node:test run.
  * Returns null when no summary is present (crash before the epilogue).
  */

--- a/scripts/root-test-runner-lib.mjs
+++ b/scripts/root-test-runner-lib.mjs
@@ -1,0 +1,172 @@
+/**
+ * Pure helpers for the root test runner (issue #1538, epic #1520).
+ *
+ * Kept free of process/spawn side effects so tests/root-test-runner-lib.test.mjs
+ * can exercise every branch. Node stdlib only, cross-platform (no shell-outs,
+ * forward-slash-normalized results).
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * The root suite's coverage, as structured entries rather than opaque glob
+ * strings. Each entry must match at least one file at run time — a pattern
+ * that matches nothing is an error (a rename or layout change silently
+ * removing coverage), not a pass.
+ */
+export const TEST_PATTERNS = [
+  { id: "tests/**/*.test.ts", base: "tests", recursive: true, suffix: ".test.ts" },
+  { id: "tests/**/*.test.mjs", base: "tests", recursive: true, suffix: ".test.mjs" },
+  { id: "packages/*/src/**/*.test.ts", base: "packages", packageSrc: true, recursive: true, suffix: ".test.ts" },
+  { id: "packages/*/src/**/*.test.tsx", base: "packages", packageSrc: true, recursive: true, suffix: ".test.tsx" },
+  { id: "dashboard/lib/*.test.ts", base: "dashboard/lib", recursive: false, suffix: ".test.ts" },
+  { id: "integrations/amb/*.test.mjs", base: "integrations/amb", recursive: false, suffix: ".test.mjs" },
+];
+
+const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".git"]);
+
+function toPosix(relPath) {
+  return relPath.split(path.sep).join("/");
+}
+
+function listFiles(dir, recursive) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (recursive && !SKIPPED_DIR_NAMES.has(entry.name)) {
+        out.push(...listFiles(full, true));
+      }
+    } else if (entry.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function packageSrcDirs(repoRoot) {
+  const packagesDir = path.join(repoRoot, "packages");
+  let entries;
+  try {
+    entries = readdirSync(packagesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesDir, entry.name, "src"));
+}
+
+/**
+ * Expand every TEST_PATTERNS entry into repo-relative posix paths.
+ * Returns { files, emptyPatterns } — callers must treat a non-empty
+ * emptyPatterns list as an error (vacuous coverage).
+ */
+export function expandTestPatterns(repoRoot, patterns = TEST_PATTERNS) {
+  const files = new Set();
+  const emptyPatterns = [];
+  for (const pattern of patterns) {
+    const roots = pattern.packageSrc
+      ? packageSrcDirs(repoRoot)
+      : [path.join(repoRoot, ...pattern.base.split("/"))];
+    let matched = 0;
+    for (const root of roots) {
+      for (const file of listFiles(root, pattern.recursive)) {
+        if (file.endsWith(pattern.suffix)) {
+          files.add(toPosix(path.relative(repoRoot, file)));
+          matched += 1;
+        }
+      }
+    }
+    if (matched === 0) {
+      emptyPatterns.push(pattern.id);
+    }
+  }
+  return { files: [...files].sort(), emptyPatterns };
+}
+
+/** Load and validate the native-dependent test manifest. Throws on malformed input. */
+export function loadNativeManifest(manifestPath) {
+  const parsed = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${manifestPath}: manifest must be a JSON object`);
+  }
+  if (parsed.version !== 1) {
+    throw new Error(`${manifestPath}: unsupported manifest version ${JSON.stringify(parsed.version)}`);
+  }
+  if (!Array.isArray(parsed.files) || parsed.files.some((file) => typeof file !== "string")) {
+    throw new Error(`${manifestPath}: manifest files must be an array of strings`);
+  }
+  return { files: [...parsed.files].sort() };
+}
+
+/**
+ * Split expanded test files into runnable vs native-excluded sets.
+ * Manifest entries that match no expanded file are reported as stale so the
+ * manifest cannot silently drift from the tree.
+ */
+export function partitionNativeDependent(files, manifestFiles) {
+  const manifest = new Set(manifestFiles);
+  const run = [];
+  const excluded = [];
+  for (const file of files) {
+    (manifest.has(file) ? excluded : run).push(file);
+  }
+  const fileSet = new Set(files);
+  const stale = manifestFiles.filter((entry) => !fileSet.has(entry));
+  return { run, excluded, stale };
+}
+
+/**
+ * Parse the trailing TAP summary from a node:test run.
+ * Returns null when no summary is present (crash before the epilogue).
+ */
+export function parseTapSummary(output) {
+  const summary = {};
+  for (const key of ["tests", "pass", "fail", "cancelled", "skipped", "todo"]) {
+    const match = output.match(new RegExp(`^# ${key} (\\d+)$`, "m"));
+    if (!match) return null;
+    summary[key] = Number(match[1]);
+  }
+  return summary;
+}
+
+/**
+ * Strong better-sqlite3 probe: importing the JS wrapper succeeds without the
+ * native binary, so only constructing a real database proves the binding
+ * works. Resolves from packages/remnic-core (the depending package) — never
+ * from the repo root, where resolution can walk up into a parent checkout.
+ * REMNIC_FORCE_NATIVE_UNAVAILABLE=1 is a test seam that simulates a broken
+ * binding without touching node_modules.
+ */
+export function probeBetterSqlite3(repoRoot, env = process.env) {
+  if (env.REMNIC_FORCE_NATIVE_UNAVAILABLE === "1") {
+    return { ok: false, reason: "forced unavailable via REMNIC_FORCE_NATIVE_UNAVAILABLE" };
+  }
+  try {
+    const anchor = pathToFileURL(path.join(repoRoot, "packages", "remnic-core", "package.json"));
+    const req = createRequire(anchor);
+    const loaded = req("better-sqlite3");
+    const Database = typeof loaded === "function" ? loaded : loaded?.default;
+    if (typeof Database !== "function") {
+      return { ok: false, reason: "module did not export a constructor" };
+    }
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = MEMORY");
+    db.close();
+    return { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: message.split("\n")[0] };
+  }
+}

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -25,6 +25,8 @@ import { fileURLToPath } from "node:url";
 
 import { appendNodeOption } from "./root-test-runner-env.mjs";
 import {
+  TEST_PATTERNS,
+  chunkArgsByLength,
   expandTestPatterns,
   loadNativeManifest,
   parseTapSummary,
@@ -92,41 +94,69 @@ if (!probe.ok) {
   );
 }
 
-const child = spawn(tsxBin, ["--test", ...filesToRun.map((file) => path.join(repoRoot, ...file.split("/")))], {
-  cwd: repoRoot,
-  env: process.env,
-  stdio: ["inherit", "pipe", "inherit"],
-});
+/** Run one tsx --test invocation, streaming output and parsing its TAP epilogue. */
+function runTsx(testArgs) {
+  return new Promise((resolve) => {
+    const child = spawn(tsxBin, ["--test", ...testArgs], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["inherit", "pipe", "inherit"],
+    });
 
-// Stream stdout live while keeping a bounded tail for the TAP summary parse.
-const TAIL_LIMIT = 64 * 1024;
-let tail = "";
-child.stdout.on("data", (chunk) => {
-  process.stdout.write(chunk);
-  tail = (tail + chunk.toString("utf-8")).slice(-TAIL_LIMIT);
-});
+    // Stream stdout live while keeping a bounded tail for the TAP summary parse.
+    const TAIL_LIMIT = 64 * 1024;
+    let tail = "";
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      tail = (tail + chunk.toString("utf-8")).slice(-TAIL_LIMIT);
+    });
 
-child.on("error", (error) => {
-  console.error(`[root-tests] ERROR: failed to launch ${tsxBin}: ${error.message}`);
-  process.exit(1);
-});
+    child.on("error", (error) => {
+      console.error(`[root-tests] ERROR: failed to launch ${tsxBin}: ${error.message}`);
+      resolve({ status: 1, summary: null });
+    });
 
-child.on("close", (status) => {
-  const summary = parseTapSummary(tail);
+    child.on("close", (status) => {
+      resolve({ status: status ?? 1, summary: parseTapSummary(tail) });
+    });
+  });
+}
+
+// Windows builds a single bounded command line per spawn, so hundreds of
+// explicit file arguments cannot ride one invocation. Healthy runs therefore
+// use the original six pattern arguments (tsx expands them internally, and
+// expandTestPatterns above already proved none are vacuous); only exclusion
+// runs pass explicit relative paths, chunked under a conservative budget.
+const ARGV_CHAR_BUDGET = 6000;
+const runsArgs =
+  filesToRun.length === files.length
+    ? [TEST_PATTERNS.map((pattern) => pattern.id)]
+    : chunkArgsByLength(filesToRun, ARGV_CHAR_BUDGET);
+
+let totalFail = 0;
+let worstStatus = 0;
+for (const [index, args] of runsArgs.entries()) {
+  if (runsArgs.length > 1) {
+    console.warn(`[root-tests] chunk ${index + 1}/${runsArgs.length} (${args.length} file(s))`);
+  }
+  const { status, summary } = await runTsx(args);
   if (summary === null) {
     console.error("[root-tests] ERROR: no TAP summary found in test output — treating as failure.");
-    process.exit(status === 0 ? 1 : (status ?? 1));
+    process.exit(status === 0 ? 1 : status);
   }
-  if (summary.fail > 0 && status === 0) {
-    console.error(
-      `[root-tests] ERROR: runner exited 0 but TAP reports ${summary.fail} failing test(s) — failing the run.`,
-    );
-    process.exit(1);
-  }
-  if (filesToRun.length !== files.length) {
-    console.warn(
-      `[root-tests] reminder: ${files.length - filesToRun.length} native-dependent file(s) were skipped this run.`,
-    );
-  }
-  process.exit(status ?? 1);
-});
+  totalFail += summary.fail;
+  if (status !== 0) worstStatus = status;
+}
+
+if (totalFail > 0 && worstStatus === 0) {
+  console.error(
+    `[root-tests] ERROR: runner exited 0 but TAP reports ${totalFail} failing test(s) — failing the run.`,
+  );
+  process.exit(1);
+}
+if (filesToRun.length !== files.length) {
+  console.warn(
+    `[root-tests] reminder: ${files.length - filesToRun.length} native-dependent file(s) were skipped this run.`,
+  );
+}
+process.exit(worstStatus);

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -1,35 +1,132 @@
-import { spawnSync } from "node:child_process";
+/**
+ * Root test runner (issue #1538, epic #1520).
+ *
+ * Guarantees:
+ *   1. Every test pattern must match at least one file — a glob silently
+ *      matching nothing is an error, not a vacuous pass.
+ *   2. The better-sqlite3 native binding is probed (by constructing a real
+ *      database) before the run. If it is broken, the runner attempts the
+ *      repo's own self-heal (scripts/ensure-better-sqlite3.mjs) once.
+ *   3. If the binding still cannot load, the native-dependent test files
+ *      listed in scripts/native-dependent-tests.json are excluded with a
+ *      loud per-file [SKIP] — instead of ~160 guaranteed failures drowning
+ *      out real regressions. With REMNIC_REQUIRE_NATIVE_TESTS=1 (CI sets
+ *      this) exclusion is forbidden and a broken binding fails the run.
+ *   4. Any test failure fails the run: the child's exit status is
+ *      propagated AND the TAP summary is parsed as belt-and-suspenders —
+ *      a missing summary or fail > 0 exits non-zero regardless.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
 import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { appendNodeOption } from "./root-test-runner-env.mjs";
+import {
+  expandTestPatterns,
+  loadNativeManifest,
+  parseTapSummary,
+  partitionNativeDependent,
+  probeBetterSqlite3,
+} from "./root-test-runner-lib.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifestPath = join(repoRoot, "scripts", "native-dependent-tests.json");
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
-const testArgs = [
-  "--test",
-  "tests/**/*.test.ts",
-  "tests/**/*.test.mjs",
-  "packages/*/src/**/*.test.ts",
-  "packages/*/src/**/*.test.tsx",
-  "dashboard/lib/*.test.ts",
-  "integrations/amb/*.test.mjs",
-];
 
 process.env.NODE_OPTIONS = appendNodeOption(
   process.env.NODE_OPTIONS,
   "--conditions=remnic-source",
 );
 
-const result = spawnSync(tsxBin, testArgs, {
-  cwd: repoRoot,
-  env: process.env,
-  stdio: "inherit",
-});
-
-if (result.error) {
-  throw result.error;
+const { files, emptyPatterns } = expandTestPatterns(repoRoot);
+if (emptyPatterns.length > 0) {
+  console.error(
+    `[root-tests] ERROR: test pattern(s) matched no files — coverage would be silently lost: ${emptyPatterns.join(", ")}`,
+  );
+  process.exit(1);
 }
 
-process.exit(result.status ?? 1);
+let filesToRun = files;
+let probe = probeBetterSqlite3(repoRoot);
+if (!probe.ok) {
+  console.warn(`[root-tests] better-sqlite3 binding unavailable: ${probe.reason}`);
+  console.warn("[root-tests] attempting self-heal via scripts/ensure-better-sqlite3.mjs ...");
+  const heal = spawnSync(
+    process.execPath,
+    [join(repoRoot, "scripts", "ensure-better-sqlite3.mjs")],
+    { cwd: repoRoot, stdio: "inherit", env: process.env },
+  );
+  if (heal.status === 0) {
+    probe = probeBetterSqlite3(repoRoot);
+  }
+}
+
+if (!probe.ok) {
+  if (process.env.REMNIC_REQUIRE_NATIVE_TESTS === "1") {
+    console.error(
+      `[root-tests] ERROR: better-sqlite3 binding unavailable (${probe.reason}) and ` +
+        "REMNIC_REQUIRE_NATIVE_TESTS=1 forbids skipping native-dependent suites.",
+    );
+    process.exit(1);
+  }
+  const manifest = loadNativeManifest(manifestPath);
+  const { run, excluded, stale } = partitionNativeDependent(files, manifest.files);
+  if (stale.length > 0) {
+    console.error(
+      `[root-tests] ERROR: scripts/native-dependent-tests.json lists files that no longer exist: ${stale.join(", ")}. Update the manifest.`,
+    );
+    process.exit(1);
+  }
+  filesToRun = run;
+  console.warn(
+    `[root-tests] SKIPPING ${excluded.length} native-dependent test file(s) (better-sqlite3 unavailable: ${probe.reason}):`,
+  );
+  for (const file of excluded) {
+    console.warn(`[root-tests]   [SKIP] ${file}`);
+  }
+  console.warn(
+    "[root-tests] restore full coverage with: pnpm rebuild better-sqlite3 (or node scripts/ensure-better-sqlite3.mjs)",
+  );
+}
+
+const child = spawn(tsxBin, ["--test", ...filesToRun.map((file) => path.join(repoRoot, ...file.split("/")))], {
+  cwd: repoRoot,
+  env: process.env,
+  stdio: ["inherit", "pipe", "inherit"],
+});
+
+// Stream stdout live while keeping a bounded tail for the TAP summary parse.
+const TAIL_LIMIT = 64 * 1024;
+let tail = "";
+child.stdout.on("data", (chunk) => {
+  process.stdout.write(chunk);
+  tail = (tail + chunk.toString("utf-8")).slice(-TAIL_LIMIT);
+});
+
+child.on("error", (error) => {
+  console.error(`[root-tests] ERROR: failed to launch ${tsxBin}: ${error.message}`);
+  process.exit(1);
+});
+
+child.on("close", (status) => {
+  const summary = parseTapSummary(tail);
+  if (summary === null) {
+    console.error("[root-tests] ERROR: no TAP summary found in test output — treating as failure.");
+    process.exit(status === 0 ? 1 : (status ?? 1));
+  }
+  if (summary.fail > 0 && status === 0) {
+    console.error(
+      `[root-tests] ERROR: runner exited 0 but TAP reports ${summary.fail} failing test(s) — failing the run.`,
+    );
+    process.exit(1);
+  }
+  if (filesToRun.length !== files.length) {
+    console.warn(
+      `[root-tests] reminder: ${files.length - filesToRun.length} native-dependent file(s) were skipped this run.`,
+    );
+  }
+  process.exit(status ?? 1);
+});

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -155,9 +155,9 @@ tests/access-mcp.test.ts(156,69): TS7031
 tests/access-mcp.test.ts(156,89): TS7031
 tests/access-mcp.test.ts(184,29): TS7031
 tests/access-mcp.test.ts(184,42): TS7031
-tests/access-service.test.ts(431,35): TS2339
 tests/access-service.test.ts(432,35): TS2339
-tests/access-service.test.ts(2060,5): TS2349
+tests/access-service.test.ts(433,35): TS2339
+tests/access-service.test.ts(2061,5): TS2349
 tests/amb-bridge.test.ts(20,8): TS7016
 tests/amb-bridge.test.ts(477,9): TS7034
 tests/amb-bridge.test.ts(482,20): TS7006

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { skipUnlessBetterSqlite3 } from "./helpers/native-binding.mjs";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
@@ -2316,7 +2317,7 @@ test("access service browses memories, lists entities, and applies review dispos
   }
 });
 
-test("access service uses projection-backed browse filters, including archived memories", async () => {
+test("access service uses projection-backed browse filters, including archived memories", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-projection-browse-"));
   try {
     await writeText(
@@ -2372,7 +2373,7 @@ test("access service uses projection-backed browse filters, including archived m
   }
 });
 
-test("access service supports explicit browse sorting for projection-backed and fallback memory pages", async () => {
+test("access service supports explicit browse sorting for projection-backed and fallback memory pages", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-browse-sort-"));
   try {
     await writeText(
@@ -2428,7 +2429,7 @@ test("access service supports explicit browse sorting for projection-backed and 
   }
 });
 
-test("access service fallback browse matches projection secondary timestamp tie breakers", async () => {
+test("access service fallback browse matches projection secondary timestamp tie breakers", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-browse-tiebreak-"));
   try {
     await writeText(
@@ -2539,7 +2540,7 @@ test("access service fallback browse infers archived status from archive paths w
   }
 });
 
-test("access service projection browse matches full content beyond preview text", async () => {
+test("access service projection browse matches full content beyond preview text", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-projection-content-"));
   try {
     const deepNeedle = "full content projection query";
@@ -2644,7 +2645,7 @@ test("access service reviewQueue and maintenance fall back to governance artifac
   }
 });
 
-test("access service serves reviewQueue and maintenance from projection when governance artifacts are gone", async () => {
+test("access service serves reviewQueue and maintenance from projection when governance artifacts are gone", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-governance-projection-"));
   try {
     await writeText(

--- a/tests/cli-maintenance-suite.test.ts
+++ b/tests/cli-maintenance-suite.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { skipUnlessBetterSqlite3 } from "./helpers/native-binding.mjs";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
@@ -96,7 +97,7 @@ alpha
   await stat(writeResult.outputPath);
 });
 
-test("rebuild-memory-projection CLI wrapper respects dry-run default and write mode", async () => {
+test("rebuild-memory-projection CLI wrapper respects dry-run default and write mode", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cli-rebuild-memory-projection-"));
   await writeText(
     memoryDir,
@@ -129,7 +130,7 @@ alpha
   await stat(writeResult.outputPath);
 });
 
-test("memory-timeline CLI wrapper reads rows from the derived projection store", async () => {
+test("memory-timeline CLI wrapper reads rows from the derived projection store", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cli-memory-timeline-"));
   await writeText(
     memoryDir,
@@ -161,7 +162,7 @@ alpha
   assert.deepEqual(rows.map((row) => row.eventType), ["created", "updated"]);
 });
 
-test("verify-memory-projection and repair-memory-projection CLI wrappers detect and repair drift", async () => {
+test("verify-memory-projection and repair-memory-projection CLI wrappers detect and repair drift", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cli-verify-memory-projection-"));
   await writeText(
     memoryDir,

--- a/tests/helpers/native-binding.d.mts
+++ b/tests/helpers/native-binding.d.mts
@@ -1,0 +1,2 @@
+export function betterSqlite3Probe(): { ok: boolean; reason?: string };
+export function skipUnlessBetterSqlite3(): false | string;

--- a/tests/helpers/native-binding.mjs
+++ b/tests/helpers/native-binding.mjs
@@ -1,0 +1,58 @@
+/**
+ * Strong better-sqlite3 availability probe for test files (issue #1538).
+ *
+ * Importing the better-sqlite3 JS wrapper succeeds even when the native
+ * binary is missing — only constructing a real database proves the binding
+ * works. Individual tests that need sqlite (memory projection store, sqlite
+ * import/export) use this to skip-with-reason instead of failing when the
+ * binding is unavailable, so mixed suites keep their non-native coverage.
+ *
+ * Wholly native suites are excluded at the runner level instead — see
+ * scripts/native-dependent-tests.json and scripts/run-root-tests.mjs.
+ */
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+let cached = null;
+
+/** @returns {{ ok: boolean, reason?: string }} */
+export function betterSqlite3Probe() {
+  if (cached !== null) return cached;
+  if (process.env.REMNIC_FORCE_NATIVE_UNAVAILABLE === "1") {
+    cached = { ok: false, reason: "forced unavailable via REMNIC_FORCE_NATIVE_UNAVAILABLE" };
+    return cached;
+  }
+  try {
+    const anchor = pathToFileURL(path.join(repoRoot, "packages", "remnic-core", "package.json"));
+    const req = createRequire(anchor);
+    const loaded = req("better-sqlite3");
+    const Database = typeof loaded === "function" ? loaded : loaded?.default;
+    if (typeof Database !== "function") {
+      cached = { ok: false, reason: "module did not export a constructor" };
+      return cached;
+    }
+    const db = new Database(":memory:");
+    db.pragma("journal_mode = MEMORY");
+    db.close();
+    cached = { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    cached = { ok: false, reason: message.split("\n")[0] };
+  }
+  return cached;
+}
+
+/**
+ * node:test `skip` option value: false when the binding works, otherwise a
+ * human-readable reason including the remediation command.
+ */
+export function skipUnlessBetterSqlite3() {
+  const probe = betterSqlite3Probe();
+  return probe.ok
+    ? false
+    : `better-sqlite3 native binding unavailable (${probe.reason}) — run: pnpm rebuild better-sqlite3`;
+}

--- a/tests/import-autodetect.test.ts
+++ b/tests/import-autodetect.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { skipUnlessBetterSqlite3 } from "./helpers/native-binding.mjs";
 import assert from "node:assert/strict";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -25,7 +26,7 @@ test("detectImportFormat detects md bundle dir", async () => {
   assert.equal(await detectImportFormat(outDir), "md");
 });
 
-test("detectImportFormat detects sqlite file", async () => {
+test("detectImportFormat detects sqlite file", { skip: skipUnlessBetterSqlite3() }, async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
   await writeFixtureMemoryDir(memDir);
   const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -44,13 +44,22 @@ test("root test runner applies remnic source conditions and test globs portably"
   );
   assert.equal(helperCheck.status, 0, helperCheck.stderr);
 
+  // Pattern coverage now lives in root-test-runner-lib.mjs as structured
+  // entries (#1538); the runner consumes them via expandTestPatterns and
+  // must keep the probe + vacuous-pattern guards wired.
+  const lib = readFileSync(join(repoRoot, "scripts", "root-test-runner-lib.mjs"), "utf8");
+  assert.match(lib, /id: "tests\/\*\*\/\*\.test\.ts"/);
+  assert.match(lib, /id: "tests\/\*\*\/\*\.test\.mjs"/);
+  assert.match(lib, /id: "packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
+  assert.match(lib, /id: "packages\/\*\/src\/\*\*\/\*\.test\.tsx"/);
+  assert.match(lib, /id: "dashboard\/lib\/\*\.test\.ts"/);
+  assert.match(lib, /id: "integrations\/amb\/\*\.test\.mjs"/);
+
   const script = readFileSync(join(repoRoot, "scripts", "run-root-tests.mjs"), "utf8");
-  assert.match(script, /"tests\/\*\*\/\*\.test\.ts"/);
-  assert.match(script, /"tests\/\*\*\/\*\.test\.mjs"/);
-  assert.match(script, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
-  assert.match(script, /"packages\/\*\/src\/\*\*\/\*\.test\.tsx"/);
-  assert.match(script, /"dashboard\/lib\/\*\.test\.ts"/);
-  assert.match(script, /"integrations\/amb\/\*\.test\.mjs"/);
+  assert.match(script, /expandTestPatterns/);
+  assert.match(script, /probeBetterSqlite3/);
+  assert.match(script, /REMNIC_REQUIRE_NATIVE_TESTS/);
+  assert.match(script, /emptyPatterns/);
   assert.match(script, /cwd: repoRoot/);
   assert.match(script, /process\.platform === "win32" \? "tsx\.cmd" : "tsx"/);
   assert.doesNotMatch(script, /shell:/);

--- a/tests/root-test-runner-lib.test.mjs
+++ b/tests/root-test-runner-lib.test.mjs
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  chunkArgsByLength,
   expandTestPatterns,
   loadNativeManifest,
   parseTapSummary,
@@ -110,6 +111,21 @@ test("parseTapSummary reads the epilogue and returns null without one", () => {
     todo: 0,
   });
   assert.equal(parseTapSummary("ok 1 - no summary here"), null);
+});
+
+test("chunkArgsByLength keeps every spawn under the budget without dropping args", () => {
+  const args = ["aaaa", "bbbb", "cccc", "dddd", "eeee"];
+  const chunks = chunkArgsByLength(args, 10);
+  // Each arg costs length+1 = 5, so two fit per 10-char chunk.
+  assert.deepEqual(chunks, [["aaaa", "bbbb"], ["cccc", "dddd"], ["eeee"]]);
+  assert.deepEqual(chunks.flat(), args);
+
+  // A single oversized argument still gets its own chunk.
+  assert.deepEqual(chunkArgsByLength(["x".repeat(50)], 10), [["x".repeat(50)]]);
+  // Empty input produces no chunks.
+  assert.deepEqual(chunkArgsByLength([], 10), []);
+  // Invalid budgets are rejected loudly.
+  assert.throws(() => chunkArgsByLength(["a"], 0), /positive integer/);
 });
 
 test("probeBetterSqlite3 honours the forced-unavailable test seam", () => {

--- a/tests/root-test-runner-lib.test.mjs
+++ b/tests/root-test-runner-lib.test.mjs
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  expandTestPatterns,
+  loadNativeManifest,
+  parseTapSummary,
+  partitionNativeDependent,
+  probeBetterSqlite3,
+} from "../scripts/root-test-runner-lib.mjs";
+
+function makeTree() {
+  const root = mkdtempSync(path.join(tmpdir(), "runner-lib-"));
+  const write = (rel) => {
+    const full = path.join(root, ...rel.split("/"));
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, "// fixture\n");
+  };
+  write("tests/a.test.ts");
+  write("tests/nested/b.test.mjs");
+  write("packages/core/src/c.test.ts");
+  write("packages/core/src/deep/d.test.tsx");
+  write("dashboard/lib/e.test.ts");
+  write("integrations/amb/f.test.mjs");
+  // Distractors that must NOT match.
+  write("tests/not-a-test.ts");
+  write("packages/core/lib/outside-src.test.ts");
+  write("dashboard/lib/nested/too-deep.test.ts");
+  return root;
+}
+
+test("expandTestPatterns matches every pattern shape and nothing else", () => {
+  const root = makeTree();
+  try {
+    const { files, emptyPatterns } = expandTestPatterns(root);
+    assert.deepEqual(emptyPatterns, []);
+    assert.deepEqual(files, [
+      "dashboard/lib/e.test.ts",
+      "integrations/amb/f.test.mjs",
+      "packages/core/src/c.test.ts",
+      "packages/core/src/deep/d.test.tsx",
+      "tests/a.test.ts",
+      "tests/nested/b.test.mjs",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("expandTestPatterns reports vacuous patterns instead of passing silently", () => {
+  const root = makeTree();
+  try {
+    rmSync(path.join(root, "integrations"), { recursive: true, force: true });
+    const { emptyPatterns } = expandTestPatterns(root);
+    assert.deepEqual(emptyPatterns, ["integrations/amb/*.test.mjs"]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("partitionNativeDependent splits, and flags stale manifest entries", () => {
+  const files = ["tests/a.test.ts", "tests/lcm.test.ts"];
+  const { run, excluded, stale } = partitionNativeDependent(files, [
+    "tests/lcm.test.ts",
+    "tests/gone.test.ts",
+  ]);
+  assert.deepEqual(run, ["tests/a.test.ts"]);
+  assert.deepEqual(excluded, ["tests/lcm.test.ts"]);
+  assert.deepEqual(stale, ["tests/gone.test.ts"]);
+});
+
+test("loadNativeManifest validates shape and rejects malformed payloads", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "runner-manifest-"));
+  const manifestPath = path.join(root, "m.json");
+  try {
+    writeFileSync(manifestPath, JSON.stringify({ version: 1, files: ["b.ts", "a.ts"] }));
+    assert.deepEqual(loadNativeManifest(manifestPath).files, ["a.ts", "b.ts"]);
+
+    writeFileSync(manifestPath, "null");
+    assert.throws(() => loadNativeManifest(manifestPath), /must be a JSON object/);
+    writeFileSync(manifestPath, JSON.stringify({ version: 2, files: [] }));
+    assert.throws(() => loadNativeManifest(manifestPath), /unsupported manifest version/);
+    writeFileSync(manifestPath, JSON.stringify({ version: 1, files: [3] }));
+    assert.throws(() => loadNativeManifest(manifestPath), /array of strings/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("parseTapSummary reads the epilogue and returns null without one", () => {
+  const output = [
+    "ok 1 - something",
+    "# tests 12",
+    "# suites 2",
+    "# pass 11",
+    "# fail 1",
+    "# cancelled 0",
+    "# skipped 0",
+    "# todo 0",
+    "# duration_ms 5",
+  ].join("\n");
+  assert.deepEqual(parseTapSummary(output), {
+    tests: 12,
+    pass: 11,
+    fail: 1,
+    cancelled: 0,
+    skipped: 0,
+    todo: 0,
+  });
+  assert.equal(parseTapSummary("ok 1 - no summary here"), null);
+});
+
+test("probeBetterSqlite3 honours the forced-unavailable test seam", () => {
+  const result = probeBetterSqlite3(process.cwd(), { REMNIC_FORCE_NATIVE_UNAVAILABLE: "1" });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /forced unavailable/);
+});
+
+test("probeBetterSqlite3 fails cleanly on a tree with no binding", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "runner-probe-"));
+  try {
+    mkdirSync(path.join(root, "packages", "remnic-core"), { recursive: true });
+    writeFileSync(
+      path.join(root, "packages", "remnic-core", "package.json"),
+      JSON.stringify({ name: "probe-fixture" }),
+    );
+    const result = probeBetterSqlite3(root, {});
+    assert.equal(result.ok, false);
+    assert.equal(typeof result.reason, "string");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Part of #1520 (Phase 1). Closes #1538.

## Corrected diagnosis (measured, not assumed)

The issue was filed on the observed claim that `npm test` exits 0 with ~171 failures. **That claim was a measurement artifact**: piping the suite through `| tail` reports tail's exit code, not the runner's. Measured properly, the runner faithfully exits 1. The real problems, verified empirically in a worktree with a broken binding:

1. `pnpm install` can complete with a broken better-sqlite3 binding, and `npm test` is then guaranteed-red with **168 failures** (10,512 tests, 163 top-level not-oks, 165 binding-error mentions) — unusable as a local gate, and real regressions hide in the noise.
2. A test glob that matches zero files passes silently (verified: `tsx --test 'no-match/*.test.ts'` exits 0) — silent coverage loss on renames.
3. Importing the better-sqlite3 JS wrapper succeeds without the native binary — weak probes give false positives; only constructing a `Database` proves the binding.

## What this PR does

**Runner (`scripts/run-root-tests.mjs`, logic in `scripts/root-test-runner-lib.mjs` for unit-testability):**
- Expands the six test patterns itself (structured entries, pure-Node walk) and **fails on any pattern matching zero files**.
- **Strong-probes** better-sqlite3 (constructs `:memory:` from the remnic-core package context — resolution anchored there so it can't walk up into a parent checkout) and on failure **self-heals once** via the existing `scripts/ensure-better-sqlite3.mjs`, then re-probes.
- If still unavailable: with `REMNIC_REQUIRE_NATIVE_TESTS=1` (now set on the CI Tests step) the run **fails immediately**; otherwise the 13 wholly-native test files in `scripts/native-dependent-tests.json` are excluded with loud per-file `[SKIP]` lines, a count, and the remediation command. Stale manifest entries fail the run.
- Belt-and-suspenders: the TAP epilogue is parsed; missing summary or `fail > 0` exits non-zero regardless of child status.

**Mixed suites:** 9 sqlite-dependent tests inside `access-service`, `cli-maintenance-suite`, and `import-autodetect` get `{ skip: skipUnlessBetterSqlite3() }` guards (shared strong-probe helper `tests/helpers/native-binding.mjs`) so their non-native coverage keeps running. `REMNIC_FORCE_NATIVE_UNAVAILABLE=1` is a test seam for the skip paths.

**Contract test** `tests/root-test-build-contract.test.ts` updated for the new architecture (patterns pinned in the lib, probe/guards pinned in the runner).

## End-to-end verification

On this branch's worktree (binding genuinely broken): the new runner detected it, **self-healed via node-gyp rebuild, and ran the full suite with zero skips** — 10,519 tests, 4 failures, exit 1. Those 4 are the payoff, not a regression: real issues previously invisible inside the 168-failure noise —
- 1 was this PR's own contract test (fixed here);
- 1 requires a clean git tree (SOTA provenance check — passes once committed);
- 2 are pre-existing environment-dependent AMB failures (external tool missing, exit 127; pass in CI; known in this dev environment) — follow-up issue to be filed for AMB capability guards;
- plus 1 order-dependent recall-hardening flake observed once (passes solo 22/22) — watching, will file with evidence if it recurs.

`tests/root-test-runner-lib.test.mjs`: 8 unit tests over expansion, vacuous detection, manifest validation/partition/staleness, TAP parsing, probe seams. Forced-unavailable smoke verified the skip path end to end.

## Checklist
- [x] All tests pass / failures accounted for above
- [x] New logic covered by tests
- [x] No secrets or personal data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test infrastructure and CI env; production runtime paths are untouched, with CI explicitly requiring full native coverage.
> 
> **Overview**
> **Root test runner** (`run-root-tests.mjs` + `root-test-runner-lib.mjs`) replaces blind `tsx --test` globs with an explicit pattern walk that **fails if any pattern matches zero files**. It **strong-probes** `better-sqlite3` (in-memory DB from `remnic-core`), **self-heals once** via `ensure-better-sqlite3.mjs`, then either runs everything, **excludes** files listed in `native-dependent-tests.json` with loud `[SKIP]` lines, or **hard-fails** when `REMNIC_REQUIRE_NATIVE_TESTS=1`. Failures are enforced via child exit code **and** parsed TAP (`fail > 0` or missing summary). Partial runs chunk explicit file paths for Windows argv limits.
> 
> **CI** sets `REMNIC_REQUIRE_NATIVE_TESTS=1` on the Tests step so native suites cannot be dropped after rebuild.
> 
> **Mixed suites** use `tests/helpers/native-binding.mjs` (`skipUnlessBetterSqlite3`) on sqlite-dependent cases in `access-service`, `cli-maintenance-suite`, and `import-autodetect` so the rest of those files still run locally.
> 
> **Tests/contracts**: `root-test-runner-lib.test.mjs` covers expansion, manifest staleness, TAP parse, chunking, and probe seams; `root-test-build-contract.test.ts` pins the new wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9db2ab4ee29f0d44d28ebae33a0a3bee7dc6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->