### PR TITLE
refactor(recall): #1539 PR1-2/6 — characterization snapshots + unifiedDedupeAndRank spine module

### DIFF
--- a/packages/remnic-core/src/recall-pipeline-stages.test.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.test.ts
@@ -229,3 +229,41 @@ test("unifiedDedupeAndRank: fallback id uses sessionId:turnIndex when id is abse
   });
   assert.equal(result.length, 1, "fallback id dedup must collapse the two items");
 });
+
+test("unifiedDedupeAndRank: dedupByContent false keeps distinct ids with identical content (event-order shape)", () => {
+  // Event-order's rankAndSelectEventOrderItems deduplicates by turn id only and
+  // keeps distinct turns even when two turns share the same cue-appended body.
+  // The spine must express that as a declared config field so PR 6's migration
+  // does not silently drop valid turns (cursor bugbot a4299851).
+  const items: EvidencePackItem[] = [
+    item(1, "What time is it?", { id: "s1:1" }),
+    item(5, "What time is it?", { id: "s1:5" }),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+    dedupByContent: false,
+  });
+  assert.equal(result.length, 2, "distinct ids with identical content must both survive when dedupByContent is false");
+});
+
+test("unifiedDedupeAndRank: dedupByContent true (default) still collapses identical content under different ids", () => {
+  const items: EvidencePackItem[] = [
+    item(1, "Duplicate body", { id: "s1:1" }),
+    item(2, "Duplicate body", { id: "s1:2" }),
+  ];
+  const resultDefault = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+  });
+  assert.equal(resultDefault.length, 1, "default dedupByContent collapses identical content");
+  const resultExplicit = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+    dedupByContent: true,
+  });
+  assert.equal(resultExplicit.length, 1, "explicit dedupByContent: true collapses identical content");
+});

--- a/packages/remnic-core/src/recall-pipeline-stages.test.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.test.ts
@@ -1,0 +1,231 @@
+// Issue #1539 PR2 — unit tests for the recall pipeline spine module.
+//
+// These tests verify `unifiedDedupeAndRank` produces the correct results for
+// each declared divergence dimension, WITHOUT changing any existing pipeline.
+// PRs 3–6 will migrate each pipeline to call this function; at that point the
+// characterization snapshots (tests/recall-pipeline-unified.test.ts) verify
+// end-to-end byte-for-byte parity.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { EvidencePackItem } from "./evidence-pack.js";
+import {
+  unifiedDedupeAndRank,
+  type RankedEvidenceItem,
+} from "./recall-pipeline-stages.js";
+
+const NO_INTENTS: never[] = [];
+const constantScorer = (_item: EvidencePackItem): number => 10;
+
+function item(
+  turnIndex: number,
+  content: string,
+  overrides: Partial<EvidencePackItem> = {},
+): EvidencePackItem {
+  return {
+    id: `s1:${turnIndex}`,
+    sessionId: "s1",
+    turnIndex,
+    role: "user",
+    content,
+    ...overrides,
+  };
+}
+
+test("unifiedDedupeAndRank: dedup collapses identical ids", () => {
+  const items = [
+    item(3, "Content A"),
+    item(3, "Content A"), // same id → deduped
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+  });
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.turnIndex, 3);
+});
+
+test("unifiedDedupeAndRank: dedup collapses identical normalized content under different ids", () => {
+  const items = [
+    item(10, "My monthly expenses are $2,400."),
+    item(11, "MY   MONTHLY   EXPENSES ARE $2,400."), // same normalized content
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+  });
+  assert.equal(result.length, 1, "expected content dedup to collapse the two items");
+  assert.equal(result[0]?.turnIndex, 10, "first-seen wins");
+});
+
+test("unifiedDedupeAndRank: DESC sort (default) orders turnIndex descending on score ties", () => {
+  const items = [
+    item(2, "Oldest"),
+    item(5, "Middle"),
+    item(9, "Newest"),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer, // all tied → turnIndex DESC
+  });
+  const turns = result.map((r) => r.turnIndex);
+  assert.deepEqual(turns, [9, 5, 2]);
+});
+
+test("unifiedDedupeAndRank: ASC sort orders turnIndex ascending on score ties", () => {
+  const items = [
+    item(30, "Latest"),
+    item(10, "Earliest"),
+    item(20, "Middle"),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+    turnIndexSortDirection: "asc",
+  });
+  const turns = result.map((r) => r.turnIndex);
+  assert.deepEqual(turns, [10, 20, 30]);
+});
+
+test("unifiedDedupeAndRank: rank primary key is always DESC regardless of turnIndex direction", () => {
+  const items = [
+    item(1, "Low rank", { score: 0 }),
+    item(2, "High rank", { score: 0 }),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: (i) => (i.turnIndex === 2 ? 100 : 1),
+    turnIndexSortDirection: "asc",
+  });
+  // rank DESC wins over turnIndex ASC: turn 2 (rank 100) comes first despite ASC.
+  assert.equal(result[0]?.turnIndex, 2);
+  assert.equal(result[1]?.turnIndex, 1);
+});
+
+test("unifiedDedupeAndRank: rankThreshold drops items below the declared threshold", () => {
+  const items = [
+    item(1, "Weak", { score: 0 }),
+    item(2, "Strong", { score: 0 }),
+    item(3, "Medium", { score: 0 }),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: (i) => {
+      if (i.turnIndex === 1) return 3;
+      if (i.turnIndex === 2) return 10;
+      return 6;
+    },
+    rankThreshold: 6,
+  });
+  const turns = result.map((r) => r.turnIndex).sort((a, b) => (a ?? 0) - (b ?? 0));
+  assert.deepEqual(turns, [2, 3], "turn 1 (rank 3) is below threshold 6 and dropped");
+});
+
+test("unifiedDedupeAndRank: transformContent is applied to output but NOT to scorer input", () => {
+  const items = [item(5, "original content")];
+  let scorerSawTransformed = false;
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: (i) => {
+      if (i.content.includes("APPENDED CUE")) scorerSawTransformed = true;
+      return 5;
+    },
+    transformContent: (content) => `${content}\nAPPENDED CUE`,
+  });
+  assert.equal(scorerSawTransformed, false, "scorer must see ORIGINAL content");
+  assert.ok(result[0]?.content.includes("APPENDED CUE"), "output must have transformed content");
+});
+
+test("unifiedDedupeAndRank: undefined turnIndex sorts to the bottom of DESC (-1 sentinel)", () => {
+  const items = [
+    item(5, "Has turn"),
+    { id: "s1:x", sessionId: "s1", role: "user", content: "No turn" }, // no turnIndex
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+    // default DESC
+  });
+  assert.equal(result[1]?.id, "s1:x", "undefined-turnIndex item sorts last in DESC");
+});
+
+test("unifiedDedupeAndRank: undefined turnIndex sorts to the bottom of ASC (MAX sentinel)", () => {
+  const items = [
+    item(5, "Has turn"),
+    { id: "s1:x", sessionId: "s1", role: "user", content: "No turn" },
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+    turnIndexSortDirection: "asc",
+  });
+  assert.equal(result[1]?.id, "s1:x", "undefined-turnIndex item sorts last in ASC");
+});
+
+test("unifiedDedupeAndRank: DESC tertiary tiebreaker is score DESC", () => {
+  // Same rank (all tied via constantScorer) AND same turnIndex → score breaks the tie.
+  const items = [
+    item(5, "Low score", { score: 10 }),
+    item(5, "High score", { score: 90 }), // same turn, deduped by content? No — different content
+  ];
+  // Wait — both have turn 5 so same id "s1:5" → second is deduped. Use different sessions.
+  const itemsDistinct: EvidencePackItem[] = [
+    { id: "s1:5", sessionId: "s1", turnIndex: 5, role: "user", content: "A", score: 10 },
+    { id: "s2:5", sessionId: "s2", turnIndex: 5, role: "user", content: "B", score: 90 },
+  ];
+  const result = unifiedDedupeAndRank(itemsDistinct, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer, // rank tied → turnIndex tied → score DESC
+  });
+  assert.equal(result[0]?.id, "s2:5", "higher score (90) ranks first on DESC tertiary");
+  assert.equal(result[1]?.id, "s1:5");
+});
+
+test("unifiedDedupeAndRank: ASC tertiary tiebreaker is content.localeCompare", () => {
+  const items: EvidencePackItem[] = [
+    { id: "s2:5", sessionId: "s2", turnIndex: 5, role: "user", content: "Banana" },
+    { id: "s1:5", sessionId: "s1", turnIndex: 5, role: "user", content: "Apple" },
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer, // rank tied → turnIndex tied → content localeCompare
+    turnIndexSortDirection: "asc",
+  });
+  assert.equal(result[0]?.content, "Apple", "localeCompare ASC: Apple < Banana");
+  assert.equal(result[1]?.content, "Banana");
+});
+
+test("unifiedDedupeAndRank: RankedEvidenceItem carries the computed rank", () => {
+  const items = [item(1, "content")];
+  const result: RankedEvidenceItem[] = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: () => 42,
+  });
+  assert.equal(result[0]?.rank, 42);
+});
+
+test("unifiedDedupeAndRank: fallback id uses sessionId:turnIndex when id is absent", () => {
+  const items: EvidencePackItem[] = [
+    { sessionId: "s1", turnIndex: 7, role: "user", content: "No explicit id" },
+    { sessionId: "s1", turnIndex: 7, role: "user", content: "Same fallback id → deduped" },
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: constantScorer,
+  });
+  assert.equal(result.length, 1, "fallback id dedup must collapse the two items");
+});

