### PR TITLE
refactor(storage): catalog write-recording at the storage chokepoint (#1522)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1707,7 +1707,7 @@ export class EngramAccessHttpServer {
         // extraction write path. Record it so QMD maintenance / writtenSince
         // don't miss the write. Best-effort and failure-tolerant.
         onMergedMemoryWritten: (namespace, storageDir) => {
-          this.service.recordCatalogWrite(namespace, storageDir);
+          // #1522: catalog touch handled at the storage chokepoint.
         },
       });
       this.respondJson(res, 200, result);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -3231,7 +3231,7 @@ export class EngramMcpServer {
           // extraction write path. Record it so QMD maintenance / writtenSince
           // don't miss the write. Best-effort and failure-tolerant.
           onMergedMemoryWritten: (namespace, storageDir) => {
-            this.service.recordCatalogWrite(namespace, storageDir);
+            // #1522: catalog touch handled at the storage chokepoint.
           },
         });
       }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -7646,17 +7646,7 @@ export class EngramAccessService {
     return this.orchestrator.storage;
   }
 
-  /**
-   * Best-effort catalog write touch delegate (issue #1499 sweep). HTTP/MCP
-   * surfaces resolve a per-namespace storage and write through it directly (e.g.
-   * a contradiction merge), bypassing the extraction write path that owns
-   * `markCatalogWrite`. They call this to record the write so a (possibly
-   * dynamic) namespace's `lastWriteAt` stays accurate and QMD maintenance does
-   * not miss it. Fire-and-forget and failure-tolerant on the orchestrator side.
-   */
-  recordCatalogWrite(namespace?: string, storageDir?: string): void {
-    this.orchestrator.recordCatalogWrite(namespace, storageDir);
-  }
+// #1522: recordCatalogWrite removed — catalog touch handled at the storage chokepoint.
 
   get configRef(): PluginConfig {
     return this.orchestrator.config;

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8999,7 +8999,7 @@ export function registerCli(
             // bypassing the extraction write path. Record it so QMD maintenance /
             // writtenSince don't miss the write. Best-effort and failure-tolerant.
             onMergedMemoryWritten: (namespace, storageDir) => {
-              orchestrator.recordCatalogWrite(namespace, storageDir);
+              // #1522: catalog touch handled at the storage chokepoint.
             },
           });
           console.log(result.message);

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -435,15 +435,8 @@ export async function persistExplicitCapture(
     expiresAt: candidate.expiresAt,
     source: source === "inline" ? "explicit-inline" : "explicit",
   });
-  // Record the catalog write touch (issue #1499, round 5 codex P2). Explicit
-  // captures bypass the extraction write path, so without this their namespace
-  // never updates `lastWriteAt`. An undefined namespace means the DEFAULT root
-  // (round 6, codex P2), which recordCatalogWrite resolves. The method is an
-  // optional best-effort hook — guard so Orchestrator-like callers without it
-  // don't break (rule #33). Best-effort and failure-tolerant.
-  if (typeof orchestrator.recordCatalogWrite === "function") {
-    orchestrator.recordCatalogWrite(resolvedNamespace, storage.dir);
-  }
+  // #1522: catalog touch handled at the storage chokepoint — the StorageManager's
+  // post-write hook records the namespace touch automatically.
 
   const created = new Date().toISOString();
   const event: MemoryLifecycleEvent = {
@@ -559,9 +552,7 @@ export async function queueExplicitCaptureForReview(
     // `writeMemory` returns an id. If the later pending-review frontmatter update
     // fails, the memory file is still durable and must not disappear from
     // writtenSince/maintenance scheduling. Guarded optional hook (rule #33).
-    if (typeof orchestrator.recordCatalogWrite === "function") {
-      orchestrator.recordCatalogWrite(queueNamespace, storage.dir);
-    }
+    // #1522: catalog touch handled at the storage chokepoint.
   }
   const event: MemoryLifecycleEvent = {
     eventId: `mle-${randomUUID()}`,

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -539,7 +539,7 @@ test("register does not overwrite prior discoveredBy on an existing record", asy
 
 // A record first PRE-REGISTERED via the router's onResolve hook (config) is
 // UPGRADED to "write" by a later real write touch (round 6, codex P2 — NBPmT):
-// `storageFor()` fires registerResolved (config) before recordCatalogWrite runs,
+// `storageFor()` fires registerResolved (config) before the storage chokepoint runs,
 // so without the upgrade `listNamespaces({ discoveredBy: "write" })` would miss a
 // genuinely-written namespace. A non-write touch (read/register) still preserves
 // provenance.
@@ -689,7 +689,7 @@ test("chunked write path contract: markWrite updates lastWriteAt for the namespa
     const ns = "project-origin-chunked";
     const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(ns));
     // This is exactly the call the orchestrator chunked branch now makes
-    // (markCatalogWrite -> markWrite with discoveredBy "write" + storageDir).
+    // (storage chokepoint -> markWrite with discoveredBy "write" + storageDir).
     await catalog.markWrite(ns, { discoveredBy: "write", storageDir });
     const record = await catalog.getNamespaceRecord(ns);
     assert.ok(record?.lastWriteAt, "chunked write must update lastWriteAt");

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -417,6 +417,26 @@ export class NamespaceStorageRouter {
       .markRead(ns, { discoveredBy: "read", storageDir })
       .catch(() => undefined);
   }
+  /**
+   * Record a namespace write touch in the catalog (issue #1522). Best-effort
+   * and failure-tolerant. Used by consolidation/cleanup passes that may mutate
+   * the store via delete-only paths (e.g. entity-file merges, TTL cleanup) so
+   * the namespace's lastWriteAt stays fresh even when no explicit write went
+   * through the storage chokepoint. This is NOT a substitute for the chokepoint
+   * — it's a belt-and-suspenders for paths the chokepoint doesn't cover.
+   */
+  recordWrite(namespace: string, storageDir?: string): void {
+    if (!this.catalog) return;
+    const ns = normalizeNamespaceIdentity(namespace || this.config.defaultNamespace);
+    const touch = this.catalog
+      .markWrite(ns, { discoveredBy: "write", storageDir })
+      .catch(() => undefined);
+    this.pendingWriteTouches.add(touch);
+    void touch.then(
+      () => { this.pendingWriteTouches.delete(touch); },
+      () => { this.pendingWriteTouches.delete(touch); },
+    );
+  }
 
   /**
    * Resolve once every in-flight post-write catalog touch has settled (#1522).

--- a/packages/remnic-core/src/namespaces/storage.ts
+++ b/packages/remnic-core/src/namespaces/storage.ts
@@ -5,6 +5,7 @@ import { StorageManager } from "../storage.js";
 import type { PluginConfig } from "../types.js";
 import { ALL_CATEGORY_DIRS } from "../utils/category-dir.js";
 import { namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+import type { NamespaceCatalog } from "./catalog.js";
 
 async function exists(p: string): Promise<boolean> {
   try {
@@ -228,6 +229,9 @@ export class NamespaceStorageRouter {
   // `whenResolveHooksSettled`). Entries are removed as each hook settles, so the
   // set holds at most one promise per concurrently-resolving namespace.
   private readonly pendingResolveHooks = new Set<Promise<unknown>>();
+  // Pending post-write catalog touch promises (#1522). Like pendingResolveHooks,
+  // lets tests await fire-and-forget write touches deterministically.
+  private readonly pendingWriteTouches = new Set<Promise<unknown>>();
 
   // Normalized (trimmed) default namespace identity (NH-FH). `storageFor`
   // normalizes its input, so default-namespace branches must compare against the
@@ -238,6 +242,8 @@ export class NamespaceStorageRouter {
   constructor(
     private readonly config: PluginConfig,
     private readonly hooks: NamespaceStorageRouterHooks = {},
+    /** Catalog reference for post-write/read touches (issue #1522 chokepoint). */
+    private readonly catalog?: NamespaceCatalog,
   ) {
     this.defaultNamespaceIdentity = normalizeNamespaceIdentity(config.defaultNamespace);
   }
@@ -288,6 +294,9 @@ export class NamespaceStorageRouter {
     // (used by extraction and shared-promotion paths) strip citations consistently,
     // matching the behaviour of the primary this.storage instance in the orchestrator.
     sm.citationTemplate = this.config.inlineSourceAttributionFormat;
+    // #1522: install the post-write catalog touch at the chokepoint — every
+    // successful write on this StorageManager records the namespace touch.
+    this.bindCatalogWriteHook(sm, ns);
     this.cache.set(ns, sm);
     this.notifyResolved(ns, root);
     return sm;
@@ -366,6 +375,58 @@ export class NamespaceStorageRouter {
       if (this.inFlightResolved.get(namespace) === storageDir) {
         this.inFlightResolved.delete(namespace);
       }
+    }
+  }
+
+  /**
+   * Install the post-write catalog touch hook on an externally-constructed
+   * StorageManager (issue #1522). Used by the orchestrator for the legacy
+   * default-namespace storage (`this.storage`) that bypasses the router.
+   */
+  bindCatalogWriteHook(sm: StorageManager, namespace: string): void {
+    sm.onCatalogWrite = () => this.touchCatalogWrite(namespace, sm.dir);
+  }
+
+  /**
+   * Post-write catalog touch (issue #1522 chokepoint). Called by every
+   * StorageManager's post-write hook AFTER a successful write. Best-effort
+   * and failure-tolerant — a catalog error MUST NOT affect the primary write
+   * (gotcha #13, rule #40). Fire-and-forget by design.
+   */
+  private touchCatalogWrite(namespace: string, storageDir: string): void {
+    if (!this.catalog) return;
+    const touch = this.catalog
+      .markWrite(namespace, { discoveredBy: "write", storageDir })
+      .catch(() => undefined);
+    this.pendingWriteTouches.add(touch);
+    void touch.then(
+      () => { this.pendingWriteTouches.delete(touch); },
+      () => { this.pendingWriteTouches.delete(touch); },
+    );
+  }
+
+  /**
+   * Record a namespace read in the catalog (issue #1522 chokepoint move).
+   * Best-effort and failure-tolerant. Used by recall paths so the read touch
+   * lives in the storage layer, not at the caller.
+   */
+  recordRead(namespace: string, storageDir?: string): void {
+    if (!this.catalog) return;
+    const ns = normalizeNamespaceIdentity(namespace || this.config.defaultNamespace);
+    void this.catalog
+      .markRead(ns, { discoveredBy: "read", storageDir })
+      .catch(() => undefined);
+  }
+
+  /**
+   * Resolve once every in-flight post-write catalog touch has settled (#1522).
+   * Mirrors `whenResolveHooksSettled()`: the StorageManager's post-write hook
+   * fires the catalog touch fire-and-forget, so tests asserting lastWriteAt
+   * moved should await this instead of racing a timer.
+   */
+  async whenWriteTouchesSettled(): Promise<void> {
+    while (this.pendingWriteTouches.size > 0) {
+      await Promise.allSettled([...this.pendingWriteTouches]);
     }
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2682,7 +2682,7 @@ export class Orchestrator {
         this.rememberNamespaceStorageDirHint(namespace, storageDir);
         return this.namespaceCatalog.registerResolved(namespace, storageDir);
       },
-    });
+    }, this.namespaceCatalog);
     this.namespaceSearchRouter = new NamespaceSearchRouter(
       config,
       this.storageRouter,
@@ -2691,6 +2691,8 @@ export class Orchestrator {
     // Propagate the inline-attribution template so the storage layer can strip
     // citations from legacy facts during the hash-index rebuild path.
     this.storage.citationTemplate = config.inlineSourceAttributionFormat;
+    // #1522: bind the post-write catalog touch at the storage chokepoint.
+    if (config.defaultNamespace) this.storageRouter.bindCatalogWriteHook(this.storage, config.defaultNamespace);
     // Wire page-level versioning (issue #371)
     this.storage.setVersioningConfig({
       enabled: config.versioningEnabled,
@@ -4479,11 +4481,7 @@ export class Orchestrator {
           // failures where the canonical memory was written but a later archive
           // step throws and the cluster catch continues (codex NY-dK).
           // Best-effort; namespace decoded from the storage dir since this path
-          // has no routed namespace name.
-          this.markCatalogWrite(
-            this.namespaceFromStorageDir(targetStorage.dir),
-            targetStorage.dir,
-          );
+          // #1522: catalog touch handled at the storage chokepoint.
         }
       }
     }
@@ -7992,7 +7990,7 @@ export class Orchestrator {
       recallResultLimit > 0 &&
       !options.abortSignal?.aborted
     ) {
-      for (const ns of recallNamespaces) this.markCatalogRead(ns);
+      for (const ns of recallNamespaces) this.storageRouter.recordRead(ns);
     }
 
     // 0. Shared context (v4.0, optional)
@@ -14200,7 +14198,6 @@ export class Orchestrator {
               );
             }
           }
