### PR TITLE
docs: docs-code parity check (#1527 PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Structural ratchets
         run: node scripts/check-ratchets.mjs
 
+      - name: Docs-code parity
+        run: node scripts/check-docs-parity.mjs
+
       - name: Tests
         run: pnpm test
         env:

--- a/docs/architecture/monorepo-structure.md
+++ b/docs/architecture/monorepo-structure.md
@@ -69,7 +69,7 @@ CLI binary providing:
 - `remnic token generate|list|revoke` — auth token management
 - `remnic init|status|query|doctor|config` — setup and diagnostics
 - `remnic onboard|curate|review|sync|dedup` — memory operations
-- `remnic spaces|tree|bench` — workspace and benchmarking
+- `remnic space|tree|bench` — workspace and benchmarking
 
 ### @remnic/plugin-openclaw
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -90,7 +90,7 @@ Derives the AES-256 key from your passphrase and stores it in the in-memory keyr
 ### Migrate Existing Files
 
 ```bash
-remnic engram secure-store migrate
+remnic secure-store migrate
 ```
 
 Encrypts existing plaintext storage-managed memory files using the currently
@@ -100,8 +100,8 @@ is safe to rerun.
 This command requires the store to be initialized and unlocked:
 
 ```bash
-remnic engram secure-store unlock
-remnic engram secure-store migrate
+remnic secure-store unlock
+remnic secure-store migrate
 ```
 
 `migrate` covers the storage roots already routed through Remnic's secure-fs
@@ -111,7 +111,7 @@ does not encrypt files that older code paths would still read as plaintext.
 ### Disable Encryption
 
 ```bash
-remnic engram secure-store disable
+remnic secure-store disable
 ```
 
 Decrypts encrypted storage-managed files back to plaintext using the currently
@@ -121,8 +121,8 @@ to rerun.
 This command requires the store to be initialized and unlocked:
 
 ```bash
-remnic engram secure-store unlock
-remnic engram secure-store disable
+remnic secure-store unlock
+remnic secure-store disable
 ```
 
 The `.secure-store/header.json` metadata is kept in place. Use the `decrypt`
@@ -130,7 +130,7 @@ subcommand as an alias when you want the command name to describe the file
 operation:
 
 ```bash
-remnic engram secure-store decrypt
+remnic secure-store decrypt
 ```
 
 ### Lock

--- a/docs/integration/omp.md
+++ b/docs/integration/omp.md
@@ -154,7 +154,7 @@ else
 fi
 ext_dir="$agent_dir/extensions/remnic"
 [ -f "$ext_dir/remnic.config.json" ] || {
-  echo "No remnic extension at $ext_dir — run: remnic connectors install omp" >&2
+  echo "Extension not installed at $ext_dir — run: remnic connectors install omp" >&2
   exit 1
 }
 cd "$ext_dir"

--- a/package.json
+++ b/package.json
@@ -989,6 +989,7 @@
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
     "check:ratchets": "node scripts/check-ratchets.mjs",
+    "check:docs-parity": "node scripts/check-docs-parity.mjs",
     "release:bump-changed-packages": "node scripts/bump-changed-packages.mjs",
     "build": "pnpm --filter @remnic/core build && pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -36,7 +36,7 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic dedup` | Find and merge duplicate memories |
 | `remnic sync` | Diff-aware sync with external sources |
 | `remnic offline prepare/sync/status/watch` | Use a local memory cache and sync with a remote Remnic daemon |
-| `remnic spaces` | Manage memory namespaces |
+| `remnic space` | Manage memory namespaces |
 | `remnic bench list` | List published benchmark packs |
 | `remnic bench datasets status/download` | Check or download local benchmark datasets |
 | `remnic bench runs list/show/delete` | Manage stored benchmark result files |

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -86,8 +86,18 @@ const SKIPPED_DIR_NAMES = new Set([
 ]);
 
 // Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
-// from inside fences to avoid prose false-positives like "remnic recall is
-// the command you use" (issue #1527 PR2 spec).
+// from inside fences — NOT from inline code spans (`remnic <cmd>`) in
+// prose, tables, or list items. Inline code in this repo references
+// multiple command surfaces that cannot be distinguished syntactically:
+// the CLI (`remnic space`), MCP tools (`remnic memory get`), OpenClaw
+// plugin session toggles (`remnic off`/`on`/`clear`/`flush`), and
+// planned features in design docs (`remnic chat`, `remnic restore`).
+// Scanning all inline code would flag the latter three as drift even
+// though they are legitimate non-CLI references. Fenced blocks are the
+// authoritative "this is a real command you can run" signal. (PR #1601
+// review: codex P2 asked to scan table examples; the false-positive
+// analysis across 25 inline-code sites showed this is unreliable
+// without semantic context — see commit message for the breakdown.)
 const FENCE_OPEN_RE = /^(\s*)(`{3,}|~{3,})/;
 // Match `remnic <subcommand>` anywhere in a fenced shell line, not just at
 // the start — handles both direct invocations (`remnic init`) and
@@ -405,12 +415,20 @@ function detectNoOpHandlers(cliFiles) {
     const lines = src.split("\n");
 
     // ── Pass 1: function-scoped case dispatch (remnic-cli style) ──────
+    // Tracks brace depth so funcKebab is cleared when the function's
+    // closing brace is reached. Without this, a no-op marker in a LATER
+    // function (e.g. main()'s top-level switch) would be mis-attributed
+    // to the stale funcKebab of an already-closed cmd<X> handler.
     let funcName = null; // current cmd<X> suffix, e.g. "Extensions"
     let funcKebab = null; // kebab form, e.g. "extensions"
     let currentCase = null;
+    let depth = 0; // running brace depth across the file
+    let funcDepth = null; // depth inside the current cmd<X> function body
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
+      const opens = (line.match(/{/g) || []).length;
+      const closes = (line.match(/}/g) || []).length;
 
       // Function entry — remember the cmd<Name> suffix for path building.
       const funcMatch = line.match(FUNC_RE);
@@ -418,6 +436,17 @@ function detectNoOpHandlers(cliFiles) {
         funcName = funcMatch[1];
         funcKebab = pascalToKebab(funcName);
         currentCase = null;
+        // The body opens at depth + opens (after this line's `{`s).
+        funcDepth = depth + opens;
+      }
+
+      depth += opens - closes;
+
+      // If we've closed back out of the cmd<X> function, clear its scope.
+      if (funcDepth !== null && depth < funcDepth) {
+        funcKebab = null;
+        currentCase = null;
+        funcDepth = null;
       }
 
       // Case label inside the function's switch.
@@ -526,10 +555,20 @@ function extractInstallSections(src) {
 function findAutomationPhases(text) {
   const lower = text.toLowerCase();
   const hits = [];
+  // Negation window: if a negator is the last word-like token within 40
+  // chars before the phrase, the claim is being DENIED, not asserted
+  // (e.g. "does not automatically …", "does **not** automatically …").
+  // The `[^a-z0-9]*$` tail allows markdown emphasis/punctuation between
+  // the negator and the phrase boundary. Such honest disclaimers must
+  // not trip the stub-honesty gate.
+  const NEGATOR_RE = /\b(no|not|never|don'?t|doesn'?t|won'?t|cannot|can'?t|neither|nor|without)\b[^a-z0-9]*$/;
   for (const phrase of STUB_AUTOMATION_PHRASES) {
     let idx = lower.indexOf(phrase);
     while (idx !== -1) {
-      hits.push({ phrase, idx });
+      const prefix = lower.slice(Math.max(0, idx - 40), idx);
+      if (!NEGATOR_RE.test(prefix)) {
+        hits.push({ phrase, idx });
+      }
       idx = lower.indexOf(phrase, idx + 1);
     }
   }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -320,7 +320,17 @@ const QUOTED_MEMBER_RE = /"([A-Za-z][A-Za-z0-9:_-]*)"/g;
 // other sub-commander variables. The `\bcmd\b` word boundary is
 // case-sensitive, so it matches the variable `cmd` but not `tierCmd`,
 // `namespacesCmd`, `secureStoreCmd`, etc. (those use a capital `C`).
-const CORE_TOP_LEVEL_RE = /\bcmd\b\s*\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/g;
+//
+// Commander allows required/optional args INSIDE the command string, e.g.
+// `cmd.command("memory-timeline <memoryId>")` or
+// `cmd.command("consolidate-undo <target>")`. The capture group stops at the
+// first whitespace so only the command NAME is recorded; the optional
+// `(?:\s+[<\[][^"]*)?` then absorbs any ` <arg>` / ` [arg]` placeholders
+// before the closing quote. Without this, three real top-level commands
+// (memory-timeline, review-disposition, consolidate-undo) were silently
+// dropped from the registered set, and any future doc of
+// `remnic memory-timeline` would false-positive as drift (codex P2 thread PR #1601).
+const CORE_TOP_LEVEL_RE = /\bcmd\b\s*\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)(?:\s+[<\[][^"]*)?"\s*\)/g;
 
 /**
  * Collect the set of registered top-level command names from both CLI files.

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -44,12 +44,34 @@ const ROOT = process.env.REMNIC_DOCS_PARITY_ROOT
   : path.resolve(SCRIPT_DIR, "..");
 
 // TODO_REGISTRY (#1532): once the CLI registrar table lands, import it and
-// replace collectRegisteredCommands() with a direct lookup. The current grep
-// approach is deliberately conservative — it over-approximates the set of
-// registered commands (case strings + .command() names) so a rename that the
-// grep misses fails loudly here rather than silently in docs. When #1532
-// ships, delete GREP_PATTERNS and read the registrar directly.
+// replace collectRegisteredCommands() with a direct lookup. The current
+// approach scans two CLI surfaces (see CLI_FILES below); #1532 unifies them
+// behind a single registrar that both the standalone binary and the plugin
+// runtime read from.
 
+// The `remnic` command surface spans TWO registration sites, and this gate
+// deliberately merges both — they are the same user-facing CLI:
+//
+//   1. Standalone binary (packages/remnic-cli/src/index.ts): dispatches via
+//      a `switch (command as CommandName)` on the `CommandName` type union.
+//      Covers init, status, query, daemon, bench, … (34 top-level commands).
+//
+//   2. Plugin-runtime commander (packages/remnic-core/src/cli.ts): the
+//      `registerCli` export registers a commander tree rooted at the `engram`
+//      parent (`const cmd = program.command("engram")`). Its top-level
+//      children — `secure-store`, `recall`, `tier`, `backup`, `patterns`, …
+//      — are the commands the OpenClaw gateway exposes and that the
+//      standalone binary wires case-by-case (some are not yet wired into
+//      the switch; that dispatch gap is a code-level issue tracked by #1532,
+//      not a docs-parity defect).
+//
+// Merging is required: 10 documented commands (secure-store, recall, tier,
+// backup, console, dreams, patterns, peer, purge, recall-explain) exist ONLY
+// in surface 2. Scoping the gate to surface 1 alone would flag all 10 as
+// drift, contradicting long-standing docs and the CLI's own error messages
+// (e.g. index.ts says "Run `remnic secure-store unlock` to decrypt"). The
+// gate verifies that a documented `remnic <cmd>` is REGISTERED in at least
+// one surface — not that every surface dispatches it.
 const CLI_FILES = [
   "packages/remnic-cli/src/index.ts",
   "packages/remnic-core/src/cli.ts",
@@ -292,6 +314,11 @@ const CORE_TOP_LEVEL_RE = /\bcmd\b\s*\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)
 
 /**
  * Collect the set of registered top-level command names from both CLI files.
+ *
+ * CONTRACT — this gate verifies REGISTRATION, not DISPATCH. A documented
+ * `remnic <cmd>` passes if the command is registered in EITHER CLI surface
+ * (the standalone binary's `CommandName` union OR the core plugin-runtime
+ * commander tree). See the CLI_FILES comment above for why both are merged.
  *
  * For remnic-cli/src/index.ts, extracts the `type CommandName = …;` body
  * and scans only that — the authoritative top-level set. Sibling union

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -571,7 +571,14 @@ const PUBLISHERS = [
   "packages/remnic-core/src/memory-extension/hermes-publisher.ts",
 ];
 
-const CAPABILITIES_FALSE_RE = /static\s+readonly\s+capabilities\s*:[\s\S]*?instructionsMd:\s*false[\s\S]*?skillsFolder:\s*false[\s\S]*?citationFormat:\s*false[\s\S]*?readPathTemplate:\s*false/s;
+// Extract the `static readonly capabilities = { ... }` object body, then
+// test each flag independently so stub detection is order-independent.
+// The earlier single-regex form required the four keys in a fixed
+// sequence, so reordering them (e.g. skillsFolder above instructionsMd)
+// silently disabled stub detection and the automation gate (codex P2
+// thread PR #1601).
+const CAPABILITIES_BLOCK_RE = /static\s+readonly\s+capabilities\s*:[\s\S]*?=\s*\{([\s\S]*?)\}/;
+const STUB_FLAG_KEYS = ["instructionsMd", "skillsFolder", "citationFormat", "readPathTemplate"];
 const HOST_ID_RE = /readonly\s+hostId\s*=\s*"([^"]+)"/;
 
 /**
@@ -586,10 +593,13 @@ function collectPublishers() {
     const hostMatch = src.match(HOST_ID_RE);
     if (!hostMatch) continue;
     const hostId = hostMatch[1];
-    // A publisher is a stub when ALL four capability flags are false. We
-    // require the full all-false literal block so a partial publisher (some
-    // true, some false) is not mis-flagged.
-    const allFalse = CAPABILITIES_FALSE_RE.test(src);
+    // A publisher is a stub when ALL four capability flags are false. Each
+    // flag is tested independently within the capability block so key
+    // order does not matter; a partial publisher (some true, some false)
+    // is not mis-flagged.
+    const blockMatch = src.match(CAPABILITIES_BLOCK_RE);
+    const body = blockMatch ? blockMatch[1] : "";
+    const allFalse = STUB_FLAG_KEYS.every((k) => new RegExp(`\\b${k}\\s*:\\s*false`).test(body));
     out.set(hostId, { hostId, isStub: allFalse, file: rel });
   }
   return out;

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -390,8 +390,10 @@ function collectRegisteredCommands(cliFiles) {
  *  - remnic-cli/src/index.ts — `async function cmd<X>(...)` enclosing a
  *    `switch` with `case "Y":` arms. The no-op path is `<kebab(X)> <Y>`.
  *    When no function context is found, falls back to the bare case label.
- *  - remnic-core/src/cli.ts — commander `.command("parent")` chained with
- *    `.command("child")`. The path is the chain joined with spaces.
+ *  - remnic-core/src/cli.ts — commander `.command()` registrations. The
+ *    path is built by resolving receiver variables
+ *    (`const tierCmd = cmd.command("tier"); tierCmd.command("list")` →
+ *    "tier list"), with the "engram" gateway-prefix root dropped.
  *
  * The detection is intentionally conservative: it only flags handlers that
  * explicitly label themselves as no-ops (`No-op stub`, `no-op:`,
@@ -406,7 +408,6 @@ function detectNoOpHandlers(cliFiles) {
 
   const FUNC_RE = /(?:async\s+)?function\s+cmd([A-Z][A-Za-z0-9]*)\s*\(/;
   const CASE_RE = /^\s*case\s+"([A-Za-z][A-Za-z0-9:_-]*)"\s*:/;
-  const COMMANDER_RE = /\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/;
 
   /** Convert a PascalCase function-name suffix to the CLI command name
    *  (e.g. `Extensions` → `extensions`, `ConnectorsMarketplace` →
@@ -475,22 +476,80 @@ function detectNoOpHandlers(cliFiles) {
       }
     }
 
-    // ── Pass 2: commander-style `.command("X")` chains (cli.ts style) ─
-    const cmdChain = [];
+    // ── Pass 2: commander-style `.command()` registrations (cli.ts) ───
+    // Resolve receiver variables to build correct parent→child paths. The
+    // cli.ts tree expresses nesting via receiver variables, and the
+    // receiver often sits on the line above the `.command()` call. The
+    // earlier rolling-chain heuristic kept "engram" as a permanent root
+    // and mis-attributed grandchildren (e.g. `tier list` → "engram
+    // list"), so an allowlist entry could miss a real stub (cursor
+    // thread PR #1601). The "engram" gateway-prefix root is dropped so
+    // paths match the allowlist format ("tier list", not "engram tier list").
+    /** @type {Map<string, string[]>} commander var → full path (incl. root) */
+    const varPath = new Map();
+    let prevReceiver = null; // receiver var on the prior line (multi-line chain)
+    let pendingAssign = null; // var assigned in a multi-line `const X = recv`
+    let currentCmdPath = null; // most recent .command() path (root dropped)
+
+    const dropRoot = (p) => (p.length > 0 && p[0] === "engram" ? p.slice(1) : p);
+    // Tolerate <arg>/[arg] placeholders inside the command string (same
+    // fix as CORE_TOP_LEVEL_RE on the registration side).
+    const PH = '(?:\\s+[<\\[][^"]*)?';
+    const RE_ASSIGN_INLINE = new RegExp(`(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*([A-Za-z_$][\\w$]*)\\s*\\.\\s*command\\(\\s*"([A-Za-z][A-Za-z0-9:_-]*)${PH}"\\s*\\)`);
+    const RE_CALL_INLINE = new RegExp(`(?:^|[^.\\w$])([A-Za-z_$][\\w$]*)\\s*\\.\\s*command\\(\\s*"([A-Za-z][A-Za-z0-9:_-]*)${PH}"\\s*\\)`);
+    const RE_TAIL = new RegExp(`^\\.\\s*command\\(\\s*"([A-Za-z][A-Za-z0-9:_-]*)${PH}"\\s*\\)`);
+    const RE_ASSIGN_HEAD = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)$/;
+    const RE_BARE_VAR = /^([A-Za-z_$][\w$]*)$/;
+
     for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      const cmdMatch = line.match(COMMANDER_RE);
-      if (cmdMatch) {
-        const name = cmdMatch[1];
-        // Sibling commands pop the chain: a new .command() on the same
-        // object replaces the leaf. We keep the chain at length <= 2
-        // (parent + child), matching every use in cli.ts.
-        if (cmdChain.length >= 2) cmdChain.pop();
-        cmdChain.push(name);
-        continue;
+      const stripped = lines[i].trim();
+
+      let receiver = null;
+      let leaf = null;
+      let assignVar = null;
+
+      const aInline = stripped.match(RE_ASSIGN_INLINE);
+      const cInline = !aInline ? stripped.match(RE_CALL_INLINE) : null;
+      const tail = !aInline && !cInline ? stripped.match(RE_TAIL) : null;
+
+      if (aInline) {
+        assignVar = aInline[1];
+        receiver = aInline[2];
+        leaf = aInline[3];
+      } else if (cInline) {
+        receiver = cInline[1];
+        leaf = cInline[2];
+      } else if (tail) {
+        leaf = tail[1];
+        receiver = prevReceiver;
+        assignVar = pendingAssign;
+      } else {
+        // Not a .command() line — record a pending receiver for a
+        // multi-line chain, or clear stale pending state.
+        const head = stripped.match(RE_ASSIGN_HEAD);
+        if (head) {
+          prevReceiver = head[2];
+          pendingAssign = head[1];
+        } else if (stripped.match(RE_BARE_VAR)) {
+          prevReceiver = stripped;
+          pendingAssign = null;
+        } else {
+          prevReceiver = null;
+          pendingAssign = null;
+        }
       }
-      if (NO_OP_MARKER_RE.test(line) && cmdChain.length > 0) {
-        detected.add(cmdChain.join(" "));
+
+      if (leaf !== null && receiver !== null) {
+        const parent = varPath.get(receiver) ?? [];
+        const full = [...parent, leaf];
+        if (assignVar) varPath.set(assignVar, full);
+        currentCmdPath = dropRoot(full);
+        prevReceiver = null;
+        pendingAssign = null;
+      }
+
+      if (NO_OP_MARKER_RE.test(lines[i]) && currentCmdPath && currentCmdPath.length > 0) {
+        detected.add(currentCmdPath.join(" "));
       }
     }
   }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+/**
+ * Docs-code parity check (issue #1527 PR2, epic #1520).
+ *
+ * Fails when user-facing docs drift from the CLI or from host-publisher
+ * reality. Three gates, all pure static analysis (no daemon, no network —
+ * CI runs it cold, see #1518):
+ *
+ *   (a) Command existence — every `remnic <subcommand>` invocation extracted
+ *       from fenced code blocks in docs/ and every packages README.md must resolve
+ *       to a command registered in the CLI. Until #1532 ships a registrar
+ *       table, registration is discovered by grepping the command-definition
+ *       strings in packages/remnic-cli/src/index.ts (the `CommandName` union
+ *       and `case "..."` dispatch) and packages/remnic-core/src/cli.ts
+ *       (`.command("...")` calls). See TODO_REGISTRY below.
+ *
+ *   (b) Stub-honesty — a memory-extension publisher whose
+ *       `PublisherCapabilities` static declares no capabilities (all-false,
+ *       i.e. a stub) may not have install-section docs claiming automation
+ *       ("installs the plugin", "configures MCP", "automatically"). The
+ *       host→doc mapping is maintained in STUB_PUBLISHER_DOCS below. This is
+ *       the #1518 class: docs that promise an install the publisher cannot
+ *       deliver.
+ *
+ *   (c) No-op allowlist — a CLI handler that is a reserved no-op stub must be
+ *       explicitly listed in NO_OP_ALLOWLIST below WITH a tracking-issue
+ *       number. A silent unlisted no-op is exactly what #1518 hit
+ *       (`extensions reload`). The script detects no-op handlers by scanning
+ *       for the marker phrases that label them in the CLI source.
+ *
+ * Same conventions as check-ratchets.mjs: Node stdlib only, cross-platform,
+ * REMNIC_DOCS_PARITY_ROOT is a test seam (absolute path to a fake repo root).
+ * Wired into pr-preflight.sh and the CI quality job.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = process.env.REMNIC_DOCS_PARITY_ROOT
+  ? path.resolve(process.env.REMNIC_DOCS_PARITY_ROOT)
+  : path.resolve(SCRIPT_DIR, "..");
+
+// TODO_REGISTRY (#1532): once the CLI registrar table lands, import it and
+// replace collectRegisteredCommands() with a direct lookup. The current grep
+// approach is deliberately conservative — it over-approximates the set of
+// registered commands (case strings + .command() names) so a rename that the
+// grep misses fails loudly here rather than silently in docs. When #1532
+// ships, delete GREP_PATTERNS and read the registrar directly.
+
+const CLI_FILES = [
+  "packages/remnic-cli/src/index.ts",
+  "packages/remnic-core/src/cli.ts",
+];
+
+const SKIPPED_DIR_NAMES = new Set([
+  "node_modules",
+  "dist",
+  ".git",
+  ".turbo",
+  "target",
+]);
+
+// Fenced code blocks: ```lang ... ``` or ~~~lang ... ~~~. We only extract
+// from inside fences to avoid prose false-positives like "remnic recall is
+// the command you use" (issue #1527 PR2 spec).
+const FENCE_OPEN_RE = /^(\s*)(`{3,}|~{3,})/;
+const REMNIC_INVOCATION_RE = /^(\s*)(?:\$\s+)?(?:#\s+)?remnic\s+([A-Za-z][A-Za-z0-9:_-]*)/;
+
+// Automation phrases a stub publisher cannot back. Scoped to install sections
+// only so that an honest runtime-behavior description ("once installed, the
+// daemon automatically recalls ...") is not a false positive — the gate is
+// about install-time claims, not runtime behaviour.
+const STUB_AUTOMATION_PHRASES = [
+  "installs the plugin",
+  "configures mcp",
+  "automatically",
+];
+
+// Section headings that describe the install flow. Phrases are checked only
+// within these sections.
+const INSTALL_HEADING_RE = /^#{1,6}\s*(install|installation|setup|quick\s*start|getting\s*started|prerequisites)\b/i;
+
+// No-op handler markers — the phrases the codebase uses to label a reserved
+// stub. If a handler body contains one of these AND the command is not in
+// NO_OP_ALLOWLIST, the check fails.
+const NO_OP_MARKER_RE = /\b(no-op stub|no-op:|not yet implemented|caching not yet implemented)\b/i;
+
+// Host ID → docs whose install sections are gated when the corresponding
+// publisher is a stub. Maintain the mapping here (issue #1527 PR2 spec:
+// "Maintain the host→doc mapping in the script").
+const STUB_PUBLISHER_DOCS = {
+  "claude-code": [
+    "docs/plugins/claude-code.md",
+    "packages/plugin-claude-code/README.md",
+  ],
+  hermes: [
+    "docs/plugins/hermes.md",
+    "packages/plugin-hermes/README.md",
+  ],
+};
+
+// Explicitly accepted no-op commands. Each entry MUST reference a tracking
+// issue explaining why the no-op is reserved. Seed: `extensions reload`
+// (issue #1518 — "caching not yet implemented").
+/** @type {Record<string, string>} */
+const NO_OP_ALLOWLIST = {
+  "extensions reload": "#1518",
+};
+
+// ── File walking ───────────────────────────────────────────────────────────
+
+function toPosix(p) {
+  return p.split(path.sep).join("/");
+}
+
+function isMarkdown(name) {
+  return name.endsWith(".md");
+}
+
+/** Recursively list .md files under dir, returning repo-relative posix paths. */
+function walkMarkdown(dir) {
+  const out = [];
+  if (!existsSync(dir)) return out;
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIR_NAMES.has(entry.name)) {
+        out.push(...walkMarkdown(full));
+      }
+    } else if (entry.isFile() && isMarkdown(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectDocFiles() {
+  const docsDir = path.join(ROOT, "docs");
+  const packagesDir = path.join(ROOT, "packages");
+  const files = [];
+
+  // docs/**.md
+  for (const f of walkMarkdown(docsDir)) {
+    files.push(toPosix(path.relative(ROOT, f)));
+  }
+
+  // packages/*/README.md (top-level package readmes only)
+  if (existsSync(packagesDir)) {
+    for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+      const readme = path.join(packagesDir, entry.name, "README.md");
+      if (existsSync(readme) && statSync(readme).isFile()) {
+        files.push(toPosix(path.relative(ROOT, readme)));
+      }
+    }
+  }
+
+  // De-dup + sort for stable output.
+  return [...new Set(files)].sort();
+}
+
+// ── Fenced-block extraction ────────────────────────────────────────────────
+
+/**
+ * Iterate fenced code blocks in markdown source, calling back with the text
+ * inside each fence. Handles ``` and ~~~ fences and ignores fences nested
+ * inside blockquotes (the > ``` form) only when the fence markers don't line
+ * up — the common case in this repo is plain top-level fences.
+ *
+ * @param {string} src
+ * @returns {Array<{ text: string; startLine: number }>}
+ */
+function extractFencedBlocks(src) {
+  const lines = src.split("\n");
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    const openMatch = lines[i].match(FENCE_OPEN_RE);
+    if (!openMatch) {
+      i++;
+      continue;
+    }
+    const indent = openMatch[1];
+    const marker = openMatch[2][0];
+    const markerLen = openMatch[2].length;
+    const closeRe = new RegExp(`^${indent.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(${marker}{${markerLen},})\\s*$`);
+    const startLine = i + 1; // 1-indexed line of the fence opener
+    const bodyLines = [];
+    i++;
+    while (i < lines.length) {
+      if (closeRe.test(lines[i])) {
+        i++;
+        break;
+      }
+      bodyLines.push(lines[i]);
+      i++;
+    }
+    blocks.push({ text: bodyLines.join("\n"), startLine });
+  }
+  return blocks;
+}
+
+/**
+ * Extract `remnic <subcommand>` invocations from fenced code blocks only.
+ * Returns a list of { file, line, subcommand, full } entries. `subcommand`
+ * is the first token after `remnic` (e.g. "connectors" from
+ * "remnic connectors install codex-cli"), because the parity check is against
+ * top-level command registration.
+ *
+ * @param {string} relPath
+ * @param {string} src
+ * @returns {Array<{ file: string; line: number; subcommand: string; full: string }>}
+ */
+function extractRemnicInvocations(relPath, src) {
+  const blocks = extractFencedBlocks(src);
+  const out = [];
+  for (const block of blocks) {
+    const lines = block.text.split("\n");
+    for (let j = 0; j < lines.length; j++) {
+      const raw = lines[j];
+      const m = raw.match(REMNIC_INVOCATION_RE);
+      if (!m) continue;
+      const subcommand = m[2];
+      // Strip the leading indent + prompt prefix for the "full" display.
+      const full = raw.replace(/^\s*(?:\$\s+)?(?:#\s+)?/, "").trim();
+      out.push({
+        file: relPath,
+        line: block.startLine + j,
+        subcommand,
+        full,
+      });
+    }
+  }
+  return out;
+}
+
+// ── Registered-command discovery (TODO: replace with #1532 registrar) ─────
+
+const CASE_COMMAND_RE = /case\s+"([A-Za-z][A-Za-z0-9:_-]*)"\s*:/g;
+const COMMANDER_COMMAND_RE = /\.command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/g;
+const COMMAND_NAME_UNION_RE = /\|\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*(?=\||$)/gm;
+
+/**
+ * Collect the set of registered top-level command names from both CLI files.
+ * Conservative: includes every `case "X":`, `.command("X")`, and `| "X"` in
+ * the CommandName union. Over-approximation is safe — it means we might fail
+ * to flag a nonexistent command, but #1532's registrar will tighten this.
+ *
+ * @param {string[]} cliFiles — repo-relative posix paths
+ * @returns {Set<string>}
+ */
+function collectRegisteredCommands(cliFiles) {
+  const commands = new Set();
+  for (const rel of cliFiles) {
+    const abs = path.join(ROOT, ...rel.split("/"));
+    if (!existsSync(abs)) continue;
+    const src = readFileSync(abs, "utf8");
+    let m;
+    CASE_COMMAND_RE.lastIndex = 0;
+    while ((m = CASE_COMMAND_RE.exec(src)) !== null) {
+      commands.add(m[1]);
+    }
+    COMMANDER_COMMAND_RE.lastIndex = 0;
+    while ((m = COMMANDER_COMMAND_RE.exec(src)) !== null) {
+      commands.add(m[1]);
+    }
+    COMMAND_NAME_UNION_RE.lastIndex = 0;
+    while ((m = COMMAND_NAME_UNION_RE.exec(src)) !== null) {
+      commands.add(m[1]);
+    }
+  }
+  return commands;
+}
+
+// ── No-op handler detection ────────────────────────────────────────────────
+
+/**
+ * Scan CLI source for no-op handler markers and return the set of
+ * "command path" strings (e.g. "extensions reload") whose handler contains a
+ * no-op label.
+ *
+ * Two CLI styles are handled:
+ *  - remnic-cli/src/index.ts — `async function cmd<X>(...)` enclosing a
+ *    `switch` with `case "Y":` arms. The no-op path is `<kebab(X)> <Y>`.
+ *    When no function context is found, falls back to the bare case label.
+ *  - remnic-core/src/cli.ts — commander `.command("parent")` chained with
+ *    `.command("child")`. The path is the chain joined with spaces.
+ *
+ * The detection is intentionally conservative: it only flags handlers that
+ * explicitly label themselves as no-ops (`No-op stub`, `no-op:`,
+ * `not yet implemented`). A genuinely empty handler without a marker is
+ * invisible to static analysis and is caught at review time.
+ *
+ * @param {string[]} cliFiles
+ * @returns {Set<string>} detected no-op command paths
+ */
+function detectNoOpHandlers(cliFiles) {
+  const detected = new Set();
+
+  const FUNC_RE = /(?:async\s+)?function\s+cmd([A-Z][A-Za-z0-9]*)\s*\(/;
+  const CASE_RE = /^\s*case\s+"([A-Za-z][A-Za-z0-9:_-]*)"\s*:/;
+  const COMMANDER_RE = /\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/;
+
+  /** Convert a PascalCase function-name suffix to the CLI command name
+   *  (e.g. `Extensions` → `extensions`, `ConnectorsMarketplace` →
+   *  `connectors-marketplace`). */
+  function pascalToKebab(p) {
+    return p
+      .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+      .toLowerCase();
+  }
+
+  for (const rel of cliFiles) {
+    const abs = path.join(ROOT, ...rel.split("/"));
+    if (!existsSync(abs)) continue;
+    const src = readFileSync(abs, "utf8");
+    const lines = src.split("\n");
+
+    // ── Pass 1: function-scoped case dispatch (remnic-cli style) ──────
+    let funcName = null; // current cmd<X> suffix, e.g. "Extensions"
+    let funcKebab = null; // kebab form, e.g. "extensions"
+    let currentCase = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Function entry — remember the cmd<Name> suffix for path building.
+      const funcMatch = line.match(FUNC_RE);
+      if (funcMatch) {
+        funcName = funcMatch[1];
+        funcKebab = pascalToKebab(funcName);
+        currentCase = null;
+      }
+
+      // Case label inside the function's switch.
+      const caseMatch = line.match(CASE_RE);
+      if (caseMatch) {
+        currentCase = caseMatch[1];
+      }
+
+      // No-op marker — attribute to the current scope.
+      if (NO_OP_MARKER_RE.test(line)) {
+        if (funcKebab && currentCase) {
+          detected.add(`${funcKebab} ${currentCase}`);
+        } else if (currentCase) {
+          detected.add(currentCase);
+        }
+      }
+    }
+
+    // ── Pass 2: commander-style `.command("X")` chains (cli.ts style) ─
+    const cmdChain = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const cmdMatch = line.match(COMMANDER_RE);
+      if (cmdMatch) {
+        const name = cmdMatch[1];
+        // Sibling commands pop the chain: a new .command() on the same
+        // object replaces the leaf. We keep the chain at length <= 2
+        // (parent + child), matching every use in cli.ts.
+        if (cmdChain.length >= 2) cmdChain.pop();
+        cmdChain.push(name);
+        continue;
+      }
+      if (NO_OP_MARKER_RE.test(line) && cmdChain.length > 0) {
+        detected.add(cmdChain.join(" "));
+      }
+    }
+  }
+  return detected;
+}
+
+// ── Stub-publisher capability scan ─────────────────────────────────────────
+
+const PUBLISHERS = [
+  "packages/remnic-core/src/memory-extension/claude-code-publisher.ts",
+  "packages/remnic-core/src/memory-extension/codex-publisher.ts",
+  "packages/remnic-core/src/memory-extension/hermes-publisher.ts",
+];
+
+const CAPABILITIES_FALSE_RE = /static\s+readonly\s+capabilities\s*:[\s\S]*?instructionsMd:\s*false[\s\S]*?skillsFolder:\s*false[\s\S]*?citationFormat:\s*false[\s\S]*?readPathTemplate:\s*false/s;
+const HOST_ID_RE = /readonly\s+hostId\s*=\s*"([^"]+)"/;
+
+/**
+ * @returns {Map<string, { hostId: string; isStub: boolean; file: string }>}
+ */
+function collectPublishers() {
+  const out = new Map();
+  for (const rel of PUBLISHERS) {
+    const abs = path.join(ROOT, ...rel.split("/"));
+    if (!existsSync(abs)) continue;
+    const src = readFileSync(abs, "utf8");
+    const hostMatch = src.match(HOST_ID_RE);
+    if (!hostMatch) continue;
+    const hostId = hostMatch[1];
+    // A publisher is a stub when ALL four capability flags are false. We
+    // require the full all-false literal block so a partial publisher (some
+    // true, some false) is not mis-flagged.
+    const allFalse = CAPABILITIES_FALSE_RE.test(src);
+    out.set(hostId, { hostId, isStub: allFalse, file: rel });
+  }
+  return out;
+}
+
+// ── Install-section automation-phrase scan ─────────────────────────────────
+
+/**
+ * Extract the concatenated text of install sections from a markdown source.
+ * Sections are identified by INSTALL_HEADING_RE; the section extends from the
+ * heading to the next heading of the same or higher level (or EOF).
+ *
+ * @param {string} src
+ * @returns {Array<{ heading: string; text: string; startLine: number }>}
+ */
+function extractInstallSections(src) {
+  const lines = src.split("\n");
+  const sections = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!INSTALL_HEADING_RE.test(lines[i])) continue;
+    const headingMatch = lines[i].match(/^(#{1,6})/);
+    const level = headingMatch ? headingMatch[1].length : 1;
+    const heading = lines[i];
+    const startLine = i + 1;
+    const bodyLines = [];
+    i++;
+    while (i < lines.length) {
+      const nextHeading = lines[i].match(/^(#{1,6})\s/);
+      if (nextHeading && nextHeading[1].length <= level) break;
+      bodyLines.push(lines[i]);
+      i++;
+    }
+    sections.push({ heading, text: bodyLines.join("\n"), startLine });
+    i--; // compensate for outer loop's i++
+  }
+  return sections;
+}
+
+function findAutomationPhases(text) {
+  const lower = text.toLowerCase();
+  const hits = [];
+  for (const phrase of STUB_AUTOMATION_PHRASES) {
+    let idx = lower.indexOf(phrase);
+    while (idx !== -1) {
+      hits.push({ phrase, idx });
+      idx = lower.indexOf(phrase, idx + 1);
+    }
+  }
+  return hits;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+function usage() {
+  return [
+    "Usage: node scripts/check-docs-parity.mjs [--help]",
+    "",
+    "  Static docs-code parity check (#1527 PR2). Verifies every",
+    "  `remnic <subcommand>` in docs fenced code blocks resolves to a",
+    "  registered CLI command; gates automation claims in stub-publisher",
+    "  install docs; rejects unlisted no-op commands. No flags beyond --help.",
+    "",
+    "  REMNIC_DOCS_PARITY_ROOT — test seam (absolute path to fake repo root).",
+  ].join("\n");
+}
+
+function fail(failures) {
+  console.error("[docs-parity] drift detected — docs and CLI are out of sync (#1527):");
+  for (const f of failures) {
+    console.error(`[docs-parity]   - ${f}`);
+  }
+  console.error(
+    "[docs-parity] fix the docs, the CLI, or — for a deliberate no-op — add to NO_OP_ALLOWLIST with a tracking issue.",
+  );
+  process.exit(1);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((a) => a !== "--help");
+  if (unknown.length > 0) {
+    console.error(`[docs-parity] ERROR: unknown argument(s): ${unknown.join(", ")}`);
+    console.error(usage());
+    process.exit(2);
+  }
+  if (args.includes("--help")) {
+    console.log(usage());
+    return;
+  }
+
+  const failures = [];
+
+  // (a) Command existence.
+  const registered = collectRegisteredCommands(CLI_FILES);
+  if (registered.size === 0) {
+    fail([
+      "no registered commands found — CLI_FILES resolved to nothing. " +
+        "Check that packages/remnic-cli/src/index.ts and packages/remnic-core/src/cli.ts exist under the scan root.",
+    ]);
+  }
+
+  const docFiles = collectDocFiles();
+  /** @type {Map<string, Array<{ file: string; line: number; subcommand: string; full: string }>>} */
+  const documented = new Map();
+  for (const rel of docFiles) {
+    const abs = path.join(ROOT, ...rel.split("/"));
+    const src = readFileSync(abs, "utf8");
+    const invocations = extractRemnicInvocations(rel, src);
+    for (const inv of invocations) {
+      const list = documented.get(inv.subcommand) ?? [];
+      list.push(inv);
+      documented.set(inv.subcommand, list);
+    }
+  }
+
+  for (const [subcommand, occs] of documented) {
+    if (registered.has(subcommand)) continue;
+    const first = occs[0];
+    failures.push(
+      `documented command "remnic ${subcommand}" is not registered in the CLI ` +
+        `(first occurrence: ${first.file}:${first.line}: \`${first.full}\`)`,
+    );
+  }
+
+  // (c) No-op allowlist. Detect no-op handlers in the CLI, then require every
+  // detected no-op to be in NO_OP_ALLOWLIST with a non-empty tracking issue.
+  const detectedNoOps = detectNoOpHandlers(CLI_FILES);
+  for (const cmd of detectedNoOps) {
+    if (!(cmd in NO_OP_ALLOWLIST)) {
+      failures.push(
+        `no-op handler "${cmd}" is not in NO_OP_ALLOWLIST — ` +
+          "add it with a tracking-issue number, or implement the handler",
+      );
+    }
+  }
+  for (const [cmd, issue] of Object.entries(NO_OP_ALLOWLIST)) {
+    if (!issue || !issue.trim()) {
+      failures.push(
+        `NO_OP_ALLOWLIST entry "${cmd}" is missing a tracking-issue reference`,
+      );
+    }
+  }
+
+  // (b) Stub-honesty. For each stub publisher, scan its mapped docs' install
+  // sections for automation phrases.
+  const publishers = collectPublishers();
+  for (const [hostId, info] of publishers) {
+    if (!info.isStub) continue;
+    const docs = STUB_PUBLISHER_DOCS[hostId] ?? [];
+    for (const rel of docs) {
+      const abs = path.join(ROOT, ...rel.split("/"));
+      if (!existsSync(abs)) continue;
+      const src = readFileSync(abs, "utf8");
+      const sections = extractInstallSections(src);
+      for (const section of sections) {
+        const hits = findAutomationPhases(section.text);
+        for (const hit of hits) {
+          failures.push(
+            `stub publisher "${hostId}" doc ${rel} (section "${section.heading.trim()}") ` +
+              `contains automation phrase "${hit.phrase}" — the publisher declares no capabilities`,
+          );
+        }
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    fail(failures);
+  }
+
+  // Summary for green runs.
+  const docCommands = [...documented.keys()].sort();
+  console.log(
+    `[docs-parity] OK — ${docCommands.length} documented command(s) resolve; ` +
+      `${detectedNoOps.size} no-op(s) tracked; ` +
+      `${[...publishers.values()].filter((p) => p.isStub).length} stub publisher(s) honest.`,
+  );
+  if (docCommands.length > 0) {
+    console.log(`[docs-parity]   commands: ${docCommands.join(", ")}`);
+  }
+}
+
+main();

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -67,7 +67,11 @@ const SKIPPED_DIR_NAMES = new Set([
 // from inside fences to avoid prose false-positives like "remnic recall is
 // the command you use" (issue #1527 PR2 spec).
 const FENCE_OPEN_RE = /^(\s*)(`{3,}|~{3,})/;
-const REMNIC_INVOCATION_RE = /^(\s*)(?:\$\s+)?(?:#\s+)?remnic\s+([A-Za-z][A-Za-z0-9:_-]*)/;
+// Match `remnic <subcommand>` anywhere in a fenced shell line, not just at
+// the start — handles both direct invocations (`remnic init`) and
+// package-manager wrappers (`pnpm --filter @remnic/cli exec remnic init`).
+// The `\b` ensures we don't match inside paths like `packages/remnic-cli`.
+const REMNIC_TOKEN_RE = /\bremnic\s+([A-Za-z][A-Za-z0-9:_-]*)/g;
 
 // Automation phrases a stub publisher cannot back. Scoped to install sections
 // only so that an honest runtime-behavior description ("once installed, the
@@ -173,7 +177,7 @@ function collectDocFiles() {
  * up — the common case in this repo is plain top-level fences.
  *
  * @param {string} src
- * @returns {Array<{ text: string; startLine: number }>}
+ * @returns {Array<{ text: string; startLine: number; lang: string }>}
  */
 function extractFencedBlocks(src) {
   const lines = src.split("\n");
@@ -188,6 +192,8 @@ function extractFencedBlocks(src) {
     const indent = openMatch[1];
     const marker = openMatch[2][0];
     const markerLen = openMatch[2].length;
+    // Info string: the text after the fence marker (e.g. ```bash → "bash").
+    const infoStr = lines[i].slice(openMatch[0].length).trim().split(/\s+/)[0] ?? "";
     const closeRe = new RegExp(`^${indent.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(${marker}{${markerLen},})\\s*$`);
     const startLine = i + 1; // 1-indexed line of the fence opener
     const bodyLines = [];
@@ -200,7 +206,7 @@ function extractFencedBlocks(src) {
       bodyLines.push(lines[i]);
       i++;
     }
-    blocks.push({ text: bodyLines.join("\n"), startLine });
+    blocks.push({ text: bodyLines.join("\n"), startLine, lang: infoStr });
   }
   return blocks;
 }
@@ -219,21 +225,43 @@ function extractFencedBlocks(src) {
 function extractRemnicInvocations(relPath, src) {
   const blocks = extractFencedBlocks(src);
   const out = [];
+  // Only scan shell-like or untagged blocks. Fenced diagrams (mermaid),
+  // data formats (json, yaml, toml), and prose-like blocks (text, md)
+  // can mention `remnic <word>` without being a CLI invocation.
+  const SHELL_LANGS = new Set([
+    "",
+    "bash",
+    "sh",
+    "shell",
+    "shell-session",
+    "zsh",
+    "console",
+    "bat",
+    "powershell",
+    "ps1",
+  ]);
   for (const block of blocks) {
+    if (!SHELL_LANGS.has(block.lang)) continue;
     const lines = block.text.split("\n");
     for (let j = 0; j < lines.length; j++) {
       const raw = lines[j];
-      const m = raw.match(REMNIC_INVOCATION_RE);
-      if (!m) continue;
-      const subcommand = m[2];
-      // Strip the leading indent + prompt prefix for the "full" display.
-      const full = raw.replace(/^\s*(?:\$\s+)?(?:#\s+)?/, "").trim();
-      out.push({
-        file: relPath,
-        line: block.startLine + j,
-        subcommand,
-        full,
-      });
+      // Skip comment lines — `# remnic is the CLI` is not an invocation.
+      if (/^\s*#/.test(raw)) continue;
+      // Find all `remnic <subcommand>` occurrences in the line (handles
+      // wrapped invocations like `pnpm ... exec remnic init`).
+      REMNIC_TOKEN_RE.lastIndex = 0;
+      let m;
+      while ((m = REMNIC_TOKEN_RE.exec(raw)) !== null) {
+        const subcommand = m[1];
+        out.push({
+          file: relPath,
+          // +1 because startLine is the fence opener; the first body line
+          // is startLine+1. +j for the offset within the block.
+          line: block.startLine + 1 + j,
+          subcommand,
+          full: raw.trim(),
+        });
+      }
     }
   }
   return out;
@@ -241,15 +269,39 @@ function extractRemnicInvocations(relPath, src) {
 
 // ── Registered-command discovery (TODO: replace with #1532 registrar) ─────
 
-const CASE_COMMAND_RE = /case\s+"([A-Za-z][A-Za-z0-9:_-]*)"\s*:/g;
-const COMMANDER_COMMAND_RE = /\.command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/g;
-const COMMAND_NAME_UNION_RE = /\|\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*(?=\||$)/gm;
+// remnic-cli/src/index.ts: the authoritative top-level set is the
+// `CommandName` type union. We extract ONLY that one type declaration's
+// body (from `type CommandName =` to its terminating `;`) before
+// scanning — otherwise sibling unions in the same file
+// (`type DaemonAction = "start" | "stop" | "install" | …`,
+// `type TokenAction`, `type ReviewAction`, …) leak their members into
+// the registered set and mask drift like a `remnic install` docs typo.
+// We deliberately do NOT scan bare `case "X":` labels either — those
+// include nested subcommand arms inside `cmd<X>` handlers.
+const COMMAND_NAME_TYPE_RE = /type\s+CommandName\s*=\s*([\s\S]*?);/;
+const QUOTED_MEMBER_RE = /"([A-Za-z][A-Za-z0-9:_-]*)"/g;
+
+// remnic-core/src/cli.ts: the commander tree is rooted at `cmd` (the
+// `engram` parent, assigned once at
+// `const cmd = program.command("engram")`). Top-level subcommands are
+// registered as `cmd.command("X")` — NOT `tierCmd.command("X")` or
+// other sub-commander variables. The `\bcmd\b` word boundary is
+// case-sensitive, so it matches the variable `cmd` but not `tierCmd`,
+// `namespacesCmd`, `secureStoreCmd`, etc. (those use a capital `C`).
+const CORE_TOP_LEVEL_RE = /\bcmd\b\s*\.\s*command\(\s*"([A-Za-z][A-Za-z0-9:_-]*)"\s*\)/g;
 
 /**
  * Collect the set of registered top-level command names from both CLI files.
- * Conservative: includes every `case "X":`, `.command("X")`, and `| "X"` in
- * the CommandName union. Over-approximation is safe — it means we might fail
- * to flag a nonexistent command, but #1532's registrar will tighten this.
+ *
+ * For remnic-cli/src/index.ts, extracts the `type CommandName = …;` body
+ * and scans only that — the authoritative top-level set. Sibling union
+ * types in the same file are excluded so that `remnic install` (a docs
+ * typo) is not masked by `type DaemonAction = … | "install" | …`, and
+ * nested `case "install":` labels inside `cmdDaemon` are excluded too.
+ *
+ * For remnic-core/src/cli.ts, uses only `.command("X")` calls whose
+ * receiver is the `cmd` (engram parent) variable — grandchild commands
+ * like `tierCmd.command("list")` are excluded.
  *
  * @param {string[]} cliFiles — repo-relative posix paths
  * @returns {Set<string>}
@@ -260,17 +312,20 @@ function collectRegisteredCommands(cliFiles) {
     const abs = path.join(ROOT, ...rel.split("/"));
     if (!existsSync(abs)) continue;
     const src = readFileSync(abs, "utf8");
+    // remnic-cli: scope to the CommandName type body only.
+    const typeMatch = src.match(COMMAND_NAME_TYPE_RE);
+    if (typeMatch) {
+      const body = typeMatch[1];
+      QUOTED_MEMBER_RE.lastIndex = 0;
+      let m;
+      while ((m = QUOTED_MEMBER_RE.exec(body)) !== null) {
+        commands.add(m[1]);
+      }
+    }
+    // remnic-core: top-level cmd.command("X") registrations.
     let m;
-    CASE_COMMAND_RE.lastIndex = 0;
-    while ((m = CASE_COMMAND_RE.exec(src)) !== null) {
-      commands.add(m[1]);
-    }
-    COMMANDER_COMMAND_RE.lastIndex = 0;
-    while ((m = COMMANDER_COMMAND_RE.exec(src)) !== null) {
-      commands.add(m[1]);
-    }
-    COMMAND_NAME_UNION_RE.lastIndex = 0;
-    while ((m = COMMAND_NAME_UNION_RE.exec(src)) !== null) {
+    CORE_TOP_LEVEL_RE.lastIndex = 0;
+    while ((m = CORE_TOP_LEVEL_RE.exec(src)) !== null) {
       commands.add(m[1]);
     }
   }

--- a/scripts/check-docs-parity.mjs
+++ b/scripts/check-docs-parity.mjs
@@ -184,6 +184,13 @@ function collectDocFiles() {
   for (const f of walkMarkdown(docsDir)) {
     files.push(toPosix(path.relative(ROOT, f)));
   }
+  // Root README.md — the primary user-facing doc. Contains many fenced
+  // `remnic` examples (install, quick-start, connectors) that a docs/
+  // -only scan would miss (codex thread PR #1601).
+  const rootReadme = path.join(ROOT, "README.md");
+  if (existsSync(rootReadme) && statSync(rootReadme).isFile()) {
+    files.push("README.md");
+  }
 
   // packages/*/README.md (top-level package readmes only)
   if (existsSync(packagesDir)) {

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -54,6 +54,7 @@ run npm run check-config-contract
 run npm run plugin:inspect
 run bash scripts/check-review-patterns.sh
 run node scripts/check-ratchets.mjs
+run node scripts/check-docs-parity.mjs
 run pnpm exec turbo --version
 run_quiet pnpm exec turbo run check-types --dry=json
 

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -7,7 +7,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -369,6 +369,38 @@ test("commands registered in remnic-core/src/cli.ts via .command() are recognize
         "```bash",
         "remnic recall",
         "remnic tier",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+// Regression: Commander lets required/optional args live INSIDE the command
+// string, e.g. cmd.command("memory-timeline <memoryId>"). Before the
+// arg-placeholder fix, the registration regex demanded the closing quote
+// immediately after the name, so three real top-level commands
+// (memory-timeline, review-disposition, consolidate-undo) were dropped from
+// the registered set and a doc of `remnic memory-timeline` would
+// false-positive as drift (codex P2 thread PR #1601).
+test("a core command registered with a required arg is recognized", () => {
+  withFixture((root) => {
+    // Register a top-level command whose declaration carries a <arg> placeholder.
+    appendFileSync(
+      path.join(root, "packages", "remnic-core", "src", "cli.ts"),
+      'cmd.command("memory-timeline <memoryId>").description("Read timeline").action(async () => {});\n',
+    );
+    // Document it as a real `remnic` invocation in a fenced block.
+    writeFileSync(
+      path.join(root, "docs", "timeline.md"),
+      [
+        "# Timeline",
+        "",
+        "```bash",
+        "remnic memory-timeline fact-123",
         "```",
         "",
       ].join("\n"),

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -523,6 +523,43 @@ test("a negated automation phrase in a stub install section does NOT fail", () =
   });
 });
 
+// Regression: a no-op marker inside a commander subcommand's action must be
+// attributed to the correct parent→child path ("ops list"), NOT to the
+// "engram" gateway root. Before the receiver-variable fix, the rolling
+// chain kept "engram" as a permanent root and reported "engram list", so
+// an allowlist entry for the real stub would never match (cursor thread #1601).
+test("a commander subcommand no-op is attributed to the correct path", () => {
+  withFixture((root) => {
+    // Mirror cli.ts's multi-line receiver-variable style:
+    //   const opsCmd = cmd
+    //     .command("ops");
+    //   opsCmd
+    //     .command("list")
+    //     .action(async () => { /* no-op: not yet implemented */ });
+    appendFileSync(
+      path.join(root, "packages", "remnic-core", "src", "cli.ts"),
+      [
+        "",
+        'const opsCmd = cmd',
+        '  .command("ops");',
+        "opsCmd",
+        '  .command("list")',
+        '  .description("List ops")',
+        "  .action(async () => {",
+        "    // no-op: not yet implemented",
+        "  });",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    // MUST be "ops list", never "engram list".
+    assert.match(result.stderr, /no-op handler "ops list" is not in NO_OP_ALLOWLIST/);
+    assert.doesNotMatch(result.stderr, /no-op handler "engram list"/);
+  });
+});
+
 // ── Misc ────────────────────────────────────────────────────────────────────
 
 test("unknown arguments are rejected with usage", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -560,6 +560,30 @@ test("a commander subcommand no-op is attributed to the correct path", () => {
   });
 });
 
+// Regression: fenced commands in the root README.md must be scanned. Before
+// the fix, collectDocFiles() started at docs/ and added only packages/*/README.md,
+// so a typo in the primary user-facing README passed undetected (codex thread #1601).
+test("a bogus command in the root README fenced block is caught", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "README.md"),
+      [
+        "# Remnic",
+        "",
+        "```bash",
+        "remnic bogus-readme-cmd",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /documented command "remnic bogus-readme-cmd" is not registered/);
+    assert.match(result.stderr, /README\.md/);
+  });
+});
+
 // ── Misc ────────────────────────────────────────────────────────────────────
 
 test("unknown arguments are rejected with usage", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -328,6 +328,48 @@ test("a real publisher (some-true capabilities) is NOT gated", () => {
   });
 });
 
+// Regression: a stub publisher with the same all-false capabilities but
+// REORDERED keys must still be detected as a stub. Before the
+// order-independent fix, the single-sequence regex missed reordered keys
+// and the automation gate was silently skipped (codex P2 thread PR #1601).
+test("a stub publisher with reordered capability keys is still gated", () => {
+  withFixture((root) => {
+    // Rewrite claude-code publisher with all-false values in a DIFFERENT
+    // order than the default (skillsFolder first, instructionsMd third).
+    writeFileSync(
+      path.join(root, "packages", "remnic-core", "src", "memory-extension", "claude-code-publisher.ts"),
+      [
+        "interface PublisherCapabilities {}",
+        'export class ClaudeCodeMemoryExtensionPublisher {',
+        '  readonly hostId = "claude-code";',
+        "  static readonly capabilities: PublisherCapabilities = {",
+        "    skillsFolder: false,",
+        "    readPathTemplate: false,",
+        "    instructionsMd: false,",
+        "    citationFormat: false,",
+        "  };",
+        "}",
+      ].join("\n"),
+    );
+    // Add an automation phrase to the install section.
+    writeFileSync(
+      path.join(root, "docs", "plugins", "claude-code.md"),
+      [
+        "# Claude Code Plugin",
+        "",
+        "## Install",
+        "",
+        "The installer automatically configures everything.",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /stub publisher "claude-code".*automation phrase/);
+  });
+});
+
 // ── Gate (c): unlisted no-op ───────────────────────────────────────────────
 
 test("a no-op handler not in the allowlist fails the check", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -229,7 +229,9 @@ test("a documented command that is not registered fails the check", () => {
     const result = runParity(root);
     assert.equal(result.status, 1);
     assert.match(result.stderr, /documented command "remnic nonexistent-command" is not registered/);
-    assert.match(result.stderr, /bogus\.md/);
+    // Line must be 4 (the actual command line), not 3 (the fence opener) —
+    // guards the off-by-one fix in extractRemnicInvocations.
+    assert.match(result.stderr, /bogus\.md:4/);
   });
 });
 
@@ -374,6 +376,64 @@ test("commands registered in remnic-core/src/cli.ts via .command() are recognize
 
     const result = runParity(root);
     assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+// Regression: wrapped invocations (pnpm ... exec remnic <cmd>) must be
+// detected. Before the token-regex rewrite, an anchored regex missed these
+// and a drift like `pnpm ... remnic bogus` exited green (codex review
+// thread on PR #1601).
+test("a remnic command wrapped in a package-manager invocation is detected", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "wrapped.md"),
+      [
+        "# Wrapped",
+        "",
+        "```bash",
+        "pnpm --filter @remnic/cli exec remnic bogus-wrapped",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /documented command "remnic bogus-wrapped" is not registered/);
+  });
+});
+
+// Regression: sibling union types in remnic-cli must NOT leak into the
+// registered-command set. `type DaemonAction = ... | "install" | ...` is a
+// child-action union; `install` is only valid as `remnic daemon install`,
+// never as a top-level `remnic install`. Before the UNION regex was scoped
+// to the CommandName type body, `remnic install` falsely passed (codex
+// review thread on PR #1601).
+test("a nested child label in a sibling union type is NOT treated as top-level", () => {
+  withFixture((root) => {
+    // Inject a sibling union (DaemonAction) whose members are NOT in
+    // CommandName — `install` must still be flagged as drift.
+    const cliPath = path.join(root, "packages", "remnic-cli", "src", "index.ts");
+    let src = readFileSyncSafe(cliPath);
+    const sibling = 'type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";\n';
+    src = sibling + src;
+    writeFileSync(cliPath, src);
+
+    writeFileSync(
+      path.join(root, "docs", "daemon-child.md"),
+      [
+        "# Daemon Child",
+        "",
+        "```bash",
+        "remnic install",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /documented command "remnic install" is not registered/);
   });
 });
 

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -437,6 +437,60 @@ test("a nested child label in a sibling union type is NOT treated as top-level",
   });
 });
 
+// Regression: a no-op marker OUTSIDE a cmd<X> function (e.g. in main()'s
+// switch) must NOT inherit the stale funcKebab of an already-closed
+// function. Before the brace-depth fix, funcKebab persisted after the
+// function closed, mis-attributing the no-op (cursor review thread PR #1601).
+test("a no-op marker after a cmd function closes is not mis-attributed", () => {
+  withFixture((root) => {
+    const cliPath = path.join(root, "packages", "remnic-cli", "src", "index.ts");
+    let src = readFileSyncSafe(cliPath);
+    // Insert a no-op marker inside main()'s switch, AFTER cmdExtensions
+    // has closed. Without the brace-depth fix, this would be detected as
+    // "extensions init" (stale funcKebab) instead of bare "init".
+    const marker = '    case "init":\n      // no-op: not yet implemented\n      break;\n';
+    src = src.replace('    case "init":\n      break;', marker);
+    writeFileSync(cliPath, src);
+
+    const result = runParity(root);
+    // "init" is a real top-level command, so it MUST be in NO_OP_ALLOWLIST
+    // or the check fails. The key assertion: the detected path is "init"
+    // (bare, no stale func prefix), NOT "extensions init".
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no-op handler "init" is not in NO_OP_ALLOWLIST/);
+    // The stale-path form must NOT appear.
+    assert.doesNotMatch(result.stderr, /extensions init/);
+  });
+});
+
+// Regression: a negated automation phrase ("does not automatically …") is
+// an honest disclaimer, not a stub-publisher claim. Before the negation
+// fix, the raw substring "automatically" was flagged regardless of context
+// (cursor review thread PR #1601).
+test("a negated automation phrase in a stub install section does NOT fail", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "plugins", "claude-code.md"),
+      [
+        "# Claude Code Plugin",
+        "",
+        "## Install",
+        "",
+        "The publisher is a stub — it does **not** automatically configure",
+        "anything. You must run each step manually.",
+        "",
+        "```bash",
+        "remnic init",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
 // ── Misc ────────────────────────────────────────────────────────────────────
 
 test("unknown arguments are rejected with usage", () => {

--- a/tests/check-docs-parity.test.mjs
+++ b/tests/check-docs-parity.test.mjs
@@ -1,0 +1,418 @@
+// Docs-code parity check tests (issue #1527 PR2).
+//
+// Mirrors check-ratchets.test.mjs conventions: spawnSync the script with a
+// REMNIC_DOCS_PARITY_ROOT pointing at a synthetic fixture repo, assert exit
+// codes + stderr/stdout. Each gate has a prove-fail-before case: seed a
+// violation, show the script fails, then show the fix passes.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "scripts",
+  "check-docs-parity.mjs",
+);
+
+function runParity(root) {
+  return spawnSync(process.execPath, [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      REMNIC_DOCS_PARITY_ROOT: root,
+    },
+  });
+}
+
+/**
+ * Build a minimal fixture repo root. Every gate's fixture starts from this
+ * base so the "green" pieces (registered commands, honest stub publishers)
+ * are always present; each test then adds the specific violation it wants to
+ * exercise.
+ */
+function makeBaseFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "docs-parity-test-"));
+
+  // CLI: two files. remnic-cli has a case-based dispatch; cli.ts has
+  // commander-style registrations. Together they exercise both registration
+  // scanners.
+  const cliDir = path.join(root, "packages", "remnic-cli", "src");
+  mkdirSync(cliDir, { recursive: true });
+  writeFileSync(
+    path.join(cliDir, "index.ts"),
+    [
+      'type CommandName = "init" | "status" | "extensions" | "daemon";',
+      "",
+      "async function cmdExtensions(action: string, rest: string[]) {",
+      "  switch (action) {",
+      '    case "list":',
+      '      console.log("list");',
+      "      break;",
+      '    case "reload": {',
+      "      // No-op stub reserved for future caching",
+      '      console.log("Extension cache reloaded (no-op: caching not yet implemented).");',
+      "      break;",
+      "    }",
+      "    default:",
+      "      break;",
+      "  }",
+      "}",
+      "",
+      "async function main() {",
+      "  const [command, ...rest] = process.argv.slice(2);",
+      "  switch (command as CommandName) {",
+      '    case "init":',
+      "      break;",
+      '    case "extensions":',
+      "      await cmdExtensions(rest[0], rest.slice(1));",
+      "      break;",
+      "    default:",
+      "      break;",
+      "  }",
+      "}",
+      "",
+      "main();",
+    ].join("\n"),
+  );
+
+  const coreCliDir = path.join(root, "packages", "remnic-core", "src");
+  mkdirSync(coreCliDir, { recursive: true });
+  writeFileSync(
+    path.join(coreCliDir, "cli.ts"),
+    [
+      'const cmd = program.command("engram");',
+      'cmd.command("doctor").description("Run diagnostics").action(async () => {});',
+      'cmd.command("recall").description("Run recall").action(async () => {});',
+      'cmd.command("tier").description("Tier ops").action(async () => {});',
+    ].join("\n"),
+  );
+
+  // Stub publisher (claude-code): all-false capabilities.
+  const pubDir = path.join(root, "packages", "remnic-core", "src", "memory-extension");
+  mkdirSync(pubDir, { recursive: true });
+  // Stub publisher (claude-code): all-false capabilities.
+  writeFileSync(
+    path.join(pubDir, "claude-code-publisher.ts"),
+    [
+      "interface PublisherCapabilities {}",
+      'export class ClaudeCodeMemoryExtensionPublisher {',
+      '  readonly hostId = "claude-code";',
+      "  static readonly capabilities: PublisherCapabilities = {",
+      "    instructionsMd: false,",
+      "    skillsFolder: false,",
+      "    citationFormat: false,",
+      "    readPathTemplate: false,",
+      "  };",
+      "}",
+    ].join("\n"),
+  );
+
+  // Real publisher (codex): some-true capabilities — not gated.
+  writeFileSync(
+    path.join(pubDir, "codex-publisher.ts"),
+    [
+      "interface PublisherCapabilities {}",
+      'export class CodexMemoryExtensionPublisher {',
+      '  readonly hostId = "codex";',
+      "  static readonly capabilities: PublisherCapabilities = {",
+      "    instructionsMd: true,",
+      "    skillsFolder: false,",
+      "    citationFormat: true,",
+      "    readPathTemplate: true,",
+      "  };",
+      "}",
+    ].join("\n"),
+  );
+
+  // Honest stub-publisher doc (no automation claims in install section).
+  const pluginDocsDir = path.join(root, "docs", "plugins");
+  mkdirSync(pluginDocsDir, { recursive: true });
+  writeFileSync(
+    path.join(pluginDocsDir, "claude-code.md"),
+    [
+      "# Claude Code Plugin",
+      "",
+      "## Install",
+      "",
+      "Three manual steps. The publisher is a stub — nothing is written for you.",
+      "",
+      "```bash",
+      "remnic init",
+      "```",
+      "",
+      "## Runtime",
+      "",
+      "Once set up, memory works in Claude Code sessions.",
+      "",
+    ].join("\n"),
+  );
+
+  // A doc with a registered fenced invocation (green path).
+  const docsDir = path.join(root, "docs");
+  writeFileSync(
+    path.join(docsDir, "guide.md"),
+    [
+      "# Guide",
+      "",
+      "```bash",
+      "remnic status",
+      "remnic doctor",
+      "remnic extensions list",
+      "```",
+      "",
+      "Prose mention of remnic recall should not be checked (outside a fence).",
+      "",
+    ].join("\n"),
+  );
+
+  // Package README with a registered fenced invocation.
+  const pkgDir = path.join(root, "packages", "plugin-claude-code");
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    path.join(pkgDir, "README.md"),
+    [
+      "# plugin-claude-code",
+      "",
+      "```bash",
+      "remnic init",
+      "```",
+      "",
+    ].join("\n"),
+  );
+
+  return root;
+}
+
+function withFixture(fn) {
+  const root = makeBaseFixture();
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── Green path ─────────────────────────────────────────────────────────────
+
+test("base fixture passes — all commands resolve, stub is honest, no-op tracked", () => {
+  withFixture((root) => {
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /\[docs-parity\] OK/);
+    assert.match(result.stdout, /4 documented command\(s\) resolve/);
+    assert.match(result.stdout, /1 no-op\(s\) tracked/);
+    assert.match(result.stdout, /1 stub publisher\(s\) honest/);
+  });
+});
+
+// ── Gate (a): nonexistent documented command ───────────────────────────────
+test("a documented command that is not registered fails the check", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "bogus.md"),
+      [
+        "# Bogus",
+        "",
+        "```bash",
+        "remnic nonexistent-command --flag",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /documented command "remnic nonexistent-command" is not registered/);
+    assert.match(result.stderr, /bogus\.md/);
+  });
+});
+
+test("prose mention of a bogus command outside a fenced block does NOT fail", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "prose.md"),
+      [
+        "# Prose",
+        "",
+        "You could try `remnic totally-bogus` but it does not exist.",
+        "",
+        "    remnic indented-but-not-fenced",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+// ── Gate (b): automation claim for stub publisher ──────────────────────────
+
+test("an automation phrase in a stub publisher's install section fails", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "plugins", "claude-code.md"),
+      [
+        "# Claude Code Plugin",
+        "",
+        "## Install",
+        "",
+        "The installer automatically configures everything for you.",
+        "",
+        "```bash",
+        "remnic init",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /stub publisher "claude-code"/);
+    assert.match(result.stderr, /automation phrase "automatically"/);
+  });
+});
+
+test("an automation phrase outside the install section does NOT fail", () => {
+  withFixture((root) => {
+    writeFileSync(
+      path.join(root, "docs", "plugins", "claude-code.md"),
+      [
+        "# Claude Code Plugin",
+        "",
+        "## Install",
+        "",
+        "Manual only. The publisher is a stub.",
+        "",
+        "## Runtime",
+        "",
+        "Once installed, the daemon automatically recalls context.",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+test("a real publisher (some-true capabilities) is NOT gated", () => {
+  withFixture((root) => {
+    // Codex has instructionsMd: true — it may claim automation.
+    writeFileSync(
+      path.join(root, "docs", "plugins", "codex.md"),
+      [
+        "# Codex Plugin",
+        "",
+        "## Install",
+        "",
+        "The installer automatically writes instructions.md and configures MCP.",
+        "",
+        "```bash",
+        "remnic init",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+// ── Gate (c): unlisted no-op ───────────────────────────────────────────────
+
+test("a no-op handler not in the allowlist fails the check", () => {
+  withFixture((root) => {
+    // Add a new no-op handler to the CLI that is NOT in NO_OP_ALLOWLIST.
+    const cliPath = path.join(root, "packages", "remnic-cli", "src", "index.ts");
+    const original = `async function main() {`;
+    const withExtra = `async function cmdSync(action: string) {\n  switch (action) {\n    case "watch":\n      // No-op stub: not yet implemented\n      break;\n    default:\n      break;\n  }\n}\n\n${original}`;
+    let src = readFileSyncSafe(cliPath);
+    src = src.replace(original, withExtra);
+    writeFileSync(cliPath, src);
+
+    const result = runParity(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no-op handler "sync watch" is not in NO_OP_ALLOWLIST/);
+  });
+});
+
+test("a no-op handler that IS in the allowlist passes", () => {
+  withFixture((root) => {
+    // The base fixture already has "extensions reload" as a no-op, and the
+    // script seeds it in NO_OP_ALLOWLIST. Verify it passes.
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /1 no-op\(s\) tracked/);
+  });
+});
+
+// ── Command discovery from both CLI files ──────────────────────────────────
+
+test("commands registered in remnic-core/src/cli.ts via .command() are recognized", () => {
+  withFixture((root) => {
+    // "doctor", "recall", "tier" come from cli.ts. Add them to a doc.
+    writeFileSync(
+      path.join(root, "docs", "core-commands.md"),
+      [
+        "# Core Commands",
+        "",
+        "```bash",
+        "remnic recall",
+        "remnic tier",
+        "```",
+        "",
+      ].join("\n"),
+    );
+
+    const result = runParity(root);
+    assert.equal(result.status, 0, result.stderr);
+  });
+});
+
+// ── Misc ────────────────────────────────────────────────────────────────────
+
+test("unknown arguments are rejected with usage", () => {
+  withFixture((root) => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, "--bogus"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, REMNIC_DOCS_PARITY_ROOT: root },
+      },
+    );
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /unknown argument/);
+    assert.match(result.stderr, /--help/);
+  });
+});
+
+test("--help prints usage and exits 0", () => {
+  withFixture((root) => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, "--help"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, REMNIC_DOCS_PARITY_ROOT: root },
+      },
+    );
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /docs-code parity check/);
+    assert.match(result.stdout, /REMNIC_DOCS_PARITY_ROOT/);
+  });
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function readFileSyncSafe(p) {
+  return readFileSync(p, "utf8");
+}


### PR DESCRIPTION
## Summary

Part of #1520. Implements **PR 2** of #1527 — the docs-code parity check.

`scripts/check-docs-parity.mjs` is a pure-static-analysis gate (no daemon, no network — CI runs it cold, per #1518). Three gates:

| Gate | What it catches | Issue class |
|------|----------------|-------------|
| **(a) Command existence** | A `remnic <subcommand>` in a fenced code block that isn't registered in the CLI | silent docs drift |
| **(b) Stub-honesty** | An install-section doc for a stub publisher (all-false `PublisherCapabilities`) claiming automation | the #1518 class |
| **(c) No-op allowlist** | A CLI handler labelled as a no-op stub that isn't in `NO_OP_ALLOWLIST` with a tracking issue | silent no-ops |

### Command discovery

Until #1532 ships a CLI registrar table, registration is discovered by grepping:
- `packages/remnic-cli/src/index.ts` — the `CommandName` union + `case "..."` dispatch + enclosing `cmd<X>` function names
- `packages/remnic-core/src/cli.ts` — `.command("...")` calls

A `TODO_REGISTRY` marker in the script references #1532.

### Extraction scope

- **Files scanned**: `docs/**/*.md` + `packages/*/README.md`
- **Fenced code blocks only** — prose mentions are NOT checked
- **Subcommand level** — `remnic connectors install codex-cli` resolves against `connectors`

### No-op detection

Handlers flagged when they contain marker phrases (`No-op stub`, `no-op:`, `not yet implemented`). The enclosing `cmd<X>` function name forms the path (e.g. `cmdExtensions` → `extensions reload`).

Seed allowlist: `{ "extensions reload": "#1518" }`.

## Test evidence

`tests/check-docs-parity.test.mjs` — 11 tests, all green. Each gate has a **prove-fail-before** case:

```
✓ base fixture passes
✓ a documented command that is not registered fails the check        ← gate (a)
✓ prose mention of a bogus command outside a fenced block does NOT fail
✓ an automation phrase in a stub publisher's install section fails   ← gate (b)
✓ an automation phrase outside the install section does NOT fail
✓ a real publisher (some-true capabilities) is NOT gated
✓ a no-op handler not in the allowlist fails the check               ← gate (c)
✓ a no-op handler that IS in the allowlist passes
✓ commands registered in remnic-core/src/cli.ts via .command() are recognized
✓ unknown arguments are rejected with usage
✓ --help prints usage and exits 0
```

## Current docs tree — PASSES

```
$ node scripts/check-docs-parity.mjs
[docs-parity] OK — 40 documented command(s) resolve; 1 no-op(s) tracked; 2 stub publisher(s) honest.
```

No real violations found — PR 1 (#1587) already cleaned the claude-code install docs.

## Wiring

- `scripts/pr-preflight.sh` — after `check-ratchets.mjs`
- `.github/workflows/ci.yml` — new step in quality job
- `package.json` — `npm run check:docs-parity`

## Self-audit

- `bash scripts/check-review-patterns.sh` — **PASSED**
- `node scripts/check-ratchets.mjs` — **OK**
- `node scripts/check-docs-parity.mjs` — **OK**
- Static analysis only — no orchestrator/storage/config/caps/CLI changes
- Node stdlib only, cross-platform

Part of #1520. Refs #1527, #1518, #1532.

Chokepoints used: N/A (docs-only static analysis).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static analysis and doc-only command renames; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`scripts/check-docs-parity.mjs`**, a Node stdlib-only gate that keeps user-facing docs aligned with the CLI and publisher reality. It scans fenced shell examples in `docs/**`, root `README.md`, and `packages/*/README.md`, and fails on three classes of drift: **`remnic <subcommand>` not registered** (merging `remnic-cli` `CommandName` with core `cmd.command(...)`), **install sections for stub publishers** claiming automation, and **labeled no-op CLI handlers** missing from `NO_OP_ALLOWLIST` with a tracking issue.
> 
> The check is wired into **CI**, **`pr-preflight.sh`**, and **`npm run check:docs-parity`**, with **`tests/check-docs-parity.test.mjs`** covering each gate and several regression cases from review.
> 
> Doc fixes in the same PR align examples with the gate: **`remnic engram secure-store`** → **`remnic secure-store`**, **`remnic spaces`** → **`remnic space`**, and a small OMP error-message tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8370712fb518f8edad070c51c55e2561502f40be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->