### PR TITLE
fix(recall): hoist no_recall short-circuit above the planner fork (#1547)

### DIFF
--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7476,8 +7476,8 @@ export class Orchestrator {
       graphExpandedIntentEnabled: caps.graphExpandedIntent,
       prompt,
     };
-    const requestedMode = options.mode;
-    // When the caller forces a mode, skip the (async, possibly LLM-backed)
+    // Issue #1547 — let the heuristic decide no_recall BEFORE the planner/non-planner fork so it fires with planner on OR off.
+    const requestedMode: RecallPlanMode | undefined = options.mode ?? (planRecallMode(prompt) === "no_recall" ? "no_recall" : undefined);
     // planner entirely — the decision is overridden anyway. Otherwise consult
     // the LLM planner when opted in (issue #1367 / Option C); it falls back to
     // the heuristic on disable / shadow / timeout / error.

--- a/tests/orchestrator-characterization.test.ts
+++ b/tests/orchestrator-characterization.test.ts
@@ -211,13 +211,17 @@ test("recall() injects seeded on-disk memories into the returned context", async
   }
 });
 
-test("recall() short-circuits no_recall intent without touching storage", async () => {
+for (const { recallPlannerEnabled, label } of [
+  { recallPlannerEnabled: true, label: "planner-on" },
+  { recallPlannerEnabled: false, label: "planner-off" },
+]) {
+test(`recall() short-circuits no_recall intent without touching storage (${label})`, async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-char-no-recall-"));
-  // The no_recall intent short-circuit is a PLANNER-path behavior: with
-  // recallPlannerEnabled disabled, a trivial "ok" prompt runs the full
-  // filesystem recall assembly instead. Pin the short-circuit under the
-  // planner (its default-on configuration), at the public entry point.
-  const orchestrator = new Orchestrator(makeConfig(memoryDir, { recallPlannerEnabled: true }));
+  // Issue #1547 — the no_recall short-circuit must fire IDENTICALLY regardless
+  // of `recallPlannerEnabled` (CLAUDE.md rule 39: feature gates identical
+  // across parallel paths). Pin BOTH configurations so a future regression
+  // that re-gates the short-circuit to the planner path trips here.
+  const orchestrator = new Orchestrator(makeConfig(memoryDir, { recallPlannerEnabled }));
   try {
     // The public recall() surface swallows errors into "", so the pinned
     // discriminator is the storage-router probe: a no_recall prompt must
@@ -225,22 +229,26 @@ test("recall() short-circuits no_recall intent without touching storage", async 
     // recallInternal-level pin in tests/recall-no-recall-short-circuit.test.ts
     // up to the public entry point.)
     let storageRouterTouched = false;
-    (orchestrator as any).storageRouter = {
+    let storageForCalls = 0;
+    (orchestrator as unknown as { storageRouter: unknown }).storageRouter = {
       storageFor: async () => {
         storageRouterTouched = true;
+        storageForCalls += 1;
         throw new Error("storageFor must not run for no_recall prompts");
       },
     };
 
-    const context = await orchestrator.recall("ok", "session-char-no-recall");
+    const context = await orchestrator.recall("ok", `session-char-no-recall-${label}`);
 
     assert.equal(context, "");
     assert.equal(storageRouterTouched, false);
+    assert.equal(storageForCalls, 0, "storageRouter.storageFor must not be called on the no_recall short-circuit");
   } finally {
     await orchestrator.destroy();
     await cleanupDir(memoryDir);
   }
 });
+}
 
 test("recall() populates the LastRecallSnapshot observable via getLastRecall()", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-char-last-recall-"));


### PR DESCRIPTION
## Summary

The `no_recall` intent short-circuit in `recallInternal` only fired on the planner path: with `recallPlannerEnabled: false` (which forces `plannedMode = "full"`), a trivial prompt like "ok" ran the full recall assembly instead of short-circuiting. This is a CLAUDE.md rule 39 violation — feature gates identical across parallel paths.

The heuristic that decides "this prompt is acknowledgement-style" already exists in `planRecallMode`. This PR moves its decision point above the planner/non-planner fork so both paths consult the same gate. When the caller does not force an explicit mode and the heuristic returns `no_recall`, the result is treated as if the caller had requested `no_recall`. The existing planner-path short-circuit (orchestrator.ts:7832) now triggers identically on both configurations.

Part of #1520.

### User-visible effect

Faster trivial-prompt recalls on non-planner configs — the no-recall fast-path was previously unreachable when `recallPlannerEnabled === false`. Planner-on configurations see no behavior change. Note: any explicit `mode` argument still wins over the heuristic.

## Test evidence

### New parameterized test
Extends characterization scenario 2 (`recall() short-circuits no_recall intent without touching storage`) from #1545 into a parameterized test that runs with `recallPlannerEnabled` both on and off. Adds a `storageFor` call counter so the storage-effect probe asserts **zero reads** on the short-circuit path, not just a boolean discriminator.



### Prove-fail-before
Verified the test catches the regression by stashing the orchestrator.ts change and re-running:
- planner-on case: PASS (was passing pre-fix — short-circuit exists on planner path)
- **planner-off case: FAIL** (`storageFor must not run for no_recall prompts`)
- After un-stashing: both pass.

### Targeted test runs (post-fix)
- `tests/orchestrator-characterization.test.ts`: 16/16 pass
- `tests/recall-no-recall-short-circuit.test.ts`: 18/18 pass (existing no-recall pins still green)
- `npm run test:entity-hardening`: 246/246 pass (entity-hardening gate touched orchestrator)

### Gates
- `npm run preflight:quick`: `[preflight] OK (quick)`
- `node scripts/check-ratchets.mjs`: `[ratchet] OK` (orchestrator LOC unchanged at 20111 — net 0 change)

### Diff size
2 files, +18/-10. Orchestrator diff is a 2-line replacement: hoisted the heuristic `planRecallMode(prompt) === "no_recall"` check into the `requestedMode` initializer so the existing planner-path short-circuit now fires identically for both planner states.

## Chokepoints used: n/a (pre-chokepoint Wave 0)

This is exactly the kind of gate-consolidation Wave 1's #1521 (ScopePlan) and #1523 (CapabilitySet) chokepoints will absorb. Until then, the minimal hoist is the right shape.

## Files changed

- `packages/remnic-core/src/orchestrator.ts` — hoist `planRecallMode(prompt) === "no_recall"` into `requestedMode` initializer (2 lines)
- `tests/orchestrator-characterization.test.ts` — parameterize scenario 2 over `recallPlannerEnabled` and add a storage-call counter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall hot-path gating for all configs when the planner is off; behavior is pinned by tests but affects when memory retrieval runs.
> 
> **Overview**
> **Hoists the acknowledgement-style `no_recall` heuristic** so it applies **before** the planner vs non-planner fork. When the caller does not pass an explicit `mode`, `planRecallMode(prompt) === "no_recall"` now sets `requestedMode` to `"no_recall"`, reusing the existing fast path that skips storage and returns empty context.
> 
> **User-visible:** Non-planner configs get faster recalls on trivial prompts like `"ok"` that previously ran full recall assembly. Planner-on behavior is unchanged. An explicit `mode` argument still overrides the heuristic.
> 
> **Tests:** The `no_recall` characterization case is parameterized for `recallPlannerEnabled` true/false and asserts `storageRouter.storageFor` is never called.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83322f6f0df1fa3a2085717f4ee4b9567802c0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->