### PR TITLE
fix(scripts): count a codex approving reaction on the PR body as sign-off

### DIFF
--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -131,7 +131,7 @@ if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .h
   exit 1
 fi
 CHECK_RUNS=""
-HEAD_COMMIT_DATE=""
+HEAD_VISIBLE_AT=""
 if [[ -n "$HEAD_SHA" ]]; then
   if ! CHECK_RUNS=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
     --jq '.check_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "neutral") | [.app.slug, .name] | @tsv' \
@@ -139,11 +139,15 @@ if [[ -n "$HEAD_SHA" ]]; then
     echo "[pre-merge] BLOCKED: Failed to read PR check runs from GitHub."
     exit 1
   fi
-  # Committer date of the head commit, used to reject stale reaction sign-offs
-  # (see the reactions block). committedDate is rewritten on rebase, so a
-  # pre-rebase reaction correctly stops counting — fail closed.
-  HEAD_COMMIT_DATE=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
-    --jq '.commit.committer.date // empty' 2>/dev/null || true)
+  # When did this exact SHA become visible on the PR? The earliest check-suite
+  # created_at for the head commit marks when the push landed and CI kicked off
+  # — a push-time signal (unlike the commit's committer/author date, which a
+  # local amend or cherry-pick can backdate). It is also stable across job
+  # re-runs (the suite is not recreated). Used to reject reaction sign-offs that
+  # predate the current head being pushed (see the reactions block). Empty when
+  # no check suite exists yet or the read fails → reactions fail closed.
+  HEAD_VISIBLE_AT=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-suites" \
+    --jq '[.check_suites[].created_at] | min // empty' 2>/dev/null || true)
 fi
 
 # Reviewer approval via a reaction on the PR body. Codex signs off on clean PRs
@@ -155,16 +159,16 @@ fi
 # CURRENT-HEAD BINDING: a reaction carries no commit SHA and GitHub does NOT
 # dismiss it when new commits are pushed, so a bare reaction would let a +1 left
 # on an earlier revision satisfy the reviewer for a newer diff it never saw.
-# Reactions cannot be SHA-pinned like issue-comment verdicts, so we bind by
-# time: a reaction only counts when it was created at/after the head commit's
-# committer date. A commit pushed after the +1 has a newer committer date and
-# invalidates the stale reaction; a rebase rewrites committer dates and does the
-# same — both fail closed, forcing a fresh sign-off. (Residual: cherry-picking a
-# commit with an OLD committer date as the new head could re-admit a reaction in
-# that window; the SHA-pinned issue-comment path remains the strong signal.)
-# If the head commit date is unknown, no reaction can be validated → none count.
-# A read failure here is non-fatal: reactions are a supplementary signal, so we
-# fall back to the other detection paths rather than blocking the whole gate.
+# Reactions cannot be SHA-pinned like issue-comment verdicts, so we bind to when
+# the current head became visible on the PR (HEAD_VISIBLE_AT = earliest
+# check-suite created_at for the head SHA — a push-time signal, not the commit's
+# author/committer date, which a local amend or cherry-pick can backdate). A
+# reaction only counts when it was created at/after the head was pushed; a +1
+# left before the current SHA landed no longer counts, forcing a fresh sign-off.
+# If head visibility cannot be proven (no check suite yet, or the read failed),
+# no reaction is credited — fail closed. A reactions read failure is likewise
+# non-fatal: we fall back to the other detection paths rather than block the gate.
+#
 # Byte-wise "is $1 strictly before $2" for two GitHub ISO-8601 UTC (…Z)
 # timestamps. Runs in a subshell so LC_ALL=C stays scoped; the fixed-width
 # format makes a byte comparison chronological.
@@ -172,17 +176,17 @@ iso_before() ( LC_ALL=C; [[ "$1" < "$2" ]] )
 
 POSITIVE_REACTIONS_RE='^(\+1|heart|hooray|rocket)$'
 POSITIVE_REACTORS=""
