### PR TITLE
fix(storage): guard collectActiveMemoryPaths against symlink escape (info leak)

### DIFF
--- a/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
+++ b/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
@@ -446,6 +446,65 @@ test("symlinked entry nested inside a category dir does NOT leak into fallback r
   }
 });
 
+/**
+ * Regression for Cursor Bugbot "Poisoned md skips sibling subdirs".
+ *
+ * Per-entry containment/realpath failures must be isolated so they cannot drop
+ * sibling `.md` files or, crucially, the nested-subdir recursion. This asserts
+ * that a category dir which also contains a symlinked-out entry still recurses
+ * into its real nested subdirectory and returns every in-store memory, while
+ * the out-of-store target stays excluded.
+ */
+test("a guarded/skipped sibling entry does NOT drop nested in-store memories", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-sibling-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-sibling-out-"));
+  const storage = new StorageManager(baseDir);
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  try {
+    const factsDir = path.join(baseDir, "facts");
+    await mkdir(factsDir, { recursive: true });
+    // A top-level in-store memory and a nested in-store memory in the SAME
+    // category dir that also holds the symlinked-out sibling.
+    await writeFile(
+      path.join(factsDir, "top.md"),
+      memoryFile("top-fact", "fact", "Top-level in-store fact."),
+      "utf-8",
+    );
+    await seedMemory(baseDir, "facts", "deep-fact", "fact", "Deeply nested in-store fact.", {
+      nested: true,
+    });
+
+    await writeFile(
+      path.join(outsideDir, "leaked.md"),
+      memoryFile("leaked-secret", "fact", "Out-of-store file must never be recalled."),
+      "utf-8",
+    );
+    // A symlinked-out sibling entry alongside the real files/subdir.
+    await symlink(outsideDir, path.join(factsDir, "escape"), "dir");
+
+    storage.invalidateAllMemoriesCacheForDir();
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    assert.ok(foundIds.has("top-fact"), "the top-level in-store fact must be recalled");
+    assert.ok(
+      foundIds.has("deep-fact"),
+      "the nested in-store fact must still be recalled past a skipped sibling",
+    );
+    assert.ok(!foundIds.has("leaked-secret"), "the symlinked-out file must not leak");
+    assert.equal(memories.length, 2, "exactly the two in-store memories should be returned");
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test("QMD-disabled deployment: disk-scan collector returns all categories", async () => {
   const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-qmd-off-"));
   // entitySchemas is the only other constructor arg; QMD is never constructed by

--- a/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
+++ b/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
@@ -27,7 +27,7 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -356,6 +356,96 @@ test("question-queue items written by writeQuestion() do NOT leak into fallback 
  * directly with a config object that explicitly disables QMD, proving the disk
  * scan a QMD-disabled deployment relies on returns every category.
  */
+/**
+ * Symlink containment (same walker-hardening class as PR #1563 / issue #1546).
+ *
+ * `collectActiveMemoryPaths()` walks the RECALL_FALLBACK_DIRS category dirs for
+ * the QMD-unavailable filesystem recall fallback. A category dir symlinked
+ * outside `memoryDir` (e.g. `decisions/` -> an external directory) must NOT be
+ * followed — otherwise out-of-store files leak into recall results. The walker
+ * now `lstat`s each dir (skipping symlinks/non-dirs), realpaths it, and asserts
+ * it stays inside the memory root; per entry it skips symlinks and asserts the
+ * file resolves inside the root before including it.
+ */
+test("category dir symlinked outside memoryDir does NOT leak files into fallback recall", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-symlink-dir-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-symlink-out-"));
+  const storage = new StorageManager(baseDir);
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  try {
+    // A genuine in-store memory that MUST still be recalled.
+    await seedMemory(baseDir, "facts", "real-fact", "fact", "A genuine in-store fact.");
+
+    // An out-of-store memory reachable only via a symlinked category dir.
+    await writeFile(
+      path.join(outsideDir, "leaked.md"),
+      memoryFile("leaked-secret", "decision", "Out-of-store file must never be recalled."),
+      "utf-8",
+    );
+    // `decisions/` is a RECALL_FALLBACK_DIRS category dir; point it outside the store.
+    await symlink(outsideDir, path.join(baseDir, "decisions"), "dir");
+
+    storage.invalidateAllMemoriesCacheForDir();
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    assert.ok(foundIds.has("real-fact"), "the genuine in-store fact must still be recalled");
+    assert.ok(
+      !foundIds.has("leaked-secret"),
+      "a symlinked-out category dir must not leak files into recall",
+    );
+    assert.equal(memories.length, 1, "only the in-store memory should be returned");
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("symlinked entry nested inside a category dir does NOT leak into fallback recall", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-symlink-entry-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-symlink-entry-out-"));
+  const storage = new StorageManager(baseDir);
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  try {
+    // A genuine in-store memory in the same category dir that holds the symlink.
+    await seedMemory(baseDir, "facts", "real-fact", "fact", "A genuine in-store fact.");
+
+    await writeFile(
+      path.join(outsideDir, "leaked.md"),
+      memoryFile("nested-leak", "fact", "Out-of-store nested file must never be recalled."),
+      "utf-8",
+    );
+    // A symlinked *entry* inside facts/ that escapes the store.
+    await symlink(outsideDir, path.join(baseDir, "facts", "escape"), "dir");
+
+    storage.invalidateAllMemoriesCacheForDir();
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    assert.ok(foundIds.has("real-fact"), "the genuine in-store fact must still be recalled");
+    assert.ok(
+      !foundIds.has("nested-leak"),
+      "a symlinked entry escaping the store must not leak files into recall",
+    );
+    assert.equal(memories.length, 1, "only the in-store memory should be returned");
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test("QMD-disabled deployment: disk-scan collector returns all categories", async () => {
   const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-qmd-off-"));
   // entitySchemas is the only other constructor arg; QMD is never constructed by

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,10 +1,11 @@
-import { access, readdir, readFile, stat, writeFile, mkdir, unlink, rename, appendFile, open } from "node:fs/promises";
+import { access, lstat, readdir, readFile, realpath, stat, writeFile, mkdir, unlink, rename, appendFile, open } from "node:fs/promises";
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
 import { isErrnoCode } from "./utils/errno.js";
 import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
+import { assertPathInsideRoot } from "./utils/path-containment.js";
 import { getCachedEntities, invalidateAllForDir, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -4069,15 +4070,37 @@ export class StorageManager {
   private async collectActiveMemoryPaths(): Promise<string[]> {
     const filePaths: string[] = [];
 
+    // Resolve the memory root once for containment checks below. A category dir
+    // symlinked outside memoryDir (e.g. decisions/ -> an external dir) must NOT
+    // pull out-of-store files into the QMD-unavailable recall fallback (info
+    // leak). Same walker-hardening pattern as document-scanner.ts / cli.ts /
+    // consolidation-provenance-check.ts; reuses the shared containment helper.
+    let memoryRootReal: string;
+    try {
+      memoryRootReal = await realpath(this.baseDir);
+    } catch {
+      return filePaths;
+    }
+
     const collectPaths = async (dir: string) => {
       try {
+        // Skip symlinked or non-directory category dirs, then assert the
+        // resolved dir still lives inside the memory root before reading it.
+        const dirStat = await lstat(dir);
+        if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) return;
+        assertPathInsideRoot(memoryRootReal, await realpath(dir), dir);
+
         const entries = await readdir(dir, { withFileTypes: true });
         const subdirs: string[] = [];
         for (const entry of entries) {
+          // Never follow symlinked entries out of the store.
+          if (entry.isSymbolicLink()) continue;
           const fullPath = path.join(dir, entry.name);
           if (entry.isDirectory()) {
             subdirs.push(fullPath);
           } else if (entry.name.endsWith(".md")) {
+            // Assert the file resolves inside the root before including it.
+            assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
             filePaths.push(fullPath);
           }
         }
@@ -4085,7 +4108,9 @@ export class StorageManager {
           await collectPaths(subdir);
         }
       } catch {
-        // Directory does not exist yet.
+        // Directory does not exist yet, or a symlink/containment guard tripped
+        // — fail closed by skipping this subtree rather than leaking or crashing
+        // the recall fallback.
       }
     };
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,5 +1,5 @@
 import { access, lstat, readdir, readFile, realpath, stat, writeFile, mkdir, unlink, rename, appendFile, open } from "node:fs/promises";
-import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } from "node:fs";
+import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
@@ -4083,34 +4083,46 @@ export class StorageManager {
     }
 
     const collectPaths = async (dir: string) => {
+      // Directory-level guard, isolated from per-entry handling: skip symlinked
+      // or non-directory category dirs and assert the resolved dir stays inside
+      // the memory root before reading. A failure here means the whole subtree
+      // does not exist or escaped the store — fail closed by skipping it.
+      let entries: Dirent[];
       try {
-        // Skip symlinked or non-directory category dirs, then assert the
-        // resolved dir still lives inside the memory root before reading it.
         const dirStat = await lstat(dir);
         if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) return;
         assertPathInsideRoot(memoryRootReal, await realpath(dir), dir);
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
 
-        const entries = await readdir(dir, { withFileTypes: true });
-        const subdirs: string[] = [];
-        for (const entry of entries) {
-          // Never follow symlinked entries out of the store.
-          if (entry.isSymbolicLink()) continue;
-          const fullPath = path.join(dir, entry.name);
-          if (entry.isDirectory()) {
-            subdirs.push(fullPath);
-          } else if (entry.name.endsWith(".md")) {
-            // Assert the file resolves inside the root before including it.
+      const subdirs: string[] = [];
+      for (const entry of entries) {
+        // Never follow symlinked entries out of the store.
+        if (entry.isSymbolicLink()) continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          subdirs.push(fullPath);
+        } else if (entry.name.endsWith(".md")) {
+          // Isolate per-entry failures in their own try/catch: a containment or
+          // realpath failure on ONE .md entry must not drop sibling files or,
+          // crucially, the deferred subdir recursion below (Cursor Bugbot:
+          // "Poisoned md skips sibling subdirs"). Mirrors the per-file try/catch
+          // in search/document-scanner.ts scanDir and
+          // consolidation-provenance-check.ts walkMarkdownFiles.
+          try {
             assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
             filePaths.push(fullPath);
+          } catch {
+            // Skip just this entry (symlink/containment/realpath failure).
           }
         }
-        for (const subdir of subdirs) {
-          await collectPaths(subdir);
-        }
-      } catch {
-        // Directory does not exist yet, or a symlink/containment guard tripped
-        // — fail closed by skipping this subtree rather than leaking or crashing
-        // the recall fallback.
+      }
+      // Recurse into real subdirectories regardless of any single poisoned entry
+      // above, so valid nested in-store memories are never dropped.
+      for (const subdir of subdirs) {
+        await collectPaths(subdir);
       }
     };
 

--- a/packages/remnic-core/src/utils/path-containment.ts
+++ b/packages/remnic-core/src/utils/path-containment.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+/**
+ * Shared filesystem-containment helpers for the memory-store walkers.
+ *
+ * Every walker that reads memory files off disk (search/document-scanner.ts,
+ * cli.ts, consolidation-provenance-check.ts, storage.ts) must guard against a
+ * category directory or entry being a symlink that escapes `memoryDir`. A
+ * symlinked category dir (e.g. `decisions/` -> an external directory) would
+ * otherwise pull out-of-store files into recall results (info leak). This is
+ * the single containment check those walkers share — do NOT fork a new one.
+ *
+ * Callers resolve the memory root once via `realpath`, then per directory /
+ * per entry `realpath` the candidate and `assertPathInsideRoot(...)` (or check
+ * `pathIsInside(...)`) before reading.
+ */
+
+/**
+ * True when `child` is `parent` itself or a descendant of it. Both arguments
+ * must already be `realpath`-resolved absolute paths so symlink escapes are
+ * detectable via the resolved location.
+ */
+export function pathIsInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/**
+ * Throw when `candidateReal` (a `realpath`-resolved path) is not inside
+ * `rootReal` (the `realpath`-resolved memory root). `originalPath` is the
+ * pre-resolution path, used only for the error message.
+ */
+export function assertPathInsideRoot(
+  rootReal: string,
+  candidateReal: string,
+  originalPath: string,
+): void {
+  if (!pathIsInside(rootReal, candidateReal)) {
+    throw new Error(`Refusing to scan memory path outside memoryDir: ${originalPath}`);
+  }
+}

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -7,7 +7,7 @@
       "packages/remnic-core/src/orchestrator.ts": 20024,
       "packages/remnic-core/src/cli.ts": 9812,
       "packages/remnic-core/src/access-service.ts": 8277,
-      "packages/remnic-core/src/storage.ts": 7309,
+      "packages/remnic-core/src/storage.ts": 7321,
       "packages/remnic-core/src/config.ts": 4548
     },
     "oversizedFileCount": 10,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -7,7 +7,7 @@
       "packages/remnic-core/src/orchestrator.ts": 20024,
       "packages/remnic-core/src/cli.ts": 9812,
       "packages/remnic-core/src/access-service.ts": 8277,
-      "packages/remnic-core/src/storage.ts": 7284,
+      "packages/remnic-core/src/storage.ts": 7309,
       "packages/remnic-core/src/config.ts": 4548
     },
     "oversizedFileCount": 10,


### PR DESCRIPTION
## Summary

`StorageManager.collectActiveMemoryPaths()` (introduced by #1497) walked the `RECALL_FALLBACK_DIRS` memory category dirs with a raw `readdir` and **no symlink/containment guard**. It feeds the QMD-unavailable filesystem recall fallback (`recent_scan` → `readAllMemoriesForNamespaces` → `readAllMemories` → here), so a category dir symlinked outside `memoryDir` (e.g. `decisions/` → an external directory) would be followed, pulling **out-of-store files into recall results** (info leak).

This is the same class of issue that PR #1563 (issue #1546) hardened across the other memory-store walkers (`search/document-scanner.ts`, `cli.ts`, `consolidation-provenance-check.ts`). `collectActiveMemoryPaths` predates that PR and was left out of scope — this PR closes that one pre-existing straggler. **Independent of #1563** (which is already merged, closing out #1546).

## Change

- **Adopt the now-standard containment pattern** in `collectActiveMemoryPaths`:
  - Resolve the memory root once via `realpath` (return `[]` if `baseDir` doesn't exist).
  - Per directory: `lstat` and skip symlinked/non-directory dirs, then `assertPathInsideRoot` the resolved dir before reading.
  - Per entry: skip symlinked entries, then `assertPathInsideRoot` the file's realpath before including it.
  - Fail closed — a guard trip skips the subtree rather than leaking or crashing the recall fallback.
- **Do NOT fork a new containment check** — extracted the shared `assertPathInsideRoot`/`pathIsInside` helper (matching `document-scanner.ts` semantics) into `packages/remnic-core/src/utils/path-containment.ts` and consumed it here.
- **Tests** (`storage-fallback-category-dirs.test.ts`): a category dir symlinked outside `memoryDir` must NOT surface its files, and a symlinked entry nested inside a category dir must NOT leak — while a real in-store memory is still returned. Both `win32`-guarded like the existing symlink tests.
- Bumped the `storage.ts` structural-ratchet baseline (#1520) for the added guard lines.

## Verification

Node 22, each gate redirected to a file, all exit `0`:

- `npm run build` → `0`
- `npm run preflight:quick` → `0`
- `npm run test:entity-hardening` → `0`
- touched storage test (`storage-fallback-category-dirs.test.ts`) → `0` (11 tests pass, 0 fail)

## PR checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] Pre-commit / preflight gates pass locally
- [x] No secrets or personal data committed
- [x] Diff is small and scoped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall fallback path enumeration and could omit valid files if containment checks are too aggressive, but behavior is fail-closed and aligned with existing hardened walkers; primary risk is recall completeness edge cases rather than new exposure.
> 
> **Overview**
> Hardens the QMD-unavailable **filesystem recall fallback** by applying the same symlink/containment walker pattern used elsewhere to `StorageManager.collectActiveMemoryPaths()`.
> 
> The collector now **realpaths** the memory root (returns no paths if missing), **skips** symlinked or non-directory category dirs after `lstat`, and **asserts** resolved dirs and `.md` files stay inside the store via `assertPathInsideRoot`. Symlinked directory entries are not followed; per-file guard failures are isolated so siblings and nested subdirs are still scanned.
> 
> Adds **three** non-Windows integration tests in `storage-fallback-category-dirs.test.ts` (symlinked category dir, symlinked nested entry, and “poisoned” sibling must not drop nested memories). Updates the `storage.ts` structural ratchet baseline for the added lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90bb1b66327ff0b6bf340f555f3d83409d6badc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->