### PR TITLE
docs(omp): document omp loader bug + bundle workaround

### DIFF
--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -120,10 +120,32 @@ omp's extension loader has a compat shim that rewrites bare
 not reach files under the extension's `node_modules`, and plain resolution
 from those files fails inside omp's compiled binary.
 
-**Workaround — pre-bundle the extension so nothing resolves at runtime:**
+**Workaround — pre-bundle the extension so nothing resolves at runtime.**
+
+Step 1: the connector-generated `index.ts` imports `@remnic/plugin-pi` via a
+`file://` URL pointing at the global install (`renderWrapper()` in
+`packages/plugin-pi/src/publisher.ts`). Bun's bundler cannot resolve
+`file://` specifiers (`Could not resolve: "file://…"`), so first convert the
+extension directory to a self-contained npm layout with a bare-specifier
+import:
 
 ```bash
 cd ~/.omp/agent/extensions/remnic
+cat > index.ts <<'EOF'
+import { createRemnicPiExtension } from "@remnic/plugin-pi";
+
+export default createRemnicPiExtension({
+  configPath: `${process.env.HOME}/.omp/agent/extensions/remnic/remnic.config.json`,
+});
+EOF
+npm init -y >/dev/null && npm install @remnic/plugin-pi
+```
+
+(Keep your existing `remnic.config.json` — only `index.ts` is replaced.)
+
+Step 2: bundle:
+
+```bash
 bun build index.ts --target=bun --outdir=dist-bundle
 ```
 

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -130,7 +130,24 @@ extension directory to a self-contained npm layout with a bare-specifier
 import:
 
 ```bash
-cd "$(dirname "$(find ~/.omp -name remnic.config.json -path '*/extensions/remnic/*' | head -1)")"
+# Resolve the extension root the same way the installer does (see
+# "Install location" above): active profile wins, then PI_CODING_AGENT_DIR,
+# then the default agent dir.
+profile="${OMP_PROFILE:-${PI_PROFILE:-}}"
+config_root="$HOME/${PI_CONFIG_DIR:-.omp}"
+if [ -n "$profile" ]; then
+  agent_dir="$config_root/profiles/$profile/agent"
+elif [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
+  agent_dir="$PI_CODING_AGENT_DIR"
+else
+  agent_dir="$config_root/agent"
+fi
+ext_dir="$agent_dir/extensions/remnic"
+[ -f "$ext_dir/remnic.config.json" ] || {
+  echo "No remnic extension at $ext_dir — run: remnic connectors install omp" >&2
+  exit 1
+}
+cd "$ext_dir"
 cat > index.ts <<'EOF'
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -133,7 +133,12 @@ import:
 # Resolve the extension root the same way the installer does (see
 # "Install location" above): active profile wins, then PI_CODING_AGENT_DIR,
 # then the default agent dir.
-profile="${OMP_PROFILE:-${PI_PROFILE:-}}"
+# Profile selection mirrors resolveOmpProfile(): OMP_PROFILE wins whenever it
+# is SET (even set-but-empty — it does not fall through to PI_PROFILE), values
+# are trimmed, and blank or the reserved "default" mean "no profile".
+if [ "${OMP_PROFILE+x}" = "x" ]; then raw_profile="$OMP_PROFILE"; else raw_profile="${PI_PROFILE-}"; fi
+profile="$(printf '%s' "$raw_profile" | xargs)"
+[ "$profile" = "default" ] && profile=""
 config_root="$HOME/${PI_CONFIG_DIR:-.omp}"
 if [ -n "$profile" ]; then
   agent_dir="$config_root/profiles/$profile/agent"

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -130,18 +130,32 @@ extension directory to a self-contained npm layout with a bare-specifier
 import:
 
 ```bash
-cd ~/.omp/agent/extensions/remnic
+cd "$(dirname "$(find ~/.omp -name remnic.config.json -path '*/extensions/remnic/*' | head -1)")"
 cat > index.ts <<'EOF'
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRemnicPiExtension } from "@remnic/plugin-pi";
 
