### PR TITLE
feat(connectors): add omp (oh-my-pi) memory connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ OpenClaw's built-in memory works for simple cases, but it doesn't scale. It lack
 
 Remnic is an open-source memory and context layer for user-aware agents. It watches agent conversations, extracts durable knowledge, and injects the right context back when it is needed. Route extraction through the OpenClaw gateway model chain, OpenAI, or a **local LLM** (Ollama, LM Studio, etc.) -- your choice.
 
-Remnic helps agents understand the people they work with: preferences, projects, constraints, decisions, patterns, and definitions of good. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Pi Coding Agent](https://pi.dev)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent can use the same governed memory store.
+Remnic helps agents understand the people they work with: preferences, projects, constraints, decisions, patterns, and definitions of good. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Pi Coding Agent](https://pi.dev)**, **[Oh My Pi (omp)](https://omp.sh)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent can use the same governed memory store.
 
 Local-first storage is a trust feature. All data can stay on your machine as plain markdown files: no cloud dependency, no subscription, and no third-party memory service required.
 
@@ -189,6 +189,7 @@ Once the Remnic daemon is running, connect any supported agent:
 remnic connectors install claude-code   # Claude Code (hooks + MCP)
 remnic connectors install codex-cli     # Codex CLI (hooks + MCP + memory extension)
 remnic connectors install pi            # Pi Coding Agent (extension + MCP + compaction)
+remnic connectors install omp           # Oh My Pi / omp (extension + MCP + compaction)
 remnic connectors install replit        # Replit (MCP only)
 pip install --upgrade remnic-hermes     # Hermes Agent (Python MemoryProvider)
 remnic connectors install hermes        # Writes Hermes config + token

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -25,17 +25,29 @@ every agent.
 omp is a first-class MCP client. This is the quickest way to validate shared
 read/write and needs no Remnic extension files.
 
-Add Remnic to `~/.omp/agent/mcp.json` (user scope) or `.omp/mcp.json` (project
-scope):
+First start the Remnic server (it serves the MCP endpoint on port 4318) and mint
+a token — the same HTTP/MCP surface every other MCP client uses (see
+[connector-setup.md](./connector-setup.md)):
+
+```bash
+remnic daemon start                       # serves http://localhost:4318/mcp
+remnic connectors install generic-mcp     # mints the connector token ($REMNIC_AUTH_TOKEN)
+```
+
+Then point omp at it via `~/.omp/agent/mcp.json` (user scope) or `.omp/mcp.json`
+(project scope) using the HTTP transport:
 
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
   "mcpServers": {
     "remnic": {
-      "type": "stdio",
-      "command": "remnic",
-      "args": ["access", "mcp-serve"]
+      "type": "http",
+      "url": "http://localhost:4318/mcp",
+      "headers": {
+        "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}",
+        "X-Engram-Namespace": "my-project"
+      }
     }
   }
 }
@@ -43,27 +55,12 @@ scope):
 
 This exposes Remnic's MCP tools (`remnic_recall`, `remnic_memory_store`,
 `remnic_briefing`, `remnic_observe`, …) to omp against the same store the other
-agents use. The stdio server authenticates as the trusted principal from your
-Remnic config/env, so no bearer token is required for a local subprocess.
+agents use. The optional `X-Engram-Namespace` header scopes memory to a
+project/team.
 
-**Cross-machine / HTTP transport.** If the daemon runs elsewhere, start the
-authenticated HTTP surface (`remnic access http-serve --port 4318`) and point
-omp at its `/mcp` endpoint with a token:
-
-```json
-{
-  "mcpServers": {
-    "remnic": {
-      "type": "http",
-      "url": "http://127.0.0.1:4318/mcp",
-      "headers": { "Authorization": "Bearer ${REMNIC_TOKEN}" }
-    }
-  }
-}
-```
-
-Generate a token with `remnic connectors install generic-mcp` (or
-`remnic token generate omp`).
+> **Transport note.** The `remnic` binary does not serve MCP over stdio — the
+> daemon's HTTP `/mcp` endpoint is the supported transport for every MCP client
+> (OpenClaw plugin mode uses `openclaw engram access http-serve --port 4318`).
 
 **Trade-off:** MCP recall is *tool-gated* — the model must decide to call
 `remnic_recall`/`remnic_briefing`. There is no automatic system-prompt
@@ -115,9 +112,11 @@ extensions from, resolved the way omp's own `DirResolver` does:
 
 Install under the same profile/env you launch omp with (e.g.
 `OMP_PROFILE=work remnic connectors install omp`) so the extension lands where
