### PR TITLE
ci: cut merge-critical wall-clock — poll-based AI gate, parallel quality jobs, sharded tests

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -59,6 +59,17 @@ Remnic is a local-first memory plugin (TypeScript monorepo, pnpm workspaces, ESM
 - **Shared mutable objects must not leak across sessions** — per-connection instances or deep-copy for `clientInfo` etc.
 - **Feature gates must be identical across all code paths** — if a gate covers the QMD path but not the fallback path, behavior diverges.
 
+### Packaging & docs-code contracts
+- **Optional packages stay optional at every layer** — `@remnic/bench`, `@remnic/export-weclone` load via computed-specifier dynamic imports (`await import("@remnic/" + "bench")`), are optional peer deps, and must NEVER appear in `noExternal` or as static imports in base install surfaces (CLI, core, plugin-openclaw).
+- **Documented behavior must be wired end-to-end** — a config property defined in the schema but never consumed in code is a bug; docs claiming "timeout applies to daemon calls" require the parameter to actually reach the client.
+- **Parsers track position during iteration** — `content.indexOf(line)` returns the FIRST occurrence; repeated lines make offsets wrong. Maintain a running offset.
+
+### CI workflows (`.github/workflows/`)
+- **Never silence quality gates** — no `|| true`, no `continue-on-error: true` on test/type/lint steps.
+- **Aggregator jobs must propagate failure** — a job that `needs:` others and gates a required status check must fail when any dependency is not `success` (skipped and cancelled count as failure).
+- **`concurrency.cancel-in-progress` must never cancel push-to-main runs** — only PR events are safe to supersede.
+- **Test shard definitions must partition, not sample** — the union of CI shards must equal the full suite; a pattern group that drops files silently loses coverage.
+
 ## Medium-Priority Checks
 
 - **Wrap external service calls in try-catch** — token generation, daemon probes, filesystem writes must not crash primary flows.
@@ -78,6 +89,7 @@ Remnic is a local-first memory plugin (TypeScript monorepo, pnpm workspaces, ESM
 - Test fixture data in `tests/fixtures/` — intentionally static.
 - Eval benchmark code in `evals/` — separate concern from core logic.
 - Docs formatting changes — only flag if they misrepresent behavior.
+- Previously reviewed, unchanged code — only flag issues introduced or made reachable by the current diff.
 
 ## Monorepo Structure
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Labels of self-hosted runners registered to this repo.
+  # `remnic` = jarvis runner pool (homelab-infra: CTs 340-342).
+  labels:
+    - remnic

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -16,19 +16,21 @@ permissions:
   issues: read
   pull-requests: read
 
-# Only the newest gate evaluation per PR matters: a fresh push, review, or
-# reviewer check_run supersedes any in-flight evaluation. check_run events
-# with no associated PR fall back to a unique group (they self-skip anyway).
-concurrency:
-  group: ai-review-gate-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   ai-reviewers:
     if: >-
       (github.event_name == 'check_run' &&
         contains(fromJSON('["cursor-bugbot","cursor"]'), github.event.check_run.app.slug)) ||
       (github.event_name != 'check_run' && github.event.pull_request.draft == false)
+    # Only the newest gate evaluation per PR matters: a fresh push, review, or
+    # reviewer check_run supersedes an in-flight evaluation. Concurrency lives
+    # at JOB level so check_run completions from unrelated apps (CI, CodeQL,
+    # ...) — whose job is skipped by the `if` above — can never cancel a live
+    # polling evaluation (cursor review on #1608). check_run events with no
+    # associated PR fall back to a unique group (they self-skip anyway).
+    concurrency:
+      group: ai-review-gate-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -16,6 +16,13 @@ permissions:
   issues: read
   pull-requests: read
 
+# Only the newest gate evaluation per PR matters: a fresh push, review, or
+# reviewer check_run supersedes any in-flight evaluation. check_run events
+# with no associated PR fall back to a unique group (they self-skip anyway).
+concurrency:
+  group: ai-review-gate-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   ai-reviewers:
     if: >-
@@ -25,11 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Wait for AI reviewers to settle
-        run: |
-          echo "Waiting 3 minutes for AI reviewers to analyse the diff..."
-          sleep 180
-
       - name: Check AI review bot activity
         uses: actions/github-script@v7
         env:
@@ -324,103 +326,133 @@ jobs:
               return;
             }
 
-            const failures = [];
-            let evaluatedCount = 0;
+            async function evaluatePullRequests() {
+              const failures = [];
+              let evaluatedCount = 0;
+              let hasBlockers = false;
 
-            for (const pr of pullRequestNumbers) {
-              const pullRequest = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pr,
-              });
-              if (pullRequest.data.draft) {
-                core.notice(`Skipping draft pull request #${pr}.`);
-                continue;
-              }
-              evaluatedCount += 1;
+              for (const pr of pullRequestNumbers) {
+                const pullRequest = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pr,
+                });
+                if (pullRequest.data.draft) {
+                  core.notice(`Skipping draft pull request #${pr}.`);
+                  continue;
+                }
+                evaluatedCount += 1;
 
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner,
-                repo,
-                pull_number: pr,
-                per_page: 100,
-              });
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner,
+                  repo,
+                  pull_number: pr,
+                  per_page: 100,
+                });
 
