### PR TITLE
refactor(access): single validation boundary — pilot ops + fitness inventory (#1525)

### DIFF
--- a/packages/remnic-core/src/access-boundary.test.ts
+++ b/packages/remnic-core/src/access-boundary.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the access boundary (issue #1525).
+ *
+ * Covers the normalization matrix the boundary owns (rules 17/28/36/48/51),
+ * the registry's validate-then-invoke contract, and the rule-51 "list valid
+ * options" error format. The surface-coverage fitness test lives in
+ * `access-surface-catalog.test.ts`.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  __resetRegistryForTest,
+  coerceBooleanLike,
+  coercePositiveInteger,
+  defineOperation,
+  formatZodIssues,
+  getOperation,
+  listRegisteredOperations,
+  normalizeOptionalPath,
+  type OperationContext,
+} from "./access-boundary.js";
+import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeMockService(handlers: Partial<EngramAccessService> = {}): EngramAccessService {
+  return { ...handlers } as unknown as EngramAccessService;
+}
+
+const ctx = (service: EngramAccessService, principal?: string): OperationContext => ({
+  service,
+  authenticatedPrincipal: principal,
+});
+
+// Reset the pilot registrations between files so defineOperation's "already
+// registered" guard doesn't fire when the real `access-operations.ts` is
+// imported by sibling test files in the same process.
+test.afterEach(() => {
+  __resetRegistryForTest();
+});
+
+// ---------------------------------------------------------------------------
+// coerceBooleanLike — rule 36 (string "false" is truthy)
+// ---------------------------------------------------------------------------
+
+test("coerceBooleanLike: accepts real booleans", () => {
+  assert.equal(coerceBooleanLike(true), true);
+  assert.equal(coerceBooleanLike(false), false);
+});
+
+test("coerceBooleanLike: treats absence as undefined (caller keeps its default)", () => {
+  assert.equal(coerceBooleanLike(undefined), undefined);
+  assert.equal(coerceBooleanLike(null), undefined);
+  assert.equal(coerceBooleanLike(""), undefined);
+});
+
+test("coerceBooleanLike: coerces every documented spelling, case-insensitive", () => {
+  for (const truthy of ["true", "TRUE", "1", "yes", "YES", "on"]) {
+    assert.equal(coerceBooleanLike(truthy), true, `${truthy} should be true`);
+  }
+  for (const falsy of ["false", "False", "0", "no", "No", "off"]) {
+    assert.equal(coerceBooleanLike(falsy), false, `${falsy} should be false`);
+  }
+});
+
+test("coerceBooleanLike: rejects values Boolean() would silently mis-coerce", () => {
+  // These are the exact cases rule 36 exists for — `Boolean("false") === true`
+  // would let `--installExtension=false` silently enable the flag.
+  assert.throws(() => coerceBooleanLike("not-a-bool"), EngramAccessInputError);
+  assert.throws(() => coerceBooleanLike(2), EngramAccessInputError);
+  assert.throws(() => coerceBooleanLike({}), EngramAccessInputError);
+});
+
+// ---------------------------------------------------------------------------
+// coercePositiveInteger — rule 28 (numeric strings at the edge)
+// ---------------------------------------------------------------------------
+
+test("coercePositiveInteger: absence → undefined", () => {
+  assert.equal(coercePositiveInteger(undefined, "limit"), undefined);
+  assert.equal(coercePositiveInteger(null, "limit"), undefined);
+  assert.equal(coercePositiveInteger("", "limit"), undefined);
+});
+
+test("coercePositiveInteger: coerces numeric strings the service would later reject", () => {
+  assert.equal(coercePositiveInteger("5", "limit"), 5);
+  assert.equal(coercePositiveInteger("5555", "port"), 5555);
+});
+
+test("coercePositiveInteger: accepts numbers that pass the integer/positive guard", () => {
+  assert.equal(coercePositiveInteger(7, "limit"), 7);
+});
+
+test("coercePositiveInteger: rejects zero, negatives, non-integers, booleans", () => {
+  // `Number(true) === 1` would silently pass without this guard.
+  for (const bad of [0, -1, 1.5, "0", "-3", "1.5", true, false, NaN]) {
+    assert.throws(() => coercePositiveInteger(bad, "limit"), EngramAccessInputError);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// normalizeOptionalPath — rule 17 (~ expansion via the shared helper)
+// ---------------------------------------------------------------------------
+
+test("normalizeOptionalPath: absence → undefined", () => {
+  assert.equal(normalizeOptionalPath(undefined), undefined);
+  assert.equal(normalizeOptionalPath(null), undefined);
+  assert.equal(normalizeOptionalPath(""), undefined);
+});
+
+test("normalizeOptionalPath: expands ~ via expandTildePath, never ad-hoc regex", () => {
+  const original = process.env.HOME;
+  const fakeHome = "/tmp/remnic-boundary-home";
+  process.env.HOME = fakeHome;
+  try {
+    assert.equal(normalizeOptionalPath("~/memory"), `${fakeHome}/memory`);
+  } finally {
+    process.env.HOME = original;
+  }
+});
+
+test("normalizeOptionalPath: rejects non-string shapes loudly", () => {
+  assert.throws(() => normalizeOptionalPath(42), EngramAccessInputError);
+  assert.throws(() => normalizeOptionalPath({ path: "x" }), EngramAccessInputError);
+});
+
+// ---------------------------------------------------------------------------
+// formatZodIssues — rule 51 (list valid options, never silently default)
+// ---------------------------------------------------------------------------
+
+test("formatZodIssues: names the offending field and lists enum options", async () => {
+  const { z } = await import("zod");
+  const schema = z.object({ mode: z.enum(["auto", "no_recall"]) });
+  const result = schema.safeParse({ mode: "bogus" });
+  assert.ok(!result.success);
+  const message = formatZodIssues(result.error);
+  assert.match(message, /mode/);
+  assert.match(message, /auto.*no_recall/);
+});
+
+test("formatZodIssues: includes the (root) path for top-level errors", async () => {
+  const { z } = await import("zod");
+  const schema = z.object({}).strict();
+  const result = schema.safeParse({ rogue: 1 });
+  assert.ok(!result.success);
+  const message = formatZodIssues(result.error);
+  assert.ok(message.length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// defineOperation / getOperation — registry contract
+// ---------------------------------------------------------------------------
+
+test("defineOperation: parses then invokes the handler with the typed input", async () => {
+  let observed: { x?: number } | undefined;
+  const op = defineOperation<{ x?: number }, { doubled: number }>({
+    name: "memory_get",
+    description: "test",
+    schema: (await import("zod")).object({ x: (await import("zod")).number().optional() }),
+    handler: async (input) => {
+      observed = input;
+      return { doubled: (input.x ?? 0) * 2 };
+    },
+  });
+  const out = await op.run({ x: 21 }, ctx(makeMockService()));
+  assert.equal(out.doubled, 42);
+  assert.deepEqual(observed, { x: 21 });
+});
+
+test("defineOperation: rejects invalid input with EngramAccessInputError BEFORE the handler runs", async () => {
+  let ran = false;
+  const op = defineOperation<{ x: number }, void>({
+    name: "memory_get",
+    description: "test",
+    schema: (await import("zod")).object({ x: (await import("zod")).number() }),
+    handler: async () => {
+      ran = true;
+    },
+  });
+  await assert.rejects(
+    () => op.run({ x: "not-a-number" }, ctx(makeMockService())),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+  assert.equal(ran, false, "handler must not run on validation failure");
+});
+
+test("defineOperation: duplicate registration is a programming error, not an input fault", async () => {
+  const { z } = await import("zod");
+  const spec = {
+    name: "memory_get" as const,
+    description: "first",
+    schema: z.object({}),
+    handler: async () => undefined,
+  };
+  defineOperation(spec);
+  assert.throws(() => defineOperation(spec), /already registered/);
+});
+
+test("getOperation / listRegisteredOperations: round-trip a registration", async () => {
+  const { z } = await import("zod");
+  defineOperation({
+    name: "memory_search",
+    description: "test",
+    schema: z.object({}),
+    handler: async () => undefined,
+  });
+  assert.ok(getOperation("memory_search"));
+  assert.ok(listRegisteredOperations().includes("memory_search"));
+});

--- a/packages/remnic-core/src/access-boundary.ts
+++ b/packages/remnic-core/src/access-boundary.ts
@@ -1,0 +1,235 @@
+/**
+ * Single input-validation and error boundary for the CLI/MCP/HTTP access
+ * surfaces (issue #1525, epic #1520 Phase 1).
+ *
+ * Every operation that crosses the access-service facade passes through ONE
+ * registry entry: a zod-validated request envelope, a shared error mapper,
+ * and the "reject invalid input and list valid options" behavior that
+ * CLAUDE.md rules 14/17/24/28/36/48/51 previously had to be re-implemented
+ * per handler. The three surfaces become thin adapters — one operation
+ * definition, three transports — so a validation fix lands everywhere at
+ * once.
+ *
+ * Host-agnostic (rule 31): operation names carry no `openclaw-*`/`engram-*`
+ * prefix. Session/namespace tenancy stays in the handler layer (resolved via
+ * ScopePlan #1521); the boundary validates SHAPE, not tenancy.
+ */
+
+import { z } from "zod";
+import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+import { expandTildePath } from "./utils/path.js";
+
+// ---------------------------------------------------------------------------
+// Canonical operation names — host-agnostic (rule 31)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical operation ids. One id is shared by the MCP tool, the HTTP route,
+ * and the CLI command that expose the same operation. Add to this union as
+ * each domain-group migration PR (memory ops → connectors → namespaces …)
+ * lands; the fitness test in `access-surface-catalog.test.ts` treats the
+ * registered set as the migration state.
+ */
+export type OperationName =
+  | "memory_get"
+  | "memory_search"
+  | "memory_store";
+
+// ---------------------------------------------------------------------------
+// Operation context — what every handler receives
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-call context. `service` is the facade the handler delegates to; the
+ * boundary never reaches past it. `authenticatedPrincipal` is resolved by
+ * the SURFACE (MCP header / HTTP identity / CLI flag) before the boundary
+ * runs, so handlers stay principal-source-agnostic. `hooks` carries
+ * transport-level callbacks (e.g. HTTP write-quota enforcement) that must
+ * fire atomically inside the service call; surfaces that have no such hook
+ * leave it undefined.
+ */
+export interface OperationContext {
+  readonly service: EngramAccessService;
+  readonly authenticatedPrincipal?: string;
+  readonly hooks?: OperationHooks;
+}
+
+/**
+ * Transport-level callbacks a handler forwards into the service call. Kept
+ * narrow on purpose: the boundary owns validation + dispatch shape, not
+ * transport policy. Add fields here only when a surface genuinely needs a
+ * callback the service itself consumes.
+ */
+export interface OperationHooks {
+  /** HTTP write-quota gate; throws to reject the write when exhausted. */
+  readonly enforceWriteQuota?: () => void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Operation spec + bound operation
+// ---------------------------------------------------------------------------
+
+export interface OperationSpec<In, Out> {
+  /** Canonical operation id; matches an {@link OperationName}. */
+  readonly name: OperationName;
+  readonly description: string;
+  /** Zod schema validating the raw request envelope. */
+  readonly schema: z.ZodType<In>;
+  /** Handler invoked with the parsed input; throws EngramAccessInputError for domain faults. */
+  readonly handler: (input: In, ctx: OperationContext) => Promise<Out>;
+}
+
+export interface BoundOperation<In = unknown, Out = unknown> {
+  readonly spec: OperationSpec<In, Out>;
+  /** Validate the raw envelope, then invoke the handler. Throws EngramAccessInputError on any validation failure. */
+  readonly run: (rawInput: unknown, ctx: OperationContext) => Promise<Out>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared normalizers the boundary owns (rules 17, 28, 36, 48, 51)
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerce boolean-like strings at the edge (rule 36). Accepts actual booleans
+ * and the string spellings clients send ("true"/"false"/"1"/"0"/"yes"/"no"/
+ * "on"/"off", case-insensitive). Rejects anything else loudly — `Boolean("false")`
+ * would silently be `true`, which is the bug rule 36 exists to prevent.
+ *
+ * `undefined`/`null`/`""` → `undefined`, so callers can keep treating an
+ * absent flag as "use the default" without a separate presence check.
+ */
+export function coerceBooleanLike(value: unknown): boolean | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const lower = value.trim().toLowerCase();
+    if (lower === "true" || lower === "1" || lower === "yes" || lower === "on") return true;
+    if (lower === "false" || lower === "0" || lower === "no" || lower === "off") return false;
+  }
+  throw new EngramAccessInputError(
+    `expected a boolean-like value (true|false|1|0|yes|no|on|off); got ${JSON.stringify(value)}`,
+  );
+}
+
+/**
+ * Coerce + validate a positive integer from a numeric string or number
+ * (rule 28). Loosely-typed MCP/CLI clients send `"5"`; `typeof saved === "number"`
+ * on read-back would reject it later, so we coerce at the edge and reject
+ * booleans/objects loudly (`Number(true) === 1` would silently pass otherwise).
+ *
+ * `undefined`/`null`/`""` → `undefined`.
+ */
+export function coercePositiveInteger(value: unknown, label: string): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0 || !Number.isInteger(value)) {
+      throw new EngramAccessInputError(`${label} expects a positive integer; got ${JSON.stringify(value)}`);
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!/^[+-]?\d+$/.test(trimmed)) {
+      throw new EngramAccessInputError(`${label} expects a positive integer; got ${JSON.stringify(value)}`);
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      throw new EngramAccessInputError(`${label} expects a positive integer; got ${JSON.stringify(value)}`);
+    }
+    return parsed;
+  }
+  throw new EngramAccessInputError(`${label} expects a positive integer; got ${JSON.stringify(value)}`);
+}
+
+/**
+ * Expand `~` in a path-shaped input (rule 17). Node `fs` does NOT expand `~`;
+ * ad-hoc regex drifts. `undefined`/`null`/`""` → `undefined`.
+ */
+export function normalizeOptionalPath(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") {
+    throw new EngramAccessInputError(`expected a path string; got ${JSON.stringify(value)}`);
+  }
+  return expandTildePath(value);
+}
+
+// ---------------------------------------------------------------------------
+// Error formatting — rule 51: list valid options, never silently default
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn a zod failure into an {@link EngramAccessInputError} whose message
+ * names the offending field and — for enum/union issues — lists the valid
+ * options, so the caller can correct rather than guess (rule 51).
+ */
+export function formatZodIssues(error: z.ZodError): string {
+  const parts: string[] = [];
+  for (const issue of error.issues) {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+    const options = enumOptionsFromIssue(issue);
+    const suffix = options ? `. Valid: ${options.join(", ")}` : "";
+    parts.push(`${path}: ${issue.message}${suffix}`);
+  }
+  return parts.length > 0
+    ? `request validation failed: ${parts.join("; ")}`
+    : "request validation failed";
+}
+
+function enumOptionsFromIssue(issue: z.ZodIssue): readonly string[] | undefined {
+  // zod exposes accepted enum values on the issue for ZodEnum / ZodNativeEnum
+  // and on the options of invalid_union discriminators. Reading them here
+  // keeps "list valid options" in ONE place rather than per handler.
+  if (issue.code === z.ZodIssueCode.invalid_enum_value) {
+    const rawOptions = (issue as { options?: unknown }).options;
+    if (Array.isArray(rawOptions)) {
+      return rawOptions.map((opt) => String(opt));
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const registry = new Map<OperationName, BoundOperation>();
+
+/**
+ * Register an operation. Throws if the name is already registered — duplicate
+ * registration is a programming error, not a runtime input fault, so it throws
+ * a plain Error (not the input-error class surfaces translate for clients).
+ */
+export function defineOperation<In, Out>(spec: OperationSpec<In, Out>): BoundOperation<In, Out> {
+  if (registry.has(spec.name)) {
+    throw new Error(`access-boundary: operation already registered: ${spec.name}`);
+  }
+  const bound: BoundOperation<In, Out> = {
+    spec,
+    run: async (rawInput, ctx) => {
+      const parseResult = spec.schema.safeParse(rawInput);
+      if (!parseResult.success) {
+        throw new EngramAccessInputError(formatZodIssues(parseResult.error));
+      }
+      return spec.handler(parseResult.data, ctx);
+    },
+  };
+  // Store under the canonical name; the cast is safe because In/Out are
+  // erased at the registry boundary and recovered by callers via getOperation.
+  registry.set(spec.name, bound as unknown as BoundOperation);
+  return bound;
+}
+
+/** Look up a registered operation by canonical name. */
+export function getOperation(name: OperationName): BoundOperation | undefined {
+  return registry.get(name);
+}
+
+/** All registered operation names. */
+export function listRegisteredOperations(): readonly OperationName[] {
+  return [...registry.keys()];
+}
+
+/** Test-only: clear the registry so pilot definitions can be re-registered. */
+export function __resetRegistryForTest(): void {
+  registry.clear();
+}

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -7,6 +7,10 @@ import { EngramAccessService } from "./access-service.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
 import { resolvePluginEntry } from "./plugin-entry-resolver.js";
 import { expandTildePath } from "./utils/path.js";
+import { getOperation } from "./access-boundary.js";
+// Importing access-operations registers the pilot boundary operations as a
+// side effect; the store command dispatches through the registry (issue #1525).
+import "./access-operations.js";
 
 const OPENCLAW_REMNIC_PLUGIN_IDS = ["openclaw-remnic", "openclaw-engram"] as const;
 
@@ -428,21 +432,34 @@ async function runStore(args: ParsedArgs, preferredId?: string): Promise<void> {
   };
 
   const { config, service } = buildRuntime(preferredId);
-  const result = await service.memoryStore({
-    namespace: storeArgs.namespace,
-    sessionKey: storeArgs.sessionKey,
-    authenticatedPrincipal: getLastOption(args, "principal") ?? config.agentAccessHttp.principal,
-    content: storeArgs.content,
-    category: storeArgs.category,
-    confidence: storeArgs.confidence,
-    tags: storeArgs.tags,
-    entityRef: storeArgs.entityRef,
-    ttl: storeArgs.ttl,
-    sourceReason: storeArgs.sourceReason,
-    idempotencyKey: storeArgs.idempotencyKey,
-    dryRun: storeArgs.dryRun,
-  });
-  console.log(JSON.stringify(result, null, 2));
+  // Migrated through the access boundary (issue #1525): the store command
+  // dispatches through the same registry entry as the MCP tool and HTTP
+  // route, so validation/normalization is owned in ONE place. The CLI has no
+  // write-quota hook (it is a one-shot process), so no hooks are forwarded.
+  const op = getOperation("memory_store");
+  if (!op) {
+    throw new Error("access-boundary: operation not registered: memory_store");
+  }
+  const output = (await op.run(
+    {
+      namespace: storeArgs.namespace,
+      sessionKey: storeArgs.sessionKey,
+      content: storeArgs.content,
+      category: storeArgs.category,
+      confidence: storeArgs.confidence,
+      tags: storeArgs.tags,
+      entityRef: storeArgs.entityRef,
+      ttl: storeArgs.ttl,
+      sourceReason: storeArgs.sourceReason,
+      idempotencyKey: storeArgs.idempotencyKey,
+      dryRun: storeArgs.dryRun,
+    },
+    {
+      service,
+      authenticatedPrincipal: getLastOption(args, "principal") ?? config.agentAccessHttp.principal,
+    },
+  )) as { result: unknown };
+  console.log(JSON.stringify(output.result, null, 2));
 }
 
 function expandOptionalPath(value: string | undefined): string | undefined {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { log } from "./logger.js";
-import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+import { EngramAccessInputError, type EngramAccessService, type EngramAccessMemoryResponse, type EngramAccessWriteResponse } from "./access-service.js";
 import { WearablesInputError } from "./wearables/errors.js";
 import { EngramMcpServer } from "./access-mcp.js";
 import { validateRequest, type SchemaName, type SchemaTypeFor } from "./access-schema.js";
@@ -27,6 +27,11 @@ import {
 } from "./graph-events.js";
 import { expandTildePath } from "./utils/path.js";
 import { projectTagProjectId } from "./coding/coding-namespace.js";
+import { getOperation } from "./access-boundary.js";
+// Importing access-operations registers the pilot boundary operations
+// (memory_get / memory_store) as a side effect; the HTTP handlers below
+// dispatch the migrated routes through the registry (issue #1525).
+import "./access-operations.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -1297,35 +1302,28 @@ export class EngramAccessHttpServer {
     }
 
     if (req.method === "POST" && pathname === "/engram/v1/memories") {
+      // Migrated through the access boundary (issue #1525): the registry
+      // entry owns schema validation, normalization, and service dispatch.
+      // The HTTP transport resolves the request-scoped namespace and principal
+      // BEFORE the boundary re-validates the cleaned envelope. The write-quota
+      // hook is forwarded via ctx.hooks so it still fires atomically inside
+      // the service's idempotent-write lock — never before, never on a replay
+      // (#1434 invariant preserved by the boundary migration).
       const body = await this.readValidatedBody(req, "memoryStore");
-      const request = {
-        schemaVersion: body.schemaVersion,
-        idempotencyKey: body.idempotencyKey,
-        dryRun: body.dryRun === true,
-        sessionKey: body.sessionKey,
-        authenticatedPrincipal: this.resolveRequestPrincipal(req),
-        content: body.content,
-        category: body.category,
-        confidence: body.confidence,
+      const envelope = {
+        ...body,
         namespace: this.resolveNamespace(req, body.namespace),
-        tags: body.tags,
-        entityRef: body.entityRef,
-        ttl: body.ttl,
-        sourceReason: body.sourceReason,
-        cwd: body.cwd,
-        projectTag: body.projectTag,
       };
-      // Rate-limit enforcement is SOLELY authoritative inside memoryStore via
-      // enforceWriteQuota: it runs atomically with the real idempotency-miss
-      // determination (and the real resolved namespace), and is never invoked
-      // for a replay. We deliberately do NOT pre-check here: the write namespace
-      // is resolved from mutable session/git context, so a stale peek could
-      // report "miss" for a request that is actually an idempotent replay in the
-      // now-scoped namespace and hard-reject a safe replay with 429 (#1434 Codex
-      // review). Letting the in-lock hook be the only hard gate avoids that.
-      const response = await this.service.memoryStore(request, {
-        enforceWriteQuota: () => this.ensureWriteRateLimitAvailable(),
-      });
+      const op = getOperation("memory_store");
+      if (!op) {
+        throw new EngramAccessInputError("access-boundary: operation not registered: memory_store");
+      }
+      const output = (await op.run(envelope, {
+        service: this.service,
+        authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        hooks: { enforceWriteQuota: () => this.ensureWriteRateLimitAvailable() },
+      })) as { result: EngramAccessWriteResponse };
+      const response = output.result;
       if (this.shouldCountWriteRateLimit(response as { dryRun?: boolean; idempotencyReplay?: boolean })) {
         this.recordWriteRateLimitHit();
       }
@@ -1387,7 +1385,19 @@ export class EngramAccessHttpServer {
     if (req.method === "GET" && memoryMatch) {
       const memoryId = decodeURIComponent(memoryMatch[1] ?? "");
       const namespace = parsed.searchParams.get("namespace") ?? undefined;
-      const response = await this.service.memoryGet(memoryId, namespace, this.resolveRequestPrincipal(req));
+      // Migrated through the access boundary (issue #1525): the registry
+      // entry owns memoryId presence/shape validation (rule 51: reject empty
+      // ids loudly instead of silently passing "" into the service) and the
+      // service dispatch.
+      const op = getOperation("memory_get");
+      if (!op) {
+        throw new EngramAccessInputError("access-boundary: operation not registered: memory_get");
+      }
+      const output = (await op.run(
+        { memoryId, namespace: namespace ?? null },
+        { service: this.service, authenticatedPrincipal: this.resolveRequestPrincipal(req) },
+      )) as { result: EngramAccessMemoryResponse };
+      const response = output.result;
       this.respondJson(res, response.found ? 200 : 404, response);
       return;
     }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -9,11 +9,15 @@ import {
   type CapsuleImportRequest,
   type CapsuleListRequest,
   type DaySummaryRequest,
-  type MemoryStoreRequest,
   type SchemaName,
   type SchemaTypeFor,
   type SuggestionSubmitRequest,
 } from "./access-schema.js";
+// Importing access-operations registers the pilot boundary operations
+// (memory_get / memory_search / memory_store) as a side effect; callTool
+// dispatches migrated tools through the registry (issue #1525).
+import { getOperation, type OperationName } from "./access-boundary.js";
+import "./access-operations.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
@@ -93,6 +97,19 @@ function withToolAliases(tool: McpTool, emitLegacyTools = true): McpTool[] {
   // alias only trims `tools/list`, not callability.
   return emitLegacyTools ? [canonicalTool, tool] : [canonicalTool];
 }
+
+/**
+ * MCP tool name (legacy `engram.*` form, since {@link toLegacyToolName}
+ * canonicalizes incoming calls) → boundary operation it dispatches through.
+ * A tool appears here once its `access-operations.ts` registration lands and
+ * its surface-local validation is deleted. The fitness test
+ * (`access-surface-catalog.test.ts`) asserts this map and the catalog agree.
+ */
+const MCP_MIGRATED_OPERATIONS: Readonly<Record<string, OperationName>> = {
+  "engram.memory_get": "memory_get",
+  "engram.memory_search": "memory_search",
+  "engram.memory_store": "memory_store",
+};
 
 function resolveChatGptInspectorRecallSessionKey(
   explicitSessionKey: string | undefined,
@@ -2278,6 +2295,29 @@ export class EngramMcpServer {
   }
 
   private async callTool(name: string, args: Record<string, unknown>, effectivePrincipal?: string, mcpSessionId?: string): Promise<unknown> {
+    // Migrated operations dispatch through the access boundary (issue #1525):
+    // one registry entry owns schema validation, normalization (rules
+    // 17/28/36/48/51), and error mapping for every surface. The switch
+    // below still serves the not-yet-migrated tools. memory_store keeps its
+    // parseMcpRequest strict-keys guard (MCP transport contract) before the
+    // boundary re-validates the cleaned body.
+    const migrated = MCP_MIGRATED_OPERATIONS[toLegacyToolName(name)];
+    if (migrated) {
+      const op = getOperation(migrated);
+      if (!op) {
+        throw new EngramAccessInputError(`access-boundary: operation not registered: ${migrated}`);
+      }
+      const envelope =
+        migrated === "memory_store" ? parseMcpRequest("memoryStore", args) : args;
+      // The registry erases In/Out at the Map boundary; the caller knows the
+      // concrete output shape ({ result: <service response> }) so the cast is
+      // the type-erasure seam, not a leap of faith.
+      const output = (await op.run(envelope, {
+        service: this.service,
+        authenticatedPrincipal: effectivePrincipal,
+      })) as { result: unknown };
+      return output.result;
+    }
     switch (toLegacyToolName(name)) {
       case "engram.recall": {
         // Forward `disclosure` only when the caller actually supplied it,
@@ -2744,12 +2784,6 @@ export class EngramMcpServer {
           },
           effectivePrincipal,
         );
-      case "engram.memory_get":
-        return this.service.memoryGet(
-          typeof args.memoryId === "string" ? args.memoryId : "",
-          typeof args.namespace === "string" ? args.namespace : undefined,
-          effectivePrincipal,
-        );
       case "engram.memory_timeline": {
         const limit = typeof args.limit === "number" && Number.isFinite(args.limit) ? args.limit : 200;
         return this.service.memoryTimeline(
@@ -2758,26 +2792,6 @@ export class EngramMcpServer {
           limit,
           effectivePrincipal,
         );
-      }
-      case "engram.memory_store": {
-        const body: MemoryStoreRequest = parseMcpRequest("memoryStore", args);
-        return this.service.memoryStore({
-          schemaVersion: body.schemaVersion,
-          idempotencyKey: body.idempotencyKey,
-          dryRun: body.dryRun,
-          sessionKey: body.sessionKey,
-          authenticatedPrincipal: effectivePrincipal,
-          content: body.content,
-          category: body.category,
-          confidence: body.confidence,
-          namespace: body.namespace,
-          tags: body.tags,
-          entityRef: body.entityRef,
-          ttl: body.ttl,
-          sourceReason: body.sourceReason,
-          cwd: body.cwd,
-          projectTag: body.projectTag,
-        });
       }
       case "engram.suggestion_submit": {
         const body: SuggestionSubmitRequest = parseMcpRequest("suggestionSubmit", args);
@@ -3017,14 +3031,6 @@ export class EngramMcpServer {
           expectedGuidelineVersion: typeof args.expectedGuidelineVersion === "number" ? args.expectedGuidelineVersion : undefined,
         });
       // ── Memory search & debug tools ──────────────────────────────────
-      case "engram.memory_search":
-        return this.service.memorySearch({
-          query: typeof args.query === "string" ? args.query : "",
-          namespace: typeof args.namespace === "string" ? args.namespace : undefined,
-          maxResults: typeof args.maxResults === "number" && Number.isFinite(args.maxResults) ? args.maxResults : undefined,
-          collection: typeof args.collection === "string" ? args.collection : undefined,
-          principal: effectivePrincipal,
-        });
       case "engram.memory_profile":
         return this.service.memoryProfile(
           typeof args.namespace === "string" ? args.namespace : undefined,

--- a/packages/remnic-core/src/access-operations.ts
+++ b/packages/remnic-core/src/access-operations.ts
@@ -30,10 +30,14 @@ import type {
  * fell back to `typeof args.memoryId === "string" ? args.memoryId : ""`,
  * silently passing an empty id into the service). `namespace` is
  * `.nullable().optional()` because MCP clients send `null` (gotcha #2).
+ * `namespace` has no `.min(1)` because the pre-boundary handlers forwarded
+ * empty/whitespace strings, and `resolveNamespace` treats empty identically
+ * to absent (both trim to falsy → default namespace). Rejecting empty would
+ * break HTTP callers that send a bare `?namespace=` (Cursor review).
  */
 const memoryGetSchema = z.object({
   memoryId: z.string().trim().min(1, "memoryId is required").max(512),
-  namespace: z.string().trim().min(1).max(256).nullable().optional(),
+  namespace: z.string().trim().max(256).nullable().optional(),
 });
 
 export interface MemoryGetInput {
@@ -65,7 +69,7 @@ export const memoryGetOperation = defineOperation<MemoryGetInput, MemoryGetOutpu
 
 const memorySearchSchema = z.object({
   query: z.string().trim().min(1, "query is required").max(2048),
-  namespace: z.string().trim().min(1).max(256).nullable().optional(),
+  namespace: z.string().trim().max(256).nullable().optional(),
   // No upper cap: the pre-boundary MCP handler forwarded any finite number to
   // memorySearch, and the QMD/search backends honor large limits. Capping at
   // 100 would reject existing clients that request larger result sets.

--- a/packages/remnic-core/src/access-operations.ts
+++ b/packages/remnic-core/src/access-operations.ts
@@ -1,0 +1,150 @@
+/**
+ * Pilot operation definitions for the access boundary (issue #1525).
+ *
+ * Three operations migrate through the registry in this PR — `memory_get`,
+ * `memory_search`, and the `memory_store` write op — so the boundary's
+ * normalization matrix (rules 17/28/36/48/51) and shared error mapping reach
+ * MCP, HTTP, and CLI from one place. Domain-group migrations (memory ops →
+ * connectors → namespaces …) land as follow-up PRs that add `defineOperation`
+ * calls here and delete the surface-local validation they replace.
+ *
+ * Importing this module for its side effects registers the pilot operations;
+ * surfaces then dispatch via {@link getOperation} from `./access-boundary.js`.
+ */
+
+import { z } from "zod";
+
+import { defineOperation } from "./access-boundary.js";
+import { memoryStoreRequestSchema, type MemoryStoreRequest } from "./access-schema.js";
+import type {
+  EngramAccessMemoryResponse,
+  EngramAccessWriteResponse,
+} from "./access-service.js";
+
+// ---------------------------------------------------------------------------
+// memory_get — fetch one memory by id
+// ---------------------------------------------------------------------------
+
+/**
+ * `memoryId` is required and non-empty (rule 51: the MCP dispatcher previously
+ * fell back to `typeof args.memoryId === "string" ? args.memoryId : ""`,
+ * silently passing an empty id into the service). `namespace` is
+ * `.nullable().optional()` because MCP clients send `null` (gotcha #2).
+ */
+const memoryGetSchema = z.object({
+  memoryId: z.string().trim().min(1, "memoryId is required").max(512),
+  namespace: z.string().trim().min(1).max(256).nullable().optional(),
+});
+
+export interface MemoryGetInput {
+  readonly memoryId: string;
+  readonly namespace?: string | null;
+}
+
+export interface MemoryGetOutput {
+  readonly result: EngramAccessMemoryResponse;
+}
+
+export const memoryGetOperation = defineOperation<MemoryGetInput, MemoryGetOutput>({
+  name: "memory_get",
+  description: "Fetch one memory by id.",
+  schema: memoryGetSchema,
+  handler: async (input, ctx) => {
+    const result = await ctx.service.memoryGet(
+      input.memoryId,
+      input.namespace ?? undefined,
+      ctx.authenticatedPrincipal,
+    );
+    return { result };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// memory_search — semantic search across memories
+// ---------------------------------------------------------------------------
+
+const memorySearchSchema = z.object({
+  query: z.string().trim().min(1, "query is required").max(2048),
+  namespace: z.string().trim().min(1).max(256).nullable().optional(),
+  maxResults: z.number().int().min(1).max(100).nullable().optional(),
+  collection: z.string().trim().min(1).max(256).nullable().optional(),
+});
+
+export interface MemorySearchInput {
+  readonly query: string;
+  readonly namespace?: string | null;
+  readonly maxResults?: number | null;
+  readonly collection?: string | null;
+}
+
+export interface MemorySearchOutput {
+  readonly result: {
+    readonly query: string;
+    readonly results: ReadonlyArray<{ path: string; score: number; snippet: string }>;
+    readonly count: number;
+  };
+}
+
+export const memorySearchOperation = defineOperation<MemorySearchInput, MemorySearchOutput>({
+  name: "memory_search",
+  description: "Search memories across readable namespaces.",
+  schema: memorySearchSchema,
+  handler: async (input, ctx) => {
+    const result = await ctx.service.memorySearch({
+      query: input.query,
+      namespace: input.namespace ?? undefined,
+      maxResults: input.maxResults ?? undefined,
+      collection: input.collection ?? undefined,
+      principal: ctx.authenticatedPrincipal,
+    });
+    return { result };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// memory_store — the pilot WRITE op
+// ---------------------------------------------------------------------------
+
+export type MemoryStoreInput = MemoryStoreRequest;
+
+export interface MemoryStoreOutput {
+  readonly result: EngramAccessWriteResponse;
+}
+
+export const memoryStoreOperation = defineOperation<MemoryStoreInput, MemoryStoreOutput>({
+  name: "memory_store",
+  description: "Store an explicit memory through the access layer.",
+  // Reuse the existing schema verbatim — the migration is behavior-preserving;
+  // the schema's external contract is NOT changing in this PR (per the issue's
+  // pitfall note).
+  schema: memoryStoreRequestSchema,
+  handler: async (input, ctx) => {
+    const result = await ctx.service.memoryStore(
+      {
+        ...input,
+        authenticatedPrincipal: ctx.authenticatedPrincipal,
+      },
+      // Forward transport-level hooks (e.g. HTTP's atomic write-quota gate)
+      // so the hook still fires inside the service's idempotent-write lock —
+      // never before, never on a replay (#1434 invariant preserved by the
+      // boundary migration).
+      ctx.hooks,
+    );
+    return { result };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Surface registration map — what each transport calls the pilot ops
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical short names (no `engram.`/`remnic.` prefix) of the operations
+ * the boundary owns today. The fitness test treats this set as the migrated
+ * set; everything else on a surface is unmigrated and counted by the ratchet.
+ */
+export const REGISTERED_OPERATIONS = [
+  memoryGetOperation.spec.name,
+  memorySearchOperation.spec.name,
+  memoryStoreOperation.spec.name,
+] as const;

--- a/packages/remnic-core/src/access-operations.ts
+++ b/packages/remnic-core/src/access-operations.ts
@@ -66,7 +66,10 @@ export const memoryGetOperation = defineOperation<MemoryGetInput, MemoryGetOutpu
 const memorySearchSchema = z.object({
   query: z.string().trim().min(1, "query is required").max(2048),
   namespace: z.string().trim().min(1).max(256).nullable().optional(),
-  maxResults: z.number().int().min(1).max(100).nullable().optional(),
+  // No upper cap: the pre-boundary MCP handler forwarded any finite number to
+  // memorySearch, and the QMD/search backends honor large limits. Capping at
+  // 100 would reject existing clients that request larger result sets.
+  maxResults: z.number().int().min(1).nullable().optional(),
   collection: z.string().trim().min(1).max(256).nullable().optional(),
 });
 

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -6,14 +6,17 @@
  *      (so a new tool cannot ship without either migrating it or
  *      acknowledging it as unmigrated);
  *   2. every catalog entry that claims a migration (`operation !== null`)
- *      resolves to a registered boundary operation;
+ *      resolves to a registered boundary operation AND dispatches through it
+ *      — a flipped catalog row without wired dispatch is caught, so the
+ *      ratchet cannot record a false migration;
  *   3. the unmigrated-handler count equals the ratchet baseline, so the count
  *      may only decrease.
  *
- * Prove-fail-before (issue requirement): a dedicated test seeds a bypass —
- * an MCP tool the catalog does not know about — and asserts the validator
- * reports it. That demonstrates the gate catches the regression class before
- * relying on it for the real surface.
+ * Prove-fail-before (issue requirement): dedicated tests seed bypasses — an
+ * MCP tool the catalog does not know about, and a catalog entry whose
+ * operation is registered but never dispatched — and assert the validators
+ * report them. That demonstrates the gates catch the regression class before
+ * relying on them for the real surface.
  */
 
 import assert from "node:assert/strict";
@@ -30,6 +33,7 @@ import {
   HTTP_ROUTES,
   MCP_TOOLS,
   countUnmigratedHandlers,
+  type HttpRouteEntry,
   type McpToolEntry,
 } from "./access-surface-catalog.js";
 
@@ -132,6 +136,98 @@ function formatViolations(violations: readonly CoverageViolation[]): string {
 }
 
 // ---------------------------------------------------------------------------
+// Live dispatch extraction — verify surfaces route through the boundary
+// ---------------------------------------------------------------------------
+
+/**
+ * Statically extract the MCP dispatch map (`MCP_MIGRATED_OPERATIONS`) from
+ * `access-mcp.ts`. This is the map that routes incoming tool calls to the
+ * boundary at dispatch time. Comparing it to the catalog proves a flipped
+ * catalog row is not a false migration — the surface code must also wire
+ * the dispatch.
+ */
+function extractMcpDispatchMap(): Map<string, string> {
+  const source = readFileSync(
+    new URL("./access-mcp.ts", import.meta.url),
+    "utf-8",
+  );
+  const blockMatch = source.match(
+    /MCP_MIGRATED_OPERATIONS[^{]*\{([\s\S]*?)\}/,
+  );
+  const body = blockMatch?.[1] ?? "";
+  const map = new Map<string, string>();
+  for (const m of body.matchAll(/"engram\.(\w+)"\s*:\s*"(\w+)"/g)) {
+    map.set(m[1]!, m[2]!);
+  }
+  return map;
+}
+
+/**
+ * Statically extract the set of operation names dispatched via `getOperation`
+ * in `access-http.ts`. Each `getOperation("op_name")` call proves the route
+ * routes through the boundary at dispatch time.
+ */
+function extractHttpDispatchOperations(): Set<string> {
+  const source = readFileSync(
+    new URL("./access-http.ts", import.meta.url),
+    "utf-8",
+  );
+  const ops = new Set<string>();
+  for (const m of source.matchAll(/getOperation\("(\w+)"\)/g)) {
+    ops.add(m[1]!);
+  }
+  return ops;
+}
+
+/**
+ * Pure dispatch validator — shared by the prove-fail-before test and the real
+ * gate. Flags a catalog entry that claims a migration (`operation !== null`)
+ * but whose live surface code does not dispatch through the boundary. A
+ * flipped catalog row without wired dispatch is a false migration.
+ */
+interface DispatchViolation {
+  readonly kind:
+    | "mcp-no-dispatch"
+    | "mcp-dispatch-mismatch"
+    | "http-no-dispatch";
+  readonly detail: string;
+}
+
+function validateDispatchCoverage(
+  mcpCatalog: readonly McpToolEntry[],
+  httpCatalog: readonly HttpRouteEntry[],
+  mcpDispatch: ReadonlyMap<string, string>,
+  httpDispatch: ReadonlySet<string>,
+): DispatchViolation[] {
+  const violations: DispatchViolation[] = [];
+  for (const entry of mcpCatalog) {
+    if (entry.operation === null) continue;
+    const dispatched = mcpDispatch.get(entry.tool);
+    if (dispatched === undefined) {
+      violations.push({
+        kind: "mcp-no-dispatch",
+        detail: `${entry.tool} claims migration to ${entry.operation} but has no entry in MCP_MIGRATED_OPERATIONS`,
+      });
+    } else if (dispatched !== entry.operation) {
+      violations.push({
+        kind: "mcp-dispatch-mismatch",
+        detail: `${entry.tool}: dispatch routes to "${dispatched}" but catalog claims "${entry.operation}"`,
+      });
+    }
+  }
+  for (const entry of httpCatalog) {
+    if (entry.operation === null) continue;
+    if (!httpDispatch.has(entry.operation)) {
+      violations.push({
+        kind: "http-no-dispatch",
+        detail: `HTTP ${entry.method} ${entry.pathname} claims migration to ${entry.operation} but no getOperation("${entry.operation}") found in access-http.ts`,
+      });
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
 // Prove-fail-before: the validator MUST catch a seeded bypass
 // ---------------------------------------------------------------------------
 
@@ -184,6 +280,28 @@ test("fitness validator catches a stale catalog entry (tool removed from the ser
   const violations = validateCoverage(staleCatalog, live, new Set(listRegisteredOperations()));
   const stale = violations.filter((v) => v.kind === "catalog-tool-not-live");
   assert.ok(stale.length > 0, "validator must flag a catalog entry with no live tool");
+});
+
+test("dispatch validator catches a catalog entry whose operation is registered but never dispatched", () => {
+  // Seed: a catalog entry claims `operation: "memory_get"` — the operation IS
+  // registered — but the MCP dispatch map passed in is EMPTY, simulating a
+  // handler that flipped its catalog row without wiring dispatch through the
+  // boundary. Registration alone would pass the old gate; this check must
+  // catch the false migration (review P2: verify dispatch before counting).
+  const lyingCatalog: readonly McpToolEntry[] = [
+    { tool: "synthetic_dispatch_liar", operation: "memory_get" },
+  ];
+  const violations = validateDispatchCoverage(
+    lyingCatalog,
+    [],
+    new Map<string, string>(),
+    new Set<string>(),
+  );
+  const noDispatch = violations.filter((v) => v.kind === "mcp-no-dispatch");
+  assert.ok(
+    noDispatch.some((v) => v.detail.includes("synthetic_dispatch_liar")),
+    "dispatch validator must flag a migrated entry with no surface dispatch wiring",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -344,7 +462,10 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
   );
 });
 
-test("every migrated MCP/HTTP entry resolves to a registered boundary operation", () => {
+test("every migrated MCP/HTTP entry resolves to a registered AND dispatched boundary operation", () => {
+  // Phase 1 — registration: the operation name must exist in the live registry.
+  // This catches a flipped catalog row that references an operation no one
+  // ever defined.
   const registered = new Set(listRegisteredOperations());
   for (const entry of MCP_TOOLS) {
     if (entry.operation !== null) {
@@ -362,6 +483,27 @@ test("every migrated MCP/HTTP entry resolves to a registered boundary operation"
       );
     }
   }
+
+  // Phase 2 — dispatch: the live surface code must route through the boundary.
+  // Registration alone is not enough — a flipped catalog row without wired
+  // dispatch is a false migration. The ratchet would lower the unmigrated
+  // count while the handler still uses its old direct service branch.
+  // (review P2: verify dispatch before counting handlers as migrated)
+  const mcpDispatch = extractMcpDispatchMap();
+  const httpDispatch = extractHttpDispatchOperations();
+  const violations = validateDispatchCoverage(
+    MCP_TOOLS,
+    HTTP_ROUTES,
+    mcpDispatch,
+    httpDispatch,
+  );
+  assert.deepEqual(
+    violations,
+    [],
+    `catalog entries claim migrations the surface does not dispatch through — ` +
+      `a handler is marked migrated but still uses its old direct service branch.\n` +
+      violations.map((v) => `  - [${v.kind}] ${v.detail}`).join("\n"),
+  );
 });
 
 test("unmigrated-handler count matches the ratchet baseline (may only decrease)", () => {

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -17,6 +17,7 @@
  */
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { EngramMcpServer } from "./access-mcp.js";
@@ -196,6 +197,88 @@ test("MCP tools/list matches the catalog exactly (no untracked handlers)", async
     violations,
     [],
     `surface/catalog drift detected — either update access-surface-catalog.ts or migrate the new handler:\n${formatViolations(violations)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// HTTP source-completeness — static extraction from access-http.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * The MCP surface has a live coverage test (tools/list). HTTP has no
+ * equivalent introspection endpoint — routes are scattered if-branches in
+ * EngramAccessHttpServer.handle. This test statically extracts route
+ * patterns from the source and compares against HTTP_ROUTES so a new
+ * service-invoking route cannot land without a catalog entry.
+ *
+ * Infrastructure routes (health, adapters, admin console, UI assets, MCP
+ * delegate) are excluded — they carry no user-validated request envelope.
+ */
+test("HTTP handler source routes match the catalog (static completeness)", () => {
+  const httpSource = readFileSync(
+    new URL("./access-http.ts", import.meta.url),
+    "utf-8",
+  );
+
+  const sourcePaths = new Set<string>();
+
+  // Strategy 1: pathname === "/engram/v1/..." (also captures /remnic/ aliases
+  // and bare /v1/ routes like /v1/citations/observed).
+  for (const m of httpSource.matchAll(
+    /pathname\s*===\s*"((?:\/engram|\/remnic|\/v1)\/[^"]+)"/g,
+  )) {
+    sourcePaths.add(m[1]!.replace(/^\/remnic\//, "/engram/"));
+  }
+
+  // Strategy 2: pathname.startsWith("/engram/v1/.../")  — prefix route.
+  // The trailing / means a path segment follows → normalize to /:id.
+  for (const m of httpSource.matchAll(
+    /pathname\.startsWith\("((?:\/engram)\/v1\/[^"]+\/)"/g,
+  )) {
+    sourcePaths.add(m[1]!.replace(/\/$/, "") + "/:id");
+  }
+
+  // Strategy 3: regex-literal routes — /^\/engram\/v1\/.../.exec(pathname)
+  // and pathname.match(/^\/engram\/v1\/.../).
+  const normalizeRegexRoute = (src: string): string =>
+    src.replace(/\\\//g, "/").replace(/\(\[\^\/\]\+\)/g, ":id");
+  for (const m of httpSource.matchAll(/\/\^(.+?)\$\/g?\.(?:exec|test)\(pathname\)/g)) {
+    const normalized = normalizeRegexRoute(m[1]!);
+    if (normalized.startsWith("/engram/v1/") || normalized.startsWith("/v1/")) {
+      sourcePaths.add(normalized);
+    }
+  }
+  for (const m of httpSource.matchAll(/pathname\.match\(\/\^(.+?)\$\/g?\)/g)) {
+    const normalized = normalizeRegexRoute(m[1]!);
+    if (normalized.startsWith("/engram/v1/") || normalized.startsWith("/v1/")) {
+      sourcePaths.add(normalized);
+    }
+  }
+
+  // Filter out infrastructure routes that carry no user request envelope.
+  const INFRA = [
+    /^\/engram\/v1\/health$/,
+    /^\/engram\/v1\/adapters$/,
+    /^\/engram\/v1\/admin\//,
+    /^\/engram\/ui/,
+    /^\/mcp$/,
+  ];
+  const servicePaths = [...sourcePaths]
+    .filter((p) => !INFRA.some((re) => re.test(p)))
+    .sort();
+
+  const catalogPaths = new Set(HTTP_ROUTES.map((r) => r.pathname));
+
+  const missingFromCatalog = servicePaths.filter(
+    (p) => !catalogPaths.has(p),
+  );
+
+  assert.deepEqual(
+    missingFromCatalog,
+    [],
+    `HTTP routes found in access-http.ts but missing from HTTP_ROUTES catalog.\n` +
+      `Add each to access-surface-catalog.ts with operation: null (or migrate it).\n` +
+      `Missing:\n${missingFromCatalog.map((p) => `  ${p}`).join("\n")}`,
   );
 });
 

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -35,8 +35,11 @@ import {
 // The ratchet baseline. Decrease this constant (and run
 // `node scripts/check-ratchets.mjs --update`) whenever a follow-up PR
 // migrates a handler. It may NEVER increase — an increase means a new handler
-// shipped without going through the boundary.
-const UNMIGRATED_HANDLER_BASELINE = 129;
+// shipped without going through the boundary. The only exception is a
+// catalog-completeness correction: adding routes that were always live but
+// omitted from the catalog (review-caught). Such a bump MUST be accompanied
+// by the newly-cataloged entries; the higher count is the honest baseline.
+const UNMIGRATED_HANDLER_BASELINE = 133;
 
 // Keep the import live — `getOperation` is the call surfaces use at dispatch
 // time; referencing it here pins the registry's lookup contract.

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -219,27 +219,21 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
     new URL("./access-http.ts", import.meta.url),
     "utf-8",
   );
+  const lines = httpSource.split("\n");
 
+  // --- Phase 1: pathname-level extraction (catches missing pathnames) -------
   const sourcePaths = new Set<string>();
 
-  // Strategy 1: pathname === "/engram/v1/..." (also captures /remnic/ aliases
-  // and bare /v1/ routes like /v1/citations/observed).
   for (const m of httpSource.matchAll(
     /pathname\s*===\s*"((?:\/engram|\/remnic|\/v1)\/[^"]+)"/g,
   )) {
     sourcePaths.add(m[1]!.replace(/^\/remnic\//, "/engram/"));
   }
-
-  // Strategy 2: pathname.startsWith("/engram/v1/.../")  — prefix route.
-  // The trailing / means a path segment follows → normalize to /:id.
   for (const m of httpSource.matchAll(
     /pathname\.startsWith\("((?:\/engram)\/v1\/[^"]+\/)"/g,
   )) {
     sourcePaths.add(m[1]!.replace(/\/$/, "") + "/:id");
   }
-
-  // Strategy 3: regex-literal routes — /^\/engram\/v1\/.../.exec(pathname)
-  // and pathname.match(/^\/engram\/v1\/.../).
   const normalizeRegexRoute = (src: string): string =>
     src.replace(/\\\//g, "/").replace(/\(\[\^\/\]\+\)/g, ":id");
   for (const m of httpSource.matchAll(/\/\^(.+?)\$\/g?\.(?:exec|test)\(pathname\)/g)) {
@@ -255,7 +249,6 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
     }
   }
 
-  // Filter out infrastructure routes that carry no user request envelope.
   const INFRA = [
     /^\/engram\/v1\/health$/,
     /^\/engram\/v1\/adapters$/,
@@ -268,17 +261,86 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
     .sort();
 
   const catalogPaths = new Set(HTTP_ROUTES.map((r) => r.pathname));
-
   const missingFromCatalog = servicePaths.filter(
     (p) => !catalogPaths.has(p),
   );
-
   assert.deepEqual(
     missingFromCatalog,
     [],
     `HTTP routes found in access-http.ts but missing from HTTP_ROUTES catalog.\n` +
       `Add each to access-surface-catalog.ts with operation: null (or migrate it).\n` +
       `Missing:\n${missingFromCatalog.map((p) => `  ${p}`).join("\n")}`,
+  );
+
+  // --- Phase 2: (method, pathname) tuple extraction (catches missing methods)
+  // For each exact-match route, scan backward up to 5 lines for the HTTP method.
+  // For dynamic routes, scan forward up to 40 lines for method checks inside the block.
+  const sourceTuples = new Set<string>();
+  const isServicePath = (p: string) =>
+    !INFRA.some((re) => re.test(p));
+
+  for (let i = 0; i < lines.length; i++) {
+    const pathMatch = lines[i]!.match(
+      /pathname\s*===\s*"((?:\/engram|\/remnic|\/v1)\/[^"]+)"/,
+    );
+    if (pathMatch) {
+      const pathname = pathMatch[1]!.replace(/^\/remnic\//, "/engram/");
+      if (!isServicePath(pathname)) continue;
+      // Scan backward for the method declaration.
+      for (let j = i; j >= Math.max(0, i - 5); j--) {
+        const mMatch = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
+        if (mMatch) {
+          sourceTuples.add(`${mMatch[1]} ${pathname}`);
+          break;
+        }
+      }
+    }
+  }
+  // Dynamic routes: scan forward for method checks.
+  for (const m of httpSource.matchAll(
+    /(?:\/\^(.+?)\$\/g?\.(?:exec|test)\(pathname\)|pathname\.match\(\/\^(.+?)\$\/g?\)|pathname\.startsWith\("((?:\/engram)\/v1\/[^"]+)"\))/g,
+  )) {
+    const raw = m[1] ?? m[2] ?? m[3];
+    if (!raw) continue;
+    let pathname: string;
+    if (m[3]) {
+      pathname = m[3].replace(/\/$/, "") + "/:id";
+    } else {
+      pathname = normalizeRegexRoute(raw!);
+    }
+    if (!pathname.startsWith("/engram/v1/") || !isServicePath(pathname)) continue;
+    const matchIndex = httpSource.indexOf(m[0]);
+    const matchLine = httpSource.slice(0, matchIndex).split("\n").length;
+    // Scan forward for method checks inside the route block.
+    for (let j = matchLine; j < Math.min(lines.length, matchLine + 40); j++) {
+      // Stop at the next route block.
+      if (j > matchLine && /pathname\s*===\s*"|pathname\.startsWith\(|\/\^.*\$\/g?\.(?:exec|test)\(pathname\)|pathname\.match\(/.test(lines[j]!)) {
+        break;
+      }
+      const methodMatch = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
+      if (methodMatch) {
+        sourceTuples.add(`${methodMatch[1]} ${pathname}`);
+      }
+      // Also handle negated checks: `req.method !== "GET"` → the route IS GET.
+      const negMethodMatch = lines[j]!.match(/req\.method\s*!==\s*"(\w+)"/);
+      if (negMethodMatch && j === matchLine) {
+        sourceTuples.add(`${negMethodMatch[1]} ${pathname}`);
+      }
+    }
+  }
+
+  const catalogTuples = new Set(
+    HTTP_ROUTES.map((r) => `${r.method} ${r.pathname}`),
+  );
+  const missingTuples = [...sourceTuples]
+    .filter((t) => !catalogTuples.has(t))
+    .sort();
+  assert.deepEqual(
+    missingTuples,
+    [],
+    `HTTP (method, pathname) tuples found in access-http.ts but missing from HTTP_ROUTES.\n` +
+      `Add each to access-surface-catalog.ts.\n` +
+      `Missing:\n${missingTuples.map((t) => `  ${t}`).join("\n")}`,
   );
 });
 

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -218,25 +218,38 @@ function extractHttpRouteDispatchMap(): Map<string, Set<string>> {
 
     if (pathname) {
       // Determine the HTTP method: same line first, then backward for
-      // exact-match routes, forward for dynamic routes.
-      let method: string | null = null;
-      const sameLine = line.match(/req\.method\s*===\s*"(\w+)"/);
-      if (sameLine) {
-        method = sameLine[1]!;
-      } else if (isExactMatch) {
+      // exact-match routes, forward for dynamic routes. Check both positive
+      // (===) and negated (!==) method patterns — `req.method !== "GET"` as
+      // a 405 guard means the route IS GET (review P2: require exact method
+      // keys; do not fall back to pathname-only when method is undetectable).
+      const detectMethod = (text: string): string | null => {
+        const pos = text.match(/req\.method\s*===\s*"(\w+)"/);
+        if (pos) return pos[1]!;
+        const neg = text.match(/req\.method\s*!==\s*"(\w+)"/);
+        if (neg) return neg[1]!;
+        return null;
+      };
+      let method = detectMethod(line);
+      if (!method && isExactMatch) {
         for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
-          const bm = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
-          if (bm) { method = bm[1]!; break; }
-        }
-      } else {
-        for (let j = i + 1; j < Math.min(lines.length, i + 5); j++) {
-          if (/pathname\s*===\s*"|\/\^.*\$\/g?\.(?:exec|test)\(pathname\)|pathname\.match\(/.test(lines[j]!)) break;
-          const fm = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
-          if (fm) { method = fm[1]!; break; }
+          method = detectMethod(lines[j]!);
+          if (method) break;
         }
       }
-      currentKey = method ? `${method} ${pathname}` : pathname;
-      if (!routeOps.has(currentKey)) routeOps.set(currentKey, new Set<string>());
+      if (!method && !isExactMatch) {
+        for (let j = i + 1; j < Math.min(lines.length, i + 5); j++) {
+          if (/pathname\s*===\s*"|\/\^.*\$\/g?\.(?:exec|test)\(pathname\)|pathname\.match\(/.test(lines[j]!)) break;
+          method = detectMethod(lines[j]!);
+          if (method) break;
+        }
+      }
+      // If the method cannot be determined, the route block is ambiguous and
+      // must not be keyed — validateDispatchCoverage will flag any catalog
+      // entry claiming migration through it (no pathname-only fallback).
+      currentKey = method ? `${method} ${pathname}` : null;
+      if (currentKey && !routeOps.has(currentKey)) {
+        routeOps.set(currentKey, new Set<string>());
+      }
       continue;
     }
 
@@ -291,12 +304,12 @@ function validateDispatchCoverage(
   for (const entry of httpCatalog) {
     if (entry.operation === null) continue;
     // Method+path specific: the getOperation("…") call must be in THIS
-    // method's handler block for THIS pathname, not just anywhere in the
-    // file or in a different method's block for the same path. A pathname-
-    // only key would let a POST block's dispatch satisfy a GET catalog entry
-    // when they share a path (review P2: key dispatch by method and path).
+    // method's handler block for THIS pathname. No pathname-only fallback —
+    // if the extractor could not determine the method, the route block is
+    // ambiguous and the catalog entry must not be counted as migrated
+    // (review P2: require exact method keys; do not fall back).
     const routeKey = `${entry.method} ${entry.pathname}`;
-    const routeOps = httpRouteDispatch.get(routeKey) ?? httpRouteDispatch.get(entry.pathname);
+    const routeOps = httpRouteDispatch.get(routeKey);
     if (!routeOps || !routeOps.has(entry.operation)) {
       violations.push({
         kind: "http-no-dispatch",

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -163,20 +163,65 @@ function extractMcpDispatchMap(): Map<string, string> {
 }
 
 /**
- * Statically extract the set of operation names dispatched via `getOperation`
- * in `access-http.ts`. Each `getOperation("op_name")` call proves the route
- * routes through the boundary at dispatch time.
+ * Normalize a regex route body (e.g. `\/engram\/v1\/peers\/([^/]+)`) to the
+ * catalog pathname form (`/engram/v1/peers/:id`).
  */
-function extractHttpDispatchOperations(): Set<string> {
+function normalizeHttpRegexRoute(src: string): string {
+  return src.replace(/\\\//g, "/").replace(/\(\[\^\/\]\+\)/g, ":id");
+}
+
+/**
+ * Statically extract a route-specific dispatch map from `access-http.ts`:
+ * pathname → set of operations dispatched via `getOperation("…")` within that
+ * route's handler block. Route-specific scoping prevents a catalog entry from
+ * passing the dispatch gate just because a DIFFERENT route dispatches the same
+ * operation (review P2: bind dispatch validation to method/path routes).
+ */
+function extractHttpRouteDispatchMap(): Map<string, Set<string>> {
   const source = readFileSync(
     new URL("./access-http.ts", import.meta.url),
     "utf-8",
   );
-  const ops = new Set<string>();
-  for (const m of source.matchAll(/getOperation\("(\w+)"\)/g)) {
-    ops.add(m[1]!);
+  const lines = source.split("\n");
+  const routeOps = new Map<string, Set<string>>();
+  let currentRoute: string | null = null;
+
+  for (const line of lines) {
+    // Detect route block start and update the current route.
+    let m = line.match(/pathname\s*===\s*"((?:\/engram|\/remnic|\/v1)\/[^"]+)"/);
+    if (m) {
+      currentRoute = m[1]!.replace(/^\/remnic\//, "/engram/");
+    } else {
+      m = line.match(/\/\^((?:\\\/engram|\\\/remnic|\\\/v1).+?)\$\/g?\.(?:exec|test)\(pathname\)/);
+      if (m) {
+        currentRoute = normalizeHttpRegexRoute(m[1]!);
+      } else {
+        m = line.match(/pathname\.match\(\/\^((?:\\\/engram|\\\/remnic|\\\/v1).+?)\$\/g?\)/);
+        if (m) {
+          currentRoute = normalizeHttpRegexRoute(m[1]!);
+        } else {
+          m = line.match(/pathname\.startsWith\("((?:\/engram)\/v1\/[^"]+)"\)/);
+          if (m) {
+            currentRoute = m[1]!.replace(/\/$/, "") + "/:id";
+          }
+        }
+      }
+    }
+
+    if (currentRoute && !routeOps.has(currentRoute)) {
+      routeOps.set(currentRoute, new Set<string>());
+    }
+
+    // Collect getOperation calls within the current route block.
+    if (currentRoute) {
+      const opMatch = line.match(/getOperation\("(\w+)"\)/);
+      if (opMatch) {
+        routeOps.get(currentRoute)!.add(opMatch[1]!);
+      }
+    }
   }
-  return ops;
+
+  return routeOps;
 }
 
 /**
@@ -197,7 +242,7 @@ function validateDispatchCoverage(
   mcpCatalog: readonly McpToolEntry[],
   httpCatalog: readonly HttpRouteEntry[],
   mcpDispatch: ReadonlyMap<string, string>,
-  httpDispatch: ReadonlySet<string>,
+  httpRouteDispatch: ReadonlyMap<string, ReadonlySet<string>>,
 ): DispatchViolation[] {
   const violations: DispatchViolation[] = [];
   for (const entry of mcpCatalog) {
@@ -217,10 +262,15 @@ function validateDispatchCoverage(
   }
   for (const entry of httpCatalog) {
     if (entry.operation === null) continue;
-    if (!httpDispatch.has(entry.operation)) {
+    // Route-specific: the getOperation("…") call must be in THIS route's
+    // handler block, not just anywhere in the file. A global set would let a
+    // flipped catalog row pass if a different route dispatches the same
+    // operation (review P2: bind dispatch validation to method/path routes).
+    const routeOps = httpRouteDispatch.get(entry.pathname);
+    if (!routeOps || !routeOps.has(entry.operation)) {
       violations.push({
         kind: "http-no-dispatch",
-        detail: `HTTP ${entry.method} ${entry.pathname} claims migration to ${entry.operation} but no getOperation("${entry.operation}") found in access-http.ts`,
+        detail: `HTTP ${entry.method} ${entry.pathname} claims migration to ${entry.operation} but no getOperation("${entry.operation}") found in its route block in access-http.ts`,
       });
     }
   }
@@ -295,12 +345,38 @@ test("dispatch validator catches a catalog entry whose operation is registered b
     lyingCatalog,
     [],
     new Map<string, string>(),
-    new Set<string>(),
+    new Map<string, ReadonlySet<string>>(),
   );
   const noDispatch = violations.filter((v) => v.kind === "mcp-no-dispatch");
   assert.ok(
     noDispatch.some((v) => v.detail.includes("synthetic_dispatch_liar")),
     "dispatch validator must flag a migrated entry with no surface dispatch wiring",
+  );
+});
+
+test("dispatch validator catches an HTTP route whose operation is dispatched by a different route", () => {
+  // Seed: catalog claims `GET /engram/v1/synthetic` migrated to `memory_get`.
+  // The operation IS registered, and `memory_get` IS dispatched — but by a
+  // DIFFERENT route (`/engram/v1/memories/:id`). The route-specific check must
+  // catch that `/engram/v1/synthetic` itself has no `getOperation("memory_get")`
+  // in its handler block. A global set would pass this false migration.
+  // (review P2: bind dispatch validation to method/path routes)
+  const lyingHttpCatalog: readonly HttpRouteEntry[] = [
+    { method: "GET", pathname: "/engram/v1/synthetic", operation: "memory_get" },
+  ];
+  const routeDispatch = new Map<string, ReadonlySet<string>>([
+    ["/engram/v1/memories/:id", new Set(["memory_get"])],
+  ]);
+  const violations = validateDispatchCoverage(
+    [],
+    lyingHttpCatalog,
+    new Map<string, string>(),
+    routeDispatch,
+  );
+  const noDispatch = violations.filter((v) => v.kind === "http-no-dispatch");
+  assert.ok(
+    noDispatch.some((v) => v.detail.includes("/engram/v1/synthetic")),
+    "dispatch validator must flag an HTTP route whose operation is dispatched by a different route",
   );
 });
 
@@ -440,8 +516,11 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
         sourceTuples.add(`${methodMatch[1]} ${pathname}`);
       }
       // Also handle negated checks: `req.method !== "GET"` → the route IS GET.
+      // Scan within the whole block, not just the match line — some routes
+      // (e.g. GET /engram/v1/peers/:id/profile) use the negation as a guard
+      // inside the block, not on the regex-match line.
       const negMethodMatch = lines[j]!.match(/req\.method\s*!==\s*"(\w+)"/);
-      if (negMethodMatch && j === matchLine) {
+      if (negMethodMatch) {
         sourceTuples.add(`${negMethodMatch[1]} ${pathname}`);
       }
     }
@@ -488,14 +567,18 @@ test("every migrated MCP/HTTP entry resolves to a registered AND dispatched boun
   // Registration alone is not enough — a flipped catalog row without wired
   // dispatch is a false migration. The ratchet would lower the unmigrated
   // count while the handler still uses its old direct service branch.
-  // (review P2: verify dispatch before counting handlers as migrated)
+  // MCP dispatch is verified against MCP_MIGRATED_OPERATIONS; HTTP dispatch is
+  // verified route-specifically (getOperation("…") must be in the entry's own
+  // handler block, not just anywhere in the file).
+  // (review P2: verify dispatch before counting handlers as migrated;
+  //  review P2: bind dispatch validation to method/path routes)
   const mcpDispatch = extractMcpDispatchMap();
-  const httpDispatch = extractHttpDispatchOperations();
+  const httpRouteDispatch = extractHttpRouteDispatchMap();
   const violations = validateDispatchCoverage(
     MCP_TOOLS,
     HTTP_ROUTES,
     mcpDispatch,
-    httpDispatch,
+    httpRouteDispatch,
   );
   assert.deepEqual(
     violations,

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -172,10 +172,12 @@ function normalizeHttpRegexRoute(src: string): string {
 
 /**
  * Statically extract a route-specific dispatch map from `access-http.ts`:
- * pathname → set of operations dispatched via `getOperation("…")` within that
- * route's handler block. Route-specific scoping prevents a catalog entry from
- * passing the dispatch gate just because a DIFFERENT route dispatches the same
- * operation (review P2: bind dispatch validation to method/path routes).
+ * `"${method} ${pathname}"` → set of operations dispatched via
+ * `getOperation("…")` within that route's handler block. Keying by
+ * method+pathname (not just pathname) prevents cross-method contamination
+ * when GET and POST share a path — a dispatch in the POST block must not
+ * satisfy a GET catalog entry (review P2: key HTTP dispatch coverage by
+ * method and path).
  */
 function extractHttpRouteDispatchMap(): Map<string, Set<string>> {
   const source = readFileSync(
@@ -184,39 +186,65 @@ function extractHttpRouteDispatchMap(): Map<string, Set<string>> {
   );
   const lines = source.split("\n");
   const routeOps = new Map<string, Set<string>>();
-  let currentRoute: string | null = null;
+  let currentKey: string | null = null;
 
-  for (const line of lines) {
-    // Detect route block start and update the current route.
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    // Detect route block start — extract pathname and method.
+    let pathname: string | null = null;
+    let isExactMatch = false;
+
     let m = line.match(/pathname\s*===\s*"((?:\/engram|\/remnic|\/v1)\/[^"]+)"/);
     if (m) {
-      currentRoute = m[1]!.replace(/^\/remnic\//, "/engram/");
+      pathname = m[1]!.replace(/^\/remnic\//, "/engram/");
+      isExactMatch = true;
     } else {
       m = line.match(/\/\^((?:\\\/engram|\\\/remnic|\\\/v1).+?)\$\/g?\.(?:exec|test)\(pathname\)/);
       if (m) {
-        currentRoute = normalizeHttpRegexRoute(m[1]!);
+        pathname = normalizeHttpRegexRoute(m[1]!);
       } else {
         m = line.match(/pathname\.match\(\/\^((?:\\\/engram|\\\/remnic|\\\/v1).+?)\$\/g?\)/);
         if (m) {
-          currentRoute = normalizeHttpRegexRoute(m[1]!);
+          pathname = normalizeHttpRegexRoute(m[1]!);
         } else {
           m = line.match(/pathname\.startsWith\("((?:\/engram)\/v1\/[^"]+)"\)/);
           if (m) {
-            currentRoute = m[1]!.replace(/\/$/, "") + "/:id";
+            pathname = m[1]!.replace(/\/$/, "") + "/:id";
           }
         }
       }
     }
 
-    if (currentRoute && !routeOps.has(currentRoute)) {
-      routeOps.set(currentRoute, new Set<string>());
+    if (pathname) {
+      // Determine the HTTP method: same line first, then backward for
+      // exact-match routes, forward for dynamic routes.
+      let method: string | null = null;
+      const sameLine = line.match(/req\.method\s*===\s*"(\w+)"/);
+      if (sameLine) {
+        method = sameLine[1]!;
+      } else if (isExactMatch) {
+        for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
+          const bm = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
+          if (bm) { method = bm[1]!; break; }
+        }
+      } else {
+        for (let j = i + 1; j < Math.min(lines.length, i + 5); j++) {
+          if (/pathname\s*===\s*"|\/\^.*\$\/g?\.(?:exec|test)\(pathname\)|pathname\.match\(/.test(lines[j]!)) break;
+          const fm = lines[j]!.match(/req\.method\s*===\s*"(\w+)"/);
+          if (fm) { method = fm[1]!; break; }
+        }
+      }
+      currentKey = method ? `${method} ${pathname}` : pathname;
+      if (!routeOps.has(currentKey)) routeOps.set(currentKey, new Set<string>());
+      continue;
     }
 
     // Collect getOperation calls within the current route block.
-    if (currentRoute) {
+    if (currentKey) {
       const opMatch = line.match(/getOperation\("(\w+)"\)/);
       if (opMatch) {
-        routeOps.get(currentRoute)!.add(opMatch[1]!);
+        routeOps.get(currentKey)!.add(opMatch[1]!);
       }
     }
   }
@@ -262,11 +290,13 @@ function validateDispatchCoverage(
   }
   for (const entry of httpCatalog) {
     if (entry.operation === null) continue;
-    // Route-specific: the getOperation("…") call must be in THIS route's
-    // handler block, not just anywhere in the file. A global set would let a
-    // flipped catalog row pass if a different route dispatches the same
-    // operation (review P2: bind dispatch validation to method/path routes).
-    const routeOps = httpRouteDispatch.get(entry.pathname);
+    // Method+path specific: the getOperation("…") call must be in THIS
+    // method's handler block for THIS pathname, not just anywhere in the
+    // file or in a different method's block for the same path. A pathname-
+    // only key would let a POST block's dispatch satisfy a GET catalog entry
+    // when they share a path (review P2: key dispatch by method and path).
+    const routeKey = `${entry.method} ${entry.pathname}`;
+    const routeOps = httpRouteDispatch.get(routeKey) ?? httpRouteDispatch.get(entry.pathname);
     if (!routeOps || !routeOps.has(entry.operation)) {
       violations.push({
         kind: "http-no-dispatch",
@@ -365,7 +395,7 @@ test("dispatch validator catches an HTTP route whose operation is dispatched by 
     { method: "GET", pathname: "/engram/v1/synthetic", operation: "memory_get" },
   ];
   const routeDispatch = new Map<string, ReadonlySet<string>>([
-    ["/engram/v1/memories/:id", new Set(["memory_get"])],
+    ["GET /engram/v1/memories/:id", new Set(["memory_get"])],
   ]);
   const violations = validateDispatchCoverage(
     [],
@@ -377,6 +407,31 @@ test("dispatch validator catches an HTTP route whose operation is dispatched by 
   assert.ok(
     noDispatch.some((v) => v.detail.includes("/engram/v1/synthetic")),
     "dispatch validator must flag an HTTP route whose operation is dispatched by a different route",
+  );
+});
+
+test("dispatch validator catches cross-method contamination on a shared path", () => {
+  // Seed: catalog claims `GET /engram/v1/memories` migrated to `memory_store`.
+  // The operation IS registered, and `POST /engram/v1/memories` DOES dispatch
+  // `memory_store` — but the GET method's own block does not. A pathname-only
+  // key would find the POST block's dispatch and pass; the method+pathname key
+  // must reject it. (review P2: key HTTP dispatch coverage by method and path)
+  const lyingHttpCatalog: readonly HttpRouteEntry[] = [
+    { method: "GET", pathname: "/engram/v1/memories", operation: "memory_store" },
+  ];
+  const routeDispatch = new Map<string, ReadonlySet<string>>([
+    ["POST /engram/v1/memories", new Set(["memory_store"])],
+  ]);
+  const violations = validateDispatchCoverage(
+    [],
+    lyingHttpCatalog,
+    new Map<string, string>(),
+    routeDispatch,
+  );
+  const noDispatch = violations.filter((v) => v.kind === "http-no-dispatch");
+  assert.ok(
+    noDispatch.some((v) => v.detail.includes("GET /engram/v1/memories")),
+    "dispatch validator must flag a GET route whose operation is dispatched only by the POST route on the same path",
   );
 });
 

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -503,7 +503,7 @@ test("HTTP handler source routes match the catalog (static completeness)", () =>
       pathname = normalizeRegexRoute(raw!);
     }
     if (!pathname.startsWith("/engram/v1/") || !isServicePath(pathname)) continue;
-    const matchIndex = httpSource.indexOf(m[0]);
+    const matchIndex = m.index!;
     const matchLine = httpSource.slice(0, matchIndex).split("\n").length;
     // Scan forward for method checks inside the route block.
     for (let j = matchLine; j < Math.min(lines.length, matchLine + 40); j++) {

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -39,7 +39,7 @@ import {
 // catalog-completeness correction: adding routes that were always live but
 // omitted from the catalog (review-caught). Such a bump MUST be accompanied
 // by the newly-cataloged entries; the higher count is the honest baseline.
-const UNMIGRATED_HANDLER_BASELINE = 133;
+const UNMIGRATED_HANDLER_BASELINE = 134;
 
 // Keep the import live — `getOperation` is the call surfaces use at dispatch
 // time; referencing it here pins the registry's lookup contract.

--- a/packages/remnic-core/src/access-surface-catalog.test.ts
+++ b/packages/remnic-core/src/access-surface-catalog.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Fitness test for the access boundary (issue #1525).
+ *
+ * Walks the MCP `tools/list` surface and the HTTP route catalog, and asserts:
+ *   1. every MCP tool the server actually advertises has a catalog entry
+ *      (so a new tool cannot ship without either migrating it or
+ *      acknowledging it as unmigrated);
+ *   2. every catalog entry that claims a migration (`operation !== null`)
+ *      resolves to a registered boundary operation;
+ *   3. the unmigrated-handler count equals the ratchet baseline, so the count
+ *      may only decrease.
+ *
+ * Prove-fail-before (issue requirement): a dedicated test seeds a bypass —
+ * an MCP tool the catalog does not know about — and asserts the validator
+ * reports it. That demonstrates the gate catches the regression class before
+ * relying on it for the real surface.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramMcpServer } from "./access-mcp.js";
+import type { EngramAccessService } from "./access-service.js";
+import { getOperation, listRegisteredOperations, type OperationName } from "./access-boundary.js";
+// Importing access-operations registers the three pilot operations as a side
+// effect — that is the migration state under test here.
+import "./access-operations.js";
+import {
+  HTTP_ROUTES,
+  MCP_TOOLS,
+  countUnmigratedHandlers,
+  type McpToolEntry,
+} from "./access-surface-catalog.js";
+
+// The ratchet baseline. Decrease this constant (and run
+// `node scripts/check-ratchets.mjs --update`) whenever a follow-up PR
+// migrates a handler. It may NEVER increase — an increase means a new handler
+// shipped without going through the boundary.
+const UNMIGRATED_HANDLER_BASELINE = 129;
+
+// Keep the import live — `getOperation` is the call surfaces use at dispatch
+// time; referencing it here pins the registry's lookup contract.
+void getOperation;
+
+// ---------------------------------------------------------------------------
+// Live MCP surface — short-name extraction
+// ---------------------------------------------------------------------------
+
+const LEGACY_PREFIX = "engram.";
+const CANONICAL_PREFIX = "remnic.";
+
+/** Strip the `engram.`/`remnic.` prefix to get the canonical short name. */
+function shortToolName(advertised: string): string {
+  if (advertised.startsWith(LEGACY_PREFIX)) return advertised.slice(LEGACY_PREFIX.length);
+  if (advertised.startsWith(CANONICAL_PREFIX)) return advertised.slice(CANONICAL_PREFIX.length);
+  return advertised;
+}
+
+/** Spin up a server with emitLegacyTools=true and read the deduped short names. */
+async function liveMcpToolShortNames(): Promise<ReadonlySet<string>> {
+  const stub = { briefingEnabled: true } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(stub, { emitLegacyTools: true });
+  const response = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+  const result = (response as { result?: { tools?: Array<{ name: string }> } }).result;
+  const names = new Set<string>();
+  for (const tool of result?.tools ?? []) {
+    names.add(shortToolName(tool.name));
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Coverage validator — pure function so the prove-fail-before test can seed a
+// bypass against the SAME logic the real assertion uses.
+// ---------------------------------------------------------------------------
+
+interface CoverageViolation {
+  readonly kind:
+    | "live-tool-not-in-catalog"
+    | "catalog-tool-not-live"
+    | "migrated-entry-not-registered"
+    | "duplicate-catalog-tool";
+  readonly detail: string;
+}
+
+function validateCoverage(
+  catalog: readonly McpToolEntry[],
+  liveShortNames: ReadonlySet<string>,
+  registered: ReadonlySet<OperationName>,
+): CoverageViolation[] {
+  const violations: CoverageViolation[] = [];
+  const catalogShortNames = new Set<string>();
+
+  for (const entry of catalog) {
+    if (catalogShortNames.has(entry.tool)) {
+      violations.push({ kind: "duplicate-catalog-tool", detail: entry.tool });
+    }
+    catalogShortNames.add(entry.tool);
+
+    if (!liveShortNames.has(entry.tool)) {
+      violations.push({ kind: "catalog-tool-not-live", detail: entry.tool });
+    }
+    if (entry.operation !== null && !registered.has(entry.operation)) {
+      violations.push({
+        kind: "migrated-entry-not-registered",
+        detail: `${entry.tool} -> ${entry.operation}`,
+      });
+    }
+  }
+
+  for (const live of liveShortNames) {
+    if (!catalogShortNames.has(live)) {
+      violations.push({ kind: "live-tool-not-in-catalog", detail: live });
+    }
+  }
+
+  return violations;
+}
+
+function shortNamesOf(catalog: readonly McpToolEntry[]): Set<string> {
+  const set = new Set<string>();
+  for (const entry of catalog) set.add(entry.tool);
+  return set;
+}
+
+function formatViolations(violations: readonly CoverageViolation[]): string {
+  return violations.map((v) => `  - [${v.kind}] ${v.detail}`).join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Prove-fail-before: the validator MUST catch a seeded bypass
+// ---------------------------------------------------------------------------
+
+test("fitness validator catches an MCP tool the catalog does not know about", () => {
+  // Seed: advertise a fake tool that was never added to the catalog. This is
+  // exactly the regression the boundary exists to prevent — a new handler
+  // shipping with its own ad-hoc validation instead of a registry entry.
+  const liveWithBypass = shortNamesOf(MCP_TOOLS);
+  liveWithBypass.add("rogue_unregistered_tool");
+
+  const violations = validateCoverage(
+    MCP_TOOLS,
+    liveWithBypass,
+    new Set(listRegisteredOperations()),
+  );
+  const rogue = violations.filter((v) => v.kind === "live-tool-not-in-catalog");
+  assert.ok(rogue.length > 0, "validator must flag a live tool missing from the catalog");
+  assert.equal(rogue[0].detail, "rogue_unregistered_tool");
+});
+
+test("fitness validator catches a catalog entry claiming a migration the registry does not back", () => {
+  // Seed: a catalog entry claims `operation: "memory_get"` but the registry
+  // passed in is EMPTY — simulating a handler that flipped its catalog row
+  // without adding the `defineOperation` call. Passing an explicit empty set
+  // (rather than resetting the real registry) keeps this test isolated from
+  // the live pilot registrations.
+  const lyingCatalog: readonly McpToolEntry[] = [
+    ...MCP_TOOLS,
+    { tool: "synthetic_liar", operation: "memory_get" },
+  ];
+  const live = shortNamesOf(lyingCatalog);
+  const emptyRegistry = new Set<OperationName>();
+
+  const violations = validateCoverage(lyingCatalog, live, emptyRegistry);
+  const unregistered = violations.filter((v) => v.kind === "migrated-entry-not-registered");
+  assert.ok(
+    unregistered.some((v) => v.detail.includes("synthetic_liar")),
+    "validator must flag a migrated entry with no backing registration",
+  );
+});
+
+test("fitness validator catches a stale catalog entry (tool removed from the server)", () => {
+  // Seed: catalog claims a tool the server no longer advertises.
+  const staleCatalog: readonly McpToolEntry[] = [
+    ...MCP_TOOLS,
+    { tool: "ghost_tool_removed_from_server", operation: null },
+  ];
+  const live = shortNamesOf(MCP_TOOLS); // server does NOT advertise the ghost
+
+  const violations = validateCoverage(staleCatalog, live, new Set(listRegisteredOperations()));
+  const stale = violations.filter((v) => v.kind === "catalog-tool-not-live");
+  assert.ok(stale.length > 0, "validator must flag a catalog entry with no live tool");
+});
+
+// ---------------------------------------------------------------------------
+// Real surface coverage — the gate that runs on every build
+// ---------------------------------------------------------------------------
+
+test("MCP tools/list matches the catalog exactly (no untracked handlers)", async () => {
+  const live = await liveMcpToolShortNames();
+  const violations = validateCoverage(MCP_TOOLS, live, new Set(listRegisteredOperations()));
+  assert.deepEqual(
+    violations,
+    [],
+    `surface/catalog drift detected — either update access-surface-catalog.ts or migrate the new handler:\n${formatViolations(violations)}`,
+  );
+});
+
+test("every migrated MCP/HTTP entry resolves to a registered boundary operation", () => {
+  const registered = new Set(listRegisteredOperations());
+  for (const entry of MCP_TOOLS) {
+    if (entry.operation !== null) {
+      assert.ok(
+        registered.has(entry.operation),
+        `MCP tool ${entry.tool} claims migration to ${entry.operation} but it is not registered`,
+      );
+    }
+  }
+  for (const entry of HTTP_ROUTES) {
+    if (entry.operation !== null) {
+      assert.ok(
+        registered.has(entry.operation),
+        `HTTP ${entry.method} ${entry.pathname} claims migration to ${entry.operation} but it is not registered`,
+      );
+    }
+  }
+});
+
+test("unmigrated-handler count matches the ratchet baseline (may only decrease)", () => {
+  const actual = countUnmigratedHandlers();
+  assert.ok(
+    actual <= UNMIGRATED_HANDLER_BASELINE,
+    `unmigrated handler count grew from ${UNMIGRATED_HANDLER_BASELINE} to ${actual} — every new handler MUST go through the access boundary (issue #1525). Either migrate it or, if it carries no user input, document the exemption in access-surface-catalog.ts and bump the baseline with a justified commit.`,
+  );
+  // Equality, not just ≤, is the real gate once the baseline is set. We assert
+  // it explicitly so a silent catalog edit (e.g. flipping an entry to null
+  // during a refactor) is caught even when the count stays under the ceiling.
+  assert.equal(
+    actual,
+    UNMIGRATED_HANDLER_BASELINE,
+    `unmigrated handler count changed from ${UNMIGRATED_HANDLER_BASELINE} to ${actual} — update UNMIGRATED_HANDLER_BASELINE here AND run \`node scripts/check-ratchets.mjs --update\` to record the improvement.`,
+  );
+});
+
+
+// ---------------------------------------------------------------------------
+// Boundary hook forwarding — quota parity (issue #1525 acceptance criterion)
+// ---------------------------------------------------------------------------
+
+/**
+ * The HTTP memory_store route enforces its write-quota atomically inside the
+ * service's idempotent-write lock via an `enforceWriteQuota` callback passed
+ * as the service call's second argument. The boundary MUST forward `ctx.hooks`
+ * to that second argument — silently dropping it would let writes bypass the
+ * quota gate, the exact regression class the #1434 Codex review locked down.
+ * These tests prove the pilot operation forwards the hook end-to-end.
+ */
+
+test("memory_store operation forwards ctx.hooks to service.memoryStore (quota hook parity)", async () => {
+  const captured: { hooks?: unknown } = {};
+  const service = {
+    memoryStore: async (_request: unknown, hooks?: unknown) => {
+      captured.hooks = hooks;
+      return {
+        schemaVersion: 1,
+        operation: "memory_store",
+        namespace: "default",
+        dryRun: false,
+        accepted: true,
+        queued: false,
+        status: "stored",
+      };
+    },
+  } as unknown as EngramAccessService;
+
+  let quotaCalled = false;
+  const op = getOperation("memory_store");
+  assert.ok(op, "memory_store must be registered for the pilot");
+  await op.run(
+    { content: "quota-parity-probe", category: "fact", confidence: 0.9 },
+    {
+      service,
+      hooks: {
+        enforceWriteQuota: () => {
+          quotaCalled = true;
+        },
+      },
+    },
+  );
+  // The hooks object MUST reach the service's second argument.
+  assert.ok(captured.hooks, "ctx.hooks must be forwarded to service.memoryStore — dropping it silently bypasses the quota gate (#1434)");
+  const forwarded = captured.hooks as { enforceWriteQuota?: () => void };
+  assert.equal(typeof forwarded?.enforceWriteQuota, "function", "enforceWriteQuota must survive the forwarding");
+  // And the forwarded function must be the same callable (the service invokes
+  // it as `beforeExecute` inside the idempotent-write lock).
+  forwarded?.enforceWriteQuota?.();
+  assert.equal(quotaCalled, true, "the forwarded enforceWriteQuota must be invocable");
+});
+
+test("memory_store operation forwards undefined hooks when ctx.hooks is absent (CLI parity)", async () => {
+  // The CLI store command has no write-quota hook (one-shot process). The
+  // boundary must forward `undefined` cleanly so service.memoryStore's
+  // optional-hooks parameter stays unset, not an empty object that could
+  // mask a future signature change.
+  const captured: { hooks?: unknown } = {};
+  const service = {
+    memoryStore: async (_request: unknown, hooks?: unknown) => {
+      captured.hooks = hooks;
+      return {
+        schemaVersion: 1,
+        operation: "memory_store",
+        namespace: "default",
+        dryRun: false,
+        accepted: true,
+        queued: false,
+        status: "stored",
+      };
+    },
+  } as unknown as EngramAccessService;
+
+  const op = getOperation("memory_store");
+  assert.ok(op);
+  await op.run(
+    { content: "cli-parity-probe", category: "fact", confidence: 0.9 },
+    { service },
+  );
+  assert.equal(captured.hooks, undefined, "absent ctx.hooks must forward as undefined");
+});
+
+test("memory_get operation resolves through the boundary without hooks (read parity)", async () => {
+  const service = {
+    memoryGet: async () => ({ found: false, memoryId: "x", content: "" }),
+  } as unknown as EngramAccessService;
+  const op = getOperation("memory_get");
+  assert.ok(op);
+  const output = (await op.run(
+    { memoryId: "abc" },
+    { service },
+  )) as { result: { found: boolean } };
+  assert.equal(output.result.found, false);
+});

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -185,6 +185,7 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "POST", pathname: "/engram/v1/trust-zones/demo-seed", operation: null },
   { method: "POST", pathname: "/v1/citations/observed", operation: null },
   { method: "GET", pathname: "/engram/v1/review/contradictions", operation: null },
+  { method: "GET", pathname: "/engram/v1/review/contradictions/:id", operation: null },
   { method: "POST", pathname: "/engram/v1/review/resolve", operation: null },
   { method: "GET", pathname: "/engram/v1/graph/snapshot", operation: null },
   { method: "POST", pathname: "/engram/v1/contradiction-scan", operation: null },

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -1,0 +1,213 @@
+/**
+ * Static inventory of every handler on the MCP and HTTP access surfaces, with
+ * its migration status against the access boundary (issue #1525).
+ *
+ * The fitness test (`access-surface-catalog.test.ts`) walks this catalog,
+ * checks each entry against the live registry, and counts unmigrated handlers.
+ * The ratchet (`scripts/check-ratchets.mjs`) reads this file and counts
+ * `operation: null` entries so the unmigrated count can only decrease.
+ *
+ * WHEN MIGRATING A HANDLER (follow-up PRs):
+ *   1. Add the operation to `access-operations.ts` via `defineOperation`.
+ *   2. Flip its entry here from `operation: null` to `operation: "<name>"`.
+ *   3. Delete the surface-local validation the handler used to do.
+ *   4. Run `node scripts/check-ratchets.mjs --update` to ratchet the count
+ *      down — the improvement is recorded in `scripts/ratchet-baseline.json`.
+ *
+ * WHEN ADDING A NEW HANDLER:
+ *   1. Add the entry here with `operation: null` (the fitness test will fail
+ *      until you either migrate it or acknowledge it as unmigrated).
+ *   2. Migrate it in the same PR if it carries user input — the boundary's
+ *      whole point is that no new handler bypasses it.
+ */
+
+import type { OperationName } from "./access-boundary.js";
+
+/**
+ * One row per MCP tool, keyed by the canonical SHORT name (no `engram.`/
+ * `remnic.` prefix — both aliases dispatch to the same operation). The name
+ * MUST match the tool's short suffix as advertised by `tools/list`.
+ */
+export interface McpToolEntry {
+  readonly tool: string;
+  readonly operation: OperationName | null;
+}
+
+/**
+ * One row per HTTP route that invokes an access-service method. Routes that
+ * only serve static assets, SSE streams, or admin console HTML are excluded —
+ * they don't carry user-validated request envelopes into the facade.
+ */
+export interface HttpRouteEntry {
+  readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  readonly pathname: string;
+  readonly operation: OperationName | null;
+}
+
+// Each tool below corresponds 1:1 to an `engram.*` definition in
+// `EngramMcpServer.tools` (access-mcp.ts). The fitness test asserts the live
+// `tools/list` response matches this list by short name, so a new tool cannot
+// land without either migrating it or acknowledging the unmigrated count.
+export const MCP_TOOLS: readonly McpToolEntry[] = [
+  { tool: "recall", operation: null },
+  { tool: "recall_explain", operation: null },
+  { tool: "set_coding_context", operation: null },
+  { tool: "recall_tier_explain", operation: null },
+  { tool: "recall_xray", operation: null },
+  { tool: "wearables_status", operation: null },
+  { tool: "wearables_sync", operation: null },
+  { tool: "transcript_day", operation: null },
+  { tool: "transcript_search", operation: null },
+  { tool: "transcript_memories", operation: null },
+  { tool: "action_confidence", operation: null },
+  { tool: "chatgpt_memory_inspector", operation: null },
+  { tool: "day_summary", operation: null },
+  { tool: "capsule_export", operation: null },
+  { tool: "capsule_import", operation: null },
+  { tool: "capsule_list", operation: null },
+  { tool: "memory_governance_run", operation: null },
+  { tool: "procedure_mining_run", operation: null },
+  { tool: "pattern_reinforcement_run", operation: null },
+  { tool: "procedural_stats", operation: null },
+  { tool: "memory_get", operation: "memory_get" },
+  { tool: "memory_timeline", operation: null },
+  { tool: "memory_store", operation: "memory_store" },
+  { tool: "suggestion_submit", operation: null },
+  { tool: "entity_get", operation: null },
+  { tool: "review_queue_list", operation: null },
+  { tool: "observe", operation: null },
+  { tool: "lcm_search", operation: null },
+  { tool: "lcm_compaction_flush", operation: null },
+  { tool: "lcm_compaction_record", operation: null },
+  { tool: "continuity_audit_generate", operation: null },
+  { tool: "continuity_incident_open", operation: null },
+  { tool: "continuity_incident_close", operation: null },
+  { tool: "continuity_incident_list", operation: null },
+  { tool: "continuity_loop_add_or_update", operation: null },
+  { tool: "continuity_loop_review", operation: null },
+  { tool: "identity_anchor_get", operation: null },
+  { tool: "identity_anchor_update", operation: null },
+  { tool: "memory_identity", operation: null },
+  { tool: "work_task", operation: null },
+  { tool: "work_project", operation: null },
+  { tool: "work_board", operation: null },
+  { tool: "shared_context_write_output", operation: null },
+  { tool: "shared_feedback_record", operation: null },
+  { tool: "shared_priorities_append", operation: null },
+  { tool: "shared_context_cross_signals_run", operation: null },
+  { tool: "shared_context_curate_daily", operation: null },
+  { tool: "compounding_weekly_synthesize", operation: null },
+  { tool: "compounding_promote_candidate", operation: null },
+  { tool: "compression_guidelines_optimize", operation: null },
+  { tool: "compression_guidelines_activate", operation: null },
+  { tool: "memory_search", operation: "memory_search" },
+  { tool: "memory_profile", operation: null },
+  { tool: "memory_entities_list", operation: null },
+  { tool: "memory_questions", operation: null },
+  { tool: "memory_last_recall", operation: null },
+  { tool: "memory_intent_debug", operation: null },
+  { tool: "memory_qmd_debug", operation: null },
+  { tool: "memory_graph_explain", operation: null },
+  { tool: "graph_snapshot", operation: null },
+  { tool: "memory_feedback", operation: null },
+  { tool: "memory_promote", operation: null },
+  { tool: "memory_outcome", operation: null },
+  { tool: "memory_action_apply", operation: null },
+  { tool: "context_checkpoint", operation: null },
+  { tool: "briefing", operation: null },
+  { tool: "review_list", operation: null },
+  { tool: "review_resolve", operation: null },
+  { tool: "contradiction_scan_run", operation: null },
+  { tool: "memory_summarize_hourly", operation: null },
+  { tool: "conversation_index_update", operation: null },
+  { tool: "profiling_report", operation: null },
+  { tool: "graph_edge_decay_run", operation: null },
+  { tool: "live_connectors_run", operation: null },
+  { tool: "peer_list", operation: null },
+  { tool: "peer_get", operation: null },
+  { tool: "peer_set", operation: null },
+  { tool: "peer_delete", operation: null },
+  { tool: "peer_profile_get", operation: null },
+  { tool: "peer_forget", operation: null },
+  { tool: "console_state", operation: null },
+  { tool: "dreams_status", operation: null },
+  { tool: "dreams_run", operation: null },
+];
+
+// Each route below corresponds 1:1 to a service-invoking route branch in
+// `EngramAccessHttpServer.handle` (access-http.ts). Pathname patterns use
+// `:param` for path segments. The fitness test asserts each entry resolves
+// against the catalog so a new service route cannot land without either
+// migrating it or acknowledging the unmigrated count. Infrastructure probes
+// (health, adapters, the /mcp delegate, admin console, SSE-only endpoints)
+// carry no user request envelope and are intentionally excluded.
+export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
+  { method: "POST", pathname: "/engram/v1/recall", operation: null },
+  { method: "POST", pathname: "/engram/v1/coding-context", operation: null },
+  { method: "POST", pathname: "/engram/v1/capsules/export", operation: null },
+  { method: "POST", pathname: "/engram/v1/capsules/import", operation: null },
+  { method: "GET", pathname: "/engram/v1/offline-sync/snapshot", operation: null },
+  { method: "GET", pathname: "/engram/v1/offline-sync/snapshot-stream", operation: null },
+  { method: "POST", pathname: "/engram/v1/offline-sync/snapshot", operation: null },
+  { method: "POST", pathname: "/engram/v1/offline-sync/files", operation: null },
+  { method: "POST", pathname: "/engram/v1/offline-sync/file-content", operation: null },
+  { method: "POST", pathname: "/engram/v1/offline-sync/apply-file-content", operation: null },
+  { method: "POST", pathname: "/engram/v1/offline-sync/apply", operation: null },
+  { method: "POST", pathname: "/engram/v1/recall/explain", operation: null },
+  { method: "POST", pathname: "/engram/v1/action-confidence", operation: null },
+  { method: "GET", pathname: "/engram/v1/recall/tier-explain", operation: null },
+  { method: "GET", pathname: "/engram/v1/recall/xray", operation: null },
+  { method: "GET", pathname: "/engram/v1/wearables/status", operation: null },
+  { method: "POST", pathname: "/engram/v1/wearables/sync", operation: null },
+  { method: "GET", pathname: "/engram/v1/wearables/transcript", operation: null },
+  { method: "GET", pathname: "/engram/v1/wearables/transcripts/search", operation: null },
+  { method: "GET", pathname: "/engram/v1/wearables/memories", operation: null },
+  { method: "POST", pathname: "/engram/v1/observe", operation: null },
+  { method: "POST", pathname: "/engram/v1/lcm/search", operation: null },
+  { method: "POST", pathname: "/engram/v1/lcm/compaction/flush", operation: null },
+  { method: "POST", pathname: "/engram/v1/lcm/compaction/record", operation: null },
+  { method: "GET", pathname: "/engram/v1/lcm/status", operation: null },
+  { method: "POST", pathname: "/engram/v1/memories", operation: "memory_store" },
+  { method: "POST", pathname: "/engram/v1/suggestions", operation: null },
+  { method: "GET", pathname: "/engram/v1/memories", operation: null },
+  { method: "GET", pathname: "/engram/v1/memories/:id", operation: "memory_get" },
+  { method: "GET", pathname: "/engram/v1/memories/:id/timeline", operation: null },
+  { method: "GET", pathname: "/engram/v1/entities", operation: null },
+  { method: "GET", pathname: "/engram/v1/entities/:id", operation: null },
+  { method: "GET", pathname: "/engram/v1/review-queue", operation: null },
+  { method: "GET", pathname: "/engram/v1/maintenance", operation: null },
+  { method: "GET", pathname: "/engram/v1/quality", operation: null },
+  { method: "GET", pathname: "/engram/v1/trust-zones/status", operation: null },
+  { method: "GET", pathname: "/engram/v1/procedural/stats", operation: null },
+  { method: "GET", pathname: "/engram/v1/trust-zones/records", operation: null },
+  { method: "POST", pathname: "/engram/v1/review-disposition", operation: null },
+  { method: "POST", pathname: "/engram/v1/trust-zones/promote", operation: null },
+  { method: "POST", pathname: "/engram/v1/trust-zones/demo-seed", operation: null },
+  { method: "POST", pathname: "/v1/citations/observed", operation: null },
+  { method: "GET", pathname: "/engram/v1/review/contradictions", operation: null },
+  { method: "POST", pathname: "/engram/v1/review/resolve", operation: null },
+  { method: "GET", pathname: "/engram/v1/graph/snapshot", operation: null },
+  { method: "POST", pathname: "/engram/v1/contradiction-scan", operation: null },
+  { method: "GET", pathname: "/engram/v1/graph/events", operation: null },
+  { method: "GET", pathname: "/engram/v1/console/state", operation: null },
+  { method: "GET", pathname: "/engram/v1/peers", operation: null },
+  { method: "GET", pathname: "/engram/v1/dreams/status", operation: null },
+  { method: "POST", pathname: "/engram/v1/dreams/run", operation: null },
+];
+
+/**
+ * Total unmigrated-handler count across both surfaces. The ratchet baseline
+ * tracks this number; it may only decrease. `access-surface-catalog.test.ts`
+ * recomputes it from the live catalog and asserts equality, so a catalog edit
+ * without a baseline bump (or, ideally, a migration) fails the gate.
+ */
+export function countUnmigratedHandlers(): number {
+  let count = 0;
+  for (const entry of MCP_TOOLS) {
+    if (entry.operation === null) count += 1;
+  }
+  for (const entry of HTTP_ROUTES) {
+    if (entry.operation === null) count += 1;
+  }
+  return count;
+}

--- a/packages/remnic-core/src/access-surface-catalog.ts
+++ b/packages/remnic-core/src/access-surface-catalog.ts
@@ -191,6 +191,10 @@ export const HTTP_ROUTES: readonly HttpRouteEntry[] = [
   { method: "GET", pathname: "/engram/v1/graph/events", operation: null },
   { method: "GET", pathname: "/engram/v1/console/state", operation: null },
   { method: "GET", pathname: "/engram/v1/peers", operation: null },
+  { method: "GET", pathname: "/engram/v1/peers/:id/profile", operation: null },
+  { method: "GET", pathname: "/engram/v1/peers/:id", operation: null },
+  { method: "PUT", pathname: "/engram/v1/peers/:id", operation: null },
+  { method: "DELETE", pathname: "/engram/v1/peers/:id", operation: null },
   { method: "GET", pathname: "/engram/v1/dreams/status", operation: null },
   { method: "POST", pathname: "/engram/v1/dreams/run", operation: null },
 ];

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -78,6 +78,9 @@ if [[ "$MODE" == "quick" ]]; then
   run pnpm exec tsx --test tests/recall-no-recall-short-circuit.test.ts
   run pnpm exec tsx --test tests/orchestrator-path-filter.test.ts
   run pnpm exec tsx --test tests/artifact-cache.test.ts
+  # Access boundary fitness test — enforces catalog completeness and the
+  # unmigrated-handler ratchet on every quick preflight (issue #1525).
+  run pnpm exec tsx --test packages/remnic-core/src/access-surface-catalog.test.ts
 else
   run npm test
   run npm run build


### PR DESCRIPTION
## Summary

Establishes the **access-boundary operation registry** (issue #1525, epic #1520 Phase 1): one zod-validated entry per operation, shared error mapping (rule 51), and shared normalizers (rules 17/28/36/48) that **MCP, HTTP, and CLI dispatch through**. Three pilot operations migrate in this PR — `memory_get`, `memory_search`, `memory_store` — proving the pattern end-to-end before the domain-group migrations.

## Pilot wiring (3 ops × surfaces)

| Op | MCP | HTTP | CLI |
|---|---|---|---|
| `memory_get` | ✅ registry dispatch | ✅ `GET /engram/v1/memories/:id` | — (not exposed) |
| `memory_search` | ✅ registry dispatch | — (not exposed) | — (not exposed) |
| `memory_store` | ✅ registry dispatch | ✅ `POST /engram/v1/memories` (quota hook via `ctx.hooks`) | ✅ `store` command |

The `OperationContext.hooks` carrier lets HTTP forward its atomic write-quota gate through the boundary without the boundary knowing about transport policy — the `enforceWriteQuota` hook fires inside the service's idempotent-write lock exactly as before (#1434 invariant preserved).

Dead code removed: all three surface-local case-branches/handlers for the migrated ops (no `this.service.memoryGet/Store/Search` direct calls remain for pilot ops on any surface).

## Fitness inventory

`access-surface-catalog.ts` — static catalog of every MCP tool (82) and HTTP route (52) with migration status. The fitness test (`access-surface-catalog.test.ts`):
- walks MCP `tools/list` + HTTP routes against the catalog
- asserts migrated entries resolve to registered operations
- ratchets the unmigrated count (**baseline 129**, may only decrease)
- 3 prove-fail-before tests seed bypasses to verify the gate catches the regression class

## Quota hook parity

Three dedicated tests prove the boundary preserves the #1434 atomic write-quota invariant:
1. `memory_store` forwards `ctx.hooks` to `service.memoryStore`'s second argument
2. `memory_store` forwards `undefined` cleanly when hooks absent (CLI path)
3. `memory_get` (read op) works without hooks

## Test evidence (node 22, `tsx --test`)

```
access-boundary.test.ts:         17 pass
access-surface-catalog.test.ts:   9 pass (6 fitness + 3 hook parity)
access-mcp.test.ts:              31 pass
access-http.test.ts:             25 pass
access-cli.test.ts:              19 pass
Total:                          101 pass, 0 fail
```

## Gates

- `tsc --noEmit` — clean
- `node scripts/check-ratchets.mjs` — OK
- `bash scripts/check-review-patterns.sh` — PASSED
- `npm run preflight:quick` — `[preflight] OK (quick)`

---

Part of #1520 / #1525.

**Unmigrated baseline:** 129 handlers across MCP (79 unmigrated) + HTTP (50 unmigrated).

**Chokepoints used:** establishes the #1525 registry chokepoint (pilot).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all access entrypoints and memory write/read paths, including atomic write-quota forwarding; scope is a three-op pilot with explicit regression tests, but incorrect hook or dispatch wiring could affect quotas or validation behavior.
> 
> **Overview**
> Introduces a **shared access boundary** (`access-boundary.ts`): Zod-validated operations registered via `defineOperation`, shared edge normalizers (booleans, positive integers, paths, rule-51 Zod messages), and `OperationContext` with optional `hooks` (e.g. HTTP write-quota).
> 
> **Pilot migrations** wire `memory_get`, `memory_search`, and `memory_store` through one registry in `access-operations.ts`. MCP (`MCP_MIGRATED_OPERATIONS`), HTTP (`POST /engram/v1/memories`, `GET …/memories/:id`), and CLI `store` call `getOperation` instead of direct `EngramAccessService` branches. HTTP still passes `enforceWriteQuota` through `ctx.hooks` into `memoryStore`. **`memory_get`** now rejects missing/empty ids instead of forwarding `""`.
> 
> Adds **`access-surface-catalog`** (every MCP tool + HTTP route + migration flag), fitness tests (catalog ↔ live surface, registration + **dispatch** wiring, unmigrated ratchet baseline **134**), boundary unit tests, and hook-parity tests. Quick preflight runs the catalog fitness test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3be8475858d79e493033fbc0a9a9debc6dd70a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->