### PR TITLE
feat(temporal): #1578 PR1 — bi-temporal validity types, resolver & gated injection filter

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3138,7 +3138,7 @@
       "temporalBiTemporal": {
         "type": "boolean",
         "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
       },
       "temporalExpiredInInjection": {
         "type": "boolean",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3135,6 +3135,16 @@
         "default": false,
         "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
       },
+      "temporalBiTemporal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+      },
+      "temporalExpiredInInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
+      },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
         "default": false,
@@ -5819,6 +5829,16 @@
       "label": "Include Superseded Facts In Recall",
       "advanced": true,
       "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "temporalBiTemporal": {
+      "label": "Bi-temporal Validity",
+      "advanced": true,
+      "help": "Master gate (issue #1578): resolve per-fact event-time at write time and exclude validity-expired facts from injection by default. Off = byte-identical to pre-#1578."
+    },
+    "temporalExpiredInInjection": {
+      "label": "Keep Expired-Validity Facts In Injection",
+      "advanced": true,
+      "help": "Escape hatch (issue #1578): keep facts whose event-time interval ended in injection candidates even with bi-temporal on."
     },
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3138,7 +3138,7 @@
       "temporalBiTemporal": {
         "type": "boolean",
         "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
       },
       "temporalExpiredInInjection": {
         "type": "boolean",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3135,6 +3135,16 @@
         "default": false,
         "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
       },
+      "temporalBiTemporal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+      },
+      "temporalExpiredInInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
+      },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
         "default": false,
@@ -5819,6 +5829,16 @@
       "label": "Include Superseded Facts In Recall",
       "advanced": true,
       "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "temporalBiTemporal": {
+      "label": "Bi-temporal Validity",
+      "advanced": true,
+      "help": "Master gate (issue #1578): resolve per-fact event-time at write time and exclude validity-expired facts from injection by default. Off = byte-identical to pre-#1578."
+    },
+    "temporalExpiredInInjection": {
+      "label": "Keep Expired-Validity Facts In Injection",
+      "advanced": true,
+      "help": "Escape hatch (issue #1578): keep facts whose event-time interval ended in injection candidates even with bi-temporal on."
     },
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",

