### PR TITLE
fix(scripts): pre-merge gate reads issue comments, not just review comments

### DIFF
--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -108,6 +108,15 @@ if ! COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --
   exit 1
 fi
 
+# `pulls/{n}/comments` returns only inline REVIEW comments. When Codex finds
+# no issues it posts its verdict ("Didn't find any major issues") as an ISSUE
+# comment, which lives on `issues/{n}/comments` — without this, clean-verdict
+# PRs are blocked forever even though the reviewer explicitly signed off.
+if ! ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].user.login' 2>/dev/null); then
+  echo "[pre-merge] BLOCKED: Failed to read PR issue comments from GitHub."
+  exit 1
+fi
+
 # Some bots (Cursor Bugbot, Kilo Code Review) post as check runs via GitHub
 # Apps rather than as PR comments. A completed check run counts as reviewer
 # activity. The app.slug field maps to reviewer aliases (e.g. "cursor" matches
@@ -126,7 +135,7 @@ if [[ -n "$HEAD_SHA" ]]; then
   fi
 fi
 
-ALL_REVIEWERS=$(printf '%s\n%s\n' "$REVIEWS" "$COMMENTS" | sort -u)
+ALL_REVIEWERS=$(printf '%s\n%s\n%s\n' "$REVIEWS" "$COMMENTS" "$ISSUE_COMMENTS" | sort -u)
 
 has_reviewer_check_run() {
   local reviewer="$1"

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -139,15 +139,20 @@ fi
 # Issue comments are PR-wide, not head-scoped, and this gate reads them for
 # exactly one reason: Codex posts its clean verdict ("Didn't find any major
 # issues … **Reviewed commit:** \`<short sha>\`") as an issue comment. Count
-# ONLY those, and only when the embedded reviewed-commit SHA is a prefix of
-# the CURRENT head. Timestamps cannot prove a verdict reviewed this SHA
-# (committer dates survive cherry-picks and rebases); the SHA pin can. Every
-# other issue comment is conversation, never reviewer activity.
+# ONLY those, and only when the SHA embedded after the "Reviewed commit"
+# label is a prefix (>= 7 hex chars, git's short-SHA floor) of the CURRENT
+# head. Timestamps cannot prove a verdict reviewed this SHA (committer dates
+# survive cherry-picks and rebases); the extracted SHA pin can. Every other
+# issue comment is conversation, never reviewer activity.
 ISSUE_COMMENTERS=""
 while IFS=$'\t' read -r ic_login ic_body; do
   [[ "$ic_login" == "chatgpt-codex-connector[bot]" ]] || continue
   grep -qiE "find any major issues|no major issues" <<< "$ic_body" || continue
-  if [[ -n "$HEAD_SHA" && "$ic_body" == *"${HEAD_SHA:0:10}"* ]]; then
+  # Extract the hex run following the "Reviewed commit" label, tolerating
+  # markdown decoration (bold markers, backticks, colon) between the two.
+  ic_sha=$(grep -oiE "reviewed commit[^0-9a-fA-F]*[0-9a-fA-F]{7,40}" <<< "$ic_body" \
+    | grep -oE "[0-9a-fA-F]{7,40}" | head -n 1 | tr '[:upper:]' '[:lower:]')
+  if [[ -n "$ic_sha" && -n "$HEAD_SHA" && "$HEAD_SHA" == "$ic_sha"* ]]; then
     ISSUE_COMMENTERS+="${ic_login}"$'\n'
   fi
 done <<< "$ISSUE_COMMENTS_RAW"

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -112,7 +112,8 @@ fi
 # no issues it posts its verdict ("Didn't find any major issues") as an ISSUE
 # comment, which lives on `issues/{n}/comments` — without this, clean-verdict
 # PRs are blocked forever even though the reviewer explicitly signed off.
-if ! ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].user.login' 2>/dev/null); then
+# Body newlines/tabs are flattened so each comment stays one TSV row.
+if ! ISSUE_COMMENTS_RAW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, .created_at, (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
   echo "[pre-merge] BLOCKED: Failed to read PR issue comments from GitHub."
   exit 1
 fi
@@ -135,7 +136,30 @@ if [[ -n "$HEAD_SHA" ]]; then
   fi
 fi
 
-ALL_REVIEWERS=$(printf '%s\n%s\n%s\n' "$REVIEWS" "$COMMENTS" "$ISSUE_COMMENTS" | sort -u)
+# Issue comments are PR-wide, not head-scoped: a clean verdict posted before
+# the latest push must not count as reviewer activity for the new head. Keep
+# only comments created after the head commit (both timestamps are ISO-8601
+# Zulu, so lexicographic comparison is chronological). For Codex, additionally
+# require the comment to actually be a clean verdict — its findings arrive as
+# review comments; only the "no major issues" sign-off is an issue comment.
+if ! HEAD_COMMIT_DATE=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" --jq '.commit.committer.date' 2>/dev/null); then
+  echo "[pre-merge] BLOCKED: Failed to read head commit date from GitHub."
+  exit 1
+fi
+ISSUE_COMMENTERS=""
+while IFS=$'\t' read -r ic_login ic_created ic_body; do
+  [[ -z "$ic_login" ]] && continue
+  if [[ -z "$ic_created" ]] || [[ ! "$ic_created" > "$HEAD_COMMIT_DATE" ]]; then
+    continue
+  fi
+  if [[ "$ic_login" == "chatgpt-codex-connector[bot]" ]] && \
+     ! grep -qiE "find any major issues|no major issues" <<< "$ic_body"; then
+    continue
+  fi
+  ISSUE_COMMENTERS+="${ic_login}"$'\n'
+done <<< "$ISSUE_COMMENTS_RAW"
+
+ALL_REVIEWERS=$(printf '%s\n%s\n%s\n' "$REVIEWS" "$COMMENTS" "$ISSUE_COMMENTERS" | sort -u)
 
 has_reviewer_check_run() {
   local reviewer="$1"

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -113,7 +113,7 @@ fi
 # comment, which lives on `issues/{n}/comments` — without this, clean-verdict
 # PRs are blocked forever even though the reviewer explicitly signed off.
 # Body newlines/tabs are flattened so each comment stays one TSV row.
-if ! ISSUE_COMMENTS_RAW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, .created_at, (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
+if ! ISSUE_COMMENTS_RAW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '.[] | [.user.login, (.body // "" | gsub("[\r\n\t]"; " "))] | @tsv' 2>/dev/null); then
   echo "[pre-merge] BLOCKED: Failed to read PR issue comments from GitHub."
   exit 1
 fi
@@ -136,27 +136,20 @@ if [[ -n "$HEAD_SHA" ]]; then
   fi
 fi
 
-# Issue comments are PR-wide, not head-scoped: a clean verdict posted before
-# the latest push must not count as reviewer activity for the new head. Keep
-# only comments created after the head commit (both timestamps are ISO-8601
-# Zulu, so lexicographic comparison is chronological). For Codex, additionally
-# require the comment to actually be a clean verdict — its findings arrive as
-# review comments; only the "no major issues" sign-off is an issue comment.
-if ! HEAD_COMMIT_DATE=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" --jq '.commit.committer.date' 2>/dev/null); then
-  echo "[pre-merge] BLOCKED: Failed to read head commit date from GitHub."
-  exit 1
-fi
+# Issue comments are PR-wide, not head-scoped, and this gate reads them for
+# exactly one reason: Codex posts its clean verdict ("Didn't find any major
+# issues … **Reviewed commit:** \`<short sha>\`") as an issue comment. Count
+# ONLY those, and only when the embedded reviewed-commit SHA is a prefix of
+# the CURRENT head. Timestamps cannot prove a verdict reviewed this SHA
+# (committer dates survive cherry-picks and rebases); the SHA pin can. Every
+# other issue comment is conversation, never reviewer activity.
 ISSUE_COMMENTERS=""
-while IFS=$'\t' read -r ic_login ic_created ic_body; do
-  [[ -z "$ic_login" ]] && continue
-  if [[ -z "$ic_created" ]] || [[ ! "$ic_created" > "$HEAD_COMMIT_DATE" ]]; then
-    continue
+while IFS=$'\t' read -r ic_login ic_body; do
+  [[ "$ic_login" == "chatgpt-codex-connector[bot]" ]] || continue
+  grep -qiE "find any major issues|no major issues" <<< "$ic_body" || continue
+  if [[ -n "$HEAD_SHA" && "$ic_body" == *"${HEAD_SHA:0:10}"* ]]; then
+    ISSUE_COMMENTERS+="${ic_login}"$'\n'
   fi
-  if [[ "$ic_login" == "chatgpt-codex-connector[bot]" ]] && \
-     ! grep -qiE "find any major issues|no major issues" <<< "$ic_body"; then
-    continue
-  fi
-  ISSUE_COMMENTERS+="${ic_login}"$'\n'
 done <<< "$ISSUE_COMMENTS_RAW"
 
 ALL_REVIEWERS=$(printf '%s\n%s\n%s\n' "$REVIEWS" "$COMMENTS" "$ISSUE_COMMENTERS" | sort -u)

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -150,8 +150,10 @@ while IFS=$'\t' read -r ic_login ic_body; do
   grep -qiE "find any major issues|no major issues" <<< "$ic_body" || continue
   # Extract the hex run following the "Reviewed commit" label, tolerating
   # markdown decoration (bold markers, backticks, colon) between the two.
+  # `|| true` keeps errexit/pipefail from aborting the gate on comments with
+  # no label (legacy unpinned verdicts) — those are simply never counted.
   ic_sha=$(grep -oiE "reviewed commit[^0-9a-fA-F]*[0-9a-fA-F]{7,40}" <<< "$ic_body" \
-    | grep -oE "[0-9a-fA-F]{7,40}" | head -n 1 | tr '[:upper:]' '[:lower:]')
+    | grep -oE "[0-9a-fA-F]{7,40}" | head -n 1 | tr '[:upper:]' '[:lower:]' || true)
   if [[ -n "$ic_sha" && -n "$HEAD_SHA" && "$HEAD_SHA" == "$ic_sha"* ]]; then
     ISSUE_COMMENTERS+="${ic_login}"$'\n'
   fi

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|issue_comments_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,6 +68,10 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
+    printf 'cursor[bot]\\n'
+    exit 0
+  fi
   if [[ "$GH_STUB_SCENARIO" == "all_required_check_runs_ok" ]]; then
     exit 0
   fi
@@ -76,6 +80,18 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
 fi
 
 if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/comments" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "issue_comments_fail" ]]; then
+    echo "issue comments unavailable" >&2
+    exit 3
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
+    printf 'chatgpt-codex-connector[bot]\\n'
+    exit 0
+  fi
   exit 0
 fi
 
@@ -191,6 +207,27 @@ test("pre-merge check fails closed when GitHub pagination does not advance", asy
     assert.equal(result.status, 1);
     assert.match(result.stdout, /BLOCKED: GitHub review thread pagination did not advance/);
     assert.equal((await readFile(countPath, "utf8")).trim(), "2");
+  });
+});
+
+test("pre-merge check accepts a codex clean-verdict ISSUE comment as reviewer activity", async () => {
+  // Codex posts "no major issues" verdicts as issue comments, not reviews or
+  // review comments — the endpoint gap this PR fixes.
+  await withGhStub("codex_issue_comment_ok", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check blocks when issue comments cannot be read", async () => {
+  await withGhStub("issue_comments_fail", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout + result.stderr, /Failed to read PR issue comments/);
   });
 });
 

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|issue_comments_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,7 +68,7 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
-  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" || "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" || "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" || "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" || "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
     printf 'cursor[bot]\\n'
     exit 0
   fi
