### PR TITLE
fix(storage): route extraction persist through CATEGORY_DIR_MAP (#1546)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { access, readFile, readdir, unlink } from "node:fs/promises";
+import { access, lstat, readFile, readdir, realpath, unlink } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 import type { Orchestrator } from "./orchestrator.js";
@@ -216,6 +216,7 @@ import {
 import { resolveHomeDir } from "./runtime/env.js";
 import { expandTildePath } from "./utils/path.js";
 import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
+import { assertPathInsideRoot } from "./utils/path-containment.js";
 import { convertMemoriesToRecords } from "./training-export/converter.js";
 import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
@@ -3327,27 +3328,63 @@ export async function resolveMemoryDirForNamespace(
  * covered without touching this walker again (#1546). Swallows per-directory
  * errors so a missing subdir reads as empty. Shared primitive for
  * `listMemoryMarkdownFilePaths`, `readAllMemoryFiles`, and future walkers.
+ *
+ * Symlink/containment hardening (mirrors `scanDir` in
+ * search/document-scanner.ts): downstream consumers include `readAllMemoryFiles`
+ * → the `dedupe-exact` / `dedupe-aggressive` commands, which `unlink()` files.
+ * Because this walker scans EVERY category root, a symlinked category dir
+ * (e.g. `decisions/` → outside `memoryDir`) could otherwise redirect the walk —
+ * and a destructive dedupe delete — outside the memory store. We resolve the
+ * memory root once, skip symlinked dirs/entries, and assert every realpath stays
+ * inside the root before descending or visiting. A single poisoned entry is
+ * skipped (logged), never aborting a legitimate dedupe run.
  */
 async function walkMemoryMarkdownFiles(
   memoryDir: string,
   visit: (fullPath: string) => void | Promise<void>,
 ): Promise<void> {
-  const roots = RECALL_FALLBACK_DIRS.map((dir) => path.join(memoryDir, dir));
+  let memoryRootReal: string;
+  try {
+    memoryRootReal = await realpath(memoryDir);
+  } catch {
+    return; // memoryDir itself does not exist — nothing to walk.
+  }
+
+  const skip = (target: string, err: unknown): void => {
+    // ENOENT (optional dir absent) is silent; containment/other errors log.
+    if (!(err instanceof Error && /ENOENT/.test(err.message))) {
+      console.debug(`walkMemoryMarkdownFiles: skipping ${target}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
 
   const walk = async (dir: string): Promise<void> => {
-    let entries: Array<{ isDirectory(): boolean; isFile(): boolean; name: string | Buffer }>;
+    // Reject symlinked / non-directory roots and anything resolving outside the
+    // memory store before reading it.
     try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Array<{
-        isDirectory(): boolean;
-        isFile(): boolean;
-        name: string | Buffer;
-      }>;
+      const dirStat = await lstat(dir);
+      if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) return;
+      assertPathInsideRoot(memoryRootReal, await realpath(dir), dir);
+    } catch (err) {
+      skip(dir, err);
+      return;
+    }
+
+    let entries: Array<{ isDirectory(): boolean; isFile(): boolean; isSymbolicLink(): boolean; name: string | Buffer }>;
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as typeof entries;
     } catch {
       return;
     }
     for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue; // never follow symlinked entries
       const entryName = typeof entry.name === "string" ? entry.name : entry.name.toString("utf-8");
       const fullPath = path.join(dir, entryName);
+      try {
+        assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
+      } catch (err) {
+        skip(fullPath, err); // poisoned entry — skip, keep walking the rest.
+        continue;
+      }
       if (entry.isDirectory()) {
         await walk(fullPath);
         continue;
@@ -3357,7 +3394,7 @@ async function walkMemoryMarkdownFiles(
     }
   };
 
-  for (const root of roots) {
+  for (const root of RECALL_FALLBACK_DIRS.map((dir) => path.join(memoryDir, dir))) {
     await walk(root);
   }
 }

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -215,6 +215,7 @@ import {
 } from "./policy-runtime.js";
 import { resolveHomeDir } from "./runtime/env.js";
 import { expandTildePath } from "./utils/path.js";
+import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
 import { convertMemoriesToRecords } from "./training-export/converter.js";
 import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
@@ -3320,17 +3321,18 @@ export async function resolveMemoryDirForNamespace(
 }
 
 /**
- * Walk `memoryDir/{facts,corrections}` recursively and invoke `visit` for
- * every `*.md` file. Intentionally swallows per-directory errors so a missing
- * subdir reads as empty. Shared primitive for `listMemoryMarkdownFilePaths`,
- * `readAllMemoryFiles`, and any future walker that needs the same roots +
- * `.md` filter.
+ * Walk every recall category directory under `memoryDir` recursively and invoke
+ * `visit` for every `*.md` file. The directory set is `RECALL_FALLBACK_DIRS`
+ * (single source of truth), so newly-routed categories (decisions/, ...) are
+ * covered without touching this walker again (#1546). Swallows per-directory
+ * errors so a missing subdir reads as empty. Shared primitive for
+ * `listMemoryMarkdownFilePaths`, `readAllMemoryFiles`, and future walkers.
  */
 async function walkMemoryMarkdownFiles(
   memoryDir: string,
   visit: (fullPath: string) => void | Promise<void>,
 ): Promise<void> {
-  const roots = [path.join(memoryDir, "facts"), path.join(memoryDir, "corrections")];
+  const roots = RECALL_FALLBACK_DIRS.map((dir) => path.join(memoryDir, dir));
 
   const walk = async (dir: string): Promise<void> => {
     let entries: Array<{ isDirectory(): boolean; isFile(): boolean; name: string | Buffer }>;
@@ -3361,16 +3363,16 @@ async function walkMemoryMarkdownFiles(
 }
 
 /**
- * List absolute paths of every `*.md` file under `memoryDir/{facts,corrections}`.
- * Used by the bulk-import CLI to derive a per-batch `memoriesCreated` count
- * via set-subtraction of "paths after extraction" against "paths before
- * extraction". Caveat: the extraction queue is shared across sessions, so
- * concurrent organic extractions that write memories between the two
- * snapshots will still inflate the reported count. Filename-set diff at
- * least correctly ignores pre-existing files and files that were deleted
- * while the batch ran.
+ * List absolute paths of every `*.md` file under each recall category directory
+ * of `memoryDir` (facts/, corrections/, decisions/, ...; see
+ * `walkMemoryMarkdownFiles`). Used by the bulk-import CLI to derive a per-batch
+ * `memoriesCreated` count via set-subtraction of "paths after extraction"
+ * against "paths before extraction". Caveat: the extraction queue is shared
+ * across sessions, so concurrent organic extractions between the two snapshots
+ * can still inflate the count; the set diff at least ignores pre-existing and
+ * deleted files. Exported for category-dir coverage tests (#1546).
  */
-async function listMemoryMarkdownFilePaths(memoryDir: string): Promise<string[]> {
+export async function listMemoryMarkdownFilePaths(memoryDir: string): Promise<string[]> {
   const paths: string[] = [];
   await walkMemoryMarkdownFiles(memoryDir, (fullPath) => {
     paths.push(fullPath);

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -29,6 +29,7 @@ import {
 // review, cursor Medium) so a future key-format change stays in
 // lock-step with the doctor scan.
 import { sidecarKey } from "./page-versioning.js";
+import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
 
 /**
  * Regex to spot a `derived_via: <value>` line in the raw YAML frontmatter
@@ -490,14 +491,14 @@ export async function runConsolidationProvenanceCheck(options: {
 
   // Parse-failure detection (PR #634 round-4 review, codex P2):
   // `readAllMemories()` silently drops files whose frontmatter
-  // doesn't parse.  Walk the facts/ and corrections/ directories for
-  // `.md` files that DO reference provenance frontmatter but didn't
-  // come back from the reader — those are the corruption cases the
-  // doctor is meant to surface.
+  // doesn't parse.  Walk every recall category directory for `.md` files
+  // that DO reference provenance frontmatter but didn't come back from the
+  // reader — those are the corruption cases the doctor is meant to surface.
+  // Uses RECALL_FALLBACK_DIRS (the single source of truth) so newly-routed
+  // categories (decisions/, preferences/, ...) are scanned too (#1546).
   try {
     const seenPaths = new Set(memories.map((m) => m.path));
-    const scanRoots = ["facts", "corrections", "procedures", "reasoning-traces"];
-    for (const rootName of scanRoots) {
+    for (const rootName of RECALL_FALLBACK_DIRS) {
       const rootPath = path.join(memoryDir, rootName);
       for await (const file of walkMarkdownFiles(rootPath, memoryDir)) {
         if (seenPaths.has(file)) continue;

--- a/packages/remnic-core/src/maintenance/memory-governance.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { StorageManager } from "../storage.js";
 import { decideLifecycleTransition } from "../lifecycle.js";
 import type { MemoryFile, MemoryStatus } from "../types.js";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 
 export type MemoryGovernanceMode = "shadow" | "apply";
 export type MemoryGovernanceReasonCode =
@@ -372,10 +373,16 @@ async function buildMalformedImportEntries(
   candidateFiles?: string[],
 ): Promise<MemoryGovernanceReviewQueueEntry[]> {
   const parsedPaths = new Set(parsedMemories.map((memory) => memory.path));
-  const filesToInspect = candidateFiles ?? [
-    ...await listMarkdownFiles(path.join(memoryDir, "facts")),
-    ...await listMarkdownFiles(path.join(memoryDir, "corrections")),
-  ];
+  // Inspect every recall category directory (RECALL_FALLBACK_DIRS — the single
+  // source of truth) so malformed files under newly-routed categories
+  // (decisions/, preferences/, ...) are surfaced too, not just facts/ (#1546).
+  const filesToInspect =
+    candidateFiles ??
+    (
+      await Promise.all(
+        RECALL_FALLBACK_DIRS.map((dir) => listMarkdownFiles(path.join(memoryDir, dir))),
+      )
+    ).flat();
   const entries: MemoryGovernanceReviewQueueEntry[] = [];
 
   for (const filePath of filesToInspect) {

--- a/packages/remnic-core/src/maintenance/memory-governance.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
-import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { StorageManager } from "../storage.js";
 import { decideLifecycleTransition } from "../lifecycle.js";
 import type { MemoryFile, MemoryStatus } from "../types.js";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
+import { assertPathInsideRoot } from "../utils/path-containment.js";
 
 export type MemoryGovernanceMode = "shadow" | "apply";
 export type MemoryGovernanceReasonCode =
@@ -338,23 +339,42 @@ function buildExplicitCaptureReviewEntries(
     }));
 }
 
-async function listMarkdownFiles(root: string): Promise<string[]> {
+/**
+ * List every `*.md` under `root`, refusing to follow symlinked directories or
+ * entries that resolve outside `containmentRoot` (a realpath-resolved memory
+ * store root). Mirrors the containment guard in consolidation-provenance's
+ * walkMarkdownFiles / the CLI walker, reusing the shared assertPathInsideRoot
+ * (rule 22). Without this, a symlinked category dir (e.g. decisions/ → outside
+ * memoryDir) would be walked and its files surfaced by the malformed-import
+ * governance sweep — an out-of-store info leak.
+ */
+async function listMarkdownFiles(root: string, containmentRoot: string): Promise<string[]> {
   const files: string[] = [];
   const walk = async (dir: string) => {
     try {
+      const dirStat = await lstat(dir);
+      if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) return;
+      assertPathInsideRoot(containmentRoot, await realpath(dir), dir);
       const entries = await readdir(dir, { withFileTypes: true });
       for (const entry of entries) {
+        if (entry.isSymbolicLink()) continue; // never follow symlinked entries
         const fullPath = path.join(dir, entry.name);
         if (entry.isDirectory()) {
           await walk(fullPath);
           continue;
         }
         if (entry.isFile() && entry.name.endsWith(".md")) {
+          try {
+            assertPathInsideRoot(containmentRoot, await realpath(fullPath), fullPath);
+          } catch {
+            continue; // poisoned entry escaping the root — skip it.
+          }
           files.push(fullPath);
         }
       }
     } catch {
-      // Directory may not exist yet.
+      // Absent dir (ENOENT), symlinked/out-of-root dir, or containment
+      // violation — skip this subtree without aborting the sweep.
     }
   };
 
@@ -376,13 +396,26 @@ async function buildMalformedImportEntries(
   // Inspect every recall category directory (RECALL_FALLBACK_DIRS — the single
   // source of truth) so malformed files under newly-routed categories
   // (decisions/, preferences/, ...) are surfaced too, not just facts/ (#1546).
+  // Resolve the containment root (realpath) once and thread it into the walker
+  // so a symlinked category dir can't escape memoryDir. If memoryDir itself
+  // can't be resolved, there is nothing valid to inspect.
+  let containmentRoot: string | null = null;
+  try {
+    containmentRoot = await realpath(memoryDir);
+  } catch {
+    containmentRoot = null;
+  }
   const filesToInspect =
     candidateFiles ??
-    (
-      await Promise.all(
-        RECALL_FALLBACK_DIRS.map((dir) => listMarkdownFiles(path.join(memoryDir, dir))),
-      )
-    ).flat();
+    (containmentRoot === null
+      ? []
+      : (
+          await Promise.all(
+            RECALL_FALLBACK_DIRS.map((dir) =>
+              listMarkdownFiles(path.join(memoryDir, dir), containmentRoot as string),
+            ),
+          )
+        ).flat());
   const entries: MemoryGovernanceReviewQueueEntry[] = [];
 
   for (const filePath of filesToInspect) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -343,6 +343,7 @@ import {
   defaultTierMigrationCycleBudget,
 } from "./compounding/engine.js";
 import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
+import { categoryDirName } from "./utils/category-dir.js";
 // IRC preference consolidation — used by eval adapter directly;
 // orchestrator integration planned for future PR.
 // import { consolidatePreferences, buildQueryAwarePreferenceSection, synthesizePreferencesFromLcm } from "./compounding/preference-consolidator.js";
@@ -1758,16 +1759,13 @@ export function resolvePersistedMemoryRelativePath(options: {
   }
   // Pick the subtree that matches the StorageManager.writeMemory routing
   // so fallback paths (used before memoryPathById has seen the fresh
-  // write) agree with where the file actually lives. Without this branch,
-  // reasoning_trace graph edges point at facts/<date>/, and subsequent
-  // graph expansion silently drops those nodes when readMemoryByPath
-  // cannot resolve them (issue #564 PR 3 review).
-  const subtree =
-    options.category === "procedure"
-      ? "procedures"
-      : options.category === "reasoning_trace"
-        ? "reasoning-traces"
-        : "facts";
+  // write) agree with where the file actually lives. Routing goes through
+  // the shared categoryDirName() chokepoint (utils/category-dir.ts) so
+  // every category — decisions/, preferences/, reasoning-traces/, ... —
+  // resolves to the same dir the writer used; otherwise graph edges point
+  // at the wrong subtree and graph expansion silently drops those nodes
+  // when readMemoryByPath cannot resolve them (issue #564 PR 3 / #1546).
+  const subtree = categoryDirName(options.category);
   const idParts = options.memoryId.split("-");
   const maybeTimestamp = Number(idParts[1]);
   if (Number.isFinite(maybeTimestamp) && maybeTimestamp > 0) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8,9 +8,11 @@ import os from "node:os";
 import { createHash, randomBytes } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import {
+  lstat,
   mkdir,
   readdir,
   readFile,
+  realpath,
   stat,
   unlink,
   writeFile,
@@ -344,6 +346,7 @@ import {
 } from "./compounding/engine.js";
 import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
 import { categoryDirName, RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
+import { assertPathInsideRoot } from "./utils/path-containment.js";
 // IRC preference consolidation — used by eval adapter directly;
 // orchestrator integration planned for future PR.
 // import { consolidatePreferences, buildQueryAwarePreferenceSection, synthesizePreferencesFromLcm } from "./compounding/preference-consolidator.js";
@@ -4793,16 +4796,34 @@ export class Orchestrator {
     // facts/ (#1546). corrections/ is flat, so corrections/<date>/ never exists
     // and is skipped by the ENOENT guard — preserving the prior exclusion. The
     // per-file created→local-day filter below is unchanged.
+    //
+    // Symlink/containment hardening (mirrors scanDir / the CLI walker): the
+    // gathered contents feed the day-summary LLM input, so a symlinked category
+    // dir (decisions/ → outside memoryDir) must not be followed and leak files.
+    // Resolve the store root once; skip symlinked / out-of-root dirs and
+    // entries; skip the scan gracefully if the root can't be resolved.
     const facts: MemoryFile[] = [];
+    let memoryRootReal: string | null = null;
+    try {
+      memoryRootReal = await realpath(storage.dir);
+    } catch {
+      memoryRootReal = null;
+    }
     for (const categoryDir of RECALL_FALLBACK_DIRS) {
+      if (memoryRootReal === null) break;
       for (const date of datesToScan) {
         const dateDir = path.join(storage.dir, categoryDir, date);
         try {
+          const dirStat = await lstat(dateDir);
+          if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) continue;
+          assertPathInsideRoot(memoryRootReal, await realpath(dateDir), dateDir);
           const entries = await readdir(dateDir, { withFileTypes: true });
           for (const entry of entries) {
+            if (entry.isSymbolicLink()) continue;
             if (!entry.name.endsWith(".md")) continue;
             const fullPath = path.join(dateDir, entry.name);
             try {
+              assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
               const raw = await readFile(fullPath, "utf-8");
               const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
               if (!fmMatch) continue;
@@ -4843,7 +4864,8 @@ export class Orchestrator {
             }
           }
         } catch {
-          // Directory doesn't exist for this category/date — nothing to read
+          // Absent dir (ENOENT), symlinked/out-of-root dir, or containment
+          // violation — skip this category/date without aborting the summary.
         }
       }
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -343,7 +343,7 @@ import {
   defaultTierMigrationCycleBudget,
 } from "./compounding/engine.js";
 import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
-import { categoryDirName } from "./utils/category-dir.js";
+import { categoryDirName, RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
 // IRC preference consolidation — used by eval adapter directly;
 // orchestrator integration planned for future PR.
 // import { consolidatePreferences, buildQueryAwarePreferenceSection, synthesizePreferencesFromLcm } from "./compounding/preference-consolidator.js";
@@ -4785,60 +4785,66 @@ export class Orchestrator {
     // a local calendar day. Scan the UTC-date envelope that overlaps the local
     // day, then filter parseable fact timestamps to that configured local day.
     const datesToScan = utcDateKeysForLocalDay(now, timeZone);
-    const factsBaseDir = path.join(storage.dir, "facts");
     const MAX_CHARS = 100_000;
 
-    // --- Read fact files from each date directory ---
+    // --- Read memory files from each category dir × date directory ---
+    // Iterate every recall category dir (RECALL_FALLBACK_DIRS — single source
+    // of truth) so the day summary includes decisions/, moments/, ... not just
+    // facts/ (#1546). corrections/ is flat, so corrections/<date>/ never exists
+    // and is skipped by the ENOENT guard — preserving the prior exclusion. The
+    // per-file created→local-day filter below is unchanged.
     const facts: MemoryFile[] = [];
-    for (const date of datesToScan) {
-      const factsDir = path.join(factsBaseDir, date);
-      try {
-        const entries = await readdir(factsDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.name.endsWith(".md")) continue;
-          const fullPath = path.join(factsDir, entry.name);
-          try {
-            const raw = await readFile(fullPath, "utf-8");
-            const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-            if (!fmMatch) continue;
-            const fmBlock = fmMatch[1];
-            const content = fmMatch[2].trim();
-            const fm: Record<string, string> = {};
-            for (const line of fmBlock.split("\n")) {
-              const colonIdx = line.indexOf(":");
-              if (colonIdx === -1) continue;
-              fm[line.slice(0, colonIdx).trim()] = line
-                .slice(colonIdx + 1)
-                .trim();
+    for (const categoryDir of RECALL_FALLBACK_DIRS) {
+      for (const date of datesToScan) {
+        const dateDir = path.join(storage.dir, categoryDir, date);
+        try {
+          const entries = await readdir(dateDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.name.endsWith(".md")) continue;
+            const fullPath = path.join(dateDir, entry.name);
+            try {
+              const raw = await readFile(fullPath, "utf-8");
+              const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+              if (!fmMatch) continue;
+              const fmBlock = fmMatch[1];
+              const content = fmMatch[2].trim();
+              const fm: Record<string, string> = {};
+              for (const line of fmBlock.split("\n")) {
+                const colonIdx = line.indexOf(":");
+                if (colonIdx === -1) continue;
+                fm[line.slice(0, colonIdx).trim()] = line
+                  .slice(colonIdx + 1)
+                  .trim();
+              }
+              const created = fm.created || "unknown";
+              const createdAt = parseFiniteDate(created);
+              if (
+                createdAt &&
+                formatDateInTimeZone(createdAt, timeZone) !== targetLocalDate
+              ) {
+                continue;
+              }
+              facts.push({
+                path: fullPath,
+                frontmatter: {
+                  id: fm.id || path.basename(entry.name, ".md"),
+                  category: (fm.category as any) || "fact",
+                  created,
+                  updated: fm.updated || created,
+                  source: fm.source || "unknown",
+                  confidence: parseFloat(fm.confidence || "0.8"),
+                  confidenceTier: (fm.confidenceTier as any) || "implied",
+                  tags: [],
+                },
+                content,
+              });
+            } catch {
+              // Skip unreadable files
             }
-            const created = fm.created || "unknown";
-            const createdAt = parseFiniteDate(created);
-            if (
-              createdAt &&
-              formatDateInTimeZone(createdAt, timeZone) !== targetLocalDate
-            ) {
-              continue;
-            }
-            facts.push({
-              path: fullPath,
-              frontmatter: {
-                id: fm.id || path.basename(entry.name, ".md"),
-                category: (fm.category as any) || "fact",
-                created,
-                updated: fm.updated || created,
-                source: fm.source || "unknown",
-                confidence: parseFloat(fm.confidence || "0.8"),
-                confidenceTier: (fm.confidenceTier as any) || "implied",
-                tags: [],
-              },
-              content,
-            });
-          } catch {
-            // Skip unreadable files
           }
+        } catch {
+          // Directory doesn't exist for this category/date — nothing to read
         }
-      } catch {
-        // Directory doesn't exist — no facts for this date
       }
     }
 

--- a/packages/remnic-core/src/page-versioning.ts
+++ b/packages/remnic-core/src/page-versioning.ts
@@ -25,6 +25,7 @@ import {
   writeFile,
   unlink,
 } from "node:fs/promises";
+import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -445,13 +446,15 @@ function computeLCS(a: string[], b: string[]): string[] {
  * optional `memoryDir` parameter is omitted.
  */
 function resolveMemoryDir(pagePath: string): string {
-  const knownSubdirs = new Set([
-    "facts",
-    "corrections",
+  // Derive the recall category dirs from ALL_CATEGORY_DIRS (single source of
+  // truth) so newly-routed categories (decisions/, preferences/, ...) are
+  // recognized when walking up to the memory root (#1546); the non-category
+  // subdirs are listed explicitly.
+  const knownSubdirs = new Set<string>([
+    ...ALL_CATEGORY_DIRS,
     "entities",
     "state",
     "artifacts",
-    "questions",
     "profiles",
   ]);
 

--- a/packages/remnic-core/src/search/document-scanner.test.ts
+++ b/packages/remnic-core/src/search/document-scanner.test.ts
@@ -78,3 +78,32 @@ test("scanMemoryDir skips nested symlink entries", async (t) => {
     await rm(outsideDir, { recursive: true, force: true });
   }
 });
+
+test("scanMemoryDir indexes memories under category dirs beyond facts/ (issue #1546)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-scan-category-"));
+  try {
+    // A decision routed into decisions/<date>/ must be picked up by the
+    // non-QMD index scanner (Orama/Meilisearch/LanceDB), not just facts/.
+    const decisionDir = path.join(memoryDir, "decisions", "2026-02-22");
+    await mkdir(decisionDir, { recursive: true });
+    await writeFile(
+      path.join(decisionDir, "decision-1.md"),
+      ["---", "id: decision-1", "category: decision", "---", "We chose blue-green deploys."].join("\n"),
+      "utf8",
+    );
+    const factsDir = path.join(memoryDir, "facts", "2026-02-22");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(
+      path.join(factsDir, "fact-1.md"),
+      ["---", "id: fact-1", "category: fact", "---", "The worker retries three times."].join("\n"),
+      "utf8",
+    );
+
+    const docs = await scanMemoryDir(memoryDir);
+    const ids = docs.map((doc) => doc.docid).sort();
+
+    assert.deepEqual(ids, ["decision-1", "fact-1"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/search/document-scanner.ts
+++ b/packages/remnic-core/src/search/document-scanner.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { lstat, readdir, readFile, realpath } from "node:fs/promises";
 import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
+import { assertPathInsideRoot } from "../utils/path-containment.js";
 
 export interface IndexableDocument {
   /** Memory ID from frontmatter or filename stem */
@@ -93,17 +94,6 @@ async function scanDir(dir: string, memoryRootReal: string): Promise<IndexableDo
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return typeof err === "object" && err !== null && "code" in err;
-}
-
-function pathIsInside(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function assertPathInsideRoot(rootReal: string, candidateReal: string, originalPath: string): void {
-  if (!pathIsInside(rootReal, candidateReal)) {
-    throw new Error(`Refusing to scan memory path outside memoryDir: ${originalPath}`);
-  }
 }
 
 /**

--- a/packages/remnic-core/src/search/document-scanner.ts
+++ b/packages/remnic-core/src/search/document-scanner.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { lstat, readdir, readFile, realpath } from "node:fs/promises";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 
 export interface IndexableDocument {
   /** Memory ID from frontmatter or filename stem */
@@ -106,13 +107,17 @@ function assertPathInsideRoot(rootReal: string, candidateReal: string, originalP
 }
 
 /**
- * Scan `facts/`, `corrections/`, `procedures/`, and `reasoning-traces/`
- * subdirs of memoryDir for indexable markdown documents.
- *
- * Note: reasoning-traces live under their own subtree (issue #564 PR 3).
- * Non-QMD backends (Orama / Meilisearch / LanceDB) build their index
- * through this helper, so any new category subtree must be listed here
- * or those backends silently stop seeing the new memories.
+ * Scan every recall category subdir of memoryDir for indexable markdown
+ * documents. The directory set is derived from `RECALL_FALLBACK_DIRS`
+ * (utils/category-dir.ts → ALL_CATEGORY_DIRS minus non-recall queue dirs) —
+ * the single source of truth — so adding a new category never requires
+ * touching this scanner. Non-QMD backends (Orama / Meilisearch / LanceDB)
+ * build their index through this helper; deriving from RECALL_FALLBACK_DIRS
+ * keeps them in parity with writeMemory's category-dir routing (issue #1546)
+ * and the QMD filesystem-fallback corpus. reasoning-traces/ and the other
+ * category dirs are covered automatically (issue #564 PR 3 no longer needs a
+ * hand-maintained list). scanDir tolerates missing dirs (ENOENT), so category
+ * dirs that do not exist yet are skipped.
  */
 export async function scanMemoryDir(memoryDir: string): Promise<IndexableDocument[]> {
   let memoryRootReal: string;
@@ -124,15 +129,8 @@ export async function scanMemoryDir(memoryDir: string): Promise<IndexableDocumen
     }
     throw err;
   }
-  const factsDir = path.join(memoryDir, "facts");
-  const correctionsDir = path.join(memoryDir, "corrections");
-  const proceduresDir = path.join(memoryDir, "procedures");
-  const reasoningTracesDir = path.join(memoryDir, "reasoning-traces");
-  const [facts, corrections, procedures, reasoningTraces] = await Promise.all([
-    scanDir(factsDir, memoryRootReal),
-    scanDir(correctionsDir, memoryRootReal),
-    scanDir(proceduresDir, memoryRootReal),
-    scanDir(reasoningTracesDir, memoryRootReal),
-  ]);
-  return [...facts, ...corrections, ...procedures, ...reasoningTraces];
+  const perDir = await Promise.all(
+    RECALL_FALLBACK_DIRS.map((dir) => scanDir(path.join(memoryDir, dir), memoryRootReal)),
+  );
+  return perDir.flat();
 }

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -59,7 +59,7 @@ import {
   parseEnvelope,
   seal,
 } from "./cipher.js";
-import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -705,15 +705,24 @@ function normalizeStorageRelativePath(rel: string): string {
   return normalized;
 }
 
-// Every recall category directory (facts/ + all CATEGORY_DIR_MAP dirs, incl.
-// questions/) must be encryptable at rest — #1546 routes decision/preference/
-// moment/... memories into their own dirs, so hardcoding only facts/corrections/
-// procedures/reasoning-traces would silently write those categories in
-// plaintext on encrypted stores. ALL_CATEGORY_DIRS is the single source of
-// truth; the extra non-category markdown roots (artifacts/archive/entities/
+// Every recall MEMORY category directory (facts/ + the CATEGORY_DIR_MAP memory
+// dirs) must be encryptable at rest — #1546 routes decision/preference/moment/...
+// memories into their own dirs, so hardcoding only facts/corrections/procedures/
+// reasoning-traces would silently write those categories in plaintext on
+// encrypted stores. RECALL_FALLBACK_DIRS is the single source of truth for that
+// set; the extra non-category markdown roots (artifacts/archive/entities/
 // identity) are appended.
+//
+// questions/ is deliberately EXCLUDED (RECALL_FALLBACK_DIRS omits the non-memory
+// queue dirs): the question queue is written/resolved through plain readFile/
+// writeFile (StorageManager.writeQuestion/resolveQuestion), NOT the secure-file
+// helpers. Encrypting questions/ here would make migration seal those files,
+// after which resolveQuestion() would read ciphertext as UTF-8, fail to update
+// the frontmatter, and overwrite/corrupt the file while returning success
+// (codex #1563 review). Keeping questions/ plaintext preserves the queue's
+// existing behavior; #1546 does not change question encryption.
 const ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS = new Set<string>([
-  ...ALL_CATEGORY_DIRS,
+  ...RECALL_FALLBACK_DIRS,
   "artifacts",
   "archive",
   "entities",

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -59,6 +59,7 @@ import {
   parseEnvelope,
   seal,
 } from "./cipher.js";
+import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 
 // ---------------------------------------------------------------------------
 // Error classes
@@ -704,11 +705,15 @@ function normalizeStorageRelativePath(rel: string): string {
   return normalized;
 }
 
-const ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS = new Set([
-  "facts",
-  "corrections",
-  "procedures",
-  "reasoning-traces",
+// Every recall category directory (facts/ + all CATEGORY_DIR_MAP dirs, incl.
+// questions/) must be encryptable at rest — #1546 routes decision/preference/
+// moment/... memories into their own dirs, so hardcoding only facts/corrections/
+// procedures/reasoning-traces would silently write those categories in
+// plaintext on encrypted stores. ALL_CATEGORY_DIRS is the single source of
+// truth; the extra non-category markdown roots (artifacts/archive/entities/
+// identity) are appended.
+const ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS = new Set<string>([
+  ...ALL_CATEGORY_DIRS,
   "artifacts",
   "archive",
   "entities",

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -935,3 +935,31 @@ test("backspace on BMP character removes exactly one character (thread 7 — reg
 
   assert.equal(result, "a");
 });
+
+test("secure-store migration encrypts memory category dirs but leaves the questions queue plaintext", async () => {
+  // #1546 routes decision/preference/... memories into their own dirs, which
+  // must be encryptable at rest. But questions/ is written/resolved via plain
+  // readFile/writeFile (writeQuestion/resolveQuestion), so encrypting it would
+  // make resolveQuestion() read ciphertext as UTF-8 and corrupt the file
+  // (codex #1563 review). Migration must seal decisions/ but skip questions/.
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "remnic-secure-store-questions-"));
+  try {
+    const memoryDir = path.join(tempRoot, "memory");
+    const decisionPath = path.join(memoryDir, "decisions", "2026-02-22", "decision-1.md");
+    const questionPath = path.join(memoryDir, "questions", "q-1.md");
+    await mkdir(path.dirname(decisionPath), { recursive: true });
+    await mkdir(path.dirname(questionPath), { recursive: true });
+    await writeFile(decisionPath, "---\ncategory: decision\n---\n\nChose Postgres.\n", "utf8");
+    await writeFile(questionPath, "---\nid: q-1\nresolved: false\n---\n\nWhat DB?\n", "utf8");
+
+    const key = deriveKeyScrypt("questions-plaintext", Buffer.alloc(KDF_SALT_LENGTH, 0x5a), FAST_SCRYPT);
+    const migrated = await migrateMemoryDirToEncrypted(memoryDir, key);
+
+    assert.equal(migrated.encrypted, 1, "only the decision memory should be encrypted");
+    assert.equal(isEncryptedFile(await readFile(decisionPath)), true, "decisions/ is encrypted at rest");
+    assert.equal(isEncryptedFile(await readFile(questionPath)), false, "questions/ stays plaintext");
+    assert.match(await readFile(questionPath, "utf8"), /What DB\?/, "question body remains readable UTF-8");
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
 import { isErrnoCode } from "./utils/errno.js";
-import { RECALL_FALLBACK_DIRS, getCategoryDir } from "./utils/category-dir.js";
+import { RECALL_FALLBACK_DIRS, getCategoryDir, categoryDirName } from "./utils/category-dir.js";
 import { getCachedEntities, invalidateAllForDir, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -4338,9 +4338,10 @@ export class StorageManager {
    * Read all memories from the cold tier by scanning the entire cold/ root
    * tree.  Previously this only scanned cold/facts/ and cold/corrections/, but
    * structuredAttributes can appear on any MemoryCategory (preference, decision,
-   * entity, etc.).  Although buildTierMemoryPath currently routes all
-   * non-correction, non-artifact memories to cold/facts/, scanning the full
-   * coldRoot ensures correctness if that routing ever changes and guards against
+   * entity, etc.).  buildTierMemoryPath now routes each category to its own
+   * cold/<dir>/ subtree via the shared categoryDirName() chokepoint (issue
+   * #1546), so cold decisions/preferences/... live outside cold/facts/.
+   * Scanning the full coldRoot covers every category dir and guards against
    * files placed in unexpected subdirectories during manual operations or future
    * refactors.
    *
@@ -4548,19 +4549,17 @@ export class StorageManager {
       return path.join(root, "artifacts", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
     }
     if (memory.frontmatter.category === "correction") {
+      // corrections/ is flat (no date subdir); preserved across tier moves.
       return path.join(root, "corrections", `${memory.frontmatter.id}.md`);
     }
-    if (memory.frontmatter.category === "procedure") {
-      return path.join(root, "procedures", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
-    }
-    if (memory.frontmatter.category === "reasoning_trace") {
-      // Issue #564 PR 3: preserve the dedicated reasoning-traces/ subtree
-      // across tier moves. Without this branch, hot→cold migration would
-      // funnel the memory into facts/, breaking isReasoningTracePath() and
-      // silently disabling the recall boost for migrated traces.
-      return path.join(root, "reasoning-traces", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
-    }
-    return path.join(root, "facts", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
+    // Every other category — decisions/, preferences/, reasoning-traces/, ...
+    // plus the facts/ fallback for fact/entity/unknown — resolves through the
+    // shared categoryDirName() chokepoint so tier moves land in the SAME dir the
+    // writer used, instead of funneling non-{correction,procedure,reasoning_trace}
+    // categories into facts/ (issue #564 PR 3 preserved reasoning-traces/; #1546
+    // generalizes it to every category dir).
+    const dir = categoryDirName(memory.frontmatter.category);
+    return path.join(root, dir, this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
   }
 
   private async writeMemoryFileAtomic(targetPath: string, memory: MemoryFile): Promise<void> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
 import { isErrnoCode } from "./utils/errno.js";
-import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
+import { RECALL_FALLBACK_DIRS, getCategoryDir } from "./utils/category-dir.js";
 import { getCachedEntities, invalidateAllForDir, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -3297,6 +3297,32 @@ export class StorageManager {
     await mkdir(path.join(this.baseDir, "config"), { recursive: true });
   }
 
+  /**
+   * Resolve the on-disk write path for a memory of the given category, creating
+   * the target directory. Category routing goes through the shared
+   * `getCategoryDir()` chokepoint (utils/category-dir.ts → CATEGORY_DIR_MAP) so
+   * decision/preference/moment/etc. outputs land in their dedicated dirs
+   * (`decisions/`, `preferences/`, ...) instead of collapsing into `facts/`
+   * (issue #1546; CLAUDE.md rule 39). `correction` keeps its historical flat
+   * layout (no `<date>` subdir) as the corrections pipeline expects; every other
+   * category — including `fact`/`entity`, which fall back to `facts/` — is dated
+   * as `<dir>/<date>/`. Read/scan/reindex already iterate every category dir
+   * (RECALL_FALLBACK_DIRS; QMD scans baseDir recursively), so writes stay found.
+   */
+  private async resolveCategoryWritePath(
+    category: MemoryCategory,
+    id: string,
+    today: string,
+  ): Promise<string> {
+    if (category === "correction") {
+      await mkdir(this.correctionsDir, { recursive: true });
+      return path.join(this.correctionsDir, `${id}.md`);
+    }
+    const datedDir = path.join(getCategoryDir(this.baseDir, category), today);
+    await mkdir(datedDir, { recursive: true });
+    return path.join(datedDir, `${id}.md`);
+  }
+
   async writeMemory(
     category: MemoryCategory,
     content: string,
@@ -3435,20 +3461,7 @@ export class StorageManager {
 
     const fileContent = `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`;
 
-    let filePath: string;
-    if (category === "correction") {
-      filePath = path.join(this.correctionsDir, `${id}.md`);
-    } else if (category === "procedure") {
-      await mkdir(path.join(this.proceduresDir, today), { recursive: true });
-      filePath = path.join(this.proceduresDir, today, `${id}.md`);
-    } else if (category === "reasoning_trace") {
-      // Issue #564 PR 3: reasoning traces live in their own subtree so recall
-      // can filter on path cheaply without parsing frontmatter.
-      await mkdir(path.join(this.reasoningTracesDir, today), { recursive: true });
-      filePath = path.join(this.reasoningTracesDir, today, `${id}.md`);
-    } else {
-      filePath = path.join(this.factsDir, today, `${id}.md`);
-    }
+    const filePath = await this.resolveCategoryWritePath(category, id, today);
 
     await this.snapshotBeforeWrite(filePath, "write");
     await writeMaybeEncryptedFile(filePath, fileContent, this.resolveWriteKey(), {}, this.baseDir);
@@ -6984,20 +6997,7 @@ export class StorageManager {
     }
     const fileContent = `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`;
 
-    let filePath: string;
-    if (category === "correction") {
-      filePath = path.join(this.correctionsDir, `${id}.md`);
-    } else if (category === "procedure") {
-      await mkdir(path.join(this.proceduresDir, today), { recursive: true });
-      filePath = path.join(this.proceduresDir, today, `${id}.md`);
-    } else if (category === "reasoning_trace") {
-      // Issue #564 PR 3: chunks of a reasoning_trace memory live alongside the
-      // parent in reasoning-traces/<date>/.
-      await mkdir(path.join(this.reasoningTracesDir, today), { recursive: true });
-      filePath = path.join(this.reasoningTracesDir, today, `${id}.md`);
-    } else {
-      filePath = path.join(this.factsDir, today, `${id}.md`);
-    }
+    const filePath = await this.resolveCategoryWritePath(category, id, today);
 
     await this.writeStorageSecureFile(filePath, fileContent);
     log.debug(`wrote chunk ${id} (${chunkIndex + 1}/${chunkTotal}) to ${filePath}`);

--- a/packages/remnic-core/src/training-export/converter.test.ts
+++ b/packages/remnic-core/src/training-export/converter.test.ts
@@ -502,4 +502,23 @@ describe("convertMemoriesToRecords", () => {
       ["a", "b", "c"],
     );
   });
+
+  it("exports memories under category dirs beyond facts/ (issue #1546)", async () => {
+    const dir = await makeTmpDir();
+    // A decision routed into decisions/<date>/ must appear in the export, not
+    // just facts/ + corrections/.
+    await writeSyntheticMemory(dir, "decisions/2026-02-22", "decision-1.md", {
+      id: "decision-1",
+      category: "decision",
+      content: "We chose blue-green deploys.",
+    });
+    await writeSyntheticMemory(dir, "facts/2026-02-22", "fact-1.md", {
+      id: "fact-1",
+      content: "The worker retries three times.",
+    });
+
+    const records = await convertMemoriesToRecords({ memoryDir: dir });
+    const ids = records.map((r) => r.sourceIds?.[0]).sort();
+    assert.deepEqual(ids, ["decision-1", "fact-1"]);
+  });
 });

--- a/packages/remnic-core/src/training-export/converter.ts
+++ b/packages/remnic-core/src/training-export/converter.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 
 import { parseStrictCliDate } from "./date-parse.js";
 import type { TrainingExportOptions, TrainingExportRecord } from "./types.js";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
 
 // ---------------------------------------------------------------------------
 // Frontmatter parsing (mirrors storage.ts but kept standalone)
@@ -266,12 +267,14 @@ export async function convertMemoriesToRecords(
   const containmentRoot = await safeRealpath(memoryDir);
   if (!containmentRoot) return [];
 
-  // Collect from facts/ and corrections/ subdirectories (mirrors storage.ts)
-  const factsDir = path.join(memoryDir, "facts");
-  const correctionsDir = path.join(memoryDir, "corrections");
-
-  const dirs = [factsDir, correctionsDir];
+  // Collect from every recall category directory (RECALL_FALLBACK_DIRS — the
+  // single source of truth), so newly-routed categories (decisions/,
+  // preferences/, ...) are exported, not just facts/ + corrections/ (#1546).
+  // collectMarkdownFiles recurses, so flat (corrections/) vs dated
+  // (decisions/<date>/) layouts are both handled.
+  const dirs = RECALL_FALLBACK_DIRS.map((dir) => path.join(memoryDir, dir));
   if (options.includeEntities) {
+    // entities/ is NOT a recall category — it stays a separate opt-in include.
     dirs.push(path.join(memoryDir, "entities"));
   }
 

--- a/packages/remnic-core/src/utils/category-dir.ts
+++ b/packages/remnic-core/src/utils/category-dir.ts
@@ -61,12 +61,18 @@ export const ALL_CATEGORY_KEYS: string[] = [
 ];
 
 /**
+ * Relative directory NAME for a category (e.g. "decisions"); "facts" for
+ * unknown / `fact` / `entity`. Single source of truth shared by every write,
+ * path-derivation, and tier-move site — never inline a category→dir ternary.
+ */
+export function categoryDirName(category: string): string {
+  return Object.hasOwn(CATEGORY_DIR_MAP, category) ? CATEGORY_DIR_MAP[category] : "facts";
+}
+
+/**
  * Resolve a category name to its directory path under memoryDir.
  * Falls back to `facts/` for unknown categories.
  */
 export function getCategoryDir(memoryDir: string, category: string): string {
-  const dir = Object.hasOwn(CATEGORY_DIR_MAP, category)
-    ? CATEGORY_DIR_MAP[category]
-    : undefined;
-  return dir ? path.join(memoryDir, dir) : path.join(memoryDir, "facts");
+  return path.join(memoryDir, categoryDirName(category));
 }

--- a/packages/remnic-core/src/utils/path-containment.ts
+++ b/packages/remnic-core/src/utils/path-containment.ts
@@ -1,0 +1,40 @@
+/**
+ * @remnic/core — Path Containment Guards
+ *
+ * Shared symlink/traversal containment helpers for filesystem walkers that
+ * scan the memory store. Extracted from search/document-scanner.ts so every
+ * walker (the search index scanner, the CLI dedupe walker, ...) enforces the
+ * SAME containment semantics instead of forking the check (CLAUDE.md rule 22).
+ *
+ * Both helpers operate on realpath()-resolved absolute paths: callers resolve
+ * symlinks first, then assert the resolved target is still inside the (also
+ * realpath-resolved) memory root. This blocks a symlinked category directory
+ * (e.g. decisions/ → /etc) from redirecting a scan — or a destructive dedupe
+ * unlink — outside the memory store.
+ */
+
+import path from "node:path";
+
+/**
+ * True when `child` is `parent` itself or nested underneath it. Both arguments
+ * must already be resolved (realpath) absolute paths.
+ */
+export function pathIsInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/**
+ * Throw if the realpath-resolved `candidateReal` escapes `rootReal`. The
+ * message references the original (pre-realpath) path so operators can locate
+ * the offending symlink/entry.
+ */
+export function assertPathInsideRoot(
+  rootReal: string,
+  candidateReal: string,
+  originalPath: string,
+): void {
+  if (!pathIsInside(rootReal, candidateReal)) {
+    throw new Error(`Refusing to scan memory path outside memoryDir: ${originalPath}`);
+  }
+}

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20028,
+      "packages/remnic-core/src/orchestrator.ts": 20050,
       "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8277,
       "packages/remnic-core/src/storage.ts": 7283,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,10 +4,10 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20024,
-      "packages/remnic-core/src/cli.ts": 9812,
+      "packages/remnic-core/src/orchestrator.ts": 20028,
+      "packages/remnic-core/src/cli.ts": 9814,
       "packages/remnic-core/src/access-service.ts": 8277,
-      "packages/remnic-core/src/storage.ts": 7284,
+      "packages/remnic-core/src/storage.ts": 7283,
       "packages/remnic-core/src/config.ts": 4548
     },
     "oversizedFileCount": 10,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -5,7 +5,7 @@
   "metrics": {
     "watchlistLoc": {
       "packages/remnic-core/src/orchestrator.ts": 20028,
-      "packages/remnic-core/src/cli.ts": 9814,
+      "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8277,
       "packages/remnic-core/src/storage.ts": 7283,
       "packages/remnic-core/src/config.ts": 4548

--- a/tests/cli-walk-memory-markdown-files.test.ts
+++ b/tests/cli-walk-memory-markdown-files.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { listMemoryMarkdownFilePaths } from "../src/cli.js";
 
 // The shared CLI memory walker (walkMemoryMarkdownFiles, exposed here via
@@ -35,5 +35,94 @@ test("listMemoryMarkdownFilePaths returns files under category dirs beyond facts
     assert.deepEqual(paths, [decisionPath, factPath].sort());
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Security regression (codex P2): the walker feeds readAllMemoryFiles →
+// dedupe-exact/dedupe-aggressive, which unlink() files. A category root
+// symlinked outside memoryDir must NOT be followed, or dedupe could delete
+// markdown outside the memory store. Mirrors scanDir's containment guard.
+test("listMemoryMarkdownFilePaths does not follow a category root symlinked outside memoryDir", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-walk-escape-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-walk-outside-"));
+  try {
+    // A file OUTSIDE the memory store that must never be returned.
+    await writeFile(
+      path.join(outsideDir, "evil.md"),
+      ["---", "id: evil", "category: decision", "---", "External file — must not be walked."].join("\n"),
+      "utf-8",
+    );
+    // decisions/ is a symlink pointing at the external dir.
+    await symlink(outsideDir, path.join(memoryDir, "decisions"), "dir");
+
+    // A legitimate memory under a real category dir — regression that normal
+    // walking still works alongside the rejected symlink.
+    const realDir = path.join(memoryDir, "facts", "2026-02-22");
+    await mkdir(realDir, { recursive: true });
+    const realPath = path.join(realDir, "real.md");
+    await writeFile(
+      realPath,
+      ["---", "id: real", "category: fact", "---", "A genuine in-store memory."].join("\n"),
+      "utf-8",
+    );
+
+    const paths = await listMemoryMarkdownFilePaths(memoryDir);
+
+    assert.deepEqual(
+      paths.filter((p) => p.endsWith("evil.md")),
+      [],
+      "must not walk into a symlinked category root that escapes memoryDir",
+    );
+    assert.deepEqual(paths, [realPath], "the real in-store memory is still returned");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+// A dated subdir under a real category dir that is itself a symlink escaping
+// memoryDir must also be skipped (nested-entry containment).
+test("listMemoryMarkdownFilePaths skips a nested subdir symlink that escapes memoryDir", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-walk-nested-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-walk-nested-outside-"));
+  try {
+    await writeFile(
+      path.join(outsideDir, "evil.md"),
+      ["---", "id: evil-nested", "category: decision", "---", "External — must not be walked."].join("\n"),
+      "utf-8",
+    );
+    const decisionsDir = path.join(memoryDir, "decisions");
+    await mkdir(decisionsDir, { recursive: true });
+    // decisions/escape → outside dir (a nested entry, not the root).
+    await symlink(outsideDir, path.join(decisionsDir, "escape"), "dir");
+
+    const realPath = path.join(decisionsDir, "2026-02-22", "real.md");
+    await mkdir(path.dirname(realPath), { recursive: true });
+    await writeFile(
+      realPath,
+      ["---", "id: real-nested", "category: decision", "---", "Genuine decision memory."].join("\n"),
+      "utf-8",
+    );
+
+    const paths = await listMemoryMarkdownFilePaths(memoryDir);
+    assert.deepEqual(
+      paths.filter((p) => p.endsWith("evil.md")),
+      [],
+      "must not follow a nested symlinked subdir that escapes memoryDir",
+    );
+    assert.deepEqual(paths, [realPath], "the real nested memory is still returned");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });

--- a/tests/cli-walk-memory-markdown-files.test.ts
+++ b/tests/cli-walk-memory-markdown-files.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { listMemoryMarkdownFilePaths } from "../src/cli.js";
+
+// The shared CLI memory walker (walkMemoryMarkdownFiles, exposed here via
+// listMemoryMarkdownFilePaths) must cover every recall category directory, not
+// just facts/ + corrections/ — otherwise CLI commands built on it (bulk-import
+// counting, dedupe, ...) would miss memories routed into decisions/,
+// preferences/, ... after issue #1546.
+test("listMemoryMarkdownFilePaths returns files under category dirs beyond facts/ (issue #1546)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-walk-category-"));
+  try {
+    const decisionDir = path.join(memoryDir, "decisions", "2026-02-22");
+    await mkdir(decisionDir, { recursive: true });
+    const decisionPath = path.join(decisionDir, "decision-1.md");
+    await writeFile(
+      decisionPath,
+      ["---", "id: decision-1", "category: decision", "---", "We chose blue-green deploys."].join("\n"),
+      "utf-8",
+    );
+
+    const factDir = path.join(memoryDir, "facts", "2026-02-22");
+    await mkdir(factDir, { recursive: true });
+    const factPath = path.join(factDir, "fact-1.md");
+    await writeFile(
+      factPath,
+      ["---", "id: fact-1", "category: fact", "---", "The worker retries three times."].join("\n"),
+      "utf-8",
+    );
+
+    const paths = (await listMemoryMarkdownFilePaths(memoryDir)).sort();
+    assert.deepEqual(paths, [decisionPath, factPath].sort());
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -252,6 +252,50 @@ test("runConsolidationProvenanceCheck flags raw derived_from that the parser dro
   }
 });
 
+test("runConsolidationProvenanceCheck surfaces a malformed .md under decisions/ (issue #1546)", async () => {
+  // The parse-failure walk must scan every recall category dir, not just
+  // facts/corrections/procedures/reasoning-traces. A malformed decision file
+  // with visible provenance YAML must be surfaced by the doctor.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-decision-"));
+  try {
+    const storage = await seedStorage(dir);
+
+    const day = "2026-04-20";
+    const decisionDir = path.join(dir, "decisions", day);
+    await mkdir(decisionDir, { recursive: true });
+
+    const id = "decision-scalar-from";
+    const filePath = path.join(decisionDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: decision",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_from: decisions/a.md:7", // scalar — not a list; parser drops it
+      "derived_via: merge",
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    const malformed = report.issues.filter(
+      (i) => i.kind === "derived_from_malformed_entry",
+    );
+    assert.equal(malformed.length, 1);
+    assert.ok(malformed[0].detail.includes("decisions/a.md:7"));
+    assert.equal(malformed[0].memoryPath, filePath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("summarizeConsolidationProvenance honors versioningSidecarDir from config", async () => {
   // Regression for PR #634 review feedback (codex P2 / cursor Medium):
   // the summarizer must thread the configured `versioningSidecarDir`

--- a/tests/day-summary-cron-routing.test.ts
+++ b/tests/day-summary-cron-routing.test.ts
@@ -213,3 +213,49 @@ test("day-summary auto-gather filters hourly summary sections by configured loca
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("gatherTodayFacts includes a decision-category memory routed to decisions/ (issue #1546)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-decision-"));
+  try {
+    // A day whose only memory is a decision routed into decisions/<utc-date>/
+    // must still produce a non-empty day summary that includes it — the scan
+    // now iterates every recall category dir, not just facts/.
+    const utcDate = "2026-06-24";
+    const created = "2026-06-24T12:00:00.000Z";
+    const dir = path.join(memoryDir, "decisions", utcDate);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "decision-1.md"),
+      [
+        "---",
+        "id: decision-1",
+        "category: decision",
+        `created: ${created}`,
+        `updated: ${created}`,
+        "source: test",
+        "confidence: 0.9",
+        "---",
+        "We chose blue-green deploys for the ingestion worker.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      daySummaryTimezone: "UTC",
+    });
+    const orchestrator = new Orchestrator(config);
+
+    const gathered = await orchestrator.gatherTodayFacts(undefined, {
+      now: new Date("2026-06-24T18:00:00Z"),
+    });
+
+    assert.notEqual(gathered.trim(), "", "day summary must not be empty for a decision-only day");
+    assert.match(gathered, /blue-green deploys for the ingestion worker/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/day-summary-cron-routing.test.ts
+++ b/tests/day-summary-cron-routing.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { validateRequest } from "../src/access-schema.js";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
@@ -257,5 +257,82 @@ test("gatherTodayFacts includes a decision-category memory routed to decisions/ 
     assert.match(gathered, /blue-green deploys for the ingestion worker/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Security regression (codex P2): gatherTodayFacts feeds file contents into the
+// day-summary LLM input. A category dir symlinked outside memoryDir must NOT be
+// followed, or an external file would leak into the summary.
+test("gatherTodayFacts does not follow a category dir symlinked outside memoryDir", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-escape-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-outside-"));
+  try {
+    const utcDate = "2026-06-24";
+    const created = "2026-06-24T12:00:00.000Z";
+
+    // External file under <outside>/<date>/, reachable only via a symlink.
+    const outsideDated = path.join(outsideDir, utcDate);
+    await mkdir(outsideDated, { recursive: true });
+    await writeFile(
+      path.join(outsideDated, "decision-external.md"),
+      [
+        "---",
+        "id: decision-external",
+        "category: decision",
+        `created: ${created}`,
+        `updated: ${created}`,
+        "source: test",
+        "confidence: 0.9",
+        "---",
+        "EXTERNAL SECRET — must not leak into the day summary.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    // decisions/ → external dir.
+    await symlink(outsideDir, path.join(memoryDir, "decisions"), "dir");
+
+    // A genuine in-store fact for the same day (regression: real scan works).
+    const realDated = path.join(memoryDir, "facts", utcDate);
+    await mkdir(realDated, { recursive: true });
+    await writeFile(
+      path.join(realDated, "fact-real.md"),
+      [
+        "---",
+        "id: fact-real",
+        "category: fact",
+        `created: ${created}`,
+        `updated: ${created}`,
+        "source: test",
+        "confidence: 0.9",
+        "---",
+        "A genuine in-store fact for the day.",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      daySummaryTimezone: "UTC",
+    });
+    const orchestrator = new Orchestrator(config);
+
+    const gathered = await orchestrator.gatherTodayFacts(undefined, {
+      now: new Date("2026-06-24T18:00:00Z"),
+    });
+
+    assert.doesNotMatch(gathered, /EXTERNAL SECRET/, "external file must not leak via the symlinked category dir");
+    assert.match(gathered, /genuine in-store fact/, "the real in-store fact is still included");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });

--- a/tests/memory-governance.test.ts
+++ b/tests/memory-governance.test.ts
@@ -1432,3 +1432,31 @@ test("bounded governance apply skips path reloads whose memory id changed", asyn
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+// NOTE: keep this test LAST so it never shifts the line numbers of the
+// pre-existing type-check baseline entries earlier in this file
+// (scripts/test-typecheck-baseline.txt pins them by line number).
+test("governance surfaces a malformed file under decisions/ (issue #1546)", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-governance-category-"));
+  try {
+    // A malformed memory routed into decisions/<date>/ must be surfaced by the
+    // malformed-import scan, which now walks every recall category directory.
+    await writeText(
+      memoryDir,
+      "decisions/2026-03-03/decision-malformed.md",
+      "---\nid: decision-malformed\ncategory: decision\ncreated: not-a-date\n",
+    );
+
+    const result = await runMemoryGovernance({
+      memoryDir,
+      mode: "shadow",
+      now: new Date("2026-03-09T12:00:00.000Z"),
+    });
+
+    const malformed = result.reviewQueue.filter((entry) => entry.reasonCode === "malformed_import");
+    assert.equal(malformed.length, 1);
+    assert.equal(malformed[0].path, path.join(memoryDir, "decisions/2026-03-03/decision-malformed.md"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-governance.test.ts
+++ b/tests/memory-governance.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { RULE_VERSION, runMemoryGovernance, restoreMemoryGovernanceRun } from "../src/maintenance/memory-governance.ts";
 import { StorageManager } from "../src/storage.ts";
 
@@ -1458,5 +1458,58 @@ test("governance surfaces a malformed file under decisions/ (issue #1546)", asyn
     assert.equal(malformed[0].path, path.join(memoryDir, "decisions/2026-03-03/decision-malformed.md"));
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// Security regression (codex P2): the malformed-import sweep must not follow a
+// category dir symlinked outside memoryDir. Kept LAST so it never shifts the
+// line-pinned test-typecheck-baseline entries earlier in this file.
+test("governance does not surface a malformed file behind a symlinked category dir (issue #1546)", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-governance-escape-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-governance-outside-"));
+  try {
+    // Malformed markdown OUTSIDE the store, reachable only via a symlink.
+    await mkdir(path.join(outsideDir, "2026-03-03"), { recursive: true });
+    await writeFile(
+      path.join(outsideDir, "2026-03-03", "decision-external.md"),
+      "---\nid: decision-external\ncategory: decision\ncreated: not-a-date\n",
+      "utf-8",
+    );
+    // decisions/ → external dir.
+    await symlink(outsideDir, path.join(memoryDir, "decisions"), "dir");
+
+    // A genuine in-store malformed decision under a REAL preferences/ dir
+    // (regression: real category dirs are still swept).
+    await writeText(
+      memoryDir,
+      "preferences/2026-03-03/preference-malformed.md",
+      "---\nid: preference-malformed\ncategory: preference\ncreated: not-a-date\n",
+    );
+
+    const result = await runMemoryGovernance({
+      memoryDir,
+      mode: "shadow",
+      now: new Date("2026-03-09T12:00:00.000Z"),
+    });
+
+    const malformed = result.reviewQueue.filter((entry) => entry.reasonCode === "malformed_import");
+    assert.equal(
+      malformed.some((entry) => entry.path.includes("decision-external.md")),
+      false,
+      "external malformed file must not be surfaced via the symlinked category dir",
+    );
+    assert.equal(
+      malformed.some((entry) => entry.path === path.join(memoryDir, "preferences/2026-03-03/preference-malformed.md")),
+      true,
+      "the real in-store malformed file is still surfaced",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });

--- a/tests/orchestrator-characterization.test.ts
+++ b/tests/orchestrator-characterization.test.ts
@@ -454,7 +454,7 @@ test("buffers are keyed by session: flushing one session leaves the other intact
 
 // ── 3. Extract (flush) ──────────────────────────────────────────────────────
 
-test("extraction persists every category under facts/ with the category in frontmatter (current behavior)", async () => {
+test("extraction routes each category into its own category dir via CATEGORY_DIR_MAP", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-char-category-dirs-"));
   const orchestrator = new Orchestrator(makeConfig(memoryDir));
   try {
@@ -476,23 +476,25 @@ test("extraction persists every category under facts/ with the category in front
     );
     await orchestrator.flushSession("session-char-categories", { reason: "session-command" });
 
-    // CURRENT behavior (pinned, not endorsed): the extraction persist path
-    // writes ALL categories under facts/<date>/ — the category-specific
-    // directories from utils/category-dir.ts (decisions/, preferences/, ...)
-    // are NOT used by this path. The category survives in the id prefix and
-    // the `category:` frontmatter field. If #1526 extraction moves change
-    // this routing, this test must be updated deliberately, not silently.
+    // CORRECTED behavior (issue #1546): the extraction persist path routes each
+    // category through the shared getCategoryDir()/CATEGORY_DIR_MAP chokepoint,
+    // so a `fact` lands under facts/ and a `decision` lands under decisions/ —
+    // no longer collapsing every category into facts/. The category still
+    // survives in the id prefix and the `category:` frontmatter field.
     const factHits = await memoryFilesContaining(path.join(memoryDir, "facts"), "retries webhooks");
-    const decisionHits = await memoryFilesContaining(path.join(memoryDir, "facts"), "blue-green deploys");
     assert.equal(factHits.length, 1, "category 'fact' persists under facts/");
-    assert.equal(decisionHits.length, 1, "category 'decision' ALSO persists under facts/ today");
+
+    // The decision no longer appears under facts/ — it is routed to decisions/.
+    assert.equal(
+      (await memoryFilesContaining(path.join(memoryDir, "facts"), "blue-green deploys")).length,
+      0,
+      "category 'decision' no longer lands under facts/",
+    );
+
+    const decisionHits = await memoryFilesContaining(path.join(memoryDir, "decisions"), "blue-green deploys");
+    assert.equal(decisionHits.length, 1, "category 'decision' persists under decisions/");
     assert.match(path.basename(decisionHits[0] ?? ""), /^decision-/);
     assert.match(await readFile(decisionHits[0] ?? "", "utf-8"), /category: decision/);
-    assert.equal(
-      (await markdownFilesUnder(path.join(memoryDir, "decisions"))).length,
-      0,
-      "the decisions/ category dir stays empty on the extraction path today",
-    );
   } finally {
     await orchestrator.destroy();
     await cleanupDir(memoryDir);

--- a/tests/orchestrator-recent-thread-paths.test.ts
+++ b/tests/orchestrator-recent-thread-paths.test.ts
@@ -139,6 +139,32 @@ test("resolvePersistedMemoryRelativePath uses corrections directory for correcti
   assert.equal(resolved, `corrections/${memoryId}.md`);
 });
 
+test("resolvePersistedMemoryRelativePath routes a decision into decisions/<date>/ (issue #1546)", () => {
+  const ts = Date.parse("2026-02-22T12:00:00.000Z");
+  const memoryId = `decision-${ts}-abcd`;
+  const resolved = resolvePersistedMemoryRelativePath({
+    memoryId,
+    pathById: new Map(),
+    category: "decision",
+  });
+
+  // The fallback dir must match StorageManager.writeMemory's category-dir
+  // routing so graph edges point at the file's real location.
+  assert.equal(resolved, `decisions/2026-02-22/${memoryId}.md`);
+});
+
+test("resolvePersistedMemoryRelativePath preserves reasoning-traces/ subtree", () => {
+  const ts = Date.parse("2026-02-22T12:00:00.000Z");
+  const memoryId = `reasoning_trace-${ts}-wxyz`;
+  const resolved = resolvePersistedMemoryRelativePath({
+    memoryId,
+    pathById: new Map(),
+    category: "reasoning_trace",
+  });
+
+  assert.equal(resolved, `reasoning-traces/2026-02-22/${memoryId}.md`);
+});
+
 test("appendMemoryToGraphContext adds newly written memory for same-run graph linking", () => {
   const allMems: MemoryFile[] = [];
   appendMemoryToGraphContext({

--- a/tests/reasoning-trace-recall.test.ts
+++ b/tests/reasoning-trace-recall.test.ts
@@ -333,4 +333,35 @@ describe("StorageManager reasoning_trace routing", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("buildTierMemoryPath routes a decision into <root>/decisions/<date>/ (issue #1546)", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-decision-tier-"));
+    try {
+      const storage = new StorageManager(dir);
+      const id = await storage.writeMemory("decision", "We chose blue-green deploys.", {
+        source: "test",
+      });
+      const memories = await storage.readAllMemories();
+      const found = memories.find((m) => m.frontmatter.id === id);
+      assert.ok(found, "stored decision should be readable");
+
+      const hot = storage.buildTierMemoryPath(found, "hot");
+      const cold = storage.buildTierMemoryPath(found, "cold");
+      assert.ok(
+        hot.includes(`${path.sep}decisions${path.sep}`),
+        `hot tier path should be under decisions/, got: ${hot}`,
+      );
+      assert.ok(
+        cold.includes(`${path.sep}cold${path.sep}decisions${path.sep}`),
+        `cold tier path should be under cold/decisions/, got: ${cold}`,
+      );
+      // The generic tail must not funnel non-fact categories into facts/.
+      assert.ok(
+        !/[\\/]facts[\\/]/.test(hot),
+        `decision must not be migrated into facts/: ${hot}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Closes #1546

## Problem

The extraction→persist funnel ignored `CATEGORY_DIR_MAP`. Both persist sites in `packages/remnic-core/src/storage.ts` (`writeMemory` and the chunk writer) hardcoded `this.factsDir` in an `else` branch that caught every category except `correction`/`procedure`/`reasoning_trace`. So `decision`, `preference`, `moment`, `commitment`, `principle`, `rule`, `skill`, and `relationship` extraction outputs all landed in `facts/<date>/` with the category recorded only in frontmatter, while the dedicated category dirs (`decisions/`, `preferences/`, ...) stayed empty on this path. Category-dir routing already worked on other write paths — a per-path divergence (CLAUDE.md rule 39).

## Write-path fix

Both persist sites now resolve their target directory through a new shared `resolveCategoryWritePath()` helper, which routes through the existing `getCategoryDir()` / `CATEGORY_DIR_MAP` chokepoint (`utils/category-dir.ts`) — no reimplementation of the mapping.

- `correction` keeps its historical **flat** layout (`corrections/<id>.md`, no date subdir) because the corrections pipeline reads it that way.
- Every other category is dated as `<dir>/<date>/<id>.md`, matching the existing facts/procedures/reasoning-traces convention. `procedure` → `procedures/<date>/` and `reasoning_trace` → `reasoning-traces/<date>/` are preserved exactly.
- `fact` and `entity` are not keys in `CATEGORY_DIR_MAP`, so `getCategoryDir()` falls them back to `facts/` — identical to prior behavior.
- `decision` → `decisions/<date>/`, `preference` → `preferences/<date>/`, etc.

## Read/write parity verification (rules 42, 43)

Newly-routed memories remain fully discoverable — no read/scan/reindex path only looks at `facts/`:

- **Filesystem fallback recall** — `StorageManager.collectActiveMemoryPaths()` iterates `RECALL_FALLBACK_DIRS` (= `ALL_CATEGORY_DIRS` minus `questions/`) and recurses subdirs, so `decisions/<date>/...` is collected (`storage.ts` ~L4124).
- **QMD reindex** — QMD indexes its collection root (`baseDir`) **recursively** via `qmd update -c <collection>`; it enumerates no hardcoded `facts/`-only subset. New files under any category dir are picked up on the next `qmd update` — the same scan-on-recall mechanism that made `facts/` writes searchable. No separate reindex trigger is needed on the write path (rule 43 is satisfied: discoverability is via the standard recursive scan, not a bypass).
- **Other consumers already category-dir-aware**: `curation/index.ts`, `review/index.ts`, `dedup/index.ts`, `projection/index.ts`, `namespaces/{migrate,catalog,storage}.ts` all import `ALL_CATEGORY_DIRS` / `ALL_CATEGORY_KEYS` / `getCategoryDir`.

## No backfill required

Already-misfiled memories under `facts/` stay readable — the fallback scan includes `facts/` and QMD indexes it. There is no data migration in this PR; the fix is forward-only for new writes. This is a deliberate decision, not an oversight.

## Scenario 8 flip

`tests/orchestrator-characterization.test.ts` scenario 8 previously **pinned** the buggy behavior ("extraction persists every category under facts/ ... (current behavior)"). It is now retitled "extraction routes each category into its own category dir via CATEGORY_DIR_MAP" and asserts: `fact` lands under `facts/`, `decision` does NOT appear under `facts/`, and `decision` lands under `decisions/` with a `decision-` id prefix and `category: decision` frontmatter. Green.

## Rule 20 sweep

`grep -rn` across `packages/`, `src/`, `tests/`, `evals/` for persist sites hardcoding `factsDir`/`"facts"` for category-bearing writes: the only production persist sites are the three in `storage.ts` (the `ensureDirectories` mkdir + the two funnels now rerouted). Remaining hits are test fixtures that intentionally write `fact`-category files directly into `facts/` (which still correctly route there). No other persist path bypasses the helper.

## Gates (measured bare)

- `npm run preflight:quick` → `preflight_exit=0` (ratchet held at baseline; helper doc trimmed so `storage.ts` stays 7284 lines)
- `npm run test:entity-hardening` → `eh_exit=0` (245 pass, 0 fail)
- `node --import tsx --test tests/orchestrator-characterization.test.ts` → `char_exit=0` (15 pass, 0 fail)

## Checklist

- [x] All tests pass
- [x] New logic covered by tests (scenario 8 asserts the routing)
- [x] Pre-commit / preflight gates pass locally
- [x] Docs/comments updated (helper doc explains routing + parity)
- [x] No secrets or personal data committed (public repo; synthetic test data)
- [x] PR diff ≤ 400 LOC (44 insertions / 42 deletions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to on-disk memory layout, indexing, encryption eligibility, and destructive dedupe walkers; mitigated by containment guards and parity with existing read paths, but mis-routing or scan gaps would affect recall and data safety.
> 
> **Overview**
> Routes **new memory writes** (including extraction persist and chunks) through `resolveCategoryWritePath()` / `getCategoryDir()` so categories like `decision` and `preference` land in `decisions/`, `preferences/`, etc., instead of defaulting into `facts/`. **Corrections** stay flat under `corrections/`; tier moves and graph path fallbacks now use shared `categoryDirName()` so hot/cold paths match where files were written.
> 
> Replaces hand-maintained `facts/`/`corrections/` (and partial category) lists across **CLI walkers**, **search indexing**, **training export**, **consolidation provenance doctor**, **memory governance**, **day summaries**, and **secure-store encryption roots** with **`RECALL_FALLBACK_DIRS`** as the single recall corpus set. **`questions/`** stays out of recall scans and is **not** encrypted at rest (queue still uses plain read/write).
> 
> Adds shared **`path-containment`** helpers and **symlink/realpath containment** on filesystem walkers that can read or **unlink** files (dedupe, governance, day-summary input), skipping poisoned paths outside `memoryDir`. Exports `listMemoryMarkdownFilePaths` and extends tests for category-dir coverage and symlink regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbee207f2d2e36216f0ccb4cc4bcfd9eba18a44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->