-if [[ -z "$HEAD_COMMIT_DATE" ]]; then
-  echo "[pre-merge] NOTE: Head commit date unknown; PR-body reactions will not count as sign-off."
+if [[ -z "$HEAD_VISIBLE_AT" ]]; then
+  echo "[pre-merge] NOTE: Head push time unknown; PR-body reactions will not count as sign-off."
 elif BODY_REACTIONS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/reactions" --paginate \
   -H "Accept: application/vnd.github+json" \
   --jq '.[] | [.user.login, .content, .created_at] | @tsv' 2>/dev/null); then
   while IFS=$'\t' read -r rx_login rx_content rx_created; do
     [[ -n "$rx_login" ]] || continue
     [[ "$rx_content" =~ $POSITIVE_REACTIONS_RE ]] || continue
-    # Reject reactions predating the head commit (stale sign-off on an older rev).
+    # Reject reactions placed before the current head was pushed (stale sign-off).
     [[ -n "$rx_created" ]] || continue
-    if iso_before "$rx_created" "$HEAD_COMMIT_DATE"; then
+    if iso_before "$rx_created" "$HEAD_VISIBLE_AT"; then
       continue
     fi
     POSITIVE_REACTORS+="${rx_login}"$'\n'

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -9,8 +9,12 @@ set -euo pipefail
 # AI reviewers had time to post reviews. This script blocks merging until
 # reviewers have weighed in and all threads are resolved.
 #
-# Reviewer activity is detected via PR reviews, PR comments, and completed
-# check runs (Cursor Bugbot and Kilo Code Review run as GitHub App checks).
+# Reviewer activity is detected via PR reviews, PR comments, completed check
+# runs (Cursor Bugbot and Kilo Code Review run as GitHub App checks), and an
+# approving reaction on the PR body. Codex (chatgpt-codex-connector[bot]) often
+# signs off on a clean PR by leaving a thumbs-up (+1) reaction on the PR
+# description rather than posting a review or comment — without reaction
+# detection those PRs block forever even though the reviewer approved.
 
 PR_NUMBER="${1:?Usage: scripts/pre-merge-check.sh <PR_NUMBER>}"
 REPO="${REMNIC_REPO:-joshuaswarren/remnic}"
@@ -136,6 +140,30 @@ if [[ -n "$HEAD_SHA" ]]; then
   fi
 fi
 
+# Reviewer approval via a reaction on the PR body. Codex signs off on clean PRs
+# with a thumbs-up (+1) reaction on the PR description instead of a review or
+# comment. Only count explicitly POSITIVE reactions as a sign-off — a "-1" or
+# "confused" reaction is the opposite of approval, and "eyes" means "still
+# looking", so none of those count. Reactions are PR-wide (not head-scoped);
+# that matches how reviews/issue-comment verdicts are already treated for
+# reviewers that post as check runs. A read failure here is non-fatal: reactions
+# are a supplementary signal, so we fall back to the other detection paths
+# rather than blocking the whole gate on a reactions-endpoint hiccup.
+POSITIVE_REACTIONS_RE='^(\+1|heart|hooray|rocket)$'
+POSITIVE_REACTORS=""
+if BODY_REACTIONS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/reactions" --paginate \
+  -H "Accept: application/vnd.github+json" \
+  --jq '.[] | [.user.login, .content] | @tsv' 2>/dev/null); then
+  while IFS=$'\t' read -r rx_login rx_content; do
+    [[ -n "$rx_login" ]] || continue
+    if [[ "$rx_content" =~ $POSITIVE_REACTIONS_RE ]]; then
+      POSITIVE_REACTORS+="${rx_login}"$'\n'
+    fi
+  done <<< "$BODY_REACTIONS"
+else
+  echo "[pre-merge] NOTE: Could not read PR body reactions; relying on reviews/comments/checks."
+fi
+
 # Issue comments are PR-wide, not head-scoped, and this gate reads them for
 # exactly one reason: Codex posts its clean verdict ("Didn't find any major
 # issues … **Reviewed commit:** \`<short sha>\`") as an issue comment. Count
@@ -188,11 +216,20 @@ has_reviewer_check_run() {
   return 1
 }
 
