### PR TITLE
ci(unsticker): clear every stuck suite, not just the newest run

### DIFF
--- a/.github/workflows/check-unsticker.yml
+++ b/.github/workflows/check-unsticker.yml
@@ -108,38 +108,39 @@ jobs:
                 .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
             }
 
-            const CURSOR_LOGINS = new Set(['cursor-bugbot', 'cursor', 'cursor-bugbot[bot]', 'cursor[bot]']);
+            const CURSOR_APP_SLUGS = new Set(['cursor-bugbot', 'cursor']);
 
-            // Current-head positive Cursor signal, mirroring the two signal
-            // shapes the gate itself trusts most: a passing cursor check run
-            // on the head, or a cursor APPROVED review pinned to the head
-            // commit. Used to decide when a FAILED gate suite is stale (it
-            // failed before the reviewer spoke) and worth its one retry.
-            async function hasPositiveCursorSignal(headSha, prNumber) {
+            // Positive Cursor CHECK on the head, judged by the LATEST run of
+            // each cursor check name (an older success never outranks a newer
+            // failure). This deliberately does NOT interpret reviews or
+            // comments: review/comment verdicts fire the gate workflow
+            // themselves (pull_request_review / pull_request_review_comment
+            // triggers), so they surface to the sweeper as a green gate suite
+            // on the head — the gate's own evaluation stays the single
+            // authority on verdict semantics. Only the check_run signal path
+            // needs separate detection here, because check_run-triggered gate
+            // runs execute in default-branch context and never create a green
+            // suite on the PR head.
+            async function hasPositiveCursorCheck(headSha) {
               const checkRuns = await github.paginate(github.rest.checks.listForRef, {
                 owner,
                 repo,
                 ref: headSha,
                 per_page: 100,
               });
-              const positiveCheck = checkRuns.some(
-                (checkRun) =>
-                  CURSOR_LOGINS.has(checkRun.app?.slug ?? '') &&
-                  checkRun.status === 'completed' &&
-                  ['success', 'neutral'].includes(checkRun.conclusion ?? ''),
-              );
-              if (positiveCheck) return true;
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner,
-                repo,
-                pull_number: prNumber,
-                per_page: 100,
-              });
-              return reviews.some(
-                (review) =>
-                  CURSOR_LOGINS.has((review.user?.login ?? '').toLowerCase()) &&
-                  review.state === 'APPROVED' &&
-                  review.commit_id === headSha,
+              const latestByName = new Map();
+              for (const checkRun of checkRuns) {
+                if (!CURSOR_APP_SLUGS.has(checkRun.app?.slug ?? '')) continue;
+                if (checkRun.status !== 'completed') continue;
+                const key = checkRun.name ?? 'unnamed';
+                const previous = latestByName.get(key);
+                const time = Date.parse(checkRun.completed_at ?? checkRun.started_at ?? '') || 0;
+                if (!previous || time >= previous.time) {
+                  latestByName.set(key, { time, conclusion: checkRun.conclusion ?? '' });
+                }
+              }
+              return [...latestByName.values()].some((entry) =>
+                ['success', 'neutral'].includes(entry.conclusion),
               );
             }
 
@@ -199,9 +200,12 @@ jobs:
               }
               // Cancelled suites are always retryable (cancellation is not a
               // verdict). Failed suites get ONE retry (run_attempt 1), and
-              // only after a positive Cursor signal exists on the head —
-              // i.e. the failure predates the reviewer's verdict and a
-              // re-evaluation can genuinely pass. The attempt bound prevents
+              // only once the head demonstrably satisfies the gate: either a
+              // sibling gate suite already re-evaluated to green (covers
+              // review/comment-delivered verdicts, which trigger the gate),
+              // or the latest cursor check run on the head is positive
+              // (covers check-only verdicts, whose gate runs land on the
+              // default branch, not the PR head). The attempt bound prevents
               // rerun loops on legitimately failing gates.
               const cancelledGate = gateRuns.filter(
                 (run) => run.status === 'completed' && run.conclusion === 'cancelled',
@@ -210,8 +214,13 @@ jobs:
                 (run) => run.status === 'completed' && run.conclusion === 'failure' && run.run_attempt === 1,
               );
               let target = cancelledGate[0] ?? null;