@@ -89,15 +89,19 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
     exit 3
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
-    printf "chatgpt-codex-connector[bot]\\t2026-01-02T00:00:00Z\\tCodex Review: Didn't find any major issues.\\n"
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. **Reviewed commit:** deadbeef\\n"
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" ]]; then
-    printf "chatgpt-codex-connector[bot]\\t2025-12-31T00:00:00Z\\tCodex Review: Didn't find any major issues.\\n"
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. **Reviewed commit:** cafebabe12\\n"
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" ]]; then
-    printf "chatgpt-codex-connector[bot]\\t2026-01-02T00:00:00Z\\tFound 2 major issues in the diff.\\n"
+    printf "chatgpt-codex-connector[bot]\\tFound 2 major issues in the diff. **Reviewed commit:** deadbeef\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
+    printf "someuser\\tLooks good to me! deadbeef\\n"
     exit 0
   fi
   exit 0
@@ -109,11 +113,6 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
     exit 5
   fi
   printf 'deadbeef\\n'
-  exit 0
-fi
-
-if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef" ]]; then
-  printf '2026-01-01T00:00:00Z\\n'
   exit 0
 fi
 
@@ -235,9 +234,10 @@ test("pre-merge check accepts a codex clean-verdict ISSUE comment as reviewer ac
   });
 });
 