+# A required reviewer counts as having signed off if they left a positive
+# reaction on the PR body (exact, case-insensitive login match).
+has_reviewer_positive_reaction() {
+  local reviewer="$1"
+  [[ -n "$POSITIVE_REACTORS" ]] || return 1
+  grep -qxiF "$reviewer" <<< "$POSITIVE_REACTORS"
+}
+
 MISSING_REVIEWERS=()
 for reviewer in "${REQUIRED_REVIEWERS[@]}"; do
   # Use exact line match (-x) to avoid substring false positives.
   if ! echo "$ALL_REVIEWERS" | grep -qxiF "$reviewer" && \
-     ! has_reviewer_check_run "$reviewer"; then
+     ! has_reviewer_check_run "$reviewer" && \
+     ! has_reviewer_positive_reaction "$reviewer"; then
     MISSING_REVIEWERS+=("$reviewer")
   fi
 done

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -131,6 +131,7 @@ if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .h
   exit 1
 fi
 CHECK_RUNS=""
+HEAD_COMMIT_DATE=""
 if [[ -n "$HEAD_SHA" ]]; then
   if ! CHECK_RUNS=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
     --jq '.check_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "neutral") | [.app.slug, .name] | @tsv' \
@@ -138,27 +139,53 @@ if [[ -n "$HEAD_SHA" ]]; then
     echo "[pre-merge] BLOCKED: Failed to read PR check runs from GitHub."
     exit 1
   fi
+  # Committer date of the head commit, used to reject stale reaction sign-offs
+  # (see the reactions block). committedDate is rewritten on rebase, so a
+  # pre-rebase reaction correctly stops counting — fail closed.
+  HEAD_COMMIT_DATE=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
+    --jq '.commit.committer.date // empty' 2>/dev/null || true)
 fi
 
 # Reviewer approval via a reaction on the PR body. Codex signs off on clean PRs
 # with a thumbs-up (+1) reaction on the PR description instead of a review or
 # comment. Only count explicitly POSITIVE reactions as a sign-off — a "-1" or
 # "confused" reaction is the opposite of approval, and "eyes" means "still
-# looking", so none of those count. Reactions are PR-wide (not head-scoped);
-# that matches how reviews/issue-comment verdicts are already treated for
-# reviewers that post as check runs. A read failure here is non-fatal: reactions
-# are a supplementary signal, so we fall back to the other detection paths
-# rather than blocking the whole gate on a reactions-endpoint hiccup.
+# looking", so none of those count.
+#
+# CURRENT-HEAD BINDING: a reaction carries no commit SHA and GitHub does NOT
+# dismiss it when new commits are pushed, so a bare reaction would let a +1 left
+# on an earlier revision satisfy the reviewer for a newer diff it never saw.
+# Reactions cannot be SHA-pinned like issue-comment verdicts, so we bind by
+# time: a reaction only counts when it was created at/after the head commit's
+# committer date. A commit pushed after the +1 has a newer committer date and
+# invalidates the stale reaction; a rebase rewrites committer dates and does the
+# same — both fail closed, forcing a fresh sign-off. (Residual: cherry-picking a
+# commit with an OLD committer date as the new head could re-admit a reaction in
+# that window; the SHA-pinned issue-comment path remains the strong signal.)
+# If the head commit date is unknown, no reaction can be validated → none count.
+# A read failure here is non-fatal: reactions are a supplementary signal, so we
+# fall back to the other detection paths rather than blocking the whole gate.
+# Byte-wise "is $1 strictly before $2" for two GitHub ISO-8601 UTC (…Z)
+# timestamps. Runs in a subshell so LC_ALL=C stays scoped; the fixed-width
+# format makes a byte comparison chronological.
+iso_before() ( LC_ALL=C; [[ "$1" < "$2" ]] )
+
 POSITIVE_REACTIONS_RE='^(\+1|heart|hooray|rocket)$'
 POSITIVE_REACTORS=""