-              if (!target && staleFailedGate.length > 0 && (await hasPositiveCursorSignal(headSha, pull.number))) {
-                target = staleFailedGate[0];
+              if (!target && staleFailedGate.length > 0) {
+                const greenSuiteExists = gateRuns.some(
+                  (run) => run.status === 'completed' && run.conclusion === 'success',
+                );
+                if (greenSuiteExists || (await hasPositiveCursorCheck(headSha))) {
+                  target = staleFailedGate[0];
+                }
               }
               if (target) {
                 await rerun(target, `${label} ai-review gate`);

--- a/.github/workflows/check-unsticker.yml
+++ b/.github/workflows/check-unsticker.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   unstick:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 10
     steps:
       - name: Rerun stuck required checks
         uses: actions/github-script@v7
@@ -85,19 +85,14 @@ jobs:
               return count;
             }
 
-            // All completed runs of `workflowFile` on `headSha` attributable
-            // to `prNumber` with a conclusion in `conclusions`. Scoped to the
-            // workflow (not the whole repo) so busy SHAs cannot push target
-            // runs past the first page (cursor review on #1610), and filtered
-            // by the run's pull_requests association so sibling PRs sharing a
-            // head SHA are not cross-rerun (codex review on #1610). Runs with
-            // an empty pull_requests array cannot be attributed and are kept.
-            //
-            // ALL matching suites matter, not just the newest: the branch
-            // ruleset requires the latest attempt of EVERY check suite on the
-            // head to pass, so one lingering cancelled/failed suite blocks the
-            // merge even when a newer run is green (#1610 postmortem).
-            async function stuckRunsFor(workflowFile, headSha, prNumber, conclusions) {
+            // All runs of `workflowFile` on `headSha` attributable to
+            // `prNumber`. Scoped to the workflow (not the whole repo) so busy
+            // SHAs cannot push target runs past the first page (cursor review
+            // on #1610), and filtered by the run's pull_requests association
+            // so sibling PRs sharing a head SHA are not cross-rerun (codex
+            // review on #1610). Runs with an empty pull_requests array cannot
+            // be attributed and are kept.
+            async function runsFor(workflowFile, headSha, prNumber) {
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
@@ -110,19 +105,26 @@ jobs:
                   const prs = run.pull_requests ?? [];
                   return prs.length === 0 || prs.some((pr) => pr.number === prNumber);
                 })
-                .filter((run) => run.status === 'completed' && conclusions.includes(run.conclusion))
                 .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
             }
 
