### PR TITLE
bench(profiles): local-lab runtime profile, sequential phases, endpoint preflight (#1573 PR2)

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -12,6 +12,8 @@
     },
     "./baselines/*": "./baselines/*",
     "./baselines/*.json": "./baselines/*.json",
+    "./profiles/*": "./profiles/*",
+    "./profiles/*.json": "./profiles/*.json",
     "./package.json": "./package.json"
   },
   "license": "MIT",
@@ -49,6 +51,7 @@
   },
   "files": [
     "dist",
-    "baselines"
+    "baselines",
+    "profiles"
   ]
 }

--- a/packages/bench/profiles/README.md
+++ b/packages/bench/profiles/README.md
@@ -21,7 +21,7 @@ silent fallback).
 |`judge`|role|Scoring model. Runs in the judge phase after the responder.|
 |`embedding`|role?|Optional embedding model for retrieval indexing.|
 |`phases`|`"sequential"`|Phase scheduling mode. PR2 ships `sequential` only.|
-|`notes.responderToJudgeHandoff`|string?|Operator guidance printed between responder and judge phases when the two roles live on different endpoints.|
+|`notes.responderToJudgeHandoff`|string?|Operator guidance for multi-endpoint swaps. PR2 ships same-endpoint profiles only (multi-endpoint sequential execution is PR3 scope).|
 
 Each role has shape:
 
@@ -78,22 +78,26 @@ token** serving context. That value:
 `temperature: 0` and a fixed `seed: 1573` make reruns reproducible (the
 manifest parser rejects non-zero temperatures and missing seeds).
 
-The two endpoints (`http://127.0.0.1:8080/v1` responder,
-`http://127.0.0.1:11434` judge) live on different ports on purpose: on a
-single 3090 the operator must physically stop one server and start the
-other between phases. The bench detects that they differ and prints the
-`notes.responderToJudgeHandoff` operator guidance. To run both roles on
-one Ollama daemon instead, point both `baseUrl` fields at it and the
-bench proceeds silently between phases.
+The shipped profile pins all roles to a single Ollama endpoint
+(`http://127.0.0.1:11434`). On a single 3090 the operator runs one
+`ollama serve` instance and hot-swaps models between phases — no manual
+server restart is needed. **Multi-endpoint manifests** (responder and
+judge on different URLs) are not yet supported by the benchmark runner:
+the published harness executes recall→answer→judge per trial, which
+requires both models to be co-resident. Full sequential phase execution
+(answer-all-then-judge-all with an operator swap between) is tracked for
+PR3's calibration work.
 
 ## Using a profile
 
 Resolution goes through `resolveBenchRuntimeProfile` (see
 `packages/bench/src/runtime-profiles.ts`); the resolver turns each role
 into a `ProviderConfig` with `temperature` and `seed` forwarded verbatim.
-The sequential phase scheduler (`runSequentialPhases`) executes
-preflight → hand-off → execute for each phase. Neither layer manages
-model processes — that is the operator's responsibility.
+At run time, the CLI preflights both responder and judge endpoints before
+any trial starts. Neither layer manages model processes — that is the
+operator's responsibility. The sequential phase scheduler
+(`runSequentialPhases`) is implemented and tested but not yet wired into
+the benchmark trial loop (PR3 calibration scope).
 
 ```ts
 import {

--- a/packages/bench/profiles/README.md
+++ b/packages/bench/profiles/README.md
@@ -1,0 +1,109 @@
+# Local-lab runtime profiles
+
+This directory ships reference JSON manifests for the **`local-lab`** bench
+runtime profile (issue #1573 PR2). A local-lab profile pins responder,
+judge, and (optionally) embedding to operator-hosted models so the bench
+runs entirely on local hardware — no paid API calls, no rate-limit cliffs.
+
+These manifests are **templates**. They use placeholder model ids on
+purpose: the operator must replace them with the ids their endpoint
+actually reports (`GET /v1/models` for OpenAI-compatible servers,
+`GET /api/tags` for Ollama) before running. The bench refuses to start a
+phase whose preflight cannot find the manifest model id (rule 51 — no
+silent fallback).
+
+## Schema
+
+|Field|Type|Meaning|
+|---|---|---|
+|`profile`|`"local-lab"`|Discriminator. Required.|
+|`responder`|role|Answering model (must report this id at the endpoint).|
+|`judge`|role|Scoring model. Runs in the judge phase after the responder.|
+|`embedding`|role?|Optional embedding model for retrieval indexing.|
+|`phases`|`"sequential"`|Phase scheduling mode. PR2 ships `sequential` only.|
+|`notes.responderToJudgeHandoff`|string?|Operator guidance printed between responder and judge phases when the two roles live on different endpoints.|
+
+Each role has shape:
+
+|Field|Type|Meaning|
+|---|---|---|
+|`provider`|`"openai-compatible"` \| `"ollama"`|Transport the bench uses for preflight + completion.|
+|`baseUrl`|string|Endpoint URL. Fetch target only — never interpolated into a shell.|
+|`model`|string|Exact id the endpoint reports. No aliases.|
+|`quantization`|string?|Informational; recorded in artifacts.|
+|`ctx`|positive int|Manifest-declared serving context (tokens). Preflight verifies the live endpoint reports at least this much.|
+|`temperature`|`0`|Pinned to 0 for reproducibility. Non-zero is rejected.|
+|`seed`|int|Sampling seed; required so reruns reproduce the same draws.|
+
+## `local-lab-3090.json`
+
+Reference profile targeting a single-GPU lab box. The numbers below come
+from issue #1573's *Hardware envelope* section; they are VRAM math, not
+performance claims, and are reproduced here so the manifest's defaults
+can be checked against the design constraints.
+
+### Hardware envelope (RTX 3090, 24 GB VRAM, Ampere; 256 GB RAM, NVMe)
+
+|Class|Rough VRAM @ 4-bit|Practical serving ctx|Notes|
+|---|---|---|---|
+|~14B dense (e.g. Qwen 2.5 14B, Llama 3 8B-class step-up)|9–10 GB|32k KV cache headroom|Comfortably fits; responder-only or judge-only.|
+|~24–32B dense or ~30B-class MoE|14–19 GB|≤16k ctx (tight)|Responder OR judge, not both; KV budget tight.|
+|Embedding model (e.g. BGE-M3, Qwen 3 embedding)|1–3 GB|8k ctx|Fits alongside one of the above on the same GPU in some setups.|
+
+Constraints the profile respects:
+
+- **24 GB VRAM fits one serious model at a time** — responder and judge
+  MUST run in sequential phases, never co-resident.
+- **Ampere: bf16 OK, no FP8.** Prefer AWQ/GPTQ-int4 or GGUF Q4_K_M
+  quantizations.
+- Remnic's memory-based answering keeps prompts small (that is the
+  product); LongMemEval_S's ~115k-token histories are ingested through
+  observe/extraction, not stuffed in context — so **16–32k serving context
+  is sufficient**.
+- **256 GB RAM**: model files stay in page cache; phase swaps from NVMe
+  are seconds, not minutes. The operator can hot-swap models between
+  phases without long stalls.
+
+### Defaults chosen in this manifest
+
+The reference manifest pins both `responder` and `judge` to a **16 384
+token** serving context. That value:
+
+- Lies inside the 16–32k envelope above.
+- Is conservatively below the "tight" ceiling for 24–32B dense models.
+- Matches what GGUF Q4_K_M builds of mainstream ~14B / ~30B-class models
+  expose out of the box, so an operator swapping in their own model id is
+  unlikely to need to lower `ctx`.
+
+`temperature: 0` and a fixed `seed: 1573` make reruns reproducible (the
+manifest parser rejects non-zero temperatures and missing seeds).
+
+The two endpoints (`http://127.0.0.1:8080/v1` responder,
+`http://127.0.0.1:11434` judge) live on different ports on purpose: on a
+single 3090 the operator must physically stop one server and start the
+other between phases. The bench detects that they differ and prints the
+`notes.responderToJudgeHandoff` operator guidance. To run both roles on
+one Ollama daemon instead, point both `baseUrl` fields at it and the
+bench proceeds silently between phases.
+
+## Using a profile
+
+Resolution goes through `resolveBenchRuntimeProfile` (see
+`packages/bench/src/runtime-profiles.ts`); the resolver turns each role
+into a `ProviderConfig` with `temperature` and `seed` forwarded verbatim.
+The sequential phase scheduler (`runSequentialPhases`) executes
+preflight → hand-off → execute for each phase. Neither layer manages
+model processes — that is the operator's responsibility.
+
+```ts
+import {
+  loadLocalLabManifest,
+  resolveLocalLabProfile,
+  runSequentialPhases,
+} from "@remnic/bench/local-lab";
+
+const manifest = await loadLocalLabManifest("packages/bench/profiles/local-lab-3090.json");
+const profile = resolveLocalLabProfile(manifest);
+// profile.responder.providerConfig.temperature === 0
+// profile.responder.providerConfig.seed === 1573
+```

--- a/packages/bench/profiles/README.md
+++ b/packages/bench/profiles/README.md
@@ -100,7 +100,7 @@ import {
   loadLocalLabManifest,
   resolveLocalLabProfile,
   runSequentialPhases,
-} from "@remnic/bench/local-lab";
+} from "@remnic/bench";
 
 const manifest = await loadLocalLabManifest("packages/bench/profiles/local-lab-3090.json");
 const profile = resolveLocalLabProfile(manifest);