-if BODY_REACTIONS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/reactions" --paginate \
+if [[ -z "$HEAD_COMMIT_DATE" ]]; then
+  echo "[pre-merge] NOTE: Head commit date unknown; PR-body reactions will not count as sign-off."
+elif BODY_REACTIONS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/reactions" --paginate \
   -H "Accept: application/vnd.github+json" \
-  --jq '.[] | [.user.login, .content] | @tsv' 2>/dev/null); then
-  while IFS=$'\t' read -r rx_login rx_content; do
+  --jq '.[] | [.user.login, .content, .created_at] | @tsv' 2>/dev/null); then
+  while IFS=$'\t' read -r rx_login rx_content rx_created; do
     [[ -n "$rx_login" ]] || continue
-    if [[ "$rx_content" =~ $POSITIVE_REACTIONS_RE ]]; then
-      POSITIVE_REACTORS+="${rx_login}"$'\n'
+    [[ "$rx_content" =~ $POSITIVE_REACTIONS_RE ]] || continue
+    # Reject reactions predating the head commit (stale sign-off on an older rev).
+    [[ -n "$rx_created" ]] || continue
+    if iso_before "$rx_created" "$HEAD_COMMIT_DATE"; then
+      continue
     fi
+    POSITIVE_REACTORS+="${rx_login}"$'\n'
   done <<< "$BODY_REACTIONS"
 else
   echo "[pre-merge] NOTE: Could not read PR body reactions; relying on reviews/comments/checks."

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -169,6 +169,18 @@ fi
 # no reaction is credited — fail closed. A reactions read failure is likewise
 # non-fatal: we fall back to the other detection paths rather than block the gate.
 #
+# ACCEPTED RESIDUAL (deliberate, repo-owner decision): check-suite created_at is
+# keyed to the SHA, not to the moment that SHA became THIS PR's head, and GitHub
+# exposes no clean per-PR "head advanced at" timestamp (Commit.pushedDate is null
+# in practice). So if the identical SHA was already pushed to another branch —
+# creating its check suite earlier — a +1 placed on the old PR revision after
+# that suite but before the PR fast-forwards to the SHA could still be credited.
+# This requires an adversarial same-SHA-on-two-branches race that does not occur
+# in this repo's one-branch-per-PR flow; the SHA-pinned issue-comment verdict
+# remains the strong signal. Reactions are a convenience sign-off, not the
+# security boundary. Tightening this further would require dropping reaction
+# support entirely (no reliable PR-scoped push signal exists).
+#
 # Byte-wise "is $1 strictly before $2" for two GitHub ISO-8601 UTC (…Z)
 # timestamps. Runs in a subshell so LC_ALL=C stays scoped; the fixed-width
 # format makes a byte comparison chronological.

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|codex_verdict_unpinned:1|generic_issue_comment_ignored:1|issue_comments_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|codex_verdict_unpinned:1|generic_issue_comment_ignored:1|issue_comments_fail:1|codex_reaction_ok:1|codex_reaction_negative:1|reaction_wrong_user:1|reactions_read_fail:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,7 +68,7 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
-  if [[ "$GH_STUB_SCENARIO" == codex_issue_comment_* || "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == codex_issue_comment_* || "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" || "$GH_STUB_SCENARIO" == "codex_reaction_ok" || "$GH_STUB_SCENARIO" == "codex_reaction_negative" || "$GH_STUB_SCENARIO" == "reaction_wrong_user" || "$GH_STUB_SCENARIO" == "reactions_read_fail" ]]; then
     printf 'cursor[bot]\\n'
     exit 0
   fi
@@ -116,6 +116,26 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
     printf "someuser\\tLooks good to me! Reviewed commit: deadbeef12\\n"
     exit 0
   fi
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/reactions" ]]; then
+  case "$GH_STUB_SCENARIO" in
+    reactions_read_fail)
+      echo "reactions unavailable" >&2
+      exit 3
+      ;;
+    codex_reaction_ok)
+      printf 'chatgpt-codex-connector[bot]\\t+1\\n'
+      ;;
+    codex_reaction_negative)
+      printf 'chatgpt-codex-connector[bot]\\tconfused\\n'
+      printf 'chatgpt-codex-connector[bot]\\t-1\\n'
+      ;;
+    reaction_wrong_user)
+      printf 'someuser\\t+1\\n'
+      ;;
+  esac
   exit 0
 fi
 