-            async function waitForRun(runId, timeoutMs) {
-              const startedAt = Date.now();
-              const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-              while (Date.now() - startedAt < timeoutMs) {
-                await sleep(10_000);
-                const { data } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-                if (data.status === 'completed') return data.conclusion;
-              }
-              return null;
+            // Current-head positive Cursor signal: a completed cursor/
+            // cursor-bugbot check run with a passing conclusion. Used to
+            // decide when a FAILED gate suite is stale (it failed before the
+            // reviewer spoke) and worth one retry.
+            async function hasPositiveCursorCheck(headSha) {
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: headSha,
+                per_page: 100,
+              });
+              return checkRuns.some(
+                (checkRun) =>
+                  ['cursor-bugbot', 'cursor'].includes(checkRun.app?.slug ?? '') &&
+                  checkRun.status === 'completed' &&
+                  ['success', 'neutral'].includes(checkRun.conclusion ?? ''),
+              );
             }
 
             async function rerun(run, label) {
@@ -149,9 +151,12 @@ jobs:
               const label = `PR #${pull.number}`;
 
               // Case 1: guard suite(s) failed but threads are now resolved.
-              // Guard runs have no concurrency group, so all can be rerun at
-              // once.
-              const guardRuns = await stuckRunsFor('review-thread-guard.yml', headSha, pull.number, ['failure']);
+              // The ruleset requires the latest attempt of EVERY suite on the
+              // head to pass, so ALL failed suites are rerun, not just the
+              // newest (#1610 postmortem). Guard runs have no concurrency
+              // group, so parallel reruns are safe.
+              const guardRuns = (await runsFor('review-thread-guard.yml', headSha, pull.number))
+                .filter((run) => run.status === 'completed' && run.conclusion === 'failure');
               if (guardRuns.length > 0) {
                 const unresolved = await unresolvedThreadCount(pull.number);
                 if (unresolved === 0) {
@@ -163,19 +168,36 @@ jobs:
                 }
               }
 
-              // Case 2: terminally cancelled AI Review Gate suite(s). Gate
-              // reruns share a per-PR concurrency group with
-              // cancel-in-progress, so firing them concurrently would just
-              // re-cancel each other — rerun serially, waiting for each to
-              // conclude (a positive-verdict re-evaluation exits in seconds).
-              // Cap the serial work per sweep; the 5-minute cadence converges
-              // any remainder on the next pass.
-              const gateRuns = await stuckRunsFor('ai-review-gate.yml', headSha, pull.number, ['cancelled']);
-              const GATE_RERUNS_PER_SWEEP = 5;
-              for (const run of gateRuns.slice(0, GATE_RERUNS_PER_SWEEP)) {
-                await rerun(run, `${label} ai-review gate`);
-                const conclusion = await waitForRun(run.id, 90_000);
-                core.info(`${label}: gate rerun ${run.id} concluded ${conclusion ?? 'timeout — continuing next sweep'}`);
-                if (conclusion === null) break;
+              // Case 2: stuck AI Review Gate suites. Gate reruns share a
+              // per-PR concurrency group with cancel-in-progress and a rerun
+              // can legitimately poll for minutes, so the sweeper NEVER
+              // waits in-sweep and NEVER reruns while any gate evaluation is
+              // live — one rerun per PR per sweep, converging on the cron
+              // cadence without ever cancelling an in-flight evaluation
+              // (cursor High / codex P2 on #1615).
+              const gateRuns = await runsFor('ai-review-gate.yml', headSha, pull.number);
+              const gateActive = gateRuns.some((run) => run.status !== 'completed');
+              if (gateActive) {
+                core.info(`${label}: a gate evaluation is already active — no gate reruns this sweep.`);
+                continue;
+              }
+              // Cancelled suites are always retryable (cancellation is not a
+              // verdict). Failed suites get ONE retry (run_attempt 1), and
+              // only after a positive Cursor signal exists on the head —
+              // i.e. the failure predates the reviewer's verdict and a
+              // re-evaluation can genuinely pass. The attempt bound prevents
+              // rerun loops on legitimately failing gates.
+              const cancelledGate = gateRuns.filter(
+                (run) => run.status === 'completed' && run.conclusion === 'cancelled',
+              );
+              const staleFailedGate = gateRuns.filter(
+                (run) => run.status === 'completed' && run.conclusion === 'failure' && run.run_attempt === 1,
+              );
+              let target = cancelledGate[0] ?? null;
+              if (!target && staleFailedGate.length > 0 && (await hasPositiveCursorCheck(headSha))) {
+                target = staleFailedGate[0];
+              }
+              if (target) {
+                await rerun(target, `${label} ai-review gate`);
               }
             }

--- a/.github/workflows/check-unsticker.yml
+++ b/.github/workflows/check-unsticker.yml
@@ -93,14 +93,14 @@ jobs:
             // review on #1610). Runs with an empty pull_requests array cannot
             // be attributed and are kept.
             async function runsFor(workflowFile, headSha, prNumber) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
                 workflow_id: workflowFile,
                 head_sha: headSha,
                 per_page: 100,
               });