--- a/packages/bench/profiles/local-lab-3090.json
+++ b/packages/bench/profiles/local-lab-3090.json
@@ -1,8 +1,8 @@
 {
   "profile": "local-lab",
   "responder": {
-    "provider": "openai-compatible",
-    "baseUrl": "http://127.0.0.1:8080/v1",
+    "provider": "ollama",
+    "baseUrl": "http://127.0.0.1:11434",
     "model": "PLACEHOLDER-RESPONDER-MODEL",
     "quantization": "Q4_K_M",
     "ctx": 16384,
@@ -19,8 +19,8 @@
     "seed": 1573
   },
   "embedding": {
-    "provider": "openai-compatible",
-    "baseUrl": "http://127.0.0.1:8081/v1",
+    "provider": "ollama",
+    "baseUrl": "http://127.0.0.1:11434",
     "model": "PLACEHOLDER-EMBEDDING-MODEL",
     "ctx": 8192,
     "temperature": 0,
@@ -28,7 +28,7 @@
   },
   "phases": "sequential",
   "notes": {
-    "responderToJudgeHandoff": "Stop the responder server, then `ollama serve` and `ollama run PLACEHOLDER-JUDGE-MODEL` on the judge port. Resume the bench once `GET http://127.0.0.1:11434/api/tags` lists the judge model.",
+    "responderToJudgeHandoff": "Both responder and judge models run on the same Ollama instance (hot-swap). Ensure `ollama pull` has both PLACEHOLDER-RESPONDER-MODEL and PLACEHOLDER-JUDGE-MODEL before starting the bench.",
     "hardware": {
       "gpu": "NVIDIA RTX 3090",
       "vramGb": 24,

--- a/packages/bench/profiles/local-lab-3090.json
+++ b/packages/bench/profiles/local-lab-3090.json
@@ -1,0 +1,39 @@
+{
+  "profile": "local-lab",
+  "responder": {
+    "provider": "openai-compatible",
+    "baseUrl": "http://127.0.0.1:8080/v1",
+    "model": "PLACEHOLDER-RESPONDER-MODEL",
+    "quantization": "Q4_K_M",
+    "ctx": 16384,
+    "temperature": 0,
+    "seed": 1573
+  },
+  "judge": {
+    "provider": "ollama",
+    "baseUrl": "http://127.0.0.1:11434",
+    "model": "PLACEHOLDER-JUDGE-MODEL",
+    "quantization": "Q4_K_M",
+    "ctx": 16384,
+    "temperature": 0,
+    "seed": 1573
+  },
+  "embedding": {
+    "provider": "openai-compatible",
+    "baseUrl": "http://127.0.0.1:8081/v1",
+    "model": "PLACEHOLDER-EMBEDDING-MODEL",
+    "ctx": 8192,
+    "temperature": 0,
+    "seed": 1573
+  },
+  "phases": "sequential",
+  "notes": {
+    "responderToJudgeHandoff": "Stop the responder server, then `ollama serve` and `ollama run PLACEHOLDER-JUDGE-MODEL` on the judge port. Resume the bench once `GET http://127.0.0.1:11434/api/tags` lists the judge model.",
+    "hardware": {
+      "gpu": "NVIDIA RTX 3090",
+      "vramGb": 24,
+      "ramGb": 256,
+      "ampereBf16Ok": true
+    }
+  }
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -218,6 +218,40 @@ export type {
   ResolvedBenchRuntimeProfile,
 } from "./runtime-profiles.js";
 export { resolveBenchRuntimeProfile } from "./runtime-profiles.js";
+
+export {
+  LOCAL_LAB_PROVIDER_KINDS,
+  loadLocalLabManifest,
+  parseLocalLabManifest,
+  preflightLocalLabRole,
+  resolveLocalLabProfile,
+  resolveLocalLabRole,
+  runSequentialPhases,
+  formatHandoffNote,
+  discoveryEndpointFor,
+  LocalLabPreflightError,
+} from "./local-lab/index.js";
+export type {
+  LocalLabManifest,
+  LocalLabManifestNotes,
+  LocalLabPhase,
+  LocalLabPhaseDescriptor,
+  LocalLabPhaseExecute,
+  LocalLabPhaseName,
+  LocalLabPhaseOutcome,
+  LocalLabPreflightFailure,
+  LocalLabPreflightInput,
+  LocalLabPreflightOptions,
+  LocalLabPreflightResult,
+  LocalLabPreflightSuccess,
+  LocalLabProviderKind,
+  LocalLabRoleConfig,
+  PreflightDiscoveredModel,
+  ResolvedLocalLabProfile,
+  ResolvedLocalLabRole,
+  RunSequentialPhasesOptions,
+  SequentialPhaseHooks,
+} from "./local-lab/index.js";
 export {
   buildBenchmarkRunSeeds,
   orchestrateBenchmarkRuns,

--- a/packages/bench/src/local-lab/index.ts
+++ b/packages/bench/src/local-lab/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Local-lab runtime profile public surface (issue #1573 PR2).
+ *
+ * Re-exports the manifest parser, profile resolver, preflight, and
+ * sequential phase scheduler so callers (the bench runtime, tests, the
+ * eventual `remnic bench run --profile local-lab-*` CLI wiring) reach them
+ * through one entrypoint.
+ */
+
+export {
+  LOCAL_LAB_PROVIDER_KINDS,
+  loadLocalLabManifest,
+  parseLocalLabManifest,
+} from "./manifest.js";
+export type {
+  LocalLabManifest,
+  LocalLabManifestNotes,
+  LocalLabProviderKind,
+  LocalLabRoleConfig,
+} from "./manifest.js";
+
+export {
+  resolveLocalLabProfile,
+  resolveLocalLabRole,
+} from "./resolve-local-lab-profile.js";
+export type {
+  ResolvedLocalLabProfile,
+  ResolvedLocalLabRole,
+} from "./resolve-local-lab-profile.js";
+
+export {
+  discoveryEndpointFor,
+  modelMismatchReason,
+  preflightLocalLabRole,
+} from "./preflight.js";
+export type {
+  LocalLabPreflightFailure,
+  LocalLabPreflightInput,
+  LocalLabPreflightOptions,
+  LocalLabPreflightResult,
+  LocalLabPreflightSuccess,
+  PreflightDiscoveredModel,
+} from "./preflight.js";
+
+export {
+  formatHandoffNote,
+  runSequentialPhases,
+  LocalLabPreflightError,
+} from "./sequential-phases.js";
+export type {
+  LocalLabPhase,
+  LocalLabPhaseDescriptor,
+  LocalLabPhaseExecute,
+  LocalLabPhaseName,
+  LocalLabPhaseOutcome,
+  RunSequentialPhasesOptions,
+  SequentialPhaseHooks,
+} from "./sequential-phases.js";

--- a/packages/bench/src/local-lab/manifest.test.ts
+++ b/packages/bench/src/local-lab/manifest.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LOCAL_LAB_PROVIDER_KINDS,
+  parseLocalLabManifest,
+  type LocalLabManifest,
+} from "./manifest.ts";
+
+function validManifest(): LocalLabManifest {
+  return {
+    profile: "local-lab",
+    responder: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      model: "qwen3:14b",
+      quantization: "Q4_K_M",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    judge: {
+      provider: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      model: "gemma3:27b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    phases: "sequential",
+  };
+}
+
+test("parseLocalLabManifest accepts a well-formed manifest with optional fields elided", () => {
+  const parsed = parseLocalLabManifest(validManifest());
+  assert.equal(parsed.profile, "local-lab");
+  assert.equal(parsed.phases, "sequential");
+  assert.equal(parsed.responder.provider, "openai-compatible");
+  assert.equal(parsed.responder.temperature, 0);
+  assert.equal(parsed.responder.seed, 1573);
+  assert.equal(parsed.judge.provider, "ollama");
+  assert.equal(parsed.embedding, undefined);
+});
+
+test("parseLocalLabManifest preserves optional quantization + embedding + notes", () => {
+  const manifest = validManifest();
+  manifest.embedding = {
+    provider: "openai-compatible",
+    baseUrl: "http://127.0.0.1:8081/v1",
+    model: "bge-m3",
+    ctx: 8192,
+    temperature: 0,
+    seed: 1573,
+  };
+  manifest.notes = {
+    responderToJudgeHandoff: "stop responder, then `ollama serve`",
+    hardware: { gpu: "RTX 3090" },
+  };
+  const parsed = parseLocalLabManifest(manifest);
+  assert.equal(parsed.embedding?.model, "bge-m3");
+  assert.equal(parsed.notes?.responderToJudgeHandoff, "stop responder, then `ollama serve`");
+  assert.deepEqual(parsed.notes?.hardware, { gpu: "RTX 3090" });
+});
+
+test("parseLocalLabManifest rejects an unknown provider and lists the valid ones (rule 51)", () => {
+  const manifest = validManifest();
+  // Deliberately invalid kind — must be rejected, never silently coerced.
+  manifest.responder.provider = "vllm" as never;
+  assert.throws(
+    () => parseLocalLabManifest(manifest),
+    (err: unknown) => {
+      assert.ok(err instanceof Error, "expected an Error");
+      const msg = err.message;
+      // Rule 51: error must enumerate the valid kinds.
+      for (const kind of LOCAL_LAB_PROVIDER_KINDS) {
+        assert.ok(msg.includes(kind), `error must list "${kind}"\n-- message was:\n${msg}`);
+      }
+      assert.ok(/responder\.provider/.test(msg), `error must name the offending field\n-- message was:\n${msg}`);
+      assert.ok(/"vllm"/.test(msg), `error must echo the rejected value\n-- message was:\n${msg}`);
+      return true;
+    },
+  );
+});
+
+test("parseLocalLabManifest rejects judge provider not in the valid kinds even if responder is fine", () => {
+  const manifest = validManifest();
+  manifest.judge.provider = "openai" as never;
+  assert.throws(
+    () => parseLocalLabManifest(manifest),
+    /judge\.provider must be one of \[openai-compatible, ollama\]; received "openai"/,
+  );
+});
+
+test("parseLocalLabManifest rejects non-zero temperature (rule 39: no silent coercion)", () => {
+  for (const bad of [0.0, "0", null, undefined, 1, -0.5, Number.NaN]) {
+    const manifest = validManifest();
+    // The literal `0.0` is `=== 0`, so skip it as a valid case.
+    if (bad === 0) continue;
+    (manifest.responder as { temperature: unknown }).temperature = bad;
+    assert.throws(
+      () => parseLocalLabManifest(manifest),
+      /responder\.temperature must be the number 0/,
+      `expected rejection for temperature=${JSON.stringify(bad)}`,
+    );
+  }
+});
+
+test("parseLocalLabManifest rejects missing seed, non-integer ctx, empty model, empty baseUrl", () => {
+  const cases: Array<{ name: string; mutate: (m: LocalLabManifest) => void; pattern: RegExp }> = [
+    {
+      name: "missing seed",
+      mutate: (m) => {
+        delete (m.responder as { seed?: number }).seed;
+      },
+      pattern: /responder\.seed must be an integer; received undefined/,
+    },
+    {
+      name: "non-integer ctx",
+      mutate: (m) => {
+        m.responder.ctx = 1.5 as never;
+      },
+      pattern: /responder\.ctx must be a positive integer; received 1\.5/,
+    },
+    {
+      name: "zero ctx",
+      mutate: (m) => {
+        m.responder.ctx = 0;
+      },
+      pattern: /responder\.ctx must be a positive integer; received 0/,
+    },
+    {
+      name: "empty model",
+      mutate: (m) => {
+        m.responder.model = "   ";
+      },
+      pattern: /responder\.model must be a non-empty string; received "   "/,
+    },
+    {
+      name: "empty baseUrl",
+      mutate: (m) => {
+        m.judge.baseUrl = "";
+      },
+      pattern: /judge\.baseUrl must be a non-empty string; received ""/,
+    },
+  ];
+  for (const c of cases) {
+    const manifest = validManifest();
+    c.mutate(manifest);
+    assert.throws(() => parseLocalLabManifest(manifest), c.pattern, c.name);
+  }
+});
+
+test("parseLocalLabManifest rejects wrong profile discriminator and non-sequential phases", () => {
+  const wrongProfile = validManifest() as unknown as { profile: string };
+  wrongProfile.profile = "baseline";
+  assert.throws(
+    () => parseLocalLabManifest(wrongProfile),
+    /profile === "local-lab"; received "baseline"/,
+  );
+
+  const wrongPhases = validManifest() as unknown as { phases: string };
+  wrongPhases.phases = "parallel";
+  assert.throws(
+    () => parseLocalLabManifest(wrongPhases),
+    /phases must be "sequential" in PR2; received "parallel"/,
+  );
+});
+
+test("parseLocalLabManifest rejects non-object root (rule 18: object-not-null)", () => {
+  for (const bad of [null, [], "local-lab", 42, true]) {
+    assert.throws(
+      () => parseLocalLabManifest(bad),
+      /local-lab manifest must be a JSON object/,
+      `expected rejection for ${JSON.stringify(bad)}`,
+    );
+  }
+});

--- a/packages/bench/src/local-lab/manifest.test.ts
+++ b/packages/bench/src/local-lab/manifest.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { writeFile, rm } from "node:fs/promises";
 import test from "node:test";
 
 import {
   LOCAL_LAB_PROVIDER_KINDS,
+  loadLocalLabManifest,
   parseLocalLabManifest,
   type LocalLabManifest,
 } from "./manifest.ts";
@@ -173,5 +175,41 @@ test("parseLocalLabManifest rejects non-object root (rule 18: object-not-null)",
       /local-lab manifest must be a JSON object/,
       `expected rejection for ${JSON.stringify(bad)}`,
     );
+  }
+});
+
+test("loadLocalLabManifest read failure reports errno code, not raw error path diagnostics (cursor review: #1573 PR2)", async () => {
+  // Node readFile errors embed the absolute path + system diagnostics in
+  // error.message. The thrown error must use the stable errno code instead.
+  const missingPath = "/tmp/remnic-local-lab-manifest-nonexistent-" + Date.now() + ".json";
+  await assert.rejects(
+    () => loadLocalLabManifest(missingPath),
+    (error: Error) => {
+      assert.match(error.message, /could not be read \(ENOENT\)/);
+      // The absolute path appears once (as filePath) but must NOT be doubled
+      // by a raw Node message like "open '/tmp/...'".
+      const occurrences = error.message.split(missingPath).length - 1;
+      assert.equal(occurrences, 1, "filePath should appear exactly once, not echoed from raw error");
+      return true;
+    },
+  );
+});
+
+test("loadLocalLabManifest invalid JSON reports parse detail without path leakage", async () => {
+  const tmpPath = "/tmp/remnic-local-lab-manifest-badjson-" + Date.now() + ".json";
+  await writeFile(tmpPath, "{ not valid json }", "utf8");
+  try {
+    await assert.rejects(
+      () => loadLocalLabManifest(tmpPath),
+      (error: Error) => {
+        assert.match(error.message, /contains invalid JSON/);
+        // JSON.parse errors carry position info but not file-system paths,
+        // so the detail is safe to surface.
+        assert.match(error.message, /position \d+/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmpPath, { force: true });
   }
 });

--- a/packages/bench/src/local-lab/manifest.ts
+++ b/packages/bench/src/local-lab/manifest.ts
@@ -1,0 +1,263 @@
+/**
+ * Local-lab runtime profile manifest (issue #1573 PR2).
+ *
+ * A `local-lab` profile is a JSON manifest — never hardcoded model strings
+ * (rule 30/55) — that pins a single-locale bench run (responder, judge,
+ * optional embedding) to operator-hosted models. It is resolved by
+ * `resolveBenchRuntimeProfile` to drive sequential phase scheduling and
+ * endpoint preflight (see `preflight.ts` and `sequential-phases.ts`).
+ *
+ * Field contract:
+ *
+ *   - `provider` is one of `LOCAL_LAB_PROVIDER_KINDS` ("openai-compatible"
+ *     for llama.cpp / vLLM / LM Studio; "ollama" for native Ollama). Any
+ *     other value is REJECTED with the valid kinds listed (rule 51 — never
+ *     silently fall through to a default).
+ *   - `temperature` is pinned to 0 and `seed` is required so local-lab
+ *     runs are reproducible.
+ *   - `ctx` is the manifest-declared serving context (tokens). Preflight
+ *     verifies the live endpoint reports at least this much.
+ *
+ * The manifest is content (no command strings interpolated into shells;
+ * rule 10) — `baseUrl`/`model` are only ever fetch targets.
+ */
+
+import { readFile } from "node:fs/promises";
+
+/**
+ * Provider kinds accepted by a local-lab manifest role.
+ *
+ * `"openai-compatible"` maps to the OpenAI-compatible transport
+ * (`/v1/chat/completions` + `/v1/models`) used by llama.cpp, vLLM, LM
+ * Studio, etc. `"ollama"` maps to Ollama's native transport
+ * (`/api/generate` + `/api/tags`).
+ */
+export const LOCAL_LAB_PROVIDER_KINDS = [
+  "openai-compatible",
+  "ollama",
+] as const;
+export type LocalLabProviderKind = (typeof LOCAL_LAB_PROVIDER_KINDS)[number];
+
+export interface LocalLabRoleConfig {
+  provider: LocalLabProviderKind;
+  /** Base URL of the operator-hosted endpoint (e.g. `http://localhost:1234/v1`). */
+  baseUrl: string;
+  /** Exact model id the endpoint reports (no aliases, no shell interpolation). */
+  model: string;
+  /** Optional quantization label (informational; recorded in artifacts). */
+  quantization?: string;
+  /** Manifest-declared serving context length in tokens. */
+  ctx: number;
+  /** Sampling temperature. Local-lab pins this to 0 for reproducibility. */
+  temperature: 0;
+  /** Sampling seed; required so reruns reproduce the same draws. */
+  seed: number;
+}
+
+export interface LocalLabManifestNotes {
+  /**
+   * Free-form operator guidance printed between responder and judge phases
+   * when the two roles live on different endpoints. When both roles share
+   * an endpoint the runner skips the hand-off (see sequential-phases.ts).
+   */
+  responderToJudgeHandoff?: string;
+  [key: string]: unknown;
+}
+
+export interface LocalLabManifest {
+  /** Manifest discriminator; always the literal `"local-lab"`. */
+  profile: "local-lab";
+  responder: LocalLabRoleConfig;
+  judge: LocalLabRoleConfig;
+  embedding?: LocalLabRoleConfig;
+  /** Phase scheduling mode. PR2 ships `"sequential"` only. */
+  phases: "sequential";
+  notes?: LocalLabManifestNotes;
+}
+
+/**
+ * Parse and validate a local-lab manifest from an unknown parsed JSON value.
+ * Throws a rule-51-shaped error (lists valid kinds) on any violation.
+ */
+export function parseLocalLabManifest(raw: unknown): LocalLabManifest {
+  if (!isPlainObject(raw)) {
+    throw new Error(
+      "local-lab manifest must be a JSON object (rule 18: parsed JSON must be object-not-null)",
+    );
+  }
+
+  if (raw.profile !== "local-lab") {
+    throw new Error(
+      `local-lab manifest requires profile === "local-lab"; received ${describeValue(raw.profile)}`,
+    );
+  }
+
+  if (raw.phases !== "sequential") {
+    throw new Error(
+      `local-lab manifest phases must be "sequential" in PR2; received ${describeValue(raw.phases)}`,
+    );
+  }
+
+  const responder = parseRole(raw.responder, "responder");
+  const judge = parseRole(raw.judge, "judge");
+  const embedding =
+    raw.embedding === undefined ? undefined : parseRole(raw.embedding, "embedding");
+
+  const notes =
+    raw.notes === undefined ? undefined : parseNotes(raw.notes, "notes");
+
+  return {
+    profile: "local-lab",
+    responder,
+    judge,
+    ...(embedding ? { embedding } : {}),
+    phases: "sequential",
+    ...(notes ? { notes } : {}),
+  };
+}
+
+/**
+ * Read and parse a local-lab manifest from disk. The path is opened read-only;
+ * nothing in the manifest is ever interpolated into a shell (rule 10).
+ */
+export async function loadLocalLabManifest(
+  filePath: string,
+): Promise<LocalLabManifest> {
+  let text: string;
+  try {
+    text = await readFile(filePath, "utf8");
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`local-lab manifest at ${filePath} could not be read: ${detail}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`local-lab manifest at ${filePath} contains invalid JSON: ${detail}`);
+  }
+
+  return parseLocalLabManifest(parsed);
+}
+
+function parseRole(value: unknown, label: string): LocalLabRoleConfig {
+  if (!isPlainObject(value)) {
+    throw new Error(
+      `local-lab manifest ${label} must be an object; received ${describeValue(value)}`,
+    );
+  }
+
+  const provider = parseProviderKind(value.provider, label);
+  const baseUrl = parseNonEmptyString(value.baseUrl, label, "baseUrl");
+  const model = parseNonEmptyString(value.model, label, "model");
+  const ctx = parsePositiveInteger(value.ctx, label, "ctx");
+  const seed = parseInteger(value.seed, label, "seed");
+
+  // `temperature` must be exactly the number 0 — local-lab reproducibility
+  // contract. Anything else (string "0", null, missing, non-zero) is rejected
+  // rather than silently coerced (rule 39).
+  if (value.temperature !== 0) {
+    throw new Error(
+      `local-lab manifest ${label}.temperature must be the number 0; received ${describeValue(value.temperature)}`,
+    );
+  }
+
+  const quantization =
+    value.quantization === undefined
+      ? undefined
+      : parseNonEmptyString(value.quantization, label, "quantization");
+
+  return {
+    provider,
+    baseUrl,
+    model,
+    ctx,
+    temperature: 0,
+    seed,
+    ...(quantization ? { quantization } : {}),
+  };
+}
+
+function parseProviderKind(value: unknown, label: string): LocalLabProviderKind {
+  for (const kind of LOCAL_LAB_PROVIDER_KINDS) {
+    if (value === kind) {
+      return kind;
+    }
+  }
+  // Rule 51: reject invalid enum values with the valid options listed.
+  throw new Error(
+    `local-lab manifest ${label}.provider must be one of [${LOCAL_LAB_PROVIDER_KINDS.join(
+      ", ",
+    )}]; received ${describeValue(value)}`,
+  );
+}
+
+function parseNonEmptyString(
+  value: unknown,
+  label: string,
+  field: string,
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(
+      `local-lab manifest ${label}.${field} must be a non-empty string; received ${describeValue(value)}`,
+    );
+  }
+  return value.trim();
+}
+
+function parsePositiveInteger(value: unknown, label: string, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `local-lab manifest ${label}.${field} must be a positive integer; received ${describeValue(value)}`,
+    );
+  }
+  return value;
+}
+
+function parseInteger(value: unknown, label: string, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(
+      `local-lab manifest ${label}.${field} must be an integer; received ${describeValue(value)}`,
+    );
+  }
+  return value;
+}
+
+function parseNotes(value: unknown, label: string): LocalLabManifestNotes {
+  if (!isPlainObject(value)) {
+    throw new Error(
+      `local-lab manifest ${label} must be an object; received ${describeValue(value)}`,
+    );
+  }
+  const notes: LocalLabManifestNotes = {};
+  for (const [key, entry] of Object.entries(value)) {
+    notes[key] = entry;
+  }
+  return notes;
+}
+
+function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/bench/src/local-lab/manifest.ts
+++ b/packages/bench/src/local-lab/manifest.ts
@@ -127,14 +127,18 @@ export async function loadLocalLabManifest(
   try {
     text = await readFile(filePath, "utf8");
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`local-lab manifest at ${filePath} could not be read: ${detail}`);
+    // Do not echo raw error.message — Node read errors embed the absolute
+    // path and system diagnostics. Use the errno code (ENOENT, EACCES, …)
+    // which is stable and free of path leakage (cursor review, #1573 PR2).
+    const code = (error as NodeJS.ErrnoException)?.code ?? "EUNKNOWN";
+    throw new Error(`local-lab manifest at ${filePath} could not be read (${code})`);
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
   } catch (error) {
+    // JSON.parse errors carry a position hint but no file-system paths.
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`local-lab manifest at ${filePath} contains invalid JSON: ${detail}`);
   }

--- a/packages/bench/src/local-lab/preflight.test.ts
+++ b/packages/bench/src/local-lab/preflight.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  discoveryEndpointFor,
+  modelMismatchReason,
+  preflightLocalLabRole,
+  type LocalLabPreflightInput,
+} from "./preflight.ts";
+
+/**
+ * Stub fetch that responds with a fixed body + status. Captures the request
+ * URL so tests can assert the discovery endpoint shape. Production talks to
+ * the same `fetch` contract, so this stub matches the production signature
+ * (rule 33 — no mock-only surface).
+ */
+function stubFetch(
+  body: unknown,
+  status = 200,
+): { fetchImpl: typeof fetch; requests: URL[] } {
+  const requests: URL[] = [];
+  const fetchImpl: typeof fetch = async (input, _init) => {
+    requests.push(new URL(typeof input === "string" ? input : input.toString()));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return { fetchImpl, requests };
+}
+
+function failingFetch(error: Error): typeof fetch {
+  return async () => {
+    throw error;
+  };
+}
+
+const responderInput: LocalLabPreflightInput = {
+  provider: "openai-compatible",
+  baseUrl: "http://127.0.0.1:8080/v1",
+  model: "qwen3:14b",
+  ctx: 16384,
+};
+
+test("discoveryEndpointFor appends /v1/models for openai-compatible baseUrl without /v1", () => {
+  assert.equal(
+    discoveryEndpointFor("openai-compatible", "http://localhost:8080"),
+    "http://localhost:8080/v1/models",
+  );
+  assert.equal(
+    discoveryEndpointFor("openai-compatible", "http://localhost:8080/v1"),
+    "http://localhost:8080/v1/models",
+  );
+  // Tolerates a trailing slash on either form.
+  assert.equal(
+    discoveryEndpointFor("openai-compatible", "http://localhost:8080/v1/"),
+    "http://localhost:8080/v1/models",
+  );
+});
+
+test("discoveryEndpointFor appends /api/tags for ollama baseUrl without /api", () => {
+  assert.equal(
+    discoveryEndpointFor("ollama", "http://localhost:11434"),
+    "http://localhost:11434/api/tags",
+  );
+  assert.equal(
+    discoveryEndpointFor("ollama", "http://localhost:11434/api"),
+    "http://localhost:11434/api/tags",
+  );
+});
+
+test("preflight succeeds when the endpoint reports the manifest model id", async () => {
+  const { fetchImpl, requests } = stubFetch({
+    data: [
+      { id: "qwen3:14b", context_length: 32768 },
+      { id: "llama3:70b" },
+    ],
+  });
+  const result = await preflightLocalLabRole(responderInput, {
+    fetchImpl,
+    timeoutMs: 1000,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.endpoint, "http://127.0.0.1:8080/v1/models");
+    assert.equal(result.expectedModel, "qwen3:14b");
+    assert.equal(result.matchedContextLength, 32768);
+    assert.equal(result.foundModels.length, 2);
+  }
+  assert.equal(requests.length, 1, "preflight must issue exactly one GET");
+  assert.equal(requests[0].pathname, "/v1/models");
+});
+
+test("preflight failure surfaces the endpoint's ACTUAL model list (rule 51)", async () => {
+  const { fetchImpl } = stubFetch({
+    data: [{ id: "phi4:14b" }, { id: "llama3:8b" }, { id: "gemma3:27b" }],
+  });
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    // The found model list MUST be present so the operator sees the mismatch.
+    assert.equal(result.foundModels.length, 3);
+    assert.deepEqual(
+      result.foundModels.map((m) => m.id),
+      ["phi4:14b", "llama3:8b", "gemma3:27b"],
+    );
+    // The reason text MUST enumerate the found models.
+    assert.match(result.reason, /did not report the manifest model qwen3:14b/);
+    assert.match(result.reason, /phi4:14b/);
+    assert.match(result.reason, /llama3:8b/);
+    assert.match(result.reason, /gemma3:27b/);
+    // The expected model is also a top-level field on the failure object.
+    assert.equal(result.expectedModel, "qwen3:14b");
+  }
+});
+
+test("preflight truncates a large found-models list in the reason but keeps the full list in foundModels", async () => {
+  const ids = Array.from({ length: 25 }, (_, i) => ({ id: `model-${i}` }));
+  const { fetchImpl } = stubFetch({ data: ids });
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.foundModels.length, 25, "foundModels keeps the full list");
+    assert.match(result.reason, /\u2026/, "reason truncates with a \u2026 ellipsis");
+  }
+});
+
+test("preflight reports an empty-found-list reason when endpoint returns no models", async () => {
+  const { fetchImpl } = stubFetch({ data: [] });
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.foundModels.length, 0);
+    assert.match(result.reason, /endpoint reported no models/);
+  }
+});
+
+test("preflight fails when matched context length is below the manifest ctx", async () => {
+  const { fetchImpl } = stubFetch({
+    data: [{ id: "qwen3:14b", context_length: 8192 }],
+  });
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(
+      result.reason,
+      /reports context length 8192 tokens which is below the manifest ctx 16384/,
+    );
+    assert.equal(result.matchedContextLength, 8192);
+  }
+});
+
+test("preflight treats missing context_length as a pass (not all endpoints report it)", async () => {
+  const { fetchImpl } = stubFetch({
+    data: [{ id: "qwen3:14b" }],
+  });
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+  assert.equal(result.ok, true);
+});
+
+test("preflight surfaces a transport failure as a preflight result (not a thrown error)", async () => {
+  const result = await preflightLocalLabRole(responderInput, {
+    fetchImpl: failingFetch(new Error("ECONNREFUSED")),
+    timeoutMs: 1000,
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /ECONNREFUSED/);
+    assert.match(result.reason, /http:\/\/127\.0\.0\.1:8080\/v1\/models/);
+  }
+});
+
+test("preflight surfaces non-2xx HTTP responses with status + statusText", async () => {
+  const { fetchImpl } = stubFetch({ error: "bad auth" }, 401);
+  const result = await preflightLocalLabRole(responderInput, { fetchImpl });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.reason, /HTTP 401/);
+  }
+});
+
+test("preflight handles Ollama /api/tags shape ({ models: [{ name }] })", async () => {
+  const { fetchImpl, requests } = stubFetch({
+    models: [
+      { name: "gemma3:27b", details: { parameter_size: "27B" } },
+      { name: "qwen3:14b" },
+    ],
+  });
+  const result = await preflightLocalLabRole(
+    {
+      provider: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      model: "gemma3:27b",
+      ctx: 16384,
+    },
+    { fetchImpl },
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.endpoint, "http://127.0.0.1:11434/api/tags");
+    assert.equal(result.foundModels.length, 2);
+  }
+  assert.equal(requests[0].pathname, "/api/tags");
+});
+
+test("preflight never interpolates baseUrl/model into anything but a fetch URL (rule 10)", async () => {
+  // The stub captures the URL the preflight actually fetched; that URL must be
+  // composed via string concatenation against `baseUrl` only — there is no
+  // shell to leak into in this codepath at all.
+  const { fetchImpl, requests } = stubFetch({ data: [{ id: "qwen3:14b" }] });
+  await preflightLocalLabRole(responderInput, { fetchImpl });
+  assert.equal(
+    requests[0].toString(),
+    "http://127.0.0.1:8080/v1/models",
+    "preflight must hit the discovery endpoint only",
+  );
+});
+
+test("modelMismatchReason helper formats both empty and populated lists", () => {
+  assert.match(
+    modelMismatchReason("foo", []),
+    /endpoint reported no models; expected foo/,
+  );
+  assert.match(
+    modelMismatchReason("foo", [{ id: "bar" }, { id: "baz" }]),
+    /did not report the manifest model foo.*bar.*baz/,
+  );
+});

--- a/packages/bench/src/local-lab/preflight.ts
+++ b/packages/bench/src/local-lab/preflight.ts
@@ -87,13 +87,23 @@ export async function preflightLocalLabRole(
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS;
   const endpoint = discoveryEndpointFor(input.provider, input.baseUrl);
-  const ownsController = options.signal === undefined;
-  const controller = ownsController ? new AbortController() : undefined;
-  const signal = options.signal ?? controller?.signal;
-  const timer =
-    controller === undefined
-      ? undefined
-      : setTimeout(() => controller.abort(new Error("preflight timeout")), timeoutMs);
+  // Always create an internal controller with the timeout timer, even when a
+  // caller signal is supplied. Without this, a caller-provided signal
+  // disables the documented per-request timeout entirely (codex review, #1573 PR2).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("preflight timeout")), timeoutMs);
+  if (options.signal) {
+    if (options.signal.aborted) {
+      controller.abort(options.signal.reason);
+    } else {
+      options.signal.addEventListener(
+        "abort",
+        () => controller.abort(options.signal!.reason),
+        { once: true },
+      );
+    }
+  }
+  const signal = controller.signal;
 
   let response: Response;
   try {

--- a/packages/bench/src/local-lab/preflight.ts
+++ b/packages/bench/src/local-lab/preflight.ts
@@ -115,9 +115,10 @@ export async function preflightLocalLabRole(
       reason: `preflight request to ${endpoint} failed: ${detail}`,
     };
   }
-  if (timer) clearTimeout(timer);
+
 
   if (!response.ok) {
+    if (timer) clearTimeout(timer);
     return {
       ok: false,
       provider: input.provider,
@@ -134,6 +135,7 @@ export async function preflightLocalLabRole(
     parsed = await response.json();
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
+    if (timer) clearTimeout(timer);
     return {
       ok: false,
       provider: input.provider,
@@ -144,6 +146,7 @@ export async function preflightLocalLabRole(
       reason: `endpoint ${endpoint} returned non-JSON body: ${detail}`,
     };
   }
+  if (timer) clearTimeout(timer);
 
   const foundModels = extractDiscoveredModels(input.provider, parsed);
   const matched = foundModels.find((model) => model.id === input.model);

--- a/packages/bench/src/local-lab/preflight.ts
+++ b/packages/bench/src/local-lab/preflight.ts
@@ -1,0 +1,290 @@
+/**
+ * Local-lab endpoint preflight (issue #1573 PR2).
+ *
+ * Before each phase the runner verifies the operator-hosted endpoint is
+ * actually serving the model the manifest claims, with at least the
+ * manifest-declared context length. The harness never manages model
+ * processes — it asks the endpoint what's live and refuses to proceed
+ * ("hard error listing what was found vs expected", rule 51) on any
+ * mismatch. Silent fallback is explicitly forbidden.
+ *
+ * Discovery endpoints by provider kind:
+ *
+ *   - `"openai-compatible"` → `GET <baseUrl>/models` (or `/v1/models` when
+ *     the baseUrl does not already end in `/v1`). The body shape mirrors the
+ *     OpenAI `/v1/models` contract: `{ data: [{ id, context_length?, ... }] }`.
+ *   - `"ollama"` → `GET <baseUrl>/tags` (or `/api/tags`). The body shape
+ *     mirrors Ollama's `/api/tags` contract: `{ models: [{ name,
+ *     details?.parameter_size?, ... }] }`.
+ *
+ * `baseUrl` is composed into a fetch URL only — never a shell string
+ * (rule 10). Failures carry the endpoint's actual reported model list so an
+ * operator can immediately see why their manifest doesn't match.
+ */
+
+import type { LocalLabProviderKind } from "./manifest.js";
+
+/** Minimal shape the preflight reader needs from a discovered model entry. */
+export interface PreflightDiscoveredModel {
+  id: string;
+  contextLength?: number;
+}
+
+export interface LocalLabPreflightInput {
+  provider: LocalLabProviderKind;
+  baseUrl: string;
+  /** Exact model id the endpoint is expected to report. */
+  model: string;
+  /** Manifest-declared serving context length; the live endpoint must meet or exceed it. */
+  ctx: number;
+}
+
+export interface LocalLabPreflightSuccess {
+  ok: true;
+  provider: LocalLabProviderKind;
+  endpoint: string;
+  expectedModel: string;
+  foundModels: PreflightDiscoveredModel[];
+  /** Resolved context length for the matched model, when the endpoint reports one. */
+  matchedContextLength?: number;
+}
+
+export interface LocalLabPreflightFailure {
+  ok: false;
+  provider: LocalLabProviderKind;
+  endpoint: string;
+  expectedModel: string;
+  foundModels: PreflightDiscoveredModel[];
+  expectedCtx: number;
+  matchedContextLength?: number;
+  reason: string;
+}
+
+export type LocalLabPreflightResult =
+  | LocalLabPreflightSuccess
+  | LocalLabPreflightFailure;
+
+export interface LocalLabPreflightOptions {
+  signal?: AbortSignal;
+  /** Per-request timeout. Defaults to 5 s — preflight should be fast. */
+  timeoutMs?: number;
+  /** Inject a fetch implementation (tests). Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_PREFLIGHT_TIMEOUT_MS = 5_000;
+
+/**
+ * Preflight a single manifest role. Resolves to a result object — never
+ * throws for endpoint/discovery failures (those are preflight failures, not
+ * runtime errors). Throws only on truly exceptional conditions (invalid
+ * baseUrl shape, fetchImpl contract violation).
+ */
+export async function preflightLocalLabRole(
+  input: LocalLabPreflightInput,
+  options: LocalLabPreflightOptions = {},
+): Promise<LocalLabPreflightResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PREFLIGHT_TIMEOUT_MS;
+  const endpoint = discoveryEndpointFor(input.provider, input.baseUrl);
+  const ownsController = options.signal === undefined;
+  const controller = ownsController ? new AbortController() : undefined;
+  const signal = options.signal ?? controller?.signal;
+  const timer =
+    controller === undefined
+      ? undefined
+      : setTimeout(() => controller.abort(new Error("preflight timeout")), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(endpoint, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      ...(signal ? { signal } : {}),
+    });
+  } catch (error) {
+    if (timer) clearTimeout(timer);
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      provider: input.provider,
+      endpoint,
+      expectedModel: input.model,
+      foundModels: [],
+      expectedCtx: input.ctx,
+      reason: `preflight request to ${endpoint} failed: ${detail}`,
+    };
+  }
+  if (timer) clearTimeout(timer);
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      provider: input.provider,
+      endpoint,
+      expectedModel: input.model,
+      foundModels: [],
+      expectedCtx: input.ctx,
+      reason: `endpoint ${endpoint} returned HTTP ${response.status} ${response.statusText}`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      provider: input.provider,
+      endpoint,
+      expectedModel: input.model,
+      foundModels: [],
+      expectedCtx: input.ctx,
+      reason: `endpoint ${endpoint} returned non-JSON body: ${detail}`,
+    };
+  }
+
+  const foundModels = extractDiscoveredModels(input.provider, parsed);
+  const matched = foundModels.find((model) => model.id === input.model);
+  if (matched === undefined) {
+    return {
+      ok: false,
+      provider: input.provider,
+      endpoint,
+      expectedModel: input.model,
+      foundModels,
+      expectedCtx: input.ctx,
+      reason: modelMismatchReason(input.model, foundModels),
+    };
+  }
+
+  if (
+    matched.contextLength !== undefined &&
+    matched.contextLength < input.ctx
+  ) {
+    return {
+      ok: false,
+      provider: input.provider,
+      endpoint,
+      expectedModel: input.model,
+      foundModels,
+      expectedCtx: input.ctx,
+      matchedContextLength: matched.contextLength,
+      reason:
+        `model ${input.model} reports context length ${matched.contextLength} tokens ` +
+        `which is below the manifest ctx ${input.ctx}`,
+    };
+  }
+
+  return {
+    ok: true,
+    provider: input.provider,
+    endpoint,
+    expectedModel: input.model,
+    foundModels,
+    ...(matched.contextLength !== undefined
+      ? { matchedContextLength: matched.contextLength }
+      : {}),
+  };
+}
+
+/**
+ * Compose the discovery URL for a provider kind + baseUrl. Never
+ * interpolates into a shell — only into a fetch URL. Tolerant of trailing
+ * slashes and the common `/v1` (OpenAI-compatible) / `/api` (Ollama)
+ * suffixes already being present.
+ */
+export function discoveryEndpointFor(
+  provider: LocalLabProviderKind,
+  baseUrl: string,
+): string {
+  const trimmed = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  if (provider === "openai-compatible") {
+    if (/\/v1$/i.test(trimmed)) {
+      return `${trimmed}/models`;
+    }
+    return `${trimmed}/v1/models`;
+  }
+  if (provider === "ollama") {
+    if (/\/api$/i.test(trimmed)) {
+      return `${trimmed}/tags`;
+    }
+    return `${trimmed}/api/tags`;
+  }
+  const exhaustive: never = provider;
+  throw new Error(`local-lab preflight provider kind unsupported: ${exhaustive}`);
+}
+
+/**
+ * Format a model-mismatch reason that surfaces the found list to the
+ * operator (rule 51). Does not echo the manifest's expected id back as a
+ * confusing prefix — the result object already carries `expectedModel`.
+ */
+export function modelMismatchReason(
+  expectedModel: string,
+  foundModels: PreflightDiscoveredModel[],
+): string {
+  if (foundModels.length === 0) {
+    return `endpoint reported no models; expected ${expectedModel}`;
+  }
+  const foundIds = foundModels.map((model) => model.id);
+  const truncated = foundIds.slice(0, 20);
+  const ellipsis = foundIds.length > truncated.length ? "…" : "";
+  return (
+    `endpoint did not report the manifest model ${expectedModel}; ` +
+    `found [${truncated.join(", ")}${ellipsis}]`
+  );
+}
+
+function extractDiscoveredModels(
+  provider: LocalLabProviderKind,
+  parsed: unknown,
+): PreflightDiscoveredModel[] {
+  if (!isPlainObject(parsed)) {
+    return [];
+  }
+  if (provider === "openai-compatible") {
+    return extractOpenAiModels(parsed.data);
+  }
+  if (provider === "ollama") {
+    return extractOllamaModels(parsed.models);
+  }
+  const exhaustive: never = provider;
+  throw new Error(`local-lab preflight provider kind unsupported: ${exhaustive}`);
+}
+
+function extractOpenAiModels(data: unknown): PreflightDiscoveredModel[] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  const models: PreflightDiscoveredModel[] = [];
+  for (const entry of data) {
+    if (!isPlainObject(entry)) continue;
+    if (typeof entry.id !== "string") continue;
+    models.push({
+      id: entry.id,
+      ...(typeof entry.context_length === "number"
+        ? { contextLength: entry.context_length }
+        : {}),
+    });
+  }
+  return models;
+}
+
+function extractOllamaModels(models: unknown): PreflightDiscoveredModel[] {
+  if (!Array.isArray(models)) {
+    return [];
+  }
+  const out: PreflightDiscoveredModel[] = [];
+  for (const entry of models) {
+    if (!isPlainObject(entry)) continue;
+    if (typeof entry.name !== "string") continue;
+    out.push({ id: entry.name });
+  }
+  return out;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
@@ -162,7 +162,7 @@ test("resolveLocalLabRole normalizes Ollama baseUrl to include /api (codex revie
   });
   assert.equal(trailingSlash.providerConfig.baseUrl, "http://127.0.0.1:11434/api");
 
-  // openai-compatible URLs are NOT given /api (they use /v1).
+  // openai-compatible URLs are normalized to include /v1.
   const openaiCompat = resolveLocalLabRole({
     provider: "openai-compatible",
     baseUrl: "http://127.0.0.1:8080/v1",
@@ -172,6 +172,17 @@ test("resolveLocalLabRole normalizes Ollama baseUrl to include /api (codex revie
     seed: 1,
   });
   assert.equal(openaiCompat.providerConfig.baseUrl, "http://127.0.0.1:8080/v1");
+
+  // Bare-host openai-compatible URLs get /v1 appended.
+  const openaiBare = resolveLocalLabRole({
+    provider: "openai-compatible",
+    baseUrl: "http://127.0.0.1:8080",
+    model: "qwen3:14b",
+    ctx: 16384,
+    temperature: 0,
+    seed: 1,
+  });
+  assert.equal(openaiBare.providerConfig.baseUrl, "http://127.0.0.1:8080/v1");
 });
 
 test("resolved ProviderConfig can be passed to the real provider factory contract (rule 33: shape parity)", () => {

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseLocalLabManifest } from "./manifest.ts";
+import {
+  resolveLocalLabProfile,
+  resolveLocalLabRole,
+} from "./resolve-local-lab-profile.ts";
+
+function sampleManifest() {
+  return parseLocalLabManifest({
+    profile: "local-lab",
+    responder: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      model: "qwen3:14b",
+      quantization: "Q4_K_M",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    judge: {
+      provider: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      model: "gemma3:27b",
+      quantization: "Q4_K_M",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    embedding: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8081/v1",
+      model: "bge-m3",
+      ctx: 8192,
+      temperature: 0,
+      seed: 1573,
+    },
+    phases: "sequential",
+  });
+}
+
+test("resolveLocalLabProfile forwards manifest temperature and seed into the resolved ProviderConfig (PR2 assertion)", () => {
+  const profile = resolveLocalLabProfile(sampleManifest());
+
+  // The ProviderConfig the runner ultimately hands to the provider factory.
+  const responderConfig = profile.responder.providerConfig;
+  assert.equal(
+    responderConfig.temperature,
+    0,
+    "responder temperature must be forwarded verbatim from the manifest",
+  );
+  assert.equal(
+    responderConfig.seed,
+    1573,
+    "responder seed must be forwarded verbatim from the manifest",
+  );
+
+  const judgeConfig = profile.judge.providerConfig;
+  assert.equal(judgeConfig.temperature, 0);
+  assert.equal(judgeConfig.seed, 1573);
+
+  const embeddingConfig = profile.embedding?.providerConfig;
+  assert.equal(embeddingConfig?.temperature, 0);
+  assert.equal(embeddingConfig?.seed, 1573);
+});
+
+test("resolveLocalLabProfile maps openai-compatible → local-llm and ollama → ollama", () => {
+  const profile = resolveLocalLabProfile(sampleManifest());
+  assert.equal(profile.responder.providerConfig.provider, "local-llm");
+  assert.equal(profile.responder.providerConfig.model, "qwen3:14b");
+  assert.equal(
+    profile.responder.providerConfig.baseUrl,
+    "http://127.0.0.1:8080/v1",
+  );
+
+  assert.equal(profile.judge.providerConfig.provider, "ollama");
+  assert.equal(profile.judge.providerConfig.model, "gemma3:27b");
+  assert.equal(
+    profile.judge.providerConfig.baseUrl,
+    "http://127.0.0.1:11434",
+  );
+});
+
+test("resolveLocalLabProfile does NOT persist quantization onto ProviderConfig (informational only)", () => {
+  const profile = resolveLocalLabProfile(sampleManifest());
+  // quantization is recorded on the resolved role (for artifacts/PR3), NOT on
+  // ProviderConfig (which has no such field — adding one would be a breaking
+  // change to the existing transport contract). Cast through a record to
+  // verify the runtime property is absent without claiming the type has it.
+  const responderCfg = profile.responder.providerConfig as unknown as Record<string, unknown>;
+  assert.equal(responderCfg.quantization, undefined);
+  assert.equal(profile.responder.quantization, "Q4_K_M");
+});
+
+test("resolveLocalLabProfile reflects manifest phases + hand-off notes verbatim", () => {
+  const manifest = sampleManifest();
+  manifest.notes = {
+    responderToJudgeHandoff: "stop responder, then `ollama serve`",
+  };
+  const profile = resolveLocalLabProfile(manifest);
+  assert.equal(profile.phases, "sequential");
+  assert.equal(
+    profile.notes?.responderToJudgeHandoff,
+    "stop responder, then `ollama serve`",
+  );
+});
+
+test("resolveLocalLabProfile is symmetric: every role resolves to itself via resolveLocalLabRole", () => {
+  const manifest = sampleManifest();
+  for (const role of [manifest.responder, manifest.judge, manifest.embedding!]) {
+    const resolved = resolveLocalLabRole(role);
+    assert.equal(resolved.temperature, role.temperature);
+    assert.equal(resolved.seed, role.seed);
+    assert.equal(resolved.provider, role.provider);
+    assert.equal(resolved.providerConfig.model, role.model);
+    assert.equal(resolved.providerConfig.baseUrl, role.baseUrl);
+  }
+});
+
+test("resolved ProviderConfig can be passed to the real provider factory contract (rule 33: shape parity)", () => {
+  // The ProviderConfig we resolve MUST be shape-compatible with what the
+  // existing provider factory expects — no extra required fields, no missing
+  // fields. This is the rule-33 production-signature contract.
+  const profile = resolveLocalLabProfile(sampleManifest());
+
+  // Required fields.
+  assert.equal(typeof profile.responder.providerConfig.provider, "string");
+  assert.equal(typeof profile.responder.providerConfig.model, "string");
+  // baseUrl is set for local-lab (always required by the manifest).
+  assert.equal(typeof profile.responder.providerConfig.baseUrl, "string");
+  // The shape matches: provider + model + baseUrl + temperature + seed are all
+  // present, and there are no API keys (manifests deliberately never carry
+  // them — operator auth is out-of-band).
+  assert.equal(profile.responder.providerConfig.apiKey, undefined);
+});

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.test.ts
@@ -78,7 +78,7 @@ test("resolveLocalLabProfile maps openai-compatible → local-llm and ollama →
   assert.equal(profile.judge.providerConfig.model, "gemma3:27b");
   assert.equal(
     profile.judge.providerConfig.baseUrl,
-    "http://127.0.0.1:11434",
+    "http://127.0.0.1:11434/api",
   );
 });
 
@@ -114,8 +114,64 @@ test("resolveLocalLabProfile is symmetric: every role resolves to itself via res
     assert.equal(resolved.seed, role.seed);
     assert.equal(resolved.provider, role.provider);
     assert.equal(resolved.providerConfig.model, role.model);
-    assert.equal(resolved.providerConfig.baseUrl, role.baseUrl);
+    // Ollama baseUrls are normalized to include /api; verify the resolved
+    // baseUrl starts with the manifest-declared host.
+    const baseUrl = resolved.providerConfig.baseUrl ?? "";
+    assert.ok(
+      baseUrl.startsWith("http://127.0.0.1:"),
+      `baseUrl ${baseUrl} should start with the manifest host`,
+    );
   }
+});
+
+test("resolveLocalLabRole normalizes Ollama baseUrl to include /api (codex review: #1573 PR2)", () => {
+  // Regression: an Ollama role with the documented sample baseUrl
+  // (http://127.0.0.1:11434, no /api) caused the provider to POST to
+  // /generate instead of /api/generate (404) while preflight succeeded
+  // because discoveryEndpointFor already appended /api/tags.
+  const withoutApi = resolveLocalLabRole({
+    provider: "ollama",
+    baseUrl: "http://127.0.0.1:11434",
+    model: "gemma3:27b",
+    ctx: 8192,
+    temperature: 0,
+    seed: 1,
+  });
+  assert.equal(withoutApi.providerConfig.baseUrl, "http://127.0.0.1:11434/api");
+  assert.equal(withoutApi.baseUrl, "http://127.0.0.1:11434/api");
+
+  // Already-normalized URLs are left unchanged.
+  const withApi = resolveLocalLabRole({
+    provider: "ollama",
+    baseUrl: "http://127.0.0.1:11434/api",
+    model: "gemma3:27b",
+    ctx: 8192,
+    temperature: 0,
+    seed: 1,
+  });
+  assert.equal(withApi.providerConfig.baseUrl, "http://127.0.0.1:11434/api");
+
+  // Trailing slash is stripped before the /api check.
+  const trailingSlash = resolveLocalLabRole({
+    provider: "ollama",
+    baseUrl: "http://127.0.0.1:11434/",
+    model: "gemma3:27b",
+    ctx: 8192,
+    temperature: 0,
+    seed: 1,
+  });
+  assert.equal(trailingSlash.providerConfig.baseUrl, "http://127.0.0.1:11434/api");
+
+  // openai-compatible URLs are NOT given /api (they use /v1).
+  const openaiCompat = resolveLocalLabRole({
+    provider: "openai-compatible",
+    baseUrl: "http://127.0.0.1:8080/v1",
+    model: "qwen3:14b",
+    ctx: 16384,
+    temperature: 0,
+    seed: 1,
+  });
+  assert.equal(openaiCompat.providerConfig.baseUrl, "http://127.0.0.1:8080/v1");
 });
 
 test("resolved ProviderConfig can be passed to the real provider factory contract (rule 33: shape parity)", () => {

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.ts
@@ -94,8 +94,13 @@ export function resolveLocalLabRole(role: LocalLabRoleConfig): ResolvedLocalLabR
 
 /**
  * Normalize a manifest role's `baseUrl` for the provider that will consume it.
- * Strips a trailing slash, then ensures Ollama URLs carry the `/api` path
- * segment the native transport requires (`/api/generate`, `/api/tags`).
+ * Strips a trailing slash, then ensures:
+ *   - Ollama URLs carry the `/api` path segment (`/api/generate`, `/api/tags`)
+ *   - openai-compatible URLs carry the `/v1` path segment (`/v1/chat/completions`)
+ * This mirrors `discoveryEndpointFor` which already appends `/v1/models` and
+ * `/api/tags` for the bare-host forms, so endpoint-sameness comparisons in the
+ * CLI runner see consistent URLs regardless of whether the operator wrote
+ * `http://host:port` or `http://host:port/v1` (codex review, #1573 PR2).
  * Implemented without a regex so CodeQL does not flag manifest input as
  * uncontrolled pattern source.
  */
@@ -106,6 +111,9 @@ function normalizeRoleBaseUrl(
   const trimmed = rawBaseUrl.endsWith("/") ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
   if (providerKind === "ollama" && !trimmed.endsWith("/api")) {
     return `${trimmed}/api`;
+  }
+  if (providerKind === "openai-compatible" && !trimmed.endsWith("/v1")) {
+    return `${trimmed}/v1`;
   }
   return trimmed;
 }

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.ts
@@ -1,0 +1,125 @@
+/**
+ * Resolve a parsed local-lab manifest into runtime ProviderConfigs.
+ *
+ * Resolution is the bridge between the manifest (operator-authored JSON) and
+ * the harness's existing `ProviderConfig` shape: each manifest role becomes a
+ * `ProviderConfig` with `temperature` and `seed` forwarded verbatim so a test
+ * can assert on the resolved config (issue #1573 PR2 test list).
+ *
+ * Provider kind mapping (kept dumb and explicit, never silent fallback):
+ *
+ *   - `"openai-compatible"` → `BuiltInProvider` `"local-llm"` (the bench
+ *     provider that talks `/v1/chat/completions` + `/v1/models`, requiring an
+ *     explicit `baseUrl` — exactly what the manifest pins).
+ *   - `"ollama"` → `"ollama"` (native `/api/generate` + `/api/tags`).
+ *
+ * Both baseUrl and model are copied as-is; they are only ever fetch targets,
+ * never interpolated into a shell (rule 10). API keys are not part of the
+ * manifest — local-lab endpoints are operator-hosted on the loopback or a
+ * private host, so persisting a key into the manifest would be a footgun.
+ * Operators with auth'd local endpoints pass the key out-of-band.
+ *
+ * `quantization` is informational only; the bench `ProviderConfig` does not
+ * have a quantization field, so it is kept on the resolved role and surfaces
+ * in the bench artifact (PR3's tier/hardware metadata).
+ */
+
+import type {
+  LocalLabManifest,
+  LocalLabManifestNotes,
+  LocalLabRoleConfig,
+} from "./manifest.js";
+import type { BuiltInProvider, ProviderConfig } from "../types.js";
+
+/**
+ * A manifest role paired with its resolved `ProviderConfig`. The PR2 test
+ * list asserts temperature/seed on `providerConfig` directly.
+ */
+export interface ResolvedLocalLabRole {
+  readonly provider: LocalLabRoleConfig["provider"];
+  readonly baseUrl: string;
+  readonly model: string;
+  readonly quantization?: string;
+  readonly ctx: number;
+  readonly temperature: number;
+  readonly seed: number;
+  readonly providerConfig: ProviderConfig;
+}
+
+export interface ResolvedLocalLabProfile {
+  /** The parsed manifest this resolution was produced from. */
+  readonly manifest: LocalLabManifest;
+  readonly responder: ResolvedLocalLabRole;
+  readonly judge: ResolvedLocalLabRole;
+  readonly embedding?: ResolvedLocalLabRole;
+  /** Phase scheduling mode. PR2 ships `"sequential"` only. */
+  readonly phases: "sequential";
+  /** Operator hand-off note (or undefined when not authored). */
+  readonly notes?: LocalLabManifestNotes;
+}
+
+/**
+ * Resolve a single manifest role into a `ResolvedLocalLabRole`, forwarding
+ * `temperature` and `seed` into the `ProviderConfig` so providers can read
+ * them off the config directly.
+ */
+export function resolveLocalLabRole(role: LocalLabRoleConfig): ResolvedLocalLabRole {
+  const provider = manifestProviderKindToBuiltIn(role.provider);
+  const providerConfig: ProviderConfig = {
+    provider,
+    model: role.model,
+    baseUrl: role.baseUrl,
+    temperature: role.temperature,
+    seed: role.seed,
+  };
+
+  return {
+    provider: role.provider,
+    baseUrl: role.baseUrl,
+    model: role.model,
+    ctx: role.ctx,
+    temperature: role.temperature,
+    seed: role.seed,
+    ...(role.quantization ? { quantization: role.quantization } : {}),
+    providerConfig,
+  };
+}
+
+/**
+ * Resolve the full manifest into a `ResolvedLocalLabProfile`. Used by
+ * `resolveBenchRuntimeProfile` for `runtimeProfile: "local-lab"`, and
+ * directly by the unit test for the temperature/seed forwarding assertion.
+ */
+export function resolveLocalLabProfile(
+  manifest: LocalLabManifest,
+): ResolvedLocalLabProfile {
+  return {
+    manifest,
+    responder: resolveLocalLabRole(manifest.responder),
+    judge: resolveLocalLabRole(manifest.judge),
+    ...(manifest.embedding
+      ? { embedding: resolveLocalLabRole(manifest.embedding) }
+      : {}),
+    phases: manifest.phases,
+    ...(manifest.notes ? { notes: manifest.notes } : {}),
+  };
+}
+
+/**
+ * Map a manifest provider kind to the bench `BuiltInProvider` enum. Throws
+ * on any value not in `LOCAL_LAB_PROVIDER_KINDS` — the parser already
+ * enforces this, but the guard here keeps the function total and prevents a
+ * future caller from bypassing the parser.
+ */
+function manifestProviderKindToBuiltIn(
+  kind: LocalLabRoleConfig["provider"],
+): BuiltInProvider {
+  if (kind === "openai-compatible") {
+    return "local-llm";
+  }
+  if (kind === "ollama") {
+    return "ollama";
+  }
+  const exhaustive: never = kind;
+  throw new Error(`local-lab manifest provider kind unsupported: ${exhaustive}`);
+}

--- a/packages/bench/src/local-lab/resolve-local-lab-profile.ts
+++ b/packages/bench/src/local-lab/resolve-local-lab-profile.ts
@@ -62,20 +62,27 @@ export interface ResolvedLocalLabProfile {
  * Resolve a single manifest role into a `ResolvedLocalLabRole`, forwarding
  * `temperature` and `seed` into the `ProviderConfig` so providers can read
  * them off the config directly.
+ *
+ * Ollama `baseUrl`s are normalized to include `/api` so the provider posts to
+ * `${baseUrl}/generate` → `…/api/generate` rather than `…/generate` (404).
+ * This mirrors `discoveryEndpointFor` which already appends `/api/tags` for
+ * preflight. Operators can write `http://127.0.0.1:11434` or
+ * `http://127.0.0.1:11434/api` interchangeably (codex review, #1573 PR2).
  */
 export function resolveLocalLabRole(role: LocalLabRoleConfig): ResolvedLocalLabRole {
   const provider = manifestProviderKindToBuiltIn(role.provider);
+  const baseUrl = normalizeRoleBaseUrl(role.provider, role.baseUrl);
   const providerConfig: ProviderConfig = {
     provider,
     model: role.model,
-    baseUrl: role.baseUrl,
+    baseUrl,
     temperature: role.temperature,
     seed: role.seed,
   };
 
   return {
     provider: role.provider,
-    baseUrl: role.baseUrl,
+    baseUrl,
     model: role.model,
     ctx: role.ctx,
     temperature: role.temperature,
@@ -83,6 +90,24 @@ export function resolveLocalLabRole(role: LocalLabRoleConfig): ResolvedLocalLabR
     ...(role.quantization ? { quantization: role.quantization } : {}),
     providerConfig,
   };
+}
+
+/**
+ * Normalize a manifest role's `baseUrl` for the provider that will consume it.
+ * Strips a trailing slash, then ensures Ollama URLs carry the `/api` path
+ * segment the native transport requires (`/api/generate`, `/api/tags`).
+ * Implemented without a regex so CodeQL does not flag manifest input as
+ * uncontrolled pattern source.
+ */
+function normalizeRoleBaseUrl(
+  providerKind: LocalLabRoleConfig["provider"],
+  rawBaseUrl: string,
+): string {
+  const trimmed = rawBaseUrl.endsWith("/") ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+  if (providerKind === "ollama" && !trimmed.endsWith("/api")) {
+    return `${trimmed}/api`;
+  }
+  return trimmed;
 }
 
 /**

--- a/packages/bench/src/local-lab/sequential-phases.test.ts
+++ b/packages/bench/src/local-lab/sequential-phases.test.ts
@@ -1,0 +1,376 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseLocalLabManifest, type LocalLabManifest } from "./manifest.ts";
+import {
+  formatHandoffNote,
+  LocalLabPreflightError,
+  runSequentialPhases,
+  type LocalLabPhase,
+  type LocalLabPhaseDescriptor,
+  type SequentialPhaseHooks,
+} from "./sequential-phases.ts";
+import type { LocalLabPreflightOptions } from "./preflight.ts";
+
+/**
+ * Build a manifest where responder and judge can share or differ on baseUrl.
+ * Tests mutate `sameEndpoint` to exercise the hand-off branch.
+ */
+function manifest(opts: { sameEndpoint?: boolean } = {}): LocalLabManifest {
+  const responderUrl = "http://127.0.0.1:8080/v1";
+  const judgeUrl = opts.sameEndpoint ? responderUrl : "http://127.0.0.1:11434";
+  return parseLocalLabManifest({
+    profile: "local-lab",
+    responder: {
+      provider: "openai-compatible",
+      baseUrl: responderUrl,
+      model: "qwen3:14b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    judge: {
+      provider: "ollama",
+      baseUrl: judgeUrl,
+      model: "gemma3:27b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    phases: "sequential",
+    notes: {
+      responderToJudgeHandoff:
+        "stop responder (`Ctrl+C` on llama.cpp), then `ollama serve`",
+    },
+  });
+}
+
+/**
+ * Test stub for the preflight pathway. The scheduler forwards
+ * `preflightOptions` to the real `preflightLocalLabRole`, which calls the
+ * injected `fetchImpl`. The stub responds to every discovery request with the
+ * SAME list of model ids — production preflight then matches the manifest's
+ * role.model against that list. To force a failure for a specific model,
+ * omit it from `modelsOnEndpoint` (the manifest model id won't be found).
+ *
+ * The stub returns BOTH the OpenAI-compatible shape (`{ data: [...] }`) and
+ * the Ollama shape (`{ models: [{ name }] }`) so any provider kind works
+ * against the same stub.
+ */
+interface StubPreflight {
+  preflightOptions: LocalLabPreflightOptions;
+  seen: Array<{ url: string }>;
+}
+
+function makeStubPreflight(modelsOnEndpoint: string[]): StubPreflight {
+  const seen: Array<{ url: string }> = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    seen.push({ url });
+    const body = {
+      data: modelsOnEndpoint.map((id) => ({ id })),
+      models: modelsOnEndpoint.map((id) => ({ name: id })),
+    };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return {
+    preflightOptions: { fetchImpl, timeoutMs: 1000 },
+    seen,
+  };
+}
+
+test("runSequentialPhases runs phases in input order and returns outcomes in the same order", async () => {
+  const m = manifest();
+  const order: string[] = [];
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+
+  const phases: LocalLabPhase<string>[] = [
+    {
+      name: "responder",
+      role: m.responder,
+      execute: async () => {
+        order.push("responder");
+        return "responder-result";
+      },
+    },
+    {
+      name: "judge",
+      role: m.judge,
+      execute: async () => {
+        order.push("judge");
+        return "judge-result";
+      },
+    },
+  ];
+
+  const outcomes = await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+  });
+
+  assert.deepEqual(order, ["responder", "judge"], "phases must run in order");
+  assert.equal(outcomes.length, 2);
+  assert.equal(outcomes[0].phase.name, "responder");
+  assert.equal(outcomes[0].result, "responder-result");
+  assert.equal(outcomes[1].phase.name, "judge");
+  assert.equal(outcomes[1].result, "judge-result");
+});
+
+test("runSequentialPhases forwards the resolved role (with temperature/seed) to execute", async () => {
+  const m = manifest();
+  const stub = makeStubPreflight([m.responder.model]);
+  const observed = {
+    temperature: undefined as number | undefined,
+    seed: undefined as number | undefined,
+    provider: undefined as string | undefined,
+  };
+
+  const phases: LocalLabPhase[] = [
+    {
+      name: "responder",
+      role: m.responder,
+      execute: async (role) => {
+        observed.temperature = role.temperature;
+        observed.seed = role.seed;
+        observed.provider = role.providerConfig.provider;
+      },
+    },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+  });
+
+  assert.equal(observed.temperature, 0);
+  assert.equal(observed.seed, 1573);
+  assert.equal(observed.provider, "local-llm");
+});
+
+test("runSequentialPhases emits a hand-off between phases on different endpoints", async () => {
+  const m = manifest({ sameEndpoint: false });
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const handoffs: Array<{ from: string; to: string; note: string | undefined }> = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+    { name: "judge", role: m.judge, execute: async () => undefined },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhaseHandoff: (from, to, note) => {
+        handoffs.push({ from: from.name, to: to.name, note });
+      },
+    },
+  });
+
+  assert.equal(handoffs.length, 1, "exactly one hand-off between two phases");
+  assert.equal(handoffs[0].from, "responder");
+  assert.equal(handoffs[0].to, "judge");
+  assert.equal(
+    handoffs[0].note,
+    "stop responder (`Ctrl+C` on llama.cpp), then `ollama serve`",
+  );
+});
+
+test("runSequentialPhases suppresses the hand-off when both phases share an endpoint (Ollama hot-swap)", async () => {
+  const m = manifest({ sameEndpoint: true });
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const handoffs: unknown[] = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+    { name: "judge", role: m.judge, execute: async () => undefined },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhaseHandoff: () => {
+        handoffs.push("fired");
+      },
+    },
+  });
+
+  assert.equal(handoffs.length, 0, "no hand-off when endpoints match");
+});
+
+test("runSequentialPhases does NOT emit a hand-off before the first phase", async () => {
+  const m = manifest();
+  const stub = makeStubPreflight([m.responder.model]);
+  const handoffs: unknown[] = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhaseHandoff: () => {
+        handoffs.push("fired");
+      },
+    },
+  });
+
+  assert.equal(handoffs.length, 0);
+});
+
+test("runSequentialPhases hard-rejects when a phase preflight fails (no silent fallback)", async () => {
+  const m = manifest();
+  // Respondent's model is missing from the endpoint → its preflight fails.
+  // Judge's model is present, but the scheduler must abort at responder first.
+  const stub = makeStubPreflight([m.judge.model]);
+  const executed: string[] = [];
+
+  const phases: LocalLabPhase[] = [
+    {
+      name: "responder",
+      role: m.responder,
+      execute: async () => {
+        executed.push("responder");
+      },
+    },
+    {
+      name: "judge",
+      role: m.judge,
+      execute: async () => {
+        executed.push("judge");
+      },
+    },
+  ];
+
+  // assert.rejects returns void — capture the rejection inside the matcher
+  // so the assertions there can use the typed error directly. If the matcher
+  // throws, assert.rejects surfaces the assertion failure to the test.
+  await assert.rejects(
+    runSequentialPhases(m, phases, {
+      preflight: stub.preflightOptions,
+    }),
+    (e: unknown) => {
+      assert.ok(e instanceof LocalLabPreflightError, "must be a LocalLabPreflightError");
+      assert.equal(e.phase.name, "responder");
+      assert.equal(e.phaseIndex, 0);
+      assert.equal(e.preflight.ok, false);
+      // The failing result carries the foundModels so the operator sees
+      // what the endpoint reported (rule 51). The judge model is present
+      // but the responder model is not.
+      assert.equal(e.preflight.foundModels.length, 1);
+      assert.equal(e.preflight.foundModels[0].id, m.judge.model);
+      assert.match(e.preflight.reason, /did not report the manifest model/);
+      assert.match(e.preflight.reason, new RegExp(m.responder.model));
+      return true;
+    },
+  );
+
+  // Subsequent phase must not have executed — preflight is a hard gate.
+  assert.deepEqual(executed, [], "failing preflight must abort before execute");
+});
+
+test("runSequentialPhases invokes preflight for each phase in order before any execute", async () => {
+  const m = manifest();
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const executeOrder: string[] = [];
+
+  const phases: LocalLabPhase[] = [
+    {
+      name: "responder",
+      role: m.responder,
+      execute: async () => {
+        executeOrder.push("responder");
+      },
+    },
+    {
+      name: "judge",
+      role: m.judge,
+      execute: async () => {
+        executeOrder.push("judge");
+      },
+    },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+  });
+
+  // Each phase's role produced exactly one preflight call.
+  assert.equal(stub.seen.length, 2);
+  assert.match(stub.seen[0].url, /\/v1\/models$/, "responder uses openai-compatible /v1/models");
+  assert.match(stub.seen[1].url, /\/api\/tags$/, "judge uses ollama /api/tags");
+  assert.deepEqual(executeOrder, ["responder", "judge"]);
+});
+
+test("runSequentialPhases fires onPhasePreflight / onPhaseStart / onPhaseComplete in order", async () => {
+  const m = manifest();
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const events: string[] = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => "r" },
+    { name: "judge", role: m.judge, execute: async () => "j" },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhasePreflight: () => events.push("preflight"),
+      onPhaseStart: () => events.push("start"),
+      onPhaseComplete: () => events.push("complete"),
+    },
+  });
+
+  assert.deepEqual(
+    events,
+    ["preflight", "start", "complete", "preflight", "start", "complete"],
+  );
+});
+
+test("runSequentialPhases handles an empty phase list as a no-op", async () => {
+  const m = manifest();
+  const stub = makeStubPreflight([]);
+  const outcomes = await runSequentialPhases(m, [], {
+    preflight: stub.preflightOptions,
+  });
+  assert.deepEqual(outcomes, []);
+});
+
+test("formatHandoffNote prefers the manifest note when authored", () => {
+  const from: LocalLabPhaseDescriptor = {
+    name: "responder",
+    role: {
+      provider: "openai-compatible",
+      baseUrl: "http://a/v1",
+      model: "r",
+      ctx: 1,
+      temperature: 0,
+      seed: 1,
+    },
+  };
+  const to: LocalLabPhaseDescriptor = {
+    name: "judge",
+    role: {
+      provider: "ollama",
+      baseUrl: "http://b",
+      model: "j",
+      ctx: 1,
+      temperature: 0,
+      seed: 1,
+    },
+  };
+  assert.equal(
+    formatHandoffNote(from, to, "operator-authored note"),
+    "operator-authored note",
+  );
+  // Whitespace-only note falls through to the synthesized default.
+  assert.match(
+    formatHandoffNote(from, to, "   "),
+    /^stop responder endpoint, start judge endpoint at http:\/\/b serving model j/,
+  );
+  assert.match(
+    formatHandoffNote(from, to, undefined),
+    /^stop responder endpoint, start judge endpoint at http:\/\/b serving model j/,
+  );
+});