-that profile scans. omp's XDG redirection (`XDG_DATA_HOME`, …) relocates
-*data* dirs (sessions/state/cache), **not** the extension dir, so it does not
-affect where the connector installs.
+that profile scans. `remnic connectors remove omp` sweeps the base agent dir and
+every `profiles/<name>/agent` under the config root, so removal cleans up a
+profile-scoped install even if the profile env is not set at remove time. omp's
+XDG redirection (`XDG_DATA_HOME`, …) relocates *data* dirs (sessions/state/cache),
+**not** the extension dir, so it does not affect where the connector installs.
 
 ### Turn off omp's built-in memory
 

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -1,0 +1,194 @@
+# Oh My Pi (omp) Integration
+
+[Oh My Pi](https://omp.sh) (`omp`, [`can1357/oh-my-pi`](https://github.com/can1357/oh-my-pi))
+is a terminal coding agent forked from [Pi](https://pi.dev). Because omp
+preserves Pi's extension API — the same `context`, `turn_end`,
+`session_shutdown`, and `session_before_compact` hooks — the existing
+`@remnic/plugin-pi` runtime extension runs on omp unchanged. Only the
+*installer* differs (omp keeps its agent files under `~/.omp/agent` instead of
+`~/.pi/agent`), so Remnic ships a dedicated **`omp` connector** that writes into
+the right place.
+
+There are two ways to give omp the **same** governed memory that OpenClaw,
+Claude Code, Codex, ChatGPT, and Pi already share. Both point omp at the *same*
+Remnic daemon + memory directory, so memory written by any agent is recalled by
+every agent.
+
+> **One brain, many front-ends.** Shared memory only requires that every agent
+> talks to one Remnic instance (one daemon URL + one `memoryDir`). omp joins as
+> another front-end; it does not get a private store.
+
+---
+
+## Path 1 — Register Remnic as an MCP server (fast, no extension)
+
+omp is a first-class MCP client. This is the quickest way to validate shared
+read/write and needs no Remnic extension files.
+
+Add Remnic to `~/.omp/agent/mcp.json` (user scope) or `.omp/mcp.json` (project
+scope):
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
+  "mcpServers": {
+    "remnic": {
+      "type": "stdio",
+      "command": "remnic",
+      "args": ["access", "mcp-serve"]
+    }
+  }
+}
+```
+
+This exposes Remnic's MCP tools (`remnic_recall`, `remnic_memory_store`,
+`remnic_briefing`, `remnic_observe`, …) to omp against the same store the other
+agents use. The stdio server authenticates as the trusted principal from your
+Remnic config/env, so no bearer token is required for a local subprocess.
+
+**Cross-machine / HTTP transport.** If the daemon runs elsewhere, start the
+authenticated HTTP surface (`remnic access http-serve --port 4318`) and point
+omp at its `/mcp` endpoint with a token:
+
+```json
+{
+  "mcpServers": {
+    "remnic": {
+      "type": "http",
+      "url": "http://127.0.0.1:4318/mcp",
+      "headers": { "Authorization": "Bearer ${REMNIC_TOKEN}" }
+    }
+  }
+}
+```
+
+Generate a token with `remnic connectors install generic-mcp` (or
+`remnic token generate omp`).
+
+**Trade-off:** MCP recall is *tool-gated* — the model must decide to call
+`remnic_recall`/`remnic_briefing`. There is no automatic system-prompt
+injection. Use an omp rule/skill to nudge a `remnic_briefing` call at session
+start, or use Path 2 for automatic recall.
+
+---
+
+## Path 2 — Install the native omp extension (recommended)
+
+Start the Remnic daemon, then install the `omp` connector:
+
+```bash
+remnic daemon start
+remnic connectors install omp
+```
+
+The installer writes (mirroring the Pi connector, under omp's agent home):
+
+- `~/.omp/agent/extensions/remnic/index.ts` — omp auto-discovery wrapper
+- `~/.omp/agent/extensions/remnic/remnic.config.json` — private daemon URL, namespace, and auth token (`0600`)
+- `~/.omp/agent/extensions/remnic/README.md` — local operator notes
+
+To skip writing the extension and only create the connector/token:
+
+```bash
+remnic connectors install omp --config installExtension=false
+```
+
+To target a non-default daemon or namespace:
+
+```bash
+remnic connectors install omp \
+  --config remnicDaemonUrl=http://127.0.0.1:4318 \
+  --config namespace=work
+```
+
+### Turn off omp's built-in memory
+
+omp ships its own memory backends (`memory.backend: local` and
+`memory.backend: mnemopi`). Those are **separate, per-project stores** that are
+*not* shared with other agents. To make Remnic the single source of truth, leave
+omp's backend off in `~/.omp/agent/config.yml`:
+
+```yaml
+memory:
+  backend: off
+```
+
+Running both means two disjoint memories; pick Remnic (shared) or Mnemopi
+(local-only), not both.
+
+## What The Extension Does
+
+- Uses the `context` hook to recall relevant Remnic context before an agent turn.
+- Uses `message_end`, `turn_end`, and `session_shutdown` hooks to observe user, assistant, and tool activity with `sourceFormat: "pi"`.
+- Uses `session_before_compact` to flush Remnic LCM for the active session before omp compacts context, then records the compaction token delta.
+- Registers Remnic MCP tools as omp tools when the Remnic daemon token is configured.
+- Persists lightweight dedupe state with omp `custom` entries so repeated turns are not re-observed.
+
+All of these hooks exist in omp's extension event surface (it is a superset of
+Pi's), so the shared runtime extension binds without modification.
+
+## omp Commands
+
+The extension registers these slash commands:
+
+- `/remnic-status` — check daemon health
+- `/remnic-recall <query>` — recall Remnic context for a query
+- `/remnic-remember <memory>` — explicitly store a memory
+- `/remnic-lcm-search <query>` — search archived context
+- `/remnic-why` — inspect the last recall explanation
+- `/remnic-compact` — request compaction
+
+## Configuration
+
+The extension loads configuration from:
+
+1. `REMNIC_OMP_CONFIG` (or `REMNIC_PI_CONFIG`, which takes precedence if both are set)
+2. The explicit `configPath` written into the auto-discovery wrapper (`~/.omp/agent/extensions/remnic/remnic.config.json`)
+
+Supported config keys:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `remnicDaemonUrl` | `http://127.0.0.1:4318` | Remnic HTTP/MCP daemon URL |
+| `authToken` | unset | Connector token generated by `remnic connectors install omp` |
+| `namespace` | unset | Remnic namespace for recall/observe/store requests |
+| `recallMode` | `auto` | Recall mode: `auto`, `minimal`, `full`, `graph_mode`, or `no_recall` |
+| `recallTopK` | `8` | Max recalled results |
+| `recallBudgetChars` | `12000` | Max recalled context injected into omp |
+| `recallEnabled` | `true` | Enable context-hook recall |
+| `observeEnabled` | `true` | Enable turn observation |
+| `observeSkipExtraction` | `false` | Archive observed messages without extraction |
+| `compactionEnabled` | `true` | Enable LCM flush/checkpoint coordination |
+| `mcpToolsEnabled` | `true` | Register Remnic MCP tools as omp tools |
+| `statusEnabled` | `true` | Set omp UI status from daemon health |
+| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout for recall/observe/compaction/commands |
+| `startupRequestTimeoutMs` | `1000` | Shorter timeout for startup-sensitive probes so a slow or offline daemon can't stall omp boot |
+
+Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
+
+### Direct load (without the connector installer)
+
+You can load the package directly, pointing it at a config via `REMNIC_OMP_CONFIG`:
+
+```bash
+REMNIC_OMP_CONFIG=~/.omp/agent/extensions/remnic/remnic.config.json \
+  omp -e npm:@remnic/plugin-pi
+```
+
+## API Surface
+
+omp uses the shared Remnic access layer, identical to Pi:
+
+- `POST /engram/v1/recall`
+- `POST /engram/v1/observe`
+- `POST /engram/v1/lcm/search`
+- `POST /engram/v1/lcm/compaction/flush`
+- `POST /engram/v1/lcm/compaction/record`
+- `POST /mcp` for MCP tool discovery and calls
+
+Both canonical `remnic.*` MCP tools and legacy `engram.*` aliases remain available through the daemon.
+
+## See Also
+
+- [Pi Coding Agent Integration](./pi.md) — the upstream Pi connector this shares its runtime with.
+- [Connector Setup Guide](./connector-setup.md) — MCP/HTTP config snippets for other agents.

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -101,6 +101,24 @@ remnic connectors install omp \
   --config namespace=work
 ```
 
+### Install location
+
+The connector writes into the same agent directory omp auto-discovers
+extensions from, resolved the way omp's own `DirResolver` does:
+
+- The config dir name is `PI_CONFIG_DIR` (default `.omp`).
+- An active profile (`OMP_PROFILE`, falling back to `PI_PROFILE`) wins and
+  targets `<configRoot>/profiles/<name>/agent`; omp discards `PI_CODING_AGENT_DIR`
+  while a profile is active.
+- Otherwise `PI_CODING_AGENT_DIR` overrides the whole agent dir.
+- Otherwise the base is `~/.omp/agent`.
+
+Install under the same profile/env you launch omp with (e.g.
+`OMP_PROFILE=work remnic connectors install omp`) so the extension lands where
+that profile scans. omp's XDG redirection (`XDG_DATA_HOME`, …) relocates
+*data* dirs (sessions/state/cache), **not** the extension dir, so it does not
+affect where the connector installs.
+
 ### Turn off omp's built-in memory
 
 omp ships its own memory backends (`memory.backend: local` and

--- a/docs/integration/pi.md
+++ b/docs/integration/pi.md
@@ -3,6 +3,9 @@
 Remnic ships a native Pi Coding Agent extension through `@remnic/plugin-pi`.
 It uses Pi's extension hooks instead of wrapping Pi with a parallel runtime.
 
+> Using the [Oh My Pi (omp)](https://omp.sh) fork? The same runtime extension
+> works there via the `omp` connector — see [omp.md](./omp.md).
+
 ## Install
 
 Start the Remnic daemon, then install the connector:

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -4,6 +4,8 @@ Remnic memory and context for [Pi Coding Agent](https://pi.dev).
 
 This package is the first-class Remnic extension for Pi. It uses Pi's extension hooks directly, so Remnic can recall context before a model call, observe useful session events after the turn, expose Remnic MCP tools inside Pi, and coordinate Pi compaction with Remnic's long-context memory archive.
 
+> **Oh My Pi (omp).** The [omp](https://omp.sh) fork preserves Pi's extension API, so this package's runtime extension runs there too. Install it with `remnic connectors install omp` (writes to `~/.omp/agent/extensions/remnic/`) via the `OmpMemoryExtensionPublisher`. See [docs/integration/omp.md](../../docs/integration/omp.md).
+
 ## What It Does
 
 - Recalls relevant Remnic context in Pi's `context` hook before an agent turn.

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -18,6 +18,28 @@ test("resolveConfigPath uses the Pi extension config location by default", () =>
   }
 });
 
+test("resolveConfigPath honors REMNIC_OMP_CONFIG for omp direct loads", () => {
+  assert.equal(
+    resolveConfigPath({
+      env: { HOME: "/home/alice", REMNIC_OMP_CONFIG: "/x/omp/remnic.config.json" },
+    }),
+    "/x/omp/remnic.config.json",
+  );
+});
+
+test("resolveConfigPath prefers REMNIC_PI_CONFIG over REMNIC_OMP_CONFIG", () => {
+  assert.equal(
+    resolveConfigPath({
+      env: {
+        HOME: "/home/alice",
+        REMNIC_PI_CONFIG: "/pi/remnic.config.json",
+        REMNIC_OMP_CONFIG: "/omp/remnic.config.json",
+      },
+    }),
+    "/pi/remnic.config.json",
+  );
+});
+
 test("resolveConfigPath honors Pi agent directory overrides", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-config-roots-"));
   try {

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -146,7 +146,13 @@ function trimTrailingSlashes(value: string): string {
 
 export function resolveConfigPath(options: LoadConfigOptions = {}): string {
   const env = options.env ?? process.env;
-  return expandTildePath(options.configPath || env.REMNIC_PI_CONFIG || defaultConfigPath(env));
+  // REMNIC_PI_CONFIG keeps precedence for upstream Pi; REMNIC_OMP_CONFIG lets an
+  // omp (oh-my-pi) direct load (`omp -e npm:@remnic/plugin-pi`) point the shared
+  // runtime module at its own config without an explicit configPath. Connector
+  // installs always pass an explicit configPath, so this only affects direct loads.
+  return expandTildePath(
+    options.configPath || env.REMNIC_PI_CONFIG || env.REMNIC_OMP_CONFIG || defaultConfigPath(env),
+  );
 }
 
 export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {

--- a/packages/plugin-pi/src/paths.test.ts
+++ b/packages/plugin-pi/src/paths.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveOmpAgentHome, resolveOmpExtensionRoot } from "./paths.js";
+
+test("resolveOmpAgentHome defaults to ~/.omp/agent", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice" }),
+    path.join("/home/alice", ".omp", "agent"),
+  );
+});
+
+test("resolveOmpAgentHome honors PI_CODING_AGENT_DIR override", () => {
+  assert.equal(
+    resolveOmpAgentHome({
+      HOME: "/home/alice",
+      PI_CODING_AGENT_DIR: "/custom/omp-agent",
+    }),
+    "/custom/omp-agent",
+  );
+});
+
+test("resolveOmpAgentHome resolves a named profile under ~/.omp/profiles", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice", OMP_PROFILE: "work" }),
+    path.join("/home/alice", ".omp", "profiles", "work", "agent"),
+  );
+});
+
+test("resolveOmpAgentHome falls back to PI_PROFILE for the profile name", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice", PI_PROFILE: "scratch" }),
+    path.join("/home/alice", ".omp", "profiles", "scratch", "agent"),
+  );
+});
+
+test("resolveOmpAgentHome treats the default profile as the base agent dir", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice", OMP_PROFILE: "default" }),
+    path.join("/home/alice", ".omp", "agent"),
+  );
+});
+
+test("resolveOmpExtensionRoot appends extensions/remnic to the agent home", () => {
+  assert.equal(
+    resolveOmpExtensionRoot({ HOME: "/home/alice" }),
+    path.join("/home/alice", ".omp", "agent", "extensions", "remnic"),
+  );
+});

--- a/packages/plugin-pi/src/paths.test.ts
+++ b/packages/plugin-pi/src/paths.test.ts
@@ -21,6 +21,33 @@ test("resolveOmpAgentHome honors PI_CODING_AGENT_DIR override", () => {
   );
 });
 
+test("resolveOmpAgentHome honors PI_CONFIG_DIR for the config dir name", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice", PI_CONFIG_DIR: ".myomp" }),
+    path.join("/home/alice", ".myomp", "agent"),
+  );
+});
+
+test("resolveOmpAgentHome lets an active profile take precedence over PI_CODING_AGENT_DIR", () => {
+  // Matches omp's DirResolver: when a profile is active, the agent-dir
+  // override is discarded, so the extension must land in the profile dir.
+  assert.equal(
+    resolveOmpAgentHome({
+      HOME: "/home/alice",
+      OMP_PROFILE: "work",
+      PI_CODING_AGENT_DIR: "/custom/omp-agent",
+    }),
+    path.join("/home/alice", ".omp", "profiles", "work", "agent"),
+  );
+});
+
+test("resolveOmpAgentHome combines PI_CONFIG_DIR with a named profile", () => {
+  assert.equal(
+    resolveOmpAgentHome({ HOME: "/home/alice", PI_CONFIG_DIR: ".myomp", PI_PROFILE: "scratch" }),
+    path.join("/home/alice", ".myomp", "profiles", "scratch", "agent"),
+  );
+});
+
 test("resolveOmpAgentHome resolves a named profile under ~/.omp/profiles", () => {
   assert.equal(
     resolveOmpAgentHome({ HOME: "/home/alice", OMP_PROFILE: "work" }),

--- a/packages/plugin-pi/src/paths.ts
+++ b/packages/plugin-pi/src/paths.ts
@@ -23,27 +23,49 @@ export function resolvePiExtensionRoot(env: NodeJS.ProcessEnv): string {
 }
 
 /**
- * Resolve the omp (oh-my-pi) agent home directory.
+ * Resolve the active omp profile from the environment, mirroring omp's
+ * `resolveProfileEnv`: `OMP_PROFILE` is authoritative, and `PI_PROFILE` is a
+ * compatibility fallback consulted **only** when `OMP_PROFILE` is undefined
+ * (an explicitly-empty `OMP_PROFILE` therefore selects the default profile).
+ * The reserved name "default" and blank values resolve to the base (no profile).
+ */
+function resolveOmpProfile(env: NodeJS.ProcessEnv): string | undefined {
+  const raw = env.OMP_PROFILE !== undefined ? env.OMP_PROFILE : env.PI_PROFILE;
+  const trimmed = raw?.trim();
+  if (!trimmed || trimmed === "default") return undefined;
+  return trimmed;
+}
+
+/**
+ * Resolve the omp (oh-my-pi) agent home directory that omp auto-discovers
+ * extensions from. Mirrors omp's `DirResolver` (packages/utils/src/dirs.ts):
  *
- * Mirrors omp's own `getAgentDir()` resolution (docs/config-usage.md):
- *   1. `PI_CODING_AGENT_DIR` is an explicit override shared with upstream Pi.
- *   2. A named profile (`OMP_PROFILE`, falling back to `PI_PROFILE`) resolves to
- *      `~/.omp/profiles/<name>/agent`. The reserved name "default" is the base.
- *   3. Otherwise the base agent dir is `~/.omp/agent`.
+ *   - The config dir name is `PI_CONFIG_DIR` (default `.omp`).
+ *   - When a profile (`OMP_PROFILE`, falling back to `PI_PROFILE`) is active it
+ *     wins and resolves to `<configRoot>/profiles/<name>/agent`; omp discards
+ *     the `PI_CODING_AGENT_DIR` override while a profile is active.
+ *   - Otherwise `PI_CODING_AGENT_DIR` overrides the whole agent dir.
+ *   - Otherwise the base agent dir is `<configRoot>/agent`.
+ *
+ * Note: omp's XDG redirection (`XDG_DATA_HOME`, etc.) applies to the `data`,
+ * `state`, and `cache` categories (sessions/state/cache) — NOT to the base
+ * agent dir that extensions are discovered from — so it is intentionally not
+ * consulted here.
  */
 export function resolveOmpAgentHome(env: NodeJS.ProcessEnv): string {
+  const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
+  const configDirName = env.PI_CONFIG_DIR?.trim() || ".omp";
+  const configRoot = path.join(home, configDirName);
+
+  const profile = resolveOmpProfile(env);
+  if (profile) {
+    return path.join(configRoot, "profiles", profile, "agent");
+  }
+
   const explicitCodingAgentDir = env.PI_CODING_AGENT_DIR?.trim();
   if (explicitCodingAgentDir) return path.resolve(expandTildePath(explicitCodingAgentDir));
 
-  const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
-  const ompHome = path.join(home, ".omp");
-
-  const profile = (env.OMP_PROFILE ?? env.PI_PROFILE)?.trim();
-  if (profile && profile !== "default") {
-    return path.join(ompHome, "profiles", profile, "agent");
-  }
-
-  return path.join(ompHome, "agent");
+  return path.join(configRoot, "agent");
 }
 
 export function resolveOmpExtensionRoot(env: NodeJS.ProcessEnv): string {

--- a/packages/plugin-pi/src/paths.ts
+++ b/packages/plugin-pi/src/paths.ts
@@ -52,10 +52,18 @@ function resolveOmpProfile(env: NodeJS.ProcessEnv): string | undefined {
  * agent dir that extensions are discovered from — so it is intentionally not
  * consulted here.
  */
-export function resolveOmpAgentHome(env: NodeJS.ProcessEnv): string {
+/**
+ * The omp config root (`~/<PI_CONFIG_DIR or .omp>`), which contains the base
+ * `agent/` dir and any `profiles/<name>/agent/` dirs.
+ */
+export function resolveOmpConfigRoot(env: NodeJS.ProcessEnv): string {
   const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
   const configDirName = env.PI_CONFIG_DIR?.trim() || ".omp";
-  const configRoot = path.join(home, configDirName);
+  return path.join(home, configDirName);
+}
+
+export function resolveOmpAgentHome(env: NodeJS.ProcessEnv): string {
+  const configRoot = resolveOmpConfigRoot(env);
 
   const profile = resolveOmpProfile(env);
   if (profile) {

--- a/packages/plugin-pi/src/paths.ts
+++ b/packages/plugin-pi/src/paths.ts
@@ -21,3 +21,31 @@ export function resolvePiAgentHome(env: NodeJS.ProcessEnv): string {
 export function resolvePiExtensionRoot(env: NodeJS.ProcessEnv): string {
   return path.join(resolvePiAgentHome(env), "extensions", REMNIC_PI_EXTENSION_DIR_NAME);
 }
+
+/**
+ * Resolve the omp (oh-my-pi) agent home directory.
+ *
+ * Mirrors omp's own `getAgentDir()` resolution (docs/config-usage.md):
+ *   1. `PI_CODING_AGENT_DIR` is an explicit override shared with upstream Pi.
+ *   2. A named profile (`OMP_PROFILE`, falling back to `PI_PROFILE`) resolves to
+ *      `~/.omp/profiles/<name>/agent`. The reserved name "default" is the base.
+ *   3. Otherwise the base agent dir is `~/.omp/agent`.
+ */
+export function resolveOmpAgentHome(env: NodeJS.ProcessEnv): string {
+  const explicitCodingAgentDir = env.PI_CODING_AGENT_DIR?.trim();
+  if (explicitCodingAgentDir) return path.resolve(expandTildePath(explicitCodingAgentDir));
+
+  const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
+  const ompHome = path.join(home, ".omp");
+
+  const profile = (env.OMP_PROFILE ?? env.PI_PROFILE)?.trim();
+  if (profile && profile !== "default") {
+    return path.join(ompHome, "profiles", profile, "agent");
+  }
+
+  return path.join(ompHome, "agent");
+}
+
+export function resolveOmpExtensionRoot(env: NodeJS.ProcessEnv): string {
+  return path.join(resolveOmpAgentHome(env), "extensions", REMNIC_PI_EXTENSION_DIR_NAME);
+}

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 
 import { type PublishContext, loadTokenStore, saveTokenStore } from "@remnic/core";
 
-import { PiMemoryExtensionPublisher } from "./publisher.js";
+import { OmpMemoryExtensionPublisher, PiMemoryExtensionPublisher } from "./publisher.js";
 
 class FailingPiPublisher extends PiMemoryExtensionPublisher {
   async renderInstructions(ctx: PublishContext): Promise<string> {
@@ -525,4 +525,130 @@ test("Pi publisher unpublish refuses owned file symlinks", async (t) => {
   assert.equal(fs.readFileSync(path.join(targetDir, "external-wrapper.ts"), "utf8"), "external wrapper\n");
   assert.equal(fs.readFileSync(path.join(extensionRoot, "remnic.config.json"), "utf8"), "{}\n");
   assert.equal(fs.readFileSync(path.join(extensionRoot, "README.md"), "utf8"), "# Remnic\n");
+});
+
+// ── omp (oh-my-pi) publisher ────────────────────────────────────────────────
+
+test("omp publisher exposes hostId omp and resolves the ~/.omp/agent extension root", async () => {
+  const publisher = new OmpMemoryExtensionPublisher();
+  assert.equal(publisher.hostId, "omp");
+  assert.equal(
+    await publisher.resolveExtensionRoot({ HOME: "/home/alice" }),
+    path.join("/home/alice", ".omp", "agent", "extensions", "remnic"),
+  );
+});
+
+test("omp publisher honors PI_CODING_AGENT_DIR for extension root", async () => {
+  const publisher = new OmpMemoryExtensionPublisher();
+  assert.equal(
+    await publisher.resolveExtensionRoot({
+      HOME: "/home/alice",
+      PI_CODING_AGENT_DIR: "/custom/omp-agent",
+    }),
+    path.join("/custom/omp-agent", "extensions", "remnic"),
+  );
+});
+
+test("omp publisher publishes config, wrapper, and readme with the omp connector token", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-publisher-test-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  const result = await publisher.publish({
+    config: {
+      daemonUrl: "http://new-daemon/",
+      memoryDir: path.join(root, "memory"),
+      namespace: "ns-omp",
+    },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  assert.equal(result.extensionRoot, extensionRoot);
+  assert.equal(result.hostId, "omp");
+
+  const cfg = JSON.parse(
+    fs.readFileSync(path.join(extensionRoot, "remnic.config.json"), "utf8"),
+  ) as Record<string, unknown>;
+  assert.equal(cfg.authToken, "omp-token");
+  assert.equal(cfg.namespace, "ns-omp");
+  assert.equal(cfg.remnicDaemonUrl, "http://new-daemon");
+
+  assert.ok(fs.existsSync(path.join(extensionRoot, "index.ts")));
+  const readme = fs.readFileSync(path.join(extensionRoot, "README.md"), "utf8");
+  assert.match(readme, /omp/i);
+});
+
+test("omp publisher refuses a symlinked extension root", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-publisher-symlink-"));
+  const home = path.join(root, "home");
+  const extensionsDir = path.join(home, ".omp", "agent", "extensions");
+  const extensionRoot = path.join(extensionsDir, "remnic");
+  const targetDir = path.join(root, "symlink-target");
+  fs.mkdirSync(extensionsDir, { recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  fs.symlinkSync(targetDir, extensionRoot, "dir");
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /must not be a symlink/,
+  );
+
+  assert.equal(fs.existsSync(path.join(targetDir, "remnic.config.json")), false);
+  assert.equal(fs.existsSync(path.join(targetDir, "index.ts")), false);
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -652,3 +652,54 @@ test("omp publisher refuses a symlinked extension root", async (t) => {
   assert.equal(fs.existsSync(path.join(targetDir, "remnic.config.json")), false);
   assert.equal(fs.existsSync(path.join(targetDir, "index.ts")), false);
 });
+
+test("omp publisher unpublish removes a profile-scoped install even without the profile env", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-profile-remove-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousConfigDir = process.env.PI_CONFIG_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.PI_CONFIG_DIR;
+  delete process.env.PI_PROFILE;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("PI_CONFIG_DIR", previousConfigDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  // Install under the "work" profile.
+  process.env.OMP_PROFILE = "work";
+  const profileRoot = path.join(home, ".omp", "profiles", "work", "agent", "extensions", "remnic");
+  const installResult = await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+  assert.equal(installResult.extensionRoot, profileRoot);
+  assert.ok(fs.existsSync(path.join(profileRoot, "remnic.config.json")));
+
+  // Remove WITHOUT the profile env set — must still find and remove the
+  // profile-scoped install instead of no-oping on the default agent dir.
+  delete process.env.OMP_PROFILE;
+  await new OmpMemoryExtensionPublisher().unpublish();
+
+  assert.equal(fs.existsSync(path.join(profileRoot, "remnic.config.json")), false);
+  assert.equal(fs.existsSync(path.join(profileRoot, "index.ts")), false);
+  assert.equal(fs.existsSync(path.join(profileRoot, "README.md")), false);
+});

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -13,11 +13,16 @@ import {
   saveTokenStore,
 } from "@remnic/core";
 
-import { resolvePiAgentHome, resolvePiExtensionRoot } from "./paths.js";
+import {
+  resolveOmpAgentHome,
+  resolveOmpExtensionRoot,
+  resolvePiAgentHome,
+  resolvePiExtensionRoot,
+} from "./paths.js";
 
 const DEFAULT_DAEMON_PORT = 4318;
-const PI_EXTENSION_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
-const PI_EXTENSION_OWNED_TEMP_FILE_PATTERN = /^(?:remnic\.config\.json|index\.ts|README\.md)\.tmp-\d+-\d+$/u;
+const EXTENSION_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
+const EXTENSION_OWNED_TEMP_FILE_PATTERN = /^(?:remnic\.config\.json|index\.ts|README\.md)\.tmp-\d+-\d+$/u;
 
 type FileSnapshot = {
   path: string;
@@ -26,9 +31,48 @@ type FileSnapshot = {
   mode?: number;
 };
 
-export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
-  readonly hostId = "pi";
+/**
+ * Host-specific parameters for a Pi-family memory extension publisher.
+ *
+ * The Remnic runtime extension is host-neutral (it only uses Pi's extension
+ * hooks, which omp preserves as a superset), so the only things that vary
+ * between hosts are *where* the extension is installed, *which* connector
+ * token it uses, and *how* it is labelled. Everything else — atomic writes,
+ * rollback, symlink guards, config merge — is shared.
+ */
+export interface HostPublisherDescriptor {
+  readonly hostId: string;
+  readonly connectorId: string;
+  readonly displayName: string;
+  readonly tokenGenerateHint: string;
+  resolveAgentHome(env: NodeJS.ProcessEnv): string;
+  resolveExtensionRoot(env: NodeJS.ProcessEnv): string;
+}
 
+const PI_HOST: HostPublisherDescriptor = {
+  hostId: "pi",
+  connectorId: "pi",
+  displayName: "Pi Coding Agent",
+  tokenGenerateHint: "remnic token generate pi",
+  resolveAgentHome: resolvePiAgentHome,
+  resolveExtensionRoot: resolvePiExtensionRoot,
+};
+
+const OMP_HOST: HostPublisherDescriptor = {
+  hostId: "omp",
+  connectorId: "omp",
+  displayName: "Oh My Pi (omp)",
+  tokenGenerateHint: "remnic token generate omp",
+  resolveAgentHome: resolveOmpAgentHome,
+  resolveExtensionRoot: resolveOmpExtensionRoot,
+};
+
+/**
+ * Shared publisher for Pi-family hosts. Concrete hosts (Pi, omp) subclass this
+ * with a {@link HostPublisherDescriptor}; the install/rollback machinery is
+ * identical across hosts.
+ */
+export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
   static readonly capabilities: PublisherCapabilities = {
     instructionsMd: false,
     skillsFolder: false,
@@ -36,14 +80,20 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
     readPathTemplate: false,
   };
 
+  protected constructor(private readonly host: HostPublisherDescriptor) {}
+
+  get hostId(): string {
+    return this.host.hostId;
+  }
+
   async resolveExtensionRoot(env?: NodeJS.ProcessEnv): Promise<string> {
-    return resolvePiExtensionRoot(env ?? process.env);
+    return this.host.resolveExtensionRoot(env ?? process.env);
   }
 
   async isHostAvailable(): Promise<boolean> {
-    // Pi auto-discovers extensions from ~/.pi/agent/extensions. The directory can
-    // be created before Pi has been launched, so availability should not block
-    // first-time installation.
+    // Pi-family agents auto-discover extensions from their agent extensions
+    // directory. The directory can be created before the agent has been
+    // launched, so availability should not block first-time installation.
     return true;
   }
 
@@ -51,17 +101,17 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
     const namespace = ctx.config.namespace ?? "default";
     const daemonUrl = resolveDaemonUrl(ctx);
     return [
-      "# Remnic for Pi",
+      `# Remnic for ${this.host.displayName}`,
       "",
-      "Remnic provides memory, retrieval, observation, MCP tools, and long-context compaction coordination for Pi Coding Agent.",
+      `Remnic provides memory, retrieval, observation, MCP tools, and long-context compaction coordination for ${this.host.displayName}.`,
       "",
       "## Installed Capabilities",
       "",
-      "- Recall relevant Remnic context in Pi's `context` hook before agent turns.",
-      '- Observe Pi user, assistant, and tool messages with `sourceFormat: "pi"`.',
-      "- Coordinate Pi `session_before_compact` with Remnic LCM flush and checkpoint recording.",
-      "- Register Remnic MCP tools as Pi tools when daemon authentication is configured.",
-      "- Persist lightweight dedupe state in Pi custom entries via `appendEntry`.",
+      "- Recall relevant Remnic context in the `context` hook before agent turns.",
+      '- Observe user, assistant, and tool messages with `sourceFormat: "pi"`.',
+      "- Coordinate `session_before_compact` with Remnic LCM flush and checkpoint recording.",
+      "- Register Remnic MCP tools as host tools when daemon authentication is configured.",
+      "- Persist lightweight dedupe state in custom entries via `appendEntry`.",
       "",
       "## Runtime",
       "",
@@ -75,21 +125,26 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
   async publish(ctx: PublishContext): Promise<PublishResult> {
     const extensionRoot = await this.resolveExtensionRoot();
-    assertSafePiExtensionRoot(extensionRoot, process.env);
+    const agentHome = this.host.resolveAgentHome(process.env);
+    assertSafeExtensionRoot(extensionRoot, agentHome);
     const filesWritten: string[] = [];
     const skipped: string[] = [];
 
-    ctx.log.info(`Publishing Pi memory extension to ${extensionRoot}`);
+    ctx.log.info(`Publishing ${this.host.displayName} memory extension to ${extensionRoot}`);
 
-    const [configPath, wrapperPath, readmePath] = piExtensionOwnedPaths(extensionRoot);
+    const [configPath, wrapperPath, readmePath] = extensionOwnedPaths(extensionRoot);
     const rootExisted = fs.existsSync(extensionRoot);
     const snapshots = snapshotFiles([configPath, wrapperPath, readmePath]);
     const priorTokenEntry =
-      ctx.rollbackTokenEntry === undefined ? snapshotPiTokenEntry() : cloneTokenEntry(ctx.rollbackTokenEntry);
+      ctx.rollbackTokenEntry === undefined
+        ? snapshotTokenEntry(this.host.connectorId)
+        : cloneTokenEntry(ctx.rollbackTokenEntry);
 
-    const token = getConnectorToken("pi");
+    const token = getConnectorToken(this.host.connectorId);
     if (!token) {
-      skipped.push("auth token unavailable; run `remnic token generate pi` and reinstall the connector");
+      skipped.push(
+        `auth token unavailable; run \`${this.host.tokenGenerateHint}\` and reinstall the connector`,
+      );
     }
 
     try {
@@ -116,7 +171,7 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
         config.namespace = ctx.config.namespace;
       }
 
-      mkdirPiExtensionRoot(extensionRoot, process.env);
+      mkdirExtensionRoot(extensionRoot, agentHome);
 
       atomicWriteFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
       filesWritten.push(configPath);
@@ -131,21 +186,21 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
         restorePublishSnapshot(extensionRoot, rootExisted, snapshots);
       } catch (restoreErr) {
         ctx.log.warn(
-          `Pi extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`
+          `${this.host.displayName} extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
         );
       }
       try {
-        restorePiTokenEntry(priorTokenEntry);
+        restoreTokenEntry(priorTokenEntry, this.host.connectorId);
       } catch (tokenErr) {
         ctx.log.warn(
-          `Pi connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`
+          `${this.host.displayName} connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`,
         );
       }
       throw err;
     }
 
     return {
-      hostId: this.hostId,
+      hostId: this.host.hostId,
       extensionRoot,
       filesWritten,
       skipped,
@@ -154,12 +209,12 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
   async unpublish(): Promise<void> {
     const extensionRoot = await this.resolveExtensionRoot();
-    assertSafePiExtensionRoot(extensionRoot, process.env);
+    assertSafeExtensionRoot(extensionRoot, this.host.resolveAgentHome(process.env));
     if (!fs.existsSync(extensionRoot)) {
       return;
     }
 
-    const removableFiles = removableOwnedExtensionFiles(piExtensionOwnedUnpublishPaths(extensionRoot));
+    const removableFiles = removableOwnedExtensionFiles(extensionOwnedUnpublishPaths(extensionRoot));
     for (const filePath of removableFiles) {
       fs.rmSync(filePath, { force: true });
     }
@@ -167,14 +222,28 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
   }
 }
 
-function piExtensionOwnedPaths(extensionRoot: string): string[] {
-  return PI_EXTENSION_OWNED_FILES.map((fileName) => path.join(extensionRoot, fileName));
+/** Publisher for upstream Pi (`~/.pi/agent/extensions/remnic`). */
+export class PiMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
+  constructor() {
+    super(PI_HOST);
+  }
 }
 
-function piExtensionOwnedUnpublishPaths(extensionRoot: string): string[] {
-  const ownedPaths = piExtensionOwnedPaths(extensionRoot);
+/** Publisher for Oh My Pi / omp (`~/.omp/agent/extensions/remnic`). */
+export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
+  constructor() {
+    super(OMP_HOST);
+  }
+}
+
+function extensionOwnedPaths(extensionRoot: string): string[] {
+  return EXTENSION_OWNED_FILES.map((fileName) => path.join(extensionRoot, fileName));
+}
+
+function extensionOwnedUnpublishPaths(extensionRoot: string): string[] {
+  const ownedPaths = extensionOwnedPaths(extensionRoot);
   for (const fileName of fs.readdirSync(extensionRoot)) {
-    if (PI_EXTENSION_OWNED_TEMP_FILE_PATTERN.test(fileName)) {
+    if (EXTENSION_OWNED_TEMP_FILE_PATTERN.test(fileName)) {
       ownedPaths.push(path.join(extensionRoot, fileName));
     }
   }
@@ -241,7 +310,7 @@ function snapshotFiles(paths: string[]): FileSnapshot[] {
     if (!fs.existsSync(filePath)) return { path: filePath, existed: false };
     const stat = fs.lstatSync(filePath);
     if (stat.isSymbolicLink()) {
-      throw new Error(`Pi extension path must not be a symlink: ${filePath}`);
+      throw new Error(`Extension path must not be a symlink: ${filePath}`);
     }
     if (!stat.isFile()) return { path: filePath, existed: false };
     return {
@@ -287,7 +356,7 @@ function canCleanNewExtensionRoot(extensionRoot: string): boolean {
     throw err;
   }
   if (stat.isSymbolicLink()) {
-    throw new Error(`Pi extension path must not be a symlink: ${extensionRoot}`);
+    throw new Error(`Extension path must not be a symlink: ${extensionRoot}`);
   }
   return stat.isDirectory();
 }
@@ -301,7 +370,7 @@ function removeEmptyDirectory(dirPath: string): void {
     throw err;
   }
   if (stat.isSymbolicLink()) {
-    throw new Error(`Pi extension path must not be a symlink: ${dirPath}`);
+    throw new Error(`Extension path must not be a symlink: ${dirPath}`);
   }
   if (!stat.isDirectory()) return;
   if (fs.readdirSync(dirPath).length > 0) return;
@@ -314,7 +383,7 @@ function removableOwnedExtensionFiles(filePaths: string[]): string[] {
     const stat = statOwnedExtensionPath(filePath);
     if (stat === null) continue;
     if (stat.isSymbolicLink()) {
-      throw new Error(`Pi extension path must not be a symlink: ${filePath}`);
+      throw new Error(`Extension path must not be a symlink: ${filePath}`);
     }
     if (stat.isFile()) removableFiles.push(filePath);
   }
@@ -332,25 +401,25 @@ function statOwnedExtensionPath(filePath: string): fs.Stats | null {
   return stat;
 }
 
-function mkdirPiExtensionRoot(extensionRoot: string, env: NodeJS.ProcessEnv): void {
-  const extensionsDir = path.join(resolvePiAgentHome(env), "extensions");
-  assertSafePiExtensionRoot(extensionRoot, env);
+function mkdirExtensionRoot(extensionRoot: string, agentHome: string): void {
+  const extensionsDir = path.join(path.resolve(agentHome), "extensions");
+  assertSafeExtensionRoot(extensionRoot, agentHome);
   fs.mkdirSync(extensionsDir, { recursive: true });
   rejectSymlinkPath(extensionsDir);
   fs.mkdirSync(extensionRoot, { recursive: true });
   rejectSymlinkPath(extensionRoot);
 }
 
-function assertSafePiExtensionRoot(extensionRoot: string, env: NodeJS.ProcessEnv): void {
-  const expected = path.join(resolvePiAgentHome(env), "extensions", "remnic");
+function assertSafeExtensionRoot(extensionRoot: string, agentHome: string): void {
+  const resolvedAgentHome = path.resolve(agentHome);
+  const expected = path.join(resolvedAgentHome, "extensions", "remnic");
   if (path.resolve(extensionRoot) !== path.resolve(expected)) {
-    throw new Error(`Pi extension root is outside the configured Pi extensions directory: ${extensionRoot}`);
+    throw new Error(`Extension root is outside the configured extensions directory: ${extensionRoot}`);
   }
-  const agentHome = path.resolve(resolvePiAgentHome(env));
-  const extensionsDir = path.join(agentHome, "extensions");
-  assertPathContained(agentHome, extensionsDir);
+  const extensionsDir = path.join(resolvedAgentHome, "extensions");
+  assertPathContained(resolvedAgentHome, extensionsDir);
   assertPathContained(extensionsDir, extensionRoot);
-  rejectSymlinkPath(agentHome);
+  rejectSymlinkPath(resolvedAgentHome);
   if (fs.existsSync(extensionsDir)) rejectSymlinkPath(extensionsDir);
   if (fs.existsSync(extensionRoot)) rejectSymlinkPath(extensionRoot);
 }
@@ -363,7 +432,7 @@ function rejectSymlinkPath(filePath: string): void {
   if (!fs.existsSync(filePath)) return;
   const stat = fs.lstatSync(filePath);
   if (stat.isSymbolicLink()) {
-    throw new Error(`Pi extension path must not be a symlink: ${filePath}`);
+    throw new Error(`Extension path must not be a symlink: ${filePath}`);
   }
 }
 
@@ -372,7 +441,7 @@ function assertPathContained(root: string, candidate: string): void {
   const candidateResolved = path.resolve(candidate);
   const relative = path.relative(rootResolved, candidateResolved);
   if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) return;
-  throw new Error(`Pi extension path escapes allowed root: ${candidate}`);
+  throw new Error(`Extension path escapes allowed root: ${candidate}`);
 }
 
 function readPriorConfig(configPath: string): Record<string, unknown> {
@@ -389,8 +458,8 @@ function readPriorConfig(configPath: string): Record<string, unknown> {
   }
 }
 
-function snapshotPiTokenEntry(): TokenEntry | null {
-  const entry = loadTokenStore().tokens.find((candidate) => candidate.connector === "pi");
+function snapshotTokenEntry(connectorId: string): TokenEntry | null {
+  const entry = loadTokenStore().tokens.find((candidate) => candidate.connector === connectorId);
   return cloneTokenEntry(entry ?? null);
 }
 
@@ -398,9 +467,9 @@ function cloneTokenEntry(entry: TokenEntry | null): TokenEntry | null {
   return entry ? { ...entry } : null;
 }
 
-function restorePiTokenEntry(priorEntry: TokenEntry | null): void {
+function restoreTokenEntry(priorEntry: TokenEntry | null, connectorId: string): void {
   const store = loadTokenStore();
-  store.tokens = store.tokens.filter((entry) => entry.connector !== "pi");
+  store.tokens = store.tokens.filter((entry) => entry.connector !== connectorId);
   if (priorEntry) store.tokens.push(priorEntry);
   saveTokenStore(store);
 }

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -15,6 +15,7 @@ import {
 
 import {
   resolveOmpAgentHome,
+  resolveOmpConfigRoot,
   resolveOmpExtensionRoot,
   resolvePiAgentHome,
   resolvePiExtensionRoot,
@@ -47,6 +48,13 @@ export interface HostPublisherDescriptor {
   readonly tokenGenerateHint: string;
   resolveAgentHome(env: NodeJS.ProcessEnv): string;
   resolveExtensionRoot(env: NodeJS.ProcessEnv): string;
+  /**
+   * Optional: every agent home `unpublish` should sweep for a stale extension,
+   * beyond the one resolved from the current env. Hosts with env-sensitive
+   * install locations (e.g. omp profiles) provide this so `remnic connectors
+   * remove` cleans up even when the remove-time env differs from install time.
+   */
+  listRemovalAgentHomes?(env: NodeJS.ProcessEnv): string[];
 }
 
 const PI_HOST: HostPublisherDescriptor = {
@@ -65,7 +73,38 @@ const OMP_HOST: HostPublisherDescriptor = {
   tokenGenerateHint: "remnic token generate omp",
   resolveAgentHome: resolveOmpAgentHome,
   resolveExtensionRoot: resolveOmpExtensionRoot,
+  listRemovalAgentHomes: ompRemovalAgentHomes,
 };
+
+/**
+ * Every omp agent home a stale extension might live under, so `unpublish` cleans
+ * up regardless of the profile/env active at remove time: the env-resolved home,
+ * the base `<configRoot>/agent`, an explicit `PI_CODING_AGENT_DIR`, and every
+ * existing `<configRoot>/profiles/<name>/agent`. Symlinked profile dirs are
+ * skipped defensively.
+ */
+function ompRemovalAgentHomes(env: NodeJS.ProcessEnv): string[] {
+  const homes = new Set<string>([resolveOmpAgentHome(env)]);
+  const configRoot = resolveOmpConfigRoot(env);
+  homes.add(path.join(configRoot, "agent"));
+
+  const explicit = env.PI_CODING_AGENT_DIR?.trim();
+  if (explicit) homes.add(path.resolve(explicit));
+
+  const profilesDir = path.join(configRoot, "profiles");
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(profilesDir, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      homes.add(path.join(profilesDir, entry.name, "agent"));
+    }
+  }
+  return [...homes];
+}
 
 /**
  * Shared publisher for Pi-family hosts. Concrete hosts (Pi, omp) subclass this
@@ -208,17 +247,24 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
   }
 
   async unpublish(): Promise<void> {
-    const extensionRoot = await this.resolveExtensionRoot();
-    assertSafeExtensionRoot(extensionRoot, this.host.resolveAgentHome(process.env));
-    if (!fs.existsSync(extensionRoot)) {
-      return;
-    }
+    const agentHomes = this.host.listRemovalAgentHomes
+      ? this.host.listRemovalAgentHomes(process.env)
+      : [this.host.resolveAgentHome(process.env)];
 
-    const removableFiles = removableOwnedExtensionFiles(extensionOwnedUnpublishPaths(extensionRoot));
-    for (const filePath of removableFiles) {
-      fs.rmSync(filePath, { force: true });
+    const seen = new Set<string>();
+    for (const agentHome of agentHomes) {
+      const extensionRoot = path.join(path.resolve(agentHome), "extensions", "remnic");
+      if (seen.has(extensionRoot)) continue;
+      seen.add(extensionRoot);
+      if (!fs.existsSync(extensionRoot)) continue;
+
+      assertSafeExtensionRoot(extensionRoot, agentHome);
+      const removableFiles = removableOwnedExtensionFiles(extensionOwnedUnpublishPaths(extensionRoot));
+      for (const filePath of removableFiles) {
+        fs.rmSync(filePath, { force: true });
+      }
+      removeEmptyDirectory(extensionRoot);
     }
-    removeEmptyDirectory(extensionRoot);
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -298,11 +298,22 @@ export {
 
 type PiPublisherModule = {
   PiMemoryExtensionPublisher: new () => MemoryExtensionPublisher;
+  OmpMemoryExtensionPublisher: new () => MemoryExtensionPublisher;
 };
 
-class LazyPiMemoryExtensionPublisher implements MemoryExtensionPublisher {
-  readonly hostId = "pi";
+/**
+ * Lazily loads a Pi-family publisher class from the optional @remnic/plugin-pi
+ * package so it is only imported when a Pi-family connector (pi, omp) is
+ * actually installed. Both hosts share one runtime extension module; only the
+ * publisher class (install location + token) differs.
+ */
+class LazyPluginPiPublisher implements MemoryExtensionPublisher {
   private delegate: Promise<MemoryExtensionPublisher> | undefined;
+
+  constructor(
+    readonly hostId: string,
+    private readonly select: (mod: PiPublisherModule) => new () => MemoryExtensionPublisher,
+  ) {}
 
   async resolveExtensionRoot(env?: NodeJS.ProcessEnv): Promise<string> {
     return (await this.load()).resolveExtensionRoot(env);
@@ -326,7 +337,7 @@ class LazyPiMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
   private async load(): Promise<MemoryExtensionPublisher> {
     this.delegate ??= loadPiPublisherModule()
-      .then((mod) => new mod.PiMemoryExtensionPublisher())
+      .then((mod) => new (this.select(mod))())
       .catch((err) => {
         this.delegate = undefined;
         throw err;
@@ -345,7 +356,8 @@ async function loadPiPublisherModule(): Promise<PiPublisherModule> {
 registerPublisher("codex", () => new CodexMemoryExtensionPublisher());
 registerPublisher("claude-code", () => new ClaudeCodeMemoryExtensionPublisher());
 registerPublisher("hermes", () => new HermesMemoryExtensionPublisher());
-registerPublisher("pi", () => new LazyPiMemoryExtensionPublisher());
+registerPublisher("pi", () => new LazyPluginPiPublisher("pi", (mod) => mod.PiMemoryExtensionPublisher));
+registerPublisher("omp", () => new LazyPluginPiPublisher("omp", (mod) => mod.OmpMemoryExtensionPublisher));
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/remnic-core/src/connectors/index.test.ts
+++ b/packages/remnic-core/src/connectors/index.test.ts
@@ -154,6 +154,26 @@ test("loadRegistry does not overwrite malformed registry.json", async (t) => {
   );
 });
 
+test("BUILTIN catalog includes the omp (oh-my-pi) connector", async (t) => {
+  const sandbox = makeSandbox(t);
+
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+    },
+    () => {
+      const registry = loadRegistry();
+      const omp = registry.connectors.find((connector) => connector.id === "omp");
+
+      assert.ok(omp, "omp connector should be present in the built-in catalog");
+      assert.equal(omp?.requiresToken, true);
+      assert.match(omp?.homepage ?? "", /omp\.sh/);
+    },
+  );
+});
+
 test("loadRegistry filters custom connectors with invalid IDs", async (t) => {
   const sandbox = makeSandbox(t);
 

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -416,6 +416,33 @@ const BUILTIN_CONNECTORS: ConnectorManifest[] = [
     requiresToken: true,
   },
   {
+    id: "omp",
+    name: "Oh My Pi (omp)",
+    version: "1.0.0",
+    description:
+      "Oh My Pi (omp) — Pi-fork coding agent; native extension for recall, observe, MCP tools, and compaction coordination",
+    capabilities: {
+      observe: true,
+      recall: true,
+      store: true,
+      search: true,
+      entities: true,
+      realtimeSync: true,
+      batch: true,
+      maxBudgetChars: 32000,
+      connectionType: "http",
+    },
+    configSchema: {
+      remnicDaemonUrl: "URL of the Remnic daemon (default: http://127.0.0.1:4318)",
+      namespace: "Optional namespace",
+      installExtension: "Install the omp extension into ~/.omp/agent/extensions/remnic (default: true)",
+    },
+    homepage: "https://omp.sh",
+    author: "Remnic",
+    tags: ["official", "ai", "omp", "pi", "coding-agent"],
+    requiresToken: true,
+  },
+  {
     id: "replit",
     name: "Replit Agent",
     version: "1.0.0",

--- a/packages/remnic-core/src/tokens.test.ts
+++ b/packages/remnic-core/src/tokens.test.ts
@@ -194,3 +194,17 @@ test("token writes invalidate the cached valid-token list", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("generateToken uses a recognizable prefix for the omp connector", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    const entry = generateToken("omp", tokensPath);
+    assert.equal(entry.connector, "omp");
+    assert.ok(
+      entry.token.startsWith("remnic_op_"),
+      `expected remnic_op_ prefix, got ${entry.token}`,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/tokens.ts
+++ b/packages/remnic-core/src/tokens.ts
@@ -27,6 +27,7 @@ const TOKEN_PREFIXES: Record<string, string> = {
   "codex": "remnic_cx_",
   "hermes": "remnic_hm_",
   "pi": "remnic_pi_",
+  "omp": "remnic_op_",
   "replit": "remnic_rl_",
   "cursor": "remnic_cu_",
   "cline": "remnic_cl_",


### PR DESCRIPTION
## Summary

Adds a first-class **`omp` connector** so [Oh My Pi (`omp`)](https://omp.sh) — [`can1357/oh-my-pi`](https://github.com/can1357/oh-my-pi), a fork of [Pi](https://pi.dev) — shares the **same** governed Remnic memory as OpenClaw, Claude Code, Codex, and Pi.

omp preserves Pi's extension API. Its `context`, `message_end`, `turn_end`, `session_shutdown`, and `session_before_compact` hooks are a **superset** of what the Remnic runtime extension uses (verified against omp's `extensibility/extensions/types.ts`), so the existing `@remnic/plugin-pi` runtime binds **unchanged**. Only the *installer* differs — omp keeps agent files under `~/.omp/agent` instead of `~/.pi/agent` — so this PR parameterizes `plugin-pi` by host rather than forking it.

## Two integration paths (both documented)

- **Path 1 — MCP registration** (fast, no extension): register Remnic's MCP server in `~/.omp/agent/mcp.json` (`remnic access mcp-serve`, or HTTP for cross-machine). Tool-gated recall.
- **Path 2 — native extension** (recommended): `remnic connectors install omp` writes the auto-discovery wrapper + private config into `~/.omp/agent/extensions/remnic/`. Automatic recall in the `context` hook, observe after turns, LCM flush on compaction.

## Changes

**Core**
- `connectors/index.ts`: `omp` catalog entry (mirrors `pi`, `requiresToken`, `omp.sh`).
- `tokens.ts`: token prefix `remnic_op_` for `omp`.

**`@remnic/plugin-pi`** (host-parameterized; Pi behavior unchanged)
- `paths.ts`: `resolveOmpAgentHome` / `resolveOmpExtensionRoot`, honoring `PI_CODING_AGENT_DIR` and `OMP_PROFILE`/`PI_PROFILE` (matches omp's own `getAgentDir()`).
- `config.ts`: `REMNIC_OMP_CONFIG` discovery for direct loads (`REMNIC_PI_CONFIG` keeps precedence).
- `publisher.ts`: extracts a shared `HostMemoryExtensionPublisher` base; `PiMemoryExtensionPublisher` and new `OmpMemoryExtensionPublisher` are thin subclasses. **All symlink guards, atomic writes, rollback, and token-rollback preserved.**

**CLI**
- `registerPublisher("omp", ...)` via a single shared lazy loader (DRYs the two Pi-family wrappers).

**Docs**
- New `docs/integration/omp.md` (Path 1 + Path 2, shared-memory model, config table, "turn off omp's Mnemopi to avoid a second store").
- README connector list + "works natively with" line; `plugin-pi` README; cross-link in `pi.md`.

## Testing

- `plugin-pi`: **89/89** (77 prior Pi tests unchanged as regression guard + new omp coverage for paths, config, and publisher incl. the symlink-refusal invariant).
- `remnic-core` connectors + tokens: **46/46** (new omp catalog + token-prefix tests).
- `tsc --noEmit`: clean for `@remnic/core`, `@remnic/plugin-pi`, `@remnic/cli`.
- `npm run lint`: pass.
- Built `@remnic/plugin-pi` and confirmed `OmpMemoryExtensionPublisher` ships from the `/publisher` entry.

Followed TDD (red → green per module); the publisher refactor kept the full Pi suite green throughout.

## À-la-carte / architecture notes

- No new package: reuses the optional `@remnic/plugin-pi` (still lazily imported by the CLI; no new base-install dependency).
- Publisher classes stay in the host adapter layer; the registry wiring lives in `@remnic/cli` (CLAUDE.md gotcha #31).
- No dependency/lockfile changes.

## PR Checklist
- [x] All tests pass (plugin-pi 89/89, core connectors/tokens 46/46)
- [x] New logic covered by tests (paths, config, publisher, catalog, token prefix)
- [x] Type-checks clean (core, plugin-pi, cli)
- [x] Lint gate passes
- [x] Docs updated (new omp guide + README + package READMEs)
- [x] No secrets or personal data (public repo — scanned staged diff)
- [ ] PR diff ≤ 400 LOC — **justified**: a new connector spans catalog + token + host-parameterized installer + CLI wiring + docs + tests; most of the diff is tests and docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive connector and installer refactor with existing symlink/rollback guards preserved; Pi behavior unchanged and covered by tests.
> 
> **Overview**
> Adds a first-class **`omp`** connector so Oh My Pi shares the same Remnic daemon and memory store as Pi and other agents. The existing `@remnic/plugin-pi` runtime is unchanged; this PR only adds host-specific install paths, CLI wiring, catalog/tokens, and docs.
> 
> **`@remnic/plugin-pi`** is refactored around a shared `HostMemoryExtensionPublisher` with thin `PiMemoryExtensionPublisher` and new `OmpMemoryExtensionPublisher` subclasses. omp installs land under `~/.omp/agent/extensions/remnic/` with path resolution that mirrors omp’s `DirResolver` (profiles via `OMP_PROFILE` / `PI_PROFILE`, `PI_CONFIG_DIR`, `PI_CODING_AGENT_DIR`). **`unpublish`** for omp sweeps base, override, and all profile agent dirs so `remnic connectors remove omp` works even when profile env differs from install time. Config discovery adds **`REMNIC_OMP_CONFIG`** for direct `omp -e npm:@remnic/plugin-pi` loads (`REMNIC_PI_CONFIG` still wins).
> 
> **Core/CLI:** built-in connector catalog entry for `omp`, token prefix `remnic_op_`, and `registerPublisher("omp", …)` via the same lazy `@remnic/plugin-pi/publisher` loader as `pi`.
> 
> **Docs:** new `docs/integration/omp.md` (MCP vs native extension), README and cross-links; guidance to disable omp’s built-in memory when using Remnic as the single store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdaf4b7976837288f709481c75c25039334e6c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->