### PR TITLE
fix(deps): bump undici to 6.27.0 and tar to 7.5.19 (Dependabot alerts, incl. 1 high)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1965,8 +1965,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   thenify-all@1.6.0:
@@ -2050,8 +2050,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   update-browserslist-db@1.2.3:
@@ -3066,9 +3066,9 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.13
+      tar: 7.5.19
       tinyglobby: 0.2.15
-      undici: 6.25.0
+      undici: 6.27.0
       which: 6.0.1
 
   node-releases@2.0.37: {}
@@ -3319,7 +3319,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.13:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -3413,7 +3413,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:


### PR DESCRIPTION
## Why

Resolves 5 of the 8 open [Dependabot alerts](https://github.com/joshuaswarren/remnic/security/dependabot), including the only **high**-severity one:

| Alert | Severity | Package | Advisory |
|---|---|---|---|
| #178 | **High** | undici | GHSA-vxpw-j846-p89q — WebSocket client DoS via fragment count bypass |
| #179 | Moderate | undici | GHSA-p88m-4jfj-68fv — HTTP header injection via Set-Cookie percent-decoding |
| #175 | Moderate | tar | GHSA-vmf3-w455-68vh — PAX size override parser differential (file smuggling) |
| #177 | Low | undici | GHSA-35p6-xmwp-9g52 — response queue poisoning via keep-alive reuse |
| #180 | Low | undici | GHSA-g8m3-5g58-fq7m — SameSite attribute downgrade |

## Triage

Both packages are **transitive** — neither is imported by any Remnic code. They enter the tree solely via `node-gyp@12.3.0` (a direct dep of the root and `@remnic/core`, used to build the `better-sqlite3` native binding). node-gyp's own ranges (`undici: ^6.25.0`, `tar: ^7.5.4`) already admit the patched versions, so this is a **lockfile-only** refresh via `pnpm update -r undici tar` — no `package.json` specifier changes.

Actual exposure was low (build-time tooling, not the memory daemon's runtime request path), but there is no reason to keep vulnerable versions pinned.

## Changes

- `pnpm-lock.yaml`: undici 6.25.0 → 6.27.0, tar 7.5.13 → 7.5.19 (8 lines)

## Checklist

- [x] `npm run preflight:quick` — `[preflight] OK (quick)`
- [x] Lockfile synced with `pnpm` (rule 15) — no specifier changes needed
- [x] No secrets or personal data in diff
- [x] Diff ≤ 400 LOC (16 lines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transitive build-time dependency versions only; no runtime or application logic changes.
> 
> **Overview**
> **Lockfile-only** refresh in `pnpm-lock.yaml` that bumps transitive **`undici`** (6.25.0 → 6.27.0) and **`tar`** (7.5.13 → 7.5.19). No `package.json` specifier changes—existing `node-gyp` ranges already allow these versions.
> 
> Both packages are pulled in only through **`node-gyp`** (used for native builds such as `better-sqlite3`), not from application runtime code. The update addresses several Dependabot advisories (including a high-severity undici WebSocket DoS issue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe67010b593d069e035a9a91229077d5bdb621e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->