@@ -346,5 +366,49 @@ test("pre-merge check rejects unrelated checks from a matching app slug", async 
     assert.equal(result.status, 1);
     assert.match(result.stdout, /Missing reviews from: cursor\[bot\]/);
     assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check accepts a codex thumbs-up reaction on the PR body as sign-off", async () => {
+  // Codex often signs off on a clean PR with a +1 reaction on the PR
+  // description rather than a review/comment/check run — the gap this fix
+  // closes. cursor[bot] is satisfied via its review; codex only via the
+  // reaction.
+  await withGhStub("codex_reaction_ok", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
+  });
+});
+
+test("pre-merge check ignores negative codex reactions (confused/-1) as sign-off", async () => {
+  await withGhStub("codex_reaction_negative", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check never credits a reviewer for another user's positive reaction", async () => {
+  await withGhStub("reaction_wrong_user", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check degrades gracefully when reactions cannot be read", async () => {
+  // A reactions-endpoint failure is non-fatal: the gate falls back to the
+  // other detection paths (here codex is otherwise absent, so it still blocks
+  // — but on a missing-reviewer verdict, not an API-read crash).
+  await withGhStub("reactions_read_fail", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Could not read PR body reactions/);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
   });
 });

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -42,7 +42,7 @@ if [[ "$1" == "api" && "$2" == "graphql" ]]; then
     malformed_page:1)
       printf '5\\t0\\n'
       ;;
-    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|codex_verdict_unpinned:1|generic_issue_comment_ignored:1|issue_comments_fail:1|codex_reaction_ok:1|codex_reaction_negative:1|reaction_wrong_user:1|reactions_read_fail:1)
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1|codex_issue_comment_ok:1|codex_issue_comment_short_sha:1|codex_issue_comment_stale:1|codex_issue_comment_not_verdict:1|codex_verdict_sha_in_prose:1|codex_verdict_unpinned:1|generic_issue_comment_ignored:1|issue_comments_fail:1|codex_reaction_ok:1|codex_reaction_stale:1|codex_reaction_negative:1|reaction_wrong_user:1|reactions_read_fail:1|reaction_head_date_missing:1)
       printf '3\\t0\\tfalse\\t\\n'
       ;;
     repeated_cursor:1)
@@ -68,7 +68,7 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
     printf 'chatgpt-codex-connector[bot]\\n'
     exit 0
   fi
-  if [[ "$GH_STUB_SCENARIO" == codex_issue_comment_* || "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" || "$GH_STUB_SCENARIO" == "codex_reaction_ok" || "$GH_STUB_SCENARIO" == "codex_reaction_negative" || "$GH_STUB_SCENARIO" == "reaction_wrong_user" || "$GH_STUB_SCENARIO" == "reactions_read_fail" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == codex_issue_comment_* || "$GH_STUB_SCENARIO" == "codex_verdict_sha_in_prose" || "$GH_STUB_SCENARIO" == "generic_issue_comment_ignored" || "$GH_STUB_SCENARIO" == codex_reaction_* || "$GH_STUB_SCENARIO" == "reaction_wrong_user" || "$GH_STUB_SCENARIO" == "reactions_read_fail" || "$GH_STUB_SCENARIO" == "reaction_head_date_missing" ]]; then
     printf 'cursor[bot]\\n'
     exit 0
   fi
@@ -119,21 +119,35 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
   exit 0
 fi
 
+# Head commit metadata (committer date) — used to reject stale reaction sign-offs.
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef1234567890abcdef1234567890abcdef" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "reaction_head_date_missing" ]]; then
+    exit 0  # empty body -> HEAD_COMMIT_DATE unknown
+  fi
+  printf '2026-06-01T00:00:00Z\\n'
+  exit 0
+fi
+
+# PR-body reactions: login <TAB> content <TAB> created_at. Head commit date in
+# the stub is 2026-06-01T00:00:00Z, so "…06-02…" is fresh and "…05-01…" is stale.
 if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/reactions" ]]; then
   case "$GH_STUB_SCENARIO" in
     reactions_read_fail)
       echo "reactions unavailable" >&2
       exit 3
       ;;
