### PR TITLE
fix(lifecycle): destroy the orchestrator on service stop (QMD daemon session leak)

### DIFF
--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1212,6 +1212,12 @@ async function releaseSharedDaemonSession(session: QmdDaemonSession | null): Pro
   }
 }
 
+// Test-only seams (#1537): lifecycle tests assert the pool reaches zero after
+// every holder disposes — the property the stop()-teardown fix restores.
+export const sharedDaemonSessionCountForTest = (): number => SHARED_DAEMON_SESSIONS.size;
+export { retainSharedDaemonSession as retainSharedDaemonSessionForTest };
+export { releaseSharedDaemonSession as releaseSharedDaemonSessionForTest };
+
 // ---------------------------------------------------------------------------
 // QmdClient
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -5406,6 +5406,12 @@ const pluginDefinition = {
         didCountStart = true;
         (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT] =
           ((globalThis as any)[CLI_ACTIVE_SERVICE_COUNT] || 0) + 1;
+        // Republish the keyed orchestrator slot. A full stop() deletes it
+        // after destroy(); a secondary registry taking over afterwards revives
+        // its captured orchestrator here, and a fresh register() while the
+        // service is running must find that live instance in the slot — not
+        // construct a split-brain second orchestrator over the same memoryDir.
+        (globalThis as any)[keys.ORCHESTRATOR] = orchestrator;
         // IMPORTANT: Do NOT put a `finally` inside the IIFE to clear INIT_PROMISE.
         // If anything in the try block throws synchronously (before the first `await`),
         // the IIFE's finally would run before the outer assignment, and the outer line

--- a/src/index.ts
+++ b/src/index.ts
@@ -5767,6 +5767,23 @@ const pluginDefinition = {
           stopHeartbeatWatcher = null;
           removeDreamingObserver?.();
           removeDreamingObserver = null;
+          // Tear down the orchestrator itself (#1537): destroy() clears the
+          // QMD maintenance timer and disposes the QMD client, the namespace
+          // router's per-namespace backends, and conversation QMD — releasing
+          // their refcounted shared daemon sessions (close-on-zero). Without
+          // this, every stop/start cycle stranded refs, the shared daemon map
+          // could never reach zero, and qmd child processes plus their map
+          // entries leaked across gateway reloads. The global slot is cleared
+          // (identity-guarded) so a subsequent start() constructs a fresh
+          // orchestrator instead of reusing a destroyed one.
+          try {
+            await orchestrator.destroy();
+          } catch (err) {
+            log.debug(`engram orchestrator destroy on stop failed: ${err}`);
+          }
+          if ((globalThis as any)[keys.ORCHESTRATOR] === orchestrator) {
+            delete (globalThis as any)[keys.ORCHESTRATOR];
+          }
           const unregisterOpenClawHostEmbeddingProvider = (globalThis as any)[
             keys.HOST_EMBEDDING_UNREGISTER
           ] as (() => void) | undefined;

--- a/tests/qmd-session-lifecycle.test.ts
+++ b/tests/qmd-session-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  releaseSharedDaemonSessionForTest,
+  retainSharedDaemonSessionForTest,
+  sharedDaemonSessionCountForTest,
+} from "../packages/remnic-core/src/qmd.js";
+
+// Shared daemon session lifecycle (#1537). Sessions are constructed lazily —
+// no child process spawns until a probe — so these tests exercise the
+// refcount/pool semantics without touching a real qmd binary. Unique paths
+// per test keep the process-global pool isolated between tests.
+
+test("same-key retains share one session; release closes on zero (#1537)", async () => {
+  const path = `qmd-lifecycle-test-${process.pid}-a`;
+  const before = sharedDaemonSessionCountForTest();
+
+  const first = retainSharedDaemonSessionForTest(path, {}, "idx");
+  const second = retainSharedDaemonSessionForTest(path, {}, "idx");
+  assert.equal(first, second, "identical keys share one session instance");
+  assert.equal(sharedDaemonSessionCountForTest(), before + 1);
+
+  await releaseSharedDaemonSessionForTest(first);
+  assert.equal(
+    sharedDaemonSessionCountForTest(),
+    before + 1,
+    "one live holder keeps the entry",
+  );
+
+  await releaseSharedDaemonSessionForTest(second);
+  assert.equal(
+    sharedDaemonSessionCountForTest(),
+    before,
+    "last release removes the entry — the property stop()-teardown restores across reload cycles",
+  );
+});
+
+test("different keys get distinct sessions and independent lifecycles", async () => {
+  const before = sharedDaemonSessionCountForTest();
+  const a = retainSharedDaemonSessionForTest(`qmd-lifecycle-test-${process.pid}-b1`, {}, "idx");
+  const b = retainSharedDaemonSessionForTest(`qmd-lifecycle-test-${process.pid}-b2`, {}, "idx");
+  assert.notEqual(a, b);
+  assert.equal(sharedDaemonSessionCountForTest(), before + 2);
+  await releaseSharedDaemonSessionForTest(a);
+  assert.equal(sharedDaemonSessionCountForTest(), before + 1);
+  await releaseSharedDaemonSessionForTest(b);
+  assert.equal(sharedDaemonSessionCountForTest(), before);
+});
+
+test("release is idempotent and tolerates null", async () => {
+  const path = `qmd-lifecycle-test-${process.pid}-c`;
+  const before = sharedDaemonSessionCountForTest();
+  const session = retainSharedDaemonSessionForTest(path, {}, "idx");
+  await releaseSharedDaemonSessionForTest(session);
+  assert.equal(sharedDaemonSessionCountForTest(), before);
+  // Double-release of an already-removed session is a no-op, not a crash —
+  // overlapping shutdown paths make this interleaving realistic.
+  await releaseSharedDaemonSessionForTest(session);
+  assert.equal(sharedDaemonSessionCountForTest(), before);
+  await releaseSharedDaemonSessionForTest(null);
+});
+
+test("an invalidated shared session self-heals by design (pinned semantics)", async () => {
+  // The wedge-inheritance concern from the audit: a crashed holder's session
+  // is REUSED by the next retain. That is safe by design — invalidate/cleanup
+  // resets the child so the next daemon probe respawns it. Pin the state
+  // machine so a refactor breaking the self-heal fails here.
+  const path = `qmd-lifecycle-test-${process.pid}-d`;
+  const session = retainSharedDaemonSessionForTest(path, {}, "idx") as unknown as {
+    invalidate(): void;
+    isActive(): boolean;
+    isLoading(): boolean;
+  };
+  session.invalidate();
+  assert.equal(session.isActive(), false, "invalidated session is not active");
+  assert.equal(session.isLoading(), false, "invalidated session is not stuck loading");
+  const reused = retainSharedDaemonSessionForTest(path, {}, "idx");
+  assert.equal(reused, session as unknown, "reuse returns the pooled session");
+  assert.equal(
+    (reused as unknown as { isLoading(): boolean }).isLoading(),
+    false,
+    "reused session is probe-ready, not wedged",
+  );
+  await releaseSharedDaemonSessionForTest(reused);
+  await releaseSharedDaemonSessionForTest(reused);
+});

--- a/tests/register-multi-registry.test.ts
+++ b/tests/register-multi-registry.test.ts
@@ -685,6 +685,62 @@ test("full stop then secondary start: SERVICE_STARTED is true, REGISTERED_GUARD 
   }
 });
 