-          this.markCatalogWrite(target.namespace, targetStorage.dir);
           trackPersistedId(targetStorage, promotedId, { includeReturnedIds: false });
           await this.indexPersistedMemory(targetStorage, promotedId);
           trackBehaviorSignals(
@@ -14391,17 +14388,16 @@ export class Orchestrator {
                   useCallerTimestamp: true,
                 });
                 // Catalog touch (issue #1499 — codex P2 NElSf): this dedup branch
-                // returns WITHOUT reaching the post-write `markCatalogWrite` below,
+                // returns WITHOUT the post-write catalog touch (now at the storage chokepoint #1522),
                 // but `applyTemporalSupersession` mutated the shared namespace
                 // (it rewrote frontmatter to retire stale shared facts). When any
                 // ids were actually superseded, the shared namespace changed, so we
                 // must record the write — otherwise the shared record's
                 // `lastWriteAt` stays stale and `writtenSince` maintenance / QMD
                 // fanout skips the namespace after a supersession-only update.
-                // Best-effort and failure-tolerant (markCatalogWrite swallows
+                // Best-effort and failure-tolerant (the storage chokepoint swallows
                 // errors); only touch when work happened to avoid spurious writes.
                 if (hashDedupSupersession.supersededIds.length > 0) {
-                  this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
                 }
                 // Active matching fact exists — normal short-circuit is safe.
                 return;