-test("pre-merge check ignores codex issue comments older than the head commit", async () => {
+test("pre-merge check rejects codex verdicts pinned to a different commit", async () => {
   // A clean verdict earned on a previous head must not carry over to new
-  // commits — the comment feed is PR-wide, not SHA-scoped.
+  // commits — the comment feed is PR-wide, not SHA-scoped. The verdict's
+  // embedded "Reviewed commit" SHA must be a prefix of the current head.
   await withGhStub("codex_issue_comment_stale", async (env) => {
     const result = runPreMergeCheck(env);
 
@@ -246,8 +246,17 @@ test("pre-merge check ignores codex issue comments older than the head commit", 
   });
 });
 
-test("pre-merge check ignores fresh codex issue comments that are not clean verdicts", async () => {
+test("pre-merge check ignores codex issue comments that are not clean verdicts", async () => {
   await withGhStub("codex_issue_comment_not_verdict", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check never counts non-codex issue comments as reviewer activity", async () => {
+  await withGhStub("generic_issue_comment_ignored", async (env) => {
     const result = runPreMergeCheck(env);
 
     assert.equal(result.status, 1);

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,7 +68,7 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
-  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" || "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" || "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == codex_issue_comment_* || "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
     printf 'cursor[bot]\\n'
     exit 0
   fi
@@ -89,7 +89,11 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
     exit 3
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
-    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. **Reviewed commit:** deadbeef\\n"
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. **Reviewed commit:** deadbeef12\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_short_sha" ]]; then
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. Reviewed commit: deadbee\\n"
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" ]]; then
@@ -97,11 +101,15 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" ]]; then
-    printf "chatgpt-codex-connector[bot]\\tFound 2 major issues in the diff. **Reviewed commit:** deadbeef\\n"
+    printf "chatgpt-codex-connector[bot]\\tFound 2 major issues in the diff. **Reviewed commit:** deadbeef12\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" ]]; then
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. Compare with deadbeef12 later. **Reviewed commit:** cafebabe12\\n"
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
-    printf "someuser\\tLooks good to me! deadbeef\\n"
+    printf "someuser\\tLooks good to me! Reviewed commit: deadbeef12\\n"
     exit 0
   fi
   exit 0
@@ -112,11 +120,11 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
     echo "gh pr view must pass --repo" >&2
     exit 5
   fi
-  printf 'deadbeef\\n'
+  printf 'deadbeef1234567890abcdef1234567890abcdef\\n'
   exit 0
 fi
 
-if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef/check-runs" ]]; then
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef1234567890abcdef1234567890abcdef/check-runs" ]]; then
   if [[ "$GH_STUB_SCENARIO" == "cursor_check_ok" ]]; then
     printf 'cursor\\tCursor Bugbot\\n'
     exit 0
@@ -231,6 +239,28 @@ test("pre-merge check accepts a codex clean-verdict ISSUE comment as reviewer ac
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /OK: All reviewers posted/);
     assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check accepts codex verdicts with a short (7-char) reviewed-commit SHA", async () => {
+  // Codex controls its own short-SHA length; the gate must accept any git
+  // short SHA (>= 7 hex chars) that is a prefix of the current head.
+  await withGhStub("codex_issue_comment_short_sha", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
+  });
+});
+
+test("pre-merge check anchors the SHA pin to the Reviewed commit label, not prose", async () => {
+  // The head SHA appearing elsewhere in the body must not satisfy the pin
+  // when the verdict's own "Reviewed commit" points at a different SHA.
+  await withGhStub("codex_verdict_sha_in_prose", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
   });
 });
 

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|issue_comments_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|issue_comments_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,7 +68,7 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
-  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" || "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" || "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" ]]; then
     printf 'cursor[bot]\\n'
     exit 0
   fi
@@ -89,7 +89,15 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
     exit 3
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_ok" ]]; then
-    printf 'chatgpt-codex-connector[bot]\\n'
+    printf "chatgpt-codex-connector[bot]\\t2026-01-02T00:00:00Z\\tCodex Review: Didn't find any major issues.\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_stale" ]]; then
+    printf "chatgpt-codex-connector[bot]\\t2025-12-31T00:00:00Z\\tCodex Review: Didn't find any major issues.\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_issue_comment_not_verdict" ]]; then
+    printf "chatgpt-codex-connector[bot]\\t2026-01-02T00:00:00Z\\tFound 2 major issues in the diff.\\n"
     exit 0
   fi
   exit 0
