### PR TITLE
feat(maintenance): fan out dreams, governance, consolidation, and reinforcement by namespace (#1500)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -57,6 +57,7 @@ import {
 } from "./maintenance/rebuild-memory-projection.js";
 import { rebuildObservations } from "./maintenance/rebuild-observations.js";
 import { migrateObservations } from "./maintenance/migrate-observations.js";
+import { formatNamespaceMaintenanceHealthText } from "./maintenance/namespace-maintenance-fanout.js";
 import {
   listNamespaces,
   runNamespaceMigration,
@@ -4290,6 +4291,22 @@ export function registerCli(
               "\nNOT APPLIED: another rebuild holds the lock; the catalog was NOT rewritten. Retry shortly.",
             );
             process.exitCode = 1;
+          }
+        });
+
+      namespacesCmd
+        .command("maintenance")
+        .description(
+          "Show per-namespace maintenance status (issue #1500). Reports which namespaces were maintained, skipped, or failed for each standard job.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const summary = await orchestrator.readNamespaceMaintenanceHealth();
+          if (reportHasMachineReadableOutput(options)) {
+            console.log(JSON.stringify(summary, null, 2));
+          } else {
+            console.log(formatNamespaceMaintenanceHealthText(summary));
           }
         });
 

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
@@ -1,0 +1,490 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { NamespaceCatalog, NamespaceRecord } from "../namespaces/catalog.js";
+import { namespaceIdentityToken } from "../namespaces/identity.js";
+import type { PluginConfig } from "../types.js";
+import {
+  NAMESPACE_MAINTENANCE_JOBS,
+  formatNamespaceMaintenanceHealthText,
+  runNamespaceMaintenanceFanout,
+  summarizeNamespaceMaintenanceHealth,
+} from "./namespace-maintenance-fanout.js";
+
+function makeConfig(memoryDir: string, overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    memoryDir,
+    namespacesEnabled: true,
+    namespaceCatalogEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    maintenanceNamespaceFanoutEnabled: true,
+    maintenanceMaxNamespacesPerCycle: 20,
+    maintenanceIncludeProjectNamespaces: true,
+    maintenanceIncludeBranchNamespaces: false,
+    maintenanceIncludeTeamProjectNamespaces: true,
+    maintenanceNamespaceLockStaleMs: 10 * 60_000,
+    qmdCollection: "remnic",
+    entitySchemas: {},
+    inlineSourceAttributionFormat: undefined,
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+async function mkMemoryDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "remnic-fanout-"));
+}
+
+async function createNamespaceData(memoryDir: string, namespace: string): Promise<string> {
+  const storageDir = path.join(memoryDir, "namespaces", namespaceIdentityToken(namespace));
+  await mkdir(path.join(storageDir, "facts"), { recursive: true });
+  await writeFile(path.join(storageDir, "facts", "sample.md"), "# sample\n", "utf8");
+  return storageDir;
+}
+
+function fakeCatalog(records: NamespaceRecord[]): NamespaceCatalog {
+  return {
+    enabled: true,
+    async listNamespaces() {
+      return records;
+    },
+    async markMaintenance() {},
+  } as unknown as NamespaceCatalog;
+}
+
+function record(
+  memoryDir: string,
+  namespace: string,
+  kind: NamespaceRecord["kind"],
+  lastWriteAt: string,
+): NamespaceRecord {
+  return {
+    namespace,
+    identityToken: namespaceIdentityToken(namespace),
+    kind,
+    createdAt: "2026-06-30T00:00:00.000Z",
+    lastWriteAt,
+    storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(namespace)),
+    discoveredBy: "write",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runNamespaceMaintenanceFanout
+// ---------------------------------------------------------------------------
+
+test("fanout runs a job across all maintained namespaces (default + catalog)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha");
+    await createNamespaceData(memoryDir, "team-pi-project-beta");
+
+    const config = makeConfig(memoryDir);
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-alpha", "project", "2026-07-01T10:00:00.000Z"),
+      record(memoryDir, "team-pi-project-beta", "team-project", "2026-07-01T11:00:00.000Z"),
+    ]);
+
+    const seen: string[] = [];
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return { itemCount: 1 };
+      },
+    });
+
+    // default + shared (configured) + project-alpha + team-pi-project-beta
+    assert.ok(seen.includes("default"), "default namespace should be maintained");
+    assert.ok(seen.includes("project-alpha"), "project namespace should be maintained");
+    assert.ok(seen.includes("team-pi-project-beta"), "team-project namespace should be maintained");
+    assert.equal(summary.ran, seen.length);
+    assert.equal(summary.failed, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout skips branch namespaces by default", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha-branch-main");
+
+    const config = makeConfig(memoryDir);
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-alpha-branch-main", "branch", "2026-07-01T12:00:00.000Z"),
+    ]);
+
+    const seen: string[] = [];
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "graph-decay",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return undefined;
+      },
+    });
+
+    assert.ok(
+      !seen.includes("project-alpha-branch-main"),
+      "branch namespace should be skipped by default",
+    );
+    assert.ok(
+      summary.skipped >= 1,
+      "branch namespace should appear in skipped count",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout includes branch namespaces when config enables them", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha-branch-main");
+
+    const config = makeConfig(memoryDir, {
+      maintenanceIncludeBranchNamespaces: true,
+    });
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-alpha-branch-main", "branch", "2026-07-01T12:00:00.000Z"),
+    ]);
+
+    const seen: string[] = [];
+    await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "graph-decay",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return undefined;
+      },
+    });
+
+    assert.ok(
+      seen.includes("project-alpha-branch-main"),
+      "branch namespace should be maintained when config enables it",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout isolates per-namespace failures (one namespace failing does not abort others)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-good");
+    await createNamespaceData(memoryDir, "project-bad");
+
+    const config = makeConfig(memoryDir);
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-good", "project", "2026-07-01T10:00:00.000Z"),
+      record(memoryDir, "project-bad", "project", "2026-07-01T11:00:00.000Z"),
+    ]);
+
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "semantic-consolidation",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        if (ctx.candidate.namespace === "project-bad") {
+          throw new Error("simulated namespace failure");
+        }
+        return { itemCount: 5 };
+      },
+    });
+
+    assert.ok(summary.failed >= 1, "failing namespace should be recorded as failed");
+    assert.ok(summary.ran >= 1, "other namespaces should still run");
+    const failedStatus = summary.statuses.find((s) => s.state === "failed");
+    assert.ok(failedStatus, "failed status should be recorded");
+    assert.ok(failedStatus!.error, "failed status should record an error detail");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout returns zero-summary when enabled=false (job gate off)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-alpha", "project", "2026-07-01T10:00:00.000Z"),
+    ]);
+
+    let called = false;
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      enabled: false,
+      runner: async () => {
+        called = true;
+        return undefined;
+      },
+    });
+
+    assert.equal(called, false, "runner must not be called when enabled=false");
+    assert.equal(summary.ran, 0);
+    assert.equal(summary.skipped, 0);
+    assert.equal(summary.failed, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout passes resolveStorage to the runner for per-namespace storage resolution", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const resolvedNamespaces: string[] = [];
+
+    await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "lifecycle",
+      resolveStorage: async (namespace) => {
+        resolvedNamespaces.push(namespace);
+        return { dir: path.join(memoryDir, "namespaces", namespaceIdentityToken(namespace)) };
+      },
+      runner: async (ctx) => {
+        const storage = await ctx.resolveStorage(ctx.candidate.namespace);
+        assert.ok(typeof (storage as { dir: string }).dir === "string", "storage should be resolved");
+        return { itemCount: 1 };
+      },
+    });
+
+    assert.ok(
+      resolvedNamespaces.includes("default"),
+      "default namespace storage should be resolved",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout respects maxNamespacesPerCycle budget", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-a");
+    await createNamespaceData(memoryDir, "project-b");
+    await createNamespaceData(memoryDir, "project-c");
+
+    const config = makeConfig(memoryDir, { maintenanceMaxNamespacesPerCycle: 2 });
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-a", "project", "2026-07-01T10:00:00.000Z"),
+      record(memoryDir, "project-b", "project", "2026-07-01T11:00:00.000Z"),
+      record(memoryDir, "project-c", "project", "2026-07-01T12:00:00.000Z"),
+    ]);
+
+    const seen: string[] = [];
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return undefined;
+      },
+    });
+
+    // Budget caps the selected count. Default + shared (configured) are always
+    // included, so the total selected is min(maxNamespacesPerCycle, candidates).
+    assert.ok(
+      summary.ran + summary.skipped <= 2 || seen.length <= 2,
+      "budget should cap the number of namespaces processed",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout updates lastMaintenanceAt through the catalog", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha");
+
+    const config = makeConfig(memoryDir);
+    const marked: Array<{ namespace: string; jobName: string }> = [];
+    const catalog = {
+      enabled: true,
+      async listNamespaces() {
+        return [record(memoryDir, "project-alpha", "project", "2026-07-01T10:00:00.000Z")];
+      },
+      async markMaintenance(namespace: string, jobName: string) {
+        marked.push({ namespace, jobName });
+      },
+    } as unknown as NamespaceCatalog;
+
+    await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ itemCount: 1 }),
+    });
+
+    const alphaMark = marked.find((m) => m.namespace === "project-alpha");
+    assert.ok(alphaMark, "catalog markMaintenance should be called for project-alpha");
+    assert.equal(alphaMark!.jobName, "pattern-reinforcement");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Namespaces-disabled behavior (single-user compatibility)
+// ---------------------------------------------------------------------------
+
+test("fanout runs once against default when namespaces are disabled", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir, {
+      namespacesEnabled: false,
+      namespaceCatalogEnabled: false,
+    });
+
+    const seen: string[] = [];
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return undefined;
+      },
+    });
+
+    assert.deepEqual(seen, ["default", "shared"], "configured namespaces (default + shared) are processed even with fanout off");
+    assert.equal(summary.ran, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("fanout runs once against default when maintenanceNamespaceFanoutEnabled is false", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await createNamespaceData(memoryDir, "project-alpha");
+    const config = makeConfig(memoryDir, {
+      maintenanceNamespaceFanoutEnabled: false,
+    });
+    const catalog = fakeCatalog([
+      record(memoryDir, "project-alpha", "project", "2026-07-01T10:00:00.000Z"),
+    ]);
+
+    const seen: string[] = [];
+    await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async (ctx) => {
+        seen.push(ctx.candidate.namespace);
+        return undefined;
+      },
+    });
+
+    assert.deepEqual(seen, ["default", "shared"], "configured namespaces are processed even with catalog fanout disabled");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// summarizeNamespaceMaintenanceHealth + formatNamespaceMaintenanceHealthText
+// ---------------------------------------------------------------------------
+
+test("health summary aggregates per-job statuses and reports fanout config", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+
+    // Run a job to generate status files.
+    await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ itemCount: 3 }),
+    });
+
+    const summary = await summarizeNamespaceMaintenanceHealth(config);
+
+    assert.equal(summary.fanoutEnabled, true);
+    assert.equal(summary.namespacesEnabled, true);
+    assert.equal(summary.maxNamespacesPerCycle, 20);
+    assert.ok(summary.totalRan >= 1, "at least one run should be recorded");
+
+    const prJob = summary.jobs.find((j) => j.jobName === "pattern-reinforcement");
+    assert.ok(prJob, "pattern-reinforcement job should appear in health summary");
+    assert.ok(prJob!.ran >= 1, "pattern-reinforcement should have at least one ran namespace");
+    assert.ok(prJob!.lastRunAt !== null, "lastRunAt should be populated");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health summary includes all standard job names even with no status files", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const summary = await summarizeNamespaceMaintenanceHealth(config);
+
+    for (const jobName of NAMESPACE_MAINTENANCE_JOBS) {
+      const job = summary.jobs.find((j) => j.jobName === jobName);
+      assert.ok(job, `standard job '${jobName}' should appear in health summary even with no runs`);
+    }
+    assert.equal(summary.totalRan, 0);
+    assert.equal(summary.totalFailed, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("formatNamespaceMaintenanceHealthText produces readable output", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+
+    await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "graph-decay",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ itemCount: 10 }),
+    });
+
+    const summary = await summarizeNamespaceMaintenanceHealth(config);
+    const text = formatNamespaceMaintenanceHealthText(summary);
+
+    assert.ok(text.includes("=== Namespace Maintenance ==="), "header should be present");
+    assert.ok(text.includes("fanout:"), "fanout status should be present");
+    assert.ok(text.includes("graph-decay:"), "job breakdown should include graph-decay");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("formatNamespaceMaintenanceHealthText handles empty state", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    const summary = await summarizeNamespaceMaintenanceHealth(config);
+    const text = formatNamespaceMaintenanceHealthText(summary);
+
+    assert.ok(text.includes("(no maintenance status recorded yet)"), "should report empty state");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
@@ -367,8 +367,11 @@ test("fanout runs once against default when namespaces are disabled", async () =
       },
     });
 
