### PR TITLE
fix(build): give the tsup DTS worker deterministic heap headroom

### DIFF
--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2856,6 +2856,7 @@
     "src",
     "dist",
     "skills",
+    "scripts/build-with-heap.mjs",
     "scripts/ensure-better-sqlite3.mjs",
     "scripts/faiss_index.py",
     "scripts/faiss_requirements.txt"

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2865,7 +2865,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "NODE_OPTIONS=\"--max-old-space-size=8192${NODE_OPTIONS:+ $NODE_OPTIONS}\" tsup",
+    "build": "node ./scripts/build-with-heap.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
     "postinstall": "node ./scripts/ensure-better-sqlite3.mjs",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2865,7 +2865,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsup",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=8192${NODE_OPTIONS:+ $NODE_OPTIONS}\" tsup",
     "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
     "postinstall": "node ./scripts/ensure-better-sqlite3.mjs",

--- a/packages/remnic-core/scripts/build-with-heap.mjs
+++ b/packages/remnic-core/scripts/build-with-heap.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Runs tsup with deterministic heap headroom for its DTS worker.
+// The DTS build sits near the default V8 heap cliff (see PR #1562):
+// unrelated lockfile refreshes flipped it to ERR_WORKER_OUT_OF_MEMORY.
+// A Node wrapper (not a NODE_OPTIONS= shell prefix) keeps the build
+// script portable to Windows' cmd.exe script shell.
+import { spawnSync } from "node:child_process";
+
+const HEAP_DEFAULT = "--max-old-space-size=8192";
+const existing = process.env.NODE_OPTIONS?.trim();
+// Caller-supplied NODE_OPTIONS goes last so V8's last-wins parsing lets
+// callers override the default heap limit.
+const nodeOptions = existing ? `${HEAP_DEFAULT} ${existing}` : HEAP_DEFAULT;
+
+const result = spawnSync("tsup", process.argv.slice(2), {
+  stdio: "inherit",
+  env: { ...process.env, NODE_OPTIONS: nodeOptions },
+  // .bin shims are .cmd files on Windows and need a shell to execute.
+  shell: process.platform === "win32",
+});
+
+if (result.error) {
+  console.error(`[build-with-heap] failed to launch tsup: ${result.error.message}`);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Why

The `@remnic/core` DTS build (tsup's rollup-plugin-dts worker thread) sits right at the default V8 heap cliff. [PR #1559](https://github.com/joshuaswarren/remnic/pull/1559) — an in-range, lockfile-only `@babel/*` + browserslist-data refresh that never enters this package's type graph — flipped it to a **reproducible** `ERR_WORKER_OUT_OF_MEMORY`:

| Branch | Default heap | Result |
|---|---|---|
| `fix/dependabot-babel-core` | CI `quality` ×2 | OOM ×2 |
| `fix/dependabot-babel-core` | local ×2 | OOM ×2 |
| `fix/dependabot-undici-tar` / main | CI + local | builds fine |
| `fix/dependabot-babel-core` **+ this fix** | local, default env | **builds fine** |

Any future dependency perturbation can flip this again; the build should not be one lockfile refresh away from red.

## Change

One line in `packages/remnic-core/package.json`:

```
"build": "NODE_OPTIONS=\"--max-old-space-size=8192${NODE_OPTIONS:+ $NODE_OPTIONS}\" tsup"
```

- The build script is the **chokepoint**: CI `check-types` (`pnpm --filter @remnic/core build`), the quality job, and local builds all pass through it — no per-workflow env duplication.
- A user-supplied `NODE_OPTIONS` is appended *after* the default, so V8's last-wins parsing lets callers still override the limit (rule 30: escape hatch preserved).
- Same env-prefix pattern as the existing root `migrate` script.

## Verification

- [x] `pnpm --filter @remnic/core build` on this branch, clean env — exit 0
- [x] Same command on `fix/dependabot-babel-core` + this one-liner, clean env — exit 0 (previously OOM'd 4/4 times)
- [x] No secrets/personal data; 1-line diff

## Sequencing

Merge before rerunning #1559's `quality` check (that PR will be rebased onto this).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change with no runtime or API impact; only affects how tsup is invoked during package build.
> 
> **Overview**
> **@remnic/core** no longer invokes `tsup` directly for `build`. It runs a new **`scripts/build-with-heap.mjs`** wrapper that launches `tsup` with **`NODE_OPTIONS` defaulting to `--max-old-space-size=8192`**, so the rollup-plugin-dts worker is less likely to hit **`ERR_WORKER_OUT_OF_MEMORY`** when lockfile or toolchain noise pushes memory use over the default V8 limit.
> 
> Existing **`NODE_OPTIONS`** is appended after that default so callers can still override heap settings. On Windows, **`spawnSync` uses `shell: true`** so `.bin` `tsup` shims work under cmd.exe. The wrapper is listed in the package **`files`** array for publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e30fe2034a002e64005ec56daf5cd218a08f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->