+test("full stop then secondary start republishes the keyed orchestrator slot for later register() calls", async () => {
+  // stop() destroys the orchestrator and deletes the keyed global slot. A
+  // secondary registry that was registered BEFORE the stop still holds the
+  // orchestrator in its closure; when its start() later revives it, the slot
+  // must be written back — otherwise a fresh register() while the service is
+  // running finds an empty slot and constructs a split-brain second
+  // orchestrator over the same memoryDir (codex review, PR #1560).
+  const saved = saveAndResetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  let primary: ReturnType<typeof buildApi> | undefined;
+  let secondary: ReturnType<typeof buildApi> | undefined;
+  let third: ReturnType<typeof buildApi> | undefined;
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    primary = buildApi("slot-primary");
+    secondary = buildApi("slot-secondary");
+
+    plugin.register(primary.api as any);
+    plugin.register(secondary.api as any);
+
+    await primary.api._registeredStart?.();
+    const liveOrchestrator = (globalThis as any)[ORCH_KEY];
+    assert.ok(liveOrchestrator, "slot should be populated after register+start");
+
+    await primary.api._registeredStop?.();
+    assert.equal(
+      (globalThis as any)[ORCH_KEY],
+      undefined,
+      "full stop should delete the keyed orchestrator slot",
+    );
+
+    // Secondary takes over: its captured orchestrator must be republished.
+    await secondary.api._registeredStart?.();
+    assert.equal(
+      (globalThis as any)[ORCH_KEY],
+      liveOrchestrator,
+      "takeover start() should republish the captured orchestrator into the slot",
+    );
+
+    // A fresh register() while the service runs must reuse the live instance.
+    third = buildApi("slot-third");
+    plugin.register(third.api as any);
+    assert.equal(
+      (globalThis as any)[ORCH_KEY],
+      liveOrchestrator,
+      "register() after takeover should reuse the live orchestrator, not construct a second one",
+    );
+  } finally {
+    await safeStop(primary?.api, secondary?.api, third?.api);
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    restoreGlobals(saved);
+  }
+});
+
 test("host embedding bridge re-registers after cleanup independently of REGISTERED_GUARD", async () => {
   const saved = saveAndResetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();


### PR DESCRIPTION
Part of #1520 (Phase 1). Closes #1537.

## Corrected premise (verified before coding)

The issue was filed from an audit claiming the shared daemon session map had "no cleanup path." Verified against the code, most of the machinery already exists: `retainSharedDaemonSession`/`releaseSharedDaemonSession` are refcounted with close-on-zero, `QmdClient.dispose()` releases correctly, `NamespaceSearchRouter.dispose()` disposes its per-namespace backends, and `Orchestrator.destroy()` wires all of it (client, router, conversation QMD, maintenance timer). The audit's "wedge inheritance" concern is also handled by design: `invalidate()`/cleanup reset the child so the next daemon probe respawns it.

**The one real gap:** nothing ever CALLS `orchestrator.destroy()` in production. The plugin's `stop()` teardown stops the HTTP server, watchers, and exporters — but leaves the orchestrator (and its QMD daemon session tree) alive, and leaves the global orchestrator slot populated. Every gateway stop/start cycle stranded refs, so the shared map could never reach zero: qmd child processes and map entries leaked across reloads, and key changes (version/env) stranded old entries forever.

## Fix

`stop()`'s shared teardown (full-stop, non-takeover path only — the existing `secondaryTookOver` guard protects live secondaries) now awaits `orchestrator.destroy()` (guarded, rule 13) and clears the global orchestrator slot (identity-guarded, so a secondary's replacement is never clobbered). A subsequent `start()` constructs a fresh orchestrator instead of reusing a destroyed one.

## Tests

`tests/qmd-session-lifecycle.test.ts` (4 tests) via minimal test-only seams (sessions construct lazily — no qmd binary spawns):
- same-key retains share one instance; last release empties the pool (the property the fix restores across reloads)
- distinct keys → distinct sessions, independent lifecycles
- double-release and null-release are safe no-ops (overlapping shutdowns are realistic)
- invalidated-session reuse is probe-ready, not wedged — pins the self-heal semantics that make the audit's wedge concern moot

Note: the test seam was kept to 4 compact lines after the structural ratchet (correctly) flagged qmd.ts crossing the 3,000-LOC threshold with a more verbose version — the ratchet working exactly as designed, on its own author.

## Checklist
- [x] All tests pass (entity-hardening + preflight:quick, exit values verified)
- [x] New logic covered by tests
- [x] No secrets or personal data
- [x] Ratchets green without baseline changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plugin lifecycle and global orchestrator ownership during gateway reloads; mistakes could cause split-brain orchestrators or premature teardown, but changes are guarded (identity checks, secondary takeover path) and heavily tested.
> 
> **Overview**
> Fixes **QMD daemon child processes and shared session map entries leaking** across gateway stop/reload cycles by wiring teardown that already existed but was never invoked in production.
> 
> **Service `stop()`** (full-stop path, not secondary takeover) now **`await orchestrator.destroy()`**, which disposes QMD clients, namespace backends, and maintenance timers so refcounted shared daemon sessions can reach zero and close. The keyed **`ORCHESTRATOR` global** is cleared only when it still points at that instance, so a later **`start()`** builds a fresh orchestrator instead of reusing a destroyed one.
> 
> **Secondary registry takeover:** when a registry’s **`start()`** runs after a full stop had deleted the global slot, it **republishes** its captured orchestrator into that slot so a later **`register()`** reuses the live instance instead of creating a second orchestrator over the same `memoryDir`.
> 
> **Tests:** minimal **test-only exports** on the shared daemon session pool plus **`qmd-session-lifecycle.test.ts`** (refcount, idempotent release, invalidate/reuse) and a **multi-registry test** for stop → secondary start → third `register()` slot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60dc5c692958ffa07553caca4a27dd3270dab0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->