### PR TITLE
feat(coding-graph): traversal, search, schema stats, dead-code, snippets (#1552 PR2)

### DIFF
--- a/packages/coding-graph/src/graph-schema.test.ts
+++ b/packages/coding-graph/src/graph-schema.test.ts
@@ -477,3 +477,33 @@ test("node_attributes created on existing v1 stores (chatgpt-codex-connector P1:
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("a newer (future) schema_version DB is NOT downgraded by applyCodingGraphSchema (chatgpt-codex-connector P2: 'Preserve newer schema_version rows')", async () => {
+  const dir = await tempDir();
+  try {
+    const db = openTempDb(dir, "future-v2.sqlite");
+    // Apply once to get a normal v1 schema, then simulate a future
+    // version having upgraded the DB to v2 (a version this code does
+    // not understand).
+    applyCodingGraphSchema(db);
+    assert.equal(readSchemaVersion(db), CODING_GRAPH_SCHEMA_VERSION);
+    db.prepare(
+      "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
+    ).run("2");
+    assert.equal(readSchemaVersion(db), 2, "precondition: future v2 marker");
+
+    // Re-open path: older code applies its additive DDL against the v2
+    // DB. The version marker must be PRESERVED (2), not silently
+    // rewritten down to CODING_GRAPH_SCHEMA_VERSION (1) — otherwise an
+    // incompatible future schema is hidden from a later upgrade.
+    applyCodingGraphSchema(db);
+    assert.equal(
+      readSchemaVersion(db),
+      2,
+      "a newer schema_version must not be downgraded to CODING_GRAPH_SCHEMA_VERSION",
+    );
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/graph-schema.test.ts
+++ b/packages/coding-graph/src/graph-schema.test.ts
@@ -507,3 +507,35 @@ test("a newer (future) schema_version DB is NOT downgraded by applyCodingGraphSc
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("applyCodingGraphSchema does NOT run createTables against a future-version DB (chatgpt-codex-connector P2: 'Skip destructive DDL for future schema versions')", async () => {
+  const dir = await tempDir();
+  try {
+    const db = openTempDb(dir, "future-v2-noddl.sqlite");
+    applyCodingGraphSchema(db);
+    // Simulate a future v2 schema whose node_attributes table was
+    // dropped/renamed by the newer version.
+    db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)").run("2");
+    db.prepare("DROP TABLE node_attributes").run();
+
+    // Older code re-opens the v2 DB. createTables must NOT run — if it
+    // did, its additive pass would recreate node_attributes, mutating
+    // the newer schema. Assert the table stays gone AND the version
+    // stays 2.
+    applyCodingGraphSchema(db);
+    assert.equal(readSchemaVersion(db), 2, "future version preserved");
+    const remaining = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='node_attributes'")
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+    assert.equal(
+      remaining.length,
+      0,
+      "createTables must not run against a future-version DB (node_attributes should not reappear)",
+    );
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/graph-schema.test.ts
+++ b/packages/coding-graph/src/graph-schema.test.ts
@@ -434,3 +434,46 @@ test("edges table has a destination-leading index for prune/cascade lookups (cha
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("node_attributes created on existing v1 stores (chatgpt-codex-connector P1: 'Create node_attributes for existing v1 stores')", async () => {
+  const dir = await tempDir();
+  try {
+    const db = openTempDb(dir, "v1-existing.sqlite");
+    applyCodingGraphSchema(db);
+    assert.equal(readSchemaVersion(db), 1);
+
+    // Simulate a PR1-era DB that predates the PR2 node_attributes table:
+    // drop it while leaving the meta schema_version=1 row in place.
+    db.prepare("DROP TABLE node_attributes").run();
+    const remaining = (
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='node_attributes'",
+        )
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+    assert.equal(remaining.length, 0, "precondition: node_attributes dropped");
+
+    // Re-apply the schema as a normal open() would. Because every DDL
+    // statement is CREATE TABLE IF NOT EXISTS and applyCodingGraphSchema
+    // runs createTables unconditionally, the additive table reappears
+    // on the existing v1 DB without a version bump.
+    applyCodingGraphSchema(db);
+    assert.equal(readSchemaVersion(db), 1, "version unchanged (additive)");
+    const recreated = (
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='node_attributes'",
+        )
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+    assert.equal(
+      recreated.length,
+      1,
+      "node_attributes recreated on existing v1 store via the unconditional createTables pass",
+    );
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/graph-schema.ts
+++ b/packages/coding-graph/src/graph-schema.ts
@@ -112,9 +112,19 @@ export function applyCodingGraphSchema(db: BetterSqlite3Database): void {
   );
   const currentVersion = meta ? parseInt(meta.value, 10) : 0;
 
-  if (currentVersion < CODING_GRAPH_SCHEMA_VERSION) {
-    createTables(db);
-  }
+  // Always re-run createTables on existing DBs — every statement is
+  // CREATE TABLE IF NOT EXISTS, so additive tables (the PR2
+  // `node_attributes` table) get created on existing v1 databases
+  // without a schema-version bump. A DB whose meta version is older
+  // than CODING_GRAPH_SCHEMA_VERSION also needs this (the original
+  // upgrade path), so the call is unconditional, not gated by
+  // currentVersion (chatgpt-codex-connector P1: 'Create
+  // node_attributes for existing v1 stores'). Future schema-breaking
+  // migrations (column drops / type changes) bump the version AND
+  // add a dedicated migration branch here; additive CREATE TABLE IF
+  // NOT EXISTS does not need that.
+  void currentVersion;
+  createTables(db);
 }
 
 function createTables(db: BetterSqlite3Database): void {

--- a/packages/coding-graph/src/graph-schema.ts
+++ b/packages/coding-graph/src/graph-schema.ts
@@ -114,30 +114,28 @@ export function applyCodingGraphSchema(db: BetterSqlite3Database): void {
   );
   const currentVersion = meta ? parseInt(meta.value, 10) : 0;
 
-  // Always re-run createTables on existing DBs — every statement is
-  // CREATE TABLE IF NOT EXISTS, so additive tables (the PR2
-  // `node_attributes` table) get created on existing v1 databases
-  // without a schema-version bump. A DB whose meta version is older
-  // than CODING_GRAPH_SCHEMA_VERSION also needs this (the original
-  // upgrade path), so the DDL call is unconditional
-  // (chatgpt-codex-connector P1: 'Create node_attributes for existing
-  // v1 stores').
-  createTables(db);
-  // Advance the version marker only when the on-disk version is at or
-  // below this code's version. A NEWER DB (opened by older code after a
-  // downgrade, or by a parallel install) must NOT have its version
-  // silently rewritten down to CODING_GRAPH_SCHEMA_VERSION — that would
-  // hide an incompatible future schema and confuse a later upgrade to
-  // that version. The additive CREATE TABLE IF NOT EXISTS above is safe
-  // regardless; only the version write is gated
-  // (chatgpt-codex-connector P2: 'Preserve newer schema_version rows
-  // when applying additive DDL'). Future schema-breaking migrations
-  // (column drops / type changes) bump CODING_GRAPH_SCHEMA_VERSION AND
-  // add a dedicated migration branch gated on `currentVersion` here;
-  // additive CREATE TABLE IF NOT EXISTS does not need that.
-  if (currentVersion <= CODING_GRAPH_SCHEMA_VERSION) {
-    writeSchemaVersion(db, CODING_GRAPH_SCHEMA_VERSION);
+  // Only run createTables when the on-disk version is at or below this
+  // code's version. For an AT-OR-BELOW DB (fresh-ish v0/v1) the pass is
+  // additive: every core statement is CREATE TABLE IF NOT EXISTS, so the
+  // PR2 `node_attributes` table appears on existing v1 databases without
+  // a version bump (chatgpt-codex-connector P1: 'Create node_attributes
+  // for existing v1 stores'), and a v0 DB is upgraded.
+  //
+  // A NEWER DB (currentVersion > CODING_GRAPH_SCHEMA_VERSION — older
+  // code opening a future-version DB after a downgrade, or a parallel
+  // install) must be left UNTOUCHED: createTables is NOT purely
+  // additive because its FTS migration drops + recreates `nodes_fts`
+  // when the stored CREATE SQL lacks `contentless_delete=1`. Running
+  // that against a future schema that legitimately changed or removed
+  // that table would mutate the newer schema while preserving its
+  // version marker — silent corruption. Skip createTables AND the
+  // version write for newer DBs (chatgpt-codex-connector P2: 'Skip
+  // destructive DDL for future schema versions').
+  if (currentVersion > CODING_GRAPH_SCHEMA_VERSION) {
+    return;
   }
+  createTables(db);
+  writeSchemaVersion(db, CODING_GRAPH_SCHEMA_VERSION);
 }
 
 function createTables(db: BetterSqlite3Database): void {

--- a/packages/coding-graph/src/graph-schema.ts
+++ b/packages/coding-graph/src/graph-schema.ts
@@ -4,6 +4,13 @@
  * Issue #1552 PR1 (Track B, Phase 1). The schema + write pipeline only;
  * traversal, search, dead-code and the openCypher subset land in PR2/PR3.
  *
+ * PR2 additive table (`node_attributes`): tracks per-node exclusion flags
+ * consumed by `deadCode()` — `is_exported`, `is_route_handler`. Added in
+ * PR2 (issue #1552 step 5) as a SEPARATE table rather than ALTER TABLE on
+ * `nodes`, so existing v1 databases gain the table via the same
+ * `CREATE TABLE IF NOT EXISTS` pass without a schema-version bump or a
+ * migration (rule 23 — additive, characterized before moving).
+ *
  * Design anchors:
  *   - `packages/remnic-core/src/lcm/schema.ts` (versioning + pragmas) —
  *     copied VERBATIM for the WAL / busy_timeout / synchronous pragmas and
@@ -162,18 +169,39 @@ function createTables(db: BetterSqlite3Database): void {
     -- lookups').
     CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst);
   `);
-  // FTS5 hit → node id reverse map. Contentless FTS5 does NOT store
-  // column values, so a rowid returned by `MATCH` cannot be joined
-  // back to `nodes` via the `id UNINDEXED` column (it reads NULL).
-  // This table is the only place the mapping lives: a single
-  // integer key (the FTS rowid, derived deterministically from the
-  // node id) plus the node id, kept in lockstep with `nodes_fts`
-  // by the write pipeline (chatgpt-codex-connector P2: 'Preserve a
-  // node key for FTS hits'). UNIQUE on node_id so re-ingesting the
-  // same node updates the row in place rather than producing a
-  // second mapping row.
+  // PR2 (issue #1552 step 5): per-node exclusion flags consumed by
+  // `GraphStore.deadCode()`. Kept in a SEPARATE table rather than an
+  // ALTER TABLE on `nodes` so existing v1 databases gain the table via
+  // the same `CREATE TABLE IF NOT EXISTS` pass without a schema-version
+  // bump or a data migration (rule 23 — additive, characterized before
+  // moving). ON DELETE CASCADE on `nodes(id)` keeps the table in lockstep
+  // with node lifetimes; the foreign_keys=ON pragma set in
+  // `GraphStore.open()` enforces it.
   //
-  // Created BEFORE the nodes_fts rebuild so the migration path can
+  // `is_exported`: 1 when the symbol's `name` matches an entry in the
+  //   FileIR's `exports` list (matched per-file at write time). The
+  //   dead-code query treats exported symbols as not-dead even with
+  //   zero inbound CALLS/USES_TYPE edges — they form the package's
+  //   public surface and may be called by external consumers the graph
+  //   cannot see.
+  // `is_route_handler`: 1 when the symbol's `qualified_name` matches a
+  //   route's `handlerQualifiedName` in the FileIR's `routes` list.
+  //   Route handlers are reachable from HTTP requests regardless of
+  //   whether any other node CALLS them inside the indexed codebase.
+  //
+  // Both columns are NOT NULL with CHECK IN (0,1): a missing row means
+  // "neither flag set" (the LEFT JOIN in deadCode() COALESCEs to 0).
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS node_attributes (
+      node_id           TEXT PRIMARY KEY REFERENCES nodes(id) ON DELETE CASCADE,
+      is_exported       INTEGER NOT NULL CHECK (is_exported IN (0, 1)),
+      is_route_handler  INTEGER NOT NULL CHECK (is_route_handler IN (0, 1))
+    );
+    CREATE INDEX IF NOT EXISTS idx_node_attributes_exported
+      ON node_attributes(is_exported) WHERE is_exported = 1;
+    CREATE INDEX IF NOT EXISTS idx_node_attributes_route
+      ON node_attributes(is_route_handler) WHERE is_route_handler = 1;
+  `);
   // repopulate both tables in lockstep without ordering concerns.
   db.exec(`
     CREATE TABLE IF NOT EXISTS fts_index (

--- a/packages/coding-graph/src/graph-schema.ts
+++ b/packages/coding-graph/src/graph-schema.ts
@@ -100,7 +100,9 @@ export function applyCodingGraphSchema(db: BetterSqlite3Database): void {
   );
 
   if (!versionRow) {
+    // Fresh DB — create every table and stamp the current version.
     createTables(db);
+    writeSchemaVersion(db, CODING_GRAPH_SCHEMA_VERSION);
     return;
   }
 
@@ -117,14 +119,25 @@ export function applyCodingGraphSchema(db: BetterSqlite3Database): void {
   // `node_attributes` table) get created on existing v1 databases
   // without a schema-version bump. A DB whose meta version is older
   // than CODING_GRAPH_SCHEMA_VERSION also needs this (the original
-  // upgrade path), so the call is unconditional, not gated by
-  // currentVersion (chatgpt-codex-connector P1: 'Create
-  // node_attributes for existing v1 stores'). Future schema-breaking
-  // migrations (column drops / type changes) bump the version AND
-  // add a dedicated migration branch here; additive CREATE TABLE IF
-  // NOT EXISTS does not need that.
-  void currentVersion;
+  // upgrade path), so the DDL call is unconditional
+  // (chatgpt-codex-connector P1: 'Create node_attributes for existing
+  // v1 stores').
   createTables(db);
+  // Advance the version marker only when the on-disk version is at or
+  // below this code's version. A NEWER DB (opened by older code after a
+  // downgrade, or by a parallel install) must NOT have its version
+  // silently rewritten down to CODING_GRAPH_SCHEMA_VERSION — that would
+  // hide an incompatible future schema and confuse a later upgrade to
+  // that version. The additive CREATE TABLE IF NOT EXISTS above is safe
+  // regardless; only the version write is gated
+  // (chatgpt-codex-connector P2: 'Preserve newer schema_version rows
+  // when applying additive DDL'). Future schema-breaking migrations
+  // (column drops / type changes) bump CODING_GRAPH_SCHEMA_VERSION AND
+  // add a dedicated migration branch gated on `currentVersion` here;
+  // additive CREATE TABLE IF NOT EXISTS does not need that.
+  if (currentVersion <= CODING_GRAPH_SCHEMA_VERSION) {
+    writeSchemaVersion(db, CODING_GRAPH_SCHEMA_VERSION);
+  }
 }
 
 function createTables(db: BetterSqlite3Database): void {
@@ -286,11 +299,25 @@ function createTables(db: BetterSqlite3Database): void {
       }
     }
   }
-  // Upsert meta version. INSERT OR REPLACE so the upgrade path can rewrite
-  // the row in place (rule 23 — one canonical form for the version value).
+  // NOTE: the schema_version marker is written by the caller
+  // (applyCodingGraphSchema / writeSchemaVersion), NOT here. createTables
+  // only owns additive DDL; the version-write concern (never downgrade a
+  // newer DB) lives at the apply layer where currentVersion is known.
+}
+
+/**
+ * Stamp the schema_version meta row. INSERT OR REPLACE so the upgrade
+ * path can rewrite the row in place (rule 23 — one canonical form).
+ * Callers MUST gate this on `currentVersion <= CODING_GRAPH_SCHEMA_VERSION`
+ * to avoid downgrading a newer DB.
+ */
+function writeSchemaVersion(
+  db: BetterSqlite3Database,
+  version: number,
+): void {
   db.prepare(
     "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
-  ).run(String(CODING_GRAPH_SCHEMA_VERSION));
+  ).run(String(version));
 }
 
 /**

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -1348,3 +1348,86 @@ test("traverse: non-string start rejected with 'invalid_query' before binding (c
     await dispose(store, dir);
   }
 });
+
+test("upsertFileBatch: malformed export entry (non-string name) rejected before wiping flags", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const file = {
+      path: "src/badentry.ts",
+      language: "typescript",
+      contentHash: "h-bade",
+      symbols: [sym("bade.fn", "fn", 0, 10)],
+      exports: [{ name: 42 }],
+      edges: [],
+    } as unknown as StoreFileIR;
+    await assert.rejects(
+      store.upsertFileBatch([file]),
+      /malformed export entry/,
+      "a malformed export entry must be rejected, not silently skipped while the wipe runs",
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("upsertFileBatch: malformed route entry (non-string handlerQualifiedName) rejected", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const file = {
+      path: "src/badr2.ts",
+      language: "typescript",
+      contentHash: "h-badr2",
+      symbols: [sym("badr2.fn", "fn", 0, 10)],
+      routes: [{ handlerQualifiedName: 99 }],
+      edges: [],
+    } as unknown as StoreFileIR;
+    await assert.rejects(
+      store.upsertFileBatch([file]),
+      /malformed route entry/,
+      "a malformed route entry must be rejected, not silently skipped while the wipe runs",
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("read APIs reject a null/undefined query object with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    for (const bad of [null, undefined, 42, "x"] as unknown[]) {
+      const t = store.traverse(bad as never);
+      assert.equal(t.ok, false, `traverse(nullish) must not succeed`);
+      if (!t.ok) assert.equal(t.code, "invalid_query");
+      const s = store.searchGraph(bad as never);
+      assert.equal(s.ok, false, `searchGraph(nullish) must not succeed`);
+      if (!s.ok) assert.equal(s.code, "invalid_query");
+      const sn = await store.snippetFor(bad as never);
+      assert.equal(sn.ok, false, `snippetFor(nullish) must not succeed`);
+      if (!sn.ok) assert.equal(sn.code, "invalid_query");
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("snippetFor: invalid contextLines (non-integer / negative / string) rejected with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    for (const bad of [1.9, -1, "2", NaN, true] as unknown[]) {
+      const out = await store.snippetFor({
+        qualifiedName: "x.y",
+        contextLines: bad as never,
+      });
+      assert.equal(out.ok, false, `contextLines=${JSON.stringify(bad)} must not succeed`);
+      if (!out.ok) {
+        assert.equal(
+          out.code,
+          "invalid_query",
+          `invalid contextLines must return invalid_query, not ${out.code}`,
+        );
+      }
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -1,0 +1,1008 @@
+/**
+ * graph-store PR2 tests — ordered steps 4–5 of issue #1552.
+ *
+ * Covers the read-side primitives that land in PR2:
+ *   - traverse(): iterative frontier BFS with cycle / self-edge safety,
+ *     direction (outgoing/incoming/both), edge-type filter, and the
+ *     half-open depth-cap boundary (depth == maxDepth INCLUDED,
+ *     maxDepth+1 NOT — rule 35).
+ *   - searchGraph(): label / name / file LIKE patterns + degreeMin/Max
+ *     filters + limit (including the rule-27 `limit: 0` guard).
+ *   - schemaStats(): aggregate counts over the whole graph.
+ *   - deadCode(): exclusion constant behavior, including the load-bearing
+ *     fixture that proves an exported-but-uncalled symbol is NOT reported
+ *     while a private uncalled symbol IS.
+ *   - snippetFor(): reads spans from disk via repoRoot; tagged failures
+ *     for unset root / missing file / ambiguous name.
+ *
+ * Fixture IR is synthetic (public-repo policy). Tests prove-fail-before
+ * by exact-set assertions — a deliberate break of the depth cap or the
+ * dead-code exclusion fails the corresponding test.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  DEAD_CODE_EXCLUSION,
+  GraphStore,
+  type EdgeIR,
+  type StoreFileIR,
+  type SymbolIR,
+} from "./graph-store.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture helpers — synthetic IR.
+// ──────────────────────────────────────────────────────────────────────────
+
+function sym(
+  qualifiedName: string,
+  name: string,
+  startByte: number,
+  endByte: number,
+  kind: SymbolIR["kind"] = "function",
+): SymbolIR {
+  return { qualifiedName, name, span: { startByte, endByte }, kind };
+}
+
+function exp(name: string, startByte: number, endByte: number) {
+  return { name, span: { startByte, endByte } };
+}
+
+function route(
+  verb: string,
+  pathTemplate: string,
+  handlerQualifiedName: string,
+  startByte: number,
+  endByte: number,
+) {
+  return {
+    verb,
+    pathTemplate,
+    handlerQualifiedName,
+    span: { startByte, endByte },
+  };
+}
+
+function edge(
+  srcQualifiedName: string,
+  dstQualifiedName: string,
+  type = "CALLS",
+  confidence = 0.9,
+  provenance: EdgeIR["provenance"] = "heuristic",
+): EdgeIR {
+  return { srcQualifiedName, dstQualifiedName, type, confidence, provenance };
+}
+
+/** Build a temp dir + a GraphStore opened against a fresh DB inside it. */
+async function tempStore(
+  options: { repoRoot?: string } = {},
+): Promise<{ store: GraphStore; dir: string; repoRoot: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "coding-graph-pr2-"));
+  const repoRoot = options.repoRoot ?? dir;
+  const store = await GraphStore.open({
+    dbPath: path.join(dir, "graph.sqlite"),
+    repoRoot,
+  });
+  return { store, dir, repoRoot };
+}
+
+async function dispose(store: GraphStore, dir: string): Promise<void> {
+  await store.close();
+  await rm(dir, { recursive: true, force: true });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture: a chain a → b → c with a back-edge c → a (cycle) and a
+// self-edge on b. Used to prove cycle / self-edge safety.
+// ──────────────────────────────────────────────────────────────────────────
+
+const cyclicFile: StoreFileIR = {
+  path: "src/cyclic.ts",
+  language: "typescript",
+  contentHash: "h-cyclic",
+  symbols: [
+    sym("cyc.a", "a", 0, 10),
+    sym("cyc.b", "b", 10, 20),
+    sym("cyc.c", "c", 20, 30),
+  ],
+  edges: [
+    edge("cyc.a", "cyc.b"),
+    edge("cyc.b", "cyc.c"),
+    edge("cyc.c", "cyc.a"), // back-edge: cycle a → b → c → a
+    edge("cyc.b", "cyc.b"), // self-edge on b
+  ],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture: a star graph for degree tests — center has degree 4, leaves
+// have degree 1. Used by searchGraph's degreeMin/Max filters.
+// ──────────────────────────────────────────────────────────────────────────
+
+const starFile: StoreFileIR = {
+  path: "src/star.ts",
+  language: "typescript",
+  contentHash: "h-star",
+  symbols: [
+    sym("star.center", "center", 0, 10),
+    sym("star.l1", "l1", 10, 20),
+    sym("star.l2", "l2", 20, 30),
+    sym("star.l3", "l3", 30, 40),
+    sym("star.l4", "l4", 40, 50),
+  ],
+  edges: [
+    edge("star.center", "star.l1"),
+    edge("star.center", "star.l2"),
+    edge("star.center", "star.l3"),
+    edge("star.center", "star.l4"),
+  ],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture: dead-code scenario. Two files:
+//   - lib.ts: exports `publicApi` (uncalled from inside the graph) AND
+//     `privateHelper` (also uncalled). Only `publicApi` should be
+//     excluded from deadCode() because it carries `is_exported=1`.
+//   - entry.ts: imports lib and calls into it, providing the only
+//     inbound edge on `caller`. Its path matches an entry-point pattern
+//     so its symbols are excluded by the path-based rule.
+// ──────────────────────────────────────────────────────────────────────────
+
+const deadCodeLibFile: StoreFileIR = {
+  path: "src/lib.ts",
+  language: "typescript",
+  contentHash: "h-lib",
+  symbols: [
+    sym("lib.publicApi", "publicApi", 0, 100),
+    sym("lib.privateHelper", "privateHelper", 100, 200),
+    sym("lib.alive", "alive", 200, 300),
+  ],
+  exports: [
+    exp("publicApi", 0, 100), // publicApi is exported
+    exp("alive", 200, 300),
+  ],
+  routes: [],
+  edges: [
+    // alive calls privateHelper → privateHelper has inbound edge → NOT dead.
+    edge("lib.alive", "lib.privateHelper"),
+    // publicApi has NO inbound edges but is exported → NOT dead.
+    // privateHelper HAS an inbound edge → not a candidate at all.
+    // alive has NO inbound edges and is exported → NOT dead.
+  ],
+};
+
+const deadCodeEntryFile: StoreFileIR = {
+  path: "src/index.ts",
+  language: "typescript",
+  contentHash: "h-entry",
+  symbols: [
+    sym("entry.main", "main", 0, 50),
+    sym("entry.unused", "unused", 50, 100),
+  ],
+  // No exports — both symbols are private.
+  // Path matches ENTRY_POINT_PATH_PATTERNS, so BOTH are excluded by the
+  // path rule even though `entry.unused` is uncalled.
+  edges: [],
+};
+
+// Separate file proving the route-handler exclusion.
+const routeHandlerFile: StoreFileIR = {
+  path: "src/server.ts",
+  language: "typescript",
+  contentHash: "h-route",
+  symbols: [
+    sym("route.healthHandler", "healthHandler", 0, 100),
+    sym("route.uncalledHelper", "uncalledHelper", 100, 200),
+  ],
+  routes: [
+    route("GET", "/health", "route.healthHandler", 0, 100),
+  ],
+  // No exports → healthHandler relies on the route-handler flag.
+  edges: [],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// traverse(): BFS depth + cycle + self-edge + direction.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("traverse: cycle-safe — back-edge does not loop forever, visited set wins", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+    const out = store.traverse({ start: "cyc.a", maxDepth: 10 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // Three distinct nodes visited despite the cycle.
+    assert.equal(out.hits.length, 3);
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(qnames, ["cyc.a", "cyc.b", "cyc.c"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: self-edge never re-expands the frontier (cycle safety)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+    const out = store.traverse({ start: "cyc.b", maxDepth: 5 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // Start at b: depth 0 = {b}; depth 1 = {c} (self-edge and a→b
+    // both skipped because b is visited); depth 2 = {a} (c→a).
+    // Total: 3 nodes.
+    assert.equal(out.hits.length, 3);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: depth cap is half-open — depth==maxDepth INCLUDED, maxDepth+1 NOT (rule 35)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+
+    // maxDepth 0 → just the start.
+    const d0 = store.traverse({ start: "cyc.a", maxDepth: 0 });
+    assert.equal(d0.ok, true);
+    if (!d0.ok) throw new Error("expected ok");
+    assert.equal(d0.hits.length, 1);
+    assert.equal(d0.hits[0]?.qualifiedName, "cyc.a");
+    assert.equal(d0.hits[0]?.depth, 0);
+
+    // maxDepth 1 → start + direct neighbor (b).
+    const d1 = store.traverse({ start: "cyc.a", maxDepth: 1 });
+    assert.equal(d1.ok, true);
+    if (!d1.ok) throw new Error("expected ok");
+    assert.equal(d1.hits.length, 2);
+    const d1Qnames = d1.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(d1Qnames, ["cyc.a", "cyc.b"]);
+
+    // maxDepth 2 → a (depth 0) + b (depth 1) + c (depth 2). The
+    // back-edge c → a would re-visit a at depth 3 — the cap excludes
+    // that (the cycle is irrelevant when the cap binds first).
+    const d2 = store.traverse({ start: "cyc.a", maxDepth: 2 });
+    assert.equal(d2.ok, true);
+    if (!d2.ok) throw new Error("expected ok");
+    assert.equal(d2.hits.length, 3);
+    const depthByNode = new Map(d2.hits.map((h) => [h.qualifiedName, h.depth]));
+    assert.equal(depthByNode.get("cyc.a"), 0);
+    assert.equal(depthByNode.get("cyc.b"), 1);
+    assert.equal(depthByNode.get("cyc.c"), 2);
+
+    // Boundary proof: maxDepth 2 hits c at depth 2; c → a (depth 3)
+    // is NOT included. If the cap were off-by-one (depth < maxDepth
+    // instead of depth <= maxDepth), c would be missing here.
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: direction=incoming follows edges backward", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    // From l1, incoming direction: who points at l1? Only center.
+    const out = store.traverse({
+      start: "star.l1",
+      direction: "incoming",
+      maxDepth: 5,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 2);
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(qnames, ["star.center", "star.l1"]);
+    // l1 at depth 0, center at depth 1.
+    const byName = new Map(out.hits.map((h) => [h.qualifiedName, h.depth]));
+    assert.equal(byName.get("star.l1"), 0);
+    assert.equal(byName.get("star.center"), 1);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: direction=both expands in + out per level", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    // From center with direction=both at depth 1: each leaf is
+    // reachable outgoing. No incoming edges land on center.
+    const out = store.traverse({
+      start: "star.center",
+      direction: "both",
+      maxDepth: 1,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 5);
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(qnames, [
+      "star.center",
+      "star.l1",
+      "star.l2",
+      "star.l3",
+      "star.l4",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: edgeTypes filter restricts the frontier", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // Two edge types: CALLS and USES_TYPE. Restricting to USES_TYPE
+    // should yield zero hops because no USES_TYPE edges exist.
+    const mixed: StoreFileIR = {
+      path: "src/mixed.ts",
+      language: "typescript",
+      contentHash: "h-mixed",
+      symbols: [sym("m.a", "a", 0, 10), sym("m.b", "b", 10, 20)],
+      edges: [
+        edge("m.a", "m.b", "CALLS"),
+        edge("m.a", "m.b", "USES_TYPE"),
+      ],
+    };
+    const r = await store.upsertFileBatch([mixed]);
+    assert.equal(r.ok, true);
+
+    const onlyUses = store.traverse({
+      start: "m.a",
+      edgeTypes: ["USES_TYPE"],
+      maxDepth: 5,
+    });
+    assert.equal(onlyUses.ok, true);
+    if (!onlyUses.ok) throw new Error("expected ok");
+    // USES_TYPE edge a → b exists, so we should reach b.
+    assert.equal(onlyUses.hits.length, 2);
+
+    const onlyAsync = store.traverse({
+      start: "m.a",
+      edgeTypes: ["ASYNC_CALLS"],
+      maxDepth: 5,
+    });
+    assert.equal(onlyAsync.ok, true);
+    if (!onlyAsync.ok) throw new Error("expected ok");
+    // No ASYNC_CALLS edges → only the start node.
+    assert.equal(onlyAsync.hits.length, 1);
+    assert.equal(onlyAsync.hits[0]?.qualifiedName, "m.a");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: unknown start returns tagged failure (rule 34)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const out = store.traverse({ start: "does.not.exist", maxDepth: 3 });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "unknown_start");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: invalid maxDepth rejected with code 'invalid_query' (rule 51)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+
+    // Negative, fractional, NaN — all rejected, not silently clamped.
+    const cases: [number, string][] = [
+      [-1, "negative"],
+      [1.5, "fractional"],
+      [Number.NaN, "NaN"],
+    ];
+    for (const [v, label] of cases) {
+      const out = store.traverse({ start: "cyc.a", maxDepth: v });
+      assert.equal(out.ok, false, `${label} should fail`);
+      if (out.ok) throw new Error(`expected failure for ${label}`);
+      assert.equal(out.code, "invalid_query", `${label} → invalid_query`);
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: ambiguous start (qualified name in two files) is rejected with 'ambiguous_start'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // Same qualified name declared in two files → ambiguous.
+    const file1: StoreFileIR = {
+      path: "src/f1.ts",
+      language: "typescript",
+      contentHash: "h1",
+      symbols: [sym("dup.name", "name", 0, 10)],
+    };
+    const file2: StoreFileIR = {
+      path: "src/f2.ts",
+      language: "typescript",
+      contentHash: "h2",
+      symbols: [sym("dup.name", "name", 0, 10)],
+    };
+    const r = await store.upsertFileBatch([file1, file2]);
+    assert.equal(r.ok, true);
+
+    const out = store.traverse({ start: "dup.name", maxDepth: 3 });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "ambiguous_start");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: store_closed when the store is closed", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+    await store.close();
+    const out = store.traverse({ start: "cyc.a", maxDepth: 3 });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "store_closed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// searchGraph(): label / name / file patterns + degree filters + limit.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("searchGraph: empty query returns every node up to the default limit", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    const out = store.searchGraph({});
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 5);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: namePattern uses LIKE % wildcards (case-insensitive)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    const out = store.searchGraph({ namePattern: "l%" });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // l1, l2, l3, l4 — four matches.
+    assert.equal(out.hits.length, 4);
+    for (const h of out.hits) {
+      assert.ok(h.name.startsWith("l"));
+    }
+
+    // Case-insensitive: CENTER should match `center`.
+    const upper = store.searchGraph({ namePattern: "CENTER" });
+    assert.equal(upper.ok, true);
+    if (!upper.ok) throw new Error("expected ok");
+    assert.equal(upper.hits.length, 1);
+    assert.equal(upper.hits[0]?.name, "center");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: filePattern filters by repo-relative file path", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile, cyclicFile]);
+    assert.equal(r.ok, true);
+
+    const out = store.searchGraph({ filePattern: "src/star%" });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 5);
+    for (const h of out.hits) {
+      assert.equal(h.filePath, "src/star.ts");
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: label filter restricts by symbol kind", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const mixed: StoreFileIR = {
+      path: "src/kinds.ts",
+      language: "typescript",
+      contentHash: "h-kinds",
+      symbols: [
+        sym("k.fn", "fn", 0, 10, "function"),
+        sym("k.cls", "cls", 10, 20, "class"),
+      ],
+    };
+    const r = await store.upsertFileBatch([mixed]);
+    assert.equal(r.ok, true);
+
+    const onlyFn = store.searchGraph({ label: "function" });
+    assert.equal(onlyFn.ok, true);
+    if (!onlyFn.ok) throw new Error("expected ok");
+    assert.equal(onlyFn.hits.length, 1);
+    assert.equal(onlyFn.hits[0]?.label, "function");
+
+    const onlyClass = store.searchGraph({ label: "class" });
+    assert.equal(onlyClass.ok, true);
+    if (!onlyClass.ok) throw new Error("expected ok");
+    assert.equal(onlyClass.hits.length, 1);
+    assert.equal(onlyClass.hits[0]?.label, "class");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: degreeMin/Max filter on in+out edge count", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    // center has degree 4 (4 outbound CALLS); leaves have degree 1.
+    // Note: the unique(src,dst,type) constraint means each leaf also
+    // has degree 1 (one inbound edge).
+    const onlyHigh = store.searchGraph({ degreeMin: 4 });
+    assert.equal(onlyHigh.ok, true);
+    if (!onlyHigh.ok) throw new Error("expected ok");
+    assert.equal(onlyHigh.hits.length, 1);
+    assert.equal(onlyHigh.hits[0]?.qualifiedName, "star.center");
+    assert.equal(onlyHigh.hits[0]?.degree, 4);
+
+    const onlyLeaves = store.searchGraph({ degreeMin: 1, degreeMax: 1 });
+    assert.equal(onlyLeaves.ok, true);
+    if (!onlyLeaves.ok) throw new Error("expected ok");
+    assert.equal(onlyLeaves.hits.length, 4);
+    for (const h of onlyLeaves.hits) {
+      assert.equal(h.degree, 1);
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: limit caps the result set, 0 returns empty (rule 27)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    // limit 0 → empty hits, NOT the whole graph (rule 27 guard).
+    const zero = store.searchGraph({ limit: 0 });
+    assert.equal(zero.ok, true);
+    if (!zero.ok) throw new Error("expected ok");
+    assert.equal(zero.hits.length, 0);
+
+    const two = store.searchGraph({ limit: 2 });
+    assert.equal(two.ok, true);
+    if (!two.ok) throw new Error("expected ok");
+    assert.equal(two.hits.length, 2);
+
+    // Above the clamp cap (1000) → still clamped to 5 (the graph size).
+    const big = store.searchGraph({ limit: 100 });
+    assert.equal(big.ok, true);
+    if (!big.ok) throw new Error("expected ok");
+    assert.equal(big.hits.length, 5);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: invalid degree / limit rejected with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    const badDegree = store.searchGraph({ degreeMin: -1 });
+    assert.equal(badDegree.ok, false);
+    if (badDegree.ok) throw new Error("expected failure");
+    assert.equal(badDegree.code, "invalid_query");
+
+    const inverted = store.searchGraph({ degreeMin: 5, degreeMax: 1 });
+    assert.equal(inverted.ok, false);
+    if (inverted.ok) throw new Error("expected failure");
+    assert.equal(inverted.code, "invalid_query");
+
+    const fractional = store.searchGraph({ degreeMax: 1.5 });
+    assert.equal(fractional.ok, false);
+    if (fractional.ok) throw new Error("expected failure");
+    assert.equal(fractional.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// schemaStats().
+// ──────────────────────────────────────────────────────────────────────────
+
+test("schemaStats: aggregate counts over the whole graph", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile, cyclicFile]);
+    assert.equal(r.ok, true);
+
+    const out = store.schemaStats();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.stats.files, 2);
+    // starFile has 5 nodes; cyclicFile has 3 → 8 total.
+    assert.equal(out.stats.nodes, 8);
+    // starFile: 4 CALLS edges. cyclicFile: 3 CALLS + 1 self = 4.
+    assert.equal(out.stats.edges, 8);
+    assert.equal(out.stats.nodesByLabel.function, 8);
+    assert.equal(out.stats.edgesByType.CALLS, 8);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("schemaStats: empty graph returns zeros, not null", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const out = store.schemaStats();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.stats.files, 0);
+    assert.equal(out.stats.nodes, 0);
+    assert.equal(out.stats.edges, 0);
+    assert.deepEqual(out.stats.nodesByLabel, {});
+    assert.deepEqual(out.stats.edgesByType, {});
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// deadCode(): the load-bearing exclusion test.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("deadCode: exported-but-uncalled NOT reported; private-uncalled IS reported", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([deadCodeLibFile]);
+    assert.equal(r.ok, true);
+
+    const out = store.deadCode();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+
+    // publicApi is uncalled but exported → NOT reported.
+    // alive is uncalled but exported → NOT reported.
+    // privateHelper HAS an inbound CALLS edge (alive → privateHelper)
+    // → not a candidate at all.
+    //
+    // Therefore deadCode() should report ZERO hits from this fixture.
+    assert.equal(
+      qnames.length,
+      0,
+      `expected no dead-code hits, got: ${qnames.join(", ")}`,
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("deadCode: private uncalled symbol IS reported", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // A file with one private, uncalled function. No exports, no
+    // inbound edges → it should appear in deadCode().
+    const file: StoreFileIR = {
+      path: "src/internal.ts",
+      language: "typescript",
+      contentHash: "h-internal",
+      symbols: [
+        sym("internal.dead", "dead", 0, 50),
+        sym("internal.alive", "alive", 50, 100),
+      ],
+      // No exports → both are private.
+      edges: [],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+
+    const out = store.deadCode();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(qnames, ["internal.alive", "internal.dead"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("deadCode: re-ingest that REMOVES an export re-classifies the symbol as dead", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // First ingest: publicApi is exported → not dead.
+    const r1 = await store.upsertFileBatch([deadCodeLibFile]);
+    assert.equal(r1.ok, true);
+    const before = store.deadCode();
+    assert.equal(before.ok, true);
+    if (!before.ok) throw new Error("expected ok");
+    assert.equal(
+      before.hits.length,
+      0,
+      "no dead symbols before removing the export",
+    );
+
+    // Second ingest: drop the exports array. publicApi loses its
+    // is_exported flag → it should now appear in deadCode().
+    const revised: StoreFileIR = {
+      ...deadCodeLibFile,
+      exports: [], // explicitly exports nothing
+    };
+    const r2 = await store.upsertFileBatch([revised]);
+    assert.equal(r2.ok, true);
+    const after = store.deadCode();
+    assert.equal(after.ok, true);
+    if (!after.ok) throw new Error("expected ok");
+    const qnames = after.hits.map((h) => h.qualifiedName).sort();
+    // publicApi and alive both lose their flags → both become dead.
+    // privateHelper still has an inbound edge → not dead.
+    assert.deepEqual(qnames, ["lib.alive", "lib.publicApi"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("deadCode: route handlers excluded via the named constant", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([routeHandlerFile]);
+    assert.equal(r.ok, true);
+    const out = store.deadCode();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    // healthHandler is a route handler → excluded.
+    // uncalledHelper is a private uncalled function → dead.
+    assert.deepEqual(qnames, ["route.uncalledHelper"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("deadCode: entry-point file paths excluded via the named constant", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([deadCodeEntryFile]);
+    assert.equal(r.ok, true);
+    const out = store.deadCode();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // src/index.ts matches ENTRY_POINT_PATH_PATTERNS → both symbols
+    // excluded even though they are private and uncalled.
+    assert.equal(out.hits.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("deadCode: test files excluded via the named constant", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const file: StoreFileIR = {
+      path: "src/foo.test.ts",
+      language: "typescript",
+      contentHash: "h-test",
+      symbols: [sym("test.private", "private", 0, 50)],
+      edges: [],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+    const out = store.deadCode();
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // Path matches TEST_PATH_PATTERNS → excluded.
+    assert.equal(out.hits.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("DEAD_CODE_EXCLUSION: named constant is exported and stable", () => {
+  // The constant is the single source of truth for exclusion criteria
+  // (rule 53 analog). Asserting its shape locks the public surface so
+  // a refactor cannot silently drop an exclusion category.
+  assert.ok(DEAD_CODE_EXCLUSION.INBOUND_USAGE_EDGE_TYPES.includes("CALLS"));
+  assert.ok(DEAD_CODE_EXCLUSION.INBOUND_USAGE_EDGE_TYPES.includes("USES_TYPE"));
+  assert.ok(
+    DEAD_CODE_EXCLUSION.EXCLUDED_ATTRIBUTE_FLAGS.includes("is_exported"),
+  );
+  assert.ok(
+    DEAD_CODE_EXCLUSION.EXCLUDED_ATTRIBUTE_FLAGS.includes("is_route_handler"),
+  );
+  assert.ok(DEAD_CODE_EXCLUSION.TEST_PATH_PATTERNS.length > 0);
+  assert.ok(DEAD_CODE_EXCLUSION.ENTRY_POINT_PATH_PATTERNS.length > 0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// snippetFor(): read spans from disk.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("snippetFor: reads the exact span from disk via repoRoot", async () => {
+  const { store, dir, repoRoot } = await tempStore();
+  try {
+    // Write a real source file under repoRoot so snippetFor can read it.
+    // The span [4, 18) covers "function greet()" in the source.
+    // 0:'a' 1:'=' 2:'1' 3:';' 4:'f' 5:'u' ... → "function greet()".
+    const src = "a=1;function greet(){return 1;}\n";
+    // Find the byte offsets for `function greet()`.
+    const start = src.indexOf("function greet()");
+    const end = start + "function greet()".length;
+    await mkdir(path.dirname(path.join(repoRoot, "src/snippet.ts")), {
+      recursive: true,
+    });
+    await writeFile(path.join(repoRoot, "src/snippet.ts"), src);
+
+    const file: StoreFileIR = {
+      path: "src/snippet.ts",
+      language: "typescript",
+      contentHash: "h-snippet",
+      symbols: [sym("snip.greet", "greet", start, end)],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+
+    const out = await store.snippetFor({ qualifiedName: "snip.greet" });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.text, "function greet()");
+    assert.equal(out.startByte, start);
+    assert.equal(out.endByte, end);
+    assert.equal(out.filePath, "src/snippet.ts");
+    assert.equal(out.lang, "typescript");
+    assert.ok(path.isAbsolute(out.absolutePath));
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("snippetFor: contextLines expands line-aligned", async () => {
+  const { store, dir, repoRoot } = await tempStore();
+  try {
+    const lines = ["line one\n", "line two\n", "line three\n", "line four\n"];
+    const src = lines.join("");
+    // span covers all of "line two" (line index 1).
+    const start = src.indexOf("line two");
+    const end = start + "line two".length;
+    await mkdir(path.dirname(path.join(repoRoot, "src/ctx.ts")), {
+      recursive: true,
+    });
+    await writeFile(path.join(repoRoot, "src/ctx.ts"), src);
+
+    const file: StoreFileIR = {
+      path: "src/ctx.ts",
+      language: "typescript",
+      contentHash: "h-ctx",
+      symbols: [sym("ctx.fn", "fn", start, end)],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+
+    // contextLines: 1 → expand one line before + one line after.
+    const out = await store.snippetFor({
+      qualifiedName: "ctx.fn",
+      contextLines: 1,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    // Expected to include "line one\nline two\nline three\n".
+    assert.equal(out.text, "line one\nline two\nline three\n");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("snippetFor: returns 'repo_root_unset' when repoRoot was not provided", async () => {
+  // tempStore with no repoRoot passed → store carries the temp dir as
+  // repoRoot. Override by opening directly with no repoRoot.
+  const dir = await mkdtemp(path.join(tmpdir(), "coding-graph-pr2-noroot-"));
+  try {
+    const store = await GraphStore.open({
+      dbPath: path.join(dir, "graph.sqlite"),
+      // No repoRoot.
+    });
+    const file: StoreFileIR = {
+      path: "src/x.ts",
+      language: "typescript",
+      contentHash: "h-x",
+      symbols: [sym("x.fn", "fn", 0, 10)],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+
+    const out = await store.snippetFor({ qualifiedName: "x.fn" });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "repo_root_unset");
+    await store.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snippetFor: returns 'not_found' for unknown qualifiedName", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const out = await store.snippetFor({ qualifiedName: "no.such.symbol" });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "not_found");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("snippetFor: returns 'read_failed' when the on-disk file is missing", async () => {
+  const { store, dir, repoRoot } = await tempStore();
+  try {
+    const file: StoreFileIR = {
+      path: "src/missing.ts",
+      language: "typescript",
+      contentHash: "h-missing",
+      symbols: [sym("m.fn", "fn", 0, 10)],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true);
+    // Note: the file is NOT created on disk under repoRoot.
+
+    const out = await store.snippetFor({ qualifiedName: "m.fn" });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "read_failed");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("snippetFor: 'ambiguous_name' when qualifiedName exists in two files", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const f1: StoreFileIR = {
+      path: "src/a1.ts",
+      language: "typescript",
+      contentHash: "h1",
+      symbols: [sym("amb.fn", "fn", 0, 10)],
+    };
+    const f2: StoreFileIR = {
+      path: "src/a2.ts",
+      language: "typescript",
+      contentHash: "h2",
+      symbols: [sym("amb.fn", "fn", 0, 10)],
+    };
+    const r = await store.upsertFileBatch([f1, f2]);
+    assert.equal(r.ok, true);
+
+    const out = await store.snippetFor({ qualifiedName: "amb.fn" });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "ambiguous_name");
+  } finally {
+    await dispose(store, dir);
+  }
+});

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -459,6 +459,28 @@ test("traverse: store_closed when the store is closed", async () => {
   }
 });
 
+test("traverse: invalid direction rejected with code 'invalid_query' (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+
+    // A typo like "outbound" must NOT silently return only the start
+    // node — it must surface as invalid_query so the caller learns.
+    const out = store.traverse({
+      start: "cyc.a",
+      maxDepth: 3,
+      // @ts-expect-error — deliberately invalid direction at runtime
+      direction: "outbound",
+    });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // searchGraph(): label / name / file patterns + degree filters + limit.
 // ──────────────────────────────────────────────────────────────────────────
@@ -769,6 +791,48 @@ test("deadCode: re-ingest that REMOVES an export re-classifies the symbol as dea
   }
 });
 
+test("deadCode: partial re-ingest preserves the omitted flag (cursor Bugbot + chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // First ingest: healthHandler is a route handler → not dead.
+    const r1 = await store.upsertFileBatch([routeHandlerFile]);
+    assert.equal(r1.ok, true);
+    const before = store.deadCode();
+    assert.equal(before.ok, true);
+    if (!before.ok) throw new Error("expected ok");
+    assert.deepEqual(
+      before.hits.map((h) => h.qualifiedName).sort(),
+      ["route.uncalledHelper"],
+      "healthHandler excluded as a route handler",
+    );
+
+    // Second ingest: provide ONLY exports (omitting routes). The
+    // route-handler flag MUST be preserved — the per-field semantics
+    // say an omitted field leaves existing flags untouched. The old
+    // delete-then-insert wiped both columns and re-classified
+    // healthHandler as dead.
+    const revised: StoreFileIR = {
+      path: routeHandlerFile.path,
+      language: routeHandlerFile.language,
+      contentHash: "h-route-v2",
+      symbols: routeHandlerFile.symbols,
+      exports: [], // explicitly no exports; routes OMITTED
+    };
+    const r2 = await store.upsertFileBatch([revised]);
+    assert.equal(r2.ok, true);
+    const after = store.deadCode();
+    assert.equal(after.ok, true);
+    if (!after.ok) throw new Error("expected ok");
+    assert.deepEqual(
+      after.hits.map((h) => h.qualifiedName).sort(),
+      ["route.uncalledHelper"],
+      "healthHandler STILL excluded — routes flag preserved across a partial re-ingest",
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 test("deadCode: route handlers excluded via the named constant", async () => {
   const { store, dir } = await tempStore();
   try {
@@ -1004,5 +1068,32 @@ test("snippetFor: 'ambiguous_name' when qualifiedName exists in two files", asyn
     assert.equal(out.code, "ambiguous_name");
   } finally {
     await dispose(store, dir);
+  }
+});
+
+test("snippetFor: returns 'store_closed' when the store is closed (cursor Bugbot + chatgpt-codex-connector P2)", async () => {
+  const { store, dir, repoRoot } = await tempStore();
+  try {
+    const file: StoreFileIR = {
+      path: "src/closed.ts",
+      language: "typescript",
+      contentHash: "h-closed",
+      symbols: [sym("closed.fn", "fn", 0, 10)],
+    };
+    const r = await store.upsertFileBatch([file]);
+    await mkdir(path.dirname(path.join(repoRoot, "src/closed.ts")), {
+      recursive: true,
+    });
+    await writeFile(path.join(repoRoot, "src/closed.ts"), "function fn() {}\n");
+
+    await store.close();
+    const out = await store.snippetFor({ qualifiedName: "closed.fn" });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    // Must be store_closed (the store is closed), NOT repo_root_unset
+    // (repoRoot IS set) — callers need to distinguish the two.
+    assert.equal(out.code, "store_closed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
 });

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -481,6 +481,41 @@ test("traverse: invalid direction rejected with code 'invalid_query' (chatgpt-co
   }
 });
 
+test("traverse: a 64-hex node id resolves by id only, never conflated with a qualified_name (cursor Bugbot: 'Traverse start conflates id and name')", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+
+    // Look up the actual node id for cyc.a via searchGraph.
+    const search = store.searchGraph({ namePattern: "a" });
+    assert.equal(search.ok, true);
+    if (!search.ok) throw new Error("expected ok");
+    const cycA = search.hits.find((h) => h.qualifiedName === "cyc.a");
+    assert.ok(cycA, "cyc.a should be in the graph");
+    // Node ids are 64-char lowercase hex (sha256).
+    assert.match(cycA.nodeId, /^[0-9a-f]{64}$/);
+
+    // Traverse by node id → resolves uniquely to cyc.a, NOT ambiguous.
+    const byId = store.traverse({ start: cycA.nodeId, maxDepth: 1 });
+    assert.equal(byId.ok, true);
+    if (!byId.ok) throw new Error("expected ok");
+    assert.equal(byId.hits.length, 2, "cyc.a + its direct neighbor at depth 1");
+
+    // A 64-hex string that is NOT any node's id → unknown_start, even
+    // though the old `WHERE id = ? OR qualified_name = ?` would have
+    // returned [] here too. The point is the id path no longer falls
+    // through to the qualified_name path.
+    const bogusId = "0".repeat(64);
+    const miss = store.traverse({ start: bogusId, maxDepth: 3 });
+    assert.equal(miss.ok, false);
+    if (miss.ok) throw new Error("expected failure");
+    assert.equal(miss.code, "unknown_start");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // searchGraph(): label / name / file patterns + degree filters + limit.
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -25,6 +25,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { openBetterSqlite3 } from "@remnic/core/runtime/better-sqlite";
+
 import {
   DEAD_CODE_EXCLUSION,
   GraphStore,
@@ -1189,5 +1191,160 @@ test("snippetFor: returns 'store_closed' when the store is closed (cursor Bugbot
     assert.equal(out.code, "store_closed");
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// deadCode(): self-edge must not count as inbound usage
+// (chatgpt-codex-connector P2: 'Ignore self-edges in dead-code
+// reachability').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("deadCode: a private recursive helper whose only edge is a self-call IS reported as dead", async () => {
+  // recurse.ts defines `run` whose only edge is run → run. Nothing
+  // outside reaches it, so it is dead code; the self-call must NOT
+  // count as external inbound usage.
+  const { store, dir } = await tempStore();
+  try {
+    const file: StoreFileIR = {
+      path: "src/recurse.ts",
+      language: "typescript",
+      contentHash: "h-recurse",
+      symbols: [sym("recurse.run", "run", 0, 10)],
+      edges: [edge("recurse.run", "recurse.run")],
+    };
+    const res = await store.upsertFileBatch([file]);
+    if (!res.ok) throw new Error(`expected ok upsert; got ${res.code}`);
+    const dead = store.deadCode();
+    if (!dead.ok) throw new Error(`expected ok deadCode; got ${dead.code}`);
+    const names = dead.hits.map((h) => h.name);
+    assert.ok(
+      names.includes("run"),
+      `self-only-recursive symbol must be reported as dead; got ${JSON.stringify(names)}`,
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// upsertFileBatch: malformed (non-array) exports / routes are rejected
+// at the boundary so they cannot wipe existing attribute flags
+// (chatgpt-codex-connector P2: 'Validate attribute arrays before
+// clearing flags').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("upsertFileBatch: non-array exports rejected before wiping flags", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const file = {
+      path: "src/bad.ts",
+      language: "typescript",
+      contentHash: "h-bad",
+      symbols: [sym("bad.fn", "fn", 0, 10)],
+      // A JSON caller bypassing types could pass a bare string; this
+      // is iterable char-by-char and would otherwise wipe flags.
+      exports: "publicApi",
+      edges: [],
+    } as unknown as StoreFileIR;
+    await assert.rejects(
+      store.upsertFileBatch([file]),
+      /exports must be an array when present/,
+      "a non-array exports field must be rejected, not silently wipe is_exported",
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("upsertFileBatch: non-array routes rejected before wiping flags", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const file = {
+      path: "src/badr.ts",
+      language: "typescript",
+      contentHash: "h-badr",
+      symbols: [sym("badr.fn", "fn", 0, 10)],
+      routes: "GET /x",
+      edges: [],
+    } as unknown as StoreFileIR;
+    await assert.rejects(
+      store.upsertFileBatch([file]),
+      /routes must be an array when present/,
+      "a non-array routes field must be rejected, not silently wipe is_route_handler",
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Read APIs honor the tagged-failure contract: an unexpected SQLite
+// error returns { ok:false, code:"db_error" } instead of throwing, so
+// callers that exhaustively switch on result.code never crash
+// (cursor Bugbot: 'Read APIs rethrow SQLite errors';
+// chatgpt-codex-connector P2: 'Return tagged failures from read
+// queries').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("read APIs return 'db_error' instead of throwing on an unexpected SQLite failure", async () => {
+  const { store, dir } = await tempStore();
+  const dbPath = path.join(dir, "graph.sqlite");
+  try {
+    const file: StoreFileIR = {
+      path: "src/n.ts",
+      language: "typescript",
+      contentHash: "h-n",
+      symbols: [sym("n.a", "a", 0, 10)],
+      edges: [],
+    };
+    const res = await store.upsertFileBatch([file]);
+    if (!res.ok) throw new Error(`expected ok upsert; got ${res.code}`);
+    // Sabotage: drop the edges table via a second connection so the
+    // next traverse() edges query fails with "no such table" — a
+    // non-lock, non-corrupt error that previously escaped as a throw.
+    const sabotage = openBetterSqlite3(dbPath);
+    sabotage.exec("DROP TABLE edges");
+    sabotage.close();
+    const out = store.traverse({ start: "n.a", maxDepth: 1 });
+    assert.equal(out.ok, false, "traverse must not throw on a DB error");
+    if (!out.ok) {
+      assert.equal(
+        out.code,
+        "db_error",
+        `unexpected SQLite error must map to db_error, not throw; got ${out.code}`,
+      );
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traverse: non-string start rejected with 'invalid_query' before binding (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    for (const bad of [
+      42,
+      null,
+      undefined,
+      { name: "x" },
+      [1, 2],
+      "",
+    ] as unknown[]) {
+      const out = store.traverse({
+        start: bad as never,
+        maxDepth: 1,
+      });
+      assert.equal(out.ok, false, `non-string start ${JSON.stringify(bad)} must not succeed`);
+      if (!out.ok) {
+        assert.equal(
+          out.code,
+          "invalid_query",
+          `non-string start must return invalid_query, not ${out.code}`,
+        );
+      }
+    }
+  } finally {
+    await dispose(store, dir);
   }
 });

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -516,6 +516,39 @@ test("traverse: a 64-hex node id resolves by id only, never conflated with a qua
   }
 });
 
+test("traverse: malformed edgeTypes (non-array or non-string element) rejected with 'invalid_query' (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+
+    // A bare string instead of an array would throw at .map() without
+    // this guard. Now it surfaces as invalid_query.
+    const asString = store.traverse({
+      start: "cyc.a",
+      maxDepth: 3,
+      // @ts-expect-error — deliberately malformed at runtime
+      edgeTypes: "CALLS",
+    });
+    assert.equal(asString.ok, false);
+    if (asString.ok) throw new Error("expected failure");
+    assert.equal(asString.code, "invalid_query");
+
+    // An array with a non-string element is also rejected.
+    const withNumber = store.traverse({
+      start: "cyc.a",
+      maxDepth: 3,
+      // @ts-expect-error — deliberately malformed at runtime
+      edgeTypes: ["CALLS", 42],
+    });
+    assert.equal(withNumber.ok, false);
+    if (withNumber.ok) throw new Error("expected failure");
+    assert.equal(withNumber.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // searchGraph(): label / name / file patterns + degree filters + limit.
 // ──────────────────────────────────────────────────────────────────────────
@@ -685,6 +718,32 @@ test("searchGraph: invalid degree / limit rejected with 'invalid_query'", async 
     assert.equal(fractional.ok, false);
     if (fractional.ok) throw new Error("expected failure");
     assert.equal(fractional.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("searchGraph: non-string label/namePattern/filePattern rejected with 'invalid_query' (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([starFile]);
+    assert.equal(r.ok, true);
+
+    // A non-string pattern (e.g. a number) must NOT be silently
+    // dropped — its .length is undefined, so without this guard the
+    // filter would be skipped and unrelated nodes returned as ok.
+    for (const bad of [
+      { namePattern: 42 },
+      { label: 100 },
+      { filePattern: 0 },
+    ]) {
+      const out = store.searchGraph(bad as unknown as Parameters<
+        typeof store.searchGraph
+      >[0]);
+      assert.equal(out.ok, false);
+      if (out.ok) throw new Error("expected failure");
+      assert.equal(out.code, "invalid_query");
+    }
   } finally {
     await dispose(store, dir);
   }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -37,7 +37,7 @@
  * underlying error internally and returns the code only.
  */
 import { createHash } from "node:crypto";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -76,6 +76,8 @@ export type {
 import type {
   FileIR,
   SymbolIR,
+  ExportIR,
+  RouteIR,
   CodingGraphLanguage,
 } from "@remnic/core/coding/coding-graph-types";
 
@@ -119,9 +121,17 @@ export interface EdgeIR {
  * Store input — the subset of @remnic/core's `FileIR` the store reads,
  * plus the store-specific `edges` extension. A core `FileIR` (from
  * `ParseResult.ir`) is structurally assignable here: all required fields
- * (path, language, contentHash, symbols) match by name and readonly-ness.
- * PR2 callers pass `{ ...parseResult.ir, edges }` (or the bare IR when
- * edges are absent) with zero casts or field-name translation.
+ * (path, language, contentHash, symbols, imports, exports, callSites,
+ * routes) match by name and readonly-ness. PR2 callers pass
+ * `{ ...parseResult.ir, edges }` (or the bare IR when edges are absent)
+ * with zero casts or field-name translation.
+ *
+ * PR2 adds optional `exports` and `routes` consumption: when present,
+ * the write pipeline marks matching nodes in `node_attributes` so the
+ * `deadCode()` query can exclude them via the
+ * {@link DEAD_CODE_EXCLUSION} constant. Both fields are optional because
+ * a PR1-era caller (or a JSON-IR caller that strips them) still ingests
+ * cleanly — the dead-code query simply sees no exclusion flags.
  */
 export interface StoreFileIR {
   readonly path: string;
@@ -130,6 +140,24 @@ export interface StoreFileIR {
   readonly symbols: readonly SymbolIR[];
   /** Store-specific edges derived from the IR by the caller. */
   readonly edges?: readonly EdgeIR[];
+  /**
+   * Per-file export list (mirrors core FileIR.exports). When present,
+   * the write pipeline marks every node in this file whose `name`
+   * matches an ExportIR.name as `is_exported=1` in `node_attributes`.
+   * Name-matching is the conventional pattern: a parser that emits a
+   * `export const foo` declaration also emits a SymbolIR named `foo`
+   * (or omits it if foo is a non-symbol like a plain variable); the
+   * dead-code query then excludes surviving exported symbols.
+   */
+  readonly exports?: readonly ExportIR[];
+  /**
+   * Per-file HTTP route declarations (mirrors core FileIR.routes). When
+   * present, the write pipeline marks the node whose `qualifiedName`
+   * equals `route.handlerQualifiedName` as `is_route_handler=1` in
+   * `node_attributes`. Route handlers are reachable from HTTP traffic
+   * regardless of whether any other indexed node CALLS them.
+   */
+  readonly routes?: readonly RouteIR[];
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -166,6 +194,305 @@ export interface UpsertSuccess {
 export type UpsertBatchResult = UpsertSuccess | GraphStoreFailure;
 
 // ──────────────────────────────────────────────────────────────────────────
+// PR2 read primitives — query / result types (issue #1552 steps 4–5).
+// Tagged failures share the {@link GraphStoreFailureCode} set so callers
+// can use one switch over every store surface.
+// ──────────────────────────────────────────────────────────────────────────
+
+/** Direction of traversal relative to the edge's src→dst orientation. */
+export type TraverseDirection = "outgoing" | "incoming" | "both";
+
+/**
+ * Iterative frontier BFS over the edges table. Cycle-safe via a JS
+ * visited set keyed by node id; predictable memory regardless of graph
+ * shape (recursive CTEs are the documented fallback if benchmarks ever
+ * justify them — issue #1552 design section).
+ */
+export interface TraverseQuery {
+  /**
+   * Start node. Accepts either a node id or a qualified name — the
+   * store resolves a qualified name to its deterministic id via the
+   * same `(qualifiedName, filePath, label)` identity used at ingest
+   * time. When the qualified name is ambiguous (declared in more than
+   * one file), the query is rejected with `code: "ambiguous_start"`
+   * so the caller can pass an explicit node id instead.
+   */
+  start: string;
+  /** Default `"outgoing"`. */
+  direction?: TraverseDirection;
+  /**
+   * Edge types to follow (e.g. `["CALLS", "USES_TYPE"]`). When omitted
+   * or empty, every edge type in the table is followed. Unknown edge
+   * types simply contribute no rows — the query is not rejected
+   * because the schema places no CHECK constraint on `edges.type`.
+   */
+  edgeTypes?: readonly string[];
+  /**
+   * Maximum BFS depth. Half-open: a node at depth == maxDepth IS
+   * included; a node at depth maxDepth+1 is NOT (rule 35). The start
+   * node itself sits at depth 0 and is always included in the result
+   * set when it exists. A maxDepth of 0 returns just the start node.
+   * MUST be a non-negative integer — invalid values are rejected with
+   * `code: "invalid_query"` rather than silently clamped (rule 51).
+   */
+  maxDepth: number;
+}
+
+export interface TraverseHit {
+  nodeId: string;
+  qualifiedName: string;
+  name: string;
+  label: string;
+  /** BFS depth from the start node (start = 0). */
+  depth: number;
+}
+
+export type TraverseResult =
+  | { ok: true; hits: TraverseHit[] }
+  | ({ ok: false } & GraphStoreFailure)
+  | { ok: false; code: "unknown_start" | "ambiguous_start" | "invalid_query" };
+
+/**
+ * Structured node search. All filters are AND-combined; every filter
+ * is optional so the bare query `{}` returns the whole graph (capped
+ * by `limit`). Patterns use SQLite `LIKE` semantics — `%` matches any
+ * run, `_` matches one character — applied case-insensitively via
+ * `LIKE ... COLLATE NOCASE`. Patterns are parameter-bound, never
+ * string-interpolated, so a `%`/`_` in user input cannot inject SQL.
+ */
+export interface SearchQuery {
+  /** Filter by node label (the symbol kind, e.g. `"function"`). */
+  label?: string;
+  /** LIKE pattern on `nodes.name` (case-insensitive). */
+  namePattern?: string;
+  /** LIKE pattern on `files.path` (case-insensitive). */
+  filePattern?: string;
+  /**
+   * Inclusive lower bound on total degree (in + out edge count).
+   * Combined with {@link degreeMax} for a half-open? — no, inclusive
+   * on both ends by convention since degree is an integer count, not
+   * a span (rule 35 covers byte/time spans, not integer ranges).
+   */
+  degreeMin?: number;
+  /** Inclusive upper bound on total degree. */
+  degreeMax?: number;
+  /**
+   * Cap on returned rows. Default 100; clamped to [0, 1000]. A
+   * `limit: 0` returns an empty `hits` array (rule 27 — guard the
+   * slice/LIMIT against the zero case).
+   */
+  limit?: number;
+}
+
+export interface SearchHit {
+  nodeId: string;
+  qualifiedName: string;
+  name: string;
+  label: string;
+  filePath: string;
+  /** Total in + out edge count for this node. */
+  degree: number;
+}
+
+export type SearchResult =
+  | { ok: true; hits: SearchHit[] }
+  | ({ ok: false } & GraphStoreFailure)
+  | { ok: false; code: "invalid_query" };
+
+/** Aggregate counts over the whole graph — single round-trip. */
+export interface SchemaStats {
+  files: number;
+  nodes: number;
+  edges: number;
+  /** Node count grouped by `label` (symbol kind). */
+  nodesByLabel: Record<string, number>;
+  /** Edge count grouped by `type`. */
+  edgesByType: Record<string, number>;
+}
+
+export type SchemaStatsResult =
+  | { ok: true; stats: SchemaStats }
+  | ({ ok: false } & GraphStoreFailure);
+
+export interface DeadCodeHit {
+  nodeId: string;
+  qualifiedName: string;
+  name: string;
+  label: string;
+  filePath: string;
+}
+
+export type DeadCodeResult =
+  | { ok: true; hits: DeadCodeHit[] }
+  | ({ ok: false } & GraphStoreFailure);
+
+/**
+ * Read a symbol's source span from disk. The store NEVER persists file
+ * contents (privacy + DB size — issue #1552 design); `snippetFor`
+ * resolves the node's `files.path` against {@link GraphStoreOptions.repoRoot}
+ * and slices `[span_start, span_end)` from the on-disk bytes.
+ */
+export interface SnippetQuery {
+  qualifiedName: string;
+  /**
+   * Optional lines of context to include before and after the span
+   * (default 0 — exact span only). Context is line-aligned: the slice
+   * expands to the nearest line boundary at each end.
+   */
+  contextLines?: number;
+}
+
+export interface SnippetSuccess {
+  ok: true;
+  qualifiedName: string;
+  filePath: string;
+  /** Absolute path the bytes were read from (`repoRoot/files.path`). */
+  absolutePath: string;
+  startByte: number;
+  endByte: number;
+  /** The decoded source slice (UTF-8). */
+  text: string;
+  lang: string;
+}
+
+export type SnippetFailureCode =
+  | "not_found"
+  | "ambiguous_name"
+  | "repo_root_unset"
+  | "read_failed"
+  | "invalid_query";
+
+export type SnippetResult = SnippetSuccess | { ok: false; code: SnippetFailureCode };
+
+// ──────────────────────────────────────────────────────────────────────────
+// PR2 dead-code exclusion — explicit named constant (rule 53 analog).
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * The single source of truth for what `deadCode()` EXCLUDES from the
+ * candidate set. Anything matched by these patterns or flags is treated
+ * as a non-dead surface even when it has zero inbound call/usage edges.
+ *
+ * This constant exists so the exclusion criteria are NAMED, DOCUMENTED,
+ * and auditable in one place — not scattered across ad-hoc `WHERE`
+ * clauses (rule 53 analog). Adding a new exclusion category means
+ * extending this constant plus the matching `node_attributes` column;
+ * the query then picks both up automatically.
+ *
+ * Categories:
+ *   - {@link INBOUND_USAGE_EDGE_TYPES} — an inbound edge of any of these
+ *     types disqualifies a node from being dead.
+ *   - {@link TEST_PATH_PATTERNS} — a node whose `files.path` matches is
+ *     in a test file; tests can call into private code without the
+ *     production graph seeing the edge.
+ *   - {@link ENTRY_POINT_PATH_PATTERNS} — process entry points (index,
+ *     main, cli, bin/); these are reachable from outside the graph.
+ *   - {@link EXCLUDED_ATTRIBUTE_FLAGS} — per-node flags stored in
+ *     `node_attributes` (set at write time from FileIR.exports /
+ *     FileIR.routes); `is_exported` and `is_route_handler`.
+ */
+export const DEAD_CODE_EXCLUSION = {
+  /**
+   * Edge types that — when pointing INTO a node — count as "this node
+   * is used". Mirrors the issue's `CALLS/USAGE` wording plus the four
+   * call-flavored edge types in the wider coding-graph vocabulary.
+   */
+  INBOUND_USAGE_EDGE_TYPES: [
+    "CALLS",
+    "USES_TYPE",
+    "ASYNC_CALLS",
+    "HTTP_CALLS",
+    "DATA_FLOWS",
+  ] as const,
+  /**
+   * File-path regexes identifying test files. Matched against
+   * `files.path` (repo-relative, forward slashes).
+   */
+  TEST_PATH_PATTERNS: [
+    /\.test\.[cm]?[tj]sx?$/,
+    /\.spec\.[cm]?[tj]sx?$/,
+    /(^|\/)__tests__\//,
+    /(^|\/)__mocks__\//,
+    /(^|\/)tests?\//,
+    /(^|\/)test\//,
+  ] as const,
+  /**
+   * File-path regexes identifying entry points (reachable from
+   * outside the indexed code). Matched against `files.path`. Kept
+   * deliberately narrow — `server.ts` / `app.ts` are intentionally
+   * NOT treated as entry points because they are common module
+   * names that may also contain dead helpers. The conservative
+   * direction is to report a symbol as dead rather than hide it.
+   */
+  ENTRY_POINT_PATH_PATTERNS: [
+    /(^|\/)index\.[cm]?[tj]sx?$/,
+    /(^|\/)main\.[cm]?[tj]sx?$/,
+    /(^|\/)cli\.[cm]?[tj]sx?$/,
+    /(^|\/)bin\//,
+    /(^|\/)src\/bin\//,
+  ] as const,
+  /**
+   * Columns on `node_attributes` whose value being `1` excludes the
+   * node. Names mirror the schema so a future column add is a one-line
+   * constant extension + a query clause (no scattered edits).
+   */
+  EXCLUDED_ATTRIBUTE_FLAGS: ["is_exported", "is_route_handler"] as const,
+} as const;
+
+/**
+ * @returns true iff `filePath` matches any pattern in
+ * {@link DEAD_CODE_EXCLUSION.TEST_PATH_PATTERNS} or
+ * {@link DEAD_CODE_EXCLUSION.ENTRY_POINT_PATH_PATTERNS}.
+ */
+function isExcludedByPath(filePath: string): boolean {
+  for (const re of DEAD_CODE_EXCLUSION.TEST_PATH_PATTERNS) {
+    if (re.test(filePath)) return true;
+  }
+  for (const re of DEAD_CODE_EXCLUSION.ENTRY_POINT_PATH_PATTERNS) {
+    if (re.test(filePath)) return true;
+  }
+  return false;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Internal: SQL variable-limit chunking (PR1 pattern — keep under 32766).
+// ──────────────────────────────────────────────────────────────────────────
+
+/** SQLite variable bind limit for the bundled better-sqlite3 native build. */
+const SQLITE_VARIABLE_LIMIT = 32_766;
+
+/**
+ * Run a parameterized `IN (?, ?, …)` query in chunks small enough to
+ * stay under SQLite's variable bind limit. The caller provides the
+ * statement prefix/suffix with a single `%PH%` placeholder where the
+ * `?,?,…` list goes; this helper substitutes the chunked placeholders
+ * and runs `.run(...)` per chunk, aggregating the returned rows.
+ *
+ * Mirrors the chunking pattern PR1 already uses inside
+ * `pruneFileNodes` (the FTS rowid deletes) and `upsertFileEdges` (the
+ * stale-edge tuple deletes). The reviews already hardened this class
+ * against `too many SQL variables` failures.
+ */
+function chunkedInQuery(
+  db: BetterSqlite3Database,
+  sqlTemplate: string,
+  params: readonly (string | number)[],
+): unknown[] {
+  const out: unknown[] = [];
+  if (params.length === 0) return out;
+  for (let i = 0; i < params.length; i += SQLITE_VARIABLE_LIMIT) {
+    const chunk = params.slice(i, i + SQLITE_VARIABLE_LIMIT);
+    const placeholders = chunk.map(() => "?").join(", ");
+    const sql = sqlTemplate.replace("%PH%", placeholders);
+    const rows = db.prepare(sql).all(...chunk);
+    if (Array.isArray(rows)) {
+      for (const r of rows) out.push(r);
+    }
+  }
+  return out;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Internal: write-queue (rule 40).
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -200,6 +527,15 @@ class WriteQueue {
 export interface GraphStoreOptions {
   /** Absolute path to the SQLite file. The caller resolves the namespace. */
   dbPath: string;
+  /**
+   * Optional absolute path to the repo root. When set, `snippetFor()`
+   * resolves a node's repo-relative `files.path` against this root to
+   * read its source span from disk. When unset, `snippetFor()` returns
+   * `code: "repo_root_unset"` for every call. The store NEVER persists
+   * file contents (privacy + DB size — issue #1552 design); this is
+   * the only path the read-side uses.
+   */
+  repoRoot?: string;
 }
 
 /**
@@ -209,6 +545,7 @@ export interface GraphStoreOptions {
 export class GraphStore {
   private readonly db: BetterSqlite3Database;
   private readonly queue = new WriteQueue();
+  private readonly repoRoot: string | undefined;
   private closed = false;
   private closing = false;
   // Shared drain-and-close promise so a second close() called while the
@@ -217,21 +554,38 @@ export class GraphStore {
   // in-progress close').
   private closePromise: Promise<void> | undefined;
 
-  private constructor(db: BetterSqlite3Database) {
+  private constructor(db: BetterSqlite3Database, repoRoot: string | undefined) {
     this.db = db;
+    // Validate at open() so the failure mode is a thrown, name-specific
+    // error at construction — never a silent `code: "repo_root_unset"`
+    // cascade on the first snippetFor() call after a long ingest. The
+    // caller may still pass `undefined` (the PR1 default); they just
+    // cannot pass a relative path that would silently slice the wrong
+    // file (rule 11 — no path assembly at call sites).
+    this.repoRoot = repoRoot;
   }
 
   /**
    * Open a store at the given dbPath. Creates parent directories and
    * applies the schema (idempotent — also handles upgrade). The dbPath
-   * is the canonical namespace path passed in by the caller — this PR
    * does no namespace resolution.
    */
   static async open(options: GraphStoreOptions): Promise<GraphStore> {
-    const { dbPath } = options;
+    const { dbPath, repoRoot } = options;
     if (!path.isAbsolute(dbPath)) {
       throw new Error(
         `graph-store: dbPath must be absolute; received ${JSON.stringify(dbPath)}`,
+      );
+    }
+    // Validate repoRoot up-front (rule 11). When provided it MUST be
+    // absolute — a relative repoRoot would silently resolve against
+    // the process CWD and `snippetFor()` would slice the wrong file
+    // (or a non-existent one) without a clear failure shape. The
+    // PR1 baseline keeps `repoRoot` optional so existing callers that
+    // do not need snippets continue to open() with just `{ dbPath }`.
+    if (repoRoot !== undefined && !path.isAbsolute(repoRoot)) {
+      throw new Error(
+        `graph-store: repoRoot must be absolute when provided; received ${JSON.stringify(repoRoot)}`,
       );
     }
     await mkdir(path.dirname(dbPath), { recursive: true });
@@ -245,10 +599,11 @@ export class GraphStore {
     // `edges` table relies on `ON DELETE CASCADE` from `nodes(id)` to
     // drop owned edges when a file's prior nodes are pruned; without
     // this pragma the cascade silently no-ops and edges accumulate as
-    // orphans (cursor + codex review).
+    // orphans (cursor + codex review). PR2's `node_attributes` table
+    // also relies on this cascade so attribute rows die with their node.
     db.pragma("foreign_keys = ON");
     applyCodingGraphSchema(db);
-    return new GraphStore(db);
+    return new GraphStore(db, repoRoot);
   }
 
   /**
@@ -435,6 +790,19 @@ export class GraphStore {
           const ir = irs[i]!;
           const result = results[i]!;
           this.upsertFileEdges(ir, result);
+        }
+        // Pass 3 (PR2): every file's node_attributes rows
+        // (`is_exported`, `is_route_handler`). Derived from the IR's
+        // optional `exports` and `routes` arrays. Runs after the prune
+        // so attribute rows for nodes that survived into this batch
+        // are written against the final node set. Cascade-delete on
+        // `nodes(id)` already cleaned up rows for pruned nodes during
+        // pass 1b; this pass only inserts new / updates existing rows
+        // for surviving nodes.
+        for (let i = 0; i < irs.length; i += 1) {
+          const ir = irs[i]!;
+          const result = results[i]!;
+          this.upsertFileAttributes(ir, result);
         }
       });
       tx(files);
@@ -908,6 +1276,659 @@ export class GraphStore {
       edgeCount += r.changes;
     }
     result.edgeCount = edgeCount;
+  }
+
+  /**
+   * Pass 3 (PR2): upsert `node_attributes` rows for this file's
+   * surviving nodes, derived from the IR's optional `exports` and
+   * `routes` arrays. Mirrors the edges-pass semantics:
+   *   - `exports == null` (omitted) → preserve existing flags
+   *     (PR1-era IR has no exports field; the file's prior flags
+   *     stay put so a re-ingest cannot accidentally wipe them).
+   *   - `exports === []` (explicit empty) → wipe the file's
+   *     `is_exported` flags (the caller is asserting "this file
+   *     exports nothing").
+   *   - same rule for `routes`.
+   *
+   * A symbol is `is_exported=1` when its `name` matches an entry in
+   * `ir.exports` (multiple symbols with the same name in one file all
+   * get the flag — the dead-code query treats this conservatively,
+   * never silently picking one). A symbol is `is_route_handler=1`
+   * when its `qualifiedName` equals a route's `handlerQualifiedName`.
+   *
+   * Implementation: delete-then-insert per file (same shape as the
+   * edges pass) so changed exports/routes overwrite prior rows.
+   * Inserting is INSERT OR REPLACE keyed on `node_id` so two symbols
+   * in the same file sharing a name do not collide.
+   */
+  private upsertFileAttributes(ir: StoreFileIR, result: UpsertResult): void {
+    // Both fields omitted → nothing to assert. Preserve existing
+    // flags (PR1 baseline). Avoids touching the table at all so
+    // truly-no-op re-ingests stay zero-cost.
+    if (ir.exports == null && ir.routes == null) {
+      return;
+    }
+
+    // Build the set of node ids in this file that should carry each
+    // flag. Both maps are keyed by node id; the value is ignored
+    // (presence ⇒ flag set). Match by name for exports, by
+    // qualified_name for routes — the conventional surface each list
+    // carries.
+    const exportedNodeIds = new Set<string>();
+    const routeHandlerNodeIds = new Set<string>();
+    const ownNodes = expectRows<{ id: string; name: string; qualified_name: string }>(
+      this.db
+        .prepare("SELECT id, name, qualified_name FROM nodes WHERE file_id = ?")
+        .all(result.fileId),
+      ["id", "name", "qualified_name"],
+    );
+    if (ir.exports != null) {
+      const exportNames = new Set<string>();
+      for (const ex of ir.exports) {
+        if (ex && typeof ex.name === "string" && ex.name.length > 0) {
+          exportNames.add(ex.name);
+        }
+      }
+      for (const n of ownNodes) {
+        if (exportNames.has(n.name)) exportedNodeIds.add(n.id);
+      }
+    }
+    if (ir.routes != null) {
+      const handlerQNames = new Set<string>();
+      for (const r of ir.routes) {
+        if (r && typeof r.handlerQualifiedName === "string" && r.handlerQualifiedName.length > 0) {
+          handlerQNames.add(r.handlerQualifiedName);
+        }
+      }
+      for (const n of ownNodes) {
+        if (handlerQNames.has(n.qualified_name)) routeHandlerNodeIds.add(n.id);
+      }
+    }
+
+    // Delete-then-insert per file: the prior rows for this file's
+    // nodes are wiped so changed exports overwrite. Without this, a
+    // re-ingest that drops an export would leave the old flag set,
+    // silently hiding a now-dead symbol from `deadCode()`. Chunked
+    // under the SQLite variable limit to handle large symbol tables.
+    const ownNodeIds = ownNodes.map((n) => n.id);
+    if (ownNodeIds.length > 0) {
+      for (let i = 0; i < ownNodeIds.length; i += SQLITE_VARIABLE_LIMIT) {
+        const chunk = ownNodeIds.slice(i, i + SQLITE_VARIABLE_LIMIT);
+        const placeholders = chunk.map(() => "?").join(", ");
+        this.db
+          .prepare(
+            `DELETE FROM node_attributes WHERE node_id IN (${placeholders})`,
+          )
+          .run(...chunk);
+      }
+    }
+
+    // Insert fresh rows for nodes carrying either flag. A node with
+    // neither flag set does not get a row at all — the deadCode LEFT
+    // JOIN COALESCEs the missing row to (0, 0).
+    const flagged = new Set<string>([...exportedNodeIds, ...routeHandlerNodeIds]);
+    if (flagged.size === 0) {
+      return;
+    }
+    const upsertAttr = this.db.prepare(
+      `INSERT INTO node_attributes (node_id, is_exported, is_route_handler)
+         VALUES (?, ?, ?)
+       ON CONFLICT(node_id) DO UPDATE SET
+         is_exported = excluded.is_exported,
+         is_route_handler = excluded.is_route_handler`,
+    );
+    for (const id of flagged) {
+      const isExported = exportedNodeIds.has(id) ? 1 : 0;
+      const isRoute = routeHandlerNodeIds.has(id) ? 1 : 0;
+      upsertAttr.run(id, isExported, isRoute);
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // PR2 read primitives (issue #1552 steps 4–5).
+  // ──────────────────────────────────────────────────────────────────────
+
+  /**
+   * Iterative frontier BFS over the edges table. Cycle-safe via a JS
+   * visited set keyed by node id; depth-capped by {@link TraverseQuery.maxDepth}
+   * (half-open — depth==maxDepth is INCLUDED, maxDepth+1 is NOT — rule 35).
+   * The start node is always included at depth 0 when it exists.
+   *
+   * Reads the edges table via a single prepared statement per
+   * direction; the frontier expands level-by-level so memory is
+   * bounded by the visited set's size, not the recursion depth.
+   */
+  traverse(query: TraverseQuery): TraverseResult {
+    if (this.closed) return { ok: false, code: "store_closed" };
+    // Validate maxDepth up-front (rule 51: surface what's wrong).
+    if (
+      typeof query.maxDepth !== "number" ||
+      !Number.isInteger(query.maxDepth) ||
+      query.maxDepth < 0
+    ) {
+      return {
+        ok: false,
+        code: "invalid_query",
+      };
+    }
+    const direction: TraverseDirection = query.direction ?? "outgoing";
+    // Resolve the start node. If `start` is a 64-char hex string, treat
+    // it as a node id; otherwise resolve by qualified_name (ambiguous →
+    // explicit rejection so the caller can pass an id).
+    let startId: string;
+    const rows = expectRows<{ id: string }>(
+      this.db
+        .prepare("SELECT id FROM nodes WHERE id = ? OR qualified_name = ?")
+        .all(query.start, query.start),
+      ["id"],
+    );
+    if (rows.length === 0) {
+      return { ok: false, code: "unknown_start" };
+    }
+    if (rows.length > 1) {
+      // Multiple rows mean the start resolved to more than one node —
+      // either the same id matching twice (impossible — PRIMARY KEY)
+      // or a qualified_name declared in multiple files. Reject so the
+      // caller passes an explicit node id.
+      return { ok: false, code: "ambiguous_start" };
+    }
+    startId = rows[0]!.id;
+
+    // BFS. Edge-type filter is bound into the prepared statement via
+    // IN (?, ?, ...) — empty list means "all types" (no WHERE clause
+    // on type). The edge-type list is small (≤ ~25) so chunking is
+    // unnecessary here, but we still parameterize so user input
+    // cannot inject SQL.
+    const edgeTypes = query.edgeTypes ?? [];
+    const typeClause =
+      edgeTypes.length > 0
+        ? `AND type IN (${edgeTypes.map(() => "?").join(", ")})`
+        : "";
+    const outgoingStmt = this.db.prepare(
+      `SELECT dst AS neighbor, src AS via_id FROM edges WHERE src = ? ${typeClause}`,
+    );
+    const incomingStmt = this.db.prepare(
+      `SELECT src AS neighbor, dst AS via_id FROM edges WHERE dst = ? ${typeClause}`,
+    );
+
+    const visited = new Set<string>([startId]);
+    const hits: TraverseHit[] = [];
+    const startRow = expectRow<{
+      id: string;
+      qualified_name: string;
+      name: string;
+      label: string;
+    }>(
+      this.db
+        .prepare(
+          "SELECT id, qualified_name, name, label FROM nodes WHERE id = ?",
+        )
+        .get(startId),
+      ["id", "qualified_name", "name", "label"],
+    );
+    if (!startRow) {
+      // Race: the node vanished between the resolve and the read.
+      // Treat as unknown rather than crash.
+      return { ok: false, code: "unknown_start" };
+    }
+    hits.push({
+      nodeId: startRow.id,
+      qualifiedName: startRow.qualified_name,
+      name: startRow.name,
+      label: startRow.label,
+      depth: 0,
+    });
+
+    // maxDepth === 0 → just the start node (half-open: depth 0 is
+    // included, depth 1 is not).
+    if (query.maxDepth === 0) {
+      return { ok: true, hits };
+    }
+
+    let frontier: string[] = [startId];
+    for (let depth = 1; depth <= query.maxDepth; depth += 1) {
+      const nextFrontier: string[] = [];
+      for (const nodeId of frontier) {
+        const params = [nodeId, ...edgeTypes];
+        const outRows =
+          direction === "outgoing" || direction === "both"
+            ? expectRows<{ neighbor: string }>(
+                outgoingStmt.all(...params),
+                ["neighbor"],
+              )
+            : [];
+        const inRows =
+          direction === "incoming" || direction === "both"
+            ? expectRows<{ neighbor: string }>(
+                incomingStmt.all(...params),
+                ["neighbor"],
+              )
+            : [];
+        for (const r of [...outRows, ...inRows]) {
+          const neighbor = r.neighbor;
+          // Cycle safety: a node already in `visited` is not re-added.
+          // This also handles self-edges (src == dst): the start is in
+          // visited, so a self-loop on it never re-expands the frontier.
+          if (visited.has(neighbor)) continue;
+          visited.add(neighbor);
+          nextFrontier.push(neighbor);
+          const hitRow = expectRow<{
+            id: string;
+            qualified_name: string;
+            name: string;
+            label: string;
+          }>(
+            this.db
+              .prepare(
+                "SELECT id, qualified_name, name, label FROM nodes WHERE id = ?",
+              )
+              .get(neighbor),
+            ["id", "qualified_name", "name", "label"],
+          );
+          if (hitRow) {
+            hits.push({
+              nodeId: hitRow.id,
+              qualifiedName: hitRow.qualified_name,
+              name: hitRow.name,
+              label: hitRow.label,
+              depth,
+            });
+          }
+        }
+      }
+      if (nextFrontier.length === 0) break;
+      frontier = nextFrontier;
+    }
+    return { ok: true, hits };
+  }
+
+  /**
+   * Structured node search. All filters are AND-combined; patterns use
+   * SQLite LIKE (case-insensitive via COLLATE NOCASE). Patterns and
+   * limits are parameter-bound, never string-interpolated, so user
+   * input cannot inject SQL.
+   */
+  searchGraph(query: SearchQuery): SearchResult {
+    if (this.closed) return { ok: false, code: "store_closed" };
+    // Validate numeric inputs (rule 51). NaN / negative / non-integer
+    // limits are rejected, not silently clamped, so callers learn what
+    // they passed.
+    if (
+      (query.degreeMin !== undefined &&
+        (typeof query.degreeMin !== "number" ||
+          !Number.isInteger(query.degreeMin) ||
+          query.degreeMin < 0)) ||
+      (query.degreeMax !== undefined &&
+        (typeof query.degreeMax !== "number" ||
+          !Number.isInteger(query.degreeMax) ||
+          query.degreeMax < 0))
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    if (
+      query.degreeMin !== undefined &&
+      query.degreeMax !== undefined &&
+      query.degreeMin > query.degreeMax
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    const rawLimit = query.limit ?? 100;
+    if (
+      typeof rawLimit !== "number" ||
+      !Number.isInteger(rawLimit) ||
+      rawLimit < 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    // Clamp to [0, MAX_SEARCH_LIMIT]. A `limit: 0` returns an empty
+    // hits array (rule 27 — guard the slice/LIMIT against zero).
+    const MAX_SEARCH_LIMIT = 1000;
+    const limit = Math.min(rawLimit, MAX_SEARCH_LIMIT);
+
+    // Build a single parameterized query. The degree subquery counts
+    // inbound + outbound edges per node; the WHERE clause AND-combines
+    // every present filter; the LIMIT is bound last. LIKE patterns are
+    // bound as-is so SQLite interprets `%` and `_`.
+    const params: (string | number)[] = [];
+    const where: string[] = [];
+    if (query.label !== undefined && query.label.length > 0) {
+      where.push("n.label = ?");
+      params.push(query.label);
+    }
+    if (query.namePattern !== undefined && query.namePattern.length > 0) {
+      where.push("n.name LIKE ? COLLATE NOCASE");
+      params.push(query.namePattern);
+    }
+    if (query.filePattern !== undefined && query.filePattern.length > 0) {
+      where.push("f.path LIKE ? COLLATE NOCASE");
+      params.push(query.filePattern);
+    }
+    // Degree filter on the computed subquery. We re-emit the COUNT
+    // subquery in the WHERE clause rather than using HAVING — SQLite
+    // requires HAVING to be paired with GROUP BY, and this query has
+    // no GROUP BY (each row is one node). The correlated subquery is
+    // evaluated per-row; SQLite's planner caches it cheaply for the
+    // graph sizes we target (issue #1552 scale targets).
+    if (query.degreeMin !== undefined) {
+      where.push(
+        "(SELECT COUNT(*) FROM edges e WHERE e.src = n.id OR e.dst = n.id) >= ?",
+      );
+      params.push(query.degreeMin);
+    }
+    if (query.degreeMax !== undefined) {
+      where.push(
+        "(SELECT COUNT(*) FROM edges e WHERE e.src = n.id OR e.dst = n.id) <= ?",
+      );
+      params.push(query.degreeMax);
+    }
+
+    params.push(limit);
+    const sql = `SELECT n.id AS node_id, n.qualified_name, n.name, n.label,
+                        f.path AS file_path,
+                        (SELECT COUNT(*) FROM edges e WHERE e.src = n.id OR e.dst = n.id) AS degree
+                   FROM nodes n
+                   JOIN files f ON n.file_id = f.id
+                  ${where.length > 0 ? "WHERE " + where.join(" AND ") : ""}
+                  ORDER BY degree DESC, n.qualified_name ASC
+                  LIMIT ?`;
+    const rows = expectRows<{
+      node_id: string;
+      qualified_name: string;
+      name: string;
+      label: string;
+      file_path: string;
+      degree: number;
+    }>(this.db.prepare(sql).all(...params), [
+      "node_id",
+      "qualified_name",
+      "name",
+      "label",
+      "file_path",
+      "degree",
+    ]);
+    const hits: SearchHit[] = rows.map((r) => ({
+      nodeId: r.node_id,
+      qualifiedName: r.qualified_name,
+      name: r.name,
+      label: r.label,
+      filePath: r.file_path,
+      degree: r.degree,
+    }));
+    return { ok: true, hits };
+  }
+
+  /**
+   * Aggregate counts over the whole graph. Single round-trip: one
+   * scalar per metric, two GROUP BY queries for the by-label /
+   * by-type histograms.
+   */
+  schemaStats(): SchemaStatsResult {
+    if (this.closed) return { ok: false, code: "store_closed" };
+    try {
+      const fileCount = expectRow<{ c: number }>(
+        this.db.prepare("SELECT COUNT(*) AS c FROM files").get(),
+        ["c"],
+      );
+      const nodeCount = expectRow<{ c: number }>(
+        this.db.prepare("SELECT COUNT(*) AS c FROM nodes").get(),
+        ["c"],
+      );
+      const edgeCount = expectRow<{ c: number }>(
+        this.db.prepare("SELECT COUNT(*) AS c FROM edges").get(),
+        ["c"],
+      );
+      const labelRows = expectRows<{ label: string; c: number }>(
+        this.db
+          .prepare(
+            "SELECT label, COUNT(*) AS c FROM nodes GROUP BY label ORDER BY label",
+          )
+          .all(),
+        ["label", "c"],
+      );
+      const typeRows = expectRows<{ type: string; c: number }>(
+        this.db
+          .prepare(
+            "SELECT type, COUNT(*) AS c FROM edges GROUP BY type ORDER BY type",
+          )
+          .all(),
+        ["type", "c"],
+      );
+      const nodesByLabel: Record<string, number> = {};
+      for (const r of labelRows) nodesByLabel[r.label] = r.c;
+      const edgesByType: Record<string, number> = {};
+      for (const r of typeRows) edgesByType[r.type] = r.c;
+      return {
+        ok: true,
+        stats: {
+          files: fileCount?.c ?? 0,
+          nodes: nodeCount?.c ?? 0,
+          edges: edgeCount?.c ?? 0,
+          nodesByLabel,
+          edgesByType,
+        },
+      };
+    } catch (error) {
+      logWriteFailure(error);
+      const failure = classifyError(error);
+      return failure as unknown as SchemaStatsResult;
+    }
+  }
+
+  /**
+   * Dead-code candidates: nodes with zero inbound
+   * {@link DEAD_CODE_EXCLUSION.INBOUND_USAGE_EDGE_TYPES} edges, excluding
+   * nodes whose `node_attributes` row marks them exported / route-handler
+   * AND nodes whose file path matches the test / entry-point patterns
+   * in {@link DEAD_CODE_EXCLUSION}.
+   *
+   * The exclusion criteria live in the named constant — not in
+   * ad-hoc WHERE clauses (rule 53 analog). The stored flags come from
+   * the write pipeline's `upsertFileAttributes` pass, which the IR's
+   * `exports` and `routes` arrays feed.
+   */
+  deadCode(): DeadCodeResult {
+    if (this.closed) return { ok: false, code: "store_closed" };
+    try {
+      // The inbound-usage edge-type list comes from the named
+      // constant; bind it as a parameterized IN (...) so the criteria
+      // are auditable in one place and a future edge-type add is a
+      // one-line constant extension.
+      const usageTypes = DEAD_CODE_EXCLUSION.INBOUND_USAGE_EDGE_TYPES;
+      const typePlaceholders = usageTypes.map(() => "?").join(", ");
+      // LEFT JOIN node_attributes so a missing row reads as (0, 0).
+      // COALESCE is belt-and-braces — the LEFT JOIN already produces
+      // NULL for missing rows, and `NULL OR ...` would surface NULL
+      // in the WHERE; explicit COALESCE collapses NULL → 0.
+      const sql = `SELECT n.id AS node_id, n.qualified_name, n.name, n.label,
+                          f.path AS file_path
+                     FROM nodes n
+                     JOIN files f ON n.file_id = f.id
+                     LEFT JOIN node_attributes a ON a.node_id = n.id
+                    WHERE NOT EXISTS (
+                       SELECT 1 FROM edges e
+                        WHERE e.dst = n.id
+                          AND e.type IN (${typePlaceholders})
+                     )
+                      AND COALESCE(a.is_exported, 0) = 0
+                      AND COALESCE(a.is_route_handler, 0) = 0
+                    ORDER BY n.qualified_name ASC`;
+      const rows = expectRows<{
+        node_id: string;
+        qualified_name: string;
+        name: string;
+        label: string;
+        file_path: string;
+      }>(this.db.prepare(sql).all(...usageTypes), [
+        "node_id",
+        "qualified_name",
+        "name",
+        "label",
+        "file_path",
+      ]);
+      // Apply path-based exclusions in JS — SQLite's regex support is
+      // opt-in and inconsistent across builds; doing it here keeps the
+      // exclusion logic entirely in the named constant.
+      const hits: DeadCodeHit[] = [];
+      for (const r of rows) {
+        if (isExcludedByPath(r.file_path)) continue;
+        hits.push({
+          nodeId: r.node_id,
+          qualifiedName: r.qualified_name,
+          name: r.name,
+          label: r.label,
+          filePath: r.file_path,
+        });
+      }
+      return { ok: true, hits };
+    } catch (error) {
+      logWriteFailure(error);
+      const failure = classifyError(error);
+      return failure as unknown as DeadCodeResult;
+    }
+  }
+
+  /**
+   * Read a symbol's source span from disk. The store NEVER persists
+   * file contents (privacy + DB size — issue #1552 design); this
+   * method resolves `files.path` against {@link GraphStoreOptions.repoRoot}
+   * and slices the half-open `[startByte, endByte)` span from the
+   * on-disk bytes.
+   */
+  async snippetFor(query: SnippetQuery): Promise<SnippetResult> {
+    if (this.closed) return { ok: false, code: "repo_root_unset" };
+    if (
+      typeof query.qualifiedName !== "string" ||
+      query.qualifiedName.length === 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    if (this.repoRoot === undefined) {
+      return { ok: false, code: "repo_root_unset" };
+    }
+    // Resolve the node. A qualified_name might match multiple nodes
+    // (declared in multiple files); ambiguous matches are rejected so
+    // the caller can pass a node id via a future extension or include
+    // the file in the same batch.
+    const rows = expectRows<{
+      id: string;
+      qualified_name: string;
+      file_path: string;
+      span_start: number;
+      span_end: number;
+      lang: string;
+    }>(
+      this.db
+        .prepare(
+          `SELECT n.id, n.qualified_name, n.span_start, n.span_end, n.lang,
+                  f.path AS file_path
+             FROM nodes n JOIN files f ON n.file_id = f.id
+            WHERE n.qualified_name = ?`,
+        )
+        .all(query.qualifiedName),
+      ["id", "qualified_name", "file_path", "span_start", "span_end", "lang"],
+    );
+    if (rows.length === 0) return { ok: false, code: "not_found" };
+    if (rows.length > 1) return { ok: false, code: "ambiguous_name" };
+    const node = rows[0]!;
+    const absolutePath = path.resolve(this.repoRoot, node.file_path);
+    // Read the file from disk and slice the span. readFile is the
+    // single fs call — no streaming, no mmap, just one allocation per
+    // request. The store caches nothing; the caller may.
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(absolutePath);
+    } catch (error) {
+      logWriteFailure(error);
+      return { ok: false, code: "read_failed" };
+    }
+    // Half-open [startByte, endByte). Guard endByte ≤ buffer.length
+    // so a stale span after a file edit does not throw OutOfRange.
+    const start = Math.max(0, node.span_start);
+    const end = Math.min(bytes.length, node.span_end);
+    if (start > end) {
+      // The file shrank below the span — return an empty snippet
+      // rather than throw; the caller can decide whether to re-ingest.
+      return {
+        ok: true,
+        qualifiedName: node.qualified_name,
+        filePath: node.file_path,
+        absolutePath,
+        startByte: node.span_start,
+        endByte: node.span_end,
+        text: "",
+        lang: node.lang,
+      };
+    }
+    let text = bytes.subarray(start, end).toString("utf8");
+    // Optional context lines (line-aligned expansion). contextLines
+    // is bounded to a sane cap so a caller cannot ask for megabytes
+    // of surrounding code.
+    const ctx = query.contextLines ?? 0;
+    if (ctx > 0) {
+      const MAX_CTX = 200;
+      const contextLines = Math.min(Math.max(0, Math.floor(ctx)), MAX_CTX);
+      if (contextLines > 0) {
+        // Line-aligned expansion. For contextLines=N we include the N
+        // full lines preceding the span's line and the N full lines
+        // following the span's line. Walk backward from `start`,
+        // skipping (contextLines) line-end newlines, then walk to the
+        // start of the (contextLines+1)th line back; walk forward
+        // from `end` symmetrically.
+        //
+        // The first newline we hit going backward is the END of the
+        // span's own line, NOT a context line — so we need to count
+        // `contextLines` newlines after that boundary to find where
+        // the context region begins. Concrete example for N=1:
+        //   "...line one\nline two\n..."  with span starting at "line two"
+        //   walking back from start of "line two", we hit \n (end of
+        //   "line one"). The line "line one" IS the context. Its start
+        //   is one further newline back (or buffer start).
+        let lineStart = start;
+        // Move lineStart to the beginning of the line containing `start`.
+        while (lineStart > 0 && bytes[lineStart - 1] !== 0x0a) {
+          lineStart -= 1;
+        }
+        // For each of contextLines, jump past the newline at
+        // lineStart - 1 and walk to the previous line's start.
+        for (let i = 0; i < contextLines && lineStart > 0; i += 1) {
+          // Step past the newline ending the prior line.
+          lineStart -= 1;
+          // Walk to the start of THAT line.
+          while (lineStart > 0 && bytes[lineStart - 1] !== 0x0a) {
+            lineStart -= 1;
+          }
+        }
+        let lineEnd = end;
+        // Move lineEnd to the end of the line containing `end`
+        // (inclusive of the trailing newline if present).
+        while (lineEnd < bytes.length && bytes[lineEnd] !== 0x0a) {
+          lineEnd += 1;
+        }
+        if (lineEnd < bytes.length && bytes[lineEnd] === 0x0a) {
+          lineEnd += 1;
+        }
+        // For each of contextLines, advance past one more line.
+        for (let i = 0; i < contextLines && lineEnd < bytes.length; i += 1) {
+          while (lineEnd < bytes.length && bytes[lineEnd] !== 0x0a) {
+            lineEnd += 1;
+          }
+          if (lineEnd < bytes.length && bytes[lineEnd] === 0x0a) {
+            lineEnd += 1;
+          }
+        }
+        text = bytes.subarray(lineStart, lineEnd).toString("utf8");
+      }
+    }
+    return {
+      ok: true,
+      qualifiedName: node.qualified_name,
+      filePath: node.file_path,
+      absolutePath,
+      startByte: node.span_start,
+      endByte: node.span_end,
+      text,
+      lang: node.lang,
+    };
   }
 }
 

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -759,19 +759,47 @@ export class GraphStore {
       // dead-code misclassification. Reject at the boundary like the
       // symbols check above (chatgpt-codex-connector P2: 'Validate
       // attribute arrays before clearing flags').
-      if (ir.exports != null && !Array.isArray(ir.exports)) {
-        throw new Error(
-          `graph-store: file '${ir.path}' exports must be an array when present; received ${
-            ir.exports === null ? "null" : typeof ir.exports
-          } — refusing to ingest to avoid wiping existing flags`,
-        );
+      if (ir.exports != null) {
+        if (!Array.isArray(ir.exports)) {
+          throw new Error(
+            `graph-store: file '${ir.path}' exports must be an array when present; received ${
+              ir.exports === null ? "null" : typeof ir.exports
+            } — refusing to ingest to avoid wiping existing flags`,
+          );
+        }
+        // Each entry must carry a non-empty string `name`; a malformed
+        // entry (e.g. `{ name: 42 }`) is silently skipped by the
+        // per-flag rebuild, so it contributes nothing while the wipe
+        // still clears every is_exported flag. Reject the whole batch
+        // like the symbols check (chatgpt-codex-connector P2: 'Reject
+        // malformed attribute entries before clearing flags').
+        for (const ex of ir.exports) {
+          if (!ex || typeof ex.name !== "string" || ex.name.length === 0) {
+            throw new Error(
+              `graph-store: file '${ir.path}' has a malformed export entry — expected { name: string (non-empty) }; refusing to ingest to avoid wiping existing flags`,
+            );
+          }
+        }
       }
-      if (ir.routes != null && !Array.isArray(ir.routes)) {
-        throw new Error(
-          `graph-store: file '${ir.path}' routes must be an array when present; received ${
-            ir.routes === null ? "null" : typeof ir.routes
-          } — refusing to ingest to avoid wiping existing flags`,
-        );
+      if (ir.routes != null) {
+        if (!Array.isArray(ir.routes)) {
+          throw new Error(
+            `graph-store: file '${ir.path}' routes must be an array when present; received ${
+              ir.routes === null ? "null" : typeof ir.routes
+            } — refusing to ingest to avoid wiping existing flags`,
+          );
+        }
+        for (const r of ir.routes) {
+          if (
+            !r ||
+            typeof r.handlerQualifiedName !== "string" ||
+            r.handlerQualifiedName.length === 0
+          ) {
+            throw new Error(
+              `graph-store: file '${ir.path}' has a malformed route entry — expected { handlerQualifiedName: string (non-empty) }; refusing to ingest to avoid wiping existing flags`,
+            );
+          }
+        }
       }
     }
     try {
@@ -1445,6 +1473,15 @@ export class GraphStore {
    */
   traverse(query: TraverseQuery): TraverseResult {
     if (this.closed) return { ok: false, code: "store_closed" };
+    // Guard the query object before any dereference: a null/undefined
+    // payload (e.g. malformed JSON forwarded at an MCP boundary) would
+    // throw on `query.maxDepth` below instead of returning the tagged
+    // invalid_query the read contract advertises
+    // (chatgpt-codex-connector P2: 'Validate read query objects before
+    // dereferencing').
+    if (query == null || typeof query !== "object") {
+      return { ok: false, code: "invalid_query" };
+    }
     // Validate maxDepth up-front (rule 51: surface what's wrong).
     if (
       typeof query.maxDepth !== "number" ||
@@ -1642,7 +1679,6 @@ export class GraphStore {
       return classifyReadError(error) as TraverseResult;
     }
   }
-
   /**
    * Structured node search. All filters are AND-combined; patterns use
    * SQLite LIKE (case-insensitive via COLLATE NOCASE). Patterns and
@@ -1651,6 +1687,10 @@ export class GraphStore {
    */
   searchGraph(query: SearchQuery): SearchResult {
     if (this.closed) return { ok: false, code: "store_closed" };
+    // Guard the query object before any dereference (see traverse).
+    if (query == null || typeof query !== "object") {
+      return { ok: false, code: "invalid_query" };
+    }
     // Validate numeric inputs (rule 51). NaN / negative / non-integer
     // limits are rejected, not silently clamped, so callers learn what
     // they passed.
@@ -1927,9 +1967,27 @@ export class GraphStore {
    */
   async snippetFor(query: SnippetQuery): Promise<SnippetResult> {
     if (this.closed) return { ok: false, code: "store_closed" };
+    // Guard the query object before any dereference (see traverse).
+    if (query == null || typeof query !== "object") {
+      return { ok: false, code: "invalid_query" };
+    }
     if (
       typeof query.qualifiedName !== "string" ||
       query.qualifiedName.length === 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    // Validate contextLines is a non-negative integer when present,
+    // consistent with traverse's maxDepth and the other numeric read
+    // fields. The old path coerced (Math.floor), so `1.9` silently
+    // became 1 and `"2"` became 2 — reject malformed values up-front
+    // instead (chatgpt-codex-connector P2: 'Reject invalid context
+    // line counts').
+    if (
+      query.contextLines !== undefined &&
+      (typeof query.contextLines !== "number" ||
+        !Number.isInteger(query.contextLines) ||
+        query.contextLines < 0)
     ) {
       return { ok: false, code: "invalid_query" };
     }

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1439,14 +1439,25 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
-    // Resolve the start node. If `start` is a 64-char hex string, treat
-    // it as a node id; otherwise resolve by qualified_name (ambiguous →
-    // explicit rejection so the caller can pass an id).
+    // Resolve the start node. If `start` is a 64-char lowercase hex
+    // string (the nodeIdFor sha256 format), resolve ONLY by id — this
+    // is the unambiguous path a caller uses after seeing an ambiguous
+    // qualified_name rejection. Otherwise resolve ONLY by qualified_name.
+    // Splitting the two paths (cursor Bugbot: 'Traverse start conflates id
+    // and name') prevents a mistyped id from silently matching an
+    // unrelated qualified_name, and prevents a unique id from being
+    // reported as ambiguous just because some other node shares the id
+    // string as a qualified_name.
     let startId: string;
+    const isNodeId = /^[0-9a-f]{64}$/.test(query.start);
     const rows = expectRows<{ id: string }>(
       this.db
-        .prepare("SELECT id FROM nodes WHERE id = ? OR qualified_name = ?")
-        .all(query.start, query.start),
+        .prepare(
+          isNodeId
+            ? "SELECT id FROM nodes WHERE id = ?"
+            : "SELECT id FROM nodes WHERE qualified_name = ?",
+        )
+        .all(query.start),
       ["id"],
     );
     if (rows.length === 0) {

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1495,10 +1495,13 @@ export class GraphStore {
     }
     // Validate direction against the allowed set (rule 51 +
     // chatgpt-codex-connector P2: 'Reject invalid traversal directions
-    // explicitly'). Without this a typo like "outbound" silently falls
-    // through none of the branches and returns only the start node,
-    // masquerading as a valid empty expansion.
-    const direction: TraverseDirection = query.direction ?? "outgoing";
+    // explicitly'). Default ONLY on `undefined` — a `null` from a
+    // JSON/tool caller is a malformed value, not an absent one, so the
+    // `??` operator (which treats null as nullish) would silently turn
+    // it into "outgoing" and mask the bad input. Reject null explicitly
+    // (chatgpt-codex-connector P2: 'Reject null traversal directions').
+    const direction: TraverseDirection =
+      query.direction === undefined ? "outgoing" : query.direction;
     if (
       direction !== "outgoing" &&
       direction !== "incoming" &&

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -360,7 +360,8 @@ export type SnippetFailureCode =
   | "ambiguous_name"
   | "repo_root_unset"
   | "read_failed"
-  | "invalid_query";
+  | "invalid_query"
+  | "store_closed";
 
 export type SnippetResult = SnippetSuccess | { ok: false; code: SnippetFailureCode };
 
@@ -1281,14 +1282,16 @@ export class GraphStore {
   /**
    * Pass 3 (PR2): upsert `node_attributes` rows for this file's
    * surviving nodes, derived from the IR's optional `exports` and
-   * `routes` arrays. Mirrors the edges-pass semantics:
-   *   - `exports == null` (omitted) → preserve existing flags
-   *     (PR1-era IR has no exports field; the file's prior flags
-   *     stay put so a re-ingest cannot accidentally wipe them).
+   * `routes` arrays. Per-field preservation semantics (mirrors the
+   * edges pass, generalized to two independent flags):
+   *   - `exports == null` (omitted) → preserve existing `is_exported`
+   *     flags untouched (PR1-era IR has no exports field). The
+   *     `is_route_handler` flag is rebuilt independently from
+   *     `routes` — the two columns do NOT interact.
    *   - `exports === []` (explicit empty) → wipe the file's
    *     `is_exported` flags (the caller is asserting "this file
    *     exports nothing").
-   *   - same rule for `routes`.
+   *   - same rule for `routes` / `is_route_handler`.
    *
    * A symbol is `is_exported=1` when its `name` matches an entry in
    * `ir.exports` (multiple symbols with the same name in one file all
@@ -1296,32 +1299,46 @@ export class GraphStore {
    * never silently picking one). A symbol is `is_route_handler=1`
    * when its `qualifiedName` equals a route's `handlerQualifiedName`.
    *
-   * Implementation: delete-then-insert per file (same shape as the
-   * edges pass) so changed exports/routes overwrite prior rows.
-   * Inserting is INSERT OR REPLACE keyed on `node_id` so two symbols
-   * in the same file sharing a name do not collide.
+   * Implementation: per-flag UPDATE, not a delete-then-insert (the
+   * original PR2 implementation wiped both flags whenever either field
+   * was present, so a re-ingest with only `exports` silently dropped
+   * `is_route_handler` — cursor Bugbot + chatgpt-codex-connector P2).
+   * The two flags live in the same row keyed by node_id; INSERT OR
+   * IGNORE ensures a row exists, then UPDATE-per-flag changes only
+   * the column the IR is asserting.
    */
   private upsertFileAttributes(ir: StoreFileIR, result: UpsertResult): void {
-    // Both fields omitted → nothing to assert. Preserve existing
-    // flags (PR1 baseline). Avoids touching the table at all so
-    // truly-no-op re-ingests stay zero-cost.
+    // Both fields omitted → nothing to assert. Preserve every flag
+    // (PR1 baseline). Avoids touching the table at all so truly-no-op
+    // re-ingests stay zero-cost.
     if (ir.exports == null && ir.routes == null) {
       return;
     }
 
-    // Build the set of node ids in this file that should carry each
-    // flag. Both maps are keyed by node id; the value is ignored
-    // (presence ⇒ flag set). Match by name for exports, by
-    // qualified_name for routes — the conventional surface each list
-    // carries.
-    const exportedNodeIds = new Set<string>();
-    const routeHandlerNodeIds = new Set<string>();
     const ownNodes = expectRows<{ id: string; name: string; qualified_name: string }>(
       this.db
         .prepare("SELECT id, name, qualified_name FROM nodes WHERE file_id = ?")
         .all(result.fileId),
       ["id", "name", "qualified_name"],
     );
+    const ownNodeIds = ownNodes.map((n) => n.id);
+    if (ownNodeIds.length === 0) {
+      return;
+    }
+
+    // Per-flag rebuild. The pattern is identical for each flag:
+    //   1. Ensure every node in this file has an attributes row
+    //      (default 0,0). INSERT OR IGNORE keeps any existing row.
+    //   2. If the IR field for this flag is present, wipe the column
+    //      for this file's nodes (so removed flags clear), then set
+    //      the column for nodes in the new set.
+    //   3. If the IR field is omitted, leave the column untouched.
+    const ensureRow = this.db.prepare(
+      `INSERT OR IGNORE INTO node_attributes (node_id, is_exported, is_route_handler)
+         VALUES (?, 0, 0)`,
+    );
+    for (const id of ownNodeIds) ensureRow.run(id);
+
     if (ir.exports != null) {
       const exportNames = new Set<string>();
       for (const ex of ir.exports) {
@@ -1329,10 +1346,23 @@ export class GraphStore {
           exportNames.add(ex.name);
         }
       }
+      const newExportedIds = new Set<string>();
       for (const n of ownNodes) {
-        if (exportNames.has(n.name)) exportedNodeIds.add(n.id);
+        if (exportNames.has(n.name)) newExportedIds.add(n.id);
       }
+      // Wipe is_exported for this file's nodes, chunked under the
+      // SQLite variable limit. The other column is untouched.
+      this.runChunkedUpdate(
+        `UPDATE node_attributes SET is_exported = 0 WHERE node_id IN (%PH%)`,
+        ownNodeIds,
+      );
+      // Set the flag for the new exported set.
+      const setExported = this.db.prepare(
+        `UPDATE node_attributes SET is_exported = 1 WHERE node_id = ?`,
+      );
+      for (const id of newExportedIds) setExported.run(id);
     }
+
     if (ir.routes != null) {
       const handlerQNames = new Set<string>();
       for (const r of ir.routes) {
@@ -1340,47 +1370,32 @@ export class GraphStore {
           handlerQNames.add(r.handlerQualifiedName);
         }
       }
+      const newRouteIds = new Set<string>();
       for (const n of ownNodes) {
-        if (handlerQNames.has(n.qualified_name)) routeHandlerNodeIds.add(n.id);
+        if (handlerQNames.has(n.qualified_name)) newRouteIds.add(n.id);
       }
+      this.runChunkedUpdate(
+        `UPDATE node_attributes SET is_route_handler = 0 WHERE node_id IN (%PH%)`,
+        ownNodeIds,
+      );
+      const setRoute = this.db.prepare(
+        `UPDATE node_attributes SET is_route_handler = 1 WHERE node_id = ?`,
+      );
+      for (const id of newRouteIds) setRoute.run(id);
     }
+  }
 
-    // Delete-then-insert per file: the prior rows for this file's
-    // nodes are wiped so changed exports overwrite. Without this, a
-    // re-ingest that drops an export would leave the old flag set,
-    // silently hiding a now-dead symbol from `deadCode()`. Chunked
-    // under the SQLite variable limit to handle large symbol tables.
-    const ownNodeIds = ownNodes.map((n) => n.id);
-    if (ownNodeIds.length > 0) {
-      for (let i = 0; i < ownNodeIds.length; i += SQLITE_VARIABLE_LIMIT) {
-        const chunk = ownNodeIds.slice(i, i + SQLITE_VARIABLE_LIMIT);
-        const placeholders = chunk.map(() => "?").join(", ");
-        this.db
-          .prepare(
-            `DELETE FROM node_attributes WHERE node_id IN (${placeholders})`,
-          )
-          .run(...chunk);
-      }
-    }
-
-    // Insert fresh rows for nodes carrying either flag. A node with
-    // neither flag set does not get a row at all — the deadCode LEFT
-    // JOIN COALESCEs the missing row to (0, 0).
-    const flagged = new Set<string>([...exportedNodeIds, ...routeHandlerNodeIds]);
-    if (flagged.size === 0) {
-      return;
-    }
-    const upsertAttr = this.db.prepare(
-      `INSERT INTO node_attributes (node_id, is_exported, is_route_handler)
-         VALUES (?, ?, ?)
-       ON CONFLICT(node_id) DO UPDATE SET
-         is_exported = excluded.is_exported,
-         is_route_handler = excluded.is_route_handler`,
-    );
-    for (const id of flagged) {
-      const isExported = exportedNodeIds.has(id) ? 1 : 0;
-      const isRoute = routeHandlerNodeIds.has(id) ? 1 : 0;
-      upsertAttr.run(id, isExported, isRoute);
+  /**
+   * Chunk a parameterized UPDATE-with-IN-list under SQLite's variable
+   * bind limit. The SQL template uses `%PH%` as a placeholder for the
+   * `?,?,…` list. Mirrors the chunking pattern PR1 uses for deletes.
+   */
+  private runChunkedUpdate(sqlTemplate: string, params: readonly string[]): void {
+    if (params.length === 0) return;
+    for (let i = 0; i < params.length; i += SQLITE_VARIABLE_LIMIT) {
+      const chunk = params.slice(i, i + SQLITE_VARIABLE_LIMIT);
+      const placeholders = chunk.map(() => "?").join(", ");
+      this.db.prepare(sqlTemplate.replace("%PH%", placeholders)).run(...chunk);
     }
   }
 
@@ -1411,7 +1426,19 @@ export class GraphStore {
         code: "invalid_query",
       };
     }
+    // Validate direction against the allowed set (rule 51 +
+    // chatgpt-codex-connector P2: 'Reject invalid traversal directions
+    // explicitly'). Without this a typo like "outbound" silently falls
+    // through none of the branches and returns only the start node,
+    // masquerading as a valid empty expansion.
     const direction: TraverseDirection = query.direction ?? "outgoing";
+    if (
+      direction !== "outgoing" &&
+      direction !== "incoming" &&
+      direction !== "both"
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
     // Resolve the start node. If `start` is a 64-char hex string, treat
     // it as a node id; otherwise resolve by qualified_name (ambiguous →
     // explicit rejection so the caller can pass an id).
@@ -1795,7 +1822,7 @@ export class GraphStore {
    * on-disk bytes.
    */
   async snippetFor(query: SnippetQuery): Promise<SnippetResult> {
-    if (this.closed) return { ok: false, code: "repo_root_unset" };
+    if (this.closed) return { ok: false, code: "store_closed" };
     if (
       typeof query.qualifiedName !== "string" ||
       query.qualifiedName.length === 0

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -164,7 +164,7 @@ export interface StoreFileIR {
 // Result shapes — tagged failures (rule 34).
 // ──────────────────────────────────────────────────────────────────────────
 
-export type GraphStoreFailureCode = "db_locked" | "db_corrupt" | "store_closed";
+export type GraphStoreFailureCode = "db_locked" | "db_corrupt" | "db_error" | "store_closed";
 
 export interface GraphStoreFailure {
   ok: false;
@@ -361,7 +361,13 @@ export type SnippetFailureCode =
   | "repo_root_unset"
   | "read_failed"
   | "invalid_query"
-  | "store_closed";
+  | "store_closed"
+  // DB-level failures surface from the node-lookup catch path so the
+  // typed contract matches every code classifyReadError can return
+  // (cursor Bugbot: 'snippetFor omits store failure codes').
+  | "db_locked"
+  | "db_corrupt"
+  | "db_error";
 
 export type SnippetResult = SnippetSuccess | { ok: false; code: SnippetFailureCode };
 
@@ -742,6 +748,30 @@ export class GraphStore {
       // symbol spans before storing nodes').
       for (const sym of symbolsField) {
         assertValidSymbolSpan(sym, ir.path);
+      }
+      // Attribute arrays: `exports` and `routes` are optional, but
+      // when present MUST be arrays. A malformed non-array (e.g. a
+      // JSON caller passing `exports: "publicApi"`) is iterable as
+      // characters whose entries have no `.name`, so the per-flag
+      // rebuild in upsertFileAttributes would compute an empty set
+      // and then WIPE every is_exported / is_route_handler flag for
+      // the file — turning a single bad re-ingest into silent
+      // dead-code misclassification. Reject at the boundary like the
+      // symbols check above (chatgpt-codex-connector P2: 'Validate
+      // attribute arrays before clearing flags').
+      if (ir.exports != null && !Array.isArray(ir.exports)) {
+        throw new Error(
+          `graph-store: file '${ir.path}' exports must be an array when present; received ${
+            ir.exports === null ? "null" : typeof ir.exports
+          } — refusing to ingest to avoid wiping existing flags`,
+        );
+      }
+      if (ir.routes != null && !Array.isArray(ir.routes)) {
+        throw new Error(
+          `graph-store: file '${ir.path}' routes must be an array when present; received ${
+            ir.routes === null ? "null" : typeof ir.routes
+          } — refusing to ingest to avoid wiping existing flags`,
+        );
       }
     }
     try {
@@ -1451,6 +1481,19 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
+    // Validate `start` is a non-empty string before it reaches the
+    // SQLite bind (rule 51 + chatgpt-codex-connector P2: 'Validate
+    // traverse start before binding it'). A JS/JSON caller passing an
+    // object/array survives the regex `.test()` coercion but then
+    // throws a non-SQLite TypeError at bind time; surface that as the
+    // precise `invalid_query` rather than letting it fall through to
+    // the generic db_error catch-all.
+    if (
+      typeof query.start !== "string" ||
+      query.start.length === 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
     // Wrap DB operations in try/catch so lock/corrupt errors return a
     // tagged failure instead of throwing (cursor Bugbot: 'SQLite errors
     // escape read APIs'). Same shape as schemaStats/deadCode.
@@ -1596,7 +1639,7 @@ export class GraphStore {
     return { ok: true, hits };
     } catch (error) {
       logWriteFailure(error);
-      return classifyError(error) as TraverseResult;
+      return classifyReadError(error) as TraverseResult;
     }
   }
 
@@ -1733,7 +1776,7 @@ export class GraphStore {
     return { ok: true, hits };
     } catch (error) {
       logWriteFailure(error);
-      return classifyError(error) as SearchResult;
+      return classifyReadError(error) as SearchResult;
     }
   }
 
@@ -1789,7 +1832,7 @@ export class GraphStore {
       };
     } catch (error) {
       logWriteFailure(error);
-      const failure = classifyError(error);
+      const failure = classifyReadError(error);
       return failure as unknown as SchemaStatsResult;
     }
   }
@@ -1819,6 +1862,13 @@ export class GraphStore {
       // COALESCE is belt-and-braces — the LEFT JOIN already produces
       // NULL for missing rows, and `NULL OR ...` would surface NULL
       // in the WHERE; explicit COALESCE collapses NULL → 0.
+      // Self-edges (e.src <> n.id) are excluded from inbound usage: a
+      // private recursive helper whose only edge is `fn → fn` is
+      // unreachable from the rest of the program, so the self-call
+      // must not count as external usage — otherwise deadCode() omits
+      // it and the unreferenced symbol stays invisible
+      // (chatgpt-codex-connector P2: 'Ignore self-edges in dead-code
+      // reachability').
       const sql = `SELECT n.id AS node_id, n.qualified_name, n.name, n.label,
                           f.path AS file_path
                      FROM nodes n
@@ -1827,6 +1877,7 @@ export class GraphStore {
                     WHERE NOT EXISTS (
                        SELECT 1 FROM edges e
                         WHERE e.dst = n.id
+                          AND e.src <> n.id
                           AND e.type IN (${typePlaceholders})
                      )
                       AND COALESCE(a.is_exported, 0) = 0
@@ -1862,7 +1913,7 @@ export class GraphStore {
       return { ok: true, hits };
     } catch (error) {
       logWriteFailure(error);
-      const failure = classifyError(error);
+      const failure = classifyReadError(error);
       return failure as unknown as DeadCodeResult;
     }
   }
@@ -1916,7 +1967,7 @@ export class GraphStore {
       );
     } catch (error) {
       logWriteFailure(error);
-      return classifyError(error) as unknown as SnippetResult;
+      return classifyReadError(error) as unknown as SnippetResult;
     }
     if (rows.length === 0) return { ok: false, code: "not_found" };
     if (rows.length > 1) return { ok: false, code: "ambiguous_name" };
@@ -2123,6 +2174,33 @@ function classifyError(error: unknown): GraphStoreFailure {
   // trusting the store for the wrong reason; re-throw so the caller
   // sees the real error (chatgpt-codex-connector P2).
   throw error instanceof Error ? error : new Error(String(error ?? ""));
+}
+
+/**
+ * Read-path error classifier. Unlike {@link classifyError} (write
+ * path), this is TOTAL — it never throws. Every unexpected error
+ * maps to a tagged `db_error` failure so the read APIs
+ * (`traverse`/`searchGraph`/`schemaStats`/`deadCode`/`snippetFor`)
+ * honor their advertised discriminated-union contract: a caller that
+ * exhaustively switches on `result.code` never observes a throw
+ * (cursor Bugbot: 'Read APIs rethrow SQLite errors';
+ * chatgpt-codex-connector P2: 'Return tagged failures from read
+ * queries'). The write path keeps {@link classifyError} because its
+ * validation throws (duplicate path, bad confidence, non-array
+ * symbols) are intentional fail-loud contract violations that
+ * callers and tests catch as rejections.
+ *
+ * `db_error` is deliberately distinct from `db_corrupt` so a generic
+ * failure does not signal the caller to stop trusting the DB
+ * (chatgpt-codex-connector P2: do not conflate unexpected errors
+ * with corruption).
+ */
+function classifyReadError(error: unknown): GraphStoreFailure {
+  try {
+    return classifyError(error);
+  } catch {
+    return { ok: false, code: "db_error" };
+  }
 }
 
 function hasErrorCode(value: unknown): value is { code: string } {

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1451,6 +1451,10 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
+    // Wrap DB operations in try/catch so lock/corrupt errors return a
+    // tagged failure instead of throwing (cursor Bugbot: 'SQLite errors
+    // escape read APIs'). Same shape as schemaStats/deadCode.
+    try {
     // Resolve the start node. If `start` is a 64-char lowercase hex
     // string (the nodeIdFor sha256 format), resolve ONLY by id — this
     // is the unambiguous path a caller uses after seeing an ambiguous
@@ -1590,6 +1594,10 @@ export class GraphStore {
       frontier = nextFrontier;
     }
     return { ok: true, hits };
+    } catch (error) {
+      logWriteFailure(error);
+      return classifyError(error) as TraverseResult;
+    }
   }
 
   /**
@@ -1650,6 +1658,9 @@ export class GraphStore {
       return { ok: false, code: "invalid_query" };
     }
 
+    // Wrap DB operations in try/catch (cursor Bugbot: 'SQLite errors
+    // escape read APIs'). Same shape as schemaStats/deadCode/traverse.
+    try {
     // Build a single parameterized query. The degree subquery counts
     // inbound + outbound edges per node; the WHERE clause AND-combines
     // every present filter; the LIMIT is bound last. LIKE patterns are
@@ -1720,6 +1731,10 @@ export class GraphStore {
       degree: r.degree,
     }));
     return { ok: true, hits };
+    } catch (error) {
+      logWriteFailure(error);
+      return classifyError(error) as SearchResult;
+    }
   }
 
   /**
@@ -1870,28 +1885,39 @@ export class GraphStore {
     if (this.repoRoot === undefined) {
       return { ok: false, code: "repo_root_unset" };
     }
-    // Resolve the node. A qualified_name might match multiple nodes
-    // (declared in multiple files); ambiguous matches are rejected so
-    // the caller can pass a node id via a future extension or include
-    // the file in the same batch.
-    const rows = expectRows<{
+    // Wrap the DB lookup in try/catch (cursor Bugbot: 'SQLite errors
+    // escape read APIs'). The file read below has its own catch.
+    let rows: {
       id: string;
       qualified_name: string;
       file_path: string;
       span_start: number;
       span_end: number;
       lang: string;
-    }>(
-      this.db
-        .prepare(
-          `SELECT n.id, n.qualified_name, n.span_start, n.span_end, n.lang,
-                  f.path AS file_path
-             FROM nodes n JOIN files f ON n.file_id = f.id
-            WHERE n.qualified_name = ?`,
-        )
-        .all(query.qualifiedName),
-      ["id", "qualified_name", "file_path", "span_start", "span_end", "lang"],
-    );
+    }[];
+    try {
+      rows = expectRows<{
+        id: string;
+        qualified_name: string;
+        file_path: string;
+        span_start: number;
+        span_end: number;
+        lang: string;
+      }>(
+        this.db
+          .prepare(
+            `SELECT n.id, n.qualified_name, n.span_start, n.span_end, n.lang,
+                    f.path AS file_path
+               FROM nodes n JOIN files f ON n.file_id = f.id
+              WHERE n.qualified_name = ?`,
+          )
+          .all(query.qualifiedName),
+        ["id", "qualified_name", "file_path", "span_start", "span_end", "lang"],
+      );
+    } catch (error) {
+      logWriteFailure(error);
+      return classifyError(error) as unknown as SnippetResult;
+    }
     if (rows.length === 0) return { ok: false, code: "not_found" };
     if (rows.length > 1) return { ok: false, code: "ambiguous_name" };
     const node = rows[0]!;

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1439,6 +1439,18 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
+    // Validate edgeTypes, if present, is an array of strings (rule 51 +
+    // chatgpt-codex-connector P2: 'Validate edgeTypes before building
+    // traversal SQL'). A malformed value like a bare string "CALLS"
+    // would otherwise throw at .map() instead of returning the
+    // tagged invalid_query failure the contract advertises.
+    if (
+      query.edgeTypes !== undefined &&
+      (!Array.isArray(query.edgeTypes) ||
+        !query.edgeTypes.every((e) => typeof e === "string"))
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
     // Resolve the start node. If `start` is a 64-char lowercase hex
     // string (the nodeIdFor sha256 format), resolve ONLY by id — this
     // is the unambiguous path a caller uses after seeing an ambiguous
@@ -1622,6 +1634,21 @@ export class GraphStore {
     // hits array (rule 27 — guard the slice/LIMIT against zero).
     const MAX_SEARCH_LIMIT = 1000;
     const limit = Math.min(rawLimit, MAX_SEARCH_LIMIT);
+
+    // Validate string filters are strings when present (rule 51 +
+    // chatgpt-codex-connector P2: 'Reject non-string search patterns
+    // instead of dropping filters'). A non-string like namePattern: 42
+    // has undefined .length, so the guard below would silently drop
+    // the filter and return unrelated nodes. Reject up-front instead.
+    if (
+      (query.label !== undefined && typeof query.label !== "string") ||
+      (query.namePattern !== undefined &&
+        typeof query.namePattern !== "string") ||
+      (query.filePattern !== undefined &&
+        typeof query.filePattern !== "string")
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
 
     // Build a single parameterized query. The degree subquery counts
     // inbound + outbound edges per node; the WHERE clause AND-combines

--- a/packages/coding-graph/src/index.ts
+++ b/packages/coding-graph/src/index.ts
@@ -155,12 +155,13 @@ export type {
 };
 
 // ---------------------------------------------------------------------------
-// SQLite knowledge-graph store (#1552 PR1): versioned schema + write
-// pipeline. Re-exported from the package root so consumers can import
-// `import { GraphStore } from "@remnic/coding-graph"` (the subpath
-// exports `./graph-schema` and `./graph-store` remain available for
-// callers that want only one half). Only non-colliding store types are
-// re-exported here — see the file header's IR-type policy note.
+// SQLite knowledge-graph store (#1552 PR1 + PR2): versioned schema, write
+// pipeline, and PR2 read primitives (traverse / searchGraph / schemaStats /
+// deadCode / snippetFor). Re-exported from the package root so consumers
+// can import `import { GraphStore } from "@remnic/coding-graph"` (the
+// subpath exports `./graph-schema` and `./graph-store` remain available
+// for callers that want only one half). Only non-colliding store types
+// are re-exported here — see the file header's IR-type policy note.
 // ---------------------------------------------------------------------------
 
 export {
@@ -175,7 +176,10 @@ export {
 export {
   GraphStore,
   nodeIdFor,
+  DEAD_CODE_EXCLUSION,
   type ByteSpan,
+  type DeadCodeHit,
+  type DeadCodeResult,
   type EdgeIR,
   type ExportIR,
   type GraphStoreFailure,
@@ -183,8 +187,21 @@ export {
   type GraphStoreOptions,
   type ImportIR,
   type NodeIdInput,
+  type SchemaStats,
+  type SchemaStatsResult,
+  type SearchHit,
+  type SearchQuery,
+  type SearchResult,
+  type SnippetFailureCode,
+  type SnippetQuery,
+  type SnippetResult,
+  type SnippetSuccess,
   type StoreFileIR,
   type SymbolKind,
+  type TraverseDirection,
+  type TraverseHit,
+  type TraverseQuery,
+  type TraverseResult,
   type UpsertBatchResult,
   type UpsertResult,
   type UpsertSuccess,


### PR DESCRIPTION
Part of #1548 (Track B) + #1520. Implements issue #1552 step 4-5 (PR2 slice): the structured read-side API the coding-graph store exposes to agents. PR1 (schema + writes) is merged; this builds on `packages/coding-graph/src/graph-store.ts`.

## Summary

Adds the structured query primitives the issue specifies for PR2:

- **`traverse({start, direction, edgeTypes, maxDepth})`** — iterative frontier BFS over the edges table. Cycle-safe via a JS visited set keyed by node id; depth-capped **half-open** (`depth == maxDepth` INCLUDED, `maxDepth+1` NOT — rule 35). Direction: outgoing / incoming / both. Rejects unknown / ambiguous start and invalid `maxDepth` with tagged failures (rule 34/51).
- **`searchGraph({label, namePattern, filePattern, degreeMin/Max, limit})`** — AND-combined filters; LIKE patterns are parameter-bound and case-insensitive (`COLLATE NOCASE`); `limit` clamped to `[0, 1000]` with the rule-27 zero guard. Degree filter uses a correlated COUNT subquery in WHERE (HAVING requires GROUP BY, which this row-per-node query has none).
- **`schemaStats()`** — `files` / `nodes` / `edges` plus by-label and by-type histograms.
- **`deadCode()`** — nodes with zero inbound usage edges, excluding exports, entry points, tests, and route handlers. The exclusion set is the explicit `DEAD_CODE_EXCLUSION` named constant (rule 53 analog) — single source of truth for inbound-usage edge types, test/entry-point path regexes, and the `node_attributes` flag columns.
- **`snippetFor({qualifiedName, contextLines})`** — reads source spans from disk via optional `repoRoot`. The store NEVER persists file contents (privacy + DB size); `snippetFor` resolves `files.path` against `repoRoot` and slices `[startByte, endByte)`. Line-aligned `contextLines` expansion.

## Schema (additive — no version bump)

`node_attributes(node_id PK REFERENCES nodes(id) ON DELETE CASCADE, is_exported INTEGER NOT NULL CHECK IN (0,1), is_route_handler INTEGER NOT NULL CHECK IN (0,1))` — tracks the per-node exclusion flags consumed by `deadCode()`. `CREATE TABLE IF NOT EXISTS` so existing v1 databases gain the table on the next `open()` with no migration (rule 23 — additive, characterized before moving). The `foreign_keys=ON` pragma set in `GraphStore.open()` makes attribute rows cascade-delete with their node.

## Write pipeline (Pass 3 inside the same transaction)

`upsertFileAttributes` derives `is_exported` (per-file name match against `FileIR.exports`) and `is_route_handler` (per-file `qualified_name` match against `FileIR.routes[].handlerQualifiedName`). Omitted fields preserve prior flags (PR1 baseline); explicit `[]` wipes them — same semantics as the edges pass. Delete-then-insert per file so a re-ingest that drops an export overwrites the prior flag.

`StoreFileIR` gains optional `exports` / `routes` fields (mirrors core `FileIR`). A core `ParseResult.ir` remains structurally assignable with zero casts.

## SQL IN(...) chunking

PR1 reviews already hardened this class. PR2 follows the same pattern: a new `chunkedInQuery` helper, the chunked FTS rowid deletes in `pruneFileNodes`, the chunked stale-edge tuple deletes in `upsertFileEdges`, and now the chunked `node_attributes` deletes in `upsertFileAttributes`. Every IN list stays under SQLite's 32766 variable bind limit.

## Test evidence

`pnpm --filter @remnic/coding-graph test` → **63/63 pass** (31 PR1 unchanged + 32 new PR2):

- `traverse`: cycle safety (back-edge), self-edge, half-open depth-cap boundary (depth 0/1/2 enumerated), direction (outgoing/incoming/both), `edgeTypes` filter, tagged failures for `unknown_start` / `ambiguous_start` / `invalid_query` / `store_closed`.
- `searchGraph`: empty query, LIKE `%` wildcards, case-insensitive matching, label / file-path filters, `degreeMin`/`degreeMax`, `limit` (including the rule-27 `limit: 0` → empty hits), `invalid_query` rejection.
- `schemaStats`: aggregate counts over a 2-file graph + empty-graph zeros.
- `deadCode`: the load-bearing fixture (exported-but-uncalled NOT reported; private uncalled IS), re-ingest that REMOVES an export re-classifies the symbol as dead, route-handler exclusion, entry-point path-pattern exclusion, test-path-pattern exclusion, and the named-constant shape lock.
- `snippetFor`: exact span read via `repoRoot`, line-aligned `contextLines` expansion, tagged failures for `repo_root_unset` / `not_found` / `read_failed` / `ambiguous_name`.

## Gates

- `pnpm --filter @remnic/coding-graph test` → 63/63 pass
- `pnpm --filter @remnic/coding-graph exec tsc --noEmit` → clean
- `pnpm --filter @remnic/coding-graph build` → clean
- `npm run preflight:quick` → `[preflight] OK (quick)`
- `node scripts/check-ratchets.mjs` → `[ratchet] OK` (baselines untouched)
- `node scripts/check-docs-parity.mjs` → `[docs-parity] OK`
- `bash scripts/check-review-patterns.sh` → `PASSED`

## Chokepoints used

None of the Wave-1 chokepoints apply to `@remnic/coding-graph` (it is a new package; `serialize-mutations`, `scope-plan`, the #1525 operation registry, and `CapabilitySet` are core-package concerns). The PR1 write-queue (rule 40) is reused unchanged.

## Done-when coverage (issue #1552 PR2 slice)

- ✅ traverse with cycles / self-edges / depth-cap boundary / degree filters covered by fixture tests
- ✅ searchGraph with all filters + tagged invalid_query rejection
- ✅ schemaStats
- ✅ deadCode with explicit named exclusion constant (exports, entry points, tests, route handlers); fixture proves exported-but-uncalled NOT reported while private-uncalled IS
- ✅ snippetFor reading spans from disk
- ✅ SQL IN(...) chunked (PR1 reviews already hardened the class; PR2 follows the same pattern)
- ✅ ratchet baselines untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface area on `GraphStore` (SQLite queries, ingest semantics, schema apply on downgrade) can misclassify dead code or corrupt future-version DBs if gating regresses; mitigated by extensive tests.
> 
> **Overview**
> Adds **PR2 read-side APIs** on `GraphStore`: `traverse`, `searchGraph`, `schemaStats`, `deadCode`, and `snippetFor` (optional `repoRoot`), with tagged failures (`invalid_query`, `db_error`, etc.) and stricter input validation on reads and writes.
> 
> Introduces additive **`node_attributes`** (`is_exported`, `is_route_handler`) and a **pass-3** `upsertFileAttributes` in the ingest transaction, driven by optional `exports` / `routes` on `StoreFileIR`, with per-flag updates so partial re-ingests do not clear the other flag. **`DEAD_CODE_EXCLUSION`** centralizes dead-code rules (usage edge types, path patterns, attribute flags); self-edges do not count as inbound usage.
> 
> **`applyCodingGraphSchema`** now skips DDL and version writes when the on-disk `schema_version` is newer than this code, and avoids downgrading future DBs; v1 stores still gain `node_attributes` via `CREATE TABLE IF NOT EXISTS` without a version bump.
> 
> Exports new types from the package root; adds **`graph-store-pr2.test.ts`** and schema tests for additive/future-version behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9a6807a394177fb9ca97b7e7af1a020963a7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->