-              return (data.workflow_runs ?? [])
+              return workflowRuns
                 .filter((run) => {
                   const prs = run.pull_requests ?? [];
                   return prs.length === 0 || prs.some((pr) => pr.number === prNumber);
@@ -108,22 +108,38 @@ jobs:
                 .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
             }
 
-            // Current-head positive Cursor signal: a completed cursor/
-            // cursor-bugbot check run with a passing conclusion. Used to
-            // decide when a FAILED gate suite is stale (it failed before the
-            // reviewer spoke) and worth one retry.
-            async function hasPositiveCursorCheck(headSha) {
+            const CURSOR_LOGINS = new Set(['cursor-bugbot', 'cursor', 'cursor-bugbot[bot]', 'cursor[bot]']);
+
+            // Current-head positive Cursor signal, mirroring the two signal
+            // shapes the gate itself trusts most: a passing cursor check run
+            // on the head, or a cursor APPROVED review pinned to the head
+            // commit. Used to decide when a FAILED gate suite is stale (it
+            // failed before the reviewer spoke) and worth its one retry.
+            async function hasPositiveCursorSignal(headSha, prNumber) {
               const checkRuns = await github.paginate(github.rest.checks.listForRef, {
                 owner,
                 repo,
                 ref: headSha,
                 per_page: 100,
               });
-              return checkRuns.some(
+              const positiveCheck = checkRuns.some(
                 (checkRun) =>
-                  ['cursor-bugbot', 'cursor'].includes(checkRun.app?.slug ?? '') &&
+                  CURSOR_LOGINS.has(checkRun.app?.slug ?? '') &&
                   checkRun.status === 'completed' &&
                   ['success', 'neutral'].includes(checkRun.conclusion ?? ''),
+              );
+              if (positiveCheck) return true;
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              return reviews.some(
+                (review) =>
+                  CURSOR_LOGINS.has((review.user?.login ?? '').toLowerCase()) &&
+                  review.state === 'APPROVED' &&
+                  review.commit_id === headSha,
               );
             }
 
@@ -194,7 +210,7 @@ jobs:
                 (run) => run.status === 'completed' && run.conclusion === 'failure' && run.run_attempt === 1,
               );
               let target = cancelledGate[0] ?? null;
-              if (!target && staleFailedGate.length > 0 && (await hasPositiveCursorCheck(headSha))) {
+              if (!target && staleFailedGate.length > 0 && (await hasPositiveCursorSignal(headSha, pull.number))) {
                 target = staleFailedGate[0];
               }
               if (target) {

--- a/.github/workflows/check-unsticker.yml
+++ b/.github/workflows/check-unsticker.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   unstick:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     steps:
       - name: Rerun stuck required checks
         uses: actions/github-script@v7
@@ -85,14 +85,19 @@ jobs:
               return count;
             }
 
-            // Latest run of `workflowFile` on `headSha` attributable to
-            // `prNumber`, or null. Scoped to the workflow (not the whole
-            // repo) so busy SHAs cannot push the target run past the first
-            // page (cursor review on #1610), and filtered by the run's
-            // pull_requests association so sibling PRs sharing a head SHA
-            // are not cross-rerun (codex review on #1610). Runs with an
-            // empty pull_requests array cannot be attributed and are kept.
-            async function latestRunFor(workflowFile, headSha, prNumber) {
+            // All completed runs of `workflowFile` on `headSha` attributable
+            // to `prNumber` with a conclusion in `conclusions`. Scoped to the
+            // workflow (not the whole repo) so busy SHAs cannot push target
+            // runs past the first page (cursor review on #1610), and filtered
+            // by the run's pull_requests association so sibling PRs sharing a
+            // head SHA are not cross-rerun (codex review on #1610). Runs with
+            // an empty pull_requests array cannot be attributed and are kept.
+            //
+            // ALL matching suites matter, not just the newest: the branch
+            // ruleset requires the latest attempt of EVERY check suite on the
+            // head to pass, so one lingering cancelled/failed suite blocks the
+            // merge even when a newer run is green (#1610 postmortem).
+            async function stuckRunsFor(workflowFile, headSha, prNumber, conclusions) {
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
@@ -100,13 +105,24 @@ jobs:
                 head_sha: headSha,
                 per_page: 100,
               });
-              const runs = (data.workflow_runs ?? [])
+              return (data.workflow_runs ?? [])
                 .filter((run) => {
                   const prs = run.pull_requests ?? [];
                   return prs.length === 0 || prs.some((pr) => pr.number === prNumber);
                 })
-                .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
-              return runs[0] ?? null;
+                .filter((run) => run.status === 'completed' && conclusions.includes(run.conclusion))
+                .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+            }
+
+            async function waitForRun(runId, timeoutMs) {
+              const startedAt = Date.now();
+              const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+              while (Date.now() - startedAt < timeoutMs) {
+                await sleep(10_000);
+                const { data } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+                if (data.status === 'completed') return data.conclusion;
+              }
+              return null;
             }
 
             async function rerun(run, label) {
@@ -132,20 +148,34 @@ jobs:
               const headSha = pull.head.sha;
               const label = `PR #${pull.number}`;
 
-              // Case 1: guard failed but threads are now resolved.
-              const guardRun = await latestRunFor('review-thread-guard.yml', headSha, pull.number);
-              if (guardRun && guardRun.status === 'completed' && guardRun.conclusion === 'failure') {
+              // Case 1: guard suite(s) failed but threads are now resolved.
+              // Guard runs have no concurrency group, so all can be rerun at
+              // once.
+              const guardRuns = await stuckRunsFor('review-thread-guard.yml', headSha, pull.number, ['failure']);
+              if (guardRuns.length > 0) {
                 const unresolved = await unresolvedThreadCount(pull.number);
                 if (unresolved === 0) {
-                  await rerun(guardRun, `${label} review-thread guard`);
+                  for (const run of guardRuns) {
+                    await rerun(run, `${label} review-thread guard`);
+                  }
                 } else {
                   core.info(`${label}: guard failing with ${unresolved} unresolved thread(s) — legitimate, skipping.`);
                 }
               }
 
-              // Case 2: newest AI Review Gate run terminally cancelled.
-              const gateRun = await latestRunFor('ai-review-gate.yml', headSha, pull.number);
-              if (gateRun && gateRun.status === 'completed' && gateRun.conclusion === 'cancelled') {
-                await rerun(gateRun, `${label} ai-review gate`);
+              // Case 2: terminally cancelled AI Review Gate suite(s). Gate
+              // reruns share a per-PR concurrency group with
+              // cancel-in-progress, so firing them concurrently would just
+              // re-cancel each other — rerun serially, waiting for each to
+              // conclude (a positive-verdict re-evaluation exits in seconds).
+              // Cap the serial work per sweep; the 5-minute cadence converges
+              // any remainder on the next pass.
+              const gateRuns = await stuckRunsFor('ai-review-gate.yml', headSha, pull.number, ['cancelled']);
+              const GATE_RERUNS_PER_SWEEP = 5;
+              for (const run of gateRuns.slice(0, GATE_RERUNS_PER_SWEEP)) {
+                await rerun(run, `${label} ai-review gate`);
+                const conclusion = await waitForRun(run.id, 90_000);
+                core.info(`${label}: gate rerun ${run.id} concluded ${conclusion ?? 'timeout — continuing next sweep'}`);
+                if (conclusion === null) break;
               }
             }

--- a/.github/workflows/check-unsticker.yml
+++ b/.github/workflows/check-unsticker.yml
@@ -199,9 +199,12 @@ jobs:
                 continue;
               }
               // Cancelled suites are always retryable (cancellation is not a
-              // verdict). Failed suites get ONE retry (run_attempt 1), and
-              // only once the head demonstrably satisfies the gate: either a
-              // sibling gate suite already re-evaluated to green (covers
+              // verdict). Failed suites are retried while run_attempt <= 2 —
+              // up to two verdict-gated retries, because a premature retry of
+              // a CANCELLED suite can itself mint an attempt-2 failure before
+              // the reviewer speaks (codex review on #1615) — and only once
+              // the head demonstrably satisfies the gate: either a sibling
+              // gate suite already re-evaluated to green (covers
               // review/comment-delivered verdicts, which trigger the gate),
               // or the latest cursor check run on the head is positive
               // (covers check-only verdicts, whose gate runs land on the
@@ -211,7 +214,7 @@ jobs:
                 (run) => run.status === 'completed' && run.conclusion === 'cancelled',
               );
               const staleFailedGate = gateRuns.filter(
-                (run) => run.status === 'completed' && run.conclusion === 'failure' && run.run_attempt === 1,
+                (run) => run.status === 'completed' && run.conclusion === 'failure' && run.run_attempt <= 2,
               );
               let target = cancelledGate[0] ?? null;
               if (!target && staleFailedGate.length > 0) {


### PR DESCRIPTION
## Summary

Merging #1610 itself exposed the gap: the ruleset evaluates the latest attempt of **every** check suite on the head, and the event-burst pattern leaves several terminally-cancelled gate suites (plus sometimes multiple failed guard suites). The v1 sweeper only reran the newest, so multi-suite bursts wouldn't fully self-heal.

- `stuckRunsFor()` returns ALL attributable completed runs with target conclusions (oldest first).
- Guard: rerun every failed suite in one sweep (no concurrency group → safe in parallel) once threads verify resolved.
- Gate: rerun serially with 90s completion waits (per-PR cancel-in-progress group would re-cancel concurrent reruns), capped at 5/sweep; the cron cadence converges any remainder.
- Job timeout raised 5→12 min to cover worst-case serial waits.

## Verification
- actionlint clean; embedded script passes `node --check`.
- The serial-wait rerun procedure is a mechanization of exactly what was executed manually to merge #1610 (6 cancelled gate suites + 1 failed guard suite → CLEAN).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gating automation (when required checks get rerun) with nuanced gate retry rules; mistakes could skip needed reruns or retry too aggressively, but guards remain thread-gated and gate retries are bounded.
> 
> **Overview**
> **Expands the Check Unsticker workflow** so branch rules that require every check suite on the head to pass can actually self-heal after event bursts.
> 
> `latestRunFor` becomes **`runsFor`**, using **`github.paginate`** to collect all attributable workflow runs on the head (not only the newest). **Review-thread guard:** when threads are resolved, the sweeper **reruns every completed failed guard run** in one pass instead of a single latest failure. **AI review gate:** it **skips gate reruns while any gate run is still in progress** (avoids fighting per-PR `cancel-in-progress` concurrency), then **at most one gate rerun per PR per sweep**—preferring **cancelled** runs, otherwise a **failed** run only if `run_attempt <= 2` and the head already looks satisfied (**a successful gate suite on the head** or **`hasPositiveCursorCheck`** for Cursor check-only paths). Job **timeout increases from 5 to 10 minutes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4940fc16eddd1b87d83ead07a9012b1cabbf572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->