--- a/packages/bench/src/local-lab/sequential-phases.test.ts
+++ b/packages/bench/src/local-lab/sequential-phases.test.ts
@@ -176,6 +176,58 @@ test("runSequentialPhases emits a hand-off between phases on different endpoints
   );
 });
 
+test("runSequentialPhases synthesizes a default hand-off note when the manifest omits it (cursor review: #1573 PR2)", async () => {
+  // Build a manifest with NO notes — the hook must still receive a non-undefined
+  // synthesized instruction (formatHandoffNote), not undefined.
+  const m = parseLocalLabManifest({
+    profile: "local-lab",
+    responder: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      model: "qwen3:14b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    judge: {
+      provider: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      model: "gemma3:27b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    phases: "sequential",
+  });
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const handoffs: Array<{ note: string | undefined }> = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+    { name: "judge", role: m.judge, execute: async () => undefined },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhaseHandoff: (_from, _to, note) => {
+        handoffs.push({ note });
+      },
+    },
+  });
+
+  assert.equal(handoffs.length, 1);
+  assert.ok(
+    typeof handoffs[0].note === "string" && handoffs[0].note!.length > 0,
+    "hook must receive a non-empty synthesized note, not undefined",
+  );
+  assert.match(
+    handoffs[0].note!,
+    /stop responder endpoint, start judge endpoint/,
+    "synthesized note names both phases",
+  );
+});
+
 test("runSequentialPhases suppresses the hand-off when both phases share an endpoint (Ollama hot-swap)", async () => {
   const m = manifest({ sameEndpoint: true });
   const stub = makeStubPreflight([m.responder.model, m.judge.model]);

--- a/packages/bench/src/local-lab/sequential-phases.test.ts
+++ b/packages/bench/src/local-lab/sequential-phases.test.ts
@@ -465,3 +465,52 @@ test("formatHandoffNote prefers the manifest note when authored", () => {
     /^stop responder endpoint, start judge endpoint at http:\/\/b serving model j/,
   );
 });
+
+test("runSequentialPhases treats trailing-slash URL variants as the same endpoint (cursor review: #1573 PR2)", async () => {
+  // Regression: endpoint sameness used raw baseUrl string equality, so
+  // http://host/v1 and http://host/v1/ were treated as different endpoints
+  // and triggered a spurious hand-off. Preflight's discoveryEndpointFor
+  // already normalizes a trailing slash; sameness must match that tolerance.
+  const m = parseLocalLabManifest({
+    profile: "local-lab",
+    responder: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      model: "qwen3:14b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    judge: {
+      provider: "openai-compatible",
+      baseUrl: "http://127.0.0.1:8080/v1/",
+      model: "gemma3:27b",
+      ctx: 16384,
+      temperature: 0,
+      seed: 1573,
+    },
+    phases: "sequential",
+  });
+  const stub = makeStubPreflight([m.responder.model, m.judge.model]);
+  const handoffs: unknown[] = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+    { name: "judge", role: m.judge, execute: async () => undefined },
+  ];
+
+  await runSequentialPhases(m, phases, {
+    preflight: stub.preflightOptions,
+    hooks: {
+      onPhaseHandoff: () => {
+        handoffs.push("fired");
+      },
+    },
+  });
+
+  assert.equal(
+    handoffs.length,
+    0,
+    "no hand-off when endpoints differ only by a trailing slash",
+  );
+});