@@ -101,6 +109,11 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
     exit 5
   fi
   printf 'deadbeef\\n'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef" ]]; then
+  printf '2026-01-01T00:00:00Z\\n'
   exit 0
 fi
 
@@ -219,6 +232,26 @@ test("pre-merge check accepts a codex clean-verdict ISSUE comment as reviewer ac
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /OK: All reviewers posted/);
     assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check ignores codex issue comments older than the head commit", async () => {
+  // A clean verdict earned on a previous head must not carry over to new
+  // commits — the comment feed is PR-wide, not SHA-scoped.
+  await withGhStub("codex_issue_comment_stale", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check ignores fresh codex issue comments that are not clean verdicts", async () => {
+  await withGhStub("codex_issue_comment_not_verdict", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
   });
 });
 

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|codex_verdict_unpinned:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -106,6 +106,10 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
   fi
   if [[ "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" ]]; then
     printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. Compare with deadbeef12 later. **Reviewed commit:** cafebabe12\\n"
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "codex_verdict_unpinned" ]]; then
+    printf "chatgpt-codex-connector[bot]\\tCodex Review: Didn't find any major issues. Hooray!\\n"
     exit 0
   fi
   if [[ "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
@@ -261,6 +265,18 @@ test("pre-merge check anchors the SHA pin to the Reviewed commit label, not pros
 
     assert.equal(result.status, 1);
     assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check ignores unpinned codex verdicts without aborting the gate", async () => {
+  // A legacy clean verdict with no "Reviewed commit" label must be skipped —
+  // not crash the errexit/pipefail script — so reviewers satisfied via
+  // reviews/check runs still pass.
+  await withGhStub("codex_verdict_unpinned", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
   });
 });
 