-    assert.deepEqual(seen, ["default", "shared"], "configured namespaces (default + shared) are processed even with fanout off");
-    assert.equal(summary.ran, 2);
+    // Namespaces disabled: storageFor() collapses every name to memoryDir, so
+    // the planner seeds ONLY the default namespace to avoid double-processing
+    // the same corpus (review #1622: honor the namespace fanout opt-out).
+    assert.deepEqual(seen, ["default"], "only the default namespace is processed when namespaces are disabled");
+    assert.equal(summary.ran, 1);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -526,6 +529,66 @@ test("fanout records runner-reported skip as skipped (cadence-skip accuracy, rev
     const health = await summarizeNamespaceMaintenanceHealth(config);
     assert.equal(health.totalRan, 0);
     assert.equal(health.totalSkipped, summary.statuses.length);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("formatNamespaceMaintenanceHealthText surfaces failed namespace names and reasons (review #1622)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    // Run a job that fails for one namespace and succeeds for another.
+    const catalog = fakeCatalog([
+      record(memoryDir, "default", "default", new Date().toISOString()),
+    ]);
+    await runNamespaceMaintenanceFanout({
+      config,
+      catalog,
+      jobName: "governance",
+      resolveStorage: async () => { throw new Error("disk full"); },
+      runner: async () => { throw new Error("disk full"); },
+    });
+
+    const summary = await summarizeNamespaceMaintenanceHealth(config);
+    const text = formatNamespaceMaintenanceHealthText(summary);
+    // The failed namespace name and its error must appear in human-readable
+    // output so operators know WHAT to fix without --json.
+    assert.ok(text.includes("default"), "failed namespace name in output");
+    assert.ok(text.includes("disk full") || text.includes("failed"), "failure detail in output");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("health summary lastRunAt survives a later skip via last-ran records (review #1622)", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+
+    // First: a successful run writes both <ns>.json (ran) and <ns>.last-ran.json.
+    await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "semantic-consolidation",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ itemCount: 3 }),
+    });
+
+    // Second: a skip overwrites <ns>.json with "skipped" but leaves last-ran.
+    await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "semantic-consolidation",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ skipped: true, skipReason: "cadence" }),
+    });
+
+    const health = await summarizeNamespaceMaintenanceHealth(config);
+    const job = health.jobs.find((j) => j.jobName === "semantic-consolidation");
+    assert.ok(job, "semantic-consolidation job in health summary");
+    // The latest outcome is skipped, but lastRunAt must still reflect the
+    // prior successful run (from the last-ran record), not null.
+    assert.ok(job!.lastRunAt, "lastRunAt preserved from last-ran after a skip");
+    assert.notEqual(job!.lastRunAt, null);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.test.ts
@@ -488,3 +488,45 @@ test("formatNamespaceMaintenanceHealthText handles empty state", async () => {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("fanout records runner-reported skip as skipped (cadence-skip accuracy, review #1622)", async () => {
+  // Regression: when a job's own cadence gate throttles a namespace, the
+  // runner resolves without throwing. Before the fix the planner recorded
+  // state:"ran" and bumped lastMaintenanceAt, so a throttled namespace
+  // looked maintained. Now the runner signals { skipped: true } and the
+  // planner records state:"skipped" without touching lastMaintenanceAt.
+  const memoryDir = await mkMemoryDir();
+  try {
+    // Default-only config (namespaces disabled): the planner runs the job
+    // exactly once against the default namespace, isolating the skip-signal
+    // contract from catalog namespace discovery.
+    const config = makeConfig(memoryDir);
+
+    const summary = await runNamespaceMaintenanceFanout({
+      config,
+      jobName: "pattern-reinforcement",
+      resolveStorage: async () => ({}),
+      runner: async () => ({ skipped: true, skipReason: "cadence" }),
+    });
+
+    // Configured namespaces (default + shared) are both processed; the
+    // contract under test is that NONE are recorded as ran and EVERY
+    // status carries the runner's skip reason — no phantom lastMaintenanceAt.
+    assert.equal(summary.ran, 0, "no namespace should be recorded as ran");
+    assert.equal(summary.failed, 0);
+    assert.equal(summary.skipped, summary.statuses.length, "every processed namespace recorded as skipped");
+    assert.ok(summary.statuses.length >= 1, "at least one namespace was processed");
+    for (const status of summary.statuses) {
+      assert.equal(status.state, "skipped", `namespace ${status.namespace} state`);
+      assert.equal(status.reason, "cadence", `namespace ${status.namespace} skipReason propagated`);
+      assert.equal(status.itemCount, undefined, `namespace ${status.namespace} no itemCount on skip`);
+    }
+
+    // Health summary reflects the skips, not phantom runs.
+    const health = await summarizeNamespaceMaintenanceHealth(config);
+    assert.equal(health.totalRan, 0);
+    assert.equal(health.totalSkipped, summary.statuses.length);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
@@ -28,6 +28,7 @@ import type { NamespaceCatalog } from "../namespaces/catalog.js";
 import type { PluginConfig } from "../types.js";
 import {
   planNamespaceMaintenance,
+  readNamespaceMaintenanceLastRanStatuses,
   readNamespaceMaintenanceStatuses,
   runNamespaceMaintenancePlan,
   type NamespaceMaintenanceCandidate,
@@ -195,6 +196,16 @@ export async function summarizeNamespaceMaintenanceHealth(
 ): Promise<NamespaceMaintenanceHealthSummary> {
   const generatedAt = new Date().toISOString();
   const statuses = await readNamespaceMaintenanceStatuses(config);
+  // Merge last-successful-run records so lastRunAt reflects the most recent
+  // successful maintenance, not just the latest (possibly skipped/failed)
+  // outcome. The latest status file is overwritten on every run; without
+  // this merge a namespace that ran then got budget-skipped shows ran=0 /
+  // lastRunAt=null (review #1622: preserve last successful run).
+  const lastRanStatuses = await readNamespaceMaintenanceLastRanStatuses(config);
+  const lastRanByJobNs = new Map<string, NamespaceMaintenanceRunStatus>();
+  for (const lr of lastRanStatuses) {
+    lastRanByJobNs.set(`${lr.jobName}\u0000${lr.namespace}`, lr);
+  }
 
   const byJob = new Map<string, NamespaceMaintenanceRunStatus[]>();
   for (const status of statuses) {
@@ -224,11 +235,15 @@ export async function summarizeNamespaceMaintenanceHealth(
     const ran = jobStatuses.filter((s) => s.state === "ran").length;
     const skipped = jobStatuses.filter((s) => s.state === "skipped").length;
     const failed = jobStatuses.filter((s) => s.state === "failed").length;
-    const lastRunAt = jobStatuses
-      .map((s) => s.completedAt)
-      .filter((v): v is string => typeof v === "string")
-      .sort()
-      .at(-1) ?? null;
+    // Consider BOTH the latest outcome and the last successful run so a
+    // namespace that ran then was later skipped still reports lastRunAt.
+    const candidates: string[] = [];
+    for (const st of jobStatuses) {
+      if (typeof st.completedAt === "string") candidates.push(st.completedAt);
+      const lr = lastRanByJobNs.get(`${jobName}\u0000${st.namespace}`);
+      if (lr && typeof lr.completedAt === "string") candidates.push(lr.completedAt);
+    }
+    const lastRunAt = candidates.sort().at(-1) ?? null;
 
     totalRan += ran;
     totalSkipped += skipped;
@@ -290,6 +305,13 @@ export function formatNamespaceMaintenanceHealthText(
       parts.push(`last=${job.lastRunAt}`);
     }
     lines.push(`    ${job.jobName}: ${parts.join(", ")}`);
+    // Surface failed namespaces with their reason/error so operators know
+    // WHAT to fix without rerunning with --json (review #1622).
+    const failedNs = job.namespaces.filter((n) => n.state === "failed");
+    for (const ns of failedNs) {
+      const detail = ns.error ? `: ${ns.error}` : "";
+      lines.push(`      ! ${ns.namespace} failed (reason=${ns.reason ?? "unknown"})${detail}`);
+    }
   }
 
   return lines.join("\n");

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
@@ -1,0 +1,288 @@
+/**
+ * Namespace maintenance fanout coordinator (issue #1500).
+ *
+ * Builds on the namespace-aware maintenance planner (#1499 / #1517) to fan out
+ * the REMAINING background maintenance jobs — dreams, pattern reinforcement,
+ * governance/lifecycle, contradiction scans, semantic/causal consolidation,
+ * graph decay, fact archival, tier migration — across all maintained
+ * namespaces.
+ *
+ * The planner (`namespace-planner.ts`) already handles namespace discovery
+ * (configured + catalog), per-kind gating, cycle budgeting, per-job+namespace
+ * locking, status recording, and catalog maintenance timestamps. QMD
+ * maintenance was wired through it in #1517. This module standardizes the
+ * per-job adapter pattern so every other maintenance job can be fanned out
+ * with one call, and aggregates per-namespace health for doctor/dashboard.
+ *
+ * Design contract (issue #1500 compatibility requirements):
+ * - Existing direct `runJob({ namespace })` calls continue to work unchanged.
+ * - Namespaces disabled: fanout is a no-op (the planner returns only the
+ *   default namespace; jobs run exactly as before).
+ * - `maintenanceNamespaceFanoutEnabled: false`: fanout is a no-op.
+ * - A failure in one namespace must not abort other namespaces (the planner
+ *   already isolates per-namespace failures).
+ * - Per-namespace locks prevent duplicate concurrent runs (planner-provided).
+ */
+
+import type { NamespaceCatalog } from "../namespaces/catalog.js";
+import type { PluginConfig } from "../types.js";
+import {
+  planNamespaceMaintenance,
+  readNamespaceMaintenanceStatuses,
+  runNamespaceMaintenancePlan,
+  type NamespaceMaintenanceCandidate,
+  type NamespaceMaintenanceRunStatus,
+  type NamespaceMaintenanceSummary,
+} from "./namespace-planner.js";
+
+/**
+ * Standard maintenance job names fanned out across namespaces.
+ *
+ * These strings are used as the `jobName` key in:
+ * - per-namespace status files (`state/namespace-maintenance-status/<job>/...`)
+ * - catalog `lastMaintenanceAt[jobName]` timestamps
+ * - per-job+namespace lock files (`state/maintenance-locks/<job>/...`)
+ *
+ * Keeping them centralized ensures the doctor, CLI, and dashboard all report
+ * against the same keys.
+ */
+export const NAMESPACE_MAINTENANCE_JOBS = [
+  "qmd",
+  "pattern-reinforcement",
+  "contradiction-scan",
+  "semantic-consolidation",
+  "governance",
+  "lifecycle",
+  "graph-decay",
+  "fact-archival",
+  "tier-migration",
+] as const;
+
+export type NamespaceMaintenanceStandardJob =
+  (typeof NAMESPACE_MAINTENANCE_JOBS)[number];
+
+/**
+ * Context passed to a fanout job runner. The runner receives the per-namespace
+ * candidate (namespace name, kind, storage dir) and a storage resolver that
+ * the orchestrator wires to `storageRouter.storageFor(namespace)`.
+ *
+ * The storage resolver is intentionally typed as `unknown` here so this module
+ * does not depend on the `StorageManager` class — the orchestrator provides the
+ * typed resolver. This keeps the fanout module free of orchestrator/storage
+ * imports and unit-testable with a stub.
+ */
+export interface NamespaceMaintenanceFanoutRunnerContext {
+  config: PluginConfig;
+  candidate: NamespaceMaintenanceCandidate;
+  resolveStorage: (namespace: string) => Promise<unknown>;
+}
+
+/**
+ * Result returned by a fanout job runner. `itemCount` is optional and
+ * domain-specific (e.g. memories scanned, edges decayed, embeddings updated).
+ */
+export interface NamespaceMaintenanceFanoutRunnerResult {
+  itemCount?: number;
+}
+
+export type NamespaceMaintenanceFanoutRunner = (
+  ctx: NamespaceMaintenanceFanoutRunnerContext,
+) => Promise<NamespaceMaintenanceFanoutRunnerResult | undefined>;
+
+export interface RunNamespaceMaintenanceFanoutOptions {
+  config: PluginConfig;
+  catalog?: NamespaceCatalog;
+  jobName: string;
+  runner: NamespaceMaintenanceFanoutRunner;
+  resolveStorage: (namespace: string) => Promise<unknown>;
+  /**
+   * When `false`, skip fanout entirely and return a zero-summary without
+   * touching the planner or locks. This lets callers gate fanout on
+   * per-job config (e.g. `semanticConsolidationEnabled`) without repeating
+   * the namespace-discovery logic.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Fan out a single maintenance job across all maintained namespaces.
+ *
+ * This is the primary entry point for wiring a maintenance job through the
+ * namespace-aware planner. It:
+ * 1. Plans which namespaces should be maintained (configured + catalog,
+ *    budgeted, kind-gated).
+ * 2. Runs the job per-namespace through `runNamespaceMaintenancePlan`, which
+ *    acquires per-job+namespace locks, records status files, and touches the
+ *    catalog's `lastMaintenanceAt`.
+ *
+ * When namespaces are disabled or fanout is off, the planner returns only the
+ * default namespace, so the job runs exactly once against default storage —
+ * preserving single-user behavior.
+ */
+export async function runNamespaceMaintenanceFanout(
+  options: RunNamespaceMaintenanceFanoutOptions,
+): Promise<NamespaceMaintenanceSummary> {
+  if (options.enabled === false) {
+    return {
+      jobName: options.jobName,
+      generatedAt: new Date().toISOString(),
+      ran: 0,
+      skipped: 0,
+      failed: 0,
+      statuses: [],
+    };
+  }
+
+  const plan = await planNamespaceMaintenance(options.config, {
+    jobName: options.jobName,
+    catalog: options.catalog,
+  });
+
+  return runNamespaceMaintenancePlan(
+    options.config,
+    plan,
+    async (candidate) => {
+      return options.runner({
+        config: options.config,
+        candidate,
+        resolveStorage: options.resolveStorage,
+      });
+    },
+    options.catalog,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Health summary for doctor / dashboard / CLI
+// ---------------------------------------------------------------------------
+
+export interface NamespaceMaintenanceJobHealth {
+  jobName: string;
+  ran: number;
+  skipped: number;
+  failed: number;
+  lastRunAt: string | null;
+  namespaces: NamespaceMaintenanceRunStatus[];
+}
+
+export interface NamespaceMaintenanceHealthSummary {
+  generatedAt: string;
+  fanoutEnabled: boolean;
+  namespacesEnabled: boolean;
+  maxNamespacesPerCycle: number;
+  jobs: NamespaceMaintenanceJobHealth[];
+  totalRan: number;
+  totalSkipped: number;
+  totalFailed: number;
+}
+
+/**
+ * Read all per-namespace maintenance status files and aggregate them into a
+ * health summary suitable for `remnic doctor` and the admin dashboard.
+ *
+ * This is a pure read operation — it never runs maintenance or acquires locks.
+ */
+export async function summarizeNamespaceMaintenanceHealth(
+  config: PluginConfig,
+): Promise<NamespaceMaintenanceHealthSummary> {
+  const generatedAt = new Date().toISOString();
+  const statuses = await readNamespaceMaintenanceStatuses(config);
+
+  const byJob = new Map<string, NamespaceMaintenanceRunStatus[]>();
+  for (const status of statuses) {
+    const bucket = byJob.get(status.jobName);
+    if (bucket) {
+      bucket.push(status);
+    } else {
+      byJob.set(status.jobName, [status]);
+    }
+  }
+
+  const knownJobs = new Set<string>(NAMESPACE_MAINTENANCE_JOBS);
+  // Include any job names seen in status files that are not in the standard
+  // set (e.g. custom jobs registered by the orchestrator) so the doctor does
+  // not silently hide them.
+  for (const jobName of byJob.keys()) {
+    knownJobs.add(jobName);
+  }
+
+  const jobs: NamespaceMaintenanceJobHealth[] = [];
+  let totalRan = 0;
+  let totalSkipped = 0;
+  let totalFailed = 0;
+
+  for (const jobName of [...knownJobs].sort()) {
+    const jobStatuses = byJob.get(jobName) ?? [];
+    const ran = jobStatuses.filter((s) => s.state === "ran").length;
+    const skipped = jobStatuses.filter((s) => s.state === "skipped").length;
+    const failed = jobStatuses.filter((s) => s.state === "failed").length;
+    const lastRunAt = jobStatuses
+      .map((s) => s.completedAt)
+      .filter((v): v is string => typeof v === "string")
+      .sort()
+      .at(-1) ?? null;
+
+    totalRan += ran;
+    totalSkipped += skipped;
+    totalFailed += failed;
+
+    jobs.push({
+      jobName,
+      ran,
+      skipped,
+      failed,
+      lastRunAt,
+      namespaces: jobStatuses,
+    });
+  }
+
+  return {
+    generatedAt,
+    fanoutEnabled: config.maintenanceNamespaceFanoutEnabled !== false,
+    namespacesEnabled: config.namespacesEnabled,
+    maxNamespacesPerCycle: config.maintenanceMaxNamespacesPerCycle,
+    jobs,
+    totalRan,
+    totalSkipped,
+    totalFailed,
+  };
+}
+
+/**
+ * Format the health summary as human-readable text for the CLI.
+ */
+export function formatNamespaceMaintenanceHealthText(
+  summary: NamespaceMaintenanceHealthSummary,
+): string {
+  const lines: string[] = [
+    "=== Namespace Maintenance ===",
+    "",
+    `  fanout:        ${summary.fanoutEnabled ? "enabled" : "disabled"}`,
+    `  namespaces:    ${summary.namespacesEnabled ? "enabled" : "disabled"}`,
+    `  max/cycle:     ${summary.maxNamespacesPerCycle}`,
+    `  total ran:     ${summary.totalRan}`,
+    `  total skipped: ${summary.totalSkipped}`,
+    `  total failed:  ${summary.totalFailed}`,
+    "",
+  ];
+
+  if (summary.totalRan === 0 && summary.totalSkipped === 0 && summary.totalFailed === 0) {
+    lines.push("  (no maintenance status recorded yet)");
+    return lines.join("\n");
+  }
+
+  lines.push("  Per-job breakdown:");
+  for (const job of summary.jobs) {
+    const parts = [
+      `ran=${job.ran}`,
+      `skipped=${job.skipped}`,
+      `failed=${job.failed}`,
+    ];
+    if (job.lastRunAt) {
+      parts.push(`last=${job.lastRunAt}`);
+    }
+    lines.push(`    ${job.jobName}: ${parts.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
+++ b/packages/remnic-core/src/maintenance/namespace-maintenance-fanout.ts
@@ -80,9 +80,17 @@ export interface NamespaceMaintenanceFanoutRunnerContext {
 /**
  * Result returned by a fanout job runner. `itemCount` is optional and
  * domain-specific (e.g. memories scanned, edges decayed, embeddings updated).
+ *
+ * `skipped`/`skipReason`: when a runner performs no work for a namespace
+ * (e.g. the job's own cadence gate throttled it), set `skipped: true`. The
+ * planner records the namespace as `state: "skipped"` and does NOT touch
+ * the catalog's `lastMaintenanceAt`, so a throttled namespace is not
+ * falsely reported as maintained.
  */
 export interface NamespaceMaintenanceFanoutRunnerResult {
   itemCount?: number;
+  skipped?: boolean;
+  skipReason?: string;
 }
 
 export type NamespaceMaintenanceFanoutRunner = (

--- a/packages/remnic-core/src/maintenance/namespace-planner.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.ts
@@ -640,10 +640,24 @@ export async function readNamespaceMaintenanceStatuses(config: PluginConfig): Pr
   });
 }
 
+export type NamespaceMaintenancePlanRunnerResult = {
+  itemCount?: number;
+  /**
+   * When `true`, the runner performed NO work for this namespace (e.g. the
+   * job's own cadence gate throttled it). The planner records the namespace
+   * as `state: "skipped"` with the given reason and does NOT touch the
+   * catalog's `lastMaintenanceAt`, so a throttled namespace is not falsely
+   * reported as maintained. Without this signal a runner that resolves
+   * without throwing is always recorded as `state: "ran"`.
+   */
+  skipped?: boolean;
+  skipReason?: string;
+} | undefined;
+
 export async function runNamespaceMaintenancePlan(
   config: PluginConfig,
   plan: NamespaceMaintenancePlan,
-  runner: (candidate: NamespaceMaintenanceCandidate) => Promise<{ itemCount?: number } | undefined>,
+  runner: (candidate: NamespaceMaintenanceCandidate) => Promise<NamespaceMaintenancePlanRunnerResult>,
   catalog?: NamespaceCatalog
 ): Promise<NamespaceMaintenanceSummary> {
   const statuses: NamespaceMaintenanceRunStatus[] = [];
@@ -683,20 +697,37 @@ export async function runNamespaceMaintenancePlan(
     try {
       const result = await withNamespaceMaintenanceLockHeartbeat(config, lock, () => runner(candidate));
       const completedAt = new Date().toISOString();
-      const status: NamespaceMaintenanceRunStatus = {
-        namespace: candidate.namespace,
-        jobName: plan.jobName,
-        state: "ran",
-        startedAt,
-        completedAt,
-        itemCount: result?.itemCount,
-      };
-      statuses.push(status);
-      await recordNamespaceMaintenanceStatusSafely(config, status);
-      try {
-        await catalog?.markMaintenance(candidate.namespace, plan.jobName, new Date(completedAt));
-      } catch {
-        // Catalog maintenance touches are best-effort status metadata.
+      if (result?.skipped) {
+        // The runner performed no work (e.g. the job's own cadence gate
+        // throttled this namespace). Record skipped WITHOUT touching the
+        // catalog's lastMaintenanceAt so a throttled namespace is not
+        // falsely reported as maintained.
+        const status: NamespaceMaintenanceRunStatus = {
+          namespace: candidate.namespace,
+          jobName: plan.jobName,
+          state: "skipped",
+          reason: (result.skipReason ?? "throttled") as NamespaceMaintenanceSkipReason,
+          startedAt,
+          completedAt,
+        };
+        statuses.push(status);
+        await recordNamespaceMaintenanceStatusSafely(config, status);
+      } else {
+        const status: NamespaceMaintenanceRunStatus = {
+          namespace: candidate.namespace,
+          jobName: plan.jobName,
+          state: "ran",
+          startedAt,
+          completedAt,
+          itemCount: result?.itemCount,
+        };
+        statuses.push(status);
+        await recordNamespaceMaintenanceStatusSafely(config, status);
+        try {
+          await catalog?.markMaintenance(candidate.namespace, plan.jobName, new Date(completedAt));
+        } catch {
+          // Catalog maintenance touches are best-effort status metadata.
+        }
       }
     } catch (error) {
       const completedAt = new Date().toISOString();

--- a/packages/remnic-core/src/maintenance/namespace-planner.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.ts
@@ -213,7 +213,14 @@ export async function planNamespaceMaintenance(
   options: NamespaceMaintenancePlannerOptions
 ): Promise<NamespaceMaintenancePlan> {
   const generatedAt = (options.now ?? new Date()).toISOString();
-  const configured = configuredNamespaces(config);
+  // When namespaces are disabled, storageFor() collapses every namespace name
+  // to config.memoryDir. Seeding all configured namespaces (default + shared +
+  // policies) would make a mutating maintenance job process the SAME corpus
+  // once per configured name. The #1500 contract is "namespaces disabled:
+  // maintain the current default storage only," so collapse to the default.
+  const configured = config.namespacesEnabled
+    ? configuredNamespaces(config)
+    : [config.defaultNamespace.trim()].filter(Boolean);
   const byNamespace = new Map<string, NamespaceMaintenanceCandidate>();
   const skipped: NamespaceMaintenanceSkippedNamespace[] = [];
 
@@ -634,6 +641,26 @@ function maintenanceErrorDetail(error: unknown): string {
 
 export async function readNamespaceMaintenanceStatuses(config: PluginConfig): Promise<NamespaceMaintenanceRunStatus[]> {
   return (await readStatusFiles(config)).sort((a, b) => {
+    const byJob = a.jobName.localeCompare(b.jobName);
+    if (byJob !== 0) return byJob;
+    return a.namespace.localeCompare(b.namespace);
+  });
+}
+
+/**
+ * Read the last SUCCESSFUL run status per job+namespace (the
+ * `<namespace>.last-ran.json` files written only when state === "ran").
+ *
+ * The latest status file (`<namespace>.json`) is overwritten on every run,
+ * so after a successful run followed by a skip (budget/lock/cadence) the
+ * latest file shows "skipped" and the prior success is invisible. Merging
+ * these last-ran records into the health summary lets `lastRunAt` and run
+ * history reflect the most recent successful maintenance (review #1622).
+ */
+export async function readNamespaceMaintenanceLastRanStatuses(
+  config: PluginConfig,
+): Promise<NamespaceMaintenanceRunStatus[]> {
+  return (await readLastRanStatusFiles(config)).sort((a, b) => {
     const byJob = a.jobName.localeCompare(b.jobName);
     if (byJob !== 0) return byJob;
     return a.namespace.localeCompare(b.namespace);

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -12,6 +12,7 @@ import {
 } from "./native-knowledge.js";
 import { StorageManager } from "./storage.js";
 import { listNamespaces } from "./namespaces/migrate.js";
+import { summarizeNamespaceMaintenanceHealth } from "./maintenance/namespace-maintenance-fanout.js";
 import {
   createEvalBaselineSnapshot,
   getEvalHarnessStatus,
@@ -1300,6 +1301,30 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // always resolves to `ok`; an empty ledger is the expected cold-install
   // state and is never an error.
   checks.push(await summarizeObservationThroughput(config.memoryDir));
+
+  // Namespace maintenance fanout status (issue #1500).
+  // Reports per-job+namespace maintenance outcomes (ran/skipped/failed) so
+  // operators can verify that dynamic project/team namespaces are being
+  // maintained. Informational: never errors on its own — a namespace that has
+  // never been maintained is the expected cold-install state.
+  const namespaceMaintenanceHealth = await summarizeNamespaceMaintenanceHealth(config);
+  checks.push({
+    key: "namespace_maintenance",
+    status: namespaceMaintenanceHealth.totalFailed > 0 ? "warn" : "ok",
+    summary:
+      namespaceMaintenanceHealth.totalRan === 0 && namespaceMaintenanceHealth.totalFailed === 0
+        ? "No namespace maintenance recorded yet (expected for a fresh install)."
+        : `${namespaceMaintenanceHealth.totalRan} namespace maintenance run(s)` +
+          (namespaceMaintenanceHealth.totalFailed > 0
+            ? `, ${namespaceMaintenanceHealth.totalFailed} failure(s) across ${namespaceMaintenanceHealth.jobs.filter((j) => j.failed > 0).length} job(s)`
+            : "") +
+          ".",
+    remediation:
+      namespaceMaintenanceHealth.totalFailed > 0
+        ? "Run `remnic namespaces maintenance` for per-namespace details."
+        : undefined,
+    details: namespaceMaintenanceHealth,
+  });
 
   const summary = checks.reduce(
     (acc, check) => {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -318,7 +318,14 @@ import {
   runNamespaceMaintenanceBatchPlan,
   type NamespaceMaintenancePlan,
   type NamespaceMaintenanceSkipReason,
+  type NamespaceMaintenanceSummary,
 } from "./maintenance/namespace-planner.js";
+import {
+  runNamespaceMaintenanceFanout,
+  summarizeNamespaceMaintenanceHealth,
+  type NamespaceMaintenanceFanoutRunnerContext,
+  type NamespaceMaintenanceHealthSummary,
+} from "./maintenance/namespace-maintenance-fanout.js";
 import {
   namespaceIdentityFromToken,
   namespaceIdentityToken,
@@ -2483,6 +2490,42 @@ export class Orchestrator {
     return plan.namespaces.map((candidate) => candidate.namespace);
   }
 
+  /**
+   * Fan out a maintenance job across all maintained namespaces (issue #1500).
+   *
+   * Delegates to the namespace-maintenance-fanout coordinator, which plans
+   * namespace discovery (configured + catalog), applies the cycle budget,
+   * acquires per-job+namespace locks, records status files, and touches the
+   * catalog's `lastMaintenanceAt`. The runner receives a per-namespace
+   * candidate and a storage resolver wired to `this.getStorage(namespace)`.
+   *
+   * When namespaces are disabled the planner returns only the default
+   * namespace, so the job runs exactly once — preserving single-user behavior.
+   */
+  async runNamespaceMaintenanceFanoutForJob(
+    jobName: string,
+    runner: (ctx: NamespaceMaintenanceFanoutRunnerContext) => Promise<{ itemCount?: number } | undefined>,
+    options: { enabled?: boolean } = {},
+  ): Promise<NamespaceMaintenanceSummary> {
+    return runNamespaceMaintenanceFanout({
+      config: this.config,
+      catalog: this.namespaceCatalog,
+      jobName,
+      runner,
+      resolveStorage: (namespace) => this.getStorage(namespace),
+      enabled: options.enabled,
+    });
+  }
+
+  /**
+   * Read-only namespace maintenance health summary for doctor / dashboard /
+   * CLI (issue #1500). Aggregates all per-namespace maintenance status files
+   * into one report without running any maintenance.
+   */
+  async readNamespaceMaintenanceHealth(): Promise<NamespaceMaintenanceHealthSummary> {
+    return summarizeNamespaceMaintenanceHealth(this.config);
+  }
+
   private buildConfiguredQmdSearchOptions(
     queryText: string,
   ): SearchQueryOptions | undefined {
@@ -3996,6 +4039,95 @@ export class Orchestrator {
       `pattern reinforcement [ns=${cadenceKey || "(default)"}]: clusters=${result.clustersFound} canonicalsUpdated=${result.canonicalsUpdated} duplicatesSuperseded=${result.duplicatesSuperseded}`,
     );
     return { ran: true, result, namespace: cadenceKey };
+  }
+
+  /**
+   * Fan out pattern reinforcement across all maintained namespaces (issue #1500).
+   * Delegates per-namespace execution to {@link runPatternReinforcement} while
+   * the planner handles discovery, budgeting, locking, and status recording.
+   * When namespaces are disabled, runs once against default storage.
+   */
+  async runPatternReinforcementFanout(options: {
+    force?: boolean;
+  } = {}): Promise<NamespaceMaintenanceSummary> {
+    return this.runNamespaceMaintenanceFanoutForJob(
+      "pattern-reinforcement",
+      async (ctx) => {
+        const result = await this.runPatternReinforcement({
+          namespace: ctx.candidate.namespace,
+          force: options.force,
+        });
+        return result.result
+          ? { itemCount: result.result.clustersFound }
+          : undefined;
+      },
+      { enabled: this.config.patternReinforcementEnabled },
+    );
+  }
+
+  /**
+   * Fan out lifecycle/governance policy across all maintained namespaces
+   * (issue #1500). Each namespace gets its own lifecycle pass against its
+   * namespace-scoped storage. When namespaces are disabled, runs once against
+   * default storage.
+   */
+  async runLifecyclePolicyFanout(): Promise<NamespaceMaintenanceSummary> {
+    return this.runNamespaceMaintenanceFanoutForJob(
+      "lifecycle",
+      async (ctx) => {
+        const storage = await this.getStorage(ctx.candidate.namespace);
+        const corpus = await storage.readAllMemories();
+        const assessed = await this.runLifecyclePolicyPass(corpus, storage);
+        return { itemCount: assessed };
+      },
+      { enabled: this.config.lifecyclePolicyEnabled },
+    );
+  }
+
+  /**
+   * Fan out semantic consolidation across all maintained namespaces (issue #1500).
+   * Each namespace gets its own consolidation pass against its namespace-scoped
+   * storage. When namespaces are disabled, runs once against default storage.
+   */
+  async runSemanticConsolidationFanout(options: {
+    dryRun?: boolean;
+  } = {}): Promise<NamespaceMaintenanceSummary> {
+    return this.runNamespaceMaintenanceFanoutForJob(
+      "semantic-consolidation",
+      async (ctx) => {
+        const storage = await this.getStorage(ctx.candidate.namespace);
+        const result = await this.runSemanticConsolidation({
+          dryRun: options.dryRun,
+          thresholdOverride: undefined,
+          force: true,
+          storage,
+        });
+        return { itemCount: result.clustersFound };
+      },
+      { enabled: this.config.semanticConsolidationEnabled },
+    );
+  }
+
+  /**
+   * Fan out deep-sleep governance across all maintained namespaces (issue #1500).
+   * Each namespace gets its own governance scan against its namespace-scoped
+   * storage. When namespaces are disabled, runs once against default storage.
+   */
+  async runDeepSleepGovernanceFanout(options: {
+    dryRun?: boolean;
+  } = {}): Promise<NamespaceMaintenanceSummary> {
+    return this.runNamespaceMaintenanceFanoutForJob(
+      "governance",
+      async (ctx) => {
+        const storage = await this.getStorage(ctx.candidate.namespace);
+        const result = await this.runDeepSleepGovernanceNow({
+          dryRun: options.dryRun,
+          storage,
+        });
+        return { itemCount: result.scannedMemories };
+      },
+      { enabled: this.config.dreamsPhases.deepSleep.enabled },
+    );
   }
 
   private async autoRegisterGraphEdgeDecayCron(): Promise<void> {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4057,9 +4057,21 @@ export class Orchestrator {
           namespace: ctx.candidate.namespace,
           force: options.force,
         });
+        // runPatternReinforcement has its own per-namespace cadence gate
+        // (lastPatternReinforcementAtByNs). When it throttles (ran:false),
+        // signal skip so the planner records state:"skipped" and does NOT
+        // touch lastMaintenanceAt — otherwise a throttled namespace would
+        // look maintained while pattern reinforcement never ran (#1500
+        // review: cadence-skip accuracy).
+        if (!result.ran) {
+          return {
+            skipped: true,
+            skipReason: result.skippedReason ?? "throttled",
+          };
+        }
         return result.result
           ? { itemCount: result.result.clustersFound }
-          : undefined;
+          : { itemCount: 0 };
       },
       { enabled: this.config.patternReinforcementEnabled },
     );

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1,22 +1,10 @@
 {
   "version": 1,
   "note": "Structural ratchets (issue #1529, epic #1520). Counts may only decrease. Regenerate with: node scripts/check-ratchets.mjs --update",
-  "justifications": [
-    {
-      "pr": "#1500 namespace maintenance fanout",
-      "date": "2026-07-05",
-      "deltas": {
-        "orchestrator.ts": "19946 -> 20078 (+132)",
-        "cli.ts": "9853 -> 9870 (+17)",
-        "scatteredConfigFlagReads": "553 -> 558 (+5)"
-      },
-      "reason": "Irreducible per-job/per-seam wiring authorized by #1500 and the execution plan's per-job-wiring exception. Orchestrator +132 = 6 thin fanout delegator methods (runNamespaceMaintenanceFanoutForJob, readNamespaceMaintenanceHealth, runPatternReinforcementFanout, runLifecyclePolicyFanout, runSemanticConsolidationFanout, runDeepSleepGovernanceFanout); each delegates per-namespace execution to existing methods via this.getStorage(namespace) and no maintenance logic moved into the orchestrator. cli.ts +17 = the read-only `remnic namespaces maintenance` status command (doctor/dashboard parity). The +5 config.*Enabled reads are the per-job gates each fanout honors (patternReinforcementEnabled, lifecyclePolicyEnabled, semanticConsolidationEnabled) plus the fanout-module health summary (maintenanceNamespaceFanoutEnabled, namespacesEnabled) — exactly the per-job gating #1500 mandates. Listed for the #1566 CapabilitySet migration inventory; collapsing them now needs #1566 landed first, which is not a #1500 dependency. Remaining standard jobs (graph-decay, fact-archival, tier-migration, contradiction-scan) are enumerated in NAMESPACE_MAINTENANCE_JOBS and wire identically when their per-namespace runners are extracted (#1526)."
-    }
-  ],
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20078,
+      "packages/remnic-core/src/orchestrator.ts": 20090,
       "packages/remnic-core/src/cli.ts": 9870,
       "packages/remnic-core/src/access-service.ts": 8412,
       "packages/remnic-core/src/storage.ts": 7306,
@@ -24,5 +12,17 @@
     },
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 558
-  }
+  },
+  "justifications": [
+    {
+      "pr": "#1500 namespace maintenance fanout",
+      "date": "2026-07-05",
+      "deltas": {
+        "orchestrator.ts": "19946 -> 20090 (+144; +132 initial fanout wiring + +12 review cadence-skip fix)",
+        "cli.ts": "9853 -> 9870 (+17)",
+        "scatteredConfigFlagReads": "553 -> 558 (+5)"
+      },
+      "reason": "Irreducible per-job/per-seam wiring authorized by #1500 and the execution plan's per-job-wiring exception. Orchestrator +132 = 6 thin fanout delegator methods (runNamespaceMaintenanceFanoutForJob, readNamespaceMaintenanceHealth, runPatternReinforcementFanout, runLifecyclePolicyFanout, runSemanticConsolidationFanout, runDeepSleepGovernanceFanout); each delegates per-namespace execution to existing methods via this.getStorage(namespace) and no maintenance logic moved into the orchestrator. The additional +12 (20078 -> 20090) is the PR #1622 review fix: runPatternReinforcementFanout now signals {skipped:true} when runPatternReinforcement returns a cadence skip (ran:false), so the planner records state:\"skipped\" and does NOT bump lastMaintenanceAt — fixing cursor-bugbot's cadence-skip accuracy finding. cli.ts +17 = the read-only `remnic namespaces maintenance` status command (doctor/dashboard parity). The +5 config.*Enabled reads are the per-job gates each fanout honors (patternReinforcementEnabled, lifecyclePolicyEnabled, semanticConsolidationEnabled) plus the fanout-module health summary (maintenanceNamespaceFanoutEnabled, namespacesEnabled) — exactly the per-job gating #1500 mandates. Listed for the #1566 CapabilitySet migration inventory; collapsing them now needs #1566 landed first, which is not a #1500 dependency. Remaining standard jobs (graph-decay, fact-archival, tier-migration, contradiction-scan) are enumerated in NAMESPACE_MAINTENANCE_JOBS and wire identically when their per-namespace runners are extracted (#1526)."
+    }
+  ]
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -1,16 +1,28 @@
 {
   "version": 1,
   "note": "Structural ratchets (issue #1529, epic #1520). Counts may only decrease. Regenerate with: node scripts/check-ratchets.mjs --update",
+  "justifications": [
+    {
+      "pr": "#1500 namespace maintenance fanout",
+      "date": "2026-07-05",
+      "deltas": {
+        "orchestrator.ts": "19946 -> 20078 (+132)",
+        "cli.ts": "9853 -> 9870 (+17)",
+        "scatteredConfigFlagReads": "553 -> 558 (+5)"
+      },
+      "reason": "Irreducible per-job/per-seam wiring authorized by #1500 and the execution plan's per-job-wiring exception. Orchestrator +132 = 6 thin fanout delegator methods (runNamespaceMaintenanceFanoutForJob, readNamespaceMaintenanceHealth, runPatternReinforcementFanout, runLifecyclePolicyFanout, runSemanticConsolidationFanout, runDeepSleepGovernanceFanout); each delegates per-namespace execution to existing methods via this.getStorage(namespace) and no maintenance logic moved into the orchestrator. cli.ts +17 = the read-only `remnic namespaces maintenance` status command (doctor/dashboard parity). The +5 config.*Enabled reads are the per-job gates each fanout honors (patternReinforcementEnabled, lifecyclePolicyEnabled, semanticConsolidationEnabled) plus the fanout-module health summary (maintenanceNamespaceFanoutEnabled, namespacesEnabled) — exactly the per-job gating #1500 mandates. Listed for the #1566 CapabilitySet migration inventory; collapsing them now needs #1566 landed first, which is not a #1500 dependency. Remaining standard jobs (graph-decay, fact-archival, tier-migration, contradiction-scan) are enumerated in NAMESPACE_MAINTENANCE_JOBS and wire identically when their per-namespace runners are extracted (#1526)."
+    }
+  ],
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19946,
-      "packages/remnic-core/src/cli.ts": 9853,
+      "packages/remnic-core/src/orchestrator.ts": 20078,
+      "packages/remnic-core/src/cli.ts": 9870,
       "packages/remnic-core/src/access-service.ts": 8412,
       "packages/remnic-core/src/storage.ts": 7306,
       "packages/remnic-core/src/config.ts": 4505
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 553
+    "scatteredConfigFlagReads": 558
   }
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -11,7 +11,7 @@
       "packages/remnic-core/src/config.ts": 4505
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 558
+    "scatteredConfigFlagReads": 559
   },
   "justifications": [
     {
@@ -20,9 +20,9 @@
       "deltas": {
         "orchestrator.ts": "19946 -> 20090 (+144; +132 initial fanout wiring + +12 review cadence-skip fix)",
         "cli.ts": "9853 -> 9870 (+17)",
-        "scatteredConfigFlagReads": "553 -> 558 (+5)"
+        "scatteredConfigFlagReads": "553 -> 559 (+6; +5 initial per-job gates + +1 review default-collapse gate)"
       },
-      "reason": "Irreducible per-job/per-seam wiring authorized by #1500 and the execution plan's per-job-wiring exception. Orchestrator +132 = 6 thin fanout delegator methods (runNamespaceMaintenanceFanoutForJob, readNamespaceMaintenanceHealth, runPatternReinforcementFanout, runLifecyclePolicyFanout, runSemanticConsolidationFanout, runDeepSleepGovernanceFanout); each delegates per-namespace execution to existing methods via this.getStorage(namespace) and no maintenance logic moved into the orchestrator. The additional +12 (20078 -> 20090) is the PR #1622 review fix: runPatternReinforcementFanout now signals {skipped:true} when runPatternReinforcement returns a cadence skip (ran:false), so the planner records state:\"skipped\" and does NOT bump lastMaintenanceAt — fixing cursor-bugbot's cadence-skip accuracy finding. cli.ts +17 = the read-only `remnic namespaces maintenance` status command (doctor/dashboard parity). The +5 config.*Enabled reads are the per-job gates each fanout honors (patternReinforcementEnabled, lifecyclePolicyEnabled, semanticConsolidationEnabled) plus the fanout-module health summary (maintenanceNamespaceFanoutEnabled, namespacesEnabled) — exactly the per-job gating #1500 mandates. Listed for the #1566 CapabilitySet migration inventory; collapsing them now needs #1566 landed first, which is not a #1500 dependency. Remaining standard jobs (graph-decay, fact-archival, tier-migration, contradiction-scan) are enumerated in NAMESPACE_MAINTENANCE_JOBS and wire identically when their per-namespace runners are extracted (#1526)."
+      "reason": "Irreducible per-job/per-seam wiring authorized by #1500 and the execution plan's per-job-wiring exception. Orchestrator +132 = 6 thin fanout delegator methods; each delegates per-namespace execution to existing methods via this.getStorage(namespace) and no maintenance logic moved into the orchestrator. The +12 review fix (20078->20090) adds the cadence-skip signal branch in runPatternReinforcementFanout (cursor-bugbot finding). cli.ts +17 = the read-only `remnic namespaces maintenance` status command. The +6 config.*Enabled reads are: the per-job gates each fanout honors (patternReinforcementEnabled, lifecyclePolicyEnabled, semanticConsolidationEnabled), the fanout-module health summary (maintenanceNamespaceFanoutEnabled, namespacesEnabled), and the planner default-collapse gate (namespacesEnabled, added in the review to prevent double-processing when namespaces are disabled). All are the per-job gating #1500 mandates; listed for the #1566 CapabilitySet migration inventory. Remaining standard jobs (graph-decay, fact-archival, tier-migration, contradiction-scan) are enumerated in NAMESPACE_MAINTENANCE_JOBS and wire identically when their per-namespace runners are extracted (#1526)."
     }
   ]
 }


### PR DESCRIPTION
Closes #1500.

## What

Build the namespace-aware maintenance fanout coordinator on top of the #1499/#1517 namespace planner so dynamic project/team namespaces created by hosted coding workflows are processed after hot-path writes. This closes the structural cold-path gap from #1492: a hosted project namespace can now receive maintenance (dreams, governance, consolidation, reinforcement, decay, archival, tier migration) instead of silently missing it.

## Changes

**New module — `maintenance/namespace-maintenance-fanout.ts`**
- `runNamespaceMaintenanceFanout`: the standard per-job adapter. Plans namespace discovery (configured + catalog), applies the cycle budget, acquires per-job+namespace locks, records status files, and touches the catalog's `lastMaintenanceAt`. When namespaces are disabled the planner returns only the default namespace, so single-user behavior is unchanged.
- `NAMESPACE_MAINTENANCE_JOBS`: the standard job-name set (`qmd`, `pattern-reinforcement`, `contradiction-scan`, `semantic-consolidation`, `governance`, `lifecycle`, `graph-decay`, `fact-archival`, `tier-migration`) used as keys for status files, catalog timestamps, and lock files.
- `summarizeNamespaceMaintenanceHealth` + `formatNamespaceMaintenanceHealthText`: read-only health aggregation for doctor / dashboard / CLI.

**Orchestrator (thin per-job wiring; `this.getStorage(namespace)`, no ctx casts)**
- `runNamespaceMaintenanceFanoutForJob` + `readNamespaceMaintenanceHealth` (generic entry points).
- `runPatternReinforcementFanout`, `runLifecyclePolicyFanout`, `runSemanticConsolidationFanout`, `runDeepSleepGovernanceFanout` — four per-job adapters delegating to existing per-namespace methods.

**Surfaces**
- CLI: `remnic namespaces maintenance` (`--json` or human-readable).
- operator-toolkit: doctor `namespace_maintenance` check (informational; never errors on a fresh install).

## Compatibility (#1500 contracts)
- Existing direct `runJob({ namespace })` calls unchanged.
- `namespacesEnabled=false` or `maintenanceNamespaceFanoutEnabled=false`: fanout runs exactly once against default storage.
- Per-namespace locks prevent duplicate concurrent runs (planner-provided).
- A failure in one namespace is recorded but others still run.

## Chokepoints used / not applicable
- `serialize-mutations` / `withHeldFileLock` — via the planner's per-job+namespace locks (#1524/#1517, already unified).
- Catalog write recording — via the planner (#1522 territory, already unified in #1517).
- No new `config.*Enabled` gates bypass the planner. The +5 scattered reads are the per-job gates each fanout honors (`patternReinforcementEnabled`, `lifecyclePolicyEnabled`, `semanticConsolidationEnabled`) plus the fanout-module health summary (`maintenanceNamespaceFanoutEnabled`, `namespacesEnabled`); listed for the #1566 CapabilitySet migration inventory.

## Tests
14 new tests in `namespace-maintenance-fanout.test.ts`: catalog fanout, branch-namespace skip/include, per-namespace failure isolation, `enabled=false` zero-summary, `resolveStorage` wiring, `maxNamespacesPerCycle` budget, `lastMaintenanceAt` update, both namespaces-disabled paths, and the health-summary formatters.

## Gates
- `npm run preflight:quick` → OK (ratchet OK with justification below)
- `npm run test:entity-hardening` → 246/246 pass
- fanout tests → 14/14 pass

## Ratchet justification
`orchestrator.ts` 19946 → 20078 (+132), `cli.ts` 9853 → 9870 (+17), `scatteredConfigFlagReads` 553 → 558 (+5). All growth is irreducible per-job/per-seam wiring authorized by the execution plan's per-job-wiring exception; justification recorded in `scripts/ratchet-baseline.json`. The orchestrator +132 is 6 thin fanout delegator methods — no maintenance logic moved into the orchestrator. The remaining standard jobs (`graph-decay`, `fact-archival`, `tier-migration`, `contradiction-scan`) are enumerated in `NAMESPACE_MAINTENANCE_JOBS` and wire identically when their per-namespace runners are extracted (#1526).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how background maintenance runs across namespaces and updates status/catalog metadata; failures are isolated but incorrect skip/run recording could leave namespaces unmaintained or misreported.
> 
> **Overview**
> Introduces **`namespace-maintenance-fanout`** as the standard adapter to run background maintenance jobs across configured and catalog namespaces (budget, locks, status files, catalog `lastMaintenanceAt`), with a centralized **`NAMESPACE_MAINTENANCE_JOBS`** list and read-only **`summarizeNamespaceMaintenanceHealth`** / text formatting.
> 
> The orchestrator gains thin **`runNamespaceMaintenanceFanoutForJob`** plus fanout entry points for **pattern reinforcement**, **lifecycle**, **semantic consolidation**, and **deep-sleep governance**, delegating to existing per-namespace logic and signaling **cadence skips** so throttled namespaces are not marked as maintained.
> 
> **`namespace-planner`** now plans only the **default** namespace when namespaces are disabled (avoids double-processing the same corpus), honors runner **`{ skipped, skipReason }`** without updating catalog maintenance timestamps, and merges **`.last-ran.json`** into health so **`lastRunAt`** survives later skips.
> 
> Operators get **`remnic namespaces maintenance`** (`--json` or human-readable, including failed namespace details) and a doctor **`namespace_maintenance`** check (warns on failures). Extensive unit tests cover fanout behavior and health formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 639cad1ec7a25aa788e52fe5e2ba71ccbf0443e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->