### PR TITLE
test(recall): de-flake assembly-budget skip tests via injectable clock

### DIFF
--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7295,6 +7295,17 @@ export class Orchestrator {
     };
   }
 
+  /**
+   * Clock source for the shared post-retrieval assembly/enrichment budget. The
+   * deadline is set from this value and every expiry check reads it back, so a
+   * test can drive the budget deterministically instead of racing the few-ms
+   * wall-clock window that made the "skips … after budget expires" tests flaky.
+   * Production behavior is unchanged — it returns the wall clock.
+   */
+  protected recallAssemblyClockMs(): number {
+    return Date.now();
+  }
+
   private async recallInternal(
     prompt: string,
     sessionKey?: string,
@@ -10261,7 +10272,7 @@ export class Orchestrator {
 
     const enrichmentAssemblyDeadlineAtMs =
       enrichmentSectionDeadlineMs > 0
-        ? Date.now() + enrichmentSectionDeadlineMs
+        ? this.recallAssemblyClockMs() + enrichmentSectionDeadlineMs
         : null;
 
     const awaitEnrichmentSection = async <T>(
@@ -10303,7 +10314,7 @@ export class Orchestrator {
       const timeoutMs =
         enrichmentAssemblyDeadlineAtMs === null
           ? null
-          : Math.max(0, enrichmentAssemblyDeadlineAtMs - Date.now());
+          : Math.max(0, enrichmentAssemblyDeadlineAtMs - this.recallAssemblyClockMs());
       if (timeoutMs === 0) {
         const settledOutcome = promise.getSettledOutcome();
         if (settledOutcome) {
@@ -10349,7 +10360,7 @@ export class Orchestrator {
     const remainingEnrichmentAssemblyMs = (): number | null =>
       enrichmentAssemblyDeadlineAtMs === null
         ? null
-        : Math.max(0, enrichmentAssemblyDeadlineAtMs - Date.now());
+        : Math.max(0, enrichmentAssemblyDeadlineAtMs - this.recallAssemblyClockMs());
 
     const awaitAssemblyStep = async <T>(
       name: string,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20100,
+      "packages/remnic-core/src/orchestrator.ts": 20111,
       "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8277,
       "packages/remnic-core/src/storage.ts": 7320,

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -980,6 +980,15 @@ test("recallInternal skips embedding fallback after assembly budget expires", as
     },
   );
 
+  // Drive the shared post-retrieval assembly budget deterministically instead
+  // of racing the 5ms wall clock: the deadline is set on the first clock read
+  // (base) and every later read is far past it, so the "skip after budget
+  // expired" gate fires every time rather than flapping on scheduler jitter.
+  let assemblyClockReads = 0;
+  const assemblyClockBase = Date.now();
+  (orchestrator as any).recallAssemblyClockMs = () =>
+    assemblyClockBase + assemblyClockReads++ * 60_000;
+
   (orchestrator as any).boxBuilderFor = () => ({
     readRecentBoxes: async () => {
       await new Promise<never>(() => {});
@@ -1029,6 +1038,15 @@ test("recallInternal skips no-QMD hot fallback after assembly budget expires", a
       parallelRetrievalEnabled: false,
     },
   );
+
+  // Drive the shared post-retrieval assembly budget deterministically instead
+  // of racing the 5ms wall clock (this test was ~1-in-3 flaky on Node 22): the
+  // deadline is set on the first clock read (base) and every later read is far
+  // past it, so the "skip after budget expired" gate fires every time.
+  let assemblyClockReads = 0;
+  const assemblyClockBase = Date.now();
+  (orchestrator as any).recallAssemblyClockMs = () =>
+    assemblyClockBase + assemblyClockReads++ * 60_000;
 
   (orchestrator as any).boxBuilderFor = () => ({
     readRecentBoxes: async () => {


### PR DESCRIPTION
## Problem

`tests/recall-hardening.test.ts` had two timing-dependent tests that intermittently failed (~1 in 3 local runs on Node 22, and caused an **unrelated CI `quality` failure on #1565**):

- `recallInternal skips no-QMD hot fallback after assembly budget expires`
- `recallInternal skips embedding fallback after assembly budget expires`

Both set `recallEnrichmentDeadlineMs: 5` and hang the box read to force the shared post-retrieval **assembly budget** to expire, then assert the fallback path is skipped. The pass/fail hinged on a ±1ms wall-clock window between:

```ts
enrichmentAssemblyDeadlineAtMs = Date.now() + 5   // budget set
// ...later, per assembly step:
Math.max(0, enrichmentAssemblyDeadlineAtMs - Date.now())  // expiry check
```

Under event-loop load from sibling tests the budget check raced the scheduler and occasionally read `1ms` instead of `0`, so the fallback step ran when the test expected it skipped. It reproduced only when the **whole file** runs (~1/6 here); **0/60 in isolation** — a classic cross-test timing flake.

## Fix

Introduce a single protected clock seam and route the budget **set** and **both** expiry checks through it:

```ts
protected recallAssemblyClockMs(): number { return Date.now(); }
```

Production behavior is unchanged (still `Date.now()`). The two tests override the seam with a monotonic-jumping stub so the shared budget is **provably expired** at every post-retrieval step — the `if (timeoutMs === 0)` skip gate now fires deterministically. This does **not** weaken the behavior under test; it removes the wall-clock race around it.

## Verification

- **Fail-before:** neutering the `if (timeoutMs === 0)` gate makes **both** tests fail → they genuinely exercise the skip behavior (not vacuous).
- **Stable after:** **75 clean full-file runs** (20 + 30 + 25) via `node --test --import tsx tests/recall-hardening.test.ts`; at the observed ~1/6 flake rate, 30 consecutive clean runs ≈ 0.4% by luck.
- `npm run preflight:quick` → OK (quick)
- `npm run test:entity-hardening` → 245/245 pass (touches `orchestrator.ts`)

The one-line `scripts/ratchet-baseline.json` bump accounts for the 11 lines the seam adds to `orchestrator.ts` (sanctioned `check-ratchets --update` path).

## Checklist
- [x] All tests pass
- [x] New logic covered by tests (deterministic override drives the exact gate)
- [x] Pre-commit / preflight gates pass locally
- [x] No secrets or personal data
- [x] PR diff small and scoped (3 files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-focused seam with production still using Date.now(); recall budget logic is refactored only to call the new hook.
> 
> **Overview**
> Fixes flaky **recall-hardening** tests that assert embedding and no-QMD fallbacks are skipped after the shared post-retrieval **assembly budget** expires.
> 
> Adds a protected **`recallAssemblyClockMs()`** seam on `Orchestrator` and routes the enrichment deadline anchor plus remaining-budget checks through it instead of inline `Date.now()`. Runtime behavior is unchanged (still wall clock); the two affected tests stub the seam with a monotonic clock so the budget is always expired when the `timeoutMs === 0` skip gate runs, removing ~5ms scheduler races under full-file load.
> 
> Updates **`scripts/ratchet-baseline.json`** for the small `orchestrator.ts` line-count increase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0584205f127f1f885378858083747df7953f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->