-export default createRemnicPiExtension({
-  configPath: `${process.env.HOME}/.omp/agent/extensions/remnic/remnic.config.json`,
-});
+// Resolve remnic.config.json relative to this file so the extension keeps
+// working under profiles / custom agent dirs (OMP_PROFILE, PI_CONFIG_DIR,
+// PI_CODING_AGENT_DIR). When bundled, this file runs from dist-bundle/, so
+// also check one level up.
+const here = dirname(fileURLToPath(import.meta.url));
+const configPath = [
+  join(here, "remnic.config.json"),
+  join(here, "..", "remnic.config.json"),
+].find(existsSync);
+
+export default createRemnicPiExtension({ configPath });
 EOF
 npm init -y >/dev/null && npm install @remnic/plugin-pi
 ```
 
-(Keep your existing `remnic.config.json` — only `index.ts` is replaced.)
+(Keep your existing `remnic.config.json` — only `index.ts` is replaced. The
+relative lookup preserves the installer-written location instead of
+hard-coding `~/.omp/agent`, so profile-scoped installs keep their token and
+namespace.)
 
 Step 2: bundle:
 

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -98,6 +98,69 @@ remnic connectors install omp \
   --config namespace=work
 ```
 
+### Known issue: omp cannot resolve the extension's npm dependencies
+
+> **Status:** open omp loader bug, confirmed against omp v16.3.5
+> (macOS arm64 and Debian x64). Tracked for an installer-side fix in the
+> Remnic repo — see the `OmpMemoryExtensionPublisher` auto-bundle issue.
+
+omp's embedded runtime fails to resolve bare npm specifiers from the
+extension's `node_modules`, even though the packages are installed and a
+system `bun` resolves them fine from the same directory. Every session start
+logs (and the extension silently never loads):
+
+```text
+Failed to load extension: ResolveMessage: Cannot find module
+'@sinclair/typebox' from
+'~/.omp/agent/extensions/remnic/node_modules/@remnic/plugin-pi/dist/index.js'
+```
+
+omp's extension loader has a compat shim that rewrites bare
+`@sinclair/typebox` imports onto its host-bundled copy, but the rewrite does
+not reach files under the extension's `node_modules`, and plain resolution
+from those files fails inside omp's compiled binary.
+
+**Workaround — pre-bundle the extension so nothing resolves at runtime:**
+
+```bash
+cd ~/.omp/agent/extensions/remnic
+bun build index.ts --target=bun --outdir=dist-bundle
+```
+
+This inlines every dependency (only `node:` builtins stay external; native
+addons such as lancedb are emitted as sibling `.node` assets — which is why
+the bundle is **per-host** and must never be copied between machines). Then
+point omp at the bundle instead of `index.ts` by adding an `omp.extensions`
+manifest to the extension's `package.json` (omp prefers the manifest over
+`index.ts`):
+
+```json
+{
+  "omp": { "extensions": ["./dist-bundle/index.js"] },
+  "scripts": {
+    "postinstall": "bun build index.ts --target=bun --outdir=dist-bundle"
+  }
+}
+```
+
+The `postinstall` script keeps the bundle fresh across `npm install` /
+`npm update` of `@remnic/plugin-pi`. For extra safety you can make the
+manifest entry a small wrapper that compares the bundle's mtime against
+`node_modules/@remnic/plugin-pi/dist/index.js` and re-runs `bun build`
+before importing the bundle, so a stale bundle can never load silently.
+
+Verify with a throwaway session — there must be no `Failed to load
+extension` line for the remnic path:
+
+```bash
+omp -p --no-session "Reply with just: ok"
+grep "Failed to load extension" ~/.omp/logs/omp.$(date +%F).log
+```
+
+Until the bundle workaround is in place, Path 1 (the raw MCP entry with an
+`Authorization: Bearer` header) still works — only tool-gated access, no
+automatic recall/observe.
+
 ### Install location
 
 The connector writes into the same agent directory omp auto-discovers

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -143,7 +143,12 @@ config_root="$HOME/${PI_CONFIG_DIR:-.omp}"
 if [ -n "$profile" ]; then
   agent_dir="$config_root/profiles/$profile/agent"
 elif [ -n "${PI_CODING_AGENT_DIR:-}" ]; then