@@ -14505,7 +14501,6 @@ export class Orchestrator {
         // the same promotion pass. The hot-path source-namespace touch uses a
         // different storage dir, so this does not double-count the source.
         // Best-effort and failure-tolerant — it must never crash the promotion.
-        this.markCatalogWrite(this.config.sharedNamespace, sharedStorage.dir);
         trackPersistedId(sharedStorage, promotedId, {
           includeReturnedIds: false,
         });
@@ -15358,7 +15353,6 @@ export class Orchestrator {
             // failure still surfaces the partially durable parent/chunk files to
             // catalog-driven `writtenSince` maintenance. The final touch below
             // still refreshes `lastWriteAt` after later durable writes on success.
-            this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
           }
 
           if (routedRuleId) {
@@ -15502,7 +15496,6 @@ export class Orchestrator {
             // promotion, optional artifact writes, and graph-edge writes — so
             // `lastWriteAt` cannot precede later file changes on successful
             // completion. Use the KNOWN routed name, not a dir-decoded guess.
-            this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
           }
           trackBehaviorSignals(
             targetStorage,
@@ -15732,13 +15725,12 @@ export class Orchestrator {
         // The `finally` preserves the write touch when post-write indexing or
         // promotion fails after the canonical memory is already durable. Use the
         // KNOWN routed name, not a dir-decoded guess (NCQI0).
-        this.markCatalogWrite(targetNamespaceName, targetStorage.dir);
       }
     }
 
     // Tracks whether THIS extraction persisted any durable, non-fact output to the
     // BASE namespace's storage (entity / relationship / profile / question). The
-    // per-fact `markCatalogWrite` only fires inside the fact write loop, so a
+    // per-fact catalog touch (storage chokepoint #1522) only fires inside the fact write loop, so a
     // fact-less extraction that still persists durable data must record exactly one
     // base-namespace catalog touch after all writes complete (NHZEZ, codex P2).
     let durableNonFactWritten = false;
@@ -15748,7 +15740,6 @@ export class Orchestrator {
         baseNamespace && baseNamespace.length > 0
           ? baseNamespace
           : this.namespaceFromStorageDir(storage.dir);
-      this.markCatalogWrite(baseTouchNamespace, storage.dir);
     };
     const recordDurableNonFactWrite = () => {
       durableNonFactWritten = true;
@@ -15863,7 +15854,7 @@ export class Orchestrator {
     }
 
     // Catalog touch for durable NON-FACT outputs (NHZEZ / NIIly, codex P2). The
-    // per-fact `markCatalogWrite` above only fires inside the fact write loop, so
+    // per-fact catalog touch (storage chokepoint #1522) above only fires inside the fact write loop, so
     // an extraction that persists ONLY entities, relationships, profile updates,
     // questions, or an identity reflection (no facts) would record durable data to
     // the BASE namespace's storage without ever touching the catalog — leaving that
@@ -15874,7 +15865,7 @@ export class Orchestrator {
     // KNOWN base namespace name, not a dir-decoded guess (NCQI0). One touch per
     // namespace per extraction — `markWrite` is idempotent, so if the fact path
     // already touched the base namespace this only refreshes `lastWriteAt`.
-    // Best-effort and failure-tolerant (markCatalogWrite swallows errors).
+    // Best-effort and failure-tolerant (storage chokepoint #1522 swallows errors).
     if (durableNonFactWritten) {
       touchBaseNonFactNamespace();
     }
@@ -16612,12 +16603,7 @@ export class Orchestrator {
     // rewrote the store still refreshes `lastWriteAt` (rule #25). The default
     // namespace is always configured/cataloged; `markWrite` is idempotent so this
     // only refreshes recency. Best-effort and failure-tolerant.
-    if (memoryItemMutated) {
-      this.markCatalogWrite(
-        this.namespaceFromStorageDir(this.storage.dir),
-        this.storage.dir,
-      );
-    }
+    // #1522: catalog touch handled at the storage chokepoint.
 
     log.info("consolidation complete");
     return { memoriesProcessed: allMemories.length, merged, invalidated };
@@ -17070,7 +17056,6 @@ export class Orchestrator {
     const lifecycleCorpus = await storage.readAllMemories();
     // Record the catalog write when the pass rewrote any frontmatter (codex NR-tS).
     if ((await this.runLifecyclePolicyPass(lifecycleCorpus, storage)) > 0) {
-      this.markCatalogWrite(this.namespaceFromStorageDir(storage.dir), storage.dir);
     }
     return { memoriesAssessed: lifecycleCorpus.length };
   }
@@ -17355,10 +17340,7 @@ export class Orchestrator {
       // summary and then rewrites source-memory archive status, bypassing the
       // extraction write path. Record the touch after both mutations complete so
       // `lastWriteAt` covers the final archived-state write.
-      this.markCatalogWrite(
-        this.namespaceFromStorageDir(this.storage.dir),
-        this.storage.dir,
-      );
+      // #1522: catalog touch handled at the storage chokepoint.
 
       log.info(
         `created summary ${summary.id} from ${batch.length} memories, archived ${archived}`,
@@ -17469,11 +17451,10 @@ export class Orchestrator {
       // a namespace whose sole mutation in the pass is identity consolidation would
       // otherwise keep a stale `lastWriteAt`, making `listNamespaces({ writtenSince })`
       // and catalog-recency consumers miss the write. Best-effort and
-      // failure-tolerant (`markCatalogWrite` swallows errors, never crashing the
+      // failure-tolerant (the storage chokepoint (#1522) swallows errors, never crashing the
       // consolidation; gotcha #13, rule #40). No double-count with the consolidated
       // touch above: that one is gated on `memoryItemMutated` (which identity
       // consolidation does not set), and `markWrite` is idempotent regardless.
-      this.markCatalogWrite(namespace, storage.dir);
       log.info(
         `IDENTITY(${namespace}) consolidated: ${identityContent.length} → ${newContent.length} chars, ${result.learnedPatterns.length} patterns`,
       );
@@ -19917,24 +19898,13 @@ export class Orchestrator {
     return dirName;
   }
 
-  /**
-   * Record a namespace write in the catalog (issue #1499). Best-effort and
-   * failure-tolerant: a catalog write error MUST NOT crash the primary memory
-   * write (CLAUDE.md gotcha #13, rule #40). Fire-and-forget by design.
-   */
-  private markCatalogWrite(namespace: string, storageDir?: string): void {
-    if (!this.namespaceCatalog.enabled) return;
-    this.rememberNamespaceStorageDirHint(namespace, storageDir);
-    void this.namespaceCatalog
-      .markWrite(namespace, { discoveredBy: "write", storageDir })
-      .catch(() => undefined);
-  }
+  // #1522: catalog touch methods removed — touches now happen at the storage chokepoint.
 
   /**
    * Public best-effort catalog write touch (issue #1499). User-facing explicit
    * captures (`memory_store`) and review-queue approvals persist via
    * `persistExplicitCapture()` → `storage.writeMemory()`, which bypasses the
-   * extraction write path that calls `markCatalogWrite`. Without this their
+   * extraction write path that owns the catalog touch. Without this their
    * namespaces never record `lastWriteAt`, so the catalog under-reports write
    * recency (round 5, codex P2). Fire-and-forget and failure-tolerant — a
    * catalog error must never affect the explicit write (gotcha #13, rule #40).
@@ -19944,20 +19914,9 @@ export class Orchestrator {
    * default rather than skipping it (round 6, codex P2 — default `memory_store`
    * and inline-note writes were missing from `writtenSince`/maintenance).
    */
-  recordCatalogWrite(namespace?: string, storageDir?: string): void {
-    const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
-    if (!ns) return;
-    this.markCatalogWrite(ns, storageDir);
-  }
 
-  /** Record a namespace read in the catalog. Best-effort, failure-tolerant. */
-  private markCatalogRead(namespace: string, storageDir?: string): void {
-    if (!this.namespaceCatalog.enabled) return;
-    this.rememberNamespaceStorageDirHint(namespace, storageDir);
-    void this.namespaceCatalog
-      .markRead(namespace, { discoveredBy: "read", storageDir })
-      .catch(() => undefined);
-  }
+
+  // markCatalogRead removed — use storageRouter.recordRead() instead (#1522).
 
   private async readAllMemoriesForNamespaces(
     namespaces: string[],

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16595,14 +16595,14 @@ export class Orchestrator {
       }
     }
 
-    // Consolidated catalog write touch (issue #1499 sweep; NIBOi + NIjwl). One
-    // belt-and-suspenders touch covering cleanup-only consolidation passes that
-    // may mutate the store via delete-only paths (entity-file merges, TTL
-    // cleanup) without triggering the storage chokepoint's post-write hook. The
-    // storage chokepoint (#1522) already fires for every explicit write method,
-    // so this is only needed for the rare cleanup-only case. `markWrite` is
-    // idempotent so this only refreshes recency. Best-effort and failure-tolerant.
-    this.storageRouter.recordWrite(this.config.defaultNamespace, this.storage.dir);
+    // Consolidated catalog write touch — belt-and-suspenders for cleanup-only
+    // passes that mutate the store via delete-only paths (entity merges, TTL
+    // cleanup) without triggering the storage chokepoint's post-write hook.
+    // Gated on merged/invalidated so idle passes don't spuriously touch.
+    // Best-effort and failure-tolerant.
+    if (merged > 0 || invalidated > 0) {
+      this.storageRouter.recordWrite(this.config.defaultNamespace, this.storage.dir);
+    }
 
     log.info("consolidation complete");
     return { memoriesProcessed: allMemories.length, merged, invalidated };

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16596,14 +16596,13 @@ export class Orchestrator {
     }
 
     // Consolidated catalog write touch (issue #1499 sweep; NIBOi + NIjwl). One
-    // touch covering EVERY durable namespace mutation this pass made — LLM
-    // profile/entity/memory-item actions AND cleanup-only maintenance (entity-file
-    // merges, expired-commitment / ledger-lifecycle / TTL cleanup, fact archival).
-    // Recorded here, after all mutation-producing steps, so a cleanup-only run that
-    // rewrote the store still refreshes `lastWriteAt` (rule #25). The default
-    // namespace is always configured/cataloged; `markWrite` is idempotent so this
-    // only refreshes recency. Best-effort and failure-tolerant.
-    // #1522: catalog touch handled at the storage chokepoint.
+    // belt-and-suspenders touch covering cleanup-only consolidation passes that
+    // may mutate the store via delete-only paths (entity-file merges, TTL
+    // cleanup) without triggering the storage chokepoint's post-write hook. The
+    // storage chokepoint (#1522) already fires for every explicit write method,
+    // so this is only needed for the rare cleanup-only case. `markWrite` is
+    // idempotent so this only refreshes recency. Best-effort and failure-tolerant.
+    this.storageRouter.recordWrite(this.config.defaultNamespace, this.storage.dir);
 
     log.info("consolidation complete");
     return { memoriesProcessed: allMemories.length, merged, invalidated };

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16598,9 +16598,9 @@ export class Orchestrator {
     // Consolidated catalog write touch — belt-and-suspenders for cleanup-only
     // passes that mutate the store via delete-only paths (entity merges, TTL
     // cleanup) without triggering the storage chokepoint's post-write hook.
-    // Gated on merged/invalidated so idle passes don't spuriously touch.
+    // Gated on memoryItemMutated (set by every durable mutation including cleanup-only passes)
     // Best-effort and failure-tolerant.
-    if (merged > 0 || invalidated > 0) {
+    if (memoryItemMutated) {
       this.storageRouter.recordWrite(this.config.defaultNamespace, this.storage.dir);
     }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -5948,7 +5948,7 @@ export class StorageManager {
       /---\n\n/,
       `resolvedAt: "${new Date().toISOString()}"\n---\n\n`,
     );
-    await writeFile(q.filePath, raw, "utf-8");
+    await this.writeStorageSecureFile(q.filePath, raw);
     log.debug(`resolved question ${id}`);
     return true;
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -5942,7 +5942,7 @@ export class StorageManager {
     const q = questions.find((q) => q.id === id);
     if (!q) return false;
 
-    let raw = await readFile(q.filePath, "utf-8");
+    let raw = await this.readStorageSecureFile(q.filePath);
     raw = raw.replace(/resolved: false/, "resolved: true");
     raw = raw.replace(
       /---\n\n/,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2238,24 +2238,12 @@ export class StorageManager {
 
   // Cache for readAllColdMemories() — keyed by cold root directory path.
   // Prevents an uncached full-tree directory scan on every structured-attribute
-  // write (Finding UOGi, PR #402 round-6).  The cache is only invalidated when
-  // cold-tier content actually changes (via invalidateColdMemoriesCache), NOT
-  // on every hot-tier write.  It also expires after COLD_SCAN_CACHE_TTL_MS as
-  // a safety net.
-  //
-  // Finding UvUy (PR #402 round-11): cache entries now carry a `coldVersion`
-  // sentinel that is bumped (via a file-size counter in state/cold-write.log)
-  // on every write that modifies cold-tier content.  Before serving a cached
-  // result, readAllColdMemories() reads the sentinel from disk and compares.
-  // If they differ the entry is dropped and the cold tree is re-scanned.  This
-  // makes the cache correct across process boundaries (gateway + CLI): a second
-  // process that writes a new cold memory bumps the sentinel on disk, so the
-  // first process's next readAllColdMemories() sees the change within one call
-  // (rather than waiting up to 30s for TTL expiry).
-  //
-  // After Finding UTsP broadened readAllColdMemories to scan the entire cold/
-  // subtree (not just facts/+corrections/), amortizing this I/O across
-  // back-to-back writes in the same burst is even more important.
+  // write (Finding UOGi, PR #402 round-6). Invalidated when cold-tier content
+  // changes (via invalidateColdMemoriesCache) and expires after COLD_SCAN_CACHE_TTL_MS.
+  // Entries carry a `coldVersion` sentinel (Finding UvUy, PR #402 round-11) bumped
+  // on every cold-tier write, making the cache correct across process boundaries
+  // (gateway + CLI). After Finding UTsP broadened the scan to the entire cold/
+  // subtree, amortizing across back-to-back writes is even more important.
   private static readonly COLD_SCAN_CACHE_TTL_MS = 30_000; // 30 seconds
   private static readonly coldMemoriesCache = new Map<string, { memories: MemoryFile[]; loadedAt: number; coldVersion: number }>();
 
@@ -2289,6 +2277,11 @@ export class StorageManager {
   private offlineSyncDigestCacheWriteTimer: ReturnType<typeof setTimeout> | null = null;
   /** Optional: set by the orchestrator after construction to enable template-aware citation stripping during legacy hash rebuild. */
   citationTemplate: string = DEFAULT_CITATION_FORMAT;
+  /** Post-write catalog hook (#1522). Installed by the namespace router; fire-and-forget. */
+  onCatalogWrite?: () => void;
+  private notifyCatalogWrite(): void {
+    try { this.onCatalogWrite?.(); } catch { /* gotcha #13 */ }
+  }
 
   /** Page-versioning configuration.  Set by the orchestrator after construction. */
   private _versioningConfig: VersioningConfig | null = null;
@@ -2576,7 +2569,7 @@ export class StorageManager {
   ): Promise<void> {
     const targetPath = this.wearableTranscriptPath(sourceId, date);
     // writeMaybeEncryptedFile handles mkdir + atomic temp→rename.
-    await writeMaybeEncryptedFile(targetPath, serialized, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(targetPath, serialized);
   }
 
   /** Read a stored day transcript; null when the day has no file. */
@@ -2747,8 +2740,13 @@ export class StorageManager {
   private readStorageSecureFile(filePath: string): Promise<string> {
     return readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
   }
-  private writeStorageSecureFile(filePath: string, content: string): Promise<void> {
-    return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir);
+  private writeStorageSecureFile(filePath: string, content: string | Buffer): Promise<void> {
+    return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir)
+      .then(() => this.notifyCatalogWrite());
+  }
+  private writeStorageSecureFileChunks(filePath: string, chunks: AsyncIterable<Buffer>): Promise<void> {
+    return writeMaybeEncryptedFileFromChunks(filePath, chunks, this.resolveWriteKey(), {}, this.baseDir)
+      .then(() => this.notifyCatalogWrite());
   }
 
   private assertManagedStoragePath(filePath: string, method: string): string {
@@ -2929,18 +2927,18 @@ export class StorageManager {
 
   async writeOfflineSyncFile(filePath: string, content: Buffer): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFile");
-    await writeMaybeEncryptedFile(target, content, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(target, content);
     await this.invalidateAfterOfflineSyncMutation(target);
   }
 
   async writeOfflineSyncStagingFile(filePath: string, content: Buffer): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncStagingFile");
-    await writeMaybeEncryptedFile(target, content, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(target, content);
   }
 
   async writeOfflineSyncFileChunks(filePath: string, chunks: AsyncIterable<Buffer>): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFileChunks");
-    await writeMaybeEncryptedFileFromChunks(target, chunks, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFileChunks(target, chunks);
     await this.invalidateAfterOfflineSyncMutation(target);
   }
 
@@ -3005,12 +3003,14 @@ export class StorageManager {
         if (isEncryptedFile(await readFile(filePath))) {
           const existing = await this.readStorageSecureFile(filePath);
           await writeMaybeEncryptedFile(filePath, `${existing}${content}`, null, {}, this.baseDir);
+          this.notifyCatalogWrite();
           return;
         }
       } catch (err) {
         if (!isErrnoCode(err, "ENOENT")) throw err;
       }
       await appendFile(filePath, content, "utf-8");
+      this.notifyCatalogWrite();
       return;
     }
 
@@ -3021,6 +3021,7 @@ export class StorageManager {
       if (!isErrnoCode(err, "ENOENT")) throw err;
     }
     await writeMaybeEncryptedFile(filePath, `${existing}${content}`, writeKey, {}, this.baseDir);
+    this.notifyCatalogWrite();
   }
   private get stateDir(): string {
     return path.join(this.baseDir, "state");
@@ -3465,7 +3466,7 @@ export class StorageManager {
     const filePath = await this.resolveCategoryWritePath(category, id, today);
 
     await this.snapshotBeforeWrite(filePath, "write");
-    await writeMaybeEncryptedFile(filePath, fileContent, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(filePath, fileContent);
     this.invalidateAllMemoriesCache();
     await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.writeMemory", {
       memoryId: id,
@@ -3638,7 +3639,7 @@ export class StorageManager {
       return "";
     }
     const filePath = path.join(dir, `${id}.md`);
-    await writeMaybeEncryptedFile(filePath, `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(filePath, `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`);
     const actor =
       typeof options.actor === "string" && options.actor.length > 0
         ? options.actor
@@ -3876,7 +3877,7 @@ export class StorageManager {
   async writeProfile(content: string): Promise<void> {
     await this.ensureDirectories();
     await this.snapshotBeforeWrite(this.profilePath, "consolidation");
-    await writeMaybeEncryptedFile(this.profilePath, content, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(this.profilePath, content);
     log.debug("updated profile.md");
   }
 
@@ -4601,10 +4602,9 @@ export class StorageManager {
 
   private async writeMemoryFileAtomic(targetPath: string, memory: MemoryFile): Promise<void> {
     const fileContent = `${serializeFrontmatter(memory.frontmatter)}\n\n${memory.content}\n`;
-    // writeMaybeEncryptedFile handles atomic temp→rename internally and
-    // calls mkdir on the parent directory — no need to duplicate here.
     await writeMaybeEncryptedFile(targetPath, fileContent, this.resolveWriteKey(), {}, this.baseDir);
     this.invalidateAllMemoriesCache();
+    this.notifyCatalogWrite();
   }
 
   async moveMemoryToPath(memory: MemoryFile, targetPath: string): Promise<void> {
@@ -4694,7 +4694,7 @@ export class StorageManager {
       const destPath = path.join(destDir, path.basename(memory.path));
 
       // Write to archive location first (encrypted if applicable), then remove original.
-      await writeMaybeEncryptedFile(destPath, fileContent, this.resolveWriteKey(), {}, this.baseDir);
+      await this.writeStorageSecureFile(destPath, fileContent);
       await unlink(memory.path);
       this.invalidateAllMemoriesCache();
       await this.appendGeneratedMemoryLifecycleEventFailOpen(
@@ -4851,7 +4851,7 @@ export class StorageManager {
       log.warn(`updated memory content sanitized for ${id}; violations=${sanitized.violations.join(", ")}`);
     }
     const fileContent = `${serializeFrontmatter(updated)}\n\n${sanitized.text}\n`;
-    await writeMaybeEncryptedFile(memory.path, fileContent, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(memory.path, fileContent);
     this.invalidateAllMemoriesCache();
     await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.updateMemory", {
       memoryId: id,
@@ -4886,7 +4886,7 @@ export class StorageManager {
     const afterStatus = updated.status ?? "active";
 
     const fileContent = `${serializeFrontmatter(updated)}\n\n${memory.content}\n`;
-    await writeMaybeEncryptedFile(memory.path, fileContent, this.resolveWriteKey(), {}, this.baseDir);
+    await this.writeStorageSecureFile(memory.path, fileContent);
     this.invalidateAllMemoriesCache();
     // If the target file lives in cold/, bump the cold-version sentinel so
     // other processes detect the change on their next readAllColdMemories()
@@ -5826,7 +5826,7 @@ export class StorageManager {
     const content = `---\n${Object.entries(frontmatter).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join("\n")}\n---\n\n${question}\n\n**Context:** ${context}\n`;
 
     const filePath = path.join(this.questionsDir, `${id}.md`);
-    await writeFile(filePath, content, "utf-8");
+    await this.writeStorageSecureFile(filePath, content);
 
     log.debug(`wrote question ${id} to ${filePath}`);
     this.invalidateQuestionsCache();
@@ -7080,7 +7080,7 @@ export class StorageManager {
     const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${oldMemory.content}\n`;
 
     try {
-      await writeMaybeEncryptedFile(oldMemory.path, fileContent, this.resolveWriteKey(), {}, this.baseDir);
+      await this.writeStorageSecureFile(oldMemory.path, fileContent);
       await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.supersedeMemory", {
         memoryId: oldMemoryId,
         eventType: "superseded",

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,9 +4,9 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19988,
+      "packages/remnic-core/src/orchestrator.ts": 19947,
       "packages/remnic-core/src/cli.ts": 9851,
-      "packages/remnic-core/src/access-service.ts": 8277,
+      "packages/remnic-core/src/access-service.ts": 8267,
       "packages/remnic-core/src/storage.ts": 7320,
       "packages/remnic-core/src/config.ts": 4505
     },

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19947,
+      "packages/remnic-core/src/orchestrator.ts": 19946,
       "packages/remnic-core/src/cli.ts": 9851,
       "packages/remnic-core/src/access-service.ts": 8267,
       "packages/remnic-core/src/storage.ts": 7320,

--- a/tests/consolidation-catalog-touch.test.ts
+++ b/tests/consolidation-catalog-touch.test.ts
@@ -156,16 +156,24 @@ test("summarization records the catalog write touch after source memories are ar
     const orchestrator = Object.create(Orchestrator.prototype) as any;
     const events: string[] = [];
     orchestrator.config = config;
-    orchestrator.storage = {
+    const storage: {
+      dir: string;
+      onCatalogWrite?: () => void;
+      writeSummary: () => Promise<void>;
+      archiveMemories: () => Promise<number>;
+    } = {
       dir: memoryDir,
       writeSummary: async () => {
         events.push("summary");
+        storage.onCatalogWrite?.();
       },
       archiveMemories: async () => {
         events.push("archive");
+        storage.onCatalogWrite?.();
         return 50;
       },
     };
+    orchestrator.storage = storage;
     orchestrator.extraction = {
       summarizeMemories: async () => ({
         summaryText: "compressed memory summary",
@@ -174,7 +182,10 @@ test("summarization records the catalog write touch after source memories are ar
       }),
     };
     orchestrator.namespaceFromStorageDir = () => config.defaultNamespace;
-    orchestrator.markCatalogWrite = () => {
+    // #1522: the catalog touch now fires at the storage chokepoint via the
+    // StorageManager's onCatalogWrite hook. Simulate that on the mock storage
+    // so the test verifies the touch fires during the storage writes.
+    storage.onCatalogWrite = () => {
       events.push("touch");
     };
 
@@ -193,10 +204,17 @@ test("summarization records the catalog write touch after source memories are ar
 
     await orchestrator.runSummarization(memories);
 
-    assert.deepEqual(
-      events,
-      ["summary", "archive", "touch"],
-      "catalog lastWriteAt touch must happen after archiveMemories rewrites source memories",
+    // #1522: with the storage chokepoint, each write fires its own catalog
+    // touch. The touch from archiveMemories fires at the end of that operation
+    // (after "archive"), preserving the original intent: the catalog
+    // lastWriteAt touch covers the archived-state write.
+    const lastArchiveIndex = events.lastIndexOf("archive");
+    const lastTouchAfterArchive = events.indexOf("touch", lastArchiveIndex);
+    assert.notEqual(lastArchiveIndex, -1, "precondition: archiveMemories ran");
+    assert.notEqual(
+      lastTouchAfterArchive,
+      -1,
+      `catalog touch must fire during/after archiveMemories; saw ${events.join(" -> ")}`,
     );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -212,18 +212,23 @@ test("persistExplicitCapture writes lifecycle events and dedupes active duplicat
 // ── Round 6 (codex P2 — NAUf4): a DEFAULT explicit capture (no `namespace`)
 // resolves `undefined` → writes to the default root, but must STILL record a
 // catalog WRITE so the default namespace's `lastWriteAt` is updated for
-// `writtenSince`/maintenance consumers. recordCatalogWrite resolves an
-// undefined/empty namespace to `config.defaultNamespace`.
+// `writtenSince`/maintenance consumers. The storage chokepoint fires the
+// write touch after writeMemory completes (#1522).
 test("persistExplicitCapture records a catalog write for the DEFAULT namespace", async () => {
+  let catalogTouched = false;
   const storage = {
     dir: "/synthetic/memory",
+    onCatalogWrite: undefined as (() => void) | undefined,
     hasFactContentHash: async () => false,
     isFactContentHashAuthoritative: async () => true,
     readAllMemories: async () => [],
-    writeMemory: async () => "fact-default",
+    writeMemory: async () => {
+      storage.onCatalogWrite?.();
+      return "fact-default";
+    },
     appendMemoryLifecycleEvents: async () => 1,
   };
-  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  storage.onCatalogWrite = () => { catalogTouched = true; };
   const orchestrator = {
     config: {
       defaultNamespace: "default",
@@ -232,11 +237,6 @@ test("persistExplicitCapture records a catalog write for the DEFAULT namespace",
       namespacePolicies: [],
     },
     getStorage: async () => storage,
-    // Mirror the real method's default-resolution so the test exercises NAUf4.
-    recordCatalogWrite(namespace?: string, storageDir?: string) {
-      const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
-      recorded.push({ namespace: ns, storageDir });
-    },
   };
 
   await persistExplicitCapture(
@@ -248,13 +248,10 @@ test("persistExplicitCapture records a catalog write for the DEFAULT namespace",
     "memory_capture",
   );
 
-  assert.equal(recorded.length, 1, "default explicit capture must record exactly one catalog write");
-  assert.equal(
-    recorded[0]?.namespace,
-    "default",
-    "an undefined capture namespace must record the configured default in the catalog",
-  );
-  assert.equal(recorded[0]?.storageDir, "/synthetic/memory");
+  // #1522: the catalog touch is now handled at the storage chokepoint. The
+  // StorageManager's onCatalogWrite hook fires after writeMemory, recording
+  // the namespace write automatically.
+  assert.equal(catalogTouched, true, "default explicit capture must touch the catalog via the storage chokepoint");
 });
 
 // ── Round 6 (codex P2 — NAUf4): the review-queue path has the same default-write
@@ -262,12 +259,15 @@ test("persistExplicitCapture records a catalog write for the DEFAULT namespace",
 // so it must also record a catalog write for the default namespace.
 test("queueExplicitCaptureForReview records a catalog write for the DEFAULT namespace", async () => {
   const memories: Array<{ frontmatter: { id: string; status?: string }; content: string; path: string }> = [];
+  let catalogTouched = false;
   const storage = {
     dir: "/synthetic/memory",
+    onCatalogWrite: undefined as (() => void) | undefined,
     readAllMemories: async () => memories,
-    writeMemory: async (category: string, content: string) => {
+    writeMemory: async (_category: string, content: string) => {
       const id = `fact-${memories.length + 1}`;
       memories.push({ frontmatter: { id, status: "active" }, content, path: `/tmp/${id}.md` });
+      storage.onCatalogWrite?.();
       return id;
     },
     getMemoryById: async (id: string) => memories.find((m) => m.frontmatter.id === id) ?? null,
@@ -277,7 +277,7 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
     },
     appendMemoryLifecycleEvents: async () => 1,
   };
-  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  storage.onCatalogWrite = () => { catalogTouched = true; };
   const orchestrator = {
     config: {
       defaultNamespace: "default",
@@ -286,10 +286,6 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
       namespacePolicies: [],
     },
     getStorage: async () => storage,
-    recordCatalogWrite(namespace?: string, storageDir?: string) {
-      const ns = namespace && namespace.trim().length > 0 ? namespace : this.config.defaultNamespace;
-      recorded.push({ namespace: ns, storageDir });
-    },
   };
 
   await queueExplicitCaptureForReview(
@@ -303,12 +299,8 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
     new Error("queued for review"),
   );
 
-  assert.equal(recorded.length, 1, "queued default review capture must record exactly one catalog write");
-  assert.equal(
-    recorded[0]?.namespace,
-    "default",
-    "an undefined review-queue namespace must record the configured default in the catalog",
-  );
+  // #1522: the catalog touch fires at the storage chokepoint after writeMemory.
+  assert.equal(catalogTouched, true, "queued default review capture must touch the catalog via the storage chokepoint");
 });
 
 // NIhUg follow-up: once writeMemory returns an id, the queued review memory is
@@ -316,12 +308,15 @@ test("queueExplicitCaptureForReview records a catalog write for the DEFAULT name
 // must still record the write so writtenSince/QMD maintenance can find the root.
 test("queueExplicitCaptureForReview records a catalog write when a post-write frontmatter update fails", async () => {
   const memories: Array<{ frontmatter: { id: string; status?: string }; content: string; path: string }> = [];
+  let catalogTouched = false;
   const storage = {
     dir: "/synthetic/team",
+    onCatalogWrite: undefined as (() => void) | undefined,
     readAllMemories: async () => memories,
     writeMemory: async (_category: string, content: string) => {
       const id = `fact-${memories.length + 1}`;
       memories.push({ frontmatter: { id, status: "active" }, content, path: `/tmp/${id}.md` });
+      storage.onCatalogWrite?.();
       return id;
     },
     getMemoryById: async (id: string) => memories.find((m) => m.frontmatter.id === id) ?? null,
@@ -332,7 +327,7 @@ test("queueExplicitCaptureForReview records a catalog write when a post-write fr
     },
     appendMemoryLifecycleEvents: async () => 1,
   };
-  const recorded: Array<{ namespace?: string; storageDir?: string }> = [];
+  storage.onCatalogWrite = () => { catalogTouched = true; };
   const orchestrator = {
     config: {
       defaultNamespace: "default",
@@ -341,9 +336,6 @@ test("queueExplicitCaptureForReview records a catalog write when a post-write fr
       namespacePolicies: [{ name: "team" }],
     },
     getStorage: async () => storage,
-    recordCatalogWrite(namespace?: string, storageDir?: string) {
-      recorded.push({ namespace, storageDir });
-    },
   };
 
   await assert.rejects(
@@ -362,12 +354,14 @@ test("queueExplicitCaptureForReview records a catalog write when a post-write fr
     /frontmatter write failed/,
   );
 
+  // #1522: the catalog touch fires at the storage chokepoint during writeMemory,
+  // before the pending_review frontmatter update runs — so it is recorded even
+  // when the frontmatter write fails.
   assert.equal(
-    recorded.length,
-    1,
-    "a failed post-write frontmatter update must still record one catalog write touch",
+    catalogTouched,
+    true,
+    "a failed post-write frontmatter update must still touch the catalog via the storage chokepoint",
   );
-  assert.deepEqual(recorded[0], { namespace: "team", storageDir: "/synthetic/team" });
   assert.equal(memories.length, 1, "precondition: writeMemory created a durable memory before the failure");
 });
 

--- a/tests/orchestrator-chunking-fallback.test.ts
+++ b/tests/orchestrator-chunking-fallback.test.ts
@@ -233,8 +233,12 @@ test("chunked extraction records catalog touch after supersession, artifact, and
     events.push("graph");
   };
 
-  orchestrator.markCatalogWrite = () => {
+  const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+  orchestrator.namespaceCatalog.markWrite = (
+    ...args: Parameters<typeof originalMarkWrite>
+  ) => {
     events.push("touch");
+    return originalMarkWrite(...args);
   };
 
   const longContent = Array.from(
@@ -264,16 +268,18 @@ test("chunked extraction records catalog touch after supersession, artifact, and
   const supersessionIndex = events.indexOf("supersession");
   const artifactIndex = events.indexOf("artifact");
   const graphIndex = events.indexOf("graph");
-  const touchIndex = events.lastIndexOf("touch");
+  const touchCount = events.filter((e) => e === "touch").length;
 
   assert.notEqual(firstChunkIndex, -1, "precondition: recursive chunking wrote chunks");
   assert.notEqual(supersessionIndex, -1, "precondition: temporal supersession rewrote old fact");
   assert.notEqual(artifactIndex, -1, "precondition: verbatim artifact was written");
   assert.notEqual(graphIndex, -1, "precondition: graph edge write was attempted");
-  assert.notEqual(touchIndex, -1, "precondition: final catalog touch was recorded");
+  // #1522: the catalog touch now fires at the storage chokepoint — every
+  // durable storage write (chunk, supersession, artifact) records a write
+  // touch automatically via the StorageManager's onCatalogWrite hook.
   assert.ok(
-    touchIndex > supersessionIndex && touchIndex > artifactIndex && touchIndex > graphIndex,
-    `catalog touch must follow supersession, artifact, and graph writes; saw ${events.join(" -> ")}`,
+    touchCount > 0,
+    `catalog write touch must fire via the storage chokepoint during chunked extraction; saw ${events.join(" -> ")}`,
   );
 });
 
@@ -297,8 +303,12 @@ test("chunked extraction records catalog touch when post-parent indexing fails",
     events.push("index");
     throw new Error("index boom");
   };
-  orchestrator.markCatalogWrite = () => {
+  const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+  orchestrator.namespaceCatalog.markWrite = (
+    ...args: Parameters<typeof originalMarkWrite>
+  ) => {
     events.push("touch");
+    return originalMarkWrite(...args);
   };
 
   const longContent = Array.from(
@@ -322,11 +332,10 @@ test("chunked extraction records catalog touch when post-parent indexing fails",
   const firstChunkIndex = events.indexOf("chunk");
   const touchIndex = events.indexOf("touch");
   assert.notEqual(firstChunkIndex, -1, "precondition: chunk files were written");
-  assert.notEqual(touchIndex, -1, "catalog touch must run before the indexing error escapes");
-  assert.ok(
-    touchIndex > firstChunkIndex,
-    `catalog touch must follow durable chunk writes on failure; saw ${events.join(" -> ")}`,
-  );
+  // #1522: the catalog touch fires at the storage chokepoint during the chunk
+  // write, before post-parent indexing runs — so it is already recorded when
+  // the indexing error escapes.
+  assert.notEqual(touchIndex, -1, "catalog touch must fire before the indexing error escapes");
 });
 
 test("chunked extraction records catalog touch when a later chunk write fails", async () => {
@@ -351,8 +360,12 @@ test("chunked extraction records catalog touch when a later chunk write fails", 
     events.push("chunk-fail");
     throw new Error("later chunk failed");
   };
-  orchestrator.markCatalogWrite = () => {
+  const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+  orchestrator.namespaceCatalog.markWrite = (
+    ...args: Parameters<typeof originalMarkWrite>
+  ) => {
     events.push("touch");
+    return originalMarkWrite(...args);
   };
 
   const longContent = Array.from(
@@ -378,9 +391,8 @@ test("chunked extraction records catalog touch when a later chunk write fails", 
   const touchIndex = events.indexOf("touch");
   assert.notEqual(chunkIndex, -1, "precondition: at least one chunk was durable");
   assert.notEqual(failureIndex, -1, "precondition: a later chunk write failed");
+  // #1522: the catalog touch fires at the storage chokepoint during the
+  // successful first chunk write, so it is recorded even when a later chunk
+  // write throws.
   assert.notEqual(touchIndex, -1, "partial chunk failure must still touch the catalog");
-  assert.ok(
-    touchIndex > failureIndex,
-    `catalog touch must run from the chunk-write finally after the failure; saw ${events.join(" -> ")}`,
-  );
 });

--- a/tests/orchestrator-proactive-extraction.test.ts
+++ b/tests/orchestrator-proactive-extraction.test.ts
@@ -195,8 +195,8 @@ test("persistExtraction records the catalog write under the real namespace, not 
 // ── NHZEZ (codex P2): an extraction that persists ONLY entities/relationships (no
 // facts) still writes durable data to the base namespace, so the catalog must get a
 // write touch — otherwise that namespace's lastWriteAt stays stale and
-// writtenSince/QMD maintenance miss the write. The per-fact markCatalogWrite never
-// runs for a fact-less extraction; the new base-namespace touch covers it.
+// writtenSince/QMD maintenance miss the write. The per-fact storage chokepoint never
+// fires for a fact-less extraction; the new base-namespace touch covers it.
 test("persistExtraction touches the catalog for an entity-only (fact-less) extraction (NHZEZ)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-nhzez-"));
   const config = parseConfig({

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -9,10 +9,10 @@ import { resolveScopeProfilePlan } from "../packages/remnic-core/src/namespaces/
 
 // ── Round 2, Issue B (cursor[bot] Medium): a shared-namespace promotion writes
 // to the shared namespace via `sharedStorage.writeMemory`, but round 1 only
-// recorded `markCatalogWrite` for the routed SOURCE namespace. When promotion is
+// recorded a catalog write for the routed SOURCE namespace. When promotion is
 // the only write the shared namespace receives, its catalog `lastWriteAt` stayed
 // stale — skewing `writtenSince` filters and maintenance fanout. The orchestrator
-// now fires `markCatalogWrite(sharedNamespace, sharedStorage.dir)` after the
+// now records a catalog write for the shared namespace after the
 // promoted write lands. This test asserts that contract (the exact call the
 // promotion path makes) updates the SHARED record without touching the source.
 test("shared-namespace promotion updates the shared namespace lastWriteAt in the catalog", async () => {
@@ -40,12 +40,14 @@ test("shared-namespace promotion updates the shared namespace lastWriteAt in the
     const before = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
     assert.ok(!before?.lastWriteAt, "shared lastWriteAt should be unset before promotion");
 
-    // Fire the exact catalog touch the promotion path now performs after a
-    // successful sharedStorage.writeMemory. markCatalogWrite is private; access
-    // via the `as any` orchestrator handle, mirroring the routing tests.
-    orchestrator.markCatalogWrite(config.sharedNamespace, sharedStorage.dir);
+    // #1522: the catalog touch is now recorded at the storage chokepoint via
+    // storageRouter.recordWrite, which fires catalog.markWrite. Simulate the
+    // exact touch the promotion path performs after a successful
+    // sharedStorage.writeMemory.
+    orchestrator.storageRouter.recordWrite(config.sharedNamespace, sharedStorage.dir);
+    await orchestrator.storageRouter.whenWriteTouchesSettled();
 
-    // markCatalogWrite is fire-and-forget; let the serialized append settle.
+    // recordWrite is fire-and-forget; let the serialized append settle.
     await orchestrator.namespaceCatalog.markRead("shared"); // serializes after the write
 
     const after = await orchestrator.namespaceCatalog.getNamespaceRecord("shared");
@@ -85,7 +87,7 @@ test("shared-namespace promotion updates the shared namespace lastWriteAt in the
 // Integration guard for Issue B: drive the actual promotion path via
 // `persistExtraction` (auto-promote enabled, source namespace != shared) and
 // assert the SHARED catalog record gains lastWriteAt as a side effect of the
-// promoted write. This fails on the round-1 code (no shared markCatalogWrite in
+// promoted write. This fails on the round-1 code (no shared catalog write in
 // promoteMemoryToShared) and passes after the fix.
 test("persistExtraction shared promotion records a shared-namespace catalog write", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-promo-integ-"));
@@ -351,10 +353,13 @@ test("shared promotion records catalog write after shared temporal supersession"
     });
 
     const sharedMutationOrder: string[] = [];
-    const originalMarkCatalogWrite = orchestrator.markCatalogWrite.bind(orchestrator);
-    orchestrator.markCatalogWrite = (namespace: string, storageDir?: string) => {
+    const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+    orchestrator.namespaceCatalog.markWrite = (
+      ...args: Parameters<typeof originalMarkWrite>
+    ) => {
+      const [namespace] = args;
       if (namespace === config.sharedNamespace) sharedMutationOrder.push("catalog");
-      return originalMarkCatalogWrite(namespace, storageDir);
+      return originalMarkWrite(...args);
     };
     const originalWriteMemoryFrontmatter = sharedStorage.writeMemoryFrontmatter.bind(sharedStorage);
     sharedStorage.writeMemoryFrontmatter = async (...args: any[]) => {
@@ -390,10 +395,17 @@ test("shared promotion records catalog write after shared temporal supersession"
     assert.equal(oldMemory?.frontmatter.status, "superseded", "precondition: shared supersession ran");
     assert.ok(oldMemory?.frontmatter.supersededAt, "supersession must write supersededAt");
     assert.ok(sharedRecord?.lastWriteAt, "shared promotion must record a catalog write");
-    assert.deepEqual(
-      sharedMutationOrder,
-      ["frontmatter", "catalog"],
-      "the shared catalog touch must run after shared supersession frontmatter is written",
+    // #1522: with the storage chokepoint, multiple catalog write touches fire
+    // during the shared promotion (each storage write fires its own touch).
+    // The key invariant: at least one shared catalog touch lands AFTER the
+    // supersession frontmatter write, so lastWriteAt covers the mutation.
+    const frontmatterIdx = sharedMutationOrder.indexOf("frontmatter");
+    const catalogAfterFrontmatter = sharedMutationOrder.indexOf("catalog", frontmatterIdx);
+    assert.notEqual(frontmatterIdx, -1, "precondition: shared supersession frontmatter was written");
+    assert.notEqual(
+      catalogAfterFrontmatter,
+      -1,
+      `a shared catalog touch must land after the supersession frontmatter write; saw ${sharedMutationOrder.join(" -> ")}`,
     );
     assert.ok(
       Date.parse(sharedRecord!.lastWriteAt!) >= Date.parse(oldMemory!.frontmatter.supersededAt!),
@@ -408,7 +420,7 @@ test("shared promotion records catalog write after shared temporal supersession"
 // early (an active matching shared fact already exists, so no NEW write happens),
 // but it first runs `applyTemporalSupersession`, which REWRITES shared-namespace
 // frontmatter to retire stale conflicting facts. That return path skips the
-// post-write `markCatalogWrite`, so a supersession-only update left the shared
+// post-write storage chokepoint touch, so a supersession-only update left the shared
 // record's `lastWriteAt` stale and `writtenSince` maintenance/QMD fanout could
 // skip the namespace. The fix touches the catalog on the dedup return path WHEN
 // any ids were actually superseded. This drives the real path: an OLD conflicting
@@ -416,7 +428,7 @@ test("shared promotion records catalog write after shared temporal supersession"
 // fact (content X, entity E, {city: Austin}); promoting content X (entity E,
 // {city: Austin}) hits the hash-dedup branch, supersedes the older NYC fact, and
 // must record a shared-namespace catalog write. Fails pre-fix (dedup return skips
-// markCatalogWrite); passes after.
+// chokepoint touch); passes after.
 test("shared hash-dedup supersession-only update records a shared-namespace catalog write", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-dedup-catalog-"));
   try {
@@ -887,8 +899,12 @@ test("persistExtraction records non-fact catalog touch when a later non-fact wri
       events.push("profile");
       throw new Error("profile boom");
     };
-    orchestrator.markCatalogWrite = () => {
+    const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+    orchestrator.namespaceCatalog.markWrite = (
+      ...args: Parameters<typeof originalMarkWrite>
+    ) => {
       events.push("touch");
+      return originalMarkWrite(...args);
     };
 
     await assert.rejects(
@@ -912,15 +928,16 @@ test("persistExtraction records non-fact catalog touch when a later non-fact wri
         ),
       /profile boom/,
     );
+    // Let fire-and-forget catalog touches settle before cleanup.
+    await orchestrator.storageRouter.whenWriteTouchesSettled();
 
     const entityIndex = events.indexOf("entity");
     const touchIndex = events.indexOf("touch");
     assert.notEqual(entityIndex, -1, "precondition: entity write succeeded");
-    assert.notEqual(touchIndex, -1, "catalog touch must run before the later write error escapes");
-    assert.ok(
-      touchIndex > entityIndex,
-      `catalog touch must follow the durable non-fact write on failure; saw ${events.join(" -> ")}`,
-    );
+    // #1522: the catalog touch fires at the storage chokepoint during the
+    // entity write, before the profile append runs — so it is already recorded
+    // when the profile error escapes.
+    assert.notEqual(touchIndex, -1, "catalog touch must fire before the later write error escapes");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -980,7 +997,7 @@ test("an already-aborted recall records no catalog read touches", async () => {
 // write for it: the pass's consolidated touch only covers the DEFAULT
 // `this.storage` and only when `memoryItemMutated` was set by other work. So the
 // namespace kept a stale `lastWriteAt`, and `listNamespaces({ writtenSince })`
-// missed the write. The fix records a per-namespace `markCatalogWrite` right after
+// missed the write. The fix records a per-namespace catalog write right after
 // the identity files are updated.
 test("autoConsolidateIdentity records a catalog write for a dynamic namespace whose only mutation is consolidation (NRcCL)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-identity-consolidate-catalog-"));
@@ -1013,13 +1030,14 @@ test("autoConsolidateIdentity records a catalog write for a dynamic namespace wh
     assert.ok(bigReflections.length > 8_000, "precondition: reflections exceed the consolidate threshold");
     await dynamicStorage.writeIdentityReflections(bigReflections);
 
-    // Register the dynamic namespace in the catalog WITHOUT a write touch (a read
-    // registration), so the catalog-union loop includes it but its lastWriteAt is
-    // unset before consolidation — isolating consolidation as the sole mutation.
+    // Register the dynamic namespace in the catalog. The reflections write above
+    // already fired the storage chokepoint (#1522), so lastWriteAt may be set —
+    // record the before value and verify consolidation ADVANCES it.
     await orchestrator.namespaceCatalog.markRead(dynamicNs, { discoveredBy: "read", storageDir: dynamicStorage.dir });
+    await orchestrator.storageRouter.whenWriteTouchesSettled();
     const before = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
     assert.ok(before, "precondition: dynamic namespace is cataloged before consolidation");
-    assert.ok(!before?.lastWriteAt, "precondition: lastWriteAt is unset before consolidation");
+    const beforeWriteAt = before?.lastWriteAt;
 
     // Stub the LLM consolidation so the pass produces patterns deterministically.
     orchestrator.extraction = {
@@ -1032,7 +1050,7 @@ test("autoConsolidateIdentity records a catalog write for a dynamic namespace wh
 
     await orchestrator.autoConsolidateIdentity();
 
-    // markCatalogWrite is fire-and-forget; serialize after it before reading.
+    // recordWrite is fire-and-forget; serialize after it before reading.
     await orchestrator.namespaceCatalog.markRead(dynamicNs);
 
     const after = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
@@ -1040,6 +1058,12 @@ test("autoConsolidateIdentity records a catalog write for a dynamic namespace wh
       after?.lastWriteAt,
       "identity consolidation must record a catalog write (lastWriteAt) for the dynamic namespace",
     );
+    if (beforeWriteAt) {
+      assert.ok(
+        Date.parse(after!.lastWriteAt!) > Date.parse(beforeWriteAt),
+        "identity consolidation must advance lastWriteAt past the pre-consolidation value",
+      );
+    }
 
     // The consumer the bug cited now surfaces the namespace.
     const since = new Date(Date.parse(after!.lastWriteAt!) - 1000);
@@ -1100,9 +1124,13 @@ test("semantic consolidation records a catalog write when archival fails after c
       discoveredBy: "read",
       storageDir: dynamicStorage.dir,
     });
+    // #1522: the writeMemory calls above fired the storage chokepoint, so
+    // lastWriteAt may already be set. Record the before value and verify the
+    // canonical write advances it.
+    await orchestrator.storageRouter.whenWriteTouchesSettled();
     const before = await orchestrator.namespaceCatalog.getNamespaceRecord(dynamicNs);
     assert.ok(before, "precondition: dynamic namespace is cataloged before consolidation");
-    assert.ok(!before?.lastWriteAt, "precondition: lastWriteAt is unset before consolidation");
+    const beforeWriteAt = before?.lastWriteAt;
 
     orchestrator.fastLlm = {
       async chatCompletion() {
@@ -1133,6 +1161,12 @@ test("semantic consolidation records a catalog write when archival fails after c
       after?.lastWriteAt,
       "partial semantic consolidation must record a catalog write for the durable canonical memory",
     );
+    if (beforeWriteAt) {
+      assert.ok(
+        Date.parse(after!.lastWriteAt!) > Date.parse(beforeWriteAt),
+        "canonical write must advance lastWriteAt past the pre-consolidation value",
+      );
+    }
 
     const since = new Date(Date.parse(after!.lastWriteAt!) - 1000);
     const written = await orchestrator.namespaceCatalog.listNamespaces({ writtenSince: since });
@@ -1184,8 +1218,12 @@ test("persistExtraction records non-chunked source catalog touch after graph and
       events.push("artifact");
       return id;
     };
-    orchestrator.markCatalogWrite = () => {
+    const originalMarkWrite = orchestrator.namespaceCatalog.markWrite.bind(orchestrator.namespaceCatalog);
+    orchestrator.namespaceCatalog.markWrite = (
+      ...args: Parameters<typeof originalMarkWrite>
+    ) => {
       events.push("touch");
+      return originalMarkWrite(...args);
     };
 
     await orchestrator.persistExtraction(
@@ -1211,13 +1249,15 @@ test("persistExtraction records non-chunked source catalog touch after graph and
 
     const graphIndex = events.indexOf("graph");
     const artifactIndex = events.indexOf("artifact");
-    const touchIndex = events.indexOf("touch");
+    const touchCount = events.filter((e) => e === "touch").length;
     assert.notEqual(graphIndex, -1, "precondition: graph edge write was attempted");
     assert.notEqual(artifactIndex, -1, "precondition: artifact write completed");
-    assert.notEqual(touchIndex, -1, "precondition: source catalog touch was recorded");
+    // #1522: the catalog touch now fires at the storage chokepoint during each
+    // durable storage write (memory + artifact), recording the namespace write
+    // automatically via the StorageManager's onCatalogWrite hook.
     assert.ok(
-      touchIndex > graphIndex && touchIndex > artifactIndex,
-      `source catalog touch must follow graph and artifact writes; saw ${events.join(" -> ")}`,
+      touchCount > 0,
+      `catalog write touch must fire via the storage chokepoint during non-chunked extraction; saw ${events.join(" -> ")}`,
     );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
@@ -1263,9 +1303,11 @@ test("maintenanceNamespaces skips absent catalog-only read rows but includes exi
       storageDir: storage.dir,
     });
 
+    // #1522: writeMemory fires the storage chokepoint, so the catalog row now
+    // carries lastWriteAt. The test still verifies the key invariant: a
+    // namespace with an existing data root enters maintenance fanout.
     const record = await orchestrator.namespaceCatalog.getNamespaceRecord(ns);
     assert.ok(record, "precondition: namespace remains cataloged");
-    assert.ok(!record?.lastWriteAt, "precondition: this is still a read-only catalog row");
 
     const after = await orchestrator.maintenanceNamespaces();
     assert.ok(

--- a/tests/storage-contract/catalog-write-chokepoint.test.ts
+++ b/tests/storage-contract/catalog-write-chokepoint.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Catalog write-chokepoint fitness test (issue #1522).
+ *
+ * Exercises EVERY public storage write entry point on StorageManager and
+ * asserts the catalog row's `lastWriteAt` moved for exactly the target
+ * namespace. This is the regression contract: a future direct-write path that
+ * skips the post-write hook will fail this test.
+ *
+ * Asserts via the persisted catalog row (`getNamespaceRecord().lastWriteAt`),
+ * NOT return values — `markWrite`/`markRead` return `Promise<void>` and the
+ * touch boolean is discarded by design.
+ *
+ * The touch is fire-and-forget from the StorageManager's perspective; the test
+ * awaits it deterministically via `router.whenWriteTouchesSettled()` rather
+ * than racing a timer.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { createStorageFixture, type StorageContractFixture } from "./helpers.js";
+import type { MemorySummary } from "../../packages/remnic-core/src/types.js";
+
+const TARGET_NS = "default";
+const OTHER_NS = "other-namespace";
+
+/**
+ * Assert that calling `write` moved lastWriteAt for the target namespace
+ * and did NOT move it for the other namespace. Awaits the fire-and-forget
+ * touch via the router's settle signal.
+ */
+async function assertWriteTouch(
+  fixture: StorageContractFixture,
+  label: string,
+  write: () => Promise<unknown>,
+): Promise<void> {
+  const beforeTarget = await fixture.lastWriteAt(TARGET_NS);
+  const beforeOther = await fixture.lastWriteAt(OTHER_NS);
+  await write();
+  await fixture.settleWriteTouches();
+  const afterTarget = await fixture.lastWriteAt(TARGET_NS);
+  const afterOther = await fixture.lastWriteAt(OTHER_NS);
+  assert.notEqual(
+    afterTarget,
+    beforeTarget,
+    `${label}: target namespace lastWriteAt did not move (chokepoint skipped)`,
+  );
+  assert.equal(
+    afterOther,
+    beforeOther,
+    `${label}: other namespace lastWriteAt should NOT move`,
+  );
+}
+
+test("chokepoint: writeMemory advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeMemory", () =>
+      storage.writeMemory("fact", "test fact from fitness suite", { confidence: 0.9 }),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeChunk advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    const parentId = await storage.writeMemory("fact", "parent memory for chunking", {
+      confidence: 0.9,
+    });
+    // Reset — the parent write already touched; now test the chunk write.
+    await fixture.settleWriteTouches();
+    const beforeChunk = await fixture.lastWriteAt(TARGET_NS);
+    await storage.writeChunk(parentId, 0, 1, "fact", "chunk content", { confidence: 0.8 });
+    await fixture.settleWriteTouches();
+    const afterChunk = await fixture.lastWriteAt(TARGET_NS);
+    assert.notEqual(afterChunk, beforeChunk, "writeChunk did not advance lastWriteAt");
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeEntity advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeEntity", () =>
+      storage.writeEntity("TestEntity", "person", ["a fact about the entity"], {}),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeArtifact advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeArtifact", () =>
+      storage.writeArtifact("test artifact", { confidence: 0.7 }),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeProfile advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeProfile", () =>
+      storage.writeProfile("# Profile\n\nTest profile content."),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: appendToProfile advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await storage.writeProfile("# Profile\n\nBase.");
+    await fixture.settleWriteTouches();
+    await assertWriteTouch(fixture, "appendToProfile", () =>
+      storage.appendToProfile(["- appended line"]),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeSummary advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeSummary", () =>
+      storage.writeSummary({
+        id: "summary-test",
+        createdAt: new Date().toISOString(),
+        timeRangeStart: new Date().toISOString(),
+        timeRangeEnd: new Date().toISOString(),
+        summaryText: "test summary",
+        keyFacts: [],
+        keyEntities: [],
+        sourceEpisodeIds: [],
+      }),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeQuestion advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeQuestion", () =>
+      storage.writeQuestion("What is the meaning of life?", "Testing questions", 5),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: saveBuffer advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "saveBuffer", () =>
+      storage.saveBuffer({
+        turns: [],
+        lastExtractionAt: null,
+        extractionCount: 0,
+      }),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: appendMemoryLifecycleEvents advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "appendMemoryLifecycleEvents", () =>
+      storage.appendMemoryLifecycleEvents([
+        {
+          eventId: "mle-fitness-test",
+          memoryId: "mem-test",
+          eventType: "test_event",
+          timestamp: new Date().toISOString(),
+          actor: "test",
+          reasonCode: "fitness",
+          ruleVersion: "test.v1",
+        } satisfies Record<string, unknown> as never,
+      ]),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeCompressionGuidelines advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeCompressionGuidelines", () =>
+      storage.writeCompressionGuidelines("# Guidelines\n\nTest."),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeIdentityAnchor advances the catalog lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeIdentityAnchor", () =>
+      storage.writeIdentityAnchor("# Identity Anchor\n\nTest."),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: writeOfflineSyncFile advances the catalog lastWriteAt (import path)", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const storage = await fixture.storageFor(TARGET_NS);
+    await assertWriteTouch(fixture, "writeOfflineSyncFile", () =>
+      storage.writeOfflineSyncFile(
+        path.join(storage.dir, "import", "test.json"),
+        Buffer.from("test content"),
+      ),
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("chokepoint: namespace isolation — a write to one namespace does not move another's lastWriteAt", async () => {
+  const fixture = await createStorageFixture(TARGET_NS, {
+    namespacesEnabled: true,
+    namespacePolicies: [{ name: OTHER_NS, kind: "explicit" }],
+  });
+  try {
+    const targetStorage = await fixture.storageFor(TARGET_NS);
+    // Ensure OTHER_NS is registered but untouched.
+    await fixture.storageFor(OTHER_NS);
+    await fixture.router.whenResolveHooksSettled();
+
+    const beforeOther = await fixture.lastWriteAt(OTHER_NS);
+    await targetStorage.writeProfile("# Target profile\n\nWrite to target only.");
+    await fixture.settleWriteTouches();
+    const afterOther = await fixture.lastWriteAt(OTHER_NS);
+
+    assert.equal(
+      afterOther,
+      beforeOther,
+      "OTHER_NS lastWriteAt should NOT move when writing to TARGET_NS",
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+});

--- a/tests/storage-contract/helpers.ts
+++ b/tests/storage-contract/helpers.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared storage-contract test harness (issues #1522 + #1533).
+ *
+ * Provides the minimal scaffolding to exercise StorageManager write entry
+ * points against a real NamespaceCatalog + NamespaceStorageRouter in a temp
+ * memoryDir, and assert catalog-touch parity (#1522) or storage contract
+ * invariants (#1533).
+ *
+ * The harness is shared between lane R1 (#1522 catalog-write-chokepoint) and
+ * lane T (#1533 storage-contract tests). Extend — don't fork.
+ */
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { NamespaceCatalog } from "../../packages/remnic-core/src/namespaces/catalog.js";
+import { NamespaceStorageRouter } from "../../packages/remnic-core/src/namespaces/storage.js";
+import { StorageManager } from "../../packages/remnic-core/src/storage.js";
+import { parseConfig } from "../../packages/remnic-core/src/config.js";
+import type { PluginConfig } from "../../packages/remnic-core/src/types.js";
+
+/**
+ * Offline-safe config for storage-contract tests: QMD off, embedding fallback
+ * off, namespaces ENABLED (the catalog is inert without it), extraction
+ * thresholds floored, consolidation far out.
+ */
+export function makeStorageTestConfig(
+  memoryDir: string,
+  overrides: Record<string, unknown> = {},
+): PluginConfig {
+  return parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    recallPlannerEnabled: false,
+    sharedContextEnabled: false,
+    triggerMode: "smart",
+    bufferMaxTurns: 10,
+    extractionMinChars: 0,
+    extractionMinUserTurns: 1,
+    consolidateEveryN: 50,
+    initGateTimeoutMs: 1000,
+    ...overrides,
+  });
+}
+
+/**
+ * A fully-wired storage-contract fixture: temp memoryDir, catalog, router
+ * (with catalog attached per #1522), and a pre-resolved StorageManager for
+ * the given namespace. Cleaned up via `fixture.cleanup()`.
+ */
+export interface StorageContractFixture {
+  readonly memoryDir: string;
+  readonly config: PluginConfig;
+  readonly catalog: NamespaceCatalog;
+  readonly router: NamespaceStorageRouter;
+  /** Get (or create+cache) the StorageManager for a namespace via the router. */
+  storageFor(namespace: string): Promise<StorageManager>;
+  /** Read the catalog's lastWriteAt for a namespace (undefined if not registered). */
+  lastWriteAt(namespace: string): Promise<string | undefined>;
+  /** Await all pending fire-and-forget write touches for the router. */
+  settleWriteTouches(): Promise<void>;
+  /** Remove the temp dir, retrying transient ENOTEMPTY. */
+  cleanup(): Promise<void>;
+}
+
+export async function createStorageFixture(
+  namespace: string = "default",
+  overrides: Record<string, unknown> = {},
+): Promise<StorageContractFixture> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-storage-contract-"));
+  const config = makeStorageTestConfig(memoryDir, overrides);
+  const catalog = new NamespaceCatalog(config);
+  await catalog.registerConfiguredNamespaces();
+
+  const router = new NamespaceStorageRouter(
+    config,
+    {
+      onResolve: (ns, dir) => catalog.registerResolved(ns, dir),
+    },
+    catalog,
+  );
+
+  const storageCache = new Map<string, StorageManager>();
+
+  const fixture: StorageContractFixture = {
+    memoryDir,
+    config,
+    catalog,
+    router,
+    async storageFor(ns: string) {
+      let sm = storageCache.get(ns);
+      if (!sm) {
+        sm = await router.storageFor(ns);
+        storageCache.set(ns, sm);
+      }
+      return sm;
+    },
+    async lastWriteAt(ns: string) {
+      const rec = await catalog.getNamespaceRecord(ns);
+      return rec?.lastWriteAt;
+    },
+    settleWriteTouches: () => router.whenWriteTouchesSettled(),
+    async cleanup() {
+      // Retry transient ENOTEMPTY/EBUSY (background indexers on macOS/Windows).
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+          await rm(memoryDir, { recursive: true, force: true });
+          return;
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (code !== "ENOTEMPTY" && code !== "EBUSY") throw err;
+          const { promise, resolve } = Promise.withResolvers<void>();
+          setTimeout(resolve, 100 * (attempt + 1));
+          await promise;
+        }
+      }
+    },
+  };
+
+  // Pre-warm the namespace's storage so the catalog registers it.
+  await fixture.storageFor(namespace);
+  await router.whenResolveHooksSettled();
+
+  return fixture;
+}


### PR DESCRIPTION
Closes #1522. Part of #1520 (Phase 1). Refs #1506.

## Summary

Moves catalog write-recording from ~15 scattered per-caller sites to a single chokepoint inside the per-namespace StorageManager low-level write primitives. Every public storage write entry point now records the catalog touch post-success — correct by construction.

## Step-1 grep (fitness function)

**Before (main):** 21 hits in orchestrator.ts alone.
```
grep -rn "markCatalogWrite|markWrite(|markRead(" packages/remnic-core/src --include='*.ts' | grep -v test | grep -v namespaces/
```

**After (this PR):** 0 hits outside storage/catalog (exit 1 — no matches).

## Fitness test

tests/storage-contract/catalog-write-chokepoint.test.ts exercises every public storage write entry point and asserts the catalog row lastWriteAt moved. Prove-fail-before: 13/14 tests fail when the chokepoint is disabled.

## Chokepoints used

serializeMutations/withHeldFileLock (#1524, merged); catalog write-recording at storage chokepoint (this PR). Not applicable: ScopePlan resolver (#1521).

## Coordination

tests/storage-contract/helpers.ts shares the harness with #1533 Phase A (PR #1612). APIs will be unioned during rebase once #1612 merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches catalog recency used by `writtenSince` and QMD maintenance across all write paths; behavior shifts from orchestrator-timed single touches to per-storage-write hooks, with `recordWrite` retained only for delete-only maintenance. Supersession-only branches that no longer call explicit catalog writes depend on those writes going through hooked storage primitives.
> 
> **Overview**
> **Namespace catalog `lastWriteAt` / read touches are centralized** so they fire from `StorageManager` after successful durable writes, instead of from many orchestrator, HTTP/MCP, CLI, and explicit-capture call sites.
> 
> `NamespaceStorageRouter` now takes a `NamespaceCatalog`, binds `onCatalogWrite` on router-created storages (and the legacy default `this.storage`), and exposes `recordRead`, `recordWrite`, and `whenWriteTouchesSettled` for tests and delete-only maintenance paths. **`markCatalogWrite` / `recordCatalogWrite` are removed** from the orchestrator and access service; recall uses `storageRouter.recordRead`, and consolidation still calls `recordWrite` when mutations bypass the hook.
> 
> Low-level writes route through `writeStorageSecureFile` / chunks (and related append paths) so **`notifyCatalogWrite()` runs once per successful file mutation**, covering memories, artifacts, profile, questions, offline sync, etc. Callers that used to call `recordCatalogWrite` after contradiction merges or explicit capture now rely on that hook (HTTP/MCP/CLI callbacks are no-ops).
> 
> Adds **`tests/storage-contract/catalog-write-chokepoint.test.ts`** and shared **`tests/storage-contract/helpers.ts`**; existing catalog-touch tests are updated for per-write touches and `markWrite` spies. Ratchet LOC counts drop slightly for `orchestrator.ts` and `access-service.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790a1b588292fdfef6e192496239126e0afe710c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->