--- a/packages/remnic-core/src/bitemporal-frontmatter.test.ts
+++ b/packages/remnic-core/src/bitemporal-frontmatter.test.ts
@@ -1,0 +1,177 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { StorageManager } from "./storage.js";
+import { isValidityExpiredNow } from "./temporal-validity.js";
+
+/**
+ * Issue #1578 PR 1 — bi-temporal validity frontmatter round-trip + injection
+ * filter unit tests.
+ *
+ * These tests pin the on-disk contract added by #1578 (`observedAt`,
+ * `eventTimeSource`) AND prove the pre-existing temporal/lifecycle fields
+ * (`created`, `updated`, `source`, `valid_at`, `invalid_at`, `forgottenAt`)
+ * round-trip unchanged alongside them — i.e. the parser was not corrupted by
+ * the additive change.  Every test goes through the public StorageManager API
+ * (`writeMemory` + `writeMemoryFrontmatter`, both of which route through the
+ * `serializeFrontmatter` chokepoint) so the serialize → parse round trip is
+ * exercised end to end.
+ *
+ * The injection filter (`isValidityExpiredNow`) is a pure function, so it is
+ * unit-tested directly with minimal frontmatter fragments.
+ */
+
+const OBSERVED = "2026-06-20T14:02:11.000Z";
+const VALID_FROM = "2026-03-01T00:00:00.000Z";
+const VALID_UNTIL = "2026-06-15T00:00:00.000Z";
+
+test("round-trip: observedAt + eventTimeSource + valid_at survive write → readAllMemories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bitemporal-rt-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "We moved offices in March.", {
+      observedAt: OBSERVED,
+      eventTimeSource: "extracted",
+      validAt: VALID_FROM,
+    });
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written, "fact must be discoverable after write");
+    assert.equal(written!.frontmatter.observedAt, OBSERVED);
+    assert.equal(written!.frontmatter.eventTimeSource, "extracted");
+    assert.equal(written!.frontmatter.valid_at, VALID_FROM);
+    // The auto-set baseline fields must remain present and well-formed.
+    assert.ok(typeof written!.frontmatter.created === "string" && written!.frontmatter.created!.length > 0);
+    assert.ok(typeof written!.frontmatter.updated === "string" && written!.frontmatter.updated!.length > 0);
+    assert.equal(written!.frontmatter.source, "extraction");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("round-trip: invalid_at + forgottenAt coexist with observedAt/eventTimeSource (parser not corrupted)", async () => {
+  // Exercises the full serialize→parse round trip through the
+  // writeMemoryFrontmatter chokepoint for the fields writeMemory does not
+  // accept as options (invalid_at, forgottenAt).  This is the direct
+  // regression guard for the "frontmatter parser corruption" risk: every
+  // pre-existing field must survive alongside the new bi-temporal fields,
+  // with no field dropped or duplicated.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bitemporal-coexist-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "Old stack was Node 18.", {
+      observedAt: OBSERVED,
+      eventTimeSource: "assumed",
+      validAt: VALID_FROM,
+    });
+
+    const before = await storage.readAllMemories();
+    const memory = before.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+
+    const ok = await storage.writeMemoryFrontmatter(memory!, {
+      invalid_at: VALID_UNTIL,
+      forgottenAt: "2026-07-01T00:00:00.000Z",
+    });
+    assert.equal(ok, true);
+
+    const after = await storage.readAllMemories();
+    const patched = after.find((m) => m.frontmatter.id === id);
+    assert.ok(patched, "patched fact must be readable");
+    const fm = patched!.frontmatter;
+    // New bi-temporal fields.
+    assert.equal(fm.observedAt, OBSERVED);
+    assert.equal(fm.eventTimeSource, "assumed");
+    // Pre-existing temporal/lifecycle fields — all present, correct values.
+    assert.equal(fm.valid_at, VALID_FROM);
+    assert.equal(fm.invalid_at, VALID_UNTIL);
+    assert.equal(fm.forgottenAt, "2026-07-01T00:00:00.000Z");
+    // Baseline identity fields untouched by the patch.
+    assert.ok(typeof fm.created === "string" && fm.created!.length > 0);
+    assert.ok(typeof fm.source === "string" && fm.source!.length > 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy memory without bi-temporal fields reads cleanly — observedAt/eventTimeSource undefined", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bitemporal-legacy-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "Legacy fact pre-dating #1578.");
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written);
+    assert.equal(written!.frontmatter.observedAt, undefined);
+    assert.equal(written!.frontmatter.eventTimeSource, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("garbage observedAt is rejected on write — corrupt timestamps cannot leak to disk", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bitemporal-reject-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    await assert.rejects(
+      () => storage.writeMemory("fact", "Bad observedAt.", { observedAt: "not-a-timestamp" }),
+      /observedAt must be a valid ISO timestamp/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("isValidityExpiredNow: absent invalid_at → never expired (still valid)", () => {
+  assert.equal(isValidityExpiredNow({ invalid_at: undefined }, Date.now()), false);
+  assert.equal(isValidityExpiredNow({ invalid_at: "" }, Date.now()), false);
+});
+
+test("isValidityExpiredNow: invalid_at in the past → expired (interval ended)", () => {
+  const now = Date.parse("2026-06-20T00:00:00.000Z");
+  assert.equal(
+    isValidityExpiredNow({ invalid_at: "2026-06-15T00:00:00.000Z" }, now),
+    true,
+  );
+});
+
+test("isValidityExpiredNow: invalid_at in the future → not expired (still within window)", () => {
+  const now = Date.parse("2026-06-20T00:00:00.000Z");
+  assert.equal(
+    isValidityExpiredNow({ invalid_at: "2026-12-31T00:00:00.000Z" }, now),
+    false,
+  );
+});
+
+test("isValidityExpiredNow: exclusive end — invalid_at == now is EXPIRED ([from, until) ended)", () => {
+  const boundary = Date.parse("2026-06-15T00:00:00.000Z");
+  // At the exact exclusive boundary the interval has ended.
+  assert.equal(
+    isValidityExpiredNow({ invalid_at: "2026-06-15T00:00:00.000Z" }, boundary),
+    true,
+  );
+});
+
+test("isValidityExpiredNow: status-orthogonal — considers invalid_at only, ignores status", () => {
+  // The filter must be status-orthogonal (issue pitfall matrix): an `active`
+  // memory can be validity-expired.  isValidityExpiredNow only receives the
+  // invalid_at field, so status never enters the decision.
+  const now = Date.parse("2026-06-20T00:00:00.000Z");
+  assert.equal(
+    isValidityExpiredNow({ invalid_at: "2026-06-15T00:00:00.000Z" }, now),
+    true,
+  );
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2084,6 +2084,12 @@ export function parseConfig(
     temporalSupersessionEnabled: cfg.temporalSupersessionEnabled !== false, // On by default
     temporalSupersessionIncludeInRecall:
       cfg.temporalSupersessionIncludeInRecall === true, // Off by default
+    // Bi-temporal validity (issue #1578). Default `false` so extraction,
+    // storage, and recall behave byte-identically to pre-#1578 until an
+    // operator opts in. `=== true` rejects non-boolean / string-coerced
+    // truthy values (rule 51 — never silently default invalid input).
+    temporalBiTemporal: cfg.temporalBiTemporal === true,
+    temporalExpiredInInjection: cfg.temporalExpiredInInjection === true,
     // Direct-answer retrieval tier (issue #518).  Default off so the
     // recall path keeps least-privileged behavior unless operators
     // explicitly opt in.

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2084,10 +2084,17 @@ export function parseConfig(
     temporalSupersessionEnabled: cfg.temporalSupersessionEnabled !== false, // On by default
     temporalSupersessionIncludeInRecall:
       cfg.temporalSupersessionIncludeInRecall === true, // Off by default
-    // Bi-temporal validity (issue #1578). Default `false` so extraction,
-    // storage, and recall behave byte-identically to pre-#1578 until an
-    // operator opts in. `=== true` rejects non-boolean / string-coerced
-    // truthy values (rule 51 — never silently default invalid input).
+    // Bi-temporal validity (issue #1578). Default `false` so recall behaves
+    // byte-identically to pre-#1578 until an operator opts in. `=== true`
+    // rejects non-boolean / string-coerced truthy values (rule 51).
+    //
+    // CURRENT scope (this PR): the recall injection filter (expired-validity
+    // facts leave default injection but stay findable by explicit search and
+    // as_of queries) + the observedAt/eventTimeSource storage fields. The
+    // extraction prompt → resolveEventTime write-time wiring lands in a
+    // follow-on PR; until then, enabling the gate exercises the filter and
+    // storage round-trip but new extractions are not yet event-time-resolved
+    // (docs kept honest — review: wire resolver before exposing the gate).
     temporalBiTemporal: cfg.temporalBiTemporal === true,
     temporalExpiredInInjection: cfg.temporalExpiredInInjection === true,
     // Direct-answer retrieval tier (issue #518).  Default off so the

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2085,8 +2085,8 @@ export function parseConfig(
     temporalSupersessionIncludeInRecall:
       cfg.temporalSupersessionIncludeInRecall === true, // Off by default
     // Bi-temporal validity (issue #1578). Default `false` so recall behaves
-    // byte-identically to pre-#1578 until an operator opts in. `=== true`
-    // rejects non-boolean / string-coerced truthy values (rule 51).
+    // byte-identically to pre-#1578 until an operator opts in. Uses coerceBool
+    // (same as recallDirectAnswerEnabled below) so CLI string "true" works.
     //
     // CURRENT scope (this PR): the recall injection filter (expired-validity
     // facts leave default injection but stay findable by explicit search and
@@ -2095,8 +2095,8 @@ export function parseConfig(
     // follow-on PR; until then, enabling the gate exercises the filter and
     // storage round-trip but new extractions are not yet event-time-resolved
     // (docs kept honest — review: wire resolver before exposing the gate).
-    temporalBiTemporal: cfg.temporalBiTemporal === true,
-    temporalExpiredInInjection: cfg.temporalExpiredInInjection === true,
+    temporalBiTemporal: coerceBool(cfg.temporalBiTemporal) ?? false,
+    temporalExpiredInInjection: coerceBool(cfg.temporalExpiredInInjection) ?? false,
     // Direct-answer retrieval tier (issue #518).  Default off so the
     // recall path keeps least-privileged behavior unless operators
     // explicitly opt in.

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -442,3 +442,31 @@ test("since <month> <year> with explicit year does not roll back (codex review r
   assert.equal(r.ok, true);
   assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
 });
+
+test("until <bare season> resolves end bound (codex review r2)", () => {
+  // "until spring" from June → spring ended May → exclusive end June 1 2026.
+  const r = resolveEventTime("until spring", "2026-06-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-06-01T00:00:00.000Z");
+});
+
+test("through <bare season> from inside the season does not roll back (codex review r2)", () => {
+  // "through summer" from July → we're in summer → end = Sep 1 2026.
+  const r = resolveEventTime("through summer", "2026-07-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-09-01T00:00:00.000Z");
+});
+
+test("until end of <season> strips prefix and resolves (codex review r2)", () => {
+  // "until end of spring" from June → same as "until spring".
+  const r = resolveEventTime("until end of spring", "2026-06-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-06-01T00:00:00.000Z");
+});
+
+test("until <bare season> from before the season rolls back (codex review r2)", () => {
+  // "until spring" from January → spring hasn't happened → last spring ended Jun 2025.
+  const r = resolveEventTime("until spring", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-06-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -356,3 +356,45 @@ test("until <future month> rolls back a year (cursor review r2 regression)", () 
   assert.equal(r.ok, true);
   assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
 });
+
+test("this winter from January rolls back to previous December (codex review r2)", () => {
+  const r = resolveEventTime("this winter", "2026-01-15T00:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-12-01T00:00:00.000Z");
+});
+
+test("this winter from February rolls back to previous December (codex review r2)", () => {
+  const r = resolveEventTime("this winter", "2026-02-15T00:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-12-01T00:00:00.000Z");
+});
+
+test("this winter from December stays in the current year (codex review r2)", () => {
+  const r = resolveEventTime("this winter", "2026-12-15T00:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-12-01T00:00:00.000Z");
+});
+
+test("this spring from January stays in the current year (season rollback regression)", () => {
+  const r = resolveEventTime("this spring", "2026-01-15T00:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
+});
+
+test("until <season> <year> advances by the full 3-month season (codex review r2)", () => {
+  const r = resolveEventTime("until spring 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-06-01T00:00:00.000Z");
+});
+
+test("through <season> <year> advances by the full 3-month season (codex review r2)", () => {
+  const r = resolveEventTime("through summer 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-09-01T00:00:00.000Z");
+});
+
+test("until <month> <year> still advances by 1 month (season fix regression)", () => {
+  const r = resolveEventTime("until March 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -470,3 +470,45 @@ test("until <bare season> from before the season rolls back (codex review r2)", 
   assert.equal(r.ok, true);
   assert.equal(r.validUntil, "2025-06-01T00:00:00.000Z");
 });
+
+// ── Review r5c+ : bare winter end-bound wraparound + since-quarter pin ────
+
+test("until <winter> from January resolves to the current winter's end (codex r5c)", () => {
+  // Anchor Jan 2026 sits in the winter that started Dec 2025. The exclusive
+  // end of THAT winter is March 1 2026 — not March 2027 (the next winter).
+  // Without the winter-wraparound year adjustment, the season start was built
+  // as Dec 2026, pushing the exclusive end a full year too far forward.
+  const r = resolveEventTime("until winter", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-01T00:00:00.000Z");
+});
+
+test("until <winter> from February resolves to the current winter's end (codex r5c)", () => {
+  const r = resolveEventTime("until winter", "2026-02-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-01T00:00:00.000Z");
+});
+
+test("through <winter> is an alias for until and wraps the same way (codex r5c)", () => {
+  const r = resolveEventTime("through winter", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-01T00:00:00.000Z");
+});
+
+test("until <winter> from December stays in the upcoming March (inside-winter regression)", () => {
+  // Anchor Dec 2026 is inside the winter that started Dec 2026; its exclusive
+  // end is March 1 2027. The wraparound fix must NOT over-roll this case.
+  const r = resolveEventTime("until winter", "2026-12-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2027-03-01T00:00:00.000Z");
+});
+
+test("since <quarter> rolls back like a bare month — 'since' is backwards-looking", () => {
+  // "since Q2" from January 2026: Q2 2026 (April) is still in the future, and
+  // "since" denotes an already-true interval, so the most recent PAST Q2 — Q2
+  // 2025 = April 1 2025 — is the correct validFrom. Quarter tokens are treated
+  // consistently with bare month/season names under the since-rollback guard.
+  const r = resolveEventTime("since Q2", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-04-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Issue #1578 PR 1 — event-time resolver table tests.
+ *
+ * The resolver is pure: (expression, anchor) in, interval out.  These tests
+ * pin the supported shapes (absolute, relative, since/until, yesterday/today/
+ * tomorrow, last/this/next period, month+year, season) and the failure modes
+ * (unresolvable garbage, bad anchor, Date overflow).  Per the issue's PR-1
+ * guide: ≥25 expressions including timezone-edge anchors, leap day, year-
+ * boundary "last December", and unresolvable garbage.
+ *
+ * Interval semantics are `[validFrom, validUntil)` — inclusive start,
+ * exclusive end (AGENTS.md §23).  Date-only END bounds convert to
+ * start-of-next-day so the end date itself is excluded.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveEventTime } from "./event-time.js";
+
+// Anchor fixed at 2026-06-15T12:00:00.000Z (a Monday in mid-June 2026).
+const ANCHOR = "2026-06-15T12:00:00.000Z";
+
+function dayMs(iso: string): number {
+  return Date.parse(iso);
+}
+
+test("absolute ISO date resolves validFrom at start-of-day UTC", () => {
+  const r = resolveEventTime("2026-03-01", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
+  assert.equal(r.validUntil, undefined);
+});
+
+test("absolute ISO datetime resolves validFrom verbatim", () => {
+  const r = resolveEventTime("2026-03-01T09:30:00Z", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-03-01T09:30:00.000Z");
+});
+
+test("since <date> resolves validFrom only", () => {
+  const r = resolveEventTime("since 2024-01-15", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-01-15T00:00:00.000Z");
+  assert.equal(r.validUntil, undefined);
+});
+
+test("until <date> resolves validUntil to start-of-NEXT-day (exclusive end)", () => {
+  // "until 2026-03-01" must exclude March 1 itself → exclusive bound at Mar 2.
+  const r = resolveEventTime("until 2026-03-01", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-02T00:00:00.000Z");
+  assert.equal(r.validFrom, undefined);
+});
+
+test("through <date> is an alias for until (exclusive end)", () => {
+  const r = resolveEventTime("through 2026-03-01", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-02T00:00:00.000Z");
+});
+
+test("until <datetime> uses the datetime verbatim (not start-of-next-day)", () => {
+  const r = resolveEventTime("until 2026-03-01T18:00:00Z", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-03-01T18:00:00.000Z");
+});
+
+test("today resolves to the anchor's start-of-day", () => {
+  const r = resolveEventTime("today", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-15T00:00:00.000Z");
+});
+
+test("yesterday resolves to the previous calendar day", () => {
+  const r = resolveEventTime("yesterday", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-14T00:00:00.000Z");
+});
+
+test("tomorrow resolves to the next calendar day", () => {
+  const r = resolveEventTime("tomorrow", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-16T00:00:00.000Z");
+});
+
+test("last week resolves to 7 days before anchor", () => {
+  const r = resolveEventTime("last week", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-08T00:00:00.000Z");
+});
+
+test("this month resolves to the 1st of the anchor's month", () => {
+  const r = resolveEventTime("this month", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-01T00:00:00.000Z");
+});
+
+test("last month resolves to the 1st of the previous month", () => {
+  const r = resolveEventTime("last month", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-05-01T00:00:00.000Z");
+});
+
+test("next year resolves to Jan 1 of the next year", () => {
+  const r = resolveEventTime("next year", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2027-01-01T00:00:00.000Z");
+});
+
+test("last December crosses the year boundary (anchor in June 2026)", () => {
+  // Anchor is June 2026; "last December" = December 2025.
+  const r = resolveEventTime("last December", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-12-01T00:00:00.000Z");
+});
+
+test("next March resolves forward across the year boundary", () => {
+  // Anchor June 2026; "next March" = March 2027.
+  const r = resolveEventTime("next March", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2027-03-01T00:00:00.000Z");
+});
+
+test("this Q3 resolves to July 1 of the anchor's year", () => {
+  const r = resolveEventTime("this Q3", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-07-01T00:00:00.000Z");
+});
+
+test("bare month+year resolves to the 1st of that month", () => {
+  const r = resolveEventTime("March 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-03-01T00:00:00.000Z");
+});
+
+test("abbreviated month+year resolves (Dec 2024)", () => {
+  const r = resolveEventTime("Dec 2024", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-12-01T00:00:00.000Z");
+});
+
+test("leap day resolves correctly (Feb 29 2024)", () => {
+  const r = resolveEventTime("2024-02-29", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-02-29T00:00:00.000Z");
+});
+
+test("timezone-edge anchor: 23:59 UTC vs 00:00 UTC do not shift the day", () => {
+  // "today" anchored at 23:59:59 UTC must still be the same UTC day.
+  const late = resolveEventTime("today", "2026-06-15T23:59:59.000Z");
+  assert.equal(late.validFrom, "2026-06-15T00:00:00.000Z");
+  // Anchored at 00:00:00 UTC — same day.
+  const early = resolveEventTime("today", "2026-06-15T00:00:00.000Z");
+  assert.equal(early.validFrom, "2026-06-15T00:00:00.000Z");
+});
+
+test("resolution is anchored to the source turn, never Date.now()", () => {
+  // "yesterday" against a 2025 anchor must yield a 2025 date, not today's
+  // yesterday — this is the replay/import correctness guarantee.
+  const r = resolveEventTime("yesterday", "2025-01-10T08:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-01-09T00:00:00.000Z");
+});
+
+// ── Failure modes ─────────────────────────────────────────────────────────
+
+test("empty / whitespace expression → ok:false", () => {
+  assert.equal(resolveEventTime("", ANCHOR).ok, false);
+  assert.equal(resolveEventTime("   ", ANCHOR).ok, false);
+  assert.equal(resolveEventTime(undefined, ANCHOR).ok, false);
+  assert.equal(resolveEventTime(null, ANCHOR).ok, false);
+});
+
+test("unresolvable garbage → ok:false (no partial output)", () => {
+  const r = resolveEventTime("sometime maybe", ANCHOR);
+  assert.equal(r.ok, false);
+  assert.equal(r.validFrom, undefined);
+  assert.equal(r.validUntil, undefined);
+});
+
+test("invalid month name → ok:false", () => {
+  const r = resolveEventTime("last Smarch", ANCHOR);
+  assert.equal(r.ok, false);
+});
+
+test("overflowed date (Feb 30) → ok:false, never Invalid Date", () => {
+  const r = resolveEventTime("2026-02-30", ANCHOR);
+  assert.equal(r.ok, false);
+  assert.equal(r.validFrom, undefined);
+});
+
+test("malformed anchor timestamp → ok:false (no silent default)", () => {
+  const r = resolveEventTime("2026-03-01", "not-a-timestamp");
+  assert.equal(r.ok, false);
+});
+
+test("since <garbage> → ok:false (does not fall back to anchor)", () => {
+  const r = resolveEventTime("since forever", ANCHOR);
+  assert.equal(r.ok, false);
+});
+
+test("until <invalid month> → ok:false", () => {
+  const r = resolveEventTime("until Smarch", ANCHOR);
+  assert.equal(r.ok, false);
+});
+
+test("case-insensitive: LAST MARCH resolves like last March", () => {
+  const r = resolveEventTime("LAST MARCH", ANCHOR);
+  assert.equal(r.ok, true);
+  // Anchor June 2026 → last March = March 2026.
+  assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
+});
+
+test("until <month-name> end bound lands on start of following month", () => {
+  // "until March" against a June anchor → exclusive end at April 1.
+  const r = resolveEventTime("until March", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-04-01T00:00:00.000Z");
+});
+
+test("interval is half-open: validFrom inclusive, validUntil exclusive", () => {
+  // A fact valid "since 2026-03-01" "until 2026-03-01" has a zero-width
+  // interval — the two bounds are equal, meaning nothing is inside [a, a).
+  const from = resolveEventTime("since 2026-03-01", ANCHOR).validFrom!;
+  const until = resolveEventTime("until 2026-03-01", ANCHOR).validUntil!;
+  assert.equal(dayMs(until) > dayMs(from), true, "exclusive end must exceed inclusive start");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -398,3 +398,47 @@ test("until <month> <year> still advances by 1 month (season fix regression)", (
   assert.equal(r.ok, true);
   assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
 });
+
+test("last summer from July rolls back a year — anchor inside season (codex review r2)", () => {
+  const r = resolveEventTime("last summer", "2026-07-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-06-01T00:00:00.000Z");
+});
+
+test("last summer from March rolls back — season not yet started (codex review r2)", () => {
+  const r = resolveEventTime("last summer", "2026-03-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-06-01T00:00:00.000Z");
+});
+
+test("last summer from September stays current year — season already passed (codex review r2)", () => {
+  const r = resolveEventTime("last summer", "2026-09-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-06-01T00:00:00.000Z");
+});
+
+test("last winter from January rolls back two years — inside winter tail (codex review r2)", () => {
+  const r = resolveEventTime("last winter", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-12-01T00:00:00.000Z");
+});
+
+test("since <bare month> from before that month rolls back (codex review r2)", () => {
+  // "since March" from January 2026 → March 2025 (most recent past March).
+  const r = resolveEventTime("since March", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-03-01T00:00:00.000Z");
+});
+
+test("since <bare month> from after that month stays current year (codex review r2 regression)", () => {
+  // "since March" from June 2026 → March 2026 (already happened).
+  const r = resolveEventTime("since March", "2026-06-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
+});
+
+test("since <month> <year> with explicit year does not roll back (codex review r2 regression)", () => {
+  const r = resolveEventTime("since March 2026", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-03-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -270,3 +270,35 @@ test("until <month> <year> exclusive end is start of following month (codex revi
   assert.equal(r.ok, true);
   assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
 });
+
+test("since <bare year> resolves to January 1 of that year (codex review r2)", () => {
+  const r = resolveEventTime("since 2024", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-01-01T00:00:00.000Z");
+});
+
+test("bare four-digit year resolves to January 1 (codex review r2)", () => {
+  const r = resolveEventTime("2023", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2023-01-01T00:00:00.000Z");
+});
+
+test("until <bare year> exclusive end is January 1 of the FOLLOWING year (codex review r2)", () => {
+  const r = resolveEventTime("until 2024", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-01-01T00:00:00.000Z");
+});
+
+test("until end of <month> strips the prefix and resolves (codex review r2)", () => {
+  const r = resolveEventTime("until end of March", ANCHOR);
+  assert.equal(r.ok, true);
+  // "end of March" backwards-looking from June 2026 anchor → exclusive end
+  // at the start of the month AFTER March 2026 = April 1 2026.
+  assert.equal(r.validUntil, "2026-04-01T00:00:00.000Z");
+});
+
+test("until end of <month> <year> strips the prefix and resolves (codex review r2)", () => {
+  const r = resolveEventTime("until end of March 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -302,3 +302,57 @@ test("until end of <month> <year> strips the prefix and resolves (codex review r
   assert.equal(r.ok, true);
   assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
 });
+
+test("last Q2 from May rolls back a year — anchor inside target quarter (codex review r2)", () => {
+  // Anchor May 2026 is inside Q2. "last Q2" must be Q2 2025 = April 1 2025.
+  const r = resolveEventTime("last Q2", "2026-05-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-04-01T00:00:00.000Z");
+});
+
+test("last Q2 from June rolls back a year — anchor in last month of target quarter (codex review r2)", () => {
+  const r = resolveEventTime("last Q2", "2026-06-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-04-01T00:00:00.000Z");
+});
+
+test("last Q2 from March stays current year — target quarter not yet started (codex review r2)", () => {
+  // Anchor March 2026. Q2 2026 hasn't started, so "last Q2" = Q2 2025.
+  const r = resolveEventTime("last Q2", "2026-03-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-04-01T00:00:00.000Z");
+});
+
+test("last Q2 from July stays current year — target quarter already completed (codex review r2)", () => {
+  // Anchor July 2026. Q2 2026 ended, so "last Q2" = Q2 2026 = April 1 2026.
+  const r = resolveEventTime("last Q2", "2026-07-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-04-01T00:00:00.000Z");
+});
+
+test("next Q2 from May rolls forward a year — anchor inside target quarter (codex review r2)", () => {
+  const r = resolveEventTime("next Q2", "2026-05-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2027-04-01T00:00:00.000Z");
+});
+
+test("until <current month> does not roll back a year (cursor review r2)", () => {
+  // Anchor mid-March 2026. "until March" should end at the current month's end.
+  const r = resolveEventTime("until March", "2026-03-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-04-01T00:00:00.000Z");
+});
+
+test("until <past month> rolls back correctly (cursor review r2 regression)", () => {
+  // Anchor June 2026. "until March" → March already ended this year → April 1 2026.
+  const r = resolveEventTime("until March", "2026-06-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2026-04-01T00:00:00.000Z");
+});
+
+test("until <future month> rolls back a year (cursor review r2 regression)", () => {
+  // Anchor January 2026. "until March" → March hasn't happened yet → April 1 2025.
+  const r = resolveEventTime("until March", "2026-01-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.test.ts
+++ b/packages/remnic-core/src/event-time.test.ts
@@ -223,3 +223,50 @@ test("interval is half-open: validFrom inclusive, validUntil exclusive", () => {
   const until = resolveEventTime("until 2026-03-01", ANCHOR).validUntil!;
   assert.equal(dayMs(until) > dayMs(from), true, "exclusive end must exceed inclusive start");
 });
+
+// ── Review fixes (cursor quarter + codex month-year after since) ─────────
+
+test("last quarter moves the quarter INDEX back, not the year (cursor review)", () => {
+  // Anchor June 2026 = Q2. "last quarter" must be Q1 = Jan 1 2026, not Apr 1.
+  const r = resolveEventTime("last quarter", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-01-01T00:00:00.000Z");
+});
+
+test("next quarter moves the quarter INDEX forward (cursor review)", () => {
+  // Anchor June 2026 = Q2. "next quarter" must be Q3 = July 1 2026.
+  const r = resolveEventTime("next quarter", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-07-01T00:00:00.000Z");
+});
+
+test("this quarter stays the current quarter (Q2 = April)", () => {
+  const r = resolveEventTime("this quarter", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2026-04-01T00:00:00.000Z");
+});
+
+test("last quarter wraps the year boundary (anchor Q1 → prev Q4 prior year)", () => {
+  // Anchor Feb 2026 = Q1. "last quarter" must be Q4 2025 = Oct 1 2025.
+  const r = resolveEventTime("last quarter", "2026-02-15T12:00:00.000Z");
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-10-01T00:00:00.000Z");
+});
+
+test("since <month> <year> resolves with the explicit year (codex review)", () => {
+  const r = resolveEventTime("since March 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2025-03-01T00:00:00.000Z");
+});
+
+test("since <season> <year> resolves (codex review)", () => {
+  const r = resolveEventTime("since spring 2024", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validFrom, "2024-03-01T00:00:00.000Z");
+});
+
+test("until <month> <year> exclusive end is start of following month (codex review)", () => {
+  const r = resolveEventTime("until March 2025", ANCHOR);
+  assert.equal(r.ok, true);
+  assert.equal(r.validUntil, "2025-04-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -233,9 +233,16 @@ function resolveQuarter(
   const d = new Date(anchorMs);
   let year = d.getUTCFullYear();
   const anchorMonth = d.getUTCMonth() + 1;
-  const qStartMonthValue = startMonth;
-  if (direction === -1 && qStartMonthValue >= anchorMonth) year -= 1;
-  else if (direction === +1 && qStartMonthValue <= anchorMonth) year += 1;
+  const anchorQ = Math.floor((anchorMonth - 1) / 3) + 1;
+  // Roll back/forward when the target quarter hasn't started yet this year
+  // (startMonth past the anchor month) OR when the anchor is currently
+  // INSIDE the target quarter (review r2: "last Q2" from May returned 2026
+  // instead of 2025 because the quarter start month had already passed but
+  // the quarter was still ongoing).
+  if (direction === -1 && (startMonth >= anchorMonth || anchorQ === qNumber))
+    year -= 1;
+  else if (direction === +1 && (startMonth <= anchorMonth || anchorQ === qNumber))
+    year += 1;
   return buildDateMs(year, startMonth, 1);
 }
 
@@ -448,7 +455,11 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
     const nd = new Date(startMs);
     nd.setUTCMonth(nd.getUTCMonth() + 1);
     let endMs = startOfDayUtc(nd.getTime());
-    if (endMs > anchorMs) {
+    // Only roll back when the named month boundary is genuinely future
+    // relative to the anchor cycle.  When the anchor IS in the named month,
+    // the end of the current month is the right boundary — do not roll back
+    // (cursor review r2: "until March" from mid-March returned the prior year).
+    if (endMs > anchorMs && d.getUTCMonth() + 1 !== monthIdx) {
       nd.setUTCFullYear(nd.getUTCFullYear() - 1);
       endMs = startOfDayUtc(nd.getTime());
     }

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -209,6 +209,19 @@ function resolveBareYear(token: string): number | null {
   return buildDateMs(Number(m[1]), 1, 1);
 }
 
+
+/**
+ * Check whether the anchor month falls inside a season's 3-month span.
+ * Seasons start at `baseMonth` and span 3 months (e.g. summer = Jun–Aug).
+ * Winter (Dec=12) wraps: Dec, Jan, Feb.
+ */
+function isInSeason(baseMonth: number, anchorMonth: number): boolean {
+  for (let i = 0; i < 3; i++) {
+    if (((baseMonth - 1 + i) % 12) + 1 === anchorMonth) return true;
+  }
+  return false;
+}
+
 function resolveSeasonYear(
   anchorMs: number,
   seasonToken: string,
@@ -219,12 +232,27 @@ function resolveSeasonYear(
   const d = new Date(anchorMs);
   let year = d.getUTCFullYear();
   const anchorMonth = d.getUTCMonth() + 1;
-  if (direction === -1 && baseMonth > anchorMonth) year -= 1;
-  else if (direction === +1 && baseMonth < anchorMonth) year += 1;
-  // "this winter" (direction 0) from Jan/Feb: winter started in the previous
-  // December. Without this, the resolver stamps facts almost a year in the
-  // future (codex review r2). Only winter (Dec) spans the year boundary.
-  else if (direction === 0 && baseMonth === 12 && anchorMonth <= 2) year -= 1;
+
+  if (direction === -1) {
+    // "last <season>": go to the previous occurrence.
+    // If the season hasn't started yet this year (baseMonth > anchorMonth)
+    // or the anchor is currently INSIDE the season, roll back a year.
+    if (baseMonth > anchorMonth || isInSeason(baseMonth, anchorMonth)) year -= 1;
+    // Winter tail (Jan/Feb): current winter started prev Dec, so "last"
+    // needs one more year back.
+    if (baseMonth === 12 && anchorMonth <= 2) year -= 1;
+  } else if (direction === +1) {
+    // "next <season>": go to the next occurrence.
+    // Winter from Jan/Feb: current winter started prev Dec; next is this Dec.
+    if (baseMonth === 12 && anchorMonth <= 2) {
+      // no year change — next winter is December of the anchor year
+    } else if (baseMonth < anchorMonth || isInSeason(baseMonth, anchorMonth)) {
+      year += 1;
+    }
+  } else if (direction === 0 && baseMonth === 12 && anchorMonth <= 2) {
+    // "this winter" from Jan/Feb: winter started in the previous December.
+    year -= 1;
+  }
   return buildDateMs(year, baseMonth, 1);
 }
 
@@ -301,11 +329,24 @@ export function resolveEventTime(
   const sinceMatch = lower.match(/^since\s+(.+)$/);
   if (sinceMatch) {
     const inner = sinceMatch[1].trim();
-    const fromMs =
+    let fromMs =
       resolveRelativePeriod(anchorMs, inner) ??
       resolveExplicitMonthYear(inner) ??
       resolveBareYear(inner) ??
       resolveAbsolute(inner);
+    // "since <bare month/season>": if the resolved start is future and the
+    // expression carries no explicit 4-digit year, the fact meant the most
+    // recent PAST occurrence of that period (codex review r2: "since March"
+    // from January produced a future validFrom).
+    if (
+      fromMs !== null &&
+      fromMs > anchorMs &&
+      !/\d{4}/.test(inner)
+    ) {
+      const nd = new Date(fromMs);
+      nd.setUTCFullYear(nd.getUTCFullYear() - 1);
+      fromMs = nd.getTime();
+    }
     const fromIso = toIsoUtc(fromMs);
     if (!fromIso) return fallback;
     return { validFrom: fromIso, ok: true };

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -196,6 +196,19 @@ function resolveExplicitMonthYear(token: string): number | null {
   return buildDateMs(year, baseMonth, 1);
 }
 
+
+/**
+ * Resolve a bare four-digit year token (e.g. "2024") to January 1 of that
+ * year.  Used by "since 2024" and bare year expressions.  Review #1578 r2:
+ * previously these fell through to ok:false, stamping the fact at ingestion
+ * time instead of the documented year start.
+ */
+function resolveBareYear(token: string): number | null {
+  const m = token.trim().match(/^(\d{4})$/);
+  if (!m) return null;
+  return buildDateMs(Number(m[1]), 1, 1);
+}
+
 function resolveSeasonYear(
   anchorMs: number,
   seasonToken: string,
@@ -279,6 +292,7 @@ export function resolveEventTime(
     const fromMs =
       resolveRelativePeriod(anchorMs, inner) ??
       resolveExplicitMonthYear(inner) ??
+      resolveBareYear(inner) ??
       resolveAbsolute(inner);
     const fromIso = toIsoUtc(fromMs);
     if (!fromIso) return fallback;
@@ -317,10 +331,11 @@ export function resolveEventTime(
     return fromIso ? { validFrom: fromIso, ok: true } : fallback;
   }
 
-  // ── bare month+year ("March 2025", "Dec 2024", "spring 2025") ─────────
+  // ── bare month+year ("March 2025", "Dec 2024", "spring 2025") or
+  // bare four-digit year ("2024") ────────────────────────────────────────
   // Explicit year is authoritative (never derived from the anchor). Shares
-  // resolveExplicitMonthYear with the since/until paths for consistency.
-  const explicitMs = resolveExplicitMonthYear(lower);
+  // resolveExplicitMonthYear / resolveBareYear with the since/until paths.
+  const explicitMs = resolveExplicitMonthYear(lower) ?? resolveBareYear(lower);
   if (explicitMs !== null) {
     const fromIso = toIsoUtc(explicitMs);
     if (fromIso) return { validFrom: fromIso, ok: true };
@@ -391,7 +406,15 @@ function resolveRelativePeriod(
  * the start of the *following* period.
  */
 function resolveEndBound(anchorMs: number, period: string): number | null {
-  const trimmed = period.trim();
+  // Strip an optional "end of " prefix so "until end of March" resolves the
+  // same as "until March".  Review #1578 r2: previously the prefix was passed
+  // unchanged and resolveEndBound returned null for the full phrase.
+  const trimmed = period.trim().replace(/^end\s+of\s+/i, "").trim();
+
+  // Bare four-digit year: exclusive end = January 1 of the FOLLOWING year.
+  if (/^\d{4}$/.test(trimmed)) {
+    return buildDateMs(Number(trimmed) + 1, 1, 1);
+  }
 
   // Absolute date/datetime end bound.
   const absMs = resolveAbsolute(trimmed);

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -177,6 +177,24 @@ function resolveMonthYear(
   }
   return null;
 }
+/**
+ * Resolve an explicit "<month|season> <year>" token (e.g. "march 2025",
+ * "dec 2024", "spring 2025") to a start-of-month ms.  The explicit year is
+ * authoritative — it is never derived from the anchor.  Returns null when
+ * the token is not in that shape or does not name a real month/season.
+ * Shared by the bare phrase path, "since <month> <year>", and the end bound
+ * so all three resolve identically (review: month-year phrases after since).
+ */
+function resolveExplicitMonthYear(token: string): number | null {
+  const m = token.trim().toLowerCase().match(/^([a-z]+)\s+(\d{4})$/);
+  if (!m) return null;
+  const year = parseInt(m[2], 10);
+  if (!Number.isInteger(year)) return null;
+  const monthIdx = monthIndex(m[1]);
+  const baseMonth = typeof monthIdx === "number" ? monthIdx : SEASON_TO_MONTH[m[1]];
+  if (typeof baseMonth !== "number") return null;
+  return buildDateMs(year, baseMonth, 1);
+}
 
 function resolveSeasonYear(
   anchorMs: number,
@@ -258,7 +276,10 @@ export function resolveEventTime(
   const sinceMatch = lower.match(/^since\s+(.+)$/);
   if (sinceMatch) {
     const inner = sinceMatch[1].trim();
-    const fromMs = resolveRelativePeriod(anchorMs, inner) ?? resolveAbsolute(inner);
+    const fromMs =
+      resolveRelativePeriod(anchorMs, inner) ??
+      resolveExplicitMonthYear(inner) ??
+      resolveAbsolute(inner);
     const fromIso = toIsoUtc(fromMs);
     if (!fromIso) return fallback;
     return { validFrom: fromIso, ok: true };
@@ -296,24 +317,13 @@ export function resolveEventTime(
     return fromIso ? { validFrom: fromIso, ok: true } : fallback;
   }
 
-  // ── bare month+year ("March 2025", "Dec 2024") or season+year ─────────
-  // The explicit year in the expression is authoritative — never derive it
-  // from the anchor (the prior bug ignored the captured year and produced
-  // the anchor's year for "March 2025").
-  const monthYear = lower.match(/^([a-z]+)\s+(\d{4})$/);
-  if (monthYear) {
-    const explicitYear = parseInt(monthYear[2], 10);
-    if (Number.isInteger(explicitYear)) {
-      const mIdx = monthIndex(monthYear[1]);
-      const baseMonth = typeof mIdx === "number" ? mIdx : SEASON_TO_MONTH[monthYear[1]];
-      if (typeof baseMonth === "number") {
-        const ms = buildDateMs(explicitYear, baseMonth, 1);
-        if (ms !== null) {
-          const fromIso = toIsoUtc(ms);
-          if (fromIso) return { validFrom: fromIso, ok: true };
-        }
-      }
-    }
+  // ── bare month+year ("March 2025", "Dec 2024", "spring 2025") ─────────
+  // Explicit year is authoritative (never derived from the anchor). Shares
+  // resolveExplicitMonthYear with the since/until paths for consistency.
+  const explicitMs = resolveExplicitMonthYear(lower);
+  if (explicitMs !== null) {
+    const fromIso = toIsoUtc(explicitMs);
+    if (fromIso) return { validFrom: fromIso, ok: true };
   }
 
   // ── absolute ISO date / datetime ───────────────────────────────────────
@@ -344,9 +354,21 @@ function resolveRelativePeriod(
     return resolveQuarter(anchorMs, Number(qTok[1]), direction);
   }
   if (lower === "quarter") {
+    // "last quarter" / "next quarter" move the quarter INDEX (with year
+    // wraparound), not just the year — resolveQuarter only nudges the year
+    // for an explicit quarter number, so routing "last quarter" through it
+    // returned the current quarter's start (review: bare last/next quarter).
     const d = new Date(anchorMs);
-    const q = Math.floor(d.getUTCMonth() / 3) + 1;
-    return resolveQuarter(anchorMs, q, direction);
+    let q = Math.floor(d.getUTCMonth() / 3) + 1;
+    let year = d.getUTCFullYear();
+    if (direction === -1) {
+      q -= 1;
+      if (q < 1) { q = 4; year -= 1; }
+    } else if (direction === +1) {
+      q += 1;
+      if (q > 4) { q = 1; year += 1; }
+    }
+    return buildDateMs(year, QUARTER_START_MONTH[q], 1);
   }
 
   // Relative unit: "week", "month", "year", "day"
@@ -377,6 +399,16 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
     // Date-only → start of next day (exclusive end).  Datetime → use as-is.
     if (!/[Tt]/.test(trimmed)) return startOfNextDayUtc(absMs);
     return absMs;
+  }
+  // Explicit "<month> <year>" end bound (e.g. "until March 2025") — the
+  // explicit year is authoritative, so exclusive end = start of the FOLLOWING
+  // month in that year (no anchor rollback). Shares resolveExplicitMonthYear
+  // with the since/bare paths (review: month-year phrases after since).
+  const explicitMs = resolveExplicitMonthYear(trimmed);
+  if (explicitMs !== null) {
+    const nd = new Date(explicitMs);
+    nd.setUTCMonth(nd.getUTCMonth() + 1);
+    return startOfDayUtc(nd.getTime());
   }
 
   // Period-name end bound: month → exclusive end at start of the FOLLOWING

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -515,6 +515,24 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
     }
     return endMs;
   }
+  // Season end bound: advance by the full 3-month season.  Same
+  // backwards-looking rollback logic as month names, but do not roll back
+  // when the anchor is currently inside the season (codex review r2: bare
+  // season end bounds like "until spring" / "through summer" returned null).
+  const seasonMonth = SEASON_TO_MONTH[lower];
+  if (typeof seasonMonth === "number") {
+    const d = new Date(anchorMs);
+    const startMs = buildDateMs(d.getUTCFullYear(), seasonMonth, 1);
+    if (startMs === null) return null;
+    const nd = new Date(startMs);
+    nd.setUTCMonth(nd.getUTCMonth() + 3);
+    let endMs = startOfDayUtc(nd.getTime());
+    if (endMs > anchorMs && !isInSeason(seasonMonth, d.getUTCMonth() + 1)) {
+      nd.setUTCFullYear(nd.getUTCFullYear() - 1);
+      endMs = startOfDayUtc(nd.getTime());
+    }
+    return endMs;
+  }
   if (lower === "year") {
     const d = new Date(anchorMs);
     return buildDateMs(d.getUTCFullYear() + 1, 1, 1);

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -1,0 +1,407 @@
+/**
+ * Event-time resolver (issue #1578).
+ *
+ * Extraction can carry an optional per-fact `eventTime` expression — an ISO
+ * date or a relative phrase verbatim from the source turn ("last March",
+ * "yesterday", "since 2024").  This module resolves such expressions into a
+ * `[validFrom, validUntil)` event-time interval, **anchored to the source
+ * turn's timestamp** — never to `Date.now()`.
+ *
+ * Why anchor (not wall-clock): replay/import of old transcripts must resolve
+ * "yesterday" against the *old* turn's yesterday, not today.  A relative
+ * expression is meaningless without its anchor; resolving it against the
+ * current time would silently rewrite history (AGENTS.md §39 — byte-identical
+ * when the feature is off; rule 35 — half-open intervals; rule 51 — never
+ * silently default invalid input).
+ *
+ * Resolution is **write-time-only**.  The on-disk frontmatter stores absolute
+ * ISO timestamps strings (`valid_at` / `invalid_at`); readers never call back
+ * into this module.  Anything unresolvable yields `ok: false` and the caller
+ * records `eventTimeSource: "assumed"` with `valid_at` copied from the
+ * ingestion anchor (`observedAt`).
+ *
+ * Interval semantics are `[validFrom, validUntil)` — inclusive start,
+ * exclusive end (AGENTS.md §23).  A date-only expression resolving an *end*
+ * bound converts to start-of-next-day so the end date itself is excluded.
+ */
+import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
+
+/**
+ * Resolved event-time interval.  All timestamps are UTC ISO strings.
+ *
+ * - `validFrom` / `validUntil` carry the half-open `[from, until)` event
+ *   interval.  Either may be absent when the expression only pinned one side
+ *   ("since 2024" → validFrom only).
+ * - `ok` is false when the expression could not be resolved.  The caller then
+ *   falls back to `eventTimeSource: "assumed"`.
+ */
+export interface ResolvedEventTime {
+  validFrom?: string;
+  validUntil?: string;
+  ok: boolean;
+}
+
+const UNITS = ["day", "week", "month", "quarter", "year"] as const;
+type RelativeUnit = (typeof UNITS)[number];
+
+function isRelativeUnit(unit: string): unit is RelativeUnit {
+  return (UNITS as readonly string[]).includes(unit);
+}
+
+/**
+ * Format a `Date` as a UTC ISO string with millisecond precision, matching the
+ * canonical frontmatter form.  Returns `undefined` when the input is not
+ * finite (the resolver treats that as unresolvable rather than emitting
+ * `Invalid Date`).
+ */
+function toIsoUtc(ms: number | null): string | undefined {
+  if (ms === null || !Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString();
+}
+
+/**
+ * Compute the start of the day (UTC) for the given ms, used when a date-only
+ * expression resolves a *start* bound — the fact holds from midnight UTC.
+ */
+function startOfDayUtc(ms: number): number {
+  const d = new Date(ms);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Compute the start of the *next* day (UTC) for the given ms, used when a
+ * date-only expression resolves an *end* bound — the exclusive `validUntil`
+ * must land on the following midnight so the end date itself is excluded
+ * (AGENTS.md §23: date-only ends convert to start-of-next-day).
+ */
+function startOfNextDayUtc(ms: number): number {
+  const d = new Date(startOfDayUtc(ms));
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.getTime();
+}
+
+const SEASON_TO_MONTH: Record<string, number> = {
+  winter: 12, // Dec–Feb anchor Dec (Northern Hemisphere convention)
+  spring: 3,
+  summer: 6,
+  fall: 9,
+  autumn: 9,
+};
+
+const MONTH_NAMES: Record<string, number> = {
+  january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,
+  july: 7, august: 8, september: 9, october: 10, november: 11, december: 12,
+  jan: 1, feb: 2, mar: 3, apr: 4, jun: 6, jul: 7, aug: 8, sep: 9, sept: 9,
+  oct: 10, nov: 11, dec: 12,
+};
+
+const QUARTER_START_MONTH: Record<number, number> = {
+  1: 1, 2: 4, 3: 7, 4: 10,
+};
+
+function monthIndex(token: string): number | undefined {
+  const idx = MONTH_NAMES[token.toLowerCase()];
+  return typeof idx === "number" ? idx : undefined;
+}
+
+/**
+ * Construct a UTC timestamp from year/month(1-12)/day with overflow validation.
+ * Returns `null` when the components do not form a real calendar date (e.g.
+ * Feb 30) rather than letting `Date` silently roll over.
+ */
+function buildDateMs(year: number, month1: number, day: number): number | null {
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month1) ||
+    month1 < 1 ||
+    month1 > 12 ||
+    !Number.isInteger(day) ||
+    day < 1 ||
+    day > daysInMonth(year, month1)
+  ) {
+    return null;
+  }
+  return Date.UTC(year, month1 - 1, day, 0, 0, 0, 0);
+}
+
+function daysInMonth(year: number, month1: number): number {
+  return new Date(Date.UTC(year, month1, 0)).getUTCDate();
+}
+
+/**
+ * Add `count` units to a UTC ms timestamp, returning the start-of-period for
+ * the resulting date.  Used by "last/this/next <unit>" resolution.
+ */
+function shiftUnit(anchorMs: number, unit: RelativeUnit, count: number): number {
+  const d = new Date(anchorMs);
+  switch (unit) {
+    case "day":
+      d.setUTCDate(d.getUTCDate() + count);
+      return startOfDayUtc(d.getTime());
+    case "week":
+      d.setUTCDate(d.getUTCDate() + count * 7);
+      return startOfDayUtc(d.getTime());
+    case "month":
+      d.setUTCMonth(d.getUTCMonth() + count, 1);
+      return startOfDayUtc(d.getTime());
+    case "quarter":
+      d.setUTCMonth(d.getUTCMonth() + count * 3, 1);
+      return startOfDayUtc(d.getTime());
+    case "year":
+      d.setUTCFullYear(d.getUTCFullYear() + count, 0, 1);
+      return startOfDayUtc(d.getTime());
+  }
+}
+
+/**
+ * Resolve "last December" / "this March" / "next Q2" against the anchor.
+ * `direction` is -1 (last), 0 (this), +1 (next).  Returns the start-of-period
+ * ms for the referenced month/season/quarter, or `null` if it cannot be
+ * placed (e.g. month token not recognized).
+ */
+function resolveMonthYear(
+  anchorMs: number,
+  monthToken: string,
+  direction: number,
+): number | null {
+  const lower = monthToken.toLowerCase();
+  const targetMonth = monthIndex(lower);
+  if (typeof targetMonth === "number") {
+    const d = new Date(anchorMs);
+    let year = d.getUTCFullYear();
+    let m = targetMonth;
+    if (direction === -1 && m >= d.getUTCMonth() + 1) year -= 1;
+    else if (direction === +1 && m <= d.getUTCMonth() + 1) year += 1;
+    return buildDateMs(year, m, 1);
+  }
+  return null;
+}
+
+function resolveSeasonYear(
+  anchorMs: number,
+  seasonToken: string,
+  direction: number,
+): number | null {
+  const baseMonth = SEASON_TO_MONTH[seasonToken.toLowerCase()];
+  if (typeof baseMonth !== "number") return null;
+  const d = new Date(anchorMs);
+  let year = d.getUTCFullYear();
+  if (direction === -1 && baseMonth > d.getUTCMonth() + 1) year -= 1;
+  else if (direction === +1 && baseMonth < d.getUTCMonth() + 1) year += 1;
+  return buildDateMs(year, baseMonth, 1);
+}
+
+function resolveQuarter(
+  anchorMs: number,
+  qNumber: number,
+  direction: number,
+): number | null {
+  const startMonth = QUARTER_START_MONTH[qNumber];
+  if (typeof startMonth !== "number") return null;
+  const d = new Date(anchorMs);
+  let year = d.getUTCFullYear();
+  const anchorMonth = d.getUTCMonth() + 1;
+  const qStartMonthValue = startMonth;
+  if (direction === -1 && qStartMonthValue >= anchorMonth) year -= 1;
+  else if (direction === +1 && qStartMonthValue <= anchorMonth) year += 1;
+  return buildDateMs(year, startMonth, 1);
+}
+
+/**
+ * Resolve an absolute ISO date/datetime to ms.  A date-only value yields
+ * start-of-day (UTC).  Returns `null` when the string is not a well-formed,
+ * non-overflowed ISO timestamp.
+ */
+function resolveAbsolute(raw: string): number | null {
+  const trimmed = raw.trim();
+  const ms = parseFlexibleIsoTimestamp(trimmed);
+  if (ms === null) return null;
+  // Date-only inputs (no T) anchor to start-of-day UTC.
+  if (!/[Tt]/.test(trimmed)) return startOfDayUtc(ms);
+  return ms;
+}
+
+/**
+ * Resolve a relative event-time expression against an anchor ISO timestamp.
+ *
+ * Supported shapes (case-insensitive, trimmed):
+ *   - absolute ISO date / datetime: `"2026-03-01"`, `"2026-03-01T00:00:00Z"`
+ *   - `"since <date|monthyear>"` → validFrom only
+ *   - `"until <date|monthyear>"` / `"through ..."` / `"until end of ..."` → validUntil only
+ *   - `"last <month|season|Qn|unit>"` → validFrom = start of referenced period
+ *   - `"this <month|season|Qn|unit>"` → validFrom = start of current period
+ *   - `"next <month|season|Qn|unit>"` → validFrom = start of referenced period
+ *   - `"yesterday"` / `"today"` / `"tomorrow"` → validFrom = start of that day
+ *
+ * Anything else returns `{ ok: false }`.  The caller then records
+ * `eventTimeSource: "assumed"`.
+ *
+ * @param expression the raw per-fact event-time phrase (may be empty/garbage)
+ * @param anchorIso  the source turn's ISO timestamp — the resolution anchor
+ */
+export function resolveEventTime(
+  expression: string | undefined | null,
+  anchorIso: string,
+): ResolvedEventTime {
+  const fallback: ResolvedEventTime = { ok: false };
+  if (typeof expression !== "string") return fallback;
+  const expr = expression.trim();
+  if (expr.length === 0) return fallback;
+
+  const anchorMs = parseFlexibleIsoTimestamp(anchorIso);
+  if (anchorMs === null || !Number.isFinite(anchorMs)) return fallback;
+
+  const lower = expr.toLowerCase();
+
+  // ── "since <x>" / "until <x>" / "through <x>" ──────────────────────────
+  const sinceMatch = lower.match(/^since\s+(.+)$/);
+  if (sinceMatch) {
+    const inner = sinceMatch[1].trim();
+    const fromMs = resolveRelativePeriod(anchorMs, inner) ?? resolveAbsolute(inner);
+    const fromIso = toIsoUtc(fromMs);
+    if (!fromIso) return fallback;
+    return { validFrom: fromIso, ok: true };
+  }
+  const untilMatch = lower.match(/^(?:until|through|till|ending)\s+(.+)$/);
+  if (untilMatch) {
+    const inner = untilMatch[1].trim();
+    const untilMs = resolveEndBound(anchorMs, inner);
+    const untilIso = toIsoUtc(untilMs);
+    if (!untilIso) return fallback;
+    return { validUntil: untilIso, ok: true };
+  }
+
+  // ── "yesterday" / "today" / "tomorrow" ─────────────────────────────────
+  if (lower === "today") {
+    const fromIso = toIsoUtc(startOfDayUtc(anchorMs));
+    return fromIso ? { validFrom: fromIso, ok: true } : fallback;
+  }
+  if (lower === "yesterday") {
+    const fromIso = toIsoUtc(shiftUnit(anchorMs, "day", -1));
+    return fromIso ? { validFrom: fromIso, ok: true } : fallback;
+  }
+  if (lower === "tomorrow") {
+    const fromIso = toIsoUtc(shiftUnit(anchorMs, "day", +1));
+    return fromIso ? { validFrom: fromIso, ok: true } : fallback;
+  }
+
+  // ── "last/this/next <period>" ──────────────────────────────────────────
+  const relMatch = lower.match(/^(last|this|next)\s+(.+)$/);
+  if (relMatch) {
+    const direction = relMatch[1] === "last" ? -1 : relMatch[1] === "next" ? +1 : 0;
+    const period = relMatch[2].trim();
+    const ms = resolveRelativePeriod(anchorMs, period, direction);
+    const fromIso = toIsoUtc(ms);
+    return fromIso ? { validFrom: fromIso, ok: true } : fallback;
+  }
+
+  // ── bare month+year ("March 2025", "Dec 2024") or season+year ─────────
+  // The explicit year in the expression is authoritative — never derive it
+  // from the anchor (the prior bug ignored the captured year and produced
+  // the anchor's year for "March 2025").
+  const monthYear = lower.match(/^([a-z]+)\s+(\d{4})$/);
+  if (monthYear) {
+    const explicitYear = parseInt(monthYear[2], 10);
+    if (Number.isInteger(explicitYear)) {
+      const mIdx = monthIndex(monthYear[1]);
+      const baseMonth = typeof mIdx === "number" ? mIdx : SEASON_TO_MONTH[monthYear[1]];
+      if (typeof baseMonth === "number") {
+        const ms = buildDateMs(explicitYear, baseMonth, 1);
+        if (ms !== null) {
+          const fromIso = toIsoUtc(ms);
+          if (fromIso) return { validFrom: fromIso, ok: true };
+        }
+      }
+    }
+  }
+
+  // ── absolute ISO date / datetime ───────────────────────────────────────
+  const absMs = resolveAbsolute(expr);
+  if (absMs !== null) {
+    const fromIso = toIsoUtc(absMs);
+    return fromIso ? { validFrom: fromIso, ok: true } : fallback;
+  }
+
+  return fallback;
+}
+
+/**
+ * Resolve a period token (with optional direction) to a start-of-period ms.
+ * Handles month/season names, quarter tokens (`q1`..`q4`), and relative units
+ * (`day/week/month/quarter/year`) used by "last week", "this month", etc.
+ */
+function resolveRelativePeriod(
+  anchorMs: number,
+  period: string,
+  direction: number = 0,
+): number | null {
+  const lower = period.trim().toLowerCase();
+
+  // Quarter token: "q1", "Q2", "quarter 3"
+  const qTok = lower.match(/^q(?:uarter)?\s?([1-4])$/);
+  if (qTok) {
+    return resolveQuarter(anchorMs, Number(qTok[1]), direction);
+  }
+  if (lower === "quarter") {
+    const d = new Date(anchorMs);
+    const q = Math.floor(d.getUTCMonth() / 3) + 1;
+    return resolveQuarter(anchorMs, q, direction);
+  }
+
+  // Relative unit: "week", "month", "year", "day"
+  if (isRelativeUnit(lower)) {
+    return shiftUnit(anchorMs, lower, direction);
+  }
+
+  // Month or season name
+  const monthMs = resolveMonthYear(anchorMs, lower, direction);
+  if (monthMs !== null) return monthMs;
+  const seasonMs = resolveSeasonYear(anchorMs, lower, direction);
+  if (seasonMs !== null) return seasonMs;
+
+  return null;
+}
+
+/**
+ * Resolve an end-bound period to an *exclusive* upper bound ms.  Date-only
+ * values convert to start-of-next-day (AGENTS.md §23); period names resolve to
+ * the start of the *following* period.
+ */
+function resolveEndBound(anchorMs: number, period: string): number | null {
+  const trimmed = period.trim();
+
+  // Absolute date/datetime end bound.
+  const absMs = resolveAbsolute(trimmed);
+  if (absMs !== null) {
+    // Date-only → start of next day (exclusive end).  Datetime → use as-is.
+    if (!/[Tt]/.test(trimmed)) return startOfNextDayUtc(absMs);
+    return absMs;
+  }
+
+  // Period-name end bound: month → exclusive end at start of the FOLLOWING
+  // month. "until <month>" is backwards-looking (the fact already stopped
+  // being true), so prefer the most recent PAST boundary: build it in the
+  // anchor year and roll back a year if that boundary is still future.
+  const lower = trimmed.toLowerCase();
+  const monthIdx = monthIndex(lower);
+  if (typeof monthIdx === "number") {
+    const d = new Date(anchorMs);
+    const startMs = buildDateMs(d.getUTCFullYear(), monthIdx, 1);
+    if (startMs === null) return null;
+    // Exclusive end = start of the month AFTER the named month.
+    const nd = new Date(startMs);
+    nd.setUTCMonth(nd.getUTCMonth() + 1);
+    let endMs = startOfDayUtc(nd.getTime());
+    if (endMs > anchorMs) {
+      nd.setUTCFullYear(nd.getUTCFullYear() - 1);
+      endMs = startOfDayUtc(nd.getTime());
+    }
+    return endMs;
+  }
+  if (lower === "year") {
+    const d = new Date(anchorMs);
+    return buildDateMs(d.getUTCFullYear() + 1, 1, 1);
+  }
+  return null;
+}

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -522,12 +522,19 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
   const seasonMonth = SEASON_TO_MONTH[lower];
   if (typeof seasonMonth === "number") {
     const d = new Date(anchorMs);
-    const startMs = buildDateMs(d.getUTCFullYear(), seasonMonth, 1);
+    const anchorMonth = d.getUTCMonth() + 1;
+    let year = d.getUTCFullYear();
+    // Winter (Dec) from Jan/Feb: the current winter started in prev Dec,
+    // so build the season start from the previous year (codex review r2:
+    // bare winter end bounds used the anchor year's December, producing
+    // an exclusive end one year too far forward).
+    if (seasonMonth === 12 && anchorMonth <= 2) year -= 1;
+    const startMs = buildDateMs(year, seasonMonth, 1);
     if (startMs === null) return null;
     const nd = new Date(startMs);
     nd.setUTCMonth(nd.getUTCMonth() + 3);
     let endMs = startOfDayUtc(nd.getTime());
-    if (endMs > anchorMs && !isInSeason(seasonMonth, d.getUTCMonth() + 1)) {
+    if (endMs > anchorMs && !isInSeason(seasonMonth, anchorMonth)) {
       nd.setUTCFullYear(nd.getUTCFullYear() - 1);
       endMs = startOfDayUtc(nd.getTime());
     }

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -218,8 +218,13 @@ function resolveSeasonYear(
   if (typeof baseMonth !== "number") return null;
   const d = new Date(anchorMs);
   let year = d.getUTCFullYear();
-  if (direction === -1 && baseMonth > d.getUTCMonth() + 1) year -= 1;
-  else if (direction === +1 && baseMonth < d.getUTCMonth() + 1) year += 1;
+  const anchorMonth = d.getUTCMonth() + 1;
+  if (direction === -1 && baseMonth > anchorMonth) year -= 1;
+  else if (direction === +1 && baseMonth < anchorMonth) year += 1;
+  // "this winter" (direction 0) from Jan/Feb: winter started in the previous
+  // December. Without this, the resolver stamps facts almost a year in the
+  // future (codex review r2). Only winter (Dec) spans the year boundary.
+  else if (direction === 0 && baseMonth === 12 && anchorMonth <= 2) year -= 1;
   return buildDateMs(year, baseMonth, 1);
 }
 
@@ -430,14 +435,18 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
     if (!/[Tt]/.test(trimmed)) return startOfNextDayUtc(absMs);
     return absMs;
   }
-  // Explicit "<month> <year>" end bound (e.g. "until March 2025") — the
-  // explicit year is authoritative, so exclusive end = start of the FOLLOWING
-  // month in that year (no anchor rollback). Shares resolveExplicitMonthYear
-  // with the since/bare paths (review: month-year phrases after since).
+  // Explicit "<month|season> <year>" end bound (e.g. "until March 2025",
+  // "through spring 2025"). The explicit year is authoritative, so the
+  // exclusive end = start of the FOLLOWING month (for a single month) or the
+  // start of the month AFTER the season ends (for a 3-month season).
+  // Review r2: seasons previously advanced only 1 month, cutting off the
+  // last 2 months of the season.
   const explicitMs = resolveExplicitMonthYear(trimmed);
   if (explicitMs !== null) {
     const nd = new Date(explicitMs);
-    nd.setUTCMonth(nd.getUTCMonth() + 1);
+    const firstWord = trimmed.toLowerCase().split(/\s+/)[0];
+    const monthAdvance = firstWord in SEASON_TO_MONTH ? 3 : 1;
+    nd.setUTCMonth(nd.getUTCMonth() + monthAdvance);
     return startOfDayUtc(nd.getTime());
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -122,7 +122,7 @@ import {
   normalizeSupersessionKey,
   shouldFilterSupersededFromRecall,
 } from "./temporal-supersession.js";
-import { isValidAsOf } from "./temporal-validity.js";
+import { isValidAsOf, isValidityExpiredNow } from "./temporal-validity.js";
 import { RelevanceStore } from "./relevance.js";
 import { NegativeExampleStore } from "./negative.js";
 import {
@@ -19195,6 +19195,7 @@ export class Orchestrator {
   ): QmdSearchResult[] {
     let lifecycleFilteredCount = 0;
     let temporalSupersededFilteredCount = 0;
+    let biTemporalExpiredFilteredCount = 0;
     let dedicatedSurfaceFilteredCount = 0;
     let forgottenFilteredCount = 0;
     let blockedPathFilteredCount = 0;
@@ -19257,6 +19258,24 @@ export class Orchestrator {
           temporalSupersededFilteredCount += 1;
           continue;
         }
+        // Bi-temporal injection filter (issue #1578): when the master gate
+        // is on and the caller did NOT pin `as_of`, drop facts whose event-
+        // time interval has ended before now. They remain findable by
+        // explicit search and `as_of` queries (escape hatch: the as_of branch
+        // above already admits historically-valid records; this filter only
+        // trims the default injection set). Gated off entirely when
+        // `temporalExpiredInInjection` is set. Status-orthogonal: an `active`
+        // fact can be validity-expired; a `superseded` one may still be within
+        // its window (issue pitfall matrix).
+        if (
+          !asOfActive &&
+          this.config.temporalBiTemporal &&
+          !this.config.temporalExpiredInInjection &&
+          isValidityExpiredNow(memory.frontmatter, Date.now())
+        ) {
+          biTemporalExpiredFilteredCount += 1;
+          continue;
+        }
 
         if (
           options?.allowDedicatedSurface !== true &&
@@ -19277,6 +19296,11 @@ export class Orchestrator {
     if (temporalSupersededFilteredCount > 0) {
       log.debug(
         `temporal supersession filter removed ${temporalSupersededFilteredCount} superseded candidates`,
+      );
+    }
+    if (biTemporalExpiredFilteredCount > 0) {
+      log.debug(
+        `bi-temporal validity filter removed ${biTemporalExpiredFilteredCount} expired-validity candidates from injection (temporal.biTemporal on)`,
       );
     }
     if (dedicatedSurfaceFilteredCount > 0) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -19258,15 +19258,17 @@ export class Orchestrator {
           temporalSupersededFilteredCount += 1;
           continue;
         }
-        // Bi-temporal injection filter (issue #1578): when the master gate
+        // Bi-temporal INJECTION filter (issue #1578): when the master gate
         // is on and the caller did NOT pin `as_of`, drop facts whose event-
-        // time interval has ended before now. They remain findable by
-        // explicit search and `as_of` queries (escape hatch: the as_of branch
-        // above already admits historically-valid records; this filter only
-        // trims the default injection set). Gated off entirely when
-        // `temporalExpiredInInjection` is set. Status-orthogonal: an `active`
-        // fact can be validity-expired; a `superseded` one may still be within
-        // its window (issue pitfall matrix).
+        // time interval has ended before now. This lives ONLY in the recall
+        // injection path (filterSearchResultsByRecallSafety) — explicit
+        // search (access-service.memorySearch → searchAcrossNamespaces /
+        // qmd.search) never routes through here, so expired-validity facts
+        // remain findable by memory_search and `as_of` queries (escape
+        // hatch: the as_of branch above also admits historically-valid
+        // records). Gated off entirely when `temporalExpiredInInjection` is
+        // set. Status-orthogonal: an `active` fact can be validity-expired;
+        // a `superseded` one may still be within its window.
         if (
           !asOfActive &&
           this.config.temporalBiTemporal &&

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -321,6 +321,22 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
   // memories round-trip unchanged; readers default `valid_at` to `created`.
   if (fm.valid_at) lines.push(`validAt: ${fm.valid_at}`);
   if (fm.invalid_at) lines.push(`invalidAt: ${fm.invalid_at}`);
+  // Issue #1578 — bi-temporal ingestion provenance.  Validate on write so a
+  // corrupt `observedAt` (non-ISO / overflowed) cannot leak onto disk; reads
+  // are permissive, mirroring the `valid_at` precedent.  `eventTimeSource` is
+  // a closed enum — reject anything outside it rather than persisting garbage.
+  if (fm.observedAt) {
+    const validated = normalizeMemoryWriteTimestamp("observedAt", fm.observedAt);
+    if (validated) lines.push(`observedAt: ${validated}`);
+  }
+  if (fm.eventTimeSource) {
+    if (fm.eventTimeSource !== "extracted" && fm.eventTimeSource !== "assumed") {
+      throw new Error(
+        `serializeFrontmatter: invalid eventTimeSource ${JSON.stringify(fm.eventTimeSource)} — expected "extracted" | "assumed"`,
+      );
+    }
+    lines.push(`eventTimeSource: ${fm.eventTimeSource}`);
+  }
   if (fm.forgottenAt) lines.push(`forgottenAt: ${fm.forgottenAt}`);
   if (fm.forgottenReason) lines.push(`forgottenReason: ${JSON.stringify(fm.forgottenReason)}`);
   // Lifecycle policy fields
@@ -808,6 +824,12 @@ function parseFrontmatter(
       // Issue #680 — explicit fact lifecycle round-trip.
       valid_at: fm.validAt || undefined,
       invalid_at: fm.invalidAt || undefined,
+      // Issue #1578 — bi-temporal ingestion provenance round-trip.
+      observedAt: fm.observedAt || undefined,
+      eventTimeSource:
+        fm.eventTimeSource === "extracted" || fm.eventTimeSource === "assumed"
+          ? fm.eventTimeSource
+          : undefined,
       forgottenAt: fm.forgottenAt || undefined,
       forgottenReason: parseFrontmatterStringValue(fm.forgottenReason),
       lifecycleState: (fm.lifecycleState as LifecycleState) || undefined,
@@ -3333,6 +3355,12 @@ export class StorageManager {
       memoryKind?: MemoryFrontmatter["memoryKind"];
       expiresAt?: string;
       validAt?: string;
+      // Issue #1578 — bi-temporal ingestion provenance.  `observedAt` is the
+      // ingestion time (when Remnic learned the fact); `eventTimeSource`
+      // records whether `validAt` was resolved from an extracted expression
+      // or assumed from the ingestion anchor.  Both validate on serialize.
+      observedAt?: string;
+      eventTimeSource?: "extracted" | "assumed";
       structuredAttributes?: Record<string, string>;
       /**
        * When provided, this string is used as the source for the fact-content
@@ -3365,6 +3393,10 @@ export class StorageManager {
     const conf = options.confidence ?? 0.8;
     const tier = confidenceTier(conf);
     const validAt = normalizeMemoryWriteTimestamp("validAt", options.validAt);
+    const observedAt = normalizeMemoryWriteTimestamp(
+      "observedAt",
+      options.observedAt,
+    );
 
     // Auto-set TTL for speculative memories
     let expiresAt: string | undefined;
@@ -3398,6 +3430,8 @@ export class StorageManager {
       sourceTurnId: options.sourceTurnId,
       memoryKind: options.memoryKind,
       valid_at: validAt,
+      observedAt,
+      eventTimeSource: options.eventTimeSource,
       structuredAttributes: options.structuredAttributes,
     };
     if (options.status !== undefined) {

--- a/packages/remnic-core/src/temporal-validity.ts
+++ b/packages/remnic-core/src/temporal-validity.ts
@@ -102,6 +102,40 @@ export function isValidAsOf(
 }
 
 /**
+ * Bi-temporal injection filter (issue #1578).
+ *
+ * Returns `true` when the fact's event-time interval has already ended before
+ * `nowMs` — i.e. it is no longer *true in the world* and should leave the
+ * default injection candidate set (it remains findable by explicit search
+ * and `as_of` queries, mirroring the lifecycle-filter escape-hatch principle
+ * in AGENTS.md §16).  Gated by `temporalBiTemporal`; the escape hatch
+ * `temporalExpiredInInjection` re-admits expired facts when a deployment
+ * prefers the older always-inject behavior.
+ *
+ * Semantics: a fact is expired-now when `invalid_at` is present and
+ * `invalid_at <= nowMs` (the exclusive upper bound has passed).  Absent
+ * `invalid_at` means "still valid" — never expired.  This is the
+ * status-orthogonal complement of `isValidAsOf` for the wall-clock instant:
+ * an `active` memory can be validity-expired, and a `superseded` one can
+ * still be validity-valid within its historical window (issue pitfall: the
+ * filter is status-orthogonal).
+ */
+export function isValidityExpiredNow(
+  fm: Pick<MemoryFrontmatter, "invalid_at">,
+  nowMs: number,
+): boolean {
+  if (!Number.isFinite(nowMs)) return false;
+  const invalidAt = fm.invalid_at?.trim();
+  if (!invalidAt || invalidAt.length === 0) return false;
+  const invalidAtMs = Date.parse(invalidAt);
+  // Unparseable invalid_at — conservatively keep the fact (do not filter on
+  // corrupt data; the as_of path already handles malformed bounds).
+  if (!Number.isFinite(invalidAtMs)) return false;
+  // Half-open interval end has passed: [valid_at, invalid_at) ended.
+  return invalidAtMs <= nowMs;
+}
+
+/**
  * Parse and validate an `as_of` value supplied at an input boundary
  * (CLI flag, HTTP query param, MCP field).  Returns parsed milliseconds
  * on success; throws a `RangeError` with a helpful message on malformed

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -788,6 +788,22 @@ export interface PluginConfig {
    * filtered out.
    */
   temporalSupersessionIncludeInRecall: boolean;
+  /**
+   * Bi-temporal validity master gate (issue #1578). When `false` (default),
+   * the extraction event-time resolver, the recall validity-injection filter,
+   * and the `asOf` injection semantics behave byte-identically to pre-#1578.
+   * Turn on to (a) resolve per-fact event-time expressions at write time,
+   * recording `observedAt`/`eventTimeSource`, and (b) exclude
+   * validity-expired facts from injection candidates by default.
+   */
+  temporalBiTemporal: boolean;
+  /**
+   * Escape hatch for the bi-temporal injection filter (issue #1578). When
+   * `true`, facts whose `[valid_at, invalid_at)` interval ended before now
+   * are kept in injection candidates even with `temporalBiTemporal` on — some
+   * deployments prefer the older (always-inject) behavior. Default `false`.
+   */
+  temporalExpiredInInjection: boolean;
   // Direct-answer retrieval tier (issue #518)
   /**
    * When true, recall checks whether a single validated memory in a
@@ -2423,6 +2439,25 @@ export interface MemoryFrontmatter {
    * point in time.
    */
   invalid_at?: string;
+  /**
+   * Ingestion time (issue #1578) — when Remnic *learned* this fact.
+   * Distinct from `created` (file creation) and `valid_at` (event-time
+   * start).  Aligns with the source turn timestamp (#1575
+   * `sources[].observedAt`).  When `eventTimeSource === "assumed"`,
+   * `valid_at` is copied from this value.
+   */
+  observedAt?: string;
+  /**
+   * Provenance of the event-time interval (issue #1578).
+   *   - `"extracted"` — a per-fact `eventTime` expression was resolved
+   *     against the source turn's timestamp and produced `valid_at` /
+   *     `invalid_at`.
+   *   - `"assumed"` — no resolvable expression; `valid_at` was copied from
+   *     `observedAt` (the ingestion anchor).
+   * Absent on memories written before #1578; readers treat absent as
+   * `"assumed"` for display purposes.
+   */
+  eventTimeSource?: "extracted" | "assumed";
   /**
    * Timestamp when the operator explicitly forgot this memory
    * (issue #686 PR 4/6).  Set by `remnic forget <id>`.  Memories with

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -790,11 +790,14 @@ export interface PluginConfig {
   temporalSupersessionIncludeInRecall: boolean;
   /**
    * Bi-temporal validity master gate (issue #1578). When `false` (default),
-   * the extraction event-time resolver, the recall validity-injection filter,
-   * and the `asOf` injection semantics behave byte-identically to pre-#1578.
-   * Turn on to (a) resolve per-fact event-time expressions at write time,
-   * recording `observedAt`/`eventTimeSource`, and (b) exclude
-   * validity-expired facts from injection candidates by default.
+   * the recall validity-injection filter and `asOf` semantics behave
+   * byte-identically to pre-#1578.
+   *
+   * Turn on to exclude validity-expired facts from default injection
+   * candidates (they remain findable by explicit search and `as_of`
+   * queries). Storage round-trips `observedAt`/`eventTimeSource`; the
+   * extraction prompt → `resolveEventTime` write-time wiring lands in a
+   * follow-on PR, so new extractions are not yet event-time-resolved.
    */
   temporalBiTemporal: boolean;
   /**

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3138,7 +3138,7 @@
       "temporalBiTemporal": {
         "type": "boolean",
         "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
       },
       "temporalExpiredInInjection": {
         "type": "boolean",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3135,6 +3135,16 @@
         "default": false,
         "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
       },
+      "temporalBiTemporal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), the extraction event-time resolver, the recall validity-injection filter, and asOf injection semantics behave byte-identically to pre-#1578. Turn on to resolve per-fact event-time expressions at write time (recording observedAt/eventTimeSource) and to exclude validity-expired facts from injection candidates by default."
+      },
+      "temporalExpiredInInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
+      },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
         "default": false,
@@ -5819,6 +5829,16 @@
       "label": "Include Superseded Facts In Recall",
       "advanced": true,
       "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "temporalBiTemporal": {
+      "label": "Bi-temporal Validity",
+      "advanced": true,
+      "help": "Master gate (issue #1578): resolve per-fact event-time at write time and exclude validity-expired facts from injection by default. Off = byte-identical to pre-#1578."
+    },
+    "temporalExpiredInInjection": {
+      "label": "Keep Expired-Validity Facts In Injection",
+      "advanced": true,
+      "help": "Escape hatch (issue #1578): keep facts whose event-time interval ended in injection candidates even with bi-temporal on."
     },
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,13 +4,18 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19946,
+      "packages/remnic-core/src/orchestrator.ts": 19970,
       "packages/remnic-core/src/cli.ts": 9853,
       "packages/remnic-core/src/access-service.ts": 8412,
-      "packages/remnic-core/src/storage.ts": 7306,
-      "packages/remnic-core/src/config.ts": 4505
+      "packages/remnic-core/src/storage.ts": 7340,
+      "packages/remnic-core/src/config.ts": 4511
     },
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 553
+  },
+  "justifications": {
+    "packages/remnic-core/src/orchestrator.ts": "+24 (19946->19970, #1578): bi-temporal injection filter in filterSearchResultsByRecallSafety — THE single shared recall-safety point (hot+filesystem-fallback parity contract); cannot move to a spine stage until #1539 lands. Gated by temporalBiTemporal, status-orthogonal.",
+    "packages/remnic-core/src/storage.ts": "+34 (7306->7340, #1578): serializeFrontmatter/parseFrontmatter round-trip for observedAt+eventTimeSource (the frontmatter chokepoint — MUST live here) + writeMemory option wiring; validate-on-write rejects corrupt timestamps.",
+    "packages/remnic-core/src/config.ts": "+6 (4505->4511, #1578): two new gates temporalBiTemporal + temporalExpiredInInjection parsed with ===true (rule 51); cannot live elsewhere."
   }
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,18 +4,18 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19970,
+      "packages/remnic-core/src/orchestrator.ts": 19972,
       "packages/remnic-core/src/cli.ts": 9853,
       "packages/remnic-core/src/access-service.ts": 8412,
       "packages/remnic-core/src/storage.ts": 7340,
-      "packages/remnic-core/src/config.ts": 4511
+      "packages/remnic-core/src/config.ts": 4518
     },
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 553
   },
   "justifications": {
-    "packages/remnic-core/src/orchestrator.ts": "+24 (19946->19970, #1578): bi-temporal injection filter in filterSearchResultsByRecallSafety — THE single shared recall-safety point (hot+filesystem-fallback parity contract); cannot move to a spine stage until #1539 lands. Gated by temporalBiTemporal, status-orthogonal.",
+    "packages/remnic-core/src/orchestrator.ts": "+26 (19946->19972, #1578): bi-temporal INJECTION filter in filterSearchResultsByRecallSafety — THE single shared recall-safety point (hot+filesystem-fallback parity); cannot move to a spine stage until #1539 lands. Gated by temporalBiTemporal, status-orthogonal; explicit search bypasses it. Comment expanded in review to document the search bypass.",
     "packages/remnic-core/src/storage.ts": "+34 (7306->7340, #1578): serializeFrontmatter/parseFrontmatter round-trip for observedAt+eventTimeSource (the frontmatter chokepoint — MUST live here) + writeMemory option wiring; validate-on-write rejects corrupt timestamps.",
-    "packages/remnic-core/src/config.ts": "+6 (4505->4511, #1578): two new gates temporalBiTemporal + temporalExpiredInInjection parsed with ===true (rule 51); cannot live elsewhere."
+    "packages/remnic-core/src/config.ts": "+13 (4505->4518, #1578): two new gates temporalBiTemporal + temporalExpiredInInjection parsed with ===true (rule 51); comment expanded in review to keep docs honest about the follow-on extraction-wiring PR."
   }
 }


### PR DESCRIPTION
## Summary

Bi-temporal validity foundation for #1578 (part of epic #1572): distinguish **event time** (when a fact holds in the world) from **ingestion time** (when Remnic learned it). Default-off master gate — byte-identical to pre-#1578 until an operator opts in.

This is **PR1** of the issue's 4-PR plan (types + storage + resolver) **plus the recall injection-filter subset of PR3**, recovered from an orphaned worktree and finished.

## What landed

**Types & storage** — additive `MemoryFrontmatter` fields `observedAt` + `eventTimeSource` ("\extracted" | "\assumed"") alongside the existing `valid_at`/`invalid_at` interval. `serializeFrontmatter` validates `observedAt` via `normalizeMemoryWriteTimestamp` (rejects non-ISO/overflowed) and `eventTimeSource` against the closed enum; `parseFrontmatter` round-trips both. `writeMemory` exposes both as options.

**Event-time resolver** (new pure module `event-time.ts`) — `resolveEventTime(expression, anchorIso)` anchored to the **source turn** timestamp (never `Date.now()`), so replay/import of old transcripts resolves against the old anchor. Handles absolute dates, month/season+year, last/this/next \<unit\>, since/until/through, today/yesterday/tomorrow. Date-only ends → start-of-next-day (exclusive bound). Overflowed dates (Feb 30) → `ok:false`, never `Invalid Date`.

**Recall injection filter** — `isValidityExpiredNow` (status-orthogonal, exclusive `[valid_at, invalid_at)`) wired into `filterSearchResultsByRecallSafety` — the **single shared recall-safety point** (hot + filesystem-fallback parity). Drops validity-expired facts from default injection when `temporalBiTemporal` is on; bypassed by `as_of` queries and the `temporalExpiredInInjection` escape hatch (expired facts stay searchable).

**Config** — `temporalBiTemporal` (master gate) + `temporalExpiredInInjection` (escape hatch), parsed with `===true` (rule 51), added to all three `openclaw.plugin.json` schemas.

## Frontmatter-parser verification

The prior agent flagged a possible parser corruption. **Verified intact**: `parseFrontmatter` returns all original fields (`created`, `updated`, `source`, `valid_at`, `invalid_at`, `forgottenAt`) plus the new `observedAt`/`eventTimeSource`, no duplicates, no dropouts. Pinned by `bitemporal-frontmatter.test.ts` (write→patch→read coexistence test).

## Fixes applied while finishing

Three resolver year-handling bugs found by the orphaned test suite (all now green):
- bare `March 2025` / `Dec 2024` — captured year was ignored, anchor year used instead.
- `until March` end-bound pushed future (start-bound logic copy-paste); now backwards-looking (most-recent-past boundary).

## Chokepoints used / not applicable
- ✅ `serializeFrontmatter` write validation (frontmatter chokepoint)
- ✅ shared `filterSearchResultsByRecallSafety` recall-safety point (hot + fallback parity)
- N/A #1525 registry (no new MCP/HTTP/CLI ops in this PR), N/A #1521 ScopePlan, N/A #1524 serialize-mutations

## Ratchet
Baseline updated with per-file `justifications` (orchestrator +24, storage +34, config +6 — irreducible per-seam wiring: the frontmatter chokepoint, the single shared filter point, the config gates). `scatteredConfigFlagReads` unchanged (553 — uses `config.temporalBiTemporal`, not a new `*Enabled` read).

## Gates
- `npm run preflight:quick` → `[preflight] OK (quick)` (lint, check-types, config-contract=673/671/671, ratchets OK, review-patterns, docs-parity, scenario tests)
- `npm run test:entity-hardening` → **246/246 pass** (mandatory: touched orchestrator/storage/config)
- New: `event-time.test.ts` 31/31, `bitemporal-frontmatter.test.ts` 9/9

## Out of scope (follow-on PRs per the issue plan)
PR2 extraction wiring, PR3 `asOf` on MCP/HTTP/CLI + supersession `validUntil` writes, PR4 LongMemEval temporal artifact.

Closes part of #1578.Refs #1572, #1520.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default recall injection when operators enable `temporalBiTemporal`, and adds validated frontmatter fields on the memory write path; defaults preserve prior behavior.
> 
> **Overview**
> **Bi-temporal validity (issue #1578, PR1)** separates ingestion time from event-time intervals on facts. New frontmatter **`observedAt`** and **`eventTimeSource`** (`extracted` | `assumed`) round-trip through `serializeFrontmatter` / `writeMemory` with ISO validation; legacy memories stay unchanged.
> 
> A new **`resolveEventTime(expression, anchorIso)`** module resolves relative phrases and absolute dates into half-open **`[valid_at, invalid_at)`** bounds anchored to the **source turn** (not wall clock). Extraction wiring to call it at write time is explicitly deferred.
> 
> **Recall** gains **`isValidityExpiredNow`** and a filter in **`filterSearchResultsByRecallSafety`**: when **`temporalBiTemporal`** is on, facts whose interval ended before now drop from default injection (still searchable and visible under **`as_of`**; **`temporalExpiredInInjection`** restores old behavior). Gates default **off** so recall matches pre-#1578 until opt-in.
> 
> Plugin schemas and **`RemnicConfig`** expose the two flags; tests cover resolver edge cases and storage round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fec3b9cbfc1e1538aa3adfa4a4305bc41cd8e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->