-  agent_dir="$PI_CODING_AGENT_DIR"
+  # Expand a leading tilde the way expandTildePath() does.
+  case "$PI_CODING_AGENT_DIR" in
+    "~") agent_dir="$HOME" ;;
+    "~/"*) agent_dir="$HOME/${PI_CODING_AGENT_DIR#\~/}" ;;
+    *) agent_dir="$PI_CODING_AGENT_DIR" ;;
+  esac
 else
   agent_dir="$config_root/agent"
 fi

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -5,6 +5,8 @@ Remnic memory and context for [Pi Coding Agent](https://pi.dev).
 This package is the first-class Remnic extension for Pi. It uses Pi's extension hooks directly, so Remnic can recall context before a model call, observe useful session events after the turn, expose Remnic MCP tools inside Pi, and coordinate Pi compaction with Remnic's long-context memory archive.
 
 > **Oh My Pi (omp).** The [omp](https://omp.sh) fork preserves Pi's extension API, so this package's runtime extension runs there too. Install it with `remnic connectors install omp` (writes to `~/.omp/agent/extensions/remnic/`) via the `OmpMemoryExtensionPublisher`. See [docs/integration/omp.md](../../docs/integration/omp.md).
+>
+> ⚠️ **omp loader bug:** current omp builds (≥ v16.3.5 confirmed) cannot resolve this package's npm dependencies from the extension's `node_modules`, so the installed extension fails to load every session (`Cannot find module '@sinclair/typebox'`). Pre-bundle it with `bun build` as described in [docs/integration/omp.md → Known issue](../../docs/integration/omp.md#known-issue-omp-cannot-resolve-the-extensions-npm-dependencies).
 
 ## What It Does
 


### PR DESCRIPTION
## Summary

- Adds a **Known issue** section to `docs/integration/omp.md` (Path 2): omp's embedded runtime cannot resolve bare npm specifiers from the extension's `node_modules`, so the connector-installed extension silently fails to load every session (`Cannot find module '@sinclair/typebox' from …/@remnic/plugin-pi/dist/index.js`).
- Documents the verified workaround: pre-bundle with `bun build index.ts --target=bun --outdir=dist-bundle`, point `omp.extensions` at the bundle, keep it fresh with a `postinstall` rebuild (and optionally a self-healing mtime-checking wrapper).
- Adds a warning callout to `packages/plugin-pi/README.md` next to the existing omp install note.

## Context

- Confirmed against omp v16.3.5 on macOS arm64 (macstudio) and Debian x64 (omp-a); both hosts had never loaded the extension since the 2026-07-03 install.
- Workaround deployed and verified on both hosts: fresh `omp -p` sessions show no `Failed to load extension` line and hooks run.
- Installer-side fix (publisher writes the bundled layout) tracked in #1598.

## Checklist

- [x] Docs-only change — no code paths touched, no tests affected
- [x] No secrets committed
- [x] Diff ≤ 400 LOC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, installer, or test code changes.
> 
> **Overview**
> Documents an **open omp loader bug** (≥ v16.3.5): the embedded runtime cannot resolve bare npm imports from the connector-installed extension’s `node_modules`, so Path 2 fails every session with `Cannot find module '@sinclair/typebox'`.
> 
> **`docs/integration/omp.md`** adds a **Known issue** section with the root cause, a **pre-bundle workaround** (`bun build`, `omp.extensions` manifest, `postinstall` rebuild, profile-aware shell to locate the extension dir), verification steps, and a note that Path 1 MCP still works until bundling is in place.
> 
> **`packages/plugin-pi/README.md`** adds a warning callout next to the omp install note linking to that section; installer auto-bundle is noted as tracked separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db57ab1bf90cc971d7e50548f5940d49dc901b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->