-    codex_reaction_ok)
-      printf 'chatgpt-codex-connector[bot]\\t+1\\n'
+    codex_reaction_ok|reaction_head_date_missing)
+      printf 'chatgpt-codex-connector[bot]\\t+1\\t2026-06-02T00:00:00Z\\n'
+      ;;
+    codex_reaction_stale)
+      printf 'chatgpt-codex-connector[bot]\\t+1\\t2026-05-01T00:00:00Z\\n'
       ;;
     codex_reaction_negative)
-      printf 'chatgpt-codex-connector[bot]\\tconfused\\n'
-      printf 'chatgpt-codex-connector[bot]\\t-1\\n'
+      printf 'chatgpt-codex-connector[bot]\\tconfused\\t2026-06-02T00:00:00Z\\n'
+      printf 'chatgpt-codex-connector[bot]\\t-1\\t2026-06-02T00:00:00Z\\n'
       ;;
     reaction_wrong_user)
-      printf 'someuser\\t+1\\n'
+      printf 'someuser\\t+1\\t2026-06-02T00:00:00Z\\n'
       ;;
   esac
   exit 0
@@ -379,6 +393,29 @@ test("pre-merge check accepts a codex thumbs-up reaction on the PR body as sign-
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /OK: All reviewers posted/);
+  });
+});
+
+test("pre-merge check rejects a codex reaction left before the current head commit", async () => {
+  // A +1 on an earlier revision must not satisfy the reviewer once a newer
+  // commit is pushed — the reaction predates the head commit's committer date.
+  await withGhStub("codex_reaction_stale", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
+  });
+});
+
+test("pre-merge check does not count reactions when the head commit date is unknown", async () => {
+  // Fail closed: without the head commit date there is no way to prove a
+  // reaction is fresh, so even a positive codex reaction must not sign off.
+  await withGhStub("reaction_head_date_missing", async (env) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Head commit date unknown/);
+    assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
   });
 });
 

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -119,17 +119,19 @@ if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/comments" ]]; then
   exit 0
 fi
 
-# Head commit metadata (committer date) — used to reject stale reaction sign-offs.
-if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef1234567890abcdef1234567890abcdef" ]]; then
+# Head-visibility time = earliest check-suite created_at for the head SHA. Used
+# to reject reaction sign-offs placed before the current head was pushed.
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef1234567890abcdef1234567890abcdef/check-suites" ]]; then
   if [[ "$GH_STUB_SCENARIO" == "reaction_head_date_missing" ]]; then
-    exit 0  # empty body -> HEAD_COMMIT_DATE unknown
+    exit 0  # empty output -> HEAD_VISIBLE_AT unknown -> fail closed
   fi
   printf '2026-06-01T00:00:00Z\\n'
   exit 0
 fi
 
-# PR-body reactions: login <TAB> content <TAB> created_at. Head commit date in
-# the stub is 2026-06-01T00:00:00Z, so "…06-02…" is fresh and "…05-01…" is stale.
+# PR-body reactions: login <TAB> content <TAB> created_at. Head-visibility time
+# in the stub is 2026-06-01T00:00:00Z, so "…06-02…" is fresh and "…05-01…" is
+# stale (placed before the head was pushed).
 if [[ "$1" == "api" && "$2" == "repos/example/repo/issues/7/reactions" ]]; then
   case "$GH_STUB_SCENARIO" in
     reactions_read_fail)
@@ -396,9 +398,9 @@ test("pre-merge check accepts a codex thumbs-up reaction on the PR body as sign-
   });
 });
 
