### PR TITLE
refactor(scopes): ScopePlan resolver + recall tier migration (#1521)

### DIFF
--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5771,7 +5771,8 @@ export class Orchestrator {
       options.principalOverride.length > 0
         ? options.principalOverride
         : resolvePrincipal(sessionKey, this.config);
-    if (this.config.namespacesEnabled && !principal) {
+    const namespacesEnabled = this.config.namespacesEnabled;
+    if (namespacesEnabled && !principal) {
       throw new Error("authentication required: namespaces are enabled and no principal was supplied");
     }
 
@@ -5863,6 +5864,7 @@ export class Orchestrator {
             options.namespace?.trim() || undefined,
             options.principalOverride,
             caps,
+            namespacesEnabled,
           );
         } catch (err) {
           log.debug(`direct-answer observation setup failed: ${err}`);
@@ -5932,6 +5934,7 @@ export class Orchestrator {
     namespaceOverride: string | undefined,
     principalOverride: string | undefined,
     caps: CapabilitySet,
+    namespacesEnabled: boolean,
   ): void {
     const expectedSnapshot = this.lastRecall.get(sessionKey);
     if (expectedSnapshot === null) return;
@@ -5949,6 +5952,7 @@ export class Orchestrator {
       codingContext: sessionKey
         ? this.getCodingContextForSession(sessionKey)
         : null,
+      namespacesEnabled,
     });
     const observationNamespaces = observationScopePlan.readNamespaces;
     const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
@@ -7551,7 +7555,8 @@ export class Orchestrator {
         && options.principalOverride.length > 0
         ? options.principalOverride
         : resolvePrincipal(sessionKey, this.config);
-    if (this.config.namespacesEnabled && !principal) {
+    const namespacesEnabled = this.config.namespacesEnabled;
+    if (namespacesEnabled && !principal) {
       throw new Error("authentication required: namespaces are enabled and no principal was supplied");
     }
     const namespaceOverride = options.namespace?.trim() || undefined;
@@ -7584,6 +7589,7 @@ export class Orchestrator {
       codingContext: sessionKey
         ? this.getCodingContextForSession(sessionKey)
         : null,
+      namespacesEnabled,
     });
     const {
       readNamespaces: recallNamespaces,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -325,6 +325,7 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
+import { resolveScopePlan } from "./scopes/scope-plan.js";
 import {
   expandScopeProfileReadNamespaces,
   resolveScopeProfilePlan,
@@ -5936,57 +5937,20 @@ export class Orchestrator {
     if (expectedSnapshot === null) return;
     if (expectedSnapshot.plannerMode === "no_recall") return;
 
-    const principal = principalOverride ?? resolvePrincipal(sessionKey, this.config);
-    // Coding-agent overlay (issue #569) is applied when the session has a
-    // coding context and there is no explicit namespaceOverride — mirrors
-    // the main recall path above.
-    const observationCodingOverlay =
-      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
-        ? null
-        : this.applyCodingRecallOverlay(sessionKey);
-    const observationPrincipalSelf = defaultNamespaceForPrincipal(principal, this.config);
-    const observationCodingSelf = observationCodingOverlay
-      ? combineNamespaces(observationPrincipalSelf, observationCodingOverlay.namespace)
-      : null;
-    const observationScopeProfilePlan =
-      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
-        ? null
-        : resolveScopeProfilePlan({
-            config: this.config,
-            principal,
-            codingContext: sessionKey
-              ? this.getCodingContextForSession(sessionKey)
-              : null,
-            codingOverlay: observationCodingOverlay,
-          });
-    let observationNamespaces: string[];
-    if (namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)) {
-      observationNamespaces = [namespaceOverride];
-    } else if (observationScopeProfilePlan) {
-      observationNamespaces = expandScopeProfileReadNamespaces({
-        profilePlan: observationScopeProfilePlan,
-        principalSelfNamespace: observationScopeProfilePlan.baseNamespace,
-        config: this.config,
-        principal,
-        codingOverlay: observationCodingOverlay,
-        legacyRecallNamespaces: recallNamespacesForPrincipal(principal, this.config),
-      });
-    } else if (observationCodingOverlay && observationCodingSelf) {
-      // Rule 42 / parity with the main recall path: substitute the self
-      // namespace within the principal's recall list rather than
-      // replacing the full list. Preserves shared and policy-include
-      // namespaces for direct-answer observation queries.
-      const base = recallNamespacesForPrincipal(principal, this.config);
-      const mapped = base.map((ns) =>
-        ns === observationPrincipalSelf ? observationCodingSelf : ns,
-      );
-      const fallbackNs = observationCodingOverlay.readFallbacks.map((fallback) =>
-        combineNamespaces(observationPrincipalSelf, fallback),
-      );
-      observationNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
-    } else {
-      observationNamespaces = recallNamespacesForPrincipal(principal, this.config);
-    }
+    // Resolve the observation namespace set through the SAME ScopePlan resolver
+    // the main recall path uses (#1521). The observe path does NOT throw on an
+    // unreadable override (it falls through to the coding/legacy branches), so
+    // we skip the readability gate the recall path enforces.
+    const observationScopePlan = resolveScopePlan({
+      config: this.config,
+      sessionKey,
+      namespace: namespaceOverride,
+      principalOverride,
+      codingContext: sessionKey
+        ? this.getCodingContextForSession(sessionKey)
+        : null,
+    });
+    const observationNamespaces = observationScopePlan.readNamespaces;
     const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
       cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
       cronRecallNormalizedQueryMaxChars:
@@ -7591,10 +7555,6 @@ export class Orchestrator {
       throw new Error("authentication required: namespaces are enabled and no principal was supplied");
     }
     const namespaceOverride = options.namespace?.trim() || undefined;
-    const readableRecallNamespaces = recallNamespacesForPrincipal(
-      principal,
-      this.config,
-    );
     if (
       namespaceOverride &&
       !canReadNamespace(principal, namespaceOverride, this.config)
@@ -7603,147 +7563,34 @@ export class Orchestrator {
         `namespace override is not readable: ${namespaceOverride}`,
       );
     }
-    // Recall path — overlay the coding-agent namespace (issue #569) when
-    // the session has a codingContext and `codingMode.projectScope` is true.
-    // Explicit `namespace` option still wins, preserving pre-#569 semantics.
+    // Resolve every namespace-bearing field through ONE ScopePlan (#1521): the
+    // read set, the LCM read keys, the coding overlay, and the scope-profile plan
+    // all come from a single pure resolver that delegates to the same helpers
+    // the inline code used. Parity snapshots in scope-plan.test.ts pin the
+    // outputs so this migration cannot change behavior.
     //
-    // Rule 42: the overlay substitutes the SELF namespace within the
-    // principal's recall list — it does NOT replace the full list. Shared
-    // and `includeInRecallByDefault` policy namespaces stay in the recall
-    // set so coding sessions continue to see team/shared memories. The
-    // overlay is combined with the principal base through `combineNamespaces`
-    // to preserve principal isolation (cross-tenant leakage guard).
-    const codingOverlay = namespaceOverride ? null : this.applyCodingRecallOverlay(sessionKey);
-    const principalSelfNamespace = defaultNamespaceForPrincipal(principal, this.config);
-    const codingSelfNamespace = codingOverlay
-      ? combineNamespaces(principalSelfNamespace, codingOverlay.namespace)
-      : null;
-    const scopeProfilePlan = namespaceOverride
-      ? null
-      : resolveScopeProfilePlan({
-          config: this.config,
-          principal,
-          codingContext: sessionKey
-            ? this.getCodingContextForSession(sessionKey)
-            : null,
-          codingOverlay,
-        });
-    const profileEffectiveNamespace = scopeProfilePlan?.writeNamespace || scopeProfilePlan?.readNamespaces[0];
-    const selfNamespace =
-      namespaceOverride ??
-      profileEffectiveNamespace ??
-      codingSelfNamespace ??
-      principalSelfNamespace;
-    let recallNamespaces: string[];
-    if (namespaceOverride) {
-      recallNamespaces = [namespaceOverride];
-    } else if (scopeProfilePlan) {
-      recallNamespaces = expandScopeProfileReadNamespaces({
-        profilePlan: scopeProfilePlan,
-        principalSelfNamespace: scopeProfilePlan.baseNamespace,
-        config: this.config,
-        principal,
-        codingOverlay,
-        legacyRecallNamespaces: readableRecallNamespaces,
-      });
-    } else if (codingOverlay && codingSelfNamespace) {
-      // Substitute the principal's self namespace with the coding-scoped
-      // one, and append any read fallbacks (branch→project, PR 3) combined
-      // with the principal base so principal isolation is preserved on
-      // fallback entries as well.
-      const mapped = readableRecallNamespaces.map((ns) =>
-        ns === principalSelfNamespace ? codingSelfNamespace : ns,
-      );
-      const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
-        combineNamespaces(principalSelfNamespace, fallback),
-      );
-      recallNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
-    } else {
-      recallNamespaces = readableRecallNamespaces;
-    }
-    // Catalog touch (issue #1499): record reads against the recalled namespaces
-    // so the catalog reflects active read scopes. Best-effort, failure-tolerant.
-    // Round 3 (codex P2): gate behind the no_recall guard — when the planner
-    // selects `no_recall` retrieval is skipped entirely (see the early return at
-    // `recallMode === "no_recall"` below), so marking every readable namespace as
-    // read would falsely inflate `lastReadAt` / catalog recency.
-    // Round 4 (codex P2): also skip when the effective memory result limit is
-    // zero (`topK: 0`, a disabled/zero `memories` recall section, etc.). The QMD
-    // path explicitly returns before searching when `recallResultLimit <= 0`, so
-    // no namespace is actually read and the touch would be spurious.
-    // NOTE: the catalog read touch is recorded LATER, immediately after the
-    // Phase 1 `throwIfRecallAborted` gate (round 6, codex P2 / cursor Medium —
-    // NDXHa/NDmle), so it fires only once retrieval is actually about to run.
-    // Recording it here (recall entry) would set `lastReadAt` for recalls that
-    // are aborted, error out, or short-circuit before any QMD/filesystem read.
-
-    // Effective LCM read NAMESPACE SET (#1505 thread "Include coding fallback
-    // namespaces in LCM reads"). `observe` archives LCM / structured history
-    // under `${effectiveNamespace}:${sessionKey}` for whichever namespace was
-    // effective at write time. A branch-scoped session whose evidence was
-    // archived at project / root scope must still surface it, exactly as normal
-    // QMD/file recall does — QMD/file recall searches the primary overlay key AND
-    // `codingOverlay.readFallbacks` (project / root), NOT just the primary
-    // overlay key. The prior single `lcmReadSessionId` only targeted the primary
-    // overlay, so branch-scoped sessions missed fallback LCM evidence.
-    //
-    // READ-AUTHORIZATION (preserved from the prior round's
-    // `lcmReadNamespaceForSession` gate; rule 39 / 42 / 48): the coding-overlay
-    // namespace AND its fallbacks are `<principal>-project-*` sub-namespaces of
-    // the principal SELF base, authorized transitively by that base. They are
-    // included ONLY when the principal self base is in the readable recall set
-    // (`readableRecallNamespaces` — gated by `defaultRecallNamespaces.includes
-    // ("self")` AND `canReadNamespace`). When the self base is NOT readable (e.g.
-    // a write-only / self-omitted principal), the overlay rows are unauthorized
-    // for this reader, so the LCM read collapses to the default store — exactly
-    // what an unqualified, unauthorized recall resolves to — and NEVER searches a
-    // `<principal>-project-*` key (no cross-tenant read leak). This mirrors what
-    // the rest of recall surfaces for such a principal (its readable
-    // shared/policy namespaces have no per-session LCM key, so they contribute
-    // nothing here). `recallNamespaces` itself appends fallbacks unconditionally
-    // for QMD/file recall; the LCM read keys apply the stricter, self-base gate
-    // so the prior round's authorization invariant is preserved.
-    const codingOverlaySelfReadable =
-      codingOverlay !== null &&
-      (scopeProfilePlan
-        ? scopeProfilePlan.layers.some((layer) => layer.id === "userProject" && layer.readable)
-        : readableRecallNamespaces.includes(principalSelfNamespace));
-    let lcmReadNamespaces: string[];
-    if (namespaceOverride) {
-      // Explicit namespace already read-authorized above (canReadNamespace gate).
-      lcmReadNamespaces = [namespaceOverride];
-    } else if (scopeProfilePlan) {
-      // Scope profiles define a layered read stack; LCM-backed evidence uses the
-      // same namespace set as QMD/file recall so team/global/shared observations
-      // are not silently skipped.
-      lcmReadNamespaces = recallNamespaces;
-    } else if (codingOverlay && codingSelfNamespace && codingOverlaySelfReadable) {
-      // Self base readable → overlay rows authorized. Read the primary overlay
-      // key first, then each coding read fallback (project → root), combined with
-      // the principal base for isolation — the SAME ordered set QMD/file recall
-      // searches for this authorized coding session.
-      const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
-        combineNamespaces(principalSelfNamespace, fallback),
-      );
-      lcmReadNamespaces = [codingSelfNamespace, ...fallbackNs];
-    } else {
-      // No overlay, OR overlay present but self base unreadable → collapse to the
-      // default store (raw sessionKey), exactly as the prior round did. No
-      // `<principal>-project-*` overlay key is searched.
-      lcmReadNamespaces = [this.config.defaultNamespace];
-    }
-    // Map the ordered, read-authorized namespace set → ordered, deduped LCM read
-    // session_id set. Single-user / no-overlay recall passes a single-namespace
-    // set that collapses to the raw `sessionKey`, so this is `[sessionKey]` —
-    // byte-for-byte the pre-#1495 single-key behavior.
-    const lcmReadSessionIds =
-      scopeProfilePlan && !sessionKey
-        ? []
-        : lcmReadSessionIdsForNamespaces(
-            lcmReadNamespaces,
-            sessionKey,
-            this.config.defaultNamespace,
-          );
+    // Catalog read touch (issue #1499) is recorded LATER — after the Phase 1
+    // abort gate — so it fires only when retrieval actually runs, not for
+    // aborted / short-circuited recalls.
+    const scopePlan = resolveScopePlan({
+      config: this.config,
+      sessionKey,
+      namespace: options.namespace,
+      principalOverride:
+        typeof options.principalOverride === "string"
+          && options.principalOverride.length > 0
+          ? options.principalOverride
+          : undefined,
+      codingContext: sessionKey
+        ? this.getCodingContextForSession(sessionKey)
+        : null,
+    });
+    const {
+      readNamespaces: recallNamespaces,
+      baseNamespace: selfNamespace,
+      scopeProfilePlan,
+      lcmReadSessionIds,
+    } = scopePlan;
     // Query an LCM-backed read across the ordered read key set and return the
     // FIRST non-empty result (#1505 fallback-namespace unification). The primary
     // overlay key is tried first; if a branch-scoped session has no rows under its

--- a/packages/remnic-core/src/scopes/scope-plan.test.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.test.ts
@@ -1,0 +1,346 @@
+/**
+ * ScopePlan resolver parity tests (issue #1521 step 2).
+ *
+ * These tests snapshot the effective namespace sets the resolver produces for a
+ * fixed matrix of inputs. The snapshots were derived by tracing the pre-migration
+ * inline resolution in `orchestrator.recallInternal` and
+ * `orchestrator.enqueueDirectAnswerObservation` — the SAME helpers in the SAME
+ * order. They MUST NOT change when consumers switch from the inline code to the
+ * resolver; if they do, the resolver diverged and must be corrected before
+ * migration lands.
+ *
+ * Input matrix (issue #1521 step 2):
+ *  - default namespace (no policies, no coding context)
+ *  - named namespace (explicit override, readable)
+ *  - coding overlay (project scope and branch scope)
+ *  - sparse metadata (empty/missing fields, no session key)
+ *  - legacy `agent:*` session keys
+ *  - scope-profile plan (active profile)
+ *  - explicit namespace override (unreadable falls through)
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveScopePlan } from "./scope-plan.js";
+import {
+  combineNamespaces,
+  lcmSessionKeyForNamespace,
+  projectNamespaceName,
+} from "../coding/coding-namespace.js";
+import type { CodingContext, PluginConfig } from "../types.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Config builders
+// ──────────────────────────────────────────────────────────────────────────
+
+function baseConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: true, branchScope: false, globalFallback: true },
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    scopeProfiles: {},
+    defaultScopeProfile: undefined,
+    teams: {},
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+/** A principal whose self namespace exists as a policy, so the overlay base is
+ * non-default and readable. */
+function withSelfPolicy(config: PluginConfig, principal: string): PluginConfig {
+  return {
+    ...config,
+    namespacePolicies: [
+      { name: principal, readPrincipals: [principal], writePrincipals: [principal] },
+      ...(config.namespacePolicies ?? []),
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [
+      { match: `${principal}:`, principal },
+      ...(config.principalFromSessionKeyRules ?? []),
+    ],
+  } as unknown as PluginConfig;
+}
+
+function codingContext(projectId: string, branch: string | null = null): CodingContext {
+  return { projectId, branch, rootPath: "/repo", defaultBranch: "main" };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 1: default namespace, no coding context
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: default namespace, no coding context → [default]", () => {
+  const plan = resolveScopePlan({
+    config: baseConfig(),
+    sessionKey: "sess-1",
+  });
+
+  assert.equal(plan.principal, "default");
+  assert.equal(plan.namespaceOverride, undefined);
+  assert.equal(plan.baseNamespace, "default");
+  assert.deepEqual(plan.readNamespaces, ["default", "shared"]);
+  assert.deepEqual(plan.readFallbacks, []);
+  assert.deepEqual(plan.lcmReadNamespaces, ["default"]);
+  assert.equal(plan.codingOverlay, null);
+  assert.equal(plan.scopeProfilePlan, null);
+  // LCM key is the raw sessionKey (default store, no overlay).
+  assert.deepEqual([...plan.lcmReadSessionIds], ["sess-1"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 2: named namespace (explicit, readable override)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: explicit readable namespace override wins", () => {
+  const config = baseConfig({
+    namespacePolicies: [
+      { name: "team-data", readPrincipals: ["default"], writePrincipals: [] },
+    ],
+  } as Partial<PluginConfig>);
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "sess-1",
+    namespace: "team-data",
+  });
+
+  assert.equal(plan.namespaceOverride, "team-data");
+  assert.equal(plan.baseNamespace, "team-data");
+  assert.deepEqual(plan.readNamespaces, ["team-data"]);
+  assert.deepEqual(plan.lcmReadNamespaces, ["team-data"]);
+  assert.equal(plan.codingOverlay, null);
+  assert.equal(plan.scopeProfilePlan, null);
+  assert.deepEqual(
+    [...plan.lcmReadSessionIds],
+    [lcmSessionKeyForNamespace("team-data", "sess-1", "default")],
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 3: coding overlay (project scope)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: coding overlay (project scope) substitutes self base", () => {
+  const config = withSelfPolicy(baseConfig(), "alice");
+  const ctx = codingContext("myproj");
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    codingContext: ctx,
+  });
+
+  const projectNs = projectNamespaceName("myproj");
+  const codingSelf = combineNamespaces("alice", projectNs);
+
+  assert.equal(plan.principal, "alice");
+  assert.equal(plan.baseNamespace, codingSelf);
+  // readNamespaces substitutes "alice" → codingSelf, keeps shared.
+  // globalFallback=true adds the root ("") fallback: combineNamespaces("alice",
+  // "") → "alice", so the principal's own namespace appears as a read fallback.
+  assert.deepEqual(plan.readNamespaces, [codingSelf, "shared", "alice"]);
+  assert.deepEqual(plan.readFallbacks, ["alice"]);
+  assert.deepEqual(plan.lcmReadNamespaces, [codingSelf, "alice"]);
+  assert.equal(plan.codingOverlay?.namespace, projectNs);
+  assert.deepEqual([...plan.codingOverlay?.readFallbacks ?? []], [""]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 4: coding overlay (branch scope) appends project fallback
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: coding overlay (branch scope) appends project + root fallbacks", () => {
+  const config = withSelfPolicy(
+    baseConfig({
+      codingMode: { projectScope: true, branchScope: true, globalFallback: true },
+    } as Partial<PluginConfig>),
+    "alice",
+  );
+  const ctx = codingContext("myproj", "feature-x");
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    codingContext: ctx,
+  });
+
+  // Verify the key invariants: overlay is non-null, base is combined with self.
+  assert.notEqual(plan.codingOverlay, null);
+  assert.notEqual(plan.baseNamespace, "alice");
+  // readNamespaces includes the coding self (branch) and fallbacks.
+  assert.ok(plan.readNamespaces.length >= 2, "branch scope must include fallbacks");
+  // LCM read includes coding self + fallbacks.
+  assert.ok(plan.lcmReadNamespaces.length >= 2, "LCM must include fallback keys");
+  // readFallbacks is non-empty (project + root when globalFallback).
+  assert.ok(plan.readFallbacks.length >= 1, "branch scope has at least project fallback");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 5: sparse metadata — no session key
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: no session key → principal undefined, default namespace", () => {
+  const plan = resolveScopePlan({
+    config: baseConfig(),
+  });
+
+  assert.equal(plan.principal, undefined);
+  assert.equal(plan.baseNamespace, "default");
+  // recallNamespacesForPrincipal(undefined) → [] (no principal).
+  assert.deepEqual(plan.readNamespaces, []);
+  assert.deepEqual(plan.lcmReadNamespaces, ["default"]);
+  // Sessionless LCM → [undefined] (archive-wide read, no session_id filter).
+  assert.deepEqual([...plan.lcmReadSessionIds], [undefined]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 6: legacy agent:* session key
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: legacy agent:* session key resolves principal via heuristic", () => {
+  const plan = resolveScopePlan({
+    config: baseConfig(),
+    sessionKey: "agent:bot-1:slack:chan-1",
+  });
+
+  // resolvePrincipal heuristic: parts[0] === "agent" → parts[1] = "bot-1".
+  assert.equal(plan.principal, "bot-1");
+  // No policy for "bot-1" → defaultNamespaceForPrincipal → "default".
+  assert.equal(plan.baseNamespace, "default");
+  // recallNamespacesForPrincipal("bot-1"): self="default" (readable), shared.
+  assert.deepEqual(plan.readNamespaces, ["default", "shared"]);
+  assert.deepEqual(plan.lcmReadNamespaces, ["default"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 7: namespacesEnabled false → single-store collapse
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: namespacesEnabled false collapses to default store", () => {
+  const config = baseConfig({ namespacesEnabled: false } as Partial<PluginConfig>);
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "sess-1",
+    codingContext: codingContext("myproj"),
+  });
+
+  // resolvePrincipal returns "default" when namespaces disabled.
+  assert.equal(plan.principal, "default");
+  assert.equal(plan.baseNamespace, "default");
+  assert.deepEqual(plan.readNamespaces, ["default"]);
+  assert.equal(plan.codingOverlay, null);
+  assert.equal(plan.scopeProfilePlan, null);
+  // Single store → raw sessionKey.
+  assert.deepEqual([...plan.lcmReadSessionIds], ["sess-1"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 8: codingMode.projectScope false → no overlay
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: projectScope false → no overlay even with coding context", () => {
+  const config = withSelfPolicy(
+    baseConfig({
+      codingMode: { projectScope: false, branchScope: false, globalFallback: true },
+    } as Partial<PluginConfig>),
+    "alice",
+  );
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    codingContext: codingContext("myproj"),
+  });
+
+  assert.equal(plan.codingOverlay, null);
+  assert.equal(plan.baseNamespace, "alice");
+  // No overlay → readable recall set unchanged (self substituted by nothing).
+  assert.deepEqual(plan.readNamespaces, ["alice", "shared"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 9: explicit override not readable → falls through (observe parity)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: unreadable namespace override falls through to coding/legacy", () => {
+  // No policy for "restricted" → canReadNamespace(default, "restricted") → false.
+  const config = withSelfPolicy(baseConfig(), "alice");
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    namespace: "restricted",
+    codingContext: codingContext("myproj"),
+  });
+
+  // Unreadable override → namespaceOverride is undefined in the plan.
+  assert.equal(plan.namespaceOverride, undefined);
+  // Falls through to coding overlay (alice has a policy + coding context).
+  assert.notEqual(plan.codingOverlay, null);
+  assert.notEqual(plan.baseNamespace, "restricted");
+  assert.notEqual(plan.baseNamespace, "alice", "base should be the overlaid namespace");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot 10: defaultRecallNamespaces omits self → overlay LCM collapses
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: self not in defaultRecallNamespaces → LCM collapses to default", () => {
+  const config = withSelfPolicy(
+    baseConfig({
+      defaultRecallNamespaces: ["shared"],
+    } as Partial<PluginConfig>),
+    "alice",
+  );
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    codingContext: codingContext("myproj"),
+  });
+
+  // Coding overlay IS resolved (coding context + projectScope).
+  assert.notEqual(plan.codingOverlay, null);
+  // codingOverlaySelfReadable = false (self "alice" not in readable set).
+  // LCM collapses to default.
+  assert.deepEqual(plan.lcmReadNamespaces, ["default"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cross-check: resolveScopePlan is pure (same inputs → same outputs)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: resolver is pure — identical inputs produce identical plans", () => {
+  const config = withSelfPolicy(baseConfig(), "alice");
+  const ctx = codingContext("myproj");
+  const opts = { config, sessionKey: "alice:sess-1", codingContext: ctx } as const;
+
+  const a = resolveScopePlan(opts);
+  const b = resolveScopePlan(opts);
+
+  assert.deepEqual(a.readNamespaces, b.readNamespaces);
+  assert.deepEqual(a.lcmReadNamespaces, b.lcmReadNamespaces);
+  assert.deepEqual([...a.lcmReadSessionIds], [...b.lcmReadSessionIds]);
+  assert.equal(a.baseNamespace, b.baseNamespace);
+  assert.equal(a.codingOverlay?.namespace, b.codingOverlay?.namespace);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Parity invariant: LCM keys derived through lcmSessionKeyForNamespace
+// (rule 22 — never hardcoded `:`-joins)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("scope-plan: LCM session ids match lcmSessionKeyForNamespace encoding", () => {
+  const config = withSelfPolicy(baseConfig(), "alice");
+  const plan = resolveScopePlan({
+    config,
+    sessionKey: "alice:sess-1",
+    codingContext: codingContext("myproj"),
+  });
+
+  // Each LCM read session id must equal lcmSessionKeyForNamespace(ns, sk, default).
+  const expected = plan.lcmReadNamespaces.map(
+    (ns) => lcmSessionKeyForNamespace(ns, "alice:sess-1", "default") ?? "alice:sess-1",
+  );
+  assert.deepEqual([...plan.lcmReadSessionIds], expected);
+});

--- a/packages/remnic-core/src/scopes/scope-plan.test.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.test.ts
@@ -76,8 +76,10 @@ function codingContext(projectId: string, branch: string | null = null): CodingC
 // ──────────────────────────────────────────────────────────────────────────
 
 test("scope-plan: default namespace, no coding context → [default]", () => {
+  const config = baseConfig();
   const plan = resolveScopePlan({
-    config: baseConfig(),
+    config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "sess-1",
   });
 
@@ -105,6 +107,7 @@ test("scope-plan: explicit readable namespace override wins", () => {
   } as Partial<PluginConfig>);
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "sess-1",
     namespace: "team-data",
   });
@@ -130,6 +133,7 @@ test("scope-plan: coding overlay (project scope) substitutes self base", () => {
   const ctx = codingContext("myproj");
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     codingContext: ctx,
   });
@@ -163,6 +167,7 @@ test("scope-plan: coding overlay (branch scope) appends project + root fallbacks
   const ctx = codingContext("myproj", "feature-x");
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     codingContext: ctx,
   });
@@ -183,8 +188,10 @@ test("scope-plan: coding overlay (branch scope) appends project + root fallbacks
 // ──────────────────────────────────────────────────────────────────────────
 
 test("scope-plan: no session key → principal undefined, default namespace", () => {
+  const config = baseConfig();
   const plan = resolveScopePlan({
-    config: baseConfig(),
+    config,
+    namespacesEnabled: config.namespacesEnabled,
   });
 
   assert.equal(plan.principal, undefined);
@@ -201,8 +208,10 @@ test("scope-plan: no session key → principal undefined, default namespace", ()
 // ──────────────────────────────────────────────────────────────────────────
 
 test("scope-plan: legacy agent:* session key resolves principal via heuristic", () => {
+  const config = baseConfig();
   const plan = resolveScopePlan({
-    config: baseConfig(),
+    config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "agent:bot-1:slack:chan-1",
   });
 
@@ -223,6 +232,7 @@ test("scope-plan: namespacesEnabled false collapses to default store", () => {
   const config = baseConfig({ namespacesEnabled: false } as Partial<PluginConfig>);
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "sess-1",
     codingContext: codingContext("myproj"),
   });
@@ -250,6 +260,7 @@ test("scope-plan: projectScope false → no overlay even with coding context", (
   );
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     codingContext: codingContext("myproj"),
   });
@@ -269,6 +280,7 @@ test("scope-plan: unreadable namespace override falls through to coding/legacy",
   const config = withSelfPolicy(baseConfig(), "alice");
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     namespace: "restricted",
     codingContext: codingContext("myproj"),
@@ -295,6 +307,7 @@ test("scope-plan: self not in defaultRecallNamespaces → LCM collapses to defau
   );
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     codingContext: codingContext("myproj"),
   });
@@ -313,7 +326,7 @@ test("scope-plan: self not in defaultRecallNamespaces → LCM collapses to defau
 test("scope-plan: resolver is pure — identical inputs produce identical plans", () => {
   const config = withSelfPolicy(baseConfig(), "alice");
   const ctx = codingContext("myproj");
-  const opts = { config, sessionKey: "alice:sess-1", codingContext: ctx } as const;
+  const opts = { config, namespacesEnabled: config.namespacesEnabled, sessionKey: "alice:sess-1", codingContext: ctx } as const;
 
   const a = resolveScopePlan(opts);
   const b = resolveScopePlan(opts);
@@ -334,6 +347,7 @@ test("scope-plan: LCM session ids match lcmSessionKeyForNamespace encoding", () 
   const config = withSelfPolicy(baseConfig(), "alice");
   const plan = resolveScopePlan({
     config,
+    namespacesEnabled: config.namespacesEnabled,
     sessionKey: "alice:sess-1",
     codingContext: codingContext("myproj"),
   });

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -159,6 +159,12 @@ export interface ResolveScopePlanOptions {
    * reaches back into orchestrator state.
    */
   readonly codingContext?: CodingContext | null;
+  /**
+   * Whether namespace routing is enabled. Callers that have already read the
+   * namespaces-enabled flag pass it here so the resolver does NOT re-read it
+   * (keeps the scattered-read ratchet from growing, #1523).
+   */
+  readonly namespacesEnabled: boolean;
 }
 
 /**
@@ -194,9 +200,12 @@ export function resolveScopePlan(options: ResolveScopePlanOptions): ScopePlan {
   // The orchestrator's `applyCodingRecallOverlay` gates on `namespacesEnabled`
   // (returning null when disabled), so the resolver must too — otherwise
   // single-store mode would produce apparent route separation with no actual
-  // storage isolation (false-isolation trap, rule 39).
+  // storage isolation (false-isolation trap, rule 39). The caller passes the
+  // pre-read flag so the resolver does not add a scattered `config.*Enabled`
+  // read (ratchet, #1523).
+  const namespacesEnabled = options.namespacesEnabled;
   const codingOverlay: CodingNamespaceOverlay | null =
-    namespaceOverrideReadable || !config.namespacesEnabled
+    namespaceOverrideReadable || !namespacesEnabled
       ? null
       : resolveCodingNamespaceOverlay(
           options.codingContext ?? null,

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -1,0 +1,311 @@
+/**
+ * ScopePlan resolver (issue #1521).
+ *
+ * A single pure function that resolves every namespace-bearing read/write path
+ * to one {@link ScopePlan} value object. Consumers (recall tiers, QMD router,
+ * LCM reads, maintenance) never call the ad-hoc resolution helpers directly —
+ * they receive a resolved plan and read its fields.
+ *
+ * The resolver DELEGATES to the existing helpers (`resolvePrincipal`,
+ * `recallNamespacesForPrincipal`, `resolveCodingNamespaceOverlay`,
+ * `resolveScopeProfilePlan`, `expandScopeProfileReadNamespaces`,
+ * `combineNamespaces`, `lcmReadSessionIdsForNamespaces`) — no logic rewrite.
+ * The ad-hoc inline resolution that previously lived in the orchestrator's
+ * `recallInternal` and `enqueueDirectAnswerObservation` paths is replaced by a
+ * single call to {@link resolveScopePlan}, eliminating the duplicated
+ * namespace-set construction that produced the largest share of #1519's review
+ * threads (scope-profile recall paths missing `readFallbacks` appends).
+ *
+ * Migration tranches (issue #1521 step 4):
+ *  - recall tiers (this PR): the two orchestrator recall entry points consume
+ *    the plan instead of building `recallNamespaces`/`observationNamespaces`
+ *    inline;
+ *  - QMD router calls, LCM reads, maintenance: follow-up PRs.
+ *
+ * CLAUDE.md rules honoured (pitfalls from the issue):
+ *  - rule 42: read/write resolve through the same layer; the coding overlay is
+ *    COMBINED with the principal base via `combineNamespaces`;
+ *  - rule 39: feature gates identical across every path the plan feeds;
+ *  - rule 22/48: LCM keys derived through `lcmSessionKeyForNamespace` (via
+ *    `lcmReadSessionIdsForNamespaces`), never hardcoded `:`-joins; unscoped LCM
+ *    search stays suppressed when `namespacesEnabled`.
+ */
+
+import {
+  canReadNamespace,
+  defaultNamespaceForPrincipal,
+  recallNamespacesForPrincipal,
+  resolvePrincipal,
+} from "../namespaces/principal.js";
+import type { ResolvedScopeProfilePlan } from "../namespaces/scope-profiles.js";
+import {
+  expandScopeProfileReadNamespaces,
+  resolveScopeProfilePlan,
+} from "../namespaces/scope-profiles.js";
+import {
+  combineNamespaces,
+  lcmReadSessionIdsForNamespaces,
+  resolveCodingNamespaceOverlay,
+  type CodingNamespaceOverlay,
+} from "../coding/coding-namespace.js";
+import type { CodingContext, PluginConfig } from "../types.js";
+
+/**
+ * A resolved scope plan: every namespace-bearing field a read or write path
+ * needs, produced by ONE call to {@link resolveScopePlan}.
+ *
+ * Consumers read these fields directly — they never re-resolve namespaces.
+ */
+export interface ScopePlan {
+  /**
+   * Resolved principal under which the operation runs. `undefined` only when
+   * `namespacesEnabled` is false (collapses to `"default"`) or no session key
+   * was supplied in single-user mode.
+   */
+  readonly principal: string | undefined;
+
+  /**
+   * Explicit namespace override, trimmed, when the caller supplied one AND it
+   * is readable by the principal. `undefined` when no override was given or the
+   * override is not readable (the plan falls through to the coding/scope-profile
+   * resolution in that case, mirroring the pre-existing observe-path behavior).
+   */
+  readonly namespaceOverride: string | undefined;
+
+  /**
+   * Resolved base (self) namespace — the effective namespace absent an explicit
+   * override. This is the principal-self namespace, optionally substituted by a
+   * scope-profile write layer or a coding overlay.
+   *
+   * Callers that persisted this as the `selfNamespace` / response namespace
+   * read it here.
+   */
+  readonly baseNamespace: string;
+
+  /**
+   * Ordered, deduped read-namespace set. Includes the coding overlay fallbacks
+   * (branch → project → root) combined with the principal base exactly once, so
+   * the #1519 miss (scope-profile path omitted `readFallbacks` appends) cannot
+   * recur — the fallback appends live in ONE place.
+   */
+  readonly readNamespaces: string[];
+
+  /**
+   * Coding overlay fallback namespaces combined with the principal base (rule
+   * 42). Empty when no coding overlay applies. These are the SAME entries
+   * appended into {@link readNamespaces} for the coding-overlay branch,
+   * surfaced separately so consumers that need just the fallback set (e.g.
+   * LCM read-key derivation) can read them without re-deriving.
+   */
+  readonly readFallbacks: string[];
+
+  /**
+   * LCM read namespace set. May differ from {@link readNamespaces} for
+   * read-authorization reasons: when the principal self base is NOT in the
+   * readable recall set, the overlay LCM keys collapse to the default store
+   * (rule 42 read/write parity; rule 48 least-privilege) even though
+   * {@link readNamespaces} still searches the overlay for QMD/file recall.
+   */
+  readonly lcmReadNamespaces: string[];
+
+  /**
+   * LCM read `session_id` set, encoded via
+   * `lcmReadSessionIdsForNamespaces` (which delegates to
+   * `lcmSessionKeyForNamespace`). Ordered and deduped; the primary overlay key
+   * is first. Single-user / no-overlay recall collapses to `[sessionKey]` —
+   * byte-for-byte the pre-#1495 behavior.
+   *
+   * Empty (`[]`) when a scope-profile plan is active and no `sessionKey` was
+   * supplied (mirrors the pre-existing guard).
+   */
+  readonly lcmReadSessionIds: ReadonlyArray<string | undefined>;
+
+  /**
+   * Resolved coding overlay, or `null` when none applies (no coding context,
+   * `codingMode.projectScope` false, `namespacesEnabled` false, or an explicit
+   * readable namespace override is set).
+   */
+  readonly codingOverlay: { readonly namespace: string; readonly readFallbacks: readonly string[] } | null;
+
+  /**
+   * Resolved scope-profile plan, or `null` when no scope profile is active.
+   * Consumers that branched on "profile vs. non-profile" read this directly.
+   */
+  readonly scopeProfilePlan: ResolvedScopeProfilePlan | null;
+}
+
+/**
+ * Options for {@link resolveScopePlan}.
+ */
+export interface ResolveScopePlanOptions {
+  /** Plugin config (namespace policies, coding mode, default namespace, …). */
+  readonly config: PluginConfig;
+  /** Session key (may derive the principal and/or coding context). */
+  readonly sessionKey?: string;
+  /**
+   * Explicit namespace override (raw — the resolver trims it). When supplied
+   * AND readable by the resolved principal, it wins over every other layer.
+   */
+  readonly namespace?: string;
+  /**
+   * Authenticated principal override. Access surfaces that already resolved
+   * identity at the transport layer pass it here so namespace ACL decisions
+   * use the same identity the surface authorized.
+   */
+  readonly principalOverride?: string;
+  /**
+   * Coding context for the session. Callers that track this on the orchestrator
+   * pass `getCodingContextForSession(sessionKey)` here; the resolver never
+   * reaches back into orchestrator state.
+   */
+  readonly codingContext?: CodingContext | null;
+}
+
+/**
+ * Resolve a {@link ScopePlan} from the inputs by delegating to the existing
+ * namespace-resolution helpers. Pure — no side effects, no orchestrator state.
+ *
+ * The caller is responsible for authorization checks that should THROW (e.g.
+ * `namespacesEnabled && !principal`, or an unreadable explicit override in the
+ * recall path). The resolver computes the plan; enforcement stays at the call
+ * site so error semantics are unchanged.
+ */
+export function resolveScopePlan(options: ResolveScopePlanOptions): ScopePlan {
+  const { config, sessionKey } = options;
+
+  const namespaceOverride = options.namespace?.trim() || undefined;
+
+  const principal =
+    typeof options.principalOverride === "string" && options.principalOverride.length > 0
+      ? options.principalOverride
+      : resolvePrincipal(sessionKey, config);
+
+  // A namespace override gates the overlay/scope-profile layers. When it is
+  // readable it wins; when it is NOT readable the plan falls through to the
+  // coding/scope-profile/legacy branches (mirrors the observe-path behavior
+  // where an unreadable override does not throw but simply does not suppress
+  // the overlay). The recall path validates readability and throws BEFORE
+  // calling the resolver, so a reachable override is always readable there.
+  const namespaceOverrideReadable =
+    namespaceOverride !== undefined && canReadNamespace(principal, namespaceOverride, config);
+
+  const readableRecallNamespaces = recallNamespacesForPrincipal(principal, config);
+
+  // The orchestrator's `applyCodingRecallOverlay` gates on `namespacesEnabled`
+  // (returning null when disabled), so the resolver must too — otherwise
+  // single-store mode would produce apparent route separation with no actual
+  // storage isolation (false-isolation trap, rule 39).
+  const codingOverlay: CodingNamespaceOverlay | null =
+    namespaceOverrideReadable || !config.namespacesEnabled
+      ? null
+      : resolveCodingNamespaceOverlay(
+          options.codingContext ?? null,
+          config.codingMode,
+          config.defaultNamespace,
+        );
+
+  const principalSelfNamespace = defaultNamespaceForPrincipal(principal, config);
+  const codingSelfNamespace = codingOverlay
+    ? combineNamespaces(principalSelfNamespace, codingOverlay.namespace)
+    : null;
+
+  const scopeProfilePlan = namespaceOverrideReadable
+    ? null
+    : resolveScopeProfilePlan({
+        config,
+        principal,
+        codingContext: options.codingContext ?? null,
+        codingOverlay,
+      });
+
+  const profileEffectiveNamespace =
+    scopeProfilePlan?.writeNamespace || scopeProfilePlan?.readNamespaces[0];
+
+  const baseNamespace = namespaceOverrideReadable
+    ? namespaceOverride!
+    : profileEffectiveNamespace ?? codingSelfNamespace ?? principalSelfNamespace;
+
+  // ── Read namespace set ────────────────────────────────────────────────────
+  let readNamespaces: string[];
+  if (namespaceOverrideReadable) {
+    readNamespaces = [namespaceOverride!];
+  } else if (scopeProfilePlan) {
+    readNamespaces = expandScopeProfileReadNamespaces({
+      profilePlan: scopeProfilePlan,
+      principalSelfNamespace: scopeProfilePlan.baseNamespace,
+      config,
+      principal,
+      codingOverlay,
+      legacyRecallNamespaces: readableRecallNamespaces,
+    });
+  } else if (codingOverlay && codingSelfNamespace) {
+    // Substitute the principal's self namespace with the coding-scoped one, and
+    // append any read fallbacks (branch → project, rule 42) combined with the
+    // principal base so principal isolation is preserved on fallback entries.
+    const mapped = readableRecallNamespaces.map((ns) =>
+      ns === principalSelfNamespace ? codingSelfNamespace : ns,
+    );
+    const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
+      combineNamespaces(principalSelfNamespace, fallback),
+    );
+    readNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
+  } else {
+    readNamespaces = readableRecallNamespaces;
+  }
+
+  const readFallbacks = codingOverlay
+    ? codingOverlay.readFallbacks.map((fb) => combineNamespaces(principalSelfNamespace, fb))
+    : [];
+
+  // ── LCM read namespace set ────────────────────────────────────────────────
+  // The LCM overlay keys are `<principal>-project-*` sub-namespaces authorized
+  // transitively by the principal SELF base. Include them ONLY when that base
+  // is in the readable recall set (rule 42 / 48). When it is NOT readable, the
+  // overlay rows are unauthorized for this reader, so the LCM read collapses to
+  // the default store — exactly what QMD/file recall surfaces for such a
+  // principal.
+  const codingOverlaySelfReadable =
+    codingOverlay !== null &&
+    (scopeProfilePlan
+      ? scopeProfilePlan.layers.some((layer) => layer.id === "userProject" && layer.readable)
+      : readableRecallNamespaces.includes(principalSelfNamespace));
+
+  let lcmReadNamespaces: string[];
+  if (namespaceOverrideReadable) {
+    lcmReadNamespaces = [namespaceOverride!];
+  } else if (scopeProfilePlan) {
+    // Scope profiles define a layered read stack; LCM-backed evidence uses the
+    // same namespace set as QMD/file recall so team/global/shared observations
+    // are not silently skipped.
+    lcmReadNamespaces = readNamespaces;
+  } else if (codingOverlay && codingSelfNamespace && codingOverlaySelfReadable) {
+    const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
+      combineNamespaces(principalSelfNamespace, fallback),
+    );
+    lcmReadNamespaces = [codingSelfNamespace, ...fallbackNs];
+  } else {
+    // No overlay, OR overlay present but self base unreadable → collapse to the
+    // default store (raw sessionKey). No `<principal>-project-*` overlay key is
+    // searched.
+    lcmReadNamespaces = [config.defaultNamespace];
+  }
+
+  const lcmReadSessionIds =
+    scopeProfilePlan && !sessionKey
+      ? []
+      : lcmReadSessionIdsForNamespaces(lcmReadNamespaces, sessionKey, config.defaultNamespace);
+
+  return {
+    principal,
+    namespaceOverride: namespaceOverrideReadable ? namespaceOverride : undefined,
+    baseNamespace,
+    readNamespaces,
+    readFallbacks,
+    lcmReadNamespaces,
+    lcmReadSessionIds,
+    codingOverlay: codingOverlay
+      ? { namespace: codingOverlay.namespace, readFallbacks: codingOverlay.readFallbacks }
+      : null,
+    scopeProfilePlan,
+  };
+}

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,13 +4,13 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20111,
+      "packages/remnic-core/src/orchestrator.ts": 19958,
       "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8277,
       "packages/remnic-core/src/storage.ts": 7320,
       "packages/remnic-core/src/config.ts": 4505
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 557
+    "scatteredConfigFlagReads": 558
   }
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,13 +4,13 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19958,
+      "packages/remnic-core/src/orchestrator.ts": 19964,
       "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8277,
       "packages/remnic-core/src/storage.ts": 7320,
       "packages/remnic-core/src/config.ts": 4505
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 558
+    "scatteredConfigFlagReads": 557
   }
 }


### PR DESCRIPTION
Part of #1520. Implements #1521 (recall tranche — QMD/LCM/maintenance tranches follow in separate PRs).

## Summary

Introduces a single `ScopePlan` resolver (`packages/remnic-core/src/scopes/scope-plan.ts`) that produces every namespace-bearing field a read or write path needs from ONE pure function call. Migrates the two orchestrator recall entry points (`recallInternal` and `enqueueDirectAnswerObservation`) to consume the plan instead of building `recallNamespaces`/`observationNamespaces` inline.

The resolver **delegates to the existing helpers** — no logic rewrite. This eliminates the duplicated namespace-set construction that produced the largest share of #1519's 105 review threads (scope-profile recall paths missing `readFallbacks` appends). The #1519 defect class — per-path fallback appends — is now structurally impossible: `readFallbacks` exists in ONE place (the resolver).

## Implementation (issue #1521 ordered steps)

- **Step 1 (inventory):** ad-hoc resolution call sites documented; recall path's inline construction migrated in this PR.
- **Step 2 (parity snapshots FIRST):** `scope-plan.test.ts` — 12 tests covering the issue's input matrix.
- **Step 3 (resolver):** `scopes/scope-plan.ts` — pure function, no orchestrator state.
- **Step 4 (recall tier migration):** `recallInternal` (−154 lines) and `enqueueDirectAnswerObservation` (−51 lines) → 1 resolver call each.
- **Step 5 (ratchet):** orchestrator.ts 20111 → 19958 LOC; baseline updated.

## Test evidence

- `scope-plan.test.ts`: **12/12 pass**
- `npm run test:entity-hardening`: **246/246 pass**
- observe-scope + LCM-parity + namespace tests: **76/76 pass**
- `npm run preflight:quick`: **`[preflight] OK (quick)`**
- `node scripts/check-ratchets.mjs`: **OK**
- `bash scripts/check-review-patterns.sh`: **PASSED**

Chokepoints used: ScopePlan resolver (`scopes/scope-plan.ts`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tenant isolation, coding overlays, scope profiles, and LCM read keys on core recall paths; behavior is intended to be parity-preserving but mistakes could change which namespaces are searched or authorized.
> 
> **Overview**
> Adds **`resolveScopePlan`** in `scopes/scope-plan.ts` so recall paths get **one** pure resolution for read namespaces, base/self namespace, coding overlay, scope profiles, LCM read keys, and fallbacks—instead of duplicating that logic in the orchestrator.
> 
> **`recallInternal`** and **`enqueueDirectAnswerObservation`** now call the resolver and use `readNamespaces`, `baseNamespace`, `lcmReadSessionIds`, etc. from the plan. Auth that **throws** (namespaces enabled without principal; unreadable explicit override on recall) stays at the call site; the observe path still **falls through** when an override is unreadable.
> 
> New **`scope-plan.test.ts`** parity matrix locks behavior to the pre-migration inline paths. **`ratchet-baseline.json`** drops `orchestrator.ts` LOC (~20111 → 19964).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2454c529094ccc30465cfdd6fa5859770496773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->