-              const issueComments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: pr,
-                per_page: 100,
-              });
+                const issueComments = await github.paginate(github.rest.issues.listComments, {
+                  owner,
+                  repo,
+                  issue_number: pr,
+                  per_page: 100,
+                });
 
-              const prComments = await github.paginate(github.rest.pulls.listReviewComments, {
-                owner,
-                repo,
-                pull_number: pr,
-                per_page: 100,
-              });
+                const prComments = await github.paginate(github.rest.pulls.listReviewComments, {
+                  owner,
+                  repo,
+                  pull_number: pr,
+                  per_page: 100,
+                });
 
-              const headSha = pullRequest.data.head.sha;
-              const headCommit = headSha
-                ? await github.rest.repos.getCommit({
-                    owner,
-                    repo,
-                    ref: headSha,
-                  })
-                : null;
-              const headCommittedAt =
-                headCommit?.data?.commit?.committer?.date ??
-                headCommit?.data?.commit?.author?.date ??
-                null;
-              const checkRuns = headSha
-                ? await github.paginate(github.rest.checks.listForRef, {
-                    owner,
-                    repo,
-                    ref: headSha,
-                    per_page: 100,
-                  })
-                : [];
+                const headSha = pullRequest.data.head.sha;
+                const headCommit = headSha
+                  ? await github.rest.repos.getCommit({
+                      owner,
+                      repo,
+                      ref: headSha,
+                    })
+                  : null;
+                const headCommittedAt =
+                  headCommit?.data?.commit?.committer?.date ??
+                  headCommit?.data?.commit?.author?.date ??
+                  null;
+                const checkRuns = headSha
+                  ? await github.paginate(github.rest.checks.listForRef, {
+                      owner,
+                      repo,
+                      ref: headSha,
+                      per_page: 100,
+                    })
+                  : [];
 
-              const result = evaluateAiReviewGate({
-                groups,
-                headSha,
-                headCommittedAt,
-                reviews,
-                issueComments,
-                reviewComments: prComments,
-                checkRuns,
-              });
+                const result = evaluateAiReviewGate({
+                  groups,
+                  headSha,
+                  headCommittedAt,
+                  reviews,
+                  issueComments,
+                  reviewComments: prComments,
+                  checkRuns,
+                });
 
-              core.info(
-                `PR #${pr} positive current-head AI review activity from: ${
-                  result.present.map(p => `${p.alias}(${p.kind}:${p.state})`).join(', ') || 'none'
-                }`,
-              );
-
-              if (result.blockers.length > 0) {
                 core.info(
-                  `PR #${pr} blocking AI review activity: ${
-                    result.blockers.map(b => `${b.alias}(${b.state})`).join(', ')
+                  `PR #${pr} positive current-head AI review activity from: ${
+                    result.present.map(p => `${p.alias}(${p.kind}:${p.state})`).join(', ') || 'none'
                   }`,
                 );
+
+                if (result.blockers.length > 0) {
+                  core.info(
+                    `PR #${pr} blocking AI review activity: ${
+                      result.blockers.map(b => `${b.alias}(${b.state})`).join(', ')
+                    }`,
+                  );
+                  hasBlockers = true;
+                }
+
+                if (!result.ok) {
+                  failures.push({ pr, reason: result.reason });
+                  continue;
+                }
+
+                core.notice(`PR #${pr}: ${result.reason}`);
               }
 
-              if (!result.ok) {
-                failures.push({ pr, reason: result.reason });
-                continue;
-              }
-
-              core.notice(`PR #${pr}: ${result.reason}`);
+              return { failures, evaluatedCount, hasBlockers };
             }
 
