### PR TITLE
docs: remote-daemon guidance for startupRequestTimeoutMs

### DIFF
--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -183,6 +183,8 @@ Supported config keys:
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
+> **Remote daemons: raise `startupRequestTimeoutMs`.** MCP tool registration happens once at session start (`tools/list` against the daemon) under this timeout, and a timeout is swallowed silently — the session simply runs without any `remnic_*` tools, while the separate (lighter) health probe can still report the daemon as ready. The `1000` default is tuned for a localhost daemon; when `remnicDaemonUrl` points at another machine (Tailscale/MagicDNS, VPN, LAN), one cold DNS resolution or relayed round trip can exceed it. Set `"startupRequestTimeoutMs": 10000` for remote daemons, and prefer a stable Tailscale IP over a MagicDNS name on hosts where MagicDNS is not enabled.
+
 ### Direct load (without the connector installer)
 
 You can load the package directly, pointing it at a config via `REMNIC_OMP_CONFIG`:

--- a/docs/integration/pi.md
+++ b/docs/integration/pi.md
@@ -83,6 +83,8 @@ Supported config keys:
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
+> **Remote daemons: raise `startupRequestTimeoutMs`.** MCP tool registration happens once at session start (`tools/list` against the daemon) under this timeout, and a timeout is swallowed silently — the session simply runs without any `remnic_*` tools, while the separate (lighter) health probe can still report the daemon as ready. The `1000` default is tuned for a localhost daemon; when `remnicDaemonUrl` points at another machine (Tailscale/MagicDNS, VPN, LAN), one cold DNS resolution or relayed round trip can exceed it. Set `"startupRequestTimeoutMs": 10000` for remote daemons, and prefer a stable Tailscale IP over a MagicDNS name on hosts where MagicDNS is not enabled.
+
 ## API Surface
 
 Pi uses the shared Remnic access layer:

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -88,6 +88,8 @@ Supported config keys:
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
+> **Remote daemons: raise `startupRequestTimeoutMs`.** MCP tool registration happens once at session start (`tools/list` against the daemon) under this timeout, and a timeout is swallowed silently — the session simply runs without any `remnic_*` tools, while the separate (lighter) health probe can still report the daemon as ready. The `1000` default is tuned for a localhost daemon; when `remnicDaemonUrl` points at another machine (Tailscale/MagicDNS, VPN, LAN), one cold DNS resolution or relayed round trip can exceed it. Set `"startupRequestTimeoutMs": 10000` for remote daemons, and prefer a stable Tailscale IP over a MagicDNS name on hosts where MagicDNS is not enabled.
+
 Example:
 
 ```json


### PR DESCRIPTION
## Summary
- Documents that MCP tool registration runs once at session start under `startupRequestTimeoutMs` (default 1000ms) with a **silent** failure mode: on timeout the session runs without any `remnic_*` tools while the lighter health probe can still show the daemon as ready.
- Adds a callout to `docs/integration/omp.md`, `docs/integration/pi.md`, and `packages/plugin-pi/README.md`: set `startupRequestTimeoutMs: 10000` when `remnicDaemonUrl` is remote (Tailscale/VPN/LAN), and prefer a stable Tailscale IP over MagicDNS on hosts without MagicDNS.

## Context
Hit in production 2026-07-04: laptop omp sessions pointed at the macstudio daemon over Tailscale registered zero remnic tools after a cold MagicDNS resolution exceeded the 1s budget, with no error surfaced anywhere. Warm `tools/list` round trips measure 65–190ms, so localhost defaults are fine — remote setups are the gap.

Docs-only change; no code paths touched.

## Checklist
- [x] Docs-only — no logic changes, no tests affected
- [x] No secrets or credentials
- [x] PR diff ≤ 400 LOC (+6 lines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, config defaults, or test changes.
> 
> **Overview**
> Adds the same **remote daemon** callout next to the `startupRequestTimeoutMs` config table in the omp integration guide, Pi integration guide, and `@remnic/plugin-pi` README.
> 
> The note explains that MCP `tools/list` at session start runs under this short timeout and **fails silently** (no `remnic_*` tools, while health can still look ready), that the **1000ms** default assumes localhost, and that remote `remnicDaemonUrl` setups (Tailscale/VPN/LAN) should use **`"startupRequestTimeoutMs": 10000`** and prefer a stable Tailscale IP over MagicDNS when MagicDNS is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df14cde37eda7af4518485075bb80128a55641a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->