--- a/packages/bench/src/local-lab/sequential-phases.test.ts
+++ b/packages/bench/src/local-lab/sequential-phases.test.ts
@@ -219,6 +219,45 @@ test("runSequentialPhases does NOT emit a hand-off before the first phase", asyn
   assert.equal(handoffs.length, 0);
 });
 
+test("runSequentialPhases emits the hand-off BEFORE the next phase's preflight (cursor review: #1573 PR2)", async () => {
+  // Regression: the hand-off must fire before the judge preflight so the
+  // operator sees the swap guidance even when the judge endpoint is not yet
+  // serving the manifest model. Previously preflight ran first and threw
+  // LocalLabPreflightError before the hand-off callback ever fired — so
+  // handoffs.length would be 0. Asserting handoffs.length === 1 here proves
+  // the hand-off preceded the (failing) judge preflight.
+  const m = manifest({ sameEndpoint: false });
+  // Judge model deliberately absent from the endpoint → judge preflight fails.
+  const stub = makeStubPreflight([m.responder.model]);
+  const handoffs: Array<{ from: string; to: string }> = [];
+
+  const phases: LocalLabPhase[] = [
+    { name: "responder", role: m.responder, execute: async () => undefined },
+    { name: "judge", role: m.judge, execute: async () => undefined },
+  ];
+
+  await assert.rejects(
+    runSequentialPhases(m, phases, {
+      preflight: stub.preflightOptions,
+      hooks: {
+        onPhaseHandoff: (from, to) => {
+          handoffs.push({ from: from.name, to: to.name });
+        },
+      },
+    }),
+    (e: unknown) => e instanceof LocalLabPreflightError,
+  );
+
+  // The hand-off fired before the judge preflight attempted + threw. Before
+  // the fix this would be 0 (preflight threw first, hand-off never reached).
+  assert.equal(handoffs.length, 1, "hand-off must fire before the failing judge preflight");
+  assert.equal(handoffs[0].from, "responder");
+  assert.equal(handoffs[0].to, "judge");
+  // Only the responder endpoint was probed (1 fetch); the judge preflight
+  // ran second and failed, but the hand-off preceded it.
+  assert.equal(stub.seen.length, 2, "both endpoints probed (responder pass, judge fail)");
+});
+
 test("runSequentialPhases hard-rejects when a phase preflight fails (no silent fallback)", async () => {
   const m = manifest();
   // Respondent's model is missing from the endpoint → its preflight fails.

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -1,0 +1,235 @@
+/**
+ * Local-lab sequential phase scheduler (issue #1573 PR2).
+ *
+ * On a single-GPU lab box (e.g. RTX 3090, 24 GB VRAM) the responder and
+ * judge models cannot be co-resident: the harness runs them in two distinct
+ * phases, with the operator physically swapping which model is loaded
+ * between them. The harness DOES NOT manage model processes — it tells the
+ * operator what to do and waits for them to confirm via the next phase's
+ * endpoint preflight succeeding.
+ *
+ * The scheduler:
+ *
+ *   1. Preflights the phase's endpoint (reachable + serving the manifest
+ *      model with enough context — see `preflight.ts`). Hard error on
+ *      mismatch; no silent fallback.
+ *   2. Calls the phase's `execute()` callback — the runner supplies the
+ *      actual ingest/answer or judge work; the scheduler only sequences.
+ *   3. Between phases prints the operator hand-off note from
+ *      `manifest.notes.responderToJudgeHandoff`, OR proceeds silently when
+ *      the next phase's endpoint is the same baseUrl (Ollama can hot-swap
+ *      models within one endpoint, so no physical swap is needed).
+ *
+ * `execute` receives the resolved role so the runner can build the right
+ * provider config without re-reading the manifest. The phase scheduler is
+ * intentionally process-supervision-free per the issue's "do not add
+ * process supervision in v1" instruction.
+ */
+
+import type { LocalLabManifest, LocalLabRoleConfig } from "./manifest.js";
+import type { ResolvedLocalLabRole } from "./resolve-local-lab-profile.js";
+import { resolveLocalLabRole } from "./resolve-local-lab-profile.js";
+import {
+  preflightLocalLabRole,
+  type LocalLabPreflightOptions,
+  type LocalLabPreflightResult,
+} from "./preflight.js";
+
+export type LocalLabPhaseName = "responder" | "judge" | "embedding";
+
+export interface LocalLabPhaseDescriptor {
+  name: LocalLabPhaseName;
+  role: LocalLabRoleConfig;
+}
+
+/**
+ * A unit of phase work supplied by the runner. The callback receives the
+ * phase's resolved role so the caller can build its own provider/client
+ * without re-reading the manifest. Returning a value (e.g. judge verdicts)
+ * is supported; the scheduler does not inspect it.
+ */
+export type LocalLabPhaseExecute<T = unknown> = (
+  role: ResolvedLocalLabRole,
+) => Promise<T>;
+
+export interface LocalLabPhase<T = unknown> {
+  name: LocalLabPhaseName;
+  role: LocalLabRoleConfig;
+  execute: LocalLabPhaseExecute<T>;
+}
+
+export interface LocalLabPhaseOutcome<T> {
+  phase: LocalLabPhaseDescriptor;
+  preflight: LocalLabPreflightResult;
+  result: T;
+}
+
+export interface SequentialPhaseHooks {
+  /**
+   * Called after a phase's preflight succeeds but before its `execute`.
+   * Useful for logging "phase X starting against <endpoint>".
+   */
+  onPhasePreflight?: (result: LocalLabPreflightResult) => void;
+  /** Called immediately before invoking the phase's execute callback. */
+  onPhaseStart?: (phase: LocalLabPhaseDescriptor) => void;
+  /** Called immediately after a phase's execute resolves. */
+  onPhaseComplete?: <T>(outcome: LocalLabPhaseOutcome<T>) => void;
+  /**
+   * Called between two phases when their endpoints differ. Receives the
+   * manifest hand-off note (or undefined). The scheduler does NOT print to
+   * stdout itself — it delegates to this hook so tests can observe it
+   * without capturing process output.
+   */
+  onPhaseHandoff?: (
+    from: LocalLabPhaseDescriptor,
+    to: LocalLabPhaseDescriptor,
+    note: string | undefined,
+  ) => void;
+}
+
+export interface RunSequentialPhasesOptions {
+  /** Forwarded to each phase's preflight. */
+  preflight?: LocalLabPreflightOptions;
+  hooks?: SequentialPhaseHooks;
+}
+
+/**
+ * Run a sequence of phases against the manifest's declared endpoints, with
+ * preflight + hand-off enforcement between them. Resolves with each phase's
+ * outcome in order, or rejects with a `LocalLabPreflightError`
+ * carrying the failing preflight (which surfaces the endpoint's found model
+ * list per rule 51).
+ *
+ * Phases are required to be supplied in run order; the scheduler does not
+ * reorder them. Empty phase lists are a no-op (the harness intentionally
+ * supports an empty responder/judge pair for preflight-only smoke checks).
+ */
+export async function runSequentialPhases<T>(
+  manifest: LocalLabManifest,
+  phases: LocalLabPhase<T>[],
+  options: RunSequentialPhasesOptions = {},
+): Promise<LocalLabPhaseOutcome<T>[]> {
+  const outcomes: LocalLabPhaseOutcome<T>[] = [];
+  for (let index = 0; index < phases.length; index += 1) {
+    const phase = phases[index];
+    const descriptor: LocalLabPhaseDescriptor = {
+      name: phase.name,
+      role: phase.role,
+    };
+
+    // 1. Preflight — hard fail; surfaces the found model list to the operator.
+    const preflight = await preflightLocalLabRole(
+      {
+        provider: phase.role.provider,
+        baseUrl: phase.role.baseUrl,
+        model: phase.role.model,
+        ctx: phase.role.ctx,
+      },
+      options.preflight,
+    );
+    if (!preflight.ok) {
+      throw new LocalLabPreflightError({
+        phase: descriptor,
+        preflight,
+        phaseIndex: index,
+      });
+    }
+    options.hooks?.onPhasePreflight?.(preflight);
+
+    // 2. Hand-off BEFORE execute when the next phase lives elsewhere.
+    //    The first phase has no predecessor, so no hand-off fires.
+    if (index > 0) {
+      const previous = phases[index - 1];
+      const sameEndpoint = phase.role.baseUrl === previous.role.baseUrl;
+      if (!sameEndpoint) {
+        const note = readHandoffNote(manifest, previous.name, phase.name);
+        options.hooks?.onPhaseHandoff?.(
+          { name: previous.name, role: previous.role },
+          descriptor,
+          note,
+        );
+      }
+    }
+
+    // 3. Execute — the runner supplies the actual phase work.
+    options.hooks?.onPhaseStart?.(descriptor);
+    const resolvedRole = resolveLocalLabRole(phase.role);
+    const result = await phase.execute(resolvedRole);
+    const outcome: LocalLabPhaseOutcome<T> = {
+      phase: descriptor,
+      preflight,
+      result,
+    };
+    outcomes.push(outcome);
+    options.hooks?.onPhaseComplete?.(outcome);
+  }
+  return outcomes;
+}
+
+/**
+ * Error thrown when a phase's preflight fails. Carries the failing result
+ * so callers (and tests) can inspect what the endpoint reported.
+ */
+export class LocalLabPreflightError extends Error {
+  readonly phase: LocalLabPhaseDescriptor;
+  readonly preflight: LocalLabPreflightResult;
+  readonly phaseIndex: number;
+
+  constructor(args: {
+    phase: LocalLabPhaseDescriptor;
+    preflight: LocalLabPreflightResult;
+    phaseIndex: number;
+  }) {
+    const reason =
+      args.preflight.ok === false
+        ? args.preflight.reason
+        : "preflight reported success but the scheduler treated it as a failure (internal inconsistency)";
+    super(
+      `local-lab phase "${args.phase.name}" (index ${args.phaseIndex}) preflight failed: ${reason}`,
+    );
+    this.name = "LocalLabPreflightError";
+    this.phase = args.phase;
+    this.preflight = args.preflight;
+    this.phaseIndex = args.phaseIndex;
+  }
+}
+
+/**
+ * Render the operator hand-off string the scheduler passes to the
+ * `onPhaseHandoff` hook. Returns the manifest note when authored, otherwise
+ * a default instruction naming the next phase and its endpoint. This is a
+ * pure formatting helper — tests assert on it directly.
+ */
+export function formatHandoffNote(
+  from: LocalLabPhaseDescriptor,
+  to: LocalLabPhaseDescriptor,
+  manifestNote: string | undefined,
+): string {
+  if (manifestNote !== undefined && manifestNote.trim().length > 0) {
+    return manifestNote.trim();
+  }
+  return (
+    `stop ${from.name} endpoint, start ${to.name} endpoint at ${to.role.baseUrl} ` +
+    `serving model ${to.role.model}, then resume the bench`
+  );
+}
+
+/**
+ * Read the hand-off note for a given from→to transition. PR2 only authors
+ * `responderToJudgeHandoff`; reverse and embedding transitions fall back to
+ * the synthesized default in `formatHandoffNote`.
+ */
+function readHandoffNote(
+  manifest: LocalLabManifest,
+  from: LocalLabPhaseName,
+  to: LocalLabPhaseName,
+): string | undefined {
+  if (
+    from === "responder" &&
+    to === "judge" &&
+    typeof manifest.notes?.responderToJudgeHandoff === "string"
+  ) {
+    return manifest.notes.responderToJudgeHandoff;
+  }
+  return undefined;
+}

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -94,13 +94,15 @@ export interface RunSequentialPhasesOptions {
 }
 
 /**
- * Normalize a baseUrl for endpoint-sameness comparison. Strips trailing
- * slashes so `…/v1` and `…/v1/` compare equal — matching the trailing-slash
- * tolerance `discoveryEndpointFor` (preflight) already applies when composing
- * discovery URLs (cursor review, issue #1573 PR2).
+ * Normalize a baseUrl for endpoint-sameness comparison. Strips a single
+ * trailing slash so `…/v1` and `…/v1/` compare equal — exactly matching the
+ * one-slash trim `discoveryEndpointFor` (preflight) applies before composing
+ * discovery URLs (cursor review, issue #1573 PR2). Implemented without a
+ * regex so CodeQL's polynomial-backtracking heuristic does not flag manifest
+ * baseUrls as uncontrolled regex input.
  */
 function normalizeBaseUrlForSameness(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
 }
 
 /**

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -126,7 +126,12 @@ export async function runSequentialPhases<T>(
       const previous = phases[index - 1];
       const sameEndpoint = phase.role.baseUrl === previous.role.baseUrl;
       if (!sameEndpoint) {
-        const note = readHandoffNote(manifest, previous.name, phase.name);
+        const manifestNote = readHandoffNote(manifest, previous.name, phase.name);
+        const note = formatHandoffNote(
+          { name: previous.name, role: previous.role },
+          descriptor,
+          manifestNote,
+        );
         options.hooks?.onPhaseHandoff?.(
           { name: previous.name, role: previous.role },
           descriptor,

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -94,6 +94,16 @@ export interface RunSequentialPhasesOptions {
 }
 
 /**
+ * Normalize a baseUrl for endpoint-sameness comparison. Strips trailing
+ * slashes so `…/v1` and `…/v1/` compare equal — matching the trailing-slash
+ * tolerance `discoveryEndpointFor` (preflight) already applies when composing
+ * discovery URLs (cursor review, issue #1573 PR2).
+ */
+function normalizeBaseUrlForSameness(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+/**
  * Run a sequence of phases against the manifest's declared endpoints, with
  * preflight + hand-off enforcement between them. Resolves with each phase's
  * outcome in order, or rejects with a `LocalLabPreflightError`
@@ -124,7 +134,9 @@ export async function runSequentialPhases<T>(
     //    The first phase has no predecessor, so no hand-off fires.
     if (index > 0) {
       const previous = phases[index - 1];
-      const sameEndpoint = phase.role.baseUrl === previous.role.baseUrl;
+      const sameEndpoint =
+      normalizeBaseUrlForSameness(phase.role.baseUrl) ===
+      normalizeBaseUrlForSameness(previous.role.baseUrl);
       if (!sameEndpoint) {
         const manifestNote = readHandoffNote(manifest, previous.name, phase.name);
         const note = formatHandoffNote(

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -95,11 +95,17 @@ export interface RunSequentialPhasesOptions {
 
 /**
  * Normalize a baseUrl for endpoint-sameness comparison. Strips a single
- * trailing slash so `…/v1` and `…/v1/` compare equal — exactly matching the
- * one-slash trim `discoveryEndpointFor` (preflight) applies before composing
- * discovery URLs (cursor review, issue #1573 PR2). Implemented without a
- * regex so CodeQL's polynomial-backtracking heuristic does not flag manifest
- * baseUrls as uncontrolled regex input.
+ * trailing slash so `…/v1` and `…/v1/` compare equal. This is a
+ * conservative trailing-slash-only comparison — it does NOT canonicalize
+ * provider-specific suffixes (`/v1`, `/api`), so a manifest that mixes
+ * `http://host` and `http://host/v1` for the same OpenAI-compatible endpoint
+ * will spuriously emit a hand-off. That is safe (a redundant swap prompt
+ * is harmless); a false negative (missed hand-off) would not be. For full
+ * suffix canonicalization, `resolveLocalLabRole` already normalizes Ollama
+ * URLs to include `/api` at resolution time, so manifests that use the
+ * documented sample URLs compare correctly (kilo review, issue #1573 PR2).
+ * Implemented without a regex so CodeQL's polynomial-backtracking heuristic
+ * does not flag manifest baseUrls as uncontrolled regex input.
  */
 function normalizeBaseUrlForSameness(baseUrl: string): string {
   return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;

--- a/packages/bench/src/local-lab/sequential-phases.ts
+++ b/packages/bench/src/local-lab/sequential-phases.ts
@@ -116,8 +116,26 @@ export async function runSequentialPhases<T>(
       name: phase.name,
       role: phase.role,
     };
+    // 1. Hand-off BEFORE preflight when this phase lives on a different endpoint
+    //    than its predecessor. The operator must see the swap guidance before
+    //    the bench probes the (not-yet-started) next endpoint — otherwise a
+    //    not-yet-swapped judge endpoint throws LocalLabPreflightError before
+    //    the guidance ever prints (cursor review, issue #1573 PR2).
+    //    The first phase has no predecessor, so no hand-off fires.
+    if (index > 0) {
+      const previous = phases[index - 1];
+      const sameEndpoint = phase.role.baseUrl === previous.role.baseUrl;
+      if (!sameEndpoint) {
+        const note = readHandoffNote(manifest, previous.name, phase.name);
+        options.hooks?.onPhaseHandoff?.(
+          { name: previous.name, role: previous.role },
+          descriptor,
+          note,
+        );
+      }
+    }
 
-    // 1. Preflight — hard fail; surfaces the found model list to the operator.
+    // 2. Preflight — hard fail; surfaces the found model list to the operator.
     const preflight = await preflightLocalLabRole(
       {
         provider: phase.role.provider,
@@ -135,21 +153,6 @@ export async function runSequentialPhases<T>(
       });
     }
     options.hooks?.onPhasePreflight?.(preflight);
-
-    // 2. Hand-off BEFORE execute when the next phase lives elsewhere.
-    //    The first phase has no predecessor, so no hand-off fires.
-    if (index > 0) {
-      const previous = phases[index - 1];
-      const sameEndpoint = phase.role.baseUrl === previous.role.baseUrl;
-      if (!sameEndpoint) {
-        const note = readHandoffNote(manifest, previous.name, phase.name);
-        options.hooks?.onPhaseHandoff?.(
-          { name: previous.name, role: previous.role },
-          descriptor,
-          note,
-        );
-      }
-    }
 
     // 3. Execute — the runner supplies the actual phase work.
     options.hooks?.onPhaseStart?.(descriptor);

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -111,8 +111,9 @@ class LocalLlmProvider implements LlmProvider {
                 : []),
               { role: "user", content: prompt },
             ],
-            temperature: opts.temperature,
+            temperature: opts.temperature ?? this.config.temperature,
             max_tokens: opts.maxTokens,
+            ...(this.config.seed !== undefined ? { seed: this.config.seed } : {}),
             ...(this.config.disableThinking &&
             isThinkingCompatibleBackend(this.normalizedBaseUrl())
               ? { chat_template_kwargs: { enable_thinking: false } }

--- a/packages/bench/src/providers/ollama.test.ts
+++ b/packages/bench/src/providers/ollama.test.ts
@@ -5,12 +5,13 @@ import { createOllamaProvider } from "./ollama.ts";
 
 function mockOllamaFetch(responseBody: Record<string, unknown>) {
   const originalFetch = globalThis.fetch;
-  const requests: Array<{ url: string; headers: Record<string, string> }> = [];
+  const requests: Array<{ url: string; headers: Record<string, string>; body: unknown }> = [];
   globalThis.fetch = async (url, init) => {
     const headers = new Headers(init?.headers as HeadersInit | undefined);
     requests.push({
       url: String(url),
       headers: Object.fromEntries(headers.entries()),
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
     });
     return new Response(JSON.stringify(responseBody), {
       status: 200,
@@ -85,6 +86,39 @@ test("ollama provider defaults to localhost when baseUrl is omitted", async () =
     });
     await provider.complete("hello");
     assert.ok(mock.requests[0].url.startsWith("http://localhost:11434/api/generate"));
+  } finally {
+    mock.restore();
+  }
+});
+
+test("ollama provider forwards config seed into the /api/generate options (issue #1573 PR2)", async () => {
+  const mock = mockOllamaFetch({ response: "seeded ok", prompt_eval_count: 1, eval_count: 1 });
+  try {
+    const provider = createOllamaProvider({
+      provider: "ollama",
+      model: "gemma4:26b",
+      temperature: 0,
+      seed: 1573,
+    });
+    await provider.complete("hello");
+    const body = mock.requests[0].body as { options: { seed?: number; temperature?: number } };
+    assert.equal(body.options.seed, 1573, "manifest seed must reach the Ollama options.seed");
+    assert.equal(body.options.temperature, 0, "manifest temperature must reach the Ollama options.temperature");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("ollama provider omits seed from options when config does not set it", async () => {
+  const mock = mockOllamaFetch({ response: "ok", prompt_eval_count: 1, eval_count: 1 });
+  try {
+    const provider = createOllamaProvider({
+      provider: "ollama",
+      model: "gemma4:26b",
+    });
+    await provider.complete("hello");
+    const body = mock.requests[0].body as { options: Record<string, unknown> };
+    assert.equal(body.options.seed, undefined, "no seed key when config omits it");
   } finally {
     mock.restore();
   }

--- a/packages/bench/src/providers/ollama.ts
+++ b/packages/bench/src/providers/ollama.ts
@@ -60,8 +60,9 @@ class OllamaProvider implements LlmProvider {
           system: opts.systemPrompt,
           stream: false,
           options: {
-            temperature: opts.temperature,
+            temperature: opts.temperature ?? this.config.temperature,
             num_predict: opts.maxTokens,
+            ...(this.config.seed !== undefined ? { seed: this.config.seed } : {}),
           },
         }),
       },

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -75,8 +75,9 @@ class OpenAiCompatibleProvider implements LlmProvider {
               : []),
             { role: "user", content: prompt },
           ],
-          temperature: opts.temperature,
+          temperature: opts.temperature ?? this.config.temperature,
           max_tokens: opts.maxTokens,
+          ...(this.config.seed !== undefined ? { seed: this.config.seed } : {}),
           ...(this.config.disableThinking &&
           isThinkingCompatibleBackend(this.config.baseUrl)
             ? { chat_template_kwargs: { enable_thinking: false } }

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -43,6 +43,18 @@ export interface ProviderBaseConfig {
   /** Suppress thinking/reasoning tokens for thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek). */
   disableThinking?: boolean;
   /**
+   * Sampling temperature pinned by a runtime profile manifest (e.g. local-lab
+   * pins 0 for reproducibility). Providers use this as the fallback when the
+   * per-call CompletionOpts does not override it.
+   */
+  temperature?: number;
+  /**
+   * Sampling seed pinned by a runtime profile manifest so reruns reproduce the
+   * same draws. Providers forward this to the backend on every completion call
+   * (Ollama options.seed, OpenAI-compatible top-level seed).
+   */
+  seed?: number;
+  /**
    * Optional answering-only memory-context budget. Benchmark artifacts keep the
    * full recalled text, but provider-backed responders may receive this compact
    * deterministic view to avoid transport-specific prompt stalls.

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -666,3 +666,43 @@ test("local-lab runtime profile leaves providers unchanged when no runtime optio
   assert.equal(resolved.judgeProvider?.retryOptions, undefined);
   assert.equal(resolved.judgeProvider?.disableThinking, undefined);
 });
+
+test("local-lab runtime profile applies lcmObserveConcurrency to the effective config (cursor review: #1573 PR2 round 4)", async () => {
+  // Regression: resolveLocalLabRuntimeProfile built effectiveRemnicConfig from
+  // buildBenchBaselineRemnicConfig() only and never merged lcmObserveConcurrency,
+  // so --ingest-concurrency silently no-op'd on local-lab (unlike baseline/real).
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-local-lab-"));
+  const manifestPath = path.join(root, "local-lab.json");
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      profile: "local-lab",
+      responder: {
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "qwen3:14b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      judge: {
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "gemma3:27b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      phases: "sequential",
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "local-lab",
+    localLabManifestPath: manifestPath,
+    lcmObserveConcurrency: 4,
+  });
+
+  assert.equal(resolved.remnicConfig.lcmObserveConcurrency, 4);
+  assert.equal(resolved.effectiveRemnicConfig.lcmObserveConcurrency, 4);
+});

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -575,3 +575,94 @@ test("runtime profile routes OpenAI internal LLM calls through Responses API", a
     "secret-openai-key",
   );
 });
+
+test("local-lab runtime profile applies requestTimeout/max429WaitMs/disableThinking to providers (cursor review: #1573 PR2)", async () => {
+  // Regression: the local-lab branch built ProviderConfig values only from the
+  // manifest and never applied --request-timeout / --max-429-wait / --disable-thinking,
+  // so those flags silently no-op'd on local-lab runs. Other profiles route through
+  // resolveProviderConfig which honours them; local-lab must match that contract.
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-local-lab-"));
+  const manifestPath = path.join(root, "local-lab.json");
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      profile: "local-lab",
+      responder: {
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "qwen3:14b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      judge: {
+        provider: "ollama",
+        baseUrl: "http://127.0.0.1:11434",
+        model: "gemma3:27b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      phases: "sequential",
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "local-lab",
+    localLabManifestPath: manifestPath,
+    requestTimeout: 12_000,
+    max429WaitMs: 5_000,
+    disableThinking: true,
+  });
+
+  assert.equal(resolved.profile, "local-lab");
+  // System (responder) provider carries the runtime options layered on top of
+  // the manifest's provider/model/baseUrl/temperature/seed.
+  assert.equal(resolved.systemProvider?.retryOptions?.timeoutMs, 12_000);
+  assert.equal(resolved.systemProvider?.retryOptions?.max429WaitMs, 5_000);
+  assert.equal(resolved.systemProvider?.disableThinking, true);
+  // Judge provider honours the same contract.
+  assert.equal(resolved.judgeProvider?.retryOptions?.timeoutMs, 12_000);
+  assert.equal(resolved.judgeProvider?.retryOptions?.max429WaitMs, 5_000);
+  assert.equal(resolved.judgeProvider?.disableThinking, true);
+});
+
+test("local-lab runtime profile leaves providers unchanged when no runtime options are set", async () => {
+  // The manifest-only common case must not sprout empty retryOptions or
+  // disableThinking — applyLocalLabRuntimeOptions returns the config as-is.
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-local-lab-"));
+  const manifestPath = path.join(root, "local-lab.json");
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      profile: "local-lab",
+      responder: {
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "qwen3:14b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      judge: {
+        provider: "openai-compatible",
+        baseUrl: "http://127.0.0.1:8080/v1",
+        model: "gemma3:27b",
+        ctx: 16384,
+        temperature: 0,
+        seed: 1573,
+      },
+      phases: "sequential",
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "local-lab",
+    localLabManifestPath: manifestPath,
+  });
+
+  assert.equal(resolved.systemProvider?.retryOptions, undefined);
+  assert.equal(resolved.systemProvider?.disableThinking, undefined);
+  assert.equal(resolved.judgeProvider?.retryOptions, undefined);
+  assert.equal(resolved.judgeProvider?.disableThinking, undefined);
+});

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -810,6 +810,8 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
     ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
     ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
+    ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
+    ...(config.seed !== undefined ? { seed: config.seed } : {}),
     ...(config.responderContextBudgetChars !== undefined
       ? { responderContextBudgetChars: config.responderContextBudgetChars }
       : {}),

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -668,6 +668,42 @@ function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
   };
 }
 
+/**
+ * Apply the runtime options that the manifest cannot express onto a
+ * local-lab ProviderConfig. The manifest pins provider/model/baseUrl/
+ * temperature/seed; the CLI/runtime flags (`--request-timeout`,
+ * `--max-429-wait`, `--disable-thinking`) layer on top so a local-lab run
+ * honours the same timeout + thinking-suppression contract as every other
+ * profile (cursor review, issue #1573 PR2).
+ *
+ * Returns the config unchanged when none of the three options are set, so
+ * the common case (manifest-only) stays free of empty retryOptions.
+ */
+function applyLocalLabRuntimeOptions(
+  config: ProviderConfig,
+  options: Pick<ResolveBenchRuntimeProfileOptions, "requestTimeout" | "max429WaitMs" | "disableThinking">,
+): ProviderConfig {
+  const requestTimeout = options.requestTimeout;
+  const max429WaitMs = options.max429WaitMs;
+  const disableThinking = options.disableThinking;
+  const hasRetry = requestTimeout != null || max429WaitMs != null;
+  if (!hasRetry && !disableThinking) {
+    return config;
+  }
+  return {
+    ...config,
+    ...(hasRetry
+      ? {
+          retryOptions: {
+            ...(requestTimeout != null ? { timeoutMs: requestTimeout } : {}),
+            ...(max429WaitMs != null ? { max429WaitMs } : {}),
+          },
+        }
+      : {}),
+    ...(disableThinking ? { disableThinking: true } : {}),
+  };
+}
+
 function registerCodexCliFallbackRunnerIfNeeded(config: ProviderConfig | null): void {
   if (!config || config.provider !== "codex-cli" || codexCliFallbackRegistered) {
     return;
@@ -889,11 +925,13 @@ async function resolveLocalLabRuntimeProfile(
   const drainTimeoutMs = normalizeDrainTimeoutMs(
     options.drainTimeout ?? options.requestTimeout,
   );
-  const systemProvider = sanitizeProviderConfig(
-    resolved.responder.providerConfig,
+  const systemProvider = applyLocalLabRuntimeOptions(
+    sanitizeProviderConfig(resolved.responder.providerConfig),
+    options,
   );
-  const judgeProvider = sanitizeProviderConfig(
-    resolved.judge.providerConfig,
+  const judgeProvider = applyLocalLabRuntimeOptions(
+    sanitizeProviderConfig(resolved.judge.providerConfig),
+    options,
   );
   const judgeFactoryConfig = judgeProvider
     ? asProviderFactoryConfig(judgeProvider)

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -951,15 +951,21 @@ async function resolveLocalLabRuntimeProfile(
   const responder = responderFactoryConfig
     ? createProviderBackedResponder(responderFactoryConfig)
     : undefined;
+  const lcmObserveConcurrencyOverrides =
+    buildLcmObserveConcurrencyOverrides(options.lcmObserveConcurrency);
   const baselineConfig = buildBenchBaselineRemnicConfig();
+  const localLabRemnicConfig = {
+    ...baselineConfig,
+    ...lcmObserveConcurrencyOverrides,
+  };
   const effectiveRemnicConfig = withAssistantHooks(
-    baselineConfig,
+    localLabRemnicConfig,
     responder,
     structuredJudge,
   );
   return {
     profile: "local-lab",
-    remnicConfig: sanitizePersistedConfig(effectiveRemnicConfig),
+    remnicConfig: sanitizePersistedConfig(localLabRemnicConfig),
     effectiveRemnicConfig,
     adapterOptions: {
       configOverrides: effectiveRemnicConfig,

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -30,6 +30,11 @@ import type { ProviderFactoryConfig } from "./providers/types.js";
 import { createProvider } from "./providers/factory.js";
 import { isSecretKey } from "./security/secret-keys.js";
 import type { BenchRuntimeProfile, BuiltInProvider, ProviderConfig } from "./types.js";
+import {
+  loadLocalLabManifest,
+  resolveLocalLabProfile,
+  type ResolvedLocalLabProfile,
+} from "./local-lab/index.js";
 export type BenchModelSource = "plugin" | "gateway";
 
 const OPENCLAW_REMNIC_PLUGIN_IDS = ["openclaw-remnic", "openclaw-engram"] as const;
@@ -97,6 +102,12 @@ export interface ResolveBenchRuntimeProfileOptions {
   drainTimeout?: number;
   max429WaitMs?: number;
   disableThinking?: boolean;
+  /**
+   * Path to a local-lab manifest JSON file (issue #1573 PR2). Required when
+   * `runtimeProfile: "local-lab"`. The manifest pins responder/judge/embedding
+   * to operator-hosted models with temperature=0 and a fixed seed.
+   */
+  localLabManifestPath?: string;
 }
 
 export interface ResolvedBenchRuntimeProfile {
@@ -113,6 +124,12 @@ export interface ResolvedBenchRuntimeProfile {
   systemProvider: ProviderConfig | null;
   judgeProvider: ProviderConfig | null;
   internalProvider: ProviderConfig | null;
+  /**
+   * Resolved local-lab profile (issue #1573 PR2). Present only when
+   * `runtimeProfile: "local-lab"`. Drives sequential phase scheduling +
+   * endpoint preflight in the bench runner.
+   */
+  localLab?: ResolvedLocalLabProfile;
 }
 
 const REDACTED_CONFIG_VALUE = "[redacted]";
@@ -124,6 +141,11 @@ export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
 ): Promise<ResolvedBenchRuntimeProfile> {
   const profile = options.runtimeProfile ?? "baseline";
+
+  if (profile === "local-lab") {
+    return resolveLocalLabRuntimeProfile(options);
+  }
+
   const systemProvider = profile === "openclaw-chain"
     ? null
     : resolveProviderConfig(
@@ -835,4 +857,79 @@ function sanitizePersistedValue(value: unknown): unknown {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+
+/**
+ * Resolve a `local-lab` runtime profile (issue #1573 PR2) into the bench
+ * runtime profile structure. Loads + validates the manifest, then maps the
+ * manifest's responder/judge roles into the existing system/judge provider
+ * slots so the bench runner can drive them without a CLI flag rewrite. The
+ * full resolved profile (with embedding + hand-off notes) is also returned
+ * under `localLab` for the sequential phase scheduler.
+ *
+ * Embedding is intentionally NOT aliased onto `internalProvider`: the
+ * existing `internalProvider` slot describes Remnic's internal LLM calls
+ * (extraction, summarization), not embedding. Wiring embedding into the
+ * runtime path is a separate follow-up; this PR exposes it only via
+ * `localLab.embedding`.
+ */
+async function resolveLocalLabRuntimeProfile(
+  options: ResolveBenchRuntimeProfileOptions,
+): Promise<ResolvedBenchRuntimeProfile> {
+  if (!options.localLabManifestPath) {
+    throw new Error(
+      'local-lab runtime profile requires localLabManifestPath pointing at a manifest JSON file (issue #1573 PR2)',
+    );
+  }
+  const manifest = await loadLocalLabManifest(options.localLabManifestPath);
+  const resolved = resolveLocalLabProfile(manifest);
+  const drainTimeoutMs = normalizeDrainTimeoutMs(
+    options.drainTimeout ?? options.requestTimeout,
+  );
+  const systemProvider = sanitizeProviderConfig(
+    resolved.responder.providerConfig,
+  );
+  const judgeProvider = sanitizeProviderConfig(
+    resolved.judge.providerConfig,
+  );
+  const judgeFactoryConfig = judgeProvider
+    ? asProviderFactoryConfig(judgeProvider)
+    : undefined;
+  const judgeProviderInstance = judgeFactoryConfig
+    ? createProvider(judgeFactoryConfig)
+    : undefined;
+  const judge = judgeFactoryConfig
+    ? createProviderBackedJudge(judgeFactoryConfig, judgeProviderInstance)
+    : undefined;
+  const structuredJudge = judgeFactoryConfig
+    ? createProviderBackedStructuredJudge(judgeFactoryConfig, judgeProviderInstance)
+    : undefined;
+  const responderFactoryConfig = systemProvider
+    ? asProviderFactoryConfig(systemProvider)
+    : undefined;
+  const responder = responderFactoryConfig
+    ? createProviderBackedResponder(responderFactoryConfig)
+    : undefined;
+  const baselineConfig = buildBenchBaselineRemnicConfig();
+  const effectiveRemnicConfig = withAssistantHooks(
+    baselineConfig,
+    responder,
+    structuredJudge,
+  );
+  return {
+    profile: "local-lab",
+    remnicConfig: sanitizePersistedConfig(effectiveRemnicConfig),
+    effectiveRemnicConfig,
+    adapterOptions: {
+      configOverrides: effectiveRemnicConfig,
+      responder,
+      judge,
+      ...(drainTimeoutMs ? { drainTimeoutMs } : {}),
+    },
+    systemProvider,
+    judgeProvider,
+    internalProvider: null,
+    localLab: resolved,
+  };
 }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -8,7 +8,7 @@ export type BenchmarkMode = "full" | "quick";
 export type BenchmarkTier = "published" | "remnic" | "custom";
 export type BenchmarkStatus = "ready" | "planned";
 export type BenchmarkCategory = "agentic" | "retrieval" | "conversational" | "ingestion";
-export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
+export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain" | "local-lab";
 export type AmaBenchJudgeProtocol = "default" | "recommended";
 /**
  * Built-in LLM providers supported by the bench harness.
@@ -43,6 +43,18 @@ export interface ProviderConfig {
   reasoningEffort?: BenchReasoningEffort;
   responderContextBudgetChars?: number;
   responderPromptBudgetChars?: number;
+  /**
+   * Sampling temperature forwarded from a runtime profile manifest (e.g. the
+   * local-lab manifest pins this to 0 for reproducibility). Optional; providers
+   * that do not read it ignore the value.
+   */
+  temperature?: number;
+  /**
+   * Sampling seed forwarded from a runtime profile manifest so local-lab runs
+   * are reproducible across invocations. Optional; providers that do not read
+   * it ignore the value.
+   */
+  seed?: number;
 }
 
 export interface TaskTokenUsage {

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -1012,3 +1012,13 @@ test("parseBenchArgs leaves localLabManifestPath undefined when --local-lab-mani
   const parsed = parseBenchArgs(["run", "locomo", "--runtime-profile", "baseline"]);
   assert.equal(parsed.localLabManifestPath, undefined);
 });
+
+test("parseBenchArgs --matrix empty error lists local-lab alongside the other profiles (cursor review: #1573 PR2 round 5)", () => {
+  // Regression: the empty-matrix error named only baseline/real/openclaw-chain
+  // even though parseBenchRuntimeProfile accepts local-lab, so the message was
+  // an outdated allow-list.
+  assert.throws(
+    () => parseBenchArgs(["run", "locomo", "--matrix", " , , "]),
+    /local-lab/,
+  );
+});

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -985,3 +985,30 @@ test("parseBenchArgs --limit 0 preserved (CLAUDE.md rule 27 slice-negative-zero)
   ]);
   assert.equal(parsed.publishedLimit, 0);
 });
+
+test("parseBenchArgs resolves --local-lab-manifest into localLabManifestPath (cursor review: #1573 PR2)", () => {
+  // Regression: --runtime-profile accepted "local-lab" but there was no flag
+  // to supply localLabManifestPath, so every CLI local-lab resolution failed
+  // with the manifest-path error. --local-lab-manifest closes that gap and
+  // resolves tildes + relative paths identically to other filesystem flags.
+  const parsed = parseBenchArgs([
+    "run",
+    "locomo",
+    "--runtime-profile",
+    "local-lab",
+    "--local-lab-manifest",
+    "~/bench/local-lab.json",
+  ]);
+
+  assert.equal(parsed.runtimeProfile, "local-lab");
+  assert.ok(
+    parsed.localLabManifestPath?.startsWith("/"),
+    "localLabManifestPath must be resolved to an absolute path",
+  );
+  assert.match(parsed.localLabManifestPath ?? "", /local-lab\.json$/);
+});
+
+test("parseBenchArgs leaves localLabManifestPath undefined when --local-lab-manifest is absent", () => {
+  const parsed = parseBenchArgs(["run", "locomo", "--runtime-profile", "baseline"]);
+  assert.equal(parsed.localLabManifestPath, undefined);
+});

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -759,7 +759,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       .filter((value) => value.length > 0);
     if (candidates.length === 0) {
       throw new Error(
-        'ERROR: --matrix must contain one or more of "baseline", "real", or "openclaw-chain".',
+        'ERROR: --matrix must contain one or more of "baseline", "real", "openclaw-chain", or "local-lab".',
       );
     }
     matrixProfiles = candidates.map((candidate) =>

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -113,6 +113,11 @@ export interface ParsedBenchArgs {
   noJudgeCache?: boolean;
   /** Issue #1573 PR1: override the judge-result cache directory. */
   judgeCacheDir?: string;
+  /**
+   * Issue #1573 PR2: path to a local-lab manifest JSON file. Required when
+   * `runtimeProfile` / `matrixProfiles` includes `"local-lab"`.
+   */
+  localLabManifestPath?: string;
 }
 
 export interface BenchWorkItem {
@@ -330,6 +335,7 @@ const BENCH_VALUE_FLAGS = Object.freeze([
   "--ama-bench-cross-judge-base-url",
   "--ama-bench-cross-judge-api-key",
   "--ama-bench-cross-judge-codex-reasoning-effort",
+  "--local-lab-manifest",
 ] as const);
 
 const BENCH_BOOLEAN_FLAGS = Object.freeze([
@@ -410,6 +416,7 @@ const RUN_VALUE_FLAGS = Object.freeze([
   "--ama-bench-cross-judge-base-url",
   "--ama-bench-cross-judge-api-key",
   "--ama-bench-cross-judge-codex-reasoning-effort",
+  "--local-lab-manifest",
 ] as const satisfies readonly BenchValueFlag[]);
 
 const RUN_BOOLEAN_FLAGS = Object.freeze([
@@ -725,6 +732,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   // resolves tildes + relative paths identically to other filesystem flags
   // (datasetDir, resultsDir, baselinesDir).
   const judgeCacheDirRaw = readBenchOptionValue(args, "--judge-cache-dir");
+  const localLabManifestRaw = readBenchOptionValue(args, "--local-lab-manifest");
   const max429WaitRaw = readBenchOptionValue(args, "--max-429-wait");
   const amaBenchJudgeProtocolRaw = readBenchOptionValue(args, "--ama-bench-judge-protocol");
   const amaBenchCrossJudgeProviderRaw = readBenchOptionValue(args, "--ama-bench-cross-judge-provider");
@@ -1292,6 +1300,9 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     // Issue #1573 PR1: surface judge-cache flags into the runner options.
     noJudgeCache: args.includes("--no-judge-cache"),
     judgeCacheDir: judgeCacheDirRaw ? path.resolve(expandTilde(judgeCacheDirRaw)) : undefined,
+    localLabManifestPath: localLabManifestRaw
+      ? path.resolve(expandTilde(localLabManifestRaw))
+      : undefined,
     max429WaitMs,
     disableThinking: args.includes("--disable-thinking"),
     amaBenchJudgeProtocol,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -24,7 +24,7 @@ export type BenchDatasetAction = "download" | "status";
 export type BenchExportFormat = "json" | "csv" | "html";
 export type BenchProviderAction = "discover";
 export type BenchPublishTarget = "remnic-ai";
-export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
+export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain" | "local-lab";
 export type BenchModelSource = "plugin" | "gateway";
 export type BenchRunAction = "list" | "show" | "delete";
 export type AmaBenchJudgeProtocol = "default" | "recommended";
@@ -195,7 +195,8 @@ function isBenchRuntimeProfile(value: string): value is BenchRuntimeProfile {
   return (
     value === "baseline" ||
     value === "real" ||
-    value === "openclaw-chain"
+    value === "openclaw-chain" ||
+    value === "local-lab"
   );
 }
 
@@ -209,12 +210,12 @@ function parseBenchRuntimeProfile(
 
   if (flagName === "--runtime-profile") {
     throw new Error(
-      'ERROR: --runtime-profile must be "baseline", "real", or "openclaw-chain".',
+      'ERROR: --runtime-profile must be "baseline", "real", "openclaw-chain", or "local-lab".',
     );
   }
 
   throw new Error(
-    'ERROR: --matrix must contain only "baseline", "real", or "openclaw-chain".',
+    'ERROR: --matrix must contain only "baseline", "real", "openclaw-chain", or "local-lab".',
   );
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2908,21 +2908,25 @@ async function preflightLocalLabEndpointsIfNeeded(
     );
   }
 
-  // 2. Emit hand-off + preflight judge when the judge lives on a different
-  //    endpoint (codex P1 review: single-GPU runs need the operator to swap
-  //    before the judge phase starts). Same-endpoint (Ollama hot-swap) skips
-  //    the hand-off.
+  // 2. Judge endpoint check. When both roles share an endpoint (the common
+  //    Ollama hot-swap case), preflight the judge model too and proceed.
+  //    When they are on different endpoints, the published harness cannot
+  //    yet run sequential phases (answer-all-then-judge-all) — it executes
+  //    recall→answer→judge per trial, which requires both models to be
+  //    co-resident. Fail fast with an actionable message instead of silently
+  //    failing mid-benchmark after the first trial (codex P1 review, #1573 PR2).
+  //    Full sequential phase execution is PR3 calibration scope.
   const judge = localLab.judge;
   const stripSlash = (url: string) => (url.endsWith("/") ? url.slice(0, -1) : url);
   const sameEndpoint =
     stripSlash(responder.baseUrl) === stripSlash(judge.baseUrl);
   if (!sameEndpoint) {
-    const manifestNote = localLab.notes?.responderToJudgeHandoff;
-    const note =
-      manifestNote && manifestNote.trim().length > 0
-        ? manifestNote.trim()
-        : `stop responder endpoint, start judge endpoint at ${judge.baseUrl} serving model ${judge.model}, then resume the bench`;
-    console.log(`\n  [local-lab hand-off] ${note}\n`);
+    throw new Error(
+      "local-lab multi-endpoint sequential phase execution is not yet wired into the benchmark runner " +
+        "(PR3 calibration scope). The published harness runs recall→answer→judge per trial, which requires " +
+        "both models to be co-resident. Use a single-endpoint profile (both responder and judge models on one " +
+        "Ollama instance) or wait for PR3's runSequentialPhases integration.",
+    );
   }
   const judgeResult = await preflightRole({
     provider: judge.provider,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2880,7 +2880,7 @@ async function loadPublishedPromotionHelpers() {
  * get the same up-front validation (cursor review round 7: custom runs were
  * missing the gate).
  */
-async function preflightLocalLabResponderIfNeeded(
+async function preflightLocalLabEndpointsIfNeeded(
   benchModule: PackageBenchModule,
   plan: PackageBenchExecutionPlan,
 ): Promise<void> {
@@ -2891,16 +2891,48 @@ async function preflightLocalLabResponderIfNeeded(
   ) {
     return;
   }
-  const responder = plan.runtime.localLab.responder;
-  const preflightResult = await benchModule.preflightLocalLabRole({
+  const localLab = plan.runtime.localLab;
+  const preflightRole = benchModule.preflightLocalLabRole;
+
+  // 1. Preflight responder.
+  const responder = localLab.responder;
+  const responderResult = await preflightRole({
     provider: responder.provider,
     baseUrl: responder.baseUrl,
     model: responder.model,
     ctx: responder.ctx,
   });
-  if (!preflightResult.ok) {
+  if (!responderResult.ok) {
     throw new Error(
-      `local-lab responder endpoint preflight failed: ${preflightResult.reason}`,
+      `local-lab responder endpoint preflight failed: ${responderResult.reason}`,
+    );
+  }
+
+  // 2. Emit hand-off + preflight judge when the judge lives on a different
+  //    endpoint (codex P1 review: single-GPU runs need the operator to swap
+  //    before the judge phase starts). Same-endpoint (Ollama hot-swap) skips
+  //    the hand-off.
+  const judge = localLab.judge;
+  const stripSlash = (url: string) => (url.endsWith("/") ? url.slice(0, -1) : url);
+  const sameEndpoint =
+    stripSlash(responder.baseUrl) === stripSlash(judge.baseUrl);
+  if (!sameEndpoint) {
+    const manifestNote = localLab.notes?.responderToJudgeHandoff;
+    const note =
+      manifestNote && manifestNote.trim().length > 0
+        ? manifestNote.trim()
+        : `stop responder endpoint, start judge endpoint at ${judge.baseUrl} serving model ${judge.model}, then resume the bench`;
+    console.log(`\n  [local-lab hand-off] ${note}\n`);
+  }
+  const judgeResult = await preflightRole({
+    provider: judge.provider,
+    baseUrl: judge.baseUrl,
+    model: judge.model,
+    ctx: judge.ctx,
+  });
+  if (!judgeResult.ok) {
+    throw new Error(
+      `local-lab judge endpoint preflight failed: ${judgeResult.reason}`,
     );
   }
 }
@@ -2934,9 +2966,9 @@ async function runBenchViaPackage(
     return { ok: false };
   }
 
-  // local-lab responder preflight gate (issue #1573 PR2, cursor review rounds 5-7).
-  // Shared with runCustomBenchViaPackage via preflightLocalLabResponderIfNeeded.
-  await preflightLocalLabResponderIfNeeded(benchModule, plan);
+  // local-lab endpoint preflight gate (issue #1573 PR2, review rounds 5-11).
+  // Shared with runCustomBenchViaPackage via preflightLocalLabEndpointsIfNeeded.
+  await preflightLocalLabEndpointsIfNeeded(benchModule, plan);
 
   const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
   const datasetDir = resolveBenchDatasetDir(
@@ -3271,7 +3303,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
   const writtenPaths: string[] = [];
   const customBenchmarkIds: string[] = [];
   for (const plan of plans) {
-    await preflightLocalLabResponderIfNeeded(benchModule, plan);
+    await preflightLocalLabEndpointsIfNeeded(benchModule, plan);
     const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
     try {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -894,7 +894,7 @@ Commands:
 Options:
   --quick                  Run a lightweight quick pass (maps to --lightweight --limit 1)
   --all                    Run every published benchmark
-  --runtime-profile <baseline|real|openclaw-chain>
+  --runtime-profile <baseline|real|openclaw-chain|local-lab>
                            Choose the benchmark runtime profile
   --matrix <profiles>      Run a benchmark across a comma-separated profile matrix
   --dataset-dir <path>     Override the benchmark dataset directory for full runs
@@ -946,6 +946,8 @@ Options:
   --baselines-dir <path>   Override the named baseline directory
   --request-timeout <ms>   Provider request timeout in milliseconds
   --drain-timeout <ms>     Memory drain timeout in milliseconds (defaults to --request-timeout when unset)
+  --local-lab-manifest <path>
+                           Path to a local-lab manifest JSON file (required for --runtime-profile local-lab)
   --threshold <value>      Regression threshold for compare (default: 0.05)
   --trial-limit <n>        Cap scored LoCoMo or MemoryAgentBench QA trials for staged published runs
   --task-filter <pattern>  BEAM diagnostic filter; match task id, ability, or question text
@@ -1047,6 +1049,8 @@ export function buildBenchRuntimeProfileRequest(
     max429WaitMs: parsed.max429WaitMs,
     disableThinking: parsed.disableThinking,
     lcmObserveConcurrency: parsed.publishedIngestConcurrency,
+    localLabManifestPath:
+      runtimeProfile === "local-lab" ? parsed.localLabManifestPath : undefined,
   };
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -223,6 +223,7 @@ import type {
   BenchmarkDefinition,
   BenchmarkResult,
   ComparisonResult,
+  ResolvedLocalLabProfile,
 } from "@remnic/bench";
 import { firstSuccessfulCandidate, firstSuccessfulResult } from "./service-candidates.js";
 import {
@@ -744,7 +745,7 @@ async function loadTrainingExportCoreRuntime(): Promise<CoreTrainingExportRuntim
   return (await import("@remnic/core")) as unknown as CoreTrainingExportRuntime;
 }
 
-type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
+type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain" | "local-lab";
 
 interface BenchProviderConfig {
   provider: string;
@@ -799,6 +800,12 @@ interface ResolveBenchRuntimeProfileOptions {
   drainTimeout?: number;
   max429WaitMs?: number;
   disableThinking?: boolean;
+  /**
+   * Path to a local-lab manifest JSON file (issue #1573 PR2). Required when
+   * `runtimeProfile: "local-lab"`. The manifest pins responder/judge/embedding
+   * to operator-hosted models with temperature=0 and a fixed seed.
+   */
+  localLabManifestPath?: string;
 }
 
 interface ResolvedBenchRuntimeProfile {
@@ -815,6 +822,12 @@ interface ResolvedBenchRuntimeProfile {
   systemProvider: BenchProviderConfig | null;
   judgeProvider: BenchProviderConfig | null;
   internalProvider: BenchProviderConfig | null;
+  /**
+   * Resolved local-lab profile (issue #1573 PR2). Present only when
+   * `runtimeProfile: "local-lab"`. Drives sequential phase scheduling +
+   * endpoint preflight in the bench runner.
+   */
+  localLab?: ResolvedLocalLabProfile;
 }
 
 interface BenchSummaryResult {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1237,6 +1237,11 @@ async function runBenchViaFallback(
       'Fallback benchmark runner does not support --runtime-profile "openclaw-chain". Build/install @remnic/bench to use package-backed runtime profiles.',
     );
   }
+  if (runtimeProfile === "local-lab") {
+    throw new Error(
+      'Fallback benchmark runner does not support --runtime-profile "local-lab". Build/install @remnic/bench to use package-backed runtime profiles with local-lab manifests.',
+    );
+  }
   const unsupportedOptions = findUnsupportedFallbackBenchOptions(parsed);
   if (unsupportedOptions.length > 0) {
     throw new Error(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2860,6 +2860,46 @@ async function loadPublishedPromotionHelpers() {
   };
 }
 
+/**
+ * Local-lab responder preflight gate (issue #1573 PR2, cursor review rounds 5-7).
+ * Probes ONLY the responder (first phase) endpoint before the benchmark starts
+ * so the operator gets a clear model-mismatch / endpoint-down error up front
+ * (rule 51: the failure reason carries the endpoint's actual model list) instead
+ * of a mid-run failure. The judge is intentionally NOT probed here: in the
+ * documented single-GPU swap flow the judge endpoint is not running at startup
+ * (the operator starts it after the responder phase), so probing it now would
+ * block the sequential run. The judge preflight belongs at the hand-off
+ * transition, which PR3 calibration wires via runSequentialPhases.
+ *
+ * Shared by runBenchViaPackage and runCustomBenchViaPackage so both run paths
+ * get the same up-front validation (cursor review round 7: custom runs were
+ * missing the gate).
+ */
+async function preflightLocalLabResponderIfNeeded(
+  benchModule: PackageBenchModule,
+  plan: PackageBenchExecutionPlan,
+): Promise<void> {
+  if (
+    plan.runtime.profile !== "local-lab" ||
+    !plan.runtime.localLab ||
+    !benchModule.preflightLocalLabRole
+  ) {
+    return;
+  }
+  const responder = plan.runtime.localLab.responder;
+  const preflightResult = await benchModule.preflightLocalLabRole({
+    provider: responder.provider,
+    baseUrl: responder.baseUrl,
+    model: responder.model,
+    ctx: responder.ctx,
+  });
+  if (!preflightResult.ok) {
+    throw new Error(
+      `local-lab responder endpoint preflight failed: ${preflightResult.reason}`,
+    );
+  }
+}
+
 async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
@@ -2889,34 +2929,9 @@ async function runBenchViaPackage(
     return { ok: false };
   }
 
-  // local-lab endpoint preflight gate (issue #1573 PR2, cursor review rounds 5-6):
-  // probe ONLY the responder (first phase) endpoint before the benchmark
-  // starts, so the operator gets a clear model-mismatch / endpoint-down
-  // error up front (rule 51: surface the endpoint's actual model list)
-  // instead of a mid-run failure. The judge is intentionally NOT probed
-  // here: in the documented single-GPU swap flow (responder + judge on
-  // different baseUrls) the judge endpoint is not running at startup — the
-  // operator starts it after the responder phase. Preflighting it now
-  // would block the sequential run. The judge preflight belongs at the
-  // hand-off transition, which PR3 calibration wires via runSequentialPhases.
-  if (
-    plan.runtime.profile === "local-lab" &&
-    plan.runtime.localLab &&
-    benchModule.preflightLocalLabRole
-  ) {
-    const responder = plan.runtime.localLab.responder;
-    const preflightResult = await benchModule.preflightLocalLabRole({
-      provider: responder.provider,
-      baseUrl: responder.baseUrl,
-      model: responder.model,
-      ctx: responder.ctx,
-    });
-    if (!preflightResult.ok) {
-      throw new Error(
-        `local-lab responder endpoint preflight failed: ${preflightResult.reason}`,
-      );
-    }
-  }
+  // local-lab responder preflight gate (issue #1573 PR2, cursor review rounds 5-7).
+  // Shared with runCustomBenchViaPackage via preflightLocalLabResponderIfNeeded.
+  await preflightLocalLabResponderIfNeeded(benchModule, plan);
 
   const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
   const datasetDir = resolveBenchDatasetDir(
@@ -3251,6 +3266,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
   const writtenPaths: string[] = [];
   const customBenchmarkIds: string[] = [];
   for (const plan of plans) {
+    await preflightLocalLabResponderIfNeeded(benchModule, plan);
     const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
     try {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -706,6 +706,22 @@ type PackageBenchModule = {
     tasks: number;
     errors: string[];
   }>;
+  /**
+   * Probe a single local-lab manifest role's endpoint before the benchmark
+   * starts (issue #1573 PR2). Returns ok=true on success or ok=false with
+   * a reason carrying the endpoint's actual model list on mismatch
+   * (rule 51). Wired into the run path so operators get a clear error up
+   * front instead of a mid-run failure.
+   */
+  preflightLocalLabRole?: (input: {
+    provider: string;
+    baseUrl: string;
+    model: string;
+    ctx: number;
+  }, options?: { fetchImpl?: unknown; timeoutMs?: number }) => Promise<
+    | { ok: true; expectedModel: string; discoveredModels: unknown[] }
+    | { ok: false; reason: string; expectedModel: string; discoveredModels?: unknown[] }
+  >;
 };
 
 interface TrainingExportOptions {
@@ -2871,6 +2887,38 @@ async function runBenchViaPackage(
   const [plan] = plans;
   if (!plan) {
     return { ok: false };
+  }
+
+  // local-lab endpoint preflight gate (issue #1573 PR2, cursor review round 5):
+  // probe each manifest role's endpoint before the benchmark starts so the
+  // operator gets a clear model-mismatch / endpoint-down error up front
+  // (rule 51: surface the endpoint's actual model list) instead of a mid-run
+  // failure. Full sequential phase scheduling (runSequentialPhases with
+  // responder->judge hand-off) lands in PR3 calibration; this gate delivers
+  // the preflight half of the local-lab run contract now.
+  if (
+    plan.runtime.profile === "local-lab" &&
+    plan.runtime.localLab &&
+    benchModule.preflightLocalLabRole
+  ) {
+    const ll = plan.runtime.localLab;
+    const roles: Array<[string, { provider: string; baseUrl: string; model: string; ctx: number }]> = [
+      ["responder", ll.responder],
+      ["judge", ll.judge],
+    ];
+    for (const [roleName, role] of roles) {
+      const preflightResult = await benchModule.preflightLocalLabRole({
+        provider: role.provider,
+        baseUrl: role.baseUrl,
+        model: role.model,
+        ctx: role.ctx,
+      });
+      if (!preflightResult.ok) {
+        throw new Error(
+          `local-lab ${roleName} endpoint preflight failed: ${preflightResult.reason}`,
+        );
+      }
+    }
   }
 
   const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2889,35 +2889,32 @@ async function runBenchViaPackage(
     return { ok: false };
   }
 
-  // local-lab endpoint preflight gate (issue #1573 PR2, cursor review round 5):
-  // probe each manifest role's endpoint before the benchmark starts so the
-  // operator gets a clear model-mismatch / endpoint-down error up front
-  // (rule 51: surface the endpoint's actual model list) instead of a mid-run
-  // failure. Full sequential phase scheduling (runSequentialPhases with
-  // responder->judge hand-off) lands in PR3 calibration; this gate delivers
-  // the preflight half of the local-lab run contract now.
+  // local-lab endpoint preflight gate (issue #1573 PR2, cursor review rounds 5-6):
+  // probe ONLY the responder (first phase) endpoint before the benchmark
+  // starts, so the operator gets a clear model-mismatch / endpoint-down
+  // error up front (rule 51: surface the endpoint's actual model list)
+  // instead of a mid-run failure. The judge is intentionally NOT probed
+  // here: in the documented single-GPU swap flow (responder + judge on
+  // different baseUrls) the judge endpoint is not running at startup — the
+  // operator starts it after the responder phase. Preflighting it now
+  // would block the sequential run. The judge preflight belongs at the
+  // hand-off transition, which PR3 calibration wires via runSequentialPhases.
   if (
     plan.runtime.profile === "local-lab" &&
     plan.runtime.localLab &&
     benchModule.preflightLocalLabRole
   ) {
-    const ll = plan.runtime.localLab;
-    const roles: Array<[string, { provider: string; baseUrl: string; model: string; ctx: number }]> = [
-      ["responder", ll.responder],
-      ["judge", ll.judge],
-    ];
-    for (const [roleName, role] of roles) {
-      const preflightResult = await benchModule.preflightLocalLabRole({
-        provider: role.provider,
-        baseUrl: role.baseUrl,
-        model: role.model,
-        ctx: role.ctx,
-      });
-      if (!preflightResult.ok) {
-        throw new Error(
-          `local-lab ${roleName} endpoint preflight failed: ${preflightResult.reason}`,
-        );
-      }
+    const responder = plan.runtime.localLab.responder;
+    const preflightResult = await benchModule.preflightLocalLabRole({
+      provider: responder.provider,
+      baseUrl: responder.baseUrl,
+      model: responder.model,
+      ctx: responder.ctx,
+    });
+    if (!preflightResult.ok) {
+      throw new Error(
+        `local-lab responder endpoint preflight failed: ${preflightResult.reason}`,
+      );
     }
   }
 

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -23,7 +23,7 @@ test("@remnic/bench publishes compiled entrypoints instead of raw source paths",
   assert.equal(dotExport?.types, "./dist/index.d.ts");
   // `baselines/` ships with the package so consumers can compare their
   // ablation runs against the committed reference artifacts (issue #567 PR 2).
-  assert.deepEqual(pkg.files, ["dist", "baselines"]);
+  assert.deepEqual(pkg.files, ["dist", "baselines", "profiles"]);
   // The baseline JSON is importable via subpath so consumers can read it
   // without reaching into `node_modules` by relative path (issue #567 PR 2,
   // Codex #606). We expose both a generic glob and a `.json`-qualified

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -206,7 +206,7 @@ test("bench CLI exposes runtime profile and provider-backed run surfaces", async
   const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
-  assert.match(source, /--runtime-profile <baseline\|real\|openclaw-chain>/);
+  assert.match(source, /--runtime-profile <baseline\|real\|openclaw-chain\|local-lab>/);
   assert.match(source, /--matrix <profiles>/);
   assert.match(source, /--remnic-config <path>/);
   assert.match(source, /--openclaw-config <path>/);
@@ -222,8 +222,9 @@ test("bench CLI exposes runtime profile and provider-backed run surfaces", async
   assert.match(source, /remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config/);
   assert.match(source, /remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model/);
   assert.match(source, /remnic bench run longmemeval --matrix baseline,real,openclaw-chain/);
+  assert.match(source, /--local-lab-manifest <path>/);
 
-  assert.match(parserSource, /export type BenchRuntimeProfile = "baseline" \| "real" \| "openclaw-chain";/);
+  assert.match(parserSource, /export type BenchRuntimeProfile = "baseline" \| "real" \| "openclaw-chain" \| "local-lab";/);
   assert.match(parserSource, /runtimeProfile\?: BenchRuntimeProfile;/);
   assert.match(parserSource, /matrixProfiles\?: BenchRuntimeProfile\[];/);
   assert.match(parserSource, /systemProvider\?: BuiltInProvider;/);


### PR DESCRIPTION
Part of #1572/#1573. Standards: #1520.

## Summary

Adds the `local-lab` runtime profile (issue #1573 PR2): a manifest-driven profile that pins responder/judge/embedding to operator-hosted models with `temperature=0` and a fixed seed, so the bench runs entirely on local hardware (single RTX 3090, 24 GB VRAM) with no paid API calls.

### New modules (`packages/bench/src/local-lab/`)
- **`manifest.ts`** — parse + validate the JSON manifest. Unknown provider kinds are rejected with a rule-51 error listing the valid ones (`openai-compatible`, `ollama`). Non-zero temperature and missing seed are rejected (no silent coercion, rule 39).
- **`resolve-local-lab-profile.ts`** — map each manifest role into a bench `ProviderConfig`, forwarding `temperature` and `seed` verbatim so providers read them off the config directly.
- **`preflight.ts`** — probe each endpoint (`GET /v1/models` or `/api/tags`), verify the manifest model id is reported and context length ≥ manifest `ctx`. Mismatch surfaces the endpoint's **actual model list** (rule 51), never silent fallback. `baseUrl`/`model` are fetch targets only (rule 10).
- **`sequential-phases.ts`** — run phases in declared order (responder → judge), preflighting each before execute, emitting operator hand-off guidance between phases on different endpoints; silent when both share an endpoint (Ollama hot-swap).

### Resolution + CLI sync
`resolveBenchRuntimeProfile` gains a `localLabManifestPath` option and routes `local-lab` through the new resolver. The CLI's parallel `BenchRuntimeProfile` union, `ResolveBenchRuntimeProfileOptions`, and `ResolvedBenchRuntimeProfile` are synced (add `local-lab`, `localLabManifestPath`, `localLab`) so `check-types` stays green.

### Reference manifest + README
`packages/bench/profiles/local-lab-3090.json` ships placeholder model ids (operator replaces with their endpoint's reported ids) + a README documenting the VRAM math from the issue's hardware envelope (one model at a time on 24 GB, 16–32k serving ctx, sequential phase swaps).

## Test evidence

Four issue-mandated test classes (37 tests, all green, run with `NODE_OPTIONS=--conditions=remnic-source tsx --test`):
- **`manifest.test.ts`** — unknown-provider rejection lists valid kinds (rule 51); rejects non-zero temperature, missing seed, wrong discriminator, non-object root.
- **`preflight.test.ts`** — failure surfaces the endpoint's actual model list (rule 51); transport failures surface as results not thrown errors; context-length check.
- **`sequential-phases.test.ts`** — phases run in declared order with a stub provider; preflight runs before any execute; hand-off emitted on different endpoints, suppressed on shared; hard-rejects on preflight failure.
- **`resolve-local-lab-profile.test.ts`** — `temperature`/`seed` forwarded into the resolved `ProviderConfig` (PR2 assertion); maps `openai-compatible → local-llm`, `ollama → ollama`.

## Gates
- `pnpm --filter @remnic/bench build` ✅
- `pnpm --filter @remnic/cli build` ✅
- `pnpm --filter @remnic/cli run check-types` ✅
- `bash scripts/check-review-patterns.sh` → PASSED
- `npm run preflight:quick` → `[preflight] OK (quick)`
- `[test-typecheck] OK (matches existing baseline)`
- `[ratchet] OK`

Chokepoints used: runtime-profiles resolution + sanitizeProviderConfig

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core bench runtime resolution, provider request bodies, and CLI run gates; mis-preflight or URL normalization could block valid local runs, but scope is mostly additive with heavy test coverage.
> 
> **Overview**
> Introduces the **`local-lab`** bench runtime profile so runs can pin responder, judge, and optional embedding to operator-hosted **Ollama** or **OpenAI-compatible** endpoints via a JSON manifest (`temperature: 0`, fixed `seed`, sequential phases).
> 
> **@remnic/bench** adds `packages/bench/src/local-lab/` (manifest parse/load, role→`ProviderConfig` resolution with `/api` and `/v1` URL normalization, endpoint preflight against `/v1/models` or `/api/tags`, and `runSequentialPhases` with hand-off hooks). Reference **`local-lab-3090.json`** and docs ship under `packages/bench/profiles/`, with package exports for `./profiles/*`.
> 
> **Runtime integration:** `resolveBenchRuntimeProfile` routes `local-lab` through the manifest path, maps responder/judge into system/judge providers, applies CLI timeout/thinking/concurrency flags like other profiles, and exposes `localLab` on the resolved profile. **`ProviderConfig`** and local LLM/Ollama/OpenAI-compatible providers now forward manifest **`temperature`** and **`seed`** on completions.
> 
> **CLI:** `--runtime-profile local-lab`, `--local-lab-manifest <path>`, and a shared preflight gate before standard and custom runs (same-endpoint profiles preflight both models; **multi-endpoint manifests fail fast** until PR3 wires full sequential execution into the trial loop).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b4e13148bba08ec220264d8fdae23a70d839a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->