-            if (failures.length > 0) {
-              core.setFailed(
-                `AI review gate failed for ${failures.map((failure) => `#${failure.pr}: ${failure.reason}`).join(' | ')}`,
+            // Poll instead of a fixed sleep: pass the moment every required
+            // reviewer has spoken on the current head. Explicit negative
+            // signals (blockers) fail immediately — a new push or review
+            // event re-fires this workflow and supersedes this run via the
+            // concurrency group, so waiting on a blocker buys nothing.
+            const POLL_INTERVAL_MS = 20_000;
+            const POLL_DEADLINE_MS = 7 * 60_000;
+            const startedAt = Date.now();
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            for (;;) {
+              const { failures, evaluatedCount, hasBlockers } = await evaluatePullRequests();
+
+              if (evaluatedCount === 0) {
+                core.setFailed('AI review gate did not evaluate any non-draft pull requests.');
+                return;
+              }
+
+              if (failures.length === 0) {
+                return;
+              }
+
+              const elapsedMs = Date.now() - startedAt;
+              if (hasBlockers || elapsedMs + POLL_INTERVAL_MS > POLL_DEADLINE_MS) {
+                core.setFailed(
+                  `AI review gate failed for ${failures.map((failure) => `#${failure.pr}: ${failure.reason}`).join(' | ')}`,
+                );
+                return;
+              }
+
+              core.info(
+                `AI review activity incomplete after ${Math.round(elapsedMs / 1000)}s — polling again in ${POLL_INTERVAL_MS / 1000}s.`,
               );
-              return;
-            }
-
-            if (evaluatedCount === 0) {
-              core.setFailed('AI review gate did not evaluate any non-draft pull requests.');
-              return;
+              await sleep(POLL_INTERVAL_MS);
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ permissions:
   contents: read
   pull-requests: read
 
+# A superseded push should not keep burning runners: cancel in-flight runs for
+# the same PR. Pushes to main are never cancelled.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-risky-paths:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -67,10 +73,60 @@ jobs:
       - name: Entity hardening suite
         run: pnpm run test:entity-hardening
 
-  quality:
+  # Static analysis: no native binding, no build artifacts needed beyond the
+  # core build that check-types performs itself.
+  checks:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run check-types
+
+      - name: Review pattern check
+        run: bash scripts/check-review-patterns.sh
+
+      - name: Structural ratchets
+        run: node scripts/check-ratchets.mjs
+
+      - name: Docs-code parity
+        run: node scripts/check-docs-parity.mjs
+
+  # The root suite (895 files) sharded by pattern group so shards run in
+  # parallel. TEST_PATTERN_GROUPS in scripts/root-test-runner-lib.mjs is an
+  # exact partition of TEST_PATTERNS (enforced by test), so the union of the
+  # shards below is exactly the unsharded suite.
+  tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: root
+            groups: '--group root --group misc'
+          - shard: packages
+            groups: '--group packages'
+    name: tests (${{ matrix.shard }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,29 +146,18 @@ jobs:
       - name: Rebuild native modules
         run: pnpm rebuild better-sqlite3
 
-      # CI hard-requires capability tests (#1541) below, which in turn
-      # hard-requires `uv` for the AMB runner scripts. Install it on the
-      # ubuntu runner so the gate has the capability it demands.
+      - name: Build @remnic/core
+        run: pnpm --filter @remnic/core build
+
+      # CI hard-requires capability tests (#1541), which in turn hard-require
+      # `uv` for the AMB runner scripts. Install it on the runner so the gate
+      # has the capability it demands.
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Typecheck
-        run: pnpm run check-types
-
-      - name: Review pattern check
-        run: bash scripts/check-review-patterns.sh
-
-      - name: Structural ratchets
-        run: node scripts/check-ratchets.mjs
-
-      - name: Docs-code parity
-        run: node scripts/check-docs-parity.mjs
 
       - name: Tests
-        run: pnpm test
+        run: node scripts/run-root-tests.mjs ${{ matrix.groups }}
         env:
           # CI rebuilds the native binding above; skipping native-dependent
           # suites here would silently drop coverage (#1538).
@@ -123,8 +168,53 @@ jobs:
           # locally instead of counting a silent skip.
           REMNIC_REQUIRE_CAPABILITY_TESTS: "1"
 
+  build-artifacts:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules
+        run: pnpm rebuild better-sqlite3
+
       - name: Build
         run: pnpm run build
 
       - name: Release artifact smoke test
         run: node scripts/check-release-artifacts.mjs
+
+  # Aggregator that preserves the required status-check context `quality`
+  # (branch ruleset) while the real work runs in parallel jobs above. Fails
+  # unless every dependency succeeded — skipped/cancelled deps are failures,
+  # never silently accepted.
+  quality:
+    needs: [checks, tests, build-artifacts]
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all CI jobs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          failed=$(echo "$NEEDS_JSON" | jq -r 'to_entries[] | select(.value.result != "success") | .key')
+          if [ -n "$failed" ]; then
+            echo "::error::CI gate failed — non-success jobs: $failed"
+            exit 1
+          fi
+          echo "All CI jobs succeeded."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,13 @@ jobs:
   # parallel. TEST_PATTERN_GROUPS in scripts/root-test-runner-lib.mjs is an
   # exact partition of TEST_PATTERNS (enforced by test), so the union of the
   # shards below is exactly the unsharded suite.
+  #
+  # Shards run on the self-hosted `remnic` pool (jarvis CTs 340-342,
+  # homelab-infra). Fallback: if the pool is down, temporarily set
+  # runs-on back to ubuntu-latest here.
   tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: [remnic]
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,15 @@ jobs:
   # exact partition of TEST_PATTERNS (enforced by test), so the union of the
   # shards below is exactly the unsharded suite.
   #
-  # Shards run on the self-hosted `remnic` pool (jarvis CTs 340-342,
-  # homelab-infra). Fallback: if the pool is down, temporarily set
-  # runs-on back to ubuntu-latest here.
+  # Runner selection (public repo, self-hosted safety): the self-hosted
+  # `remnic` pool (jarvis CTs 340-342, homelab-infra) only serves pushes to
+  # main and SAME-REPO pull requests. Fork PRs — even ones whose workflows a
+  # maintainer approved — run on GitHub-hosted runners so external code can
+  # never execute on homelab hardware. Pool down? Temporarily replace the
+  # expression with 'ubuntu-latest'.
   tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: [remnic]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'remnic' || 'ubuntu-latest' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,17 @@ jobs:
       - name: Rebuild native modules
         run: pnpm rebuild better-sqlite3
 
-      - name: Build @remnic/core
-        run: pnpm --filter @remnic/core build
+      # Tests need @remnic/core AND @remnic/bench dist output. The bench dist
+      # requirement is load-bearing: tests/remnic-cli-dataset-resolution.test.ts
+      # loads @remnic/bench through the CLI's optional-bench loader, and when
+      # dist/ is absent the tsx/esm/api tsImport fallback breaks subsequent
+      # dynamic .ts imports in the same process (latent bug — main's serial
+      # quality job only passed because the recursive check-types step
+      # side-built bench/dist before Tests ran).
+      - name: Build workspace packages needed by tests
+        run: |
+          pnpm --filter @remnic/core build
+          pnpm --filter @remnic/bench build
 
       # CI hard-requires capability tests (#1541), which in turn hard-require
       # `uv` for the AMB runner scripts. Install it on the runner so the gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
   # expression with 'ubuntu-latest'.
   tests:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'remnic' || 'ubuntu-latest' }}
+    # remnic pool only for same-repo PRs and main-ref runs; workflow_dispatch
+    # on any other ref stays on hosted runners (codex P2 on #1608).
+    runs-on: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && github.ref == 'refs/heads/main')) && 'remnic' || 'ubuntu-latest' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -1,0 +1,44 @@
+name: Runner Smoke
+
+# Manual health check for the self-hosted `remnic` runner pool (jarvis LXCs).
+# Verifies a runner can check out, install deps, build the native binding,
+# and run a real test file — the same capabilities the CI tests job needs.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: remnic
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner facts
+        run: |
+          echo "host: $(hostname)"
+          echo "cpus: $(nproc)"
+          free -h | head -2
+          df -h / | tail -1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules
+        run: pnpm rebuild better-sqlite3
+
+      - name: Test-runner lib suite
+        run: pnpm exec tsx --test tests/root-test-runner-lib.test.mjs

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -12,6 +12,10 @@ permissions:
 
 jobs:
   smoke:
+    # Self-hosted safety: manual dispatch can target any ref, so pin this
+    # workflow to main — the pool only ever executes reviewed, merged code
+    # (codex review on #1608). Branch health-checks belong on hosted runners.
+    if: github.ref == 'refs/heads/main'
     runs-on: remnic
     timeout-minutes: 15
     steps:

--- a/docs/plans/2026-07-04-ci-speedup-plan.md
+++ b/docs/plans/2026-07-04-ci-speedup-plan.md
@@ -92,6 +92,10 @@ Rollout (follows existing conventions in `homelab-infra`):
 
 - Repo → Settings → Actions: set fork-PR workflow approval to
   **"Require approval for all outside collaborators"**.
+- `runs-on` expression gate in `ci.yml`: the `remnic` pool only serves pushes
+  and same-repo PRs; fork PRs run on GitHub-hosted runners even after a
+  maintainer approves their workflows. External code never executes on
+  homelab hardware.
 - Dedicated remnic runner CTs only. **Never** share runners between remnic
   (public) and Deckard/client repos (private) — a malicious fork PR on the
   public repo must have nothing to steal. No secrets on the runner beyond

--- a/docs/plans/2026-07-04-ci-speedup-plan.md
+++ b/docs/plans/2026-07-04-ci-speedup-plan.md
@@ -1,0 +1,162 @@
+# CI + AI-Review Speedup Plan
+
+Date: 2026-07-04
+Status: Phase 1 implemented in this PR; Phases 2-3 are infra/process follow-ups.
+
+## Problem
+
+PR merge latency is dominated by CI wall-clock and AI-reviewer gating, not by
+reviewer quality. Measured on the last 100 workflow runs and 30 merged PRs:
+
+| Fact | Measurement |
+|---|---|
+| `quality` job wall-clock | ~11 min (Tests 7.25 m, Typecheck 2.45 m, serial) |
+| `@remnic/core` tsup build repeats | 3× per quality job (check-types, test, build each prepend it) |
+| Root suite | 895 test files in ONE `tsx --test` process, no sharding |
+| AI Review Gate | fixed `sleep 180` per fire; fires 2-4× per push (34 of last 100 runs) |
+| Cursor Bugbot actual latency | starts ≤0.5 min after push, finishes in 0.8-2.1 min |
+| Heavy-PR round trips | 5-9 push→review→push cycles (#1591: 28 commits, 82 reviews; #1593: 5 labeled "round-N" commits) |
+| Per-push always-on CI | ~28-34 runner-minutes across 10+ workflows |
+
+Cost reality check (changes the optimization target):
+
+- `joshuaswarren/remnic` is a **public repo** → standard `ubuntu-latest`
+  minutes are **$0**. All 20 jobs use `ubuntu-latest`.
+- Bugbot is on a **flat subscription** → per-review cost is $0.
+- Therefore remnic's problem is **pure wall-clock latency** (plus free-tier
+  concurrency contention across the account's repos). Money savings apply to
+  **private/client repos** (see "Generalizing to private repos" below).
+
+## Phase 1 — implemented in this PR (no infra required)
+
+1. **AI Review Gate: poll instead of sleep.**
+   `sleep 180` removed. The gate now evaluates immediately and re-polls every
+   20 s (7 min deadline) with early exit the moment every required reviewer
+   has positive current-head activity. Explicit negative verdicts still fail
+   immediately. Since Bugbot finishes in ~2 min, gate-green latency drops
+   from ~3.2+ min to ~Bugbot-actual. A per-PR `concurrency` group with
+   `cancel-in-progress` collapses the 2-4× multi-fire stampede to one live
+   evaluation per PR.
+
+2. **`quality` split into parallel jobs.**
+   `checks` (lint + typecheck + review-patterns + ratchets), `tests`
+   (2-way shard), and `build-artifacts` now run in parallel; a tiny `quality`
+   aggregator preserves the required status-check context without touching
+   the branch ruleset. Aggregator fails unless every dependency reports
+   `success` (skipped/cancelled are failures — no silenced gates).
+
+3. **Test sharding.**
+   `scripts/run-root-tests.mjs --group <root|packages|misc>` selects pattern
+   groups. `TEST_PATTERN_GROUPS` is an exact partition of `TEST_PATTERNS`,
+   enforced by a test, so shards can never silently drop coverage. CI runs
+   `root+misc` and `packages` shards concurrently (~518 vs ~377 files).
+
+4. **Superseded-push cancellation.**
+   `ci.yml` gets a per-PR concurrency group (`cancel-in-progress` for PR
+   events only, never for pushes to `main`). Rapid agent push loops stop
+   queueing stale runs behind fresh ones.
+
+Expected merge-critical path per push: **~11 min → ~6-7 min** on hosted
+runners (setup + longest test shard + aggregator), and the gate goes green
+~1-3 min after Bugbot instead of 3-6+.
+
+## Phase 2 — homelab runners (infra, ~1 day)
+
+`~/src/homelab-infra` already runs **~15 GitHub Actions runner LXCs** across
+the Proxmox cluster with nightly-prune/weekly-restart/telemetry automation
+(`scripts/ci-runner-*`), currently serving Deckard CI. Findings:
+
+- proxmox2/3/4/5/z1 are documented as I/O- or capacity-saturated ("do not add
+  workers"); proxmox (192.168.2.3) has modest headroom.
+- **jarvis** (EPYC 7443P 24C/48T, 256 GB ECC, 3.5 TiB free local-lvm, dual
+  10 GbE) is the only node with real capacity; the ML VM leaves ~60 GB +
+  spare cores on the host.
+
+Rollout (follows existing conventions in `homelab-infra`):
+
+1. Create 1-2 Debian-12 unprivileged LXCs on **jarvis** (6-8 vCPU, 16-24 GB,
+   rootfs on jarvis `local-lvm` — never QNAP NFS/iSCSI), standard runner
+   feature set (`nesting=1,keyctl=1,fuse=1`, `onboot=1`), one runner per CT,
+   registered to `joshuaswarren/remnic` with labels
+   `[self-hosted, remnic]` and `--no-default-labels`.
+2. Enroll jarvis in Tailscale (currently `NeedsLogin`) and wire the existing
+   `ci-runner-nightly-maintenance` + Gatus health checks.
+3. Flip `runs-on` for the `tests` shards (and optionally `checks`) to
+   `[self-hosted, remnic]`. With 8 vCPU/shard, `node:test` concurrency
+   doubles vs the 4-vCPU hosted runner → tests ~2-3 min; a warm pnpm store
+   and prebuilt better-sqlite3 remove another ~1 min of setup.
+4. Keep one shard runnable on `ubuntu-latest` as fallback if jarvis reboots
+   (labels are per-job; a manual `workflow_dispatch` input can switch).
+
+**Security (public repo — non-negotiable):**
+
+- Repo → Settings → Actions: set fork-PR workflow approval to
+  **"Require approval for all outside collaborators"**.
+- Dedicated remnic runner CTs only. **Never** share runners between remnic
+  (public) and Deckard/client repos (private) — a malicious fork PR on the
+  public repo must have nothing to steal. No secrets on the runner beyond
+  its registration token; runners are outbound-HTTPS-only (fits the
+  locked-down MikroTik posture).
+- Existing weekly-restart + nightly-prune automation approximates ephemeral
+  hygiene; move to true ephemeral (JIT registration, `--ephemeral`) if
+  outside contributions grow.
+
+## Phase 3 — review round-trip reduction (process + settings)
+
+The dominant residual cost is 5-9 push→review→push cycles per heavy PR.
+Levers, in order of effort:
+
+1. **Cursor dashboard: enable incremental re-review** ("only review what's
+   new since the last review", June 2026 Bugbot update). Kills re-flagging
+   of already-reviewed code that drives rounds 4+.
+2. **Draft-first agent workflow.** CI (`quality`) and both gates already
+   skip drafts. Agents should open PRs as drafts, iterate against local
+   preflight (`npm run preflight:quick` + `review:cursor`), and flip to
+   ready once — collapsing N review rounds into 1-2. Candidate enforcement:
+   a `pr-loop` skill update instructing agents to use `gh pr create --draft`.
+3. **Reviewer context files.** `.cursor/BUGBOT.md` extended in this PR with
+   packaging/docs-contract/CI-workflow rules and a "don't re-flag unchanged
+   code" note. Codex reviews already consume `AGENTS.md`.
+4. **Batch-fix discipline** is already mandated
+   (`docs/ops/pr-review-hardening-playbook.md`); the draft-first workflow is
+   what makes it cheap to follow.
+
+Not viable: GitHub **merge queue** — org-owned repos only; remnic is
+user-owned. Revisit if the repo ever moves into an org.
+
+## Generalizing to private/client repos (e.g. Blend)
+
+Private repos pay real money per minute, so the same playbook has direct
+dollar ROI there — with different constraints:
+
+1. **Self-hosted runners are SAFER on private repos** (no fork-PR exposure)
+   and eliminate per-minute billing entirely. Blend CI could run on a
+   dedicated LXC pool (the Deckard pattern: one-runner-per-CT, labeled, with
+   the existing `ci-runner-*` maintenance) — **but check the client
+   contract/data-handling terms before running client code on homelab
+   hardware.** If client governance forbids it, use a SOC2 managed runner
+   service (Blacksmith/WarpBuild/Namespace/Depot, ~50-70% cheaper per minute
+   than GitHub-hosted and ~2× faster; drop-in `runs-on` change) or RunsOn
+   inside the client's own AWS account (~90% cheaper, stays in their
+   security perimeter).
+2. **The workflow patterns port as-is:** kill fixed sleeps (poll with early
+   exit), per-PR `concurrency` + `cancel-in-progress`, split serial mega-jobs
+   into parallel jobs behind a required-check aggregator, shard tests, dedupe
+   repeated builds, path-filter expensive suites.
+3. **The review patterns port as-is:** repo-level `BUGBOT.md` (+ per-dir
+   files for big repos), draft-first iteration, batch-fix rounds, local
+   pre-push AI review. On metered Bugbot/Codex plans these also cut review
+   spend directly.
+4. **Order of operations for any client repo:** measure first (`gh run list`
+   + job timings), kill pure-waste minutes (sleeps, redundant builds,
+   unconditioned triggers), then parallelize, then move compute off GitHub
+   only if the bill still matters.
+
+## Measurements to watch after merge
+
+- `gh run list --workflow CI --json createdAt,updatedAt` — expect quality
+  aggregate ≤7 min per push.
+- AI Review Gate runs per push should drop to ~1 live run (cancelled runs
+  are expected and free-ish); gate-green should track Bugbot completion
+  within ~30 s.
+- Heavy-PR wall-clock open→merge; target: halve #1591-class PRs.

--- a/scripts/root-test-runner-lib.mjs
+++ b/scripts/root-test-runner-lib.mjs
@@ -26,6 +26,66 @@ export const TEST_PATTERNS = [
   { id: "integrations/amb/*.test.mjs", base: "integrations/amb", recursive: false, suffix: ".test.mjs" },
 ];
 
+/**
+ * Named pattern groups for CI test sharding (issue: CI wall-clock). Every
+ * TEST_PATTERNS id must belong to exactly one group — the companion test
+ * enforces the partition so a new pattern cannot silently escape sharded CI.
+ */
+export const TEST_PATTERN_GROUPS = Object.freeze({
+  root: ["tests/**/*.test.ts", "tests/**/*.test.mjs"],
+  packages: ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.test.tsx"],
+  misc: ["dashboard/lib/*.test.ts", "integrations/amb/*.test.mjs"],
+});
+
+/**
+ * Resolve --group selections into TEST_PATTERNS entries.
+ * No groups selected → the full pattern list (unsharded behavior).
+ * Unknown group names are an error, never a silent no-op.
+ */
+export function selectTestPatterns(groupNames, patterns = TEST_PATTERNS) {
+  if (!Array.isArray(groupNames)) {
+    throw new Error("selectTestPatterns: groupNames must be an array");
+  }
+  if (groupNames.length === 0) return patterns;
+  const validGroups = Object.keys(TEST_PATTERN_GROUPS).join(", ");
+  const ids = new Set();
+  for (const name of groupNames) {
+    const groupIds = TEST_PATTERN_GROUPS[name];
+    if (!groupIds) {
+      throw new Error(`Unknown test group "${name}". Valid groups: ${validGroups}`);
+    }
+    for (const id of groupIds) ids.add(id);
+  }
+  const selected = patterns.filter((pattern) => ids.has(pattern.id));
+  if (selected.length === 0) {
+    throw new Error(`Test group selection [${groupNames.join(", ")}] matched no patterns.`);
+  }
+  return selected;
+}
+
+/**
+ * Parse root-test-runner CLI arguments. Only `--group <name>` (repeatable)
+ * is accepted; anything else is an error — invalid input is rejected, not
+ * silently reinterpreted as "run everything".
+ */
+export function parseRunnerArgs(argv) {
+  const groups = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--group") {
+      const value = argv[index + 1];
+      if (typeof value !== "string" || value.startsWith("--")) {
+        throw new Error("--group requires a group name argument");
+      }
+      if (!groups.includes(value)) groups.push(value);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument "${arg}". Usage: run-root-tests.mjs [--group <name>]...`);
+  }
+  return { groups };
+}
+
 const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".git"]);
 
 function toPosix(relPath) {

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -25,13 +25,14 @@ import { fileURLToPath } from "node:url";
 
 import { appendNodeOption } from "./root-test-runner-env.mjs";
 import {
-  TEST_PATTERNS,
   chunkArgsByLength,
   expandTestPatterns,
   loadNativeManifest,
+  parseRunnerArgs,
   parseTapSummary,
   partitionNativeDependent,
   probeBetterSqlite3,
+  selectTestPatterns,
 } from "./root-test-runner-lib.mjs";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -43,7 +44,22 @@ process.env.NODE_OPTIONS = appendNodeOption(
   "--conditions=remnic-source",
 );
 
-const { files, emptyPatterns } = expandTestPatterns(repoRoot);
+let selectedGroups;
+let selectedPatterns;
+try {
+  ({ groups: selectedGroups } = parseRunnerArgs(process.argv.slice(2)));
+  selectedPatterns = selectTestPatterns(selectedGroups);
+} catch (error) {
+  console.error(`[root-tests] ERROR: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+if (selectedGroups.length > 0) {
+  console.warn(
+    `[root-tests] running pattern group(s): ${selectedGroups.join(", ")} (${selectedPatterns.length} pattern(s))`,
+  );
+}
+
+const { files, emptyPatterns } = expandTestPatterns(repoRoot, selectedPatterns);
 if (emptyPatterns.length > 0) {
   console.error(
     `[root-tests] ERROR: test pattern(s) matched no files — coverage would be silently lost: ${emptyPatterns.join(", ")}`,
@@ -76,9 +92,17 @@ if (!probe.ok) {
   }
   const manifest = loadNativeManifest(manifestPath);
   const { run, excluded, stale } = partitionNativeDependent(files, manifest.files);
-  if (stale.length > 0) {
+  // Under --group sharding `files` is a subset of the tree, so manifest
+  // entries belonging to other groups are not stale — validate staleness
+  // against the full pattern expansion before failing.
+  let staleEntries = stale;
+  if (selectedGroups.length > 0 && stale.length > 0) {
+    const fullFiles = new Set(expandTestPatterns(repoRoot).files);
+    staleEntries = stale.filter((entry) => !fullFiles.has(entry));
+  }
+  if (staleEntries.length > 0) {
     console.error(
-      `[root-tests] ERROR: scripts/native-dependent-tests.json lists files that no longer exist: ${stale.join(", ")}. Update the manifest.`,
+      `[root-tests] ERROR: scripts/native-dependent-tests.json lists files that no longer exist: ${staleEntries.join(", ")}. Update the manifest.`,
     );
     process.exit(1);
   }
@@ -124,13 +148,13 @@ function runTsx(testArgs) {
 
 // Windows builds a single bounded command line per spawn, so hundreds of
 // explicit file arguments cannot ride one invocation. Healthy runs therefore
-// use the original six pattern arguments (tsx expands them internally, and
+// pass the selected pattern arguments (tsx expands them internally, and
 // expandTestPatterns above already proved none are vacuous); only exclusion
 // runs pass explicit relative paths, chunked under a conservative budget.
 const ARGV_CHAR_BUDGET = 6000;
 const runsArgs =
   filesToRun.length === files.length
-    ? [TEST_PATTERNS.map((pattern) => pattern.id)]
+    ? [selectedPatterns.map((pattern) => pattern.id)]
     : chunkArgsByLength(filesToRun, ARGV_CHAR_BUDGET);
 
 let totalFail = 0;

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -39,6 +39,12 @@ const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const manifestPath = join(repoRoot, "scripts", "native-dependent-tests.json");
 const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 
+// Resolve tsx regardless of how this script was launched: `node scripts/…`
+// has no package-manager PATH injection (unlike `pnpm test`), so prepend the
+// workspace bin dir explicitly. Fixes `spawn tsx ENOENT` under bare node.
+const workspaceBinDir = join(repoRoot, "node_modules", ".bin");
+process.env.PATH = `${workspaceBinDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
 process.env.NODE_OPTIONS = appendNodeOption(
   process.env.NODE_OPTIONS,
   "--conditions=remnic-source",

--- a/tests/root-test-runner-lib.test.mjs
+++ b/tests/root-test-runner-lib.test.mjs
@@ -4,12 +4,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  TEST_PATTERNS,
+  TEST_PATTERN_GROUPS,
   chunkArgsByLength,
   expandTestPatterns,
   loadNativeManifest,
+  parseRunnerArgs,
   parseTapSummary,
   partitionNativeDependent,
   probeBetterSqlite3,
+  selectTestPatterns,
 } from "../scripts/root-test-runner-lib.mjs";
 
 function makeTree() {
@@ -148,4 +152,58 @@ test("probeBetterSqlite3 fails cleanly on a tree with no binding", () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("TEST_PATTERN_GROUPS is an exact partition of TEST_PATTERNS", () => {
+  const grouped = Object.values(TEST_PATTERN_GROUPS).flat();
+  const groupedSet = new Set(grouped);
+  assert.equal(grouped.length, groupedSet.size, "a pattern id appears in more than one group");
+  assert.deepEqual(
+    [...groupedSet].sort(),
+    TEST_PATTERNS.map((pattern) => pattern.id).sort(),
+    "groups must cover every TEST_PATTERNS id and nothing else",
+  );
+});
+
+test("selectTestPatterns with no groups returns the full pattern list", () => {
+  assert.deepEqual(selectTestPatterns([]), TEST_PATTERNS);
+});
+
+test("selectTestPatterns filters to the requested groups only", () => {
+  const selected = selectTestPatterns(["packages"]);
+  assert.deepEqual(
+    selected.map((pattern) => pattern.id),
+    ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.test.tsx"],
+  );
+  const combined = selectTestPatterns(["root", "misc"]);
+  assert.deepEqual(
+    combined.map((pattern) => pattern.id).sort(),
+    [
+      "dashboard/lib/*.test.ts",
+      "integrations/amb/*.test.mjs",
+      "tests/**/*.test.mjs",
+      "tests/**/*.test.ts",
+    ],
+  );
+});
+
+test("selectTestPatterns rejects unknown group names", () => {
+  assert.throws(() => selectTestPatterns(["nope"]), /Unknown test group "nope"/);
+  assert.throws(() => selectTestPatterns("root"), /must be an array/);
+});
+
+test("parseRunnerArgs parses repeatable --group and dedupes", () => {
+  assert.deepEqual(parseRunnerArgs([]), { groups: [] });
+  assert.deepEqual(parseRunnerArgs(["--group", "root"]), { groups: ["root"] });
+  assert.deepEqual(
+    parseRunnerArgs(["--group", "root", "--group", "misc", "--group", "root"]),
+    { groups: ["root", "misc"] },
+  );
+});
+
+test("parseRunnerArgs rejects unknown arguments and missing values", () => {
+  assert.throws(() => parseRunnerArgs(["--shard"]), /Unknown argument "--shard"/);
+  assert.throws(() => parseRunnerArgs(["root"]), /Unknown argument "root"/);
+  assert.throws(() => parseRunnerArgs(["--group"]), /requires a group name/);
+  assert.throws(() => parseRunnerArgs(["--group", "--group"]), /requires a group name/);
 });


### PR DESCRIPTION
## Summary

Phase 1 of `docs/plans/2026-07-04-ci-speedup-plan.md` (measurements + full plan in that doc):

- **AI Review Gate:** replace the fixed 180s sleep with immediate evaluation + 20s polling (7min deadline, early exit on pass, immediate fail on explicit negative verdicts). Per-PR concurrency group cancels superseded evaluations. Gate-green now tracks Bugbot completion (~2min) instead of a 3-6min floor.
- **CI:** split the serial ~11min quality job into parallel `checks` / `tests` (2-way shard) / `build-artifacts` jobs behind a `quality` aggregator that preserves the required status-check context and fails on any non-success dependency (skipped counts as failure).
- **Test sharding:** `run-root-tests.mjs --group <root|packages|misc>`; `TEST_PATTERN_GROUPS` is an exact partition of `TEST_PATTERNS` (test-enforced), invalid args are rejected, and the native-manifest stale-check validates against the full expansion under sharding.
- **Superseded-push cancellation** on CI for PR events only (never main).
- **BUGBOT.md:** packaging/docs-contract/CI-workflow rules + no-reflagging-unchanged-code note.
- **Runner Smoke:** dispatch-only health check for the new self-hosted `remnic` runner pool (jarvis CTs 340-342, registered + online), plus `.github/actionlint.yaml` declaring the label.

Expected: ~11min → ~6-7min merge-critical path per push on hosted runners; the self-hosted `runs-on` flip (phase 2) follows separately once the pool proves healthy.

## Verification

- `npm run preflight:quick` → `[preflight] OK (quick)`
- 14/14 root-test-runner-lib tests pass (incl. new partition/arg-parsing coverage)
- `node scripts/run-root-tests.mjs --group misc` E2E green locally (one pre-existing env-dependent AMB failure reproduces identically on main)
- actionlint clean on all touched workflows; gate script passes `node --check`
- Error paths verified: unknown `--group`/argument rejected with exit 1

## Notes for reviewers

- The `quality` required-check context is preserved via the aggregator job — no ruleset changes needed.
- `check_run`-triggered gate runs use main's workflow version until this merges; `pull_request`-triggered runs on this PR already exercise the new polling path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge gating and required `quality` CI topology (aggregator + sharded tests); mistakes could block merges or drop coverage, though partition tests and strict aggregator failure handling mitigate shard gaps.
> 
> **Overview**
> **Phase 1 CI/review latency work** targets merge-critical wall-clock (~11 min → ~6–7 min) without changing branch rulesets.
> 
> The **AI Review Gate** drops the fixed **180s sleep** for immediate evaluation plus **20s polling** (7 min cap), early pass when required reviewers are green on the current head, and immediate fail on blockers. A **per-PR job-level `concurrency`** group with `cancel-in-progress` collapses duplicate gate runs.
> 
> **`ci.yml`** splits the serial `quality` job into parallel **`checks`**, **`tests`** (matrix: `root+misc` vs `packages` via `run-root-tests.mjs --group`), and **`build-artifacts`**, with a **`quality` aggregator** that fails on any non-`success` dependency. PR-only **`concurrency`** cancels superseded CI runs; **main pushes are never cancelled**. The **`tests`** job builds `@remnic/core` and `@remnic/bench` before tests, uses conditional **`remnic`** self-hosted runners (same-repo PRs + main only; forks stay on `ubuntu-latest`), and adds **`runner-smoke.yml`** plus **`.github/actionlint.yaml`** for the pool.
> 
> **Test sharding** adds `TEST_PATTERN_GROUPS`, `selectTestPatterns` / `parseRunnerArgs`, partition tests, and runner fixes (workspace `tsx` on PATH, native-manifest stale check against full expansion under `--group`).
> 
> **`.cursor/BUGBOT.md`** gains packaging/docs/CI workflow rules and a note not to re-flag unchanged code; **`docs/plans/2026-07-04-ci-speedup-plan.md`** documents measurements and follow-up phases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c0fec0739bf7dc983afdddeb96cbb9ec32c49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->