--- a/packages/remnic-core/src/recall-pipeline-stages.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.ts
@@ -1,0 +1,277 @@
+/**
+ * Issue #1539 PR2 — the staged recall pipeline spine.
+ *
+ * The four recall pipelines (`targeted-fact-recall.ts`, `response-guidance-
+ * recall.ts`, `explicit-cue-recall.ts`, `event-order-recall.ts`) implement
+ * the same stage sequence — intent → candidate collection → dedup → rank →
+ * filter → slice → metadata insertion → token budgeting — with ~70%
+ * near-duplicate code. The most dangerous divergence is the sort
+ * comparator: guidance/targeted-fact sort `turnIndex` DESC (recency) while
+ * event-order sorts `turnIndex` ASC (chronological). The comparators are
+ * byte-identical except for this direction — copy-pasting into a new
+ * chronological pipeline silently inverts the ordering.
+ *
+ * This module centralizes the **dedup + score + threshold-filter + sort**
+ * stages behind one declared config object. Per-tier divergence (threshold
+ * value, sort direction, content transformation) becomes a declared config
+ * field instead of embedded code.
+ *
+ * **PR 2 scope:** extract the module with NO pipeline changes. PRs 3–6
+ * migrate each pipeline to call `unifiedDedupeAndRank` one at a time,
+ * re-running the characterization snapshots
+ * (`tests/recall-pipeline-unified.test.ts`) to verify byte-for-byte parity.
+ *
+ * Future PRs will add the remaining stages from the issue's Solution
+ * (`mergeAcrossLcmKeys`, `insertMetadata`) once the per-tier hooks are
+ * factored out of each pipeline.
+ *
+ * @see https://github.com/joshuaswarren/remnic/issues/1539
+ */
+
+import type { EvidencePackItem } from "./evidence-pack.js";
+
+/** A ranked evidence item: an `EvidencePackItem` with a computed `rank`. */
+export interface RankedEvidenceItem extends EvidencePackItem {
+  rank: number;
+}
+
+/**
+ * Sort direction for the turn-index secondary key. This is the divergence
+ * issue #1539 identifies: relevance-ranked pipelines (targeted-fact,
+ * response-guidance) sort `turnIndex` DESC (recency — latest first); the
+ * chronological pipeline (event-order) sorts `turnIndex` ASC (earliest
+ * first). The rank primary key is ALWAYS DESC (higher rank first); only
+ * the `turnIndex` tiebreaker flips direction.
+ */
+export type TurnIndexSortDirection = "desc" | "asc";
+
+/**
+ * Configuration for the unified dedup + score + threshold-filter + sort
+ * pass. Each pipeline declares its divergences as fields here instead of
+ * embedding them in pipeline-specific code.
+ *
+ * The issue's Solution defines the intended full config object
+ * (`RecallPipelineConfig`); this interface is extracted incrementally:
+ *   - PR 2 (this PR): dedup/score/threshold/sort only
+ *   - PRs 3–6: migrate each pipeline to consume the spine
+ *   - future: add `mergeAcrossLcmKeys`, `insertMetadata` once the per-tier
+ *     hooks are factored out of each pipeline
+ */
+export interface UnifiedRankConfig<TIntent> {
+  /** The user query — passed to the scorer. */
+  query: string;
+  /**
+   * Per-tier intent classification result (already computed by the caller;
+   * intent classification stays per-tier because it is genuinely
+   * per-tier per issue #1539 Pitfall 1).
+   */
+  intents: TIntent[];
+  /**
+   * Score an item using its ORIGINAL (pre-transform) content. Higher = more
+   * relevant. The return value becomes the item's `rank`. For pipelines
+   * that don't score (explicit-cue), pass a constant scorer — the config
+   * makes the no-scoring policy explicit.
+   */
+  scoreEvidence: (
+    item: EvidencePackItem,
+    query: string,
+    intents: TIntent[],
+  ) => number;
+  /**
+   * Optional content transformation applied to each surviving item's
+   * OUTPUT content (NOT to the content the scorer sees). Per-tier
+   * cue-appenders go here:
+   *   - targeted-fact: `appendNormalizedNumericCues`
+   *   - response-guidance: `appendGuidanceCues`
+   *   - event-order: `appendChronologicalCues`
+   *
+   * The dedup key uses the TRANSFORMED content. This is equivalent to
+   * deduping on original content for all existing pipelines because every
+   * transform is a deterministic append (same original → same transformed →
+   * same key; different originals → different transformed → different key).
+   */
+  transformContent?: (content: string, intents: TIntent[]) => string;
+  /**
+   * Items with `rank` below this threshold are dropped. `undefined` = no
+   * filter. Event-order declares `rankThreshold: 6` here instead of
+   * inlining an undocumented `.filter((item) => item.rank >= 6)` (the
+   * "hardcoded rank threshold that exists in no config and no other
+   * pipeline" from issue #1539's audit).
+   */
+  rankThreshold?: number;
+  /**
+   * Sort direction for the `turnIndex` secondary key.
+   *
+   * - `"desc"` (default): relevance-ranked pipelines (targeted-fact,
+   *   response-guidance) sort `turnIndex` DESC. Undefined `turnIndex`
+   *   falls to `-1` (bottom of a DESC list). Tertiary tiebreaker:
+   *   `score DESC`.
+   * - `"asc"`: the chronological pipeline (event-order) sorts `turnIndex`
+   *   ASC. Undefined `turnIndex` falls to `Number.MAX_SAFE_INTEGER`
+   *   (bottom of an ASC list). Tertiary tiebreaker: `content.localeCompare`.
+   *
+   * The rank primary key is ALWAYS DESC regardless of this setting.
+   */
+  turnIndexSortDirection?: TurnIndexSortDirection;
+}
+
+/**
+ * Sentinel for undefined `turnIndex` when sorting DESC. `-1` sorts below
+ * every real turn index (which are `>= 0`), so missing `turn_index` always
+ * lands at the bottom of a DESC-ordered list — never wins ordering over a
+ * real turn.
+ */
+const UNDEFINED_TURN_INDEX_DESC_SENTINEL = -1;
+
+/**
+ * Sentinel for undefined `turnIndex` when sorting ASC.
+ * `Number.MAX_SAFE_INTEGER` sorts above every real turn index, so missing
+ * `turn_index` always lands at the bottom of an ASC-ordered list.
+ */
+const UNDEFINED_TURN_INDEX_ASC_SENTINEL = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Deduplicate, score, threshold-filter, and sort evidence items under one
+ * unified policy.
+ *
+ * **Stage order** (matches every existing pipeline's rank/dedupe function):
+ *   1. **dedup** by `id` + normalized content (first-seen wins). The dedup
+ *      key uses transformed content if `transformContent` is declared.
+ *   2. **score** each surviving item on its ORIGINAL content (the transform
+ *      does not influence the score).
+ *   3. **threshold-filter**: drop items with `rank < rankThreshold` (if
+ *      declared).
+ *   4. **sort**: `rank DESC` → `turnIndex` (direction-configurable) →
+ *      tertiary tiebreaker (`score DESC` for relevance pipelines,
+ *      `content.localeCompare` for chronological pipelines).
+ *
+ * This function does NOT slice (`maxResults`), budget, or format — those
+ * stages remain per-tier because they interact with per-tier metadata
+ * insertion. The issue's Solution describes a future `insertMetadata` hook
+ * that will make budget-adjustment uniform; that lands in the per-tier
+ * migration PRs.
+ *
+ * @example
+ * // Relevance-ranked pipeline (targeted-fact shape):
+ * unifiedDedupeAndRank(items, {
+ *   query,
+ *   intents: [],
+ *   scoreEvidence: (item, q) => scoreTargetedFact(item, q),
+ *   transformContent: (content) => appendNormalizedNumericCues(content),
+ *   // turnIndexSortDirection defaults to "desc"
+ * });
+ *
+ * @example
+ * // Chronological pipeline (event-order shape):
+ * unifiedDedupeAndRank(items, {
+ *   query,
+ *   intents: [],
+ *   scoreEvidence: (item, q) => scoreEventOrder(item, q),
+ *   transformContent: (content) => appendChronologicalCues(content, query),
+ *   rankThreshold: 6,           // declared, not inlined
+ *   turnIndexSortDirection: "asc",
+ * });
+ */
+export function unifiedDedupeAndRank<TIntent>(
+  items: readonly EvidencePackItem[],
+  config: UnifiedRankConfig<TIntent>,
+): RankedEvidenceItem[] {
+  const transformContent = config.transformContent ?? ((content: string) => content);
+  const direction: TurnIndexSortDirection = config.turnIndexSortDirection ?? "desc";
+
+  // Stage 1: dedup by id + normalized (transformed) content.
+  // First-seen wins, matching every existing pipeline.
+  const seenIds = new Set<string>();
+  const seenContent = new Set<string>();
+  const survivors: Array<{ original: EvidencePackItem; transformedContent: string }> = [];
+
+  for (const item of items) {
+    const id = resolveItemId(item);
+    if (id && seenIds.has(id)) continue;
+
+    const transformedContent = transformContent(item.content, config.intents);
+    const contentKey = transformedContent.toLowerCase().replace(/\s+/g, " ").trim();
+    if (seenContent.has(contentKey)) continue;
+    if (id) seenIds.add(id);
+    seenContent.add(contentKey);
+    survivors.push({ original: item, transformedContent });
+  }
+
+  // Stage 2: score on ORIGINAL content (transforms don't influence the score).
+  const scored: RankedEvidenceItem[] = survivors.map(({ original, transformedContent }) => ({
+    ...original,
+    content: transformedContent,
+    rank: config.scoreEvidence(original, config.query, config.intents),
+  }));
+
+  // Stage 3: threshold-filter (declared, not inlined).
+  const filtered =
+    typeof config.rankThreshold === "number"
+      ? scored.filter((item) => item.rank >= (config.rankThreshold as number))
+      : scored;
+
+  // Stage 4: sort.
+  // rank is ALWAYS DESC (higher rank first).
+  // turnIndex direction is configurable: DESC (relevance) or ASC (chronology).
+  // The tertiary tiebreaker follows the direction:
+  //   DESC → score DESC; ASC → content.localeCompare.
+  return filtered.sort(makeComparator(direction));
+}
+
+/**
+ * Build the sort comparator for the configured direction. Extracted so the
+ * comparator's two shapes (DESC / ASC) can be tested independently and so
+ * the direction divergence is visible in ONE place.
+ */
+function makeComparator(
+  direction: TurnIndexSortDirection,
+): (left: RankedEvidenceItem, right: RankedEvidenceItem) => number {
+  if (direction === "asc") {
+    // Chronological (event-order): rank DESC → turnIndex ASC → content localeCompare.
+    // Matches event-order-recall.ts:159-164 (rankedByScore sort) byte-for-byte.
+    return (left, right) => {
+      if (right.rank !== left.rank) return right.rank - left.rank;
+      const leftTurn =
+        typeof left.turnIndex === "number"
+          ? left.turnIndex
+          : UNDEFINED_TURN_INDEX_ASC_SENTINEL;
+      const rightTurn =
+        typeof right.turnIndex === "number"
+          ? right.turnIndex
+          : UNDEFINED_TURN_INDEX_ASC_SENTINEL;
+      if (leftTurn !== rightTurn) return leftTurn - rightTurn;
+      return left.content.localeCompare(right.content);
+    };
+  }
+  // Relevance-ranked (targeted-fact, response-guidance):
+  // rank DESC → turnIndex DESC → score DESC.
+  // Matches targeted-fact-recall.ts:239-245 and response-guidance-recall.ts:374-380
+  // byte-for-byte.
+  return (left, right) => {
+    if (right.rank !== left.rank) return right.rank - left.rank;
+    const leftTurn =
+      typeof left.turnIndex === "number"
+        ? left.turnIndex
+        : UNDEFINED_TURN_INDEX_DESC_SENTINEL;
+    const rightTurn =
+      typeof right.turnIndex === "number"
+        ? right.turnIndex
+        : UNDEFINED_TURN_INDEX_DESC_SENTINEL;
+    if (rightTurn !== leftTurn) return rightTurn - leftTurn;
+    return (right.score ?? 0) - (left.score ?? 0);
+  };
+}
+
+
+/**
+ * Resolve an evidence item's id. Falls back to `sessionId:turnIndex` when
+ * `id` is absent — mirrors every existing pipeline's fallback and
+ * `evidence-pack.ts`'s `evidenceItemFallbackId`.
+ */
+function resolveItemId(item: EvidencePackItem): string | undefined {
+  if (item.id) return item.id;
+  if (item.sessionId && typeof item.turnIndex === "number") {
+    return `${item.sessionId}:${item.turnIndex}`;
+  }
+  return undefined;
+}

--- a/packages/remnic-core/src/recall-pipeline-stages.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.ts
@@ -92,6 +92,18 @@ export interface UnifiedRankConfig<TIntent> {
    */
   transformContent?: (content: string, intents: TIntent[]) => string;
   /**
+   * Whether to deduplicate by normalized (transformed) content in addition to
+   * id. Default `true` — matches targeted-fact, response-guidance, and
+   * explicit-cue, which all collapse later items sharing a normalized content
+   * key. Event-order sets this to `false`: its rank pass
+   * (`rankAndSelectEventOrderItems`) deduplicates by turn id only and keeps
+   * distinct turns even when two turns share the same cue-appended body
+   * (legitimate repeated turns in a chronological transcript). Making this a
+   * declared field prevents PR 6's migration from silently dropping valid
+   * turns (cursor bugbot a4299851).
+   */
+  dedupByContent?: boolean;
+  /**
    * Items with `rank` below this threshold are dropped. `undefined` = no
    * filter. Event-order declares `rankThreshold: 6` here instead of
    * inlining an undocumented `.filter((item) => item.rank >= 6)` (the
@@ -178,9 +190,12 @@ export function unifiedDedupeAndRank<TIntent>(
 ): RankedEvidenceItem[] {
   const transformContent = config.transformContent ?? ((content: string) => content);
   const direction: TurnIndexSortDirection = config.turnIndexSortDirection ?? "desc";
+  const dedupByContent = config.dedupByContent !== false;
 
-  // Stage 1: dedup by id + normalized (transformed) content.
-  // First-seen wins, matching every existing pipeline.
+  // Stage 1: dedup by id (+ normalized transformed content when enabled).
+  // First-seen wins, matching every existing pipeline. Event-order opts out
+  // of content dedup (dedupByContent: false) because it keeps distinct turns
+  // even when two turns share the same cue-appended body.
   const seenIds = new Set<string>();
   const seenContent = new Set<string>();
   const survivors: Array<{ original: EvidencePackItem; transformedContent: string }> = [];
@@ -190,10 +205,12 @@ export function unifiedDedupeAndRank<TIntent>(
     if (id && seenIds.has(id)) continue;
 
     const transformedContent = transformContent(item.content, config.intents);
-    const contentKey = transformedContent.toLowerCase().replace(/\s+/g, " ").trim();
-    if (seenContent.has(contentKey)) continue;
+    if (dedupByContent) {
+      const contentKey = transformedContent.toLowerCase().replace(/\s+/g, " ").trim();
+      if (seenContent.has(contentKey)) continue;
+      seenContent.add(contentKey);
+    }
     if (id) seenIds.add(id);
-    seenContent.add(contentKey);
     survivors.push({ original: item, transformedContent });
   }
 

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -1185,6 +1185,7 @@ test("semantic consolidation records a catalog write when archival fails after c
 // primary memory and the derived writes.
 test("persistExtraction records non-chunked source catalog touch after graph and artifact writes", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-nonchunk-touch-order-"));
+  let cleanup: (() => Promise<void>) | undefined;
   try {
     const config = parseConfig({
       openaiApiKey: "sk-test",
@@ -1204,6 +1205,7 @@ test("persistExtraction records non-chunked source catalog touch after graph and
     });
 
     const orchestrator = new Orchestrator(config) as any;
+    cleanup = () => orchestrator.destroy();
     const ns = "project-origin-nonchunk-order";
     const storage = await orchestrator.getStorage(ns);
     await storage.ensureDirectories();
@@ -1260,6 +1262,7 @@ test("persistExtraction records non-chunked source catalog touch after graph and
       `catalog write touch must fire via the storage chokepoint during non-chunked extraction; saw ${events.join(" -> ")}`,
     );
   } finally {
+    await cleanup?.().catch(() => undefined);
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/tests/recall-pipeline-unified.test.ts
+++ b/tests/recall-pipeline-unified.test.ts
@@ -510,40 +510,15 @@ test("divergence: event-order ranks ASC (turnIndex ascending after the score gat
   );
 });
 
-test("divergence: DESC tertiary tiebreaker is score DESC among numbered turns", async () => {
-  // When rank ties AND turnIndex ties, the DESC comparator falls back to
-  // `score DESC`. Here we pin that behavior: two search hits on distinct
-  // sessions but the SAME turn_index produce two candidates whose rank
-  // ties (same scorer input shape); the higher-scoring one ranks first.
-  //
-  // (The undefined-turnIndex sentinel behavior — DESC: -1, ASC:
-  // Number.MAX_SAFE_INTEGER — is a property of the COMPARATOR that the
-  // spine centralizes, not of the end-to-end pipeline. Real engine items
-  // always carry a numeric `turn_index`, so the sentinel is unreachable
-  // through the builder surface. It is tested directly against the spine
-  // module in `packages/remnic-core/src/recall-pipeline-stages.test.ts`
-  // — tests "undefined turnIndex sorts to the bottom of DESC (-1 sentinel)"
-  // and "undefined turnIndex sorts to the bottom of ASC (MAX sentinel)".)
-  const sessions = new Map<string, FixtureMessage[]>([
-    [FIXTURE_SESSION_PRIMARY, [
-      { turn_index: 5, role: "user", content: TARGETED_FACT_CONTENT },
-      { turn_index: 6, role: "user", content: "We discussed the monthly expenses figure at length." },
-    ]],
-  ]);
-  const engine = new FakeLcmEngine(sessions, new Map([[FIXTURE_SESSION_PRIMARY, [5, 6]]]));
-  const output = await buildTargetedFactRecallSection({
-    engine,
-    sessionId: FIXTURE_SESSION_PRIMARY,
-    query: "What are my monthly expenses?",
-    maxChars: 6_000,
-    maxSearchResults: 16,
-  });
-  const pos5 = output.indexOf("turn 5,");
-  const pos6 = output.indexOf("turn 6,");
-  if (pos5 > -1 && pos6 > -1) {
-    assert.ok(pos5 < pos6, `expected higher-scoring turn 5 first, got pos5=${pos5} pos6=${pos6}`);
-  }
-});
+// NOTE: the DESC tertiary score tiebreaker, the ASC content.localeCompare
+// tiebreaker, and the undefined-turnIndex sentinel behavior (DESC: -1,
+// ASC: Number.MAX_SAFE_INTEGER) are comparator properties centralized in
+// the spine module (PR2 recall-pipeline-stages.ts). They are tested
+// directly in recall-pipeline-stages.test.ts (tests 3-12). They are not
+// observable through the end-to-end builder surface because real engines
+// always produce items with numeric turn_index, and the end-to-end
+// pipelines' rank and turnIndex values are almost never simultaneously
+// tied at the builder level.
 
 test("divergence: fallback-merge — strong fallback hit outranks weak primary hit", async () => {
   // #1505 fallback merge: the primary session has NO evidence for this

--- a/tests/recall-pipeline-unified.test.ts
+++ b/tests/recall-pipeline-unified.test.ts
@@ -153,7 +153,8 @@ export class FakeLcmEngine implements ExplicitCueRecallEngine {
     if (sessionId && this.faultingSessions.has(sessionId)) {
       throw new Error(`FakeLcmEngine: simulated read fault on session ${sessionId}`);
     }
-    const messages = sessionId ? this.sessions.get(sessionId) : undefined;
+    if (!sessionId) return [];
+    const messages = this.sessions.get(sessionId);
     if (!messages) return [];
     const hits = this.searchHitsBySession.get(sessionId) ?? [];
     return hits

--- a/tests/recall-pipeline-unified.test.ts
+++ b/tests/recall-pipeline-unified.test.ts
@@ -510,14 +510,20 @@ test("divergence: event-order ranks ASC (turnIndex ascending after the score gat
   );
 });
 
-test("divergence: undefined turnIndex handled (DESC: -1 sentinel; ASC: MAX_SAFE_INTEGER sentinel)", async () => {
-  // When `turnIndex` is undefined, the DESC comparator falls back to -1
-  // (sorts to the bottom of a DESC list); the ASC comparator falls back to
-  // Number.MAX_SAFE_INTEGER (also sorts to the bottom of an ASC list). Both
-  // sentinels pin the same contract: missing turn_index never wins ordering.
-  // Here we pin the DESC behavior via targeted-fact: a search hit on turn 5
-  // (numeric fact, high score) must rank above any item that loses on the
-  // rank/turnIndex/score tuple.
+test("divergence: DESC tertiary tiebreaker is score DESC among numbered turns", async () => {
+  // When rank ties AND turnIndex ties, the DESC comparator falls back to
+  // `score DESC`. Here we pin that behavior: two search hits on distinct
+  // sessions but the SAME turn_index produce two candidates whose rank
+  // ties (same scorer input shape); the higher-scoring one ranks first.
+  //
+  // (The undefined-turnIndex sentinel behavior — DESC: -1, ASC:
+  // Number.MAX_SAFE_INTEGER — is a property of the COMPARATOR that the
+  // spine centralizes, not of the end-to-end pipeline. Real engine items
+  // always carry a numeric `turn_index`, so the sentinel is unreachable
+  // through the builder surface. It is tested directly against the spine
+  // module in `packages/remnic-core/src/recall-pipeline-stages.test.ts`
+  // — tests "undefined turnIndex sorts to the bottom of DESC (-1 sentinel)"
+  // and "undefined turnIndex sorts to the bottom of ASC (MAX sentinel)".)
   const sessions = new Map<string, FixtureMessage[]>([
     [FIXTURE_SESSION_PRIMARY, [
       { turn_index: 5, role: "user", content: TARGETED_FACT_CONTENT },
@@ -718,6 +724,33 @@ test("divergence: zero-limit contracts (0 maxResults / 0 maxItems / 0 maxChars a
     maxSearchResults: 0,
   });
   assert.equal(guidanceEmptyResults, "", "response-guidance maxSearchResults=0 must yield empty");
+
+  const guidanceEmptyBudget = await buildResponseGuidanceRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "How should I approach editting my draft?",
+    maxChars: 0,
+    maxSearchResults: 8,
+  });
+  assert.equal(guidanceEmptyBudget, "", "response-guidance maxChars=0 must yield empty");
+
+  const explicitEmptyReferences = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What did I say at turn 1?",
+    maxChars: 4_000,
+    maxReferences: 0,
+  });
+  assert.equal(explicitEmptyReferences, "", "explicit-cue maxReferences=0 must yield empty");
+
+  const explicitEmptyBudget = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What did I say at turn 1?",
+    maxChars: 0,
+    maxReferences: 4,
+  });
+  assert.equal(explicitEmptyBudget, "", "explicit-cue maxChars=0 must yield empty");
 });
 
 test("divergence: planner-mode gating contract (null/undefined engine yields empty for every pipeline)", async () => {

--- a/tests/recall-pipeline-unified.test.ts
+++ b/tests/recall-pipeline-unified.test.ts
@@ -1,0 +1,759 @@
+// Issue #1539 PR1 — Characterization tests for the four recall pipelines.
+//
+// These snapshots pin the CURRENT outputs of `buildTargetedFactRecallSection`,
+// `buildResponseGuidanceRecallSection`, `buildExplicitCueRecallSection`, and
+// `buildEventOrderRecallSection` on a fixed fixture corpus. They MUST survive
+// the spine migration byte-for-byte: each migration PR (targeted-fact →
+// response-guidance → explicit-cue → event-order) re-runs this file and
+// asserts the snapshots are unchanged (with the single declared exception of
+// event-order's outline-budget accounting fix, which lands in its own
+// migration PR and is captured by an additional snapshot there).
+//
+// The behaviors pinned here are exactly the divergences the spine must
+// declare as config fields (issue #1539 "Solution"):
+//   - dedup by id + normalized content
+//   - threshold filtering (event-order's hardcoded rank >= 6)
+//   - rank DESC / turnIndex secondary / score tertiary ordering
+//   - event-order's ASC ordering (chronological)
+//   - undefined turnIndex handling
+//   - fallback-merge (strong fallback hit outranks weak primary; cross-key
+//     content dedup; per-key fault isolation)
+//   - event-order does NOT call `gatherAcrossReadSessions` (turn_index is
+//     local to each session_id)
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ExplicitCueRecallEngine } from "../packages/remnic-core/src/explicit-cue-recall.js";
+import { buildExplicitCueRecallSection } from "../packages/remnic-core/src/explicit-cue-recall.js";
+import { buildEventOrderRecallSection } from "../packages/remnic-core/src/event-order-recall.js";
+import { buildResponseGuidanceRecallSection } from "../packages/remnic-core/src/response-guidance-recall.js";
+import { buildTargetedFactRecallSection } from "../packages/remnic-core/src/targeted-fact-recall.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture corpus — a small, deterministic transcript that triggers all four
+// pipelines. The exact contents are chosen so each pipeline produces stable,
+// non-empty output AND so the divergence dimensions (dedup, threshold, sort
+// direction, fallback-merge) are observable through the builder output.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FixtureMessage {
+  turn_index: number;
+  role: string;
+  content: string;
+}
+
+export const FIXTURE_SESSION_PRIMARY = "user:test:primary";
+export const FIXTURE_SESSION_FALLBACK = "user:test:fallback";
+
+const TARGETED_FACT_CONTENT =
+  "My monthly expenses are $2,400 — rent is $1,200, groceries $400, transport $300, and the rest is savings.";
+
+// `isGuidanceEvidence` for the "editing" intent requires BOTH an editing
+// vocabulary anchor (scrivener | split-screen | side-by-side | ...) AND an
+// editing root word (edit | draft | revision | ...). The content below is
+// crafted to clear that filter so the guidance pipeline produces stable
+// non-empty output.
+const GUIDANCE_EDITING_CONTENT =
+  "For editing drafts, I prefer Scrivener's split-screen mode so revisions can compare notes side-by-side.";
+
+const CHRONOLOGY_CONTENT =
+  "The order in which I introduced topics was: pronunciation, then vocabulary, then grammar, then conversation practice.";
+
+const FIXTURE_MESSAGES: FixtureMessage[] = [
+  {
+    turn_index: 1,
+    role: "user",
+    content:
+      "I started learning Turkish pronunciation with quantitative targets: 30 minutes daily, focusing on vowel harmony.",
+  },
+  {
+    turn_index: 2,
+    role: "assistant",
+    content:
+      "A structured practice plan with daily repetition will build vowel harmony intuition over four weeks.",
+  },
+  {
+    turn_index: 3,
+    role: "user",
+    content: TARGETED_FACT_CONTENT,
+  },
+  {
+    turn_index: 4,
+    role: "assistant",
+    content:
+      "Tracking monthly expenses at $2,400 with that breakdown gives you roughly $500 of discretionary savings each month.",
+  },
+  {
+    turn_index: 5,
+    role: "user",
+    content: GUIDANCE_EDITING_CONTENT,
+  },
+  {
+    turn_index: 6,
+    role: "assistant",
+    content:
+      "I will use Scrivener split-screen for revisions so each edit pass can compare notes side-by-side as you asked.",
+  },
+  {
+    turn_index: 7,
+    role: "user",
+    content: CHRONOLOGY_CONTENT,
+  },
+  {
+    turn_index: 8,
+    role: "assistant",
+    content:
+      "That sequence — pronunciation, vocabulary, grammar, conversation — follows a solid progressive language-learning arc.",
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────
+// FakeLcmEngine — supports multiple session IDs and records every call so the
+// fallback-merge and event-order-no-merge properties can be asserted.
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface FakeEngineCall {
+  op: "searchContextFull" | "expandContext" | "getStats";
+  sessionId?: string;
+  query?: string;
+  limit?: number;
+  fromTurn?: number;
+  toTurn?: number;
+}
+
+export class FakeLcmEngine implements ExplicitCueRecallEngine {
+  readonly calls: FakeEngineCall[] = [];
+  readonly enabled = true;
+
+  constructor(
+    private readonly sessions: Map<string, FixtureMessage[]>,
+    private readonly searchHitsBySession: Map<string, number[]> = new Map(),
+    private readonly faultingSessions: ReadonlySet<string> = new Set(),
+  ) {}
+
+  reset(): void {
+    this.calls.length = 0;
+  }
+
+  async searchContextFull(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<
+    Array<{
+      turn_index: number;
+      role: string;
+      content: string;
+      session_id: string;
+      score?: number;
+    }>
+  > {
+    this.calls.push({ op: "searchContextFull", query, limit, sessionId });
+    if (sessionId && this.faultingSessions.has(sessionId)) {
+      throw new Error(`FakeLcmEngine: simulated read fault on session ${sessionId}`);
+    }
+    const messages = sessionId ? this.sessions.get(sessionId) : undefined;
+    if (!messages) return [];
+    const hits = this.searchHitsBySession.get(sessionId) ?? [];
+    return hits
+      .map((turnIndex, index) => {
+        const message = messages.find((entry) => entry.turn_index === turnIndex);
+        if (!message) return null;
+        return {
+          turn_index: message.turn_index,
+          role: message.role,
+          content: message.content,
+          session_id: sessionId,
+          score: 100 - index,
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  }
+
+  async expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+    _maxTokens: number,
+  ): Promise<Array<{ turn_index: number; role: string; content: string }>> {
+    this.calls.push({ op: "expandContext", sessionId, fromTurn, toTurn });
+    if (this.faultingSessions.has(sessionId)) {
+      throw new Error(`FakeLcmEngine: simulated read fault on session ${sessionId}`);
+    }
+    const messages = this.sessions.get(sessionId);
+    if (!messages) return [];
+    return messages.filter(
+      (message) => message.turn_index >= fromTurn && message.turn_index <= toTurn,
+    );
+  }
+
+  async getStats(sessionId?: string): Promise<{
+    totalMessages: number;
+    maxTurnIndex?: number;
+  }> {
+    this.calls.push({ op: "getStats", sessionId });
+    if (sessionId && this.faultingSessions.has(sessionId)) {
+      throw new Error(`FakeLcmEngine: simulated read fault on session ${sessionId}`);
+    }
+    const messages = sessionId ? this.sessions.get(sessionId) : undefined;
+    if (!messages) return { totalMessages: 0 };
+    return {
+      totalMessages: messages.length,
+      maxTurnIndex: Math.max(...messages.map((message) => message.turn_index)),
+    };
+  }
+}
+
+function makeFixtureEngine(opts?: {
+  fallbackMessages?: FixtureMessage[];
+  searchHitsPrimary?: number[];
+  searchHitsFallback?: number[];
+  faultingSessions?: ReadonlySet<string>;
+}): FakeLcmEngine {
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, FIXTURE_MESSAGES],
+  ]);
+  if (opts?.fallbackMessages) {
+    sessions.set(FIXTURE_SESSION_FALLBACK, opts.fallbackMessages);
+  }
+  const searchHits = new Map<string, number[]>();
+  if (opts?.searchHitsPrimary) {
+    searchHits.set(FIXTURE_SESSION_PRIMARY, opts.searchHitsPrimary);
+  }
+  if (opts?.searchHitsFallback && opts.fallbackMessages) {
+    searchHits.set(FIXTURE_SESSION_FALLBACK, opts.searchHitsFallback);
+  }
+  return new FakeLcmEngine(
+    sessions,
+    searchHits,
+    opts?.faultingSessions ?? new Set<string>(),
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Snapshot tests — pin the EXACT current output of each pipeline on the
+// fixture corpus. These strings are the migration target: every spine PR
+// must reproduce them byte-for-byte. The label format `[sessionId, turn N,
+// role(, score NNN.NNN)]` is owned by evidence-pack.ts (shared by all four
+// pipelines), so it is already stable across the migration; the snapshot
+// pins the per-pipeline content selection, ordering, cue-appending, and
+// summary insertion.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("snapshot: targeted-fact pipeline on fixture corpus (single session)", async () => {
+  const engine = makeFixtureEngine({ searchHitsPrimary: [3] });
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 1_200,
+    maxSearchResults: 8,
+    maxScanWindowTurns: 8,
+    maxScanWindowTokens: 4_000,
+  });
+  // Snapshot pinned at #1539 PR1. Targeted-fact:
+  //   - appends `Normalized numeric cues: …` to each item (per-tier hook)
+  //   - ranks DESC (turn 3 score=100 above turn 4 unscored)
+  //   - budget-adjusts: the summary insertion is subtracted from the
+  //     evidence budget BEFORE buildEvidencePack runs
+  // The spine migration MUST reproduce this byte-for-byte.
+  assert.equal(output, TARGETED_FACT_SNAPSHOT);
+});
+
+const TARGETED_FACT_SNAPSHOT = [
+  "## Targeted fact evidence",
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 3, user, score 100.000]: ${TARGETED_FACT_CONTENT}`,
+  "",
+  "Normalized numeric cues: 2400 dollars; 1200 dollars; 400 dollars; 300 dollars.",
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 4, assistant]: Tracking monthly expenses at $2,400 with that breakdown gives you roughly $500 of discretionary savings each month.`,
+  "",
+  "Normalized numeric cues: 2400 dollars; 500 dollars.",
+].join("\n");
+
+test("snapshot: response-guidance pipeline on fixture corpus (single session)", async () => {
+  const engine = makeFixtureEngine({ searchHitsPrimary: [5] });
+  const output = await buildResponseGuidanceRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "How should I approach editting my draft?",
+    maxChars: 1_600,
+    maxSearchResults: 8,
+    maxScanWindowTurns: 8,
+    maxScanWindowTokens: 4_000,
+  });
+  // Snapshot pinned at #1539 PR1. Response-guidance:
+  //   - appends `Normalized response guidance: …` cue to each item's content
+  //     (per-tier hook: `appendGuidanceCues`)
+  //   - inserts a single cue preamble right after the title (budget-adjusted:
+  //     `maxChars - cueInsertion.length` is passed to buildEvidencePack)
+  //   - ranks DESC (turn 5, score=100, above turn 6, unscored)
+  assert.equal(output, RESPONSE_GUIDANCE_SNAPSHOT);
+});
+
+const RESPONSE_GUIDANCE_SNAPSHOT = [
+  "## Response guidance evidence",
+  "",
+  "Normalized response guidance: use split-screen view; side-by-side comparison.",
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 5, user, score 100.000]: Normalized response guidance: use split-screen view; side-by-side comparison.`,
+  "",
+  GUIDANCE_EDITING_CONTENT,
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 6, assistant]: Normalized response guidance: use split-screen view; side-by-side comparison.`,
+  "",
+  "I will use Scrivener split-screen for revisions so each edit pass can compare notes side-by-side as you asked.",
+].join("\n");
+
+test("snapshot: explicit-cue pipeline on fixture corpus (single session)", async () => {
+  const engine = makeFixtureEngine({ searchHitsPrimary: [1] });
+  const output = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What did I say at turn 1?",
+    maxChars: 1_600,
+    maxReferences: 4,
+  });
+  // Snapshot pinned at #1539 PR1. Explicit-cue:
+  //   - intentionally UNSCORED (issue #1539: "keep its intentional no-scoring
+  //     behavior — the config makes that explicit"); insertion order is the
+  //     contract, NOT score order
+  //   - turn-1 query triggers turn-reference collection → expand around
+  //     turn 1, picking up turns 1, 2, 3 within the budget
+  assert.equal(output, EXPLICIT_CUE_SNAPSHOT);
+});
+
+const EXPLICIT_CUE_SNAPSHOT = [
+  "## Explicit Cue Evidence",
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 1, user]: I started learning Turkish pronunciation with quantitative targets: 30 minutes daily, focusing on vowel harmony.`,
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 2, assistant]: A structured practice plan with daily repetition will build vowel harmony intuition over four weeks.`,
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 3, user]: ${TARGETED_FACT_CONTENT}`,
+].join("\n");
+
+test("snapshot: event-order pipeline on fixture corpus (single session)", async () => {
+  const engine = makeFixtureEngine();
+  const output = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What is the order in which I introduced topics?",
+    maxChars: 2_400,
+    maxItems: 8,
+    maxScanWindowTurns: 12,
+    maxScanWindowTokens: 8_000,
+  });
+  // Snapshot pinned at #1539 PR1. Event-order:
+  //   - ASC sort (turn_index ascending after the rank>=6 gate)
+  //   - prepend `Chronological cue labels: …` to each item (per-tier hook)
+  //   - summary line with chronology outline
+  //   - NOTE: this snapshot is taken with a generous budget (2400 chars)
+  //     so the outline-budget-accounting fix in the event-order migration
+  //     PR does NOT change this output. A separate tight-budget snapshot
+  //     in the event-order migration PR will pin the corrected behavior.
+  assert.equal(output, EVENT_ORDER_SNAPSHOT);
+});
+
+const EVENT_ORDER_SNAPSHOT = [
+  "## Chronological event evidence",
+  "",
+  "Chronological evidence is sorted by turn number. Chronology outline: turn 7: interaction with introduced; turn 7: interaction with topics. Use these turns to preserve the order in which the user raised the topics.",
+  "",
+  `[${FIXTURE_SESSION_PRIMARY}, turn 7, user]: Chronological cue labels: interaction with introduced; interaction with topics.`,
+  "",
+  "The order in which I introduced topics was: pronunciation, then vocabulary, then grammar, then conversation practice.",
+].join("\n");
+
+// ──────────────────────────────────────────────────────────────────────────
+// Divergence-pinning tests — each test pins one declared divergence so the
+// spine migration can be verified field-by-field.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("divergence: dedup collapses identical ids (same turn_index hit twice)", async () => {
+  // Two search hits on the same turn_index produce two raw candidates, but
+  // the rank/dedupe pass collapses them to one item (id-based dedup).
+  const engine = makeFixtureEngine({ searchHitsPrimary: [3, 3] });
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 4_000,
+    maxSearchResults: 16,
+  });
+  const matches = output.match(/turn 3,/g) ?? [];
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one 'turn 3' label after id-dedup, got ${matches.length} in:\n${output}`,
+  );
+});
+
+test("divergence: dedup collapses whitespace-only content differences (normalized content key)", async () => {
+  // Two distinct turns whose content differs ONLY in whitespace/case: the
+  // normalized-content dedup key (`toLowerCase().replace(/\s+/g, " ").trim()`)
+  // must collapse them to one item — the FIRST seen wins.
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 10, role: "user", content: TARGETED_FACT_CONTENT },
+      { turn_index: 11, role: "user", content: TARGETED_FACT_CONTENT.toUpperCase() },
+    ]],
+  ]);
+  const engine = new FakeLcmEngine(sessions, new Map([[FIXTURE_SESSION_PRIMARY, [10, 11]]]));
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 4_000,
+    maxSearchResults: 16,
+  });
+  const turn10Matches = output.match(/turn 10,/g) ?? [];
+  const turn11Matches = output.match(/turn 11,/g) ?? [];
+  assert.equal(turn10Matches.length, 1, `expected turn 10 once, got ${turn10Matches.length} in:\n${output}`);
+  assert.equal(turn11Matches.length, 0, `expected turn 11 deduped away, got ${turn11Matches.length}`);
+});
+
+test("divergence: event-order threshold filter drops items scoring below rank 6", async () => {
+  // The hardcoded `rank >= 6` filter (event-order-recall.ts line ~158,
+  // inlined and undocumented pre-spine) must drop filler turns that don't
+  // engage the chronology vocabulary. The spine makes this a declared
+  // `rankThreshold: 6` config field.
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 1, role: "user", content: "Hello, nice weather today." },
+      { turn_index: 2, role: "user", content: CHRONOLOGY_CONTENT },
+      { turn_index: 3, role: "user", content: "I had lunch at noon." },
+    ]],
+  ]);
+  const engine = new FakeLcmEngine(sessions);
+  const output = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What is the order in which I introduced topics?",
+    maxChars: 4_000,
+    maxItems: 8,
+    maxScanWindowTurns: 12,
+    maxScanWindowTokens: 4_000,
+  });
+  assert.ok(
+    output.includes(`[${FIXTURE_SESSION_PRIMARY}, turn 2,`),
+    `expected turn 2 in event-order output, got:\n${output}`,
+  );
+  assert.ok(!output.includes("turn 1,"), "filler turn 1 must be threshold-filtered");
+  assert.ok(!output.includes("turn 3,"), "filler turn 3 must be threshold-filtered");
+});
+
+test("divergence: targeted-fact ranks DESC (turnIndex DESC among score ties)", async () => {
+  // Three numeric-fact turns with similar scoring: the DESC sort breaks
+  // ties by turnIndex DESC (recency) — the latest update ranks first.
+  // Each turn uses the `finally reached` recency cue that
+  // `scoreTargetedFactEvidence` rewards, so all three clear the evidence
+  // filter and the comparator is exercised on the full set.
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 2, role: "user", content: "My monthly expenses finally reached $1,000 last year." },
+      { turn_index: 5, role: "user", content: "My monthly expenses finally reached $2,400 after the raise." },
+      { turn_index: 9, role: "user", content: "My monthly expenses finally reached $3,000 after the move." },
+    ]],
+  ]);
+  const engine = new FakeLcmEngine(sessions);
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 6_000,
+    maxSearchResults: 16,
+  });
+  const pos9 = output.indexOf("turn 9,");
+  const pos5 = output.indexOf("turn 5,");
+  const pos2 = output.indexOf("turn 2,");
+  assert.ok(pos9 > -1, `expected turn 9 in output:\n${output}`);
+  assert.ok(pos5 > -1, `expected turn 5 in output:\n${output}`);
+  assert.ok(pos2 > -1, `expected turn 2 in output:\n${output}`);
+  assert.ok(
+    pos9 < pos5 && pos5 < pos2,
+    `expected DESC turn ordering 9 < 5 < 2, got positions ${pos9}, ${pos5}, ${pos2}`,
+  );
+});
+
+test("divergence: event-order ranks ASC (turnIndex ascending after the score gate)", async () => {
+  // Three chronology turns that all clear the rank>=6 gate. Event-order
+  // must emit them in turnIndex ASC order — the OPPOSITE of the relevance-
+  // ranked pipelines. This is the divergence the spine declares as
+  // `secondarySort` (ASC=chronological vs DESC=recency).
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 30, role: "user", content: "The order in which I introduced topics was: pronunciation, then vocabulary, then grammar." },
+      { turn_index: 10, role: "user", content: "The order in which I introduced topics was: setup, then plan, then execute." },
+      { turn_index: 20, role: "user", content: "The order in which I introduced topics was: reading, then writing, then speaking." },
+    ]],
+  ]);
+  const engine = new FakeLcmEngine(sessions);
+  const output = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What is the order in which I introduced topics?",
+    maxChars: 6_000,
+    maxItems: 8,
+    maxScanWindowTurns: 12,
+    maxScanWindowTokens: 8_000,
+  });
+  const pos10 = output.indexOf("turn 10,");
+  const pos20 = output.indexOf("turn 20,");
+  const pos30 = output.indexOf("turn 30,");
+  assert.ok(pos10 > -1 && pos20 > -1 && pos30 > -1, `all three turns present in:\n${output}`);
+  assert.ok(
+    pos10 < pos20 && pos20 < pos30,
+    `expected ASC ordering 10 < 20 < 30, got ${pos10}, ${pos20}, ${pos30}`,
+  );
+});
+
+test("divergence: undefined turnIndex handled (DESC: -1 sentinel; ASC: MAX_SAFE_INTEGER sentinel)", async () => {
+  // When `turnIndex` is undefined, the DESC comparator falls back to -1
+  // (sorts to the bottom of a DESC list); the ASC comparator falls back to
+  // Number.MAX_SAFE_INTEGER (also sorts to the bottom of an ASC list). Both
+  // sentinels pin the same contract: missing turn_index never wins ordering.
+  // Here we pin the DESC behavior via targeted-fact: a search hit on turn 5
+  // (numeric fact, high score) must rank above any item that loses on the
+  // rank/turnIndex/score tuple.
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 5, role: "user", content: TARGETED_FACT_CONTENT },
+      { turn_index: 6, role: "user", content: "We discussed the monthly expenses figure at length." },
+    ]],
+  ]);
+  const engine = new FakeLcmEngine(sessions, new Map([[FIXTURE_SESSION_PRIMARY, [5, 6]]]));
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 6_000,
+    maxSearchResults: 16,
+  });
+  const pos5 = output.indexOf("turn 5,");
+  const pos6 = output.indexOf("turn 6,");
+  if (pos5 > -1 && pos6 > -1) {
+    assert.ok(pos5 < pos6, `expected higher-scoring turn 5 first, got pos5=${pos5} pos6=${pos6}`);
+  }
+});
+
+test("divergence: fallback-merge — strong fallback hit outranks weak primary hit", async () => {
+  // #1505 fallback merge: the primary session has NO evidence for this
+  // query; the fallback session has a strong numeric-fact mention. The
+  // merged pass must surface the fallback's evidence — without #1505, the
+  // short-circuit on the empty primary would have returned "".
+  const fallbackMessages: FixtureMessage[] = [
+    { turn_index: 2, role: "user", content: "My monthly expenses are exactly $2,400.50, broken down precisely." },
+  ];
+  const engine = makeFixtureEngine({
+    fallbackMessages,
+    searchHitsPrimary: [],
+    searchHitsFallback: [2],
+  });
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    sessionIds: [FIXTURE_SESSION_PRIMARY, FIXTURE_SESSION_FALLBACK],
+    query: "What are my monthly expenses?",
+    maxChars: 4_000,
+    maxSearchResults: 16,
+  });
+  assert.ok(
+    output.includes("$2,400.50"),
+    `expected fallback evidence in merged output, got:\n${output}`,
+  );
+});
+
+test("divergence: fallback-merge — cross-key content dedup", async () => {
+  // Both sessions carry the SAME content under different session_ids. The
+  // merged dedup pass keys on normalized content (NOT session_id+turn_index),
+  // so the duplicate must collapse to one emission.
+  const fallbackMessages: FixtureMessage[] = [
+    { turn_index: 7, role: "user", content: TARGETED_FACT_CONTENT },
+  ];
+  const sessions = new Map<string, FixtureMessage[]>([
+    [FIXTURE_SESSION_PRIMARY, [
+      { turn_index: 3, role: "user", content: TARGETED_FACT_CONTENT },
+    ]],
+    [FIXTURE_SESSION_FALLBACK, fallbackMessages],
+  ]);
+  const engine = new FakeLcmEngine(
+    sessions,
+    new Map([[FIXTURE_SESSION_PRIMARY, [3]], [FIXTURE_SESSION_FALLBACK, [7]]]),
+  );
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    sessionIds: [FIXTURE_SESSION_PRIMARY, FIXTURE_SESSION_FALLBACK],
+    query: "What are my monthly expenses?",
+    maxChars: 6_000,
+    maxSearchResults: 16,
+  });
+  const occurrences = (output.match(/turn 3,|turn 7,/g) ?? []).length;
+  assert.equal(
+    occurrences,
+    1,
+    `expected cross-key content dedup to emit exactly one of turn 3 / turn 7, got ${occurrences} in:\n${output}`,
+  );
+});
+
+test("divergence: fallback-merge — per-key fault isolation (a corrupt fallback does not discard primary evidence)", async () => {
+  // The fallback session FAULTS on read; the primary session's evidence
+  // must still surface. `gatherAcrossReadSessions` isolates the per-key
+  // failure rather than letting it abort the whole pass — this is the
+  // fault-isolation contract the spine must preserve.
+  const fallbackMessages: FixtureMessage[] = [
+    { turn_index: 2, role: "user", content: "Fallback content that will never be read." },
+  ];
+  const engine = makeFixtureEngine({
+    fallbackMessages,
+    searchHitsPrimary: [3],
+    searchHitsFallback: [2],
+    faultingSessions: new Set([FIXTURE_SESSION_FALLBACK]),
+  });
+  const output = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    sessionIds: [FIXTURE_SESSION_PRIMARY, FIXTURE_SESSION_FALLBACK],
+    query: "What are my monthly expenses?",
+    maxChars: 4_000,
+    maxSearchResults: 16,
+  });
+  assert.ok(
+    output.includes("$2,400"),
+    `expected primary evidence to survive fallback fault, got:\n${output}`,
+  );
+  assert.ok(
+    !output.includes("Fallback content that will never be read."),
+    "faulting fallback must NOT contribute evidence",
+  );
+});
+
+test("divergence: event-order does NOT call gatherAcrossReadSessions (turn_index is local to each session_id)", async () => {
+  // Event-order's `EventOrderRecallOptions` carries only a single `sessionId`
+  // (no `sessionIds`). Even if the orchestrator's outer `firstNonEmptyLcmRead`
+  // walks the key set, the BUILDER itself never sees more than one session.
+  // This test pins that contract: pass an ordered key set in `sessionIds`
+  // (via a cast), and verify the builder ignores it and reads ONLY `sessionId`.
+  const fallbackMessages: FixtureMessage[] = [
+    { turn_index: 1, role: "user", content: "Fallback-only chronology: the order in which I introduced topics was setup first." },
+  ];
+  const engine = makeFixtureEngine({ fallbackMessages });
+  const output = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    // Intentionally pass sessionIds via cast; the builder must not honor it.
+    ...( { sessionIds: [FIXTURE_SESSION_PRIMARY, FIXTURE_SESSION_FALLBACK] } as unknown as Record<string, unknown> ),
+    query: "What is the order in which I introduced topics?",
+    maxChars: 4_000,
+    maxItems: 8,
+    maxScanWindowTurns: 12,
+    maxScanWindowTokens: 4_000,
+  } as Parameters<typeof buildEventOrderRecallSection>[0]);
+  // Only the primary session was read; the fallback's chronology content
+  // does NOT appear (turn_index is local — merging would misstate order).
+  assert.ok(
+    !output.includes("Fallback-only chronology"),
+    `event-order must NOT merge across keys; fallback leaked into:\n${output}`,
+  );
+  const fallbackCalls = engine.calls.filter(
+    (call) => call.sessionId === FIXTURE_SESSION_FALLBACK,
+  );
+  assert.equal(
+    fallbackCalls.length,
+    0,
+    `event-order must not read fallback sessions, but got calls: ${JSON.stringify(fallbackCalls)}`,
+  );
+});
+
+test("divergence: zero-limit contracts (0 maxResults / 0 maxItems / 0 maxChars all return empty)", async () => {
+  // Per AGENTS.md §3 ("Config is runtime API"): `enabled=false` and `0`
+  // limits are compatibility contracts, NEVER coerce to non-zero. Each
+  // builder must respect a zero limit by returning "".
+  const engine = makeFixtureEngine({ searchHitsPrimary: [3] });
+
+  const targetedEmptyResults = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 4_000,
+    maxSearchResults: 0,
+  });
+  assert.equal(targetedEmptyResults, "", "targeted-fact maxSearchResults=0 must yield empty");
+
+  const targetedEmptyBudget = await buildTargetedFactRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What are my monthly expenses?",
+    maxChars: 0,
+    maxSearchResults: 8,
+  });
+  assert.equal(targetedEmptyBudget, "", "targeted-fact maxChars=0 must yield empty");
+
+  const eventEmptyItems = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What is the order in which I introduced topics?",
+    maxChars: 4_000,
+    maxItems: 0,
+  });
+  assert.equal(eventEmptyItems, "", "event-order maxItems=0 must yield empty");
+
+  const eventEmptyBudget = await buildEventOrderRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "What is the order in which I introduced topics?",
+    maxChars: 0,
+    maxItems: 8,
+  });
+  assert.equal(eventEmptyBudget, "", "event-order maxChars=0 must yield empty");
+
+  const guidanceEmptyResults = await buildResponseGuidanceRecallSection({
+    engine,
+    sessionId: FIXTURE_SESSION_PRIMARY,
+    query: "How should I approach editting my draft?",
+    maxChars: 4_000,
+    maxSearchResults: 0,
+  });
+  assert.equal(guidanceEmptyResults, "", "response-guidance maxSearchResults=0 must yield empty");
+});
+
+test("divergence: planner-mode gating contract (null/undefined engine yields empty for every pipeline)", async () => {
+  // The orchestrator gates each builder with `(recallMode !== "no_recall")`
+  // BEFORE invoking it (orchestrator.ts lines ~10298, 10341, 10390, 10444,
+  // 10493). The builders themselves do not see the mode; they simply require
+  // an enabled engine. Pin that contract: a null engine yields empty
+  // regardless of query/budget, so the no_recall short-circuit composes
+  // correctly with the per-builder engine guard.
+  const outputs = await Promise.all([
+    buildTargetedFactRecallSection({
+      engine: null,
+      sessionId: FIXTURE_SESSION_PRIMARY,
+      query: "What are my monthly expenses?",
+      maxChars: 4_000,
+    }),
+    buildResponseGuidanceRecallSection({
+      engine: null,
+      sessionId: FIXTURE_SESSION_PRIMARY,
+      query: "How should I approach editting my draft?",
+      maxChars: 4_000,
+    }),
+    buildExplicitCueRecallSection({
+      engine: null,
+      sessionId: FIXTURE_SESSION_PRIMARY,
+      query: "What did I say at turn 1?",
+      maxChars: 4_000,
+    }),
+    buildEventOrderRecallSection({
+      engine: null,
+      sessionId: FIXTURE_SESSION_PRIMARY,
+      query: "What is the order in which I introduced topics?",
+      maxChars: 4_000,
+    }),
+  ]);
+  for (const [index, output] of outputs.entries()) {
+    assert.equal(output, "", `builder ${index} must return empty for null engine`);
+  }
+});


### PR DESCRIPTION
## What

Part of #1539 (recall spine unification, epic #1520). **PR 1–2 of 6** (combined: characterization tests + spine extraction; PRs 3–6 migrate one pipeline each).

This PR combines the two non-behavioral foundation steps of #1539 into one coherent landing — the spine module ships alongside the snapshots that will pin its migration in PRs 3–6.

### Step 1 — characterization snapshots (`tests/recall-pipeline-unified.test.ts`)

Pins the CURRENT outputs of `buildTargetedFactRecallSection`, `buildResponseGuidanceRecallSection`, `buildExplicitCueRecallSection`, and `buildEventOrderRecallSection` on a fixed fixture corpus (15 tests). These snapshots MUST survive the spine migration byte-for-byte. Each subsequent PR re-runs this file and asserts the snapshots are unchanged (except the one declared event-order budget fix in PR 6).

Also pins the divergences the spine must make declared policy (issue audit):
- dedup by id + normalized content (first-seen wins)
- event-order threshold filter (`rank >= 6`, currently inlined/undocumented)
- rank DESC / turnIndex DESC (relevance tiers) vs turnIndex ASC (event-order)
- undefined turnIndex handling
- fallback-merge behavior (strong fallback outranks weak primary; cross-key content dedup; per-key fault isolation)
- event-order does NOT call `gatherAcrossReadSessions`

### Step 2 — spine extraction (`packages/remnic-core/src/recall-pipeline-stages.ts`, 277 LOC + 13 unit tests)

Extracts `unifiedDedupeAndRank()` + the `UnifiedRankConfig<TIntent>` interface. **NO pipeline changes** — the module is extracted with its own unit test suite (13 tests). The most dangerous divergence this addresses (issue audit): the sort comparators in targeted-fact (239–245), response-guidance (374–380), and event-order (159–164) are byte-identical EXCEPT sort direction — event-order sorts turnIndex ASC (chronological) where the others sort DESC (recency). The spine makes direction a declared config field (`TurnIndexSortDirection`).

Per-tier policy that was previously embedded code is now a declared field:
- `rankThreshold` (event-order's hardcoded `rank >= 6` filter, now declared)
- `turnIndexSortDirection` (`"desc"` default; `"asc"` for event-order)
- `transformContent` (per-tier cue-appenders)
- `scoreEvidence` (scored on ORIGINAL content; transform does not influence the score)

## Why

The four recall pipelines (15,773 LOC total) implement the same stage sequence with ~70% near-duplicate code. Divergences (threshold, sort direction, LCM merge opt-out) live as embedded code with no structural guard — the next change can silently miss one pipeline (#1511 had to touch three of four). This PR lands the characterization net + the shared spine; PRs 3–6 migrate each pipeline to a config object.

## Done-when progress (#1539)

- [x] Step 1: characterization snapshots survive migration unchanged
- [x] Step 2: `unifiedDedupeAndRank()` + config interface extracted, no pipeline changes
- [ ] Step 3: targeted-fact migration (PR 3/6)
- [ ] Step 4: response-guidance migration (PR 4/6)
- [ ] Step 5: explicit-cue migration (PR 5/6)
- [ ] Step 6: event-order migration + declared budget fix (PR 6/6)

Issue done-when = "the four files are thin config + collection modules (spine owns dedup/rank/budget/merge policy), a fifth pipeline would be a config file, and the divergences are declared fields with tests." This PR delivers the spine + the divergence tests; the four migrations follow.

## Verification

- `npx tsx --test tests/recall-pipeline-unified.test.ts` → 15/15 pass
- `cd packages/remnic-core && npx tsx --test src/recall-pipeline-stages.test.ts` → 13/13 pass
- `npx tsx --test tests/recall-pipeline-assembly.test.ts` → 12/12 pass (orchestrator shim assembly green)
- `npm run test:entity-hardening` → 246/246 pass
- `npm run preflight:quick` → `[preflight] OK (quick)`
- `node scripts/check-ratchets.mjs` → `[ratchet] OK`

## Chokepoints used / not applicable

This IS the recall-pipeline spine chokepoint (#1539 Solution). No `orchestrator.ts` / `storage.ts` / `config.ts` changes — pure additive (2 new files in `packages/remnic-core/src/`, 1 new test file in `tests/`).

## Per-issue PR sequence

PR 1–2 of 6 (characterization + spine extraction). PRs 3–6 migrate one pipeline each in risk order: targeted-fact → response-guidance → explicit-cue → event-order (last, with the declared budget-accounting fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Recall dedup/rank/sort rules are correctness-critical for injected context, but this PR only adds tests and dead code until PRs 3–6 wire the spine; migration risk is deferred.
> 
> **Overview**
> Adds **#1539** foundation work with **no changes** to the four existing recall builders yet.
> 
> **Characterization net** (`tests/recall-pipeline-unified.test.ts`): byte-for-byte snapshots and divergence tests for targeted-fact, response-guidance, explicit-cue, and event-order (dedup, event-order `rank >= 6`, DESC vs ASC `turnIndex`, fallback merge, zero limits, null engine).
> 
> **Shared spine** (`recall-pipeline-stages.ts`): new `unifiedDedupeAndRank` + `UnifiedRankConfig` centralizing dedup → score (on original content) → optional `rankThreshold` → sort, with declared **`turnIndexSortDirection`**, **`dedupByContent`** (event-order id-only dedup), and **`transformContent`**. Fifteen unit tests cover comparator and dedup edge cases.
> 
> **Test hygiene**: non-chunked `persistExtraction` catalog test now calls `orchestrator.destroy()` in `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be6590fdafb88a126ca56ca9f21f80334d07a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->