-test("pre-merge check rejects a codex reaction left before the current head commit", async () => {
+test("pre-merge check rejects a codex reaction placed before the head was pushed", async () => {
   // A +1 on an earlier revision must not satisfy the reviewer once a newer
-  // commit is pushed — the reaction predates the head commit's committer date.
+  // commit is pushed — the reaction predates the head's check-suite (push) time.
   await withGhStub("codex_reaction_stale", async (env) => {
     const result = runPreMergeCheck(env);
 
@@ -407,14 +409,14 @@ test("pre-merge check rejects a codex reaction left before the current head comm
   });
 });
 
-test("pre-merge check does not count reactions when the head commit date is unknown", async () => {
-  // Fail closed: without the head commit date there is no way to prove a
+test("pre-merge check does not count reactions when the head push time is unknown", async () => {
+  // Fail closed: without a push-visibility timestamp there is no way to prove a
   // reaction is fresh, so even a positive codex reaction must not sign off.
   await withGhStub("reaction_head_date_missing", async (env) => {
     const result = runPreMergeCheck(env);
 
     assert.equal(result.status, 1);
-    assert.match(result.stdout, /Head commit date unknown/);
+    assert.match(result.stdout, /Head push time unknown/);
     assert.match(result.stdout, /Missing reviews from: chatgpt-codex-connector\[bot\]/);
   });
 });


### PR DESCRIPTION
## Summary

`scripts/pre-merge-check.sh` detects AI-reviewer activity via PR reviews, PR comments, SHA-pinned codex issue-comment verdicts, and reviewer check runs — but **not reactions**. Codex (`chatgpt-codex-connector[bot]`) frequently signs off on a clean PR by leaving a **thumbs-up (`+1`) reaction on the PR description** instead of posting a review or comment. When it does, the gate blocks forever even though the required reviewer has approved.

Observed on #1565: every enforced CI check was green and Cursor had approved, but `pre-merge-check.sh` reported `BLOCKED: Missing reviews from: chatgpt-codex-connector[bot]` — codex's only signal was a `+1` reaction on the PR body.

## Change

- Add PR-body reaction detection to `pre-merge-check.sh`: a required reviewer counts as having weighed in if they left an explicitly **positive** reaction (`+1`, `heart`, `hooray`, `rocket`) on the PR body.
  - Negative/ambiguous reactions (`-1`, `confused`, `eyes`) never count.
  - A positive reaction from a **non-reviewer** is not credited to the reviewer (exact login match).
  - The reactions read is **non-fatal** — a failure prints a NOTE and falls back to the existing detection paths rather than crashing the gate.
- Extend `tests/pre-merge-check.test.mjs` (+4 tests): codex `+1` signs off; negative reactions and other users' reactions still block; a reactions-endpoint failure degrades to a missing-reviewer verdict, not an API-read crash.

## Verification

Node 22:
- `node --test tests/pre-merge-check.test.mjs` → **20 pass / 0 fail** (16 existing + 4 new)
- `npm run preflight:quick` → OK
- Manual runs against live PRs: `pre-merge-check.sh 1565` now **passes** (codex via reaction; it is not in the reviews list); `1563`/`1560` still pass via review detection (no regression).

## Notes

Independent, tooling-only follow-up split out of the #1565 work per the narrow-PR workflow. No product code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only merge gate logic with fail-closed defaults; no product, auth, or data-path changes.
> 
> **Overview**
> Fixes false **BLOCKED** merges when Codex only leaves a **+1** (or other positive emoji) on the PR description instead of a review, comment, or check run.
> 
> `pre-merge-check.sh` now treats **positive** PR-body reactions (`+1`, `heart`, `hooray`, `rocket`) from required reviewers as sign-off, with **exact login** matching and **no credit** for `-1`, `confused`, or `eyes`. Reactions are bound to the current head by comparing `created_at` to **`HEAD_VISIBLE_AT`** (earliest check-suite `created_at` for the head SHA); if that push time is unknown, reactions are **not** counted. A failed reactions API call logs a NOTE and falls back to existing paths instead of aborting the script.
> 
> `tests/pre-merge-check.test.mjs` extends the `gh` stub (check-suites + reactions) and adds cases for fresh/stale reactions, unknown head time, negative reactions, wrong user, and reactions read failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5796fcd35b8d02f89012e804c5ead08ddef50cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->