### PR DESCRIPTION
The pre-merge guard's docstring promises reviewer detection via reviews, comments, and check runs — but it reads `pulls/{n}/comments` (inline review comments only). Codex posts its clean verdicts ("Didn't find any major issues") as **issue comments** on `issues/{n}/comments`, so any PR codex signed off on without leaving threads was blocked indefinitely.

This adds the issue-comments feed to the reviewer haystack (same login-based matching as the two existing sources).

**Known pre-existing limitation, unchanged in scope:** none of the three comment/review sources are head-SHA-scoped (only check runs are), so a stale verdict from an older head satisfies the gate; the CI `ai-reviewers` job does the SHA-scoped verification. Tightening that across all sources would be a follow-up.

Verified: PR #1543 and #1545 (both carrying clean codex issue-comment verdicts on their current heads, cursor + Kilo check runs green, 0 threads) flip from BLOCKED to OK; a PR with no codex activity still blocks.

- [x] Behavior verified against live PRs
- [x] No secrets or personal data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-blocking reviewer detection; mis-parsing Codex verdicts or SHA pins could block good PRs or accept stale sign-offs, though scope is narrow and heavily covered by new tests.
> 
> **Overview**
> The pre-merge guard now reads **`issues/{n}/comments`** so Codex sign-offs that only appear as issue comments (clean “no major issues” verdicts) are no longer treated as missing reviews.
> 
> Only **`chatgpt-codex-connector[bot]`** comments matching a clean-verdict phrase count, and only when the hex SHA after the **“Reviewed commit”** label is a prefix of the current PR head (7–40 hex chars, markdown-tolerant parsing). Stale pins, issue-finding verdicts, arbitrary user comments, and unpinned legacy verdicts are ignored; API failure to load issue comments still **blocks** merge.
> 
> Tests extend the **`gh`** stub with issue-comment scenarios (match, short SHA, stale SHA, wrong verdict, SHA in prose vs label, unpinned, generic user, API fail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314b1b7c09000925ac3586985aa45299eae82bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->