### PR TITLE
feat(extraction): faithfulness gate — entailment verification of extracted facts (#1576)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3658,6 +3658,27 @@
         "default": "",
         "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
       },
+      "extractionFaithfulnessGate": {
+        "type": "string",
+        "enum": ["off", "shadow", "enforce"],
+        "default": "off",
+        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+      },
+      "extractionFaithfulnessModel": {
+        "type": "string",
+        "default": "",
+        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+      },
+      "extractionFaithfulnessContextChars": {
+        "type": "number",
+        "default": 400,
+        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+      },
+      "extractionFaithfulnessTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3658,6 +3658,27 @@
         "default": "",
         "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
       },
+      "extractionFaithfulnessGate": {
+        "type": "string",
+        "enum": ["off", "shadow", "enforce"],
+        "default": "off",
+        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+      },
+      "extractionFaithfulnessModel": {
+        "type": "string",
+        "default": "",
+        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+      },
+      "extractionFaithfulnessContextChars": {
+        "type": "number",
+        "default": 400,
+        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+      },
+      "extractionFaithfulnessTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2034,3 +2034,19 @@ test("parseConfig provenance.enabled honors REMNIC_/ENGRAM_ env fallback (issue 
     else delete process.env.ENGRAM_PROVENANCE_ENABLED;
   }
 });
+
+test("parseConfig rejects a present-but-non-string extractionFaithfulnessGate (safety gate must not silently disable, #1576 Ob4RQ)", () => {
+  assert.equal(parseConfig({}).extractionFaithfulnessGate, "off");
+  assert.equal(parseConfig({ extractionFaithfulnessGate: null }).extractionFaithfulnessGate, "off");
+  assert.equal(parseConfig({ extractionFaithfulnessGate: "enforce" }).extractionFaithfulnessGate, "enforce");
+  assert.equal(parseConfig({ extractionFaithfulnessGate: "ENFORCE" }).extractionFaithfulnessGate, "enforce");
+  for (const bad of [true, 1, {}, ["enforce"]] as unknown[]) {
+    assert.throws(
+      () => parseConfig({ extractionFaithfulnessGate: bad } as Record<string, unknown>),
+      /extractionFaithfulnessGate must be one of/,
+      `present non-string ${JSON.stringify(bad)} must reject, not default to off`,
+    );
+  }
+  // A present-but-unknown string still rejects (pre-existing behavior preserved).
+  assert.throws(() => parseConfig({ extractionFaithfulnessGate: "on" }), /extractionFaithfulnessGate must be one of/);
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2927,18 +2927,18 @@ export function parseConfig(
       typeof cfg.extractionFaithfulnessModel === "string"
         ? cfg.extractionFaithfulnessModel
         : "",
-    extractionFaithfulnessContextChars:
-      typeof cfg.extractionFaithfulnessContextChars === "number" &&
-      Number.isFinite(cfg.extractionFaithfulnessContextChars) &&
-      cfg.extractionFaithfulnessContextChars > 0
-        ? Math.min(Math.round(cfg.extractionFaithfulnessContextChars), 4000)
-        : 400,
-    extractionFaithfulnessTimeoutMs:
-      typeof cfg.extractionFaithfulnessTimeoutMs === "number" &&
-      Number.isFinite(cfg.extractionFaithfulnessTimeoutMs) &&
-      cfg.extractionFaithfulnessTimeoutMs > 0
-        ? Math.min(Math.round(cfg.extractionFaithfulnessTimeoutMs), 60_000)
-        : 8000,
+    // Numeric knobs go through coerceNumber so CLI operators can pass
+    // --config extractionFaithfulnessTimeoutMs=4000 without the string
+    // silently dropping to the default. Matches the coercion contract applied
+    // to other numeric config keys (CLAUDE.md rule #28 / gotcha #36).
+    extractionFaithfulnessContextChars: (() => {
+      const n = coerceNumber(cfg.extractionFaithfulnessContextChars);
+      return n !== undefined && n > 0 ? Math.min(Math.round(n), 4000) : 400;
+    })(),
+    extractionFaithfulnessTimeoutMs: (() => {
+      const n = coerceNumber(cfg.extractionFaithfulnessTimeoutMs);
+      return n !== undefined && n > 0 ? Math.min(Math.round(n), 60_000) : 8000;
+    })(),
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2914,13 +2914,13 @@ export function parseConfig(
     // (rule 39: byte-identical pre-feature pipeline). Invalid values are
     // rejected listing valid options (rule 51).
     extractionFaithfulnessGate: (() => {
-      const raw =
-        typeof cfg.extractionFaithfulnessGate === "string"
-          ? cfg.extractionFaithfulnessGate.trim().toLowerCase()
-          : "off";
+      const v = cfg.extractionFaithfulnessGate;
+      if (v === undefined || v === null) return "off";
+      // Present-but-invalid (true/1/{}) must reject, not silently disable the gate (Ob4RQ).
+      const raw = typeof v === "string" ? v.trim().toLowerCase() : v;
       if (raw === "off" || raw === "shadow" || raw === "enforce") return raw;
       throw new Error(
-        `extractionFaithfulnessGate must be one of "off" | "shadow" | "enforce" (got ${JSON.stringify(cfg.extractionFaithfulnessGate)})`,
+        `extractionFaithfulnessGate must be one of "off" | "shadow" | "enforce" (got ${JSON.stringify(v)})`,
       );
     })(),
     extractionFaithfulnessModel:

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2909,6 +2909,36 @@ export function parseConfig(
     collectJudgeTrainingPairs: coerceBool(cfg.collectJudgeTrainingPairs) === true,
     judgeTrainingDir:
       typeof cfg.judgeTrainingDir === "string" ? cfg.judgeTrainingDir : "",
+    // Extraction faithfulness gate (issue #1576). Entailment-verification of
+    // extracted facts against verified source spans (#1575). Default "off"
+    // (rule 39: byte-identical pre-feature pipeline). Invalid values are
+    // rejected listing valid options (rule 51).
+    extractionFaithfulnessGate: (() => {
+      const raw =
+        typeof cfg.extractionFaithfulnessGate === "string"
+          ? cfg.extractionFaithfulnessGate.trim().toLowerCase()
+          : "off";
+      if (raw === "off" || raw === "shadow" || raw === "enforce") return raw;
+      throw new Error(
+        `extractionFaithfulnessGate must be one of "off" | "shadow" | "enforce" (got ${JSON.stringify(cfg.extractionFaithfulnessGate)})`,
+      );
+    })(),
+    extractionFaithfulnessModel:
+      typeof cfg.extractionFaithfulnessModel === "string"
+        ? cfg.extractionFaithfulnessModel
+        : "",
+    extractionFaithfulnessContextChars:
+      typeof cfg.extractionFaithfulnessContextChars === "number" &&
+      Number.isFinite(cfg.extractionFaithfulnessContextChars) &&
+      cfg.extractionFaithfulnessContextChars > 0
+        ? Math.min(Math.round(cfg.extractionFaithfulnessContextChars), 4000)
+        : 400,
+    extractionFaithfulnessTimeoutMs:
+      typeof cfg.extractionFaithfulnessTimeoutMs === "number" &&
+      Number.isFinite(cfg.extractionFaithfulnessTimeoutMs) &&
+      cfg.extractionFaithfulnessTimeoutMs > 0
+        ? Math.min(Math.round(cfg.extractionFaithfulnessTimeoutMs), 60_000)
+        : 8000,
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -61,9 +61,10 @@ export interface ConsoleStateOrchestratorLike {
   getConsoleDaemonInfo?: () => ConsoleDaemonInfo;
   /**
    * Optional faithfulness gate distribution (issue #1576). Returns the
-   * per-orchestrator running counters when the gate is active.
+   * per-orchestrator running counters when the gate is active, or undefined
+   * when the gate is off (so the snapshot omits the block).
    */
-  getConsoleFaithfulnessDistribution?: () => ConsoleFaithfulnessDistribution;
+  getConsoleFaithfulnessDistribution?: () => ConsoleFaithfulnessDistribution | undefined;
 }
 
 export interface ConsoleBufferState {

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -59,6 +59,11 @@ export interface ConsoleStateOrchestratorLike {
    * version read from disk.
    */
   getConsoleDaemonInfo?: () => ConsoleDaemonInfo;
+  /**
+   * Optional faithfulness gate distribution (issue #1576). Returns the
+   * per-orchestrator running counters when the gate is active.
+   */
+  getConsoleFaithfulnessDistribution?: () => ConsoleFaithfulnessDistribution;
 }
 
 export interface ConsoleBufferState {
@@ -120,6 +125,18 @@ export interface ConsoleDaemonInfo {
   version: string;
 }
 
+/**
+ * Faithfulness gate verdict distribution (issue #1576). Surfaced via
+ * console_state so `remnic doctor` can render how the gate is performing.
+ */
+export interface ConsoleFaithfulnessDistribution {
+  entailed: number;
+  contradicted: number;
+  unsupported: number;
+  unchecked: number;
+  skippedNoSpan: number;
+}
+
 export interface ConsoleStateSnapshot {
   /** ISO-8601 capture timestamp. */
   capturedAt: string;
@@ -129,6 +146,8 @@ export interface ConsoleStateSnapshot {
   maintenanceLedgerTail: ConsoleMaintenanceLedgerEvent[];
   qmdProbe: ConsoleQmdProbeState;
   daemon: ConsoleDaemonInfo;
+  /** Faithfulness gate distribution (issue #1576). Absent when the gate is off. */
+  faithfulness?: ConsoleFaithfulnessDistribution;
   /**
    * Subsystem read errors. One entry per failed reader keyed by
    * subsystem name (e.g. `"bufferState: ..."`). An empty array means
@@ -163,6 +182,17 @@ export async function gatherConsoleState(
   const qmdProbe = readQmdProbe(orchestrator, errors);
   const daemon = readDaemonInfo(orchestrator, errors);
 
+  // Faithfulness gate distribution (issue #1576). Optional — absent when
+  // the gate is off or the orchestrator does not expose the accessor.
+  let faithfulness: ConsoleFaithfulnessDistribution | undefined;
+  try {
+    if (typeof orchestrator.getConsoleFaithfulnessDistribution === "function") {
+      faithfulness = orchestrator.getConsoleFaithfulnessDistribution();
+    }
+  } catch (err) {
+    errors.push(`faithfulness: ${describeError(err)}`);
+  }
+
   return {
     capturedAt,
     bufferState,
@@ -171,6 +201,7 @@ export async function gatherConsoleState(
     maintenanceLedgerTail,
     qmdProbe,
     daemon,
+    ...(faithfulness ? { faithfulness } : {}),
     errors,
   };
 }

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -890,6 +890,37 @@ test("checkFaithfulnessBatch: no override keeps the local backend first (regress
   assert.equal(result.results[0]?.ok, true);
 });
 
+test("checkFaithfulnessBatch: local call is bounded by timeoutMs, not the batch signal (kilo)", async () => {
+  // LocalLlmClient.chatCompletion does not read options.signal — it uses its
+  // own per-attempt AbortController keyed on timeoutMs. The gate must forward
+  // timeoutMs (so each local attempt is bounded by the faithfulness budget)
+  // and must NOT forward the batch signal (dead code the local client drops).
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = baseConfig();
+  const captured: Array<{ options: Record<string, unknown> }> = [];
+  const localLlm = {
+    chatCompletion: async (
+      _messages: Array<{ role: string; content: string }>,
+      options: Record<string, unknown> = {},
+    ) => {
+      captured.push({ options });
+      return { content: JSON.stringify([{ index: 0, verdict: "entailed" }]) };
+    },
+  };
+  await checkFaithfulnessBatch(
+    inputs,
+    config,
+    localLlm as unknown as LocalLlmClient,
+    stubFallbackLlm("[]"),
+  );
+  assert.equal(captured.length, 1, "local backend runs once");
+  const opts = captured[0]?.options;
+  assert.equal(typeof opts?.timeoutMs, "number", "timeoutMs is forwarded to bound each local attempt");
+  assert.equal(opts?.operation, "extraction-faithfulness");
+  assert.equal("signal" in (opts ?? {}), false, "batch signal is not forwarded to the local client (it ignores it)");
+  assert.equal("model" in (opts ?? {}), false, "model override is not forwarded to the local client (it ignores it)");
+});
+
 // ---------------------------------------------------------------------------
 // #1576: multi-source verification — codex P2 (PRRT_kwDORJXyws6ObYQ_)
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./extraction-faithfulness.js";
 import type { FaithfulnessResult } from "./extraction-faithfulness.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
+import type { LocalLlmClient } from "./local-llm.js";
 import type { MemoryFrontmatter } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -821,3 +822,117 @@ test("applyFaithfulnessVerdict: bumps verdict counters at apply time (cursor rev
   assert.equal(counters.unchecked, 1);
 });
 
+
+// ---------------------------------------------------------------------------
+// #1576: model-override routing — codex P2 (PRRT_kwDORJXyws6ObYQ8)
+// ---------------------------------------------------------------------------
+
+test("checkFaithfulnessBatch: extractionFaithfulnessModel override routes to gateway, skips local (codex P2)", async () => {
+  // LocalLlmClient always sends config.localLlmModel and ignores options.model,
+  // so a local success would silently run the wrong model and the override
+  // would never reach the gateway. When an override is set the local backend
+  // must be skipped and the gateway fallback must receive the override model.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "verifier-ft-v1",
+  });
+  const localCalls: Array<{ options: unknown }> = [];
+  const localLlm = {
+    chatCompletion: async (
+      _messages: Array<{ role: string; content: string }>,
+      options: Record<string, unknown> = {},
+    ) => {
+      localCalls.push({ options });
+      return {
+        content: JSON.stringify([{ index: 0, verdict: "unsupported" }]),
+      };
+    },
+  };
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  const fallbackContent = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    localLlm as unknown as LocalLlmClient,
+    stubFallbackLlm(fallbackContent, fallbackCalls),
+  );
+  assert.equal(localCalls.length, 0, "local LLM must be skipped when a model override is set");
+  assert.equal(fallbackCalls.length, 1, "gateway fallback must run with the override");
+  const opts = fallbackCalls[0]?.options as Record<string, unknown>;
+  assert.equal(opts?.model, "verifier-ft-v1", "override model must reach the gateway");
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed", "gateway verdict is used, not the local one");
+  }
+});
+
+test("checkFaithfulnessBatch: no override keeps the local backend first (regression guard)", async () => {
+  // Without an override, the local backend must still be tried first (the
+  // override-skip is conditional, not unconditional).
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = baseConfig();
+  const localCalls: number[] = [];
+  const localLlm = {
+    chatCompletion: async () => {
+      localCalls.push(1);
+      return { content: JSON.stringify([{ index: 0, verdict: "entailed" }]) };
+    },
+  };
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    localLlm as unknown as LocalLlmClient,
+    stubFallbackLlm("[]", fallbackCalls),
+  );
+  assert.equal(localCalls.length, 1, "local backend is used when no override is set");
+  assert.equal(fallbackCalls.length, 0, "fallback is not reached when local succeeds");
+  assert.equal(result.results[0]?.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// #1576: multi-source verification — codex P2 (PRRT_kwDORJXyws6ObYQ_)
+// ---------------------------------------------------------------------------
+
+test("runFaithfulnessGateBatch: multi-source facts verify against ALL source spans (codex P2)", async () => {
+  // A composite fact whose support is split across two adjacent source spans.
+  // Previously only sources[0] reached the verifier; the second span (the
+  // actual support for the date/status) was discarded, risking a false
+  // unsupported verdict (and a spurious pending_review in enforce mode). The
+  // verifier must now see the full evidence.
+  const facts = [
+    {
+      content: "The Acme project launched in March 2024 at beta status.",
+      sources: [
+        { quote: "We started the Acme project earlier this year." },
+        { quote: "It launched in March 2024 at beta status." },
+      ],
+    },
+  ];
+  const counters = createFaithfulnessCounters();
+  const captured: Array<{ messages: Array<{ role: string; content: string }>; options: unknown }> = [];
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm(llm, captured),
+    counters,
+  );
+  assert.ok(result instanceof Map);
+  assert.equal(result.size, 1);
+  const r0 = result.get(0);
+  assert.equal(r0?.ok, true);
+  if (r0?.ok) assert.equal(r0.verdict, "entailed");
+  // The verifier prompt must include BOTH source spans, not just sources[0].
+  const userMsg = captured[0]?.messages.find((m) => m.role === "user");
+  assert.ok(
+    userMsg?.content.includes("We started the Acme project"),
+    "first source span must reach the verifier prompt",
+  );
+  assert.ok(
+    userMsg?.content.includes("It launched in March 2024 at beta status."),
+    "second source span must reach the verifier prompt (multi-source fix)",
+  );
+});

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Tests for extraction-faithfulness.ts (issue #1576 PR 1).
+ *
+ * All tests stub the LLM adapter — no network, no GPU. The stub signatures
+ * match the production LocalLlmClient / FallbackLlmClient interfaces so
+ * these tests exercise the real call→parse→tag path.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import {
+  checkFaithfulnessBatch,
+  parseFaithfulnessResponse,
+  serializeFaithfulnessFields,
+  parseFaithfulnessField,
+  runFaithfulnessGateBatch,
+  applyFaithfulnessVerdict,
+  createFaithfulnessCounters,
+  FAITHFULNESS_PROMPT_HASH,
+} from "./extraction-faithfulness.js";
+import type { FaithfulnessResult } from "./extraction-faithfulness.js";
+import type { FallbackLlmClient } from "./fallback-llm.js";
+import type { MemoryFrontmatter } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — stub LLM clients
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a stub FallbackLlmClient that returns the given content.
+ * The stub's call signature matches the real client.
+ */
+function stubFallbackLlm(
+  content: string | null,
+  captured?: Array<{ messages: unknown; options: unknown }>,
+  modelUsed = "stub-model",
+): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    chatCompletion: async (
+      messages: Array<{ role: string; content: string }>,
+      options: Record<string, unknown>,
+    ) => {
+      if (captured) captured.push({ messages, options });
+      if (content === null) return null;
+      return { content, modelUsed, usage: undefined };
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+/**
+ * Create a stub FallbackLlmClient that throws on call (simulates network error).
+ */
+function throwingFallbackLlm(error: Error): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    chatCompletion: async () => {
+      throw error;
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+/**
+ * Create a stub FallbackLlmClient that never resolves within the test timeout
+ * (simulates a hung request). We resolve after a long delay; the gate's own
+ * AbortController will fire first.
+ */
+function slowFallbackLlm(delayMs: number): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    chatCompletion: async () => {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return { content: "[]", modelUsed: "slow", usage: undefined };
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+function baseConfig(): ReturnType<typeof parseConfig> {
+  return parseConfig({
+    extractionFaithfulnessTimeoutMs: 200,
+    extractionFaithfulnessContextChars: 400,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// parseFaithfulnessResponse — pure, no LLM
+// ---------------------------------------------------------------------------
+
+test("parseFaithfulnessResponse: valid array with all three verdicts", () => {
+  const raw = JSON.stringify([
+    { index: 0, verdict: "entailed", rationale: "direct paraphrase" },
+    { index: 1, verdict: "contradicted", rationale: "opposite meaning" },
+    { index: 2, verdict: "unsupported", rationale: "not in quote" },
+  ]);
+  const map = parseFaithfulnessResponse(raw, 3);
+  assert.ok(map);
+  assert.equal(map.size, 3);
+  assert.equal(map.get(0)?.verdict, "entailed");
+  assert.equal(map.get(1)?.verdict, "contradicted");
+  assert.equal(map.get(2)?.verdict, "unsupported");
+});
+
+test("parseFaithfulnessResponse: partial array (missing index → null map if none valid)", () => {
+  const raw = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 2, verdict: "unsupported" },
+  ]);
+  const map = parseFaithfulnessResponse(raw, 3);
+  assert.ok(map);
+  assert.equal(map.size, 2);
+  assert.equal(map.get(0)?.verdict, "entailed");
+  assert.equal(map.get(2)?.verdict, "unsupported");
+  assert.ok(!map.has(1));
+});
+
+test("parseFaithfulnessResponse: empty string → null", () => {
+  assert.equal(parseFaithfulnessResponse("", 1), null);
+  assert.equal(parseFaithfulnessResponse("   ", 1), null);
+});
+
+test("parseFaithfulnessResponse: malformed JSON → null", () => {
+  assert.equal(parseFaithfulnessResponse("maybe?", 1), null);
+  assert.equal(parseFaithfulnessResponse("{broken", 1), null);
+  assert.equal(parseFaithfulnessResponse("I think it's entailed", 1), null);
+});
+
+test("parseFaithfulnessResponse: valid JSON but wrong shape → null", () => {
+  assert.equal(parseFaithfulnessResponse('{"key": "value"}', 1), null);
+  assert.equal(parseFaithfulnessResponse("[]", 1), null);
+  assert.equal(parseFaithfulnessResponse('["not", "objects"]', 1), null);
+});
+
+test("parseFaithfulnessResponse: entries with invalid verdict strings are dropped", () => {
+  const raw = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 1, verdict: "maybe" },
+    { index: 2, verdict: "unsupported" },
+  ]);
+  const map = parseFaithfulnessResponse(raw, 3);
+  assert.ok(map);
+  assert.equal(map.size, 2);
+  assert.ok(map.has(0));
+  assert.ok(!map.has(1));
+  assert.ok(map.has(2));
+});
+
+test("parseFaithfulnessResponse: index out of range is dropped", () => {
+  const raw = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 99, verdict: "unsupported" },
+  ]);
+  const map = parseFaithfulnessResponse(raw, 2);
+  assert.ok(map);
+  assert.equal(map.size, 1);
+  assert.ok(map.has(0));
+  assert.ok(!map.has(99));
+});
+
+test("parseFaithfulnessResponse: rationale is capped at 500 chars", () => {
+  const longRationale = "A".repeat(600);
+  const raw = JSON.stringify([
+    { index: 0, verdict: "entailed", rationale: longRationale },
+  ]);
+  const map = parseFaithfulnessResponse(raw, 1);
+  assert.ok(map);
+  assert.equal(map.get(0)?.rationale?.length, 500);
+});
+
+test("parseFaithfulnessResponse: JSON embedded in fenced code block", () => {
+  const raw = "```json\n" +
+    '  [{"index": 0, "verdict": "entailed", "rationale": "ok"}]\n' +
+  "  ```";
+  const map = parseFaithfulnessResponse(raw, 1);
+  assert.ok(map);
+  assert.equal(map.get(0)?.verdict, "entailed");
+});
+
+// ---------------------------------------------------------------------------
+// checkFaithfulnessBatch — entailed / contradicted / unsupported fixtures
+// ---------------------------------------------------------------------------
+
+test("checkFaithfulnessBatch: entailed — paraphrase of duration", async () => {
+  const inputs = [{
+    factText: "The user has used Vim for approximately a decade.",
+    quote: "I've been using Vim for about ten years now.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "entailed", rationale: "Paraphrase of the same duration." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed");
+    assert.ok(result.results[0].rationale);
+  }
+});
+
+test("checkFaithfulnessBatch: contradicted — negation (stopped vs active)", async () => {
+  const inputs = [{
+    factText: "The user drinks coffee regularly.",
+    quote: "I stopped drinking coffee last month.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "contradicted", rationale: "Quote negates the fact." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "contradicted");
+  }
+});
+
+test("checkFaithfulnessBatch: unsupported — entity swap (Vim → Emacs)", async () => {
+  const inputs = [{
+    factText: "The user prefers Emacs.",
+    quote: "I've been using Vim for about ten years now.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "unsupported", rationale: "Quote mentions Vim, not Emacs." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "unsupported");
+  }
+});
+
+test("checkFaithfulnessBatch: contradicted — date shift", async () => {
+  const inputs = [{
+    factText: "The project started in January 2024.",
+    quote: "We kicked off the project in March 2024.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "contradicted", rationale: "January vs March." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "contradicted");
+  }
+});
+
+test("checkFaithfulnessBatch: contradicted — quantity change", async () => {
+  const inputs = [{
+    factText: "The team has 50 engineers.",
+    quote: "We have a team of 12 engineers.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "contradicted", rationale: "50 vs 12." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "contradicted");
+  }
+});
+
+test("checkFaithfulnessBatch: unsupported — unrelated quote", async () => {
+  const inputs = [{
+    factText: "The user lives in Tokyo.",
+    quote: "I love playing chess on weekends.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "unsupported", rationale: "No location info in quote." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "unsupported");
+  }
+});
+
+test("checkFaithfulnessBatch: entailed — pronoun resolution", async () => {
+  const inputs = [{
+    factText: "Alice is a senior engineer at Acme Corp.",
+    quote: "Alice is a senior engineer at Acme Corp.",
+    context: "We were discussing the team structure.",
+  }];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "entailed", rationale: "Exact match." },
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed");
+  }
+});
+
+test("checkFaithfulnessBatch: batch of 3 — all processed in one LLM call", async () => {
+  const inputs = [
+    { factText: "Fact A", quote: "Quote A" },
+    { factText: "Fact B", quote: "Quote B" },
+    { factText: "Fact C", quote: "Quote C" },
+  ];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 1, verdict: "contradicted" },
+    { index: 2, verdict: "unsupported" },
+  ]);
+  const captured: Array<{ messages: unknown; options: unknown }> = [];
+  const result = await checkFaithfulnessBatch(
+    inputs, baseConfig(), null, stubFallbackLlm(llm, captured),
+  );
+  assert.equal(captured.length, 1, "should make exactly one LLM call for the batch");
+  assert.equal(result.results.length, 3);
+  assert.equal(result.results[0]?.ok && result.results[0].verdict, "entailed");
+  assert.equal(result.results[1]?.ok && result.results[1].verdict, "contradicted");
+  assert.equal(result.results[2]?.ok && result.results[2].verdict, "unsupported");
+});
+
+// ---------------------------------------------------------------------------
+// checkFaithfulnessBatch — error paths
+// ---------------------------------------------------------------------------
+
+test("checkFaithfulnessBatch: empty quote → no_span", async () => {
+  const inputs = [{ factText: "Some fact", quote: "" }];
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm("[]"));
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "no_span");
+  }
+});
+
+test("checkFaithfulnessBatch: missing quote property → no_span", async () => {
+  const inputs = [{ factText: "Some fact", quote: "   " }];
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm("[]"));
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "no_span");
+  }
+});
+
+test("checkFaithfulnessBatch: empty factText → no_span", async () => {
+  const inputs = [{ factText: "", quote: "Some quote" }];
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm("[]"));
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "no_span");
+  }
+});
+
+test("checkFaithfulnessBatch: backend returns null → backend_unavailable", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(null));
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "backend_unavailable");
+  }
+});
+
+test("checkFaithfulnessBatch: backend throws → backend_unavailable", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const result = await checkFaithfulnessBatch(
+    inputs, baseConfig(), null, throwingFallbackLlm(new Error("ECONNREFUSED")),
+  );
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "backend_unavailable");
+  }
+});
+
+test("checkFaithfulnessBatch: malformed LLM output → malformed_output", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const result = await checkFaithfulnessBatch(
+    inputs, baseConfig(), null, stubFallbackLlm("maybe? I think so."),
+  );
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "malformed_output");
+  }
+});
+
+test("checkFaithfulnessBatch: timeout → tagged timeout, not a crash", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  // Use a very short timeout and a slow LLM to force the abort path.
+  const config = parseConfig({ extractionFaithfulnessTimeoutMs: 50 });
+  const result = await checkFaithfulnessBatch(
+    inputs, config, null, slowFallbackLlm(5000),
+  );
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "timeout");
+  }
+});
+
+test("checkFaithfulnessBatch: LLM returns partial results — missing index → malformed_output", async () => {
+  const inputs = [
+    { factText: "Fact A", quote: "Quote A" },
+    { factText: "Fact B", quote: "Quote B" },
+  ];
+  // LLM only returns index 0, missing index 1
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results.length, 2);
+  assert.equal(result.results[0]?.ok && result.results[0].verdict, "entailed");
+  assert.equal(result.results[1]?.ok, false);
+  if (!result.results[1]?.ok) {
+    assert.equal(result.results[1].error.code, "malformed_output");
+  }
+});
+
+test("checkFaithfulnessBatch: no inputs with quotes → no LLM call, all no_span", async () => {
+  const inputs = [
+    { factText: "Fact A", quote: "" },
+    { factText: "Fact B", quote: "" },
+  ];
+  const captured: Array<{ messages: unknown; options: unknown }> = [];
+  const result = await checkFaithfulnessBatch(
+    inputs, baseConfig(), null, stubFallbackLlm("[]", captured),
+  );
+  assert.equal(captured.length, 0, "no LLM call when all inputs lack quotes");
+  assert.equal(result.elapsedMs, 0);
+  assert.equal(result.results[0]?.ok, false);
+  assert.equal(result.results[1]?.ok, false);
+});
+
+test("checkFaithfulnessBatch: mixed — some with quotes, some without", async () => {
+  const inputs = [
+    { factText: "Fact A", quote: "Quote A" },
+    { factText: "Fact B", quote: "" },
+    { factText: "Fact C", quote: "Quote C" },
+  ];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 1, verdict: "unsupported" }, // maps to checkable index 1 (Fact C)
+  ]);
+  const result = await checkFaithfulnessBatch(inputs, baseConfig(), null, stubFallbackLlm(llm));
+  assert.equal(result.results.length, 3);
+  // Index 0: entailed
+  assert.equal(result.results[0]?.ok && result.results[0].verdict, "entailed");
+  // Index 1: no_span (empty quote)
+  assert.equal(result.results[1]?.ok, false);
+  if (!result.results[1]?.ok) {
+    assert.equal(result.results[1].error.code, "no_span");
+  }
+  // Index 2: unsupported (second checkable item)
+  assert.equal(result.results[2]?.ok && result.results[2].verdict, "unsupported");
+});
+
+test("checkFaithfulnessBatch: elapsedMs is non-negative", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const result = await checkFaithfulnessBatch(
+    inputs, baseConfig(), null, stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }])),
+  );
+  assert.ok(result.elapsedMs >= 0);
+});
+
+// ---------------------------------------------------------------------------
+// Prompt hash — stable for caching
+// ---------------------------------------------------------------------------
+
+test("FAITHFULNESS_PROMPT_HASH is a 64-char hex string", () => {
+  assert.equal(FAITHFULNESS_PROMPT_HASH.length, 64);
+  assert.match(FAITHFULNESS_PROMPT_HASH, /^[0-9a-f]{64}$/);
+});
+
+// ---------------------------------------------------------------------------
+// Frontmatter serialization round-trip
+// ---------------------------------------------------------------------------
+
+test("serializeFaithfulnessFields: absent field → no line emitted (byte-identical)", () => {
+  const lines: string[] = [];
+  const fm: MemoryFrontmatter = {
+    id: "test",
+    category: "preference",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    source: "test",
+    confidence: 0.9,
+    confidenceTier: "explicit",
+    tags: [],
+  };
+  serializeFaithfulnessFields(fm, lines);
+  assert.equal(lines.length, 0);
+});
+
+test("serializeFaithfulnessFields: present field → single JSON line", () => {
+  const lines: string[] = [];
+  const fm: MemoryFrontmatter = {
+    id: "test",
+    category: "preference",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    source: "test",
+    confidence: 0.9,
+    confidenceTier: "explicit",
+    tags: [],
+    faithfulness: { verdict: "entailed", model: "glm-4.7-flash", rationale: "ok" },
+  };
+  serializeFaithfulnessFields(fm, lines);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0]!, /^faithfulness: /);
+  const parsed = JSON.parse(lines[0]!.replace(/^faithfulness: /, ""));
+  assert.equal(parsed.verdict, "entailed");
+  assert.equal(parsed.model, "glm-4.7-flash");
+});
+
+test("parseFaithfulnessField: round-trip", () => {
+  const fm: MemoryFrontmatter = {
+    id: "test",
+    category: "preference",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    source: "test",
+    confidence: 0.9,
+    confidenceTier: "explicit",
+    tags: [],
+    faithfulness: { verdict: "contradicted", model: "m", rationale: "r", at: "2026-01-01T00:00:00Z" },
+  };
+  const lines: string[] = [];
+  serializeFaithfulnessFields(fm, lines);
+  const raw = lines[0]!.replace(/^faithfulness: /, "");
+  const parsed = parseFaithfulnessField(raw);
+  assert.deepEqual(parsed, { verdict: "contradicted", model: "m", rationale: "r", at: "2026-01-01T00:00:00Z" });
+});
+
+test("parseFaithfulnessField: undefined / blank / corrupt → undefined", () => {
+  assert.equal(parseFaithfulnessField(undefined), undefined);
+  assert.equal(parseFaithfulnessField(""), undefined);
+  assert.equal(parseFaithfulnessField("   "), undefined);
+  assert.equal(parseFaithfulnessField("{broken json"), undefined);
+  assert.equal(parseFaithfulnessField('"a string"'), undefined);
+  assert.equal(parseFaithfulnessField("[]"), undefined);
+  assert.equal(parseFaithfulnessField('{}'), undefined);
+  assert.equal(parseFaithfulnessField('{"verdict": "maybe"}'), undefined);
+});
+
+test("parseFaithfulnessField: accepts all valid verdict values", () => {
+  for (const v of ["entailed", "contradicted", "unsupported", "unchecked", "skipped_no_span"]) {
+    const parsed = parseFaithfulnessField(JSON.stringify({ verdict: v }));
+    assert.equal(parsed?.verdict, v);
+  }
+});
+
+test("serializeFaithfulnessFields: empty verdict omitted → no line", () => {
+  const lines: string[] = [];
+  const fm = {
+    faithfulness: { verdict: "" as "entailed" },
+  } as MemoryFrontmatter;
+  serializeFaithfulnessFields(fm, lines);
+  assert.equal(lines.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// runFaithfulnessGateBatch / applyFaithfulnessVerdict — orchestration helpers
+// (issue #1576). These are the orchestrator-facing API; the substantive
+// algorithm is covered by the checkFaithfulnessBatch tests above.
+// ---------------------------------------------------------------------------
+
+test("createFaithfulnessCounters: returns zeroed counters", () => {
+  assert.deepEqual(createFaithfulnessCounters(), {
+    entailed: 0,
+    contradicted: 0,
+    unsupported: 0,
+    unchecked: 0,
+    skippedNoSpan: 0,
+  });
+});
+
+test("runFaithfulnessGateBatch: facts without sources skipped (no LLM call)", async () => {
+  const facts = [
+    { content: "Fact with no sources" },
+    { content: "Another", sources: [] },
+  ];
+  const captured: Array<{ messages: unknown; options: unknown }> = [];
+  const counters = createFaithfulnessCounters();
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm("[]", captured),
+    counters,
+  );
+  assert.equal(captured.length, 0, "no LLM call when no facts have sources");
+  assert.ok(result instanceof Map, "no-sources batch returns an empty map");
+  assert.equal(result.size, 0);
+  assert.equal(counters.entailed, 0);
+});
+
+test("runFaithfulnessGateBatch: builds index→result map + updates counters", async () => {
+  // Fact 0 has a source, fact 1 does NOT, fact 2 has a source. The batch
+  // skips fact 1, so the LLM sees 2 inputs and results map back to the
+  // ORIGINAL fact indices (0 and 2), not batch positions.
+  const facts = [
+    { content: "Fact 0", sources: [{ quote: "Quote 0" }] },
+    { content: "Fact 1 (no sources)" },
+    { content: "Fact 2", sources: [{ quote: "Quote 2" }] },
+  ];
+  const llm = JSON.stringify([
+    { index: 0, verdict: "entailed" },
+    { index: 1, verdict: "contradicted" },
+  ]);
+  const counters = createFaithfulnessCounters();
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm(llm),
+    counters,
+  );
+  assert.ok(result instanceof Map, "batch returns a map on success");
+  assert.equal(result.size, 2);
+  assert.equal(result.has(1), false, "fact without a source is absent from the map");
+  const r0 = result.get(0);
+  assert.equal(r0?.ok, true);
+  if (r0?.ok) assert.equal(r0.verdict, "entailed");
+  const r2 = result.get(2);
+  assert.equal(r2?.ok, true);
+  if (r2?.ok) assert.equal(r2.verdict, "contradicted");
+  assert.equal(counters.entailed, 1);
+  assert.equal(counters.contradicted, 1);
+});
+
+test("runFaithfulnessGateBatch: backend throw → unchecked result, fail-open (checklist §4)", async () => {
+  // checkFaithfulnessBatch is total: it catches an LLM throw and surfaces it
+  // as an ok:false result rather than propagating. So the gate records the
+  // failure as "unchecked" and proceeds — a backend outage never blocks writes.
+  const facts = [{ content: "Fact", sources: [{ quote: "Quote" }] }];
+  const counters = createFaithfulnessCounters();
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "enforce",
+    baseConfig(),
+    null,
+    throwingFallbackLlm(new Error("ECONNREFUSED")),
+    counters,
+  );
+  assert.ok(result instanceof Map);
+  const r0 = result.get(0);
+  assert.equal(r0?.ok, false);
+  if (!r0?.ok) assert.equal(r0.error.code, "backend_unavailable");
+  assert.equal(counters.unchecked, 1);
+});
+
+test("applyFaithfulnessVerdict: gate off (null map) → no frontmatter", () => {
+  const counters = createFaithfulnessCounters();
+  const r = applyFaithfulnessVerdict(null, 0, "off", "fact", counters);
+  assert.equal(r.faithfulness, undefined);
+  assert.equal(r.enforceStatus, undefined);
+  assert.equal(counters.skippedNoSpan, 0);
+});
+
+test("applyFaithfulnessVerdict: fact absent from map → skipped_no_span, never gated", () => {
+  const counters = createFaithfulnessCounters();
+  const map = new Map();
+  const r = applyFaithfulnessVerdict(map, 5, "enforce", "legacy fact", counters);
+  assert.equal(r.faithfulness?.verdict, "skipped_no_span");
+  assert.equal(r.enforceStatus, undefined);
+  assert.equal(counters.skippedNoSpan, 1);
+});
+
+test("applyFaithfulnessVerdict: enforce + unsupported → pending_review (issue #1576 done-when)", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([[0, { ok: true, verdict: "unsupported" as const, model: "stub-model" }]]);
+  const r = applyFaithfulnessVerdict(map, 0, "enforce", "hallucinated fact", counters);
+  assert.equal(r.faithfulness?.verdict, "unsupported");
+  assert.equal(r.faithfulness?.model, "stub-model");
+  assert.equal(r.enforceStatus, "pending_review");
+});
+
+test("applyFaithfulnessVerdict: enforce + contradicted → pending_review", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([[0, { ok: true, verdict: "contradicted" as const, model: "stub" }]]);
+  const r = applyFaithfulnessVerdict(map, 0, "enforce", "wrong fact", counters);
+  assert.equal(r.enforceStatus, "pending_review");
+});
+
+test("applyFaithfulnessVerdict: shadow + unsupported → recorded but NOT gated", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([[0, { ok: true, verdict: "unsupported" as const, model: "stub" }]]);
+  const r = applyFaithfulnessVerdict(map, 0, "shadow", "fact", counters);
+  assert.equal(r.faithfulness?.verdict, "unsupported");
+  assert.equal(r.enforceStatus, undefined);
+});
+
+test("applyFaithfulnessVerdict: entailed → proceeds, no enforce", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([[0, { ok: true, verdict: "entailed" as const, model: "stub" }]]);
+  const r = applyFaithfulnessVerdict(map, 0, "enforce", "fact", counters);
+  assert.equal(r.faithfulness?.verdict, "entailed");
+  assert.equal(r.enforceStatus, undefined);
+});
+
+test("applyFaithfulnessVerdict: per-fact backend failure (ok:false) → unchecked, proceeds", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([[0, { ok: false, error: { code: "timeout" as const } }]]);
+  const r = applyFaithfulnessVerdict(map, 0, "enforce", "fact", counters);
+  assert.equal(r.faithfulness?.verdict, "unchecked");
+  assert.equal(r.enforceStatus, undefined);
+});

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -430,20 +430,27 @@ test("checkFaithfulnessBatch: timeout → tagged timeout, not a crash", async ()
   }
 });
 
-test("checkFaithfulnessBatch: content returned as the timer fires is used, not discarded (cursor race)", async () => {
-  // The abort timer fires at 50ms (timedOut=true), but the LLM returns valid
-  // content at 80ms — a response that lands just as the abort propagates. The
-  // race fix must honor the real verdict instead of throwing it away as a
-  // timeout (cursor review PRRT_kwDORJXyws6ObXbj).
+test("checkFaithfulnessBatch: content landing within the budget is used; content past the budget fails open as timeout", async () => {
+  // The batch races the LLM call against extractionFaithfulnessTimeoutMs so a
+  // wedged/slow backend cannot hold the extraction flush past the budget
+  // (codex review PRRT_kwDORJXyws6ObgMJ). Content that lands WITHIN the budget
+  // is used; content that lands AFTER the budget fails open as timeout.
   const inputs = [{ factText: "Fact", quote: "Quote" }];
   const config = parseConfig({ extractionFaithfulnessTimeoutMs: 50 });
   const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
-  const result = await checkFaithfulnessBatch(
-    inputs, config, null, racingFallbackLlm(80, llm),
-  );
-  assert.equal(result.results[0]?.ok, true, "racing content must be used, not timed out");
-  if (result.results[0]?.ok) {
-    assert.equal(result.results[0].verdict, "entailed");
+
+  // Within budget (30ms < 50ms): the real verdict is used.
+  const within = await checkFaithfulnessBatch(inputs, config, null, racingFallbackLlm(30, llm));
+  assert.equal(within.results[0]?.ok, true, "content within the budget must be used");
+  if (within.results[0]?.ok) {
+    assert.equal(within.results[0].verdict, "entailed");
+  }
+
+  // Past budget (80ms > 50ms): fail open as timeout, do not block the flush.
+  const past = await checkFaithfulnessBatch(inputs, config, null, racingFallbackLlm(80, llm));
+  assert.equal(past.results[0]?.ok, false, "content past the budget fails open as timeout");
+  if (!past.results[0]?.ok) {
+    assert.equal(past.results[0].error.code, "timeout");
   }
 });
 
@@ -966,4 +973,32 @@ test("runFaithfulnessGateBatch: multi-source facts verify against ALL source spa
     userMsg?.content.includes("It launched in March 2024 at beta status."),
     "second source span must reach the verifier prompt (multi-source fix)",
   );
+});
+
+test("checkFaithfulnessBatch: a wedged local backend that ignores the signal still fails open at the budget (codex P2)", async () => {
+  // LocalLlmClient ignores options.signal and aborts each attempt via its own
+  // controller. A wedged local verifier that never resolves within the budget
+  // must NOT hold the batch past extractionFaithfulnessTimeoutMs — the race
+  // returns timeout promptly so the extraction flush is not blocked
+  // (codex review PRRT_kwDORJXyws6ObgMJ).
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({ extractionFaithfulnessTimeoutMs: 50 });
+  const hungLocal = {
+    // Never resolves within the test window and ignores any signal.
+    chatCompletion: async () => {
+      const { promise } = Promise.withResolvers<never>();
+      return promise;
+    },
+  };
+  const startedAt = Date.now();
+  const result = await checkFaithfulnessBatch(
+    inputs, config, hungLocal as unknown as LocalLlmClient, null,
+  );
+  const elapsed = Date.now() - startedAt;
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "timeout");
+  }
+  // The batch returned near the budget, not after the hung promise.
+  assert.ok(elapsed < 1000, `batch must fail open near the budget, not block (elapsed=${elapsed}ms)`);
 });

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -18,6 +18,7 @@ import {
   runFaithfulnessGateBatch,
   applyFaithfulnessVerdict,
   createFaithfulnessCounters,
+  locateFactQuote,
   FAITHFULNESS_PROMPT_HASH,
 } from "./extraction-faithfulness.js";
 import type { FaithfulnessResult } from "./extraction-faithfulness.js";
@@ -560,7 +561,7 @@ test("createFaithfulnessCounters: returns zeroed counters", () => {
   });
 });
 
-test("runFaithfulnessGateBatch: facts without sources skipped (no LLM call)", async () => {
+test("runFaithfulnessGateBatch: facts with no span and no sourceText match skipped", async () => {
   const facts = [
     { content: "Fact with no sources" },
     { content: "Another", sources: [] },
@@ -574,10 +575,35 @@ test("runFaithfulnessGateBatch: facts without sources skipped (no LLM call)", as
     null,
     stubFallbackLlm("[]", captured),
     counters,
+    "", // no source text → no fallback quote
   );
-  assert.equal(captured.length, 0, "no LLM call when no facts have sources");
-  assert.ok(result instanceof Map, "no-sources batch returns an empty map");
+  assert.equal(captured.length, 0, "no LLM call when no facts have a located quote");
+  assert.ok(result instanceof Map, "returns an empty map");
   assert.equal(result.size, 0);
+  assert.equal(counters.entailed, 0);
+});
+
+test("runFaithfulnessGateBatch: locateFactQuote fallback feeds the gate when no #1575 sources", async () => {
+  // Fact has no `sources` but the source text contains a matching sentence →
+  // locateFactQuote finds it so the gate actually runs (P1 fix).
+  const facts = [{ content: "The user prefers Vim." }];
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const counters = createFaithfulnessCounters();
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm(llm),
+    counters,
+    "I have used Vim for ten years and I really prefer Vim over Emacs.",
+  );
+  assert.ok(result instanceof Map);
+  assert.equal(result.size, 1);
+  const r0 = result.get(0);
+  assert.equal(r0?.ok, true);
+  if (r0?.ok) assert.equal(r0.verdict, "entailed");
+  // counters still 0 here — bumped at apply time.
   assert.equal(counters.entailed, 0);
 });
 
@@ -612,8 +638,9 @@ test("runFaithfulnessGateBatch: builds index→result map + updates counters", a
   const r2 = result.get(2);
   assert.equal(r2?.ok, true);
   if (r2?.ok) assert.equal(r2.verdict, "contradicted");
-  assert.equal(counters.entailed, 1);
-  assert.equal(counters.contradicted, 1);
+  // Counters are bumped at apply time (applyFaithfulnessVerdict), not here.
+  assert.equal(counters.entailed, 0);
+  assert.equal(counters.contradicted, 0);
 });
 
 test("runFaithfulnessGateBatch: backend throw → unchecked result, fail-open (checklist §4)", async () => {
@@ -634,6 +661,11 @@ test("runFaithfulnessGateBatch: backend throw → unchecked result, fail-open (c
   const r0 = result.get(0);
   assert.equal(r0?.ok, false);
   if (!r0?.ok) assert.equal(r0.error.code, "backend_unavailable");
+  // Counters bump at apply time (cursor review), so still 0 after the batch.
+  assert.equal(counters.unchecked, 0);
+  // Applying the verdict bumps unchecked.
+  const applied = applyFaithfulnessVerdict(result, 0, "enforce", "Fact", counters);
+  assert.equal(applied.faithfulness?.verdict, "unchecked");
   assert.equal(counters.unchecked, 1);
 });
 
@@ -692,4 +724,40 @@ test("applyFaithfulnessVerdict: per-fact backend failure (ok:false) → unchecke
   const r = applyFaithfulnessVerdict(map, 0, "enforce", "fact", counters);
   assert.equal(r.faithfulness?.verdict, "unchecked");
   assert.equal(r.enforceStatus, undefined);
+});
+
+test("locateFactQuote: finds the best-overlap sentence", () => {
+  const src = "I drove to Berlin yesterday. My favorite editor is Vim.";
+  assert.equal(
+    locateFactQuote("The user likes Vim.", src),
+    "My favorite editor is Vim.",
+  );
+});
+
+test("locateFactQuote: returns undefined below the overlap threshold", () => {
+  const src = "The weather is sunny. Stocks rose 2 percent.";
+  assert.equal(locateFactQuote("The user lives in Tokyo.", src), undefined);
+});
+
+test("locateFactQuote: empty inputs → undefined", () => {
+  assert.equal(locateFactQuote("", "text"), undefined);
+  assert.equal(locateFactQuote("fact", ""), undefined);
+});
+
+test("applyFaithfulnessVerdict: bumps verdict counters at apply time (cursor review)", () => {
+  const counters = createFaithfulnessCounters();
+  const map: Map<number, FaithfulnessResult> = new Map([
+    [0, { ok: true, verdict: "entailed", model: "m" }],
+    [1, { ok: true, verdict: "contradicted", model: "m" }],
+    [2, { ok: true, verdict: "unsupported", model: "m" }],
+    [3, { ok: false, error: { code: "timeout" } }],
+  ]);
+  applyFaithfulnessVerdict(map, 0, "enforce", "f0", counters);
+  applyFaithfulnessVerdict(map, 1, "enforce", "f1", counters);
+  applyFaithfulnessVerdict(map, 2, "enforce", "f2", counters);
+  applyFaithfulnessVerdict(map, 3, "enforce", "f3", counters);
+  assert.equal(counters.entailed, 1);
+  assert.equal(counters.contradicted, 1);
+  assert.equal(counters.unsupported, 1);
+  assert.equal(counters.unchecked, 1);
 });

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -761,3 +761,4 @@ test("applyFaithfulnessVerdict: bumps verdict counters at apply time (cursor rev
   assert.equal(counters.unsupported, 1);
   assert.equal(counters.unchecked, 1);
 });
+

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -65,15 +65,57 @@ function throwingFallbackLlm(error: Error): FallbackLlmClient {
 
 /**
  * Create a stub FallbackLlmClient that never resolves within the test timeout
- * (simulates a hung request). We resolve after a long delay; the gate's own
- * AbortController will fire first.
+ * (simulates a hung request). Respects the gate's AbortSignal: when the
+ * signal fires, the stub throws — mirroring a real fetch that is aborted by
+ * the gate timer. (The previous stub ignored the signal and returned "[]"
+ * after the delay, which is unrealistic and masked the timeout-race fix.)
  */
 function slowFallbackLlm(delayMs: number): FallbackLlmClient {
   return {
     isAvailable: () => true,
-    chatCompletion: async () => {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    chatCompletion: async (
+      _messages: Array<{ role: string; content: string }>,
+      options: Record<string, unknown> = {},
+    ) => {
+      const signal = options.signal as AbortSignal | undefined;
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const timer = setTimeout(resolve, delayMs);
+      if (signal) {
+        if (signal.aborted) {
+          clearTimeout(timer);
+          throw new Error("aborted");
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      }
+      await promise;
       return { content: "[]", modelUsed: "slow", usage: undefined };
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+/**
+ * Create a stub FallbackLlmClient that IGNORES the abort signal and returns
+ * valid content after a delay longer than the gate's timeout. This simulates
+ * the race the cursor review flagged (#1576): the abort timer fires
+ * (`timedOut = true`) but the response lands a moment later with genuine
+ * verdicts. The race fix must honor that content instead of discarding it as
+ * a timeout error.
+ */
+function racingFallbackLlm(delayMs: number, content: string): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    chatCompletion: async () => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      setTimeout(resolve, delayMs);
+      await promise;
+      return { content, modelUsed: "racing", usage: undefined };
     },
   } as unknown as FallbackLlmClient;
 }
@@ -384,6 +426,23 @@ test("checkFaithfulnessBatch: timeout → tagged timeout, not a crash", async ()
   assert.equal(result.results[0]?.ok, false);
   if (!result.results[0]?.ok) {
     assert.equal(result.results[0].error.code, "timeout");
+  }
+});
+
+test("checkFaithfulnessBatch: content returned as the timer fires is used, not discarded (cursor race)", async () => {
+  // The abort timer fires at 50ms (timedOut=true), but the LLM returns valid
+  // content at 80ms — a response that lands just as the abort propagates. The
+  // race fix must honor the real verdict instead of throwing it away as a
+  // timeout (cursor review PRRT_kwDORJXyws6ObXbj).
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({ extractionFaithfulnessTimeoutMs: 50 });
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const result = await checkFaithfulnessBatch(
+    inputs, config, null, racingFallbackLlm(80, llm),
+  );
+  assert.equal(result.results[0]?.ok, true, "racing content must be used, not timed out");
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed");
   }
 });
 

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -20,6 +20,7 @@ import {
   createFaithfulnessCounters,
   locateFactQuote,
   FAITHFULNESS_PROMPT_HASH,
+  extractContextWindow,
 } from "./extraction-faithfulness.js";
 import type { FaithfulnessResult } from "./extraction-faithfulness.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
@@ -1001,4 +1002,98 @@ test("checkFaithfulnessBatch: a wedged local backend that ignores the signal sti
   }
   // The batch returned near the budget, not after the hung promise.
   assert.ok(elapsed < 1000, `batch must fail open near the budget, not block (elapsed=${elapsed}ms)`);
+});
+
+
+// ---------------------------------------------------------------------------
+// #1576: fallback-locator source context — codex P2 (PRRT_kwDORJXyws6OblI1)
+// extractionFaithfulnessContextChars must actually reach the verifier in the
+// fallback-locator path, otherwise composite facts whose support depends on
+// surrounding source text get misrouted to pending_review in enforce mode.
+// ---------------------------------------------------------------------------
+
+test("extractContextWindow: returns a bounded window centered on the quote", () => {
+  const sourceText =
+    "We started the Acme project earlier this year. It launched in March 2024 at beta status. The team is small.";
+  const quote = "It launched in March 2024 at beta status.";
+  // contextChars=40 must bound the window; the quote itself is 42 chars so the
+  // window is at least the quote plus a sliver of neighbors on each side.
+  const ctx = extractContextWindow(sourceText, quote, 40);
+  assert.ok(ctx, "expected a context window");
+  assert.ok(ctx!.length <= 40, `window must be bounded by contextChars (got ${ctx!.length})`);
+  assert.ok(ctx!.includes("launched"), "window must overlap the quote");
+});
+
+test("extractContextWindow: grows neighbors when budget exceeds quote length", () => {
+  const sourceText =
+    "Earlier the project was unnamed. We started the Acme project earlier this year. Later we renamed it.";
+  const quote = "We started the Acme project earlier this year.";
+  const ctx = extractContextWindow(sourceText, quote, 120);
+  assert.ok(ctx, "expected a context window");
+  assert.ok(ctx!.length <= 120, `window bounded (got ${ctx!.length})`);
+  // Neighboring sentences must be pulled in now that the budget allows it.
+  assert.ok(ctx!.includes("Earlier the project was unnamed"), "preceding context included");
+  assert.ok(ctx!.includes("Later we renamed it"), "following context included");
+});
+
+test("extractContextWindow: returns undefined when quote is absent from sourceText", () => {
+  assert.equal(extractContextWindow("some source", "not present", 400), undefined);
+  assert.equal(extractContextWindow("", "x", 400), undefined);
+  assert.equal(extractContextWindow("source", "s", 0), undefined);
+});
+
+test("runFaithfulnessGateBatch: fallback locator injects CONTEXT into the verifier prompt (codex P2 PRRT_kwDORJXyws6OblI1)", async () => {
+  // No #1575 sources → the fallback locator locates a quote from sourceText.
+  // Previously the input never set `context`, so the surrounding turn text
+  // (and thus extractionFaithfulnessContextChars) was ignored in production.
+  // The verifier prompt must now include a CONTEXT line around the quote.
+  const facts = [{ content: "The Acme project launched in March." }];
+  const sourceText =
+    "We started the Acme project earlier this year. It launched in March at beta status. The team is small.";
+  const captured: Array<{ messages: Array<{ role: string; content: string }>; options: unknown }> = [];
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  const result = await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm(llm, captured),
+    createFaithfulnessCounters(),
+    sourceText,
+  );
+  assert.ok(result instanceof Map);
+  assert.equal(result.size, 1);
+  const userMsg = captured[0]?.messages.find((m) => m.role === "user");
+  assert.ok(userMsg, "verifier was called");
+  assert.match(userMsg!.content, /CONTEXT:/, "fallback-locator prompt must include a CONTEXT line");
+  // The surrounding sentence must be present in the context window.
+  assert.ok(
+    userMsg!.content.includes("We started the Acme project"),
+    "context window must include the neighboring source text",
+  );
+});
+
+test("runFaithfulnessGateBatch: #1575 verified spans do NOT synthesize a context window (regression guard)", async () => {
+  // When per-fact sources are present, the verified span already carries full
+  // evidence — no fallback context window should be synthesized.
+  const facts = [
+    {
+      content: "The Acme project launched in March 2024 at beta status.",
+      sources: [{ quote: "It launched in March 2024 at beta status." }],
+    },
+  ];
+  const captured: Array<{ messages: Array<{ role: string; content: string }>; options: unknown }> = [];
+  const llm = JSON.stringify([{ index: 0, verdict: "entailed" }]);
+  await runFaithfulnessGateBatch(
+    facts,
+    "shadow",
+    baseConfig(),
+    null,
+    stubFallbackLlm(llm, captured),
+    createFaithfulnessCounters(),
+    "We started the Acme project earlier this year. It launched in March 2024 at beta status.",
+  );
+  const userMsg = captured[0]?.messages.find((m) => m.role === "user");
+  assert.ok(userMsg);
+  assert.doesNotMatch(userMsg!.content, /CONTEXT:/, "no context window for #1575 verified spans");
 });

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1097,3 +1097,16 @@ test("runFaithfulnessGateBatch: #1575 verified spans do NOT synthesize a context
   assert.ok(userMsg);
   assert.doesNotMatch(userMsg!.content, /CONTEXT:/, "no context window for #1575 verified spans");
 });
+
+test("parseFaithfulnessResponse: object-wrapped arrays unwrap (results/verdicts/entries/facts) — gate-bypass fix #1576 Ob4RO", () => {
+  // Before the fix these object-wrapped shapes were rejected as malformed, so in
+  // enforce mode the batch went `unchecked` and unsupported facts wrote ACTIVE.
+  for (const key of ["results", "verdicts", "entries", "facts"]) {
+    const raw = JSON.stringify({ [key]: [{ index: 0, verdict: "unsupported", rationale: "x" }] });
+    const map = parseFaithfulnessResponse(raw, 1);
+    assert.ok(map, `${key}-wrapped array should parse, not be rejected as malformed`);
+    assert.equal(map.get(0)?.verdict, "unsupported");
+  }
+  // A wrapper object with no recognized array key still returns null (no over-match).
+  assert.equal(parseFaithfulnessResponse('{"data": {"nested": []}}', 1), null);
+});

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -1,0 +1,762 @@
+/**
+ * Extraction faithfulness gate — entailment verification of extracted
+ * facts against their verified source spans (issue #1576).
+ *
+ * Part of #1572 (glass-box memory). Depends on #1575 (provenance spans).
+ * Improved later by #1585 (fine-tuned local gate model).
+ *
+ * Unlike the extraction-judge (#376), which gates on fact-worthiness
+ * ("is this worth remembering?"), this module gates on faithfulness
+ * ("is this fact actually supported by what was said?"). Hallucinated
+ * or mis-paraphrased extractions become durable memories, get recalled
+ * with confidence, and poison downstream answers — the highest-severity
+ * accuracy failure a memory system can have.
+ *
+ * Design constraints:
+ *   - Tagged results only — a backend failure is distinguishable from a
+ *     genuine verdict (rule 34 / checklist §22: never conflate "empty"
+ *     with "failed").
+ *   - The gate consumes the QUOTE, not the whole conversation — passing
+ *     full turns re-introduces the hallucination surface you're guarding
+ *     and blows the latency budget.
+ *   - No module-level state — batch queues hang off the orchestrator
+ *     instance (rule 11).
+ *   - Byte-identical pre-feature pipeline when mode is "off" (rule 39).
+ *   - Graceful degradation — a backend failure never blocks writes
+ *     (checklist §4); the fact proceeds with verdict "unchecked".
+ *   - Never mutate mw_*\/trust fields — faithfulness is its own
+ *     frontmatter island consumed by #1577.
+ */
+
+import { createHash } from "node:crypto";
+
+import { log } from "./logger.js";
+import type { PluginConfig, MemoryFrontmatter, FaithfulnessFrontmatter } from "./types.js";
+import type { LocalLlmClient } from "./local-llm.js";
+import { type FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
+import { extractJsonCandidates } from "./json-extract.js";
+
+// Re-export for callers importing from this module.
+export type { FaithfulnessFrontmatter } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * The three entailment verdicts. "unchecked" is NOT a member of this union —
+ * it lives only in the frontmatter to mark facts that bypassed the gate
+ * (backend failure, no span, mode=off). A real verdict is always one of
+ * these three.
+ */
+export type FaithfulnessVerdict = "entailed" | "contradicted" | "unsupported";
+
+/**
+ * Failure codes for tagged-error results. Each is distinguishable so callers
+ * and telemetry can tell "no span available" from "the backend was down".
+ */
+export type FaithfulnessFailureCode =
+  | "no_span"
+  | "backend_unavailable"
+  | "malformed_output"
+  | "timeout";
+
+/**
+ * Tagged result — success carries the verdict + model + optional rationale;
+ * failure carries only the error code. Never conflate the two (rule 34).
+ */
+export type FaithfulnessResult =
+  | { ok: true; verdict: FaithfulnessVerdict; model: string; rationale?: string }
+  | { ok: false; error: { code: FaithfulnessFailureCode } };
+
+/**
+ * Input for a single faithfulness check. The quote is the verified span from
+ * #1575; context is optional surrounding turn text (bounded by
+ * faithfulnessContextChars).
+ */
+export interface FaithfulnessCheckInput {
+  factText: string;
+  quote: string;
+  context?: string;
+}
+
+/**
+ * Shape persisted to frontmatter (issue #1576). Serialized as a single JSON
+ * line so it round-trips through the existing YAML parser without special
+ * handling.
+ *
+ * `verdict: "unchecked"` marks a fact that entered the gate but could not be
+ * evaluated (backend failure, timeout). It is distinct from the field being
+ * absent (which means the gate was off entirely or the fact predates #1576).
+ */
+
+// ---------------------------------------------------------------------------
+// Sealed prompt (hash lets #1573-style caching key on it)
+// ---------------------------------------------------------------------------
+
+const FAITHFULNESS_SYSTEM_PROMPT = `You are a faithfulness verifier for a memory system. Given a QUOTE from the source conversation and an extracted FACT, determine whether the FACT is supported by the QUOTE.
+
+Rules:
+- "entailed" — the FACT directly follows from the QUOTE (paraphrase is OK).
+- "contradicted" — the FACT asserts something the QUOTE directly negates.
+- "unsupported" — the FACT introduces information not present in the QUOTE.
+
+Answer with a JSON array. Each element: {"index": <int>, "verdict": "entailed"|"contradicted"|"unsupported", "rationale": "<one sentence>"}.
+
+Examples:
+QUOTE: "I've been using Vim for about ten years now."
+FACT: "The user has used Vim for approximately a decade."
+{"index": 0, "verdict": "entailed", "rationale": "Paraphrase of the same duration."}
+
+QUOTE: "I've been using Vim for about ten years now."
+FACT: "The user prefers Emacs."
+{"index": 0, "verdict": "unsupported", "rationale": "QUOTE mentions Vim, not Emacs."}
+
+QUOTE: "I stopped drinking coffee last month."
+FACT: "The user drinks coffee regularly."
+{"index": 0, "verdict": "contradicted", "rationale": "QUOTE says they stopped; FACT claims the opposite."}`;
+
+/**
+ * SHA-256 hash of the sealed system prompt. Cache keys and prompt-version
+ * telemetry include this so a prompt change is detectable (#1573-style
+ * caching can invalidate stale entries).
+ */
+export const FAITHFULNESS_PROMPT_HASH = createHash("sha256")
+  .update(FAITHFULNESS_SYSTEM_PROMPT)
+  .digest("hex");
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the user-prompt payload for a batch of (fact, quote) pairs.
+ * Each pair is numbered so the LLM's response can be correlated back.
+ *
+ * Context (when provided) is included after the quote, clearly delimited,
+ * so the model knows it is supplementary — not the primary evidence.
+ */
+function buildBatchPrompt(inputs: FaithfulnessCheckInput[], contextChars: number): string {
+  const parts: string[] = [];
+  for (let i = 0; i < inputs.length; i++) {
+    const inp = inputs[i];
+    if (!inp) continue;
+    const quote = inp.quote.slice(0, contextChars);
+    parts.push(`--- Item ${i} ---
+QUOTE: "${quote}"`);
+    if (inp.context && inp.context.trim().length > 0) {
+      parts.push(`CONTEXT: "${inp.context.slice(0, contextChars)}"`);
+    }
+    parts.push(`FACT: "${inp.factText}"
+
+Respond with the JSON array entry for index ${i}.`);
+  }
+  parts.push(`\nRespond now with a single JSON array covering indexes 0–${inputs.length - 1}.`);
+  return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+const VALID_VERDICTS = new Set<string>(["entailed", "contradicted", "unsupported"]);
+
+/**
+ * Parsed LLM response entry — validated shape.
+ */
+interface ParsedFaithfulnessEntry {
+  index: number;
+  verdict: FaithfulnessVerdict;
+  rationale?: string;
+}
+
+/**
+ * Parse the LLM response into a map of index → entry. Returns null when the
+ * response is unparseable (rules 13/18: malformed output → tagged error,
+ * never a crash).
+ *
+ * Accepts both a bare JSON array and a JSON array embedded in surrounding
+ * text (the `extractJsonCandidates` helper handles fenced blocks and
+ * code-block-wrapped JSON).
+ */
+export function parseFaithfulnessResponse(
+  raw: string,
+  expectedCount: number,
+): Map<number, ParsedFaithfulnessEntry> | null {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+
+  const candidates = extractJsonCandidates(raw);
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    const map = parseEntries(parsed, expectedCount);
+    if (map) return map;
+  }
+
+  // Last resort: the model may have returned bare objects without array
+  // wrapping — try parsing the whole thing as a single entry.
+  try {
+    const single = JSON.parse(raw.trim());
+    const map = parseEntries([single], expectedCount);
+    if (map) return map;
+  } catch {
+    // fall through
+  }
+
+  return null;
+}
+
+function parseEntries(
+  data: unknown,
+  expectedCount: number,
+): Map<number, ParsedFaithfulnessEntry> | null {
+  if (!Array.isArray(data)) return null;
+  const map = new Map<number, ParsedFaithfulnessEntry>();
+  for (const entry of data) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const idx = typeof obj.index === "number" ? obj.index : undefined;
+    if (idx === undefined || idx < 0 || idx >= expectedCount) continue;
+    const verdictRaw = typeof obj.verdict === "string" ? obj.verdict : undefined;
+    if (!verdictRaw || !VALID_VERDICTS.has(verdictRaw)) continue;
+    const rationale =
+      typeof obj.rationale === "string" && obj.rationale.trim().length > 0
+        ? obj.rationale.trim().slice(0, 500)
+        : undefined;
+    map.set(idx, {
+      index: idx,
+      verdict: verdictRaw as FaithfulnessVerdict,
+      rationale,
+    });
+  }
+  return map.size > 0 ? map : null;
+}
+
+// ---------------------------------------------------------------------------
+// LLM call helper
+// ---------------------------------------------------------------------------
+
+interface LlmCallResult {
+  content: string | null;
+  modelUsed: string | null;
+}
+
+/**
+ * Call the model routing chain (local → fallback) with the faithfulness
+ * classification prompt. Mirrors `callJudgeLlm` in extraction-judge.ts so
+ * the same routing, model-override, and gateway-chain logic applies.
+ *
+ * Returns the raw content string and the model that produced it, or
+ * `{ content: null, modelUsed: null }` when every backend is unavailable.
+ */
+async function callFaithfulnessLlm(
+  systemPrompt: string,
+  userPrompt: string,
+  config: PluginConfig,
+  localLlm: LocalLlmClient | null,
+  fallbackLlm: FallbackLlmClient | null,
+  timeoutMs: number,
+): Promise<LlmCallResult> {
+  const messages: Array<{ role: "system" | "user"; content: string }> = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userPrompt },
+  ];
+
+  const modelOverride = config.extractionFaithfulnessModel || undefined;
+
+  // When modelSource is "gateway", skip localLlm and go directly to the
+  // gateway-routed backend (same precedence as the extraction judge).
+  const skipLocal = config.modelSource === "gateway";
+  const gatewayChain = gatewayTaskChainOptions(config);
+
+  let modelUsed: string | null = null;
+
+  // Try local LLM first (unless modelSource says gateway)
+  if (localLlm && !skipLocal) {
+    try {
+      const result = await callLocalLlm(localLlm, messages, {
+        temperature: 0.1,
+        maxTokens: 2048,
+        responseFormat: { type: "json_object" },
+        timeoutMs,
+        operation: "extraction-faithfulness",
+        ...(modelOverride ? { model: modelOverride } : {}),
+      });
+      if (result.content) {
+        return { content: result.content, modelUsed: result.modelUsed ?? "local" };
+      }
+    } catch (err) {
+      log.debug(
+        `extraction-faithfulness: local LLM failed, trying fallback: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Try fallback LLM
+  if (fallbackLlm) {
+    try {
+      const result = await fallbackLlm.chatCompletion(
+        messages as Array<{ role: "system" | "user" | "assistant"; content: string }>,
+        {
+          temperature: 0.1,
+          maxTokens: 2048,
+          timeoutMs,
+          ...(modelOverride ? { model: modelOverride } : {}),
+          ...gatewayChain,
+        },
+      );
+      if (result?.content) {
+        return { content: result.content, modelUsed: result.modelUsed ?? "fallback" };
+      }
+    } catch (err) {
+      log.debug(
+        `extraction-faithfulness: fallback LLM failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return { content: null, modelUsed: null };
+}
+
+/**
+ * Call the local LLM's chatCompletion through a narrow, typed interface.
+ * LocalLlmClient.chatCompletion accepts an options bag that includes an
+ * `operation` discriminator; we forward it so the client can route
+ * appropriately.
+ */
+interface LocalLlmCallOptions {
+  temperature: number;
+  maxTokens: number;
+  responseFormat?: { type: string };
+  timeoutMs: number;
+  operation: string;
+  model?: string;
+}
+
+interface LocalLlmCallResponse {
+  content: string | null;
+  modelUsed?: string;
+}
+
+async function callLocalLlm(
+  client: LocalLlmClient,
+  messages: Array<{ role: "system" | "user"; content: string }>,
+  options: LocalLlmCallOptions,
+): Promise<LocalLlmCallResponse> {
+  // LocalLlmClient.chatCompletion returns { content: string } — we use a
+  // typed call signature so no `any` leaks. The local client does not
+  // expose modelUsed, so we return "local" as the model identifier.
+  const result = await client.chatCompletion(messages, options);
+  return {
+    content: result?.content ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core batch check
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a batch faithfulness check — per-input results plus timing.
+ */
+export interface FaithfulnessBatchResult {
+  results: FaithfulnessResult[];
+  /** Wall-clock duration of the LLM call (0 when backend was not called). */
+  elapsedMs: number;
+}
+
+/**
+ * Evaluate a batch of (fact, quote) pairs for faithfulness.
+ *
+ * - Calls the LLM once with all pairs (bounded by `inputs.length`).
+ * - On timeout → every input gets `{ ok: false, code: "timeout" }`.
+ * - On backend unavailable → `{ ok: false, code: "backend_unavailable" }`.
+ * - On malformed output → `{ ok: false, code: "malformed_output" }`.
+ * - Inputs with empty quotes get `{ ok: false, code: "no_span" }` and are
+ *   NOT sent to the LLM.
+ *
+ * No module-level state: the caller (orchestrator) owns any caches.
+ */
+export async function checkFaithfulnessBatch(
+  inputs: FaithfulnessCheckInput[],
+  config: PluginConfig,
+  localLlm: LocalLlmClient | null,
+  fallbackLlm: FallbackLlmClient | null,
+): Promise<FaithfulnessBatchResult> {
+  const timeoutMs =
+    typeof config.extractionFaithfulnessTimeoutMs === "number" &&
+    Number.isFinite(config.extractionFaithfulnessTimeoutMs) &&
+    config.extractionFaithfulnessTimeoutMs > 0
+      ? config.extractionFaithfulnessTimeoutMs
+      : 8000;
+
+  const contextChars =
+    typeof config.extractionFaithfulnessContextChars === "number" &&
+    Number.isFinite(config.extractionFaithfulnessContextChars) &&
+    config.extractionFaithfulnessContextChars > 0
+      ? config.extractionFaithfulnessContextChars
+      : 400;
+
+  // Partition: inputs with a real quote vs. inputs without one.
+  const results: FaithfulnessResult[] = new Array(inputs.length);
+  const checkableIndices: number[] = [];
+  const checkableInputs: FaithfulnessCheckInput[] = [];
+
+  for (let i = 0; i < inputs.length; i++) {
+    const inp = inputs[i];
+    if (!inp || !inp.quote || inp.quote.trim().length === 0) {
+      results[i] = { ok: false, error: { code: "no_span" } };
+    } else if (!inp.factText || inp.factText.trim().length === 0) {
+      results[i] = { ok: false, error: { code: "no_span" } };
+    } else {
+      checkableIndices.push(i);
+      checkableInputs.push(inp);
+    }
+  }
+
+  if (checkableInputs.length === 0) {
+    return { results, elapsedMs: 0 };
+  }
+
+  const userPrompt = buildBatchPrompt(checkableInputs, contextChars);
+  const startedAt = Date.now();
+
+  let timedOut = false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    const llmResult = await callFaithfulnessLlm(
+      FAITHFULNESS_SYSTEM_PROMPT,
+      userPrompt,
+      config,
+      localLlm,
+      fallbackLlm,
+      timeoutMs,
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    if (timedOut) {
+      for (const idx of checkableIndices) {
+        results[idx] = { ok: false, error: { code: "timeout" } };
+      }
+      return { results, elapsedMs };
+    }
+
+    if (!llmResult.content) {
+      for (const idx of checkableIndices) {
+        results[idx] = { ok: false, error: { code: "backend_unavailable" } };
+      }
+      return { results, elapsedMs };
+    }
+
+    const parsed = parseFaithfulnessResponse(llmResult.content, checkableInputs.length);
+    if (!parsed) {
+      for (const idx of checkableIndices) {
+        results[idx] = { ok: false, error: { code: "malformed_output" } };
+      }
+      return { results, elapsedMs };
+    }
+
+    for (let j = 0; j < checkableIndices.length; j++) {
+      const inputIdx = checkableIndices[j];
+      if (inputIdx === undefined) continue;
+      const entry = parsed.get(j);
+      if (entry) {
+        results[inputIdx] = {
+          ok: true,
+          verdict: entry.verdict,
+          model: llmResult.modelUsed ?? "unknown",
+          ...(entry.rationale ? { rationale: entry.rationale } : {}),
+        };
+      } else {
+        // LLM response was missing this index
+        results[inputIdx] = { ok: false, error: { code: "malformed_output" } };
+      }
+    }
+
+    return { results, elapsedMs };
+  } catch (err) {
+    const elapsedMs = Date.now() - startedAt;
+    if (timedOut || isAbortError(err)) {
+      for (const idx of checkableIndices) {
+        results[idx] = { ok: false, error: { code: "timeout" } };
+      }
+      return { results, elapsedMs };
+    }
+    log.warn(
+      `extraction-faithfulness: batch check threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    for (const idx of checkableIndices) {
+      results[idx] = { ok: false, error: { code: "backend_unavailable" } };
+    }
+    return { results, elapsedMs };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const maybe = err as { name?: string; message?: string };
+  return (
+    maybe.name === "AbortError" ||
+    maybe.message === "This operation was aborted" ||
+    maybe.message === "The operation was aborted"
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Extraction-path orchestration helpers (issue #1576)
+//
+// These wrap checkFaithfulnessBatch + verdict application so the orchestrator
+// holds only thin delegation (ground rule 4: god files gain thin wiring only).
+// The core algorithm lives above; these are call-site glue.
+// ---------------------------------------------------------------------------
+
+/**
+ * Telemetry counters for the faithfulness gate. Hang off the orchestrator
+ * instance (rule 11: no module-level state) and surface via console_state so
+ * `remnic doctor` renders the verdict distribution.
+ */
+export interface FaithfulnessGateCounters {
+  entailed: number;
+  contradicted: number;
+  unsupported: number;
+  unchecked: number;
+  skippedNoSpan: number;
+}
+
+/**
+ * Create a fresh zeroed counters object. Callers store it on the orchestrator
+ * instance and pass it by reference to the gate helpers, which mutate it.
+ */
+export function createFaithfulnessCounters(): FaithfulnessGateCounters {
+  return { entailed: 0, contradicted: 0, unsupported: 0, unchecked: 0, skippedNoSpan: 0 };
+}
+
+/**
+ * Structural slice of an extracted fact that the gate reads. Kept loose so
+ * this pure module does not depend on the full `ExtractedFact` type.
+ */
+export interface FaithfulnessGateFact {
+  content: string;
+  sources?: { quote?: string }[];
+}
+
+/**
+ * Run the faithfulness batch over a list of extracted facts and return a map
+ * keyed by the ORIGINAL fact index → result. Facts without a usable verified
+ * source span are omitted from the batch (they are tagged `skipped_no_span`
+ * at apply time, never gated — don't punish legacy data). Updates `counters`
+ * for console_state telemetry.
+ *
+ * Fail-open: any pipeline error is caught, logged, and an empty map returned
+ * so the caller records `unchecked`/`skipped_no_span` and proceeds — a gate
+ * outage must never block memory writes (checklist §4).
+ */
+export async function runFaithfulnessGateBatch(
+  facts: readonly FaithfulnessGateFact[],
+  mode: "shadow" | "enforce",
+  config: PluginConfig,
+  localLlm: LocalLlmClient | null,
+  fallbackLlm: FallbackLlmClient | null,
+  counters: FaithfulnessGateCounters,
+): Promise<Map<number, FaithfulnessResult> | null> {
+  const resultsByFactIndex = new Map<number, FaithfulnessResult>();
+  try {
+    const inputs: { factIndex: number; input: FaithfulnessCheckInput }[] = [];
+    for (let fi = 0; fi < facts.length; fi++) {
+      const f = facts[fi];
+      if (!f || typeof f.content !== "string" || !f.content.trim()) continue;
+      const sources = Array.isArray(f.sources) ? f.sources : [];
+      if (sources.length === 0) continue; // no verified span — skip, don't gate
+      const firstSource = sources[0];
+      if (!firstSource || typeof firstSource.quote !== "string" || !firstSource.quote.trim()) {
+        continue;
+      }
+      inputs.push({
+        factIndex: fi,
+        input: { factText: f.content, quote: firstSource.quote },
+      });
+    }
+    if (inputs.length === 0) return resultsByFactIndex;
+    const batch = await checkFaithfulnessBatch(
+      inputs.map((x) => x.input),
+      config,
+      localLlm,
+      fallbackLlm,
+    );
+    for (let j = 0; j < inputs.length; j++) {
+      const entry = inputs[j];
+      if (entry) resultsByFactIndex.set(entry.factIndex, batch.results[j]!);
+    }
+    for (const result of batch.results) {
+      if (result.ok) {
+        if (result.verdict === "entailed") counters.entailed++;
+        else if (result.verdict === "contradicted") counters.contradicted++;
+        else if (result.verdict === "unsupported") counters.unsupported++;
+      } else {
+        counters.unchecked++;
+      }
+    }
+    log.info(
+      `extraction-faithfulness[${mode}]: ${inputs.length} facts checked, ` +
+        `entailed=${counters.entailed} contradicted=${counters.contradicted} ` +
+        `unsupported=${counters.unsupported} unchecked=${counters.unchecked}, ` +
+        `${batch.elapsedMs}ms`,
+    );
+  } catch (err) {
+    // Fail-open: a pipeline error never blocks writes (checklist §4). Return
+    // null so applyFaithfulnessVerdict records nothing (the gate did not run),
+    // mirroring mode=off — distinct from the empty-map case where facts had no
+    // sources and should be tagged skipped_no_span.
+    log.warn(
+      `extraction-faithfulness: pipeline error, proceeding without gating (fail-open): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+  return resultsByFactIndex;
+}
+
+/**
+ * Apply a pre-computed faithfulness verdict to a single fact, producing the
+ * frontmatter record + an optional enforce-mode `pending_review` status.
+ *
+ * - `resultsByFactIndex` null (gate off) → nothing (rule 39: byte-identical).
+ * - fact has no entry (no verified span) → `skipped_no_span`, never gated.
+ * - backend failure (`ok: false`) → `unchecked`, fact proceeds (checklist §4).
+ * - enforce + unsupported/contradicted → `pending_review` (memory persists,
+ *   enters the review queue, never silently dropped).
+ *
+ * Mutates `counters.skippedNoSpan` for facts without a span.
+ */
+export function applyFaithfulnessVerdict(
+  resultsByFactIndex: Map<number, FaithfulnessResult> | null,
+  factLoopIndex: number,
+  mode: "off" | "shadow" | "enforce",
+  factContent: string,
+  counters: FaithfulnessGateCounters,
+): {
+  faithfulness: FaithfulnessFrontmatter | undefined;
+  enforceStatus: "pending_review" | undefined;
+} {
+  if (!resultsByFactIndex) {
+    return { faithfulness: undefined, enforceStatus: undefined };
+  }
+  const result = resultsByFactIndex.get(factLoopIndex);
+  if (!result) {
+    // No result for this fact index — it had no verified source span.
+    counters.skippedNoSpan++;
+    return {
+      faithfulness: { verdict: "skipped_no_span", at: new Date().toISOString() },
+      enforceStatus: undefined,
+    };
+  }
+  if (result.ok) {
+    const fm: FaithfulnessFrontmatter = {
+      verdict: result.verdict,
+      ...(result.model ? { model: result.model } : {}),
+      ...(result.rationale ? { rationale: result.rationale } : {}),
+      at: new Date().toISOString(),
+    };
+    let enforceStatus: "pending_review" | undefined;
+    if (
+      mode === "enforce" &&
+      (result.verdict === "unsupported" || result.verdict === "contradicted")
+    ) {
+      enforceStatus = "pending_review";
+      log.info(
+        `extraction-faithfulness[enforce]: routing "${factContent.slice(0, 60)}…" to pending_review (verdict=${result.verdict})`,
+      );
+    }
+    return { faithfulness: fm, enforceStatus };
+  }
+  // Backend failure — record as unchecked, fact proceeds (graceful degradation).
+  return {
+    faithfulness: { verdict: "unchecked", at: new Date().toISOString() },
+    enforceStatus: undefined,
+  };
+}
+// ---------------------------------------------------------------------------
+// Frontmatter serialization (single-line JSON, like provenance sources)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical key order for the serialized `faithfulness` frontmatter field.
+ * Deterministic emission (rule 38).
+ */
+const FAITHFULNESS_KEY_ORDER = ["verdict", "model", "rationale", "at"] as const;
+
+/**
+ * Serialize the `faithfulness` frontmatter field as a single JSON line,
+ * appended to `lines`. Called from `serializeFrontmatter` in storage.ts.
+ *
+ * Contract: when `fm.faithfulness` is absent, no line is emitted — the
+ * memory round-trips byte-identical to pre-#1576 behavior (rule 39).
+ */
+export function serializeFaithfulnessFields(fm: MemoryFrontmatter, lines: string[]): void {
+  if (!fm.faithfulness) return;
+  const fm2 = fm.faithfulness;
+  const canonical: Record<string, unknown> = {};
+  for (const key of FAITHFULNESS_KEY_ORDER) {
+    const val = fm2[key];
+    if (val !== undefined && val !== null && val !== "") {
+      canonical[key] = val;
+    }
+  }
+  // verdict is always present on a valid FaithfulnessFrontmatter
+  if (!canonical.verdict) return;
+  lines.push(`faithfulness: ${JSON.stringify(canonical)}`);
+}
+
+/**
+ * Parse the `faithfulness` frontmatter line from its single-line JSON form.
+ * Returns `undefined` for missing, blank, or corrupt values so a malformed
+ * frontmatter never poisons downstream readers (rule 34 spirit).
+ */
+export function parseFaithfulnessField(
+  raw: string | undefined,
+): FaithfulnessFrontmatter | undefined {
+  if (!raw || typeof raw !== "string" || raw.trim().length === 0) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const obj = parsed as Record<string, unknown>;
+    const verdictRaw = typeof obj.verdict === "string" ? obj.verdict : undefined;
+    if (!verdictRaw) return undefined;
+    const validVerdicts = new Set([
+      "entailed",
+      "contradicted",
+      "unsupported",
+      "unchecked",
+      "skipped_no_span",
+    ]);
+    if (!validVerdicts.has(verdictRaw)) return undefined;
+    const result: FaithfulnessFrontmatter = {
+      verdict: verdictRaw as FaithfulnessFrontmatter["verdict"],
+    };
+    if (typeof obj.model === "string" && obj.model.length > 0) {
+      result.model = obj.model;
+    }
+    if (typeof obj.rationale === "string" && obj.rationale.length > 0) {
+      result.rationale = obj.rationale.slice(0, 500);
+    }
+    if (typeof obj.at === "string" && obj.at.length > 0) {
+      result.at = obj.at;
+    }
+    return result;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -454,7 +454,11 @@ export async function checkFaithfulnessBatch(
     );
     const elapsedMs = Date.now() - startedAt;
 
-    if (timedOut) {
+    // Cursor review: if the LLM returned usable content, use it even when
+    // the abort timer raced — a response that lands just as the timer fires
+    // has real verdicts. Only fall back to timeout errors when there is no
+    // content to parse (the call genuinely did not complete in time).
+    if (timedOut && !llmResult.content) {
       for (const idx of checkableIndices) {
         results[idx] = { ok: false, error: { code: "timeout" } };
       }

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -286,7 +286,13 @@ async function callFaithfulnessLlm(
 
   let modelUsed: string | null = null;
 
-  // Try local LLM first (only when no override routes the call to gateway)
+  // Try local LLM first (only when no override routes the call to gateway).
+  // The local client uses its OWN per-attempt AbortController keyed on
+  // `timeoutMs` (it does not read options.signal — see LocalLlmChatCompletionOptions),
+  // so the batch `signal` is not forwarded here; `timeoutMs` bounds each local
+  // attempt instead. The batch AbortController still governs the fallback path,
+  // which DOES honor the signal. (Matches extraction-judge.ts, which also passes
+  // no signal to the local client.)
   if (localLlm && !skipLocal) {
     try {
       const result = await callLocalLlm(localLlm, messages, {
@@ -295,7 +301,6 @@ async function callFaithfulnessLlm(
         responseFormat: { type: "json_object" },
         timeoutMs,
         operation: "extraction-faithfulness",
-        ...(signal ? { signal } : {}),
       });
       if (result.content) {
         return { content: result.content, modelUsed: result.modelUsed ?? "local" };
@@ -346,8 +351,6 @@ interface LocalLlmCallOptions {
   responseFormat?: { type: string };
   timeoutMs: number;
   operation: string;
-  model?: string;
-  signal?: AbortSignal;
 }
 
 interface LocalLlmCallResponse {

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -275,14 +275,18 @@ async function callFaithfulnessLlm(
 
   const modelOverride = config.extractionFaithfulnessModel || undefined;
 
-  // When modelSource is "gateway", skip localLlm and go directly to the
-  // gateway-routed backend (same precedence as the extraction judge).
-  const skipLocal = config.modelSource === "gateway";
+  // Skip the local backend when (a) modelSource is "gateway", or (b) a
+  // faithfulness model override is set. The local client always sends
+  // config.localLlmModel and silently ignores options.model, so a local
+  // success would run the wrong model and prevent the override from ever
+  // reaching the gateway. Routing straight to the gateway honors the
+  // override (codex review PRRT_kwDORJXyws6ObYQ8).
+  const skipLocal = config.modelSource === "gateway" || Boolean(modelOverride);
   const gatewayChain = gatewayTaskChainOptions(config);
 
   let modelUsed: string | null = null;
 
-  // Try local LLM first (unless modelSource says gateway)
+  // Try local LLM first (only when no override routes the call to gateway)
   if (localLlm && !skipLocal) {
     try {
       const result = await callLocalLlm(localLlm, messages, {
@@ -291,7 +295,6 @@ async function callFaithfulnessLlm(
         responseFormat: { type: "json_object" },
         timeoutMs,
         operation: "extraction-faithfulness",
-        ...(modelOverride ? { model: modelOverride } : {}),
         ...(signal ? { signal } : {}),
       });
       if (result.content) {
@@ -697,14 +700,19 @@ export async function runFaithfulnessGateBatch(
   for (let fi = 0; fi < facts.length; fi++) {
     const f = facts[fi];
     if (!f || typeof f.content !== "string" || !f.content.trim()) continue;
-    // Prefer a #1575 verified span; fall back to a located quote from the
+    // Prefer #1575 verified spans; fall back to a located quote from the
     // source turn text so the gate runs even before per-fact sources are
     // attached. Without either, the fact is skipped_no_span (never gated).
+    // A composite fact may be supported by multiple adjacent spans — collect
+    // every valid source quote so the verifier sees the full evidence, not
+    // just sources[0] (codex review PRRT_kwDORJXyws6ObYQ_).
     const sources = Array.isArray(f.sources) ? f.sources : [];
-    const firstSource = sources[0];
+    const sourceQuotes = sources
+      .map((s) => (s && typeof s.quote === "string" ? s.quote.trim() : ""))
+      .filter((q) => q.length > 0);
     const quote =
-      firstSource && typeof firstSource.quote === "string" && firstSource.quote.trim()
-        ? firstSource.quote
+      sourceQuotes.length > 0
+        ? sourceQuotes.join("\n")
         : locateFactQuote(f.content, sourceText);
     if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
     inputs.push({ factIndex: fi, input: { factText: f.content, quote } });

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -680,25 +680,29 @@ export async function runFaithfulnessGateBatch(
    */
   sourceText = "",
 ): Promise<Map<number, FaithfulnessResult> | null> {
+  // Phase 1 — build the checkable inputs. This is pure (no LLM, no throw):
+  // locateFactQuote and the source/span selection never reject. Keeping it
+  // outside the try lets the catch walk the same inputs to tag a pipeline
+  // failure as "unchecked" rather than dropping it on the floor.
+  const inputs: { factIndex: number; input: FaithfulnessCheckInput }[] = [];
+  for (let fi = 0; fi < facts.length; fi++) {
+    const f = facts[fi];
+    if (!f || typeof f.content !== "string" || !f.content.trim()) continue;
+    // Prefer a #1575 verified span; fall back to a located quote from the
+    // source turn text so the gate runs even before per-fact sources are
+    // attached. Without either, the fact is skipped_no_span (never gated).
+    const sources = Array.isArray(f.sources) ? f.sources : [];
+    const firstSource = sources[0];
+    const quote =
+      firstSource && typeof firstSource.quote === "string" && firstSource.quote.trim()
+        ? firstSource.quote
+        : locateFactQuote(f.content, sourceText);
+    if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
+    inputs.push({ factIndex: fi, input: { factText: f.content, quote } });
+  }
   const resultsByFactIndex = new Map<number, FaithfulnessResult>();
+  if (inputs.length === 0) return resultsByFactIndex;
   try {
-    const inputs: { factIndex: number; input: FaithfulnessCheckInput }[] = [];
-    for (let fi = 0; fi < facts.length; fi++) {
-      const f = facts[fi];
-      if (!f || typeof f.content !== "string" || !f.content.trim()) continue;
-      // Prefer a #1575 verified span; fall back to a located quote from the
-      // source turn text so the gate runs even before per-fact sources are
-      // attached. Without either, the fact is skipped_no_span (never gated).
-      const sources = Array.isArray(f.sources) ? f.sources : [];
-      const firstSource = sources[0];
-      const quote =
-        firstSource && typeof firstSource.quote === "string" && firstSource.quote.trim()
-          ? firstSource.quote
-          : locateFactQuote(f.content, sourceText);
-      if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
-      inputs.push({ factIndex: fi, input: { factText: f.content, quote } });
-    }
-    if (inputs.length === 0) return resultsByFactIndex;
     const batch = await checkFaithfulnessBatch(
       inputs.map((x) => x.input),
       config,
@@ -717,14 +721,18 @@ export async function runFaithfulnessGateBatch(
       `extraction-faithfulness[${mode}]: ${inputs.length} facts checked, ${batch.elapsedMs}ms`,
     );
   } catch (err) {
-    // Fail-open: a pipeline error never blocks writes (checklist §4). Return
-    // null so applyFaithfulnessVerdict records nothing (the gate did not run),
-    // mirroring mode=off — distinct from the empty-map case where facts had no
-    // sources and should be tagged skipped_no_span.
+    // Fail-open: a pipeline error never blocks writes (checklist §4). Tag each
+    // checkable fact as backend_unavailable so applyFaithfulnessVerdict records
+    // "unchecked" (issue spec: backend failure → unchecked). Returning null
+    // here would make a shadow/enforce batch failure indistinguishable from
+    // gate-off, losing the telemetry signal (cursor review). Facts with no
+    // located span stay absent → skipped_no_span at apply time.
     log.warn(
-      `extraction-faithfulness: pipeline error, proceeding without gating (fail-open): ${err instanceof Error ? err.message : String(err)}`,
+      `extraction-faithfulness: pipeline error, tagging ${inputs.length} checkable facts as unchecked (fail-open): ${err instanceof Error ? err.message : String(err)}`,
     );
-    return null;
+    for (const { factIndex } of inputs) {
+      resultsByFactIndex.set(factIndex, { ok: false, error: { code: "backend_unavailable" } });
+    }
   }
   return resultsByFactIndex;
 }

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -691,6 +691,35 @@ const LOCATE_QUOTE_MIN_OVERLAP = 0.3;
  * consumes a span, not the whole conversation (issue #1576 design constraint).
  * #1575's NLI-verified per-fact locator will replace this when it lands.
  */
+/**
+ * Extract a bounded window of `sourceText` centered on the located `quote`,
+ * bounded by `contextChars` (the config's "window around the quote" semantics).
+ *
+ * Used by the fallback-locator path in `runFaithfulnessGateBatch` so the
+ * verifier sees surrounding turn text — without it,
+ * `extractionFaithfulnessContextChars` is effectively ignored in the
+ * production path (codex review PRRT_kwDORJXyws6OblI1). Returns undefined when
+ * the quote is absent from sourceText (e.g. it was truncated by maxQuoteChars).
+ */
+export function extractContextWindow(
+  sourceText: string,
+  quote: string,
+  contextChars: number,
+): string | undefined {
+  if (!sourceText || !quote || !(contextChars > 0)) return undefined;
+  const idx = sourceText.indexOf(quote);
+  if (idx < 0) return undefined;
+  const quoteEnd = idx + quote.length;
+  const center = Math.floor((idx + quoteEnd) / 2);
+  const half = Math.floor(contextChars / 2);
+  let start = Math.max(0, center - half);
+  const end = Math.min(sourceText.length, start + contextChars);
+  // Re-anchor start so the window uses the full budget when end clamped.
+  start = Math.max(0, end - contextChars);
+  const window = sourceText.slice(start, end).trim();
+  return window.length > 0 ? window : undefined;
+}
+
 export function locateFactQuote(
   factText: string,
   sourceText: string,
@@ -750,12 +779,32 @@ export async function runFaithfulnessGateBatch(
     const sourceQuotes = sources
       .map((s) => (s && typeof s.quote === "string" ? s.quote.trim() : ""))
       .filter((q) => q.length > 0);
+    const usingFallbackLocator = sourceQuotes.length === 0;
     const quote =
       sourceQuotes.length > 0
         ? sourceQuotes.join("\n")
         : locateFactQuote(f.content, sourceText);
     if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
-    inputs.push({ factIndex: fi, input: { factText: f.content, quote } });
+    // Pass source context into the verifier so extractionFaithfulnessContextChars
+    // actually applies in the fallback-locator path (codex P2
+    // PRRT_kwDORJXyws6OblI1). #1575 verified spans already carry full evidence,
+    // so context is only synthesized for the fallback locator.
+    const fallbackContext =
+      usingFallbackLocator
+        ? extractContextWindow(
+            sourceText,
+            quote,
+            config.extractionFaithfulnessContextChars,
+          )
+        : undefined;
+    inputs.push({
+      factIndex: fi,
+      input: {
+        factText: f.content,
+        quote,
+        ...(fallbackContext ? { context: fallbackContext } : {}),
+      },
+    });
   }
   const resultsByFactIndex = new Map<number, FaithfulnessResult>();
   if (inputs.length === 0) return resultsByFactIndex;

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -220,7 +220,20 @@ function parseEntries(
   data: unknown,
   expectedCount: number,
 ): Map<number, ParsedFaithfulnessEntry> | null {
-  if (!Array.isArray(data)) return null;
+  if (!Array.isArray(data)) {
+    // Accept object-wrapped arrays — {"results":[...]}, {"verdicts":[...]},
+    // {"entries":[...]}, {"facts":[...]} — a common JSON-object prompt shape the
+    // extraction-judge parser already accepts. Rejecting them marked the whole
+    // batch malformed_output; in enforce mode those facts then wrote as ACTIVE
+    // (gate bypass — codex Ob4RO).
+    if (data && typeof data === "object") {
+      for (const key of ["results", "verdicts", "entries", "facts"]) {
+        const inner = (data as Record<string, unknown>)[key];
+        if (Array.isArray(inner)) return parseEntries(inner, expectedCount);
+      }
+    }
+    return null;
+  }
   const map = new Map<number, ParsedFaithfulnessEntry>();
   for (const entry of data) {
     if (!entry || typeof entry !== "object") continue;

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -266,6 +266,7 @@ async function callFaithfulnessLlm(
   localLlm: LocalLlmClient | null,
   fallbackLlm: FallbackLlmClient | null,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<LlmCallResult> {
   const messages: Array<{ role: "system" | "user"; content: string }> = [
     { role: "system", content: systemPrompt },
@@ -291,6 +292,7 @@ async function callFaithfulnessLlm(
         timeoutMs,
         operation: "extraction-faithfulness",
         ...(modelOverride ? { model: modelOverride } : {}),
+        ...(signal ? { signal } : {}),
       });
       if (result.content) {
         return { content: result.content, modelUsed: result.modelUsed ?? "local" };
@@ -313,6 +315,7 @@ async function callFaithfulnessLlm(
           timeoutMs,
           ...(modelOverride ? { model: modelOverride } : {}),
           ...gatewayChain,
+          ...(signal ? { signal } : {}),
         },
       );
       if (result?.content) {
@@ -341,6 +344,7 @@ interface LocalLlmCallOptions {
   timeoutMs: number;
   operation: string;
   model?: string;
+  signal?: AbortSignal;
 }
 
 interface LocalLlmCallResponse {
@@ -446,6 +450,7 @@ export async function checkFaithfulnessBatch(
       localLlm,
       fallbackLlm,
       timeoutMs,
+      controller.signal,
     );
     const elapsedMs = Date.now() - startedAt;
 

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -443,13 +443,23 @@ export async function checkFaithfulnessBatch(
 
   let timedOut = false;
   const controller = new AbortController();
+  // Race the LLM call against the budget so the batch fails open at
+  // `timeoutMs` regardless of which backend is in flight. The local backend
+  // ignores the batch AbortSignal (it aborts each attempt via its own
+  // controller keyed on `timeoutMs`), so awaiting callFaithfulnessLlm directly
+  // could block past the budget on a slow/retrying local verifier. The timer
+  // both aborts the fallback (which honors the signal) and resolves the race
+  // so the batch returns promptly; the in-flight local call aborts on its own
+  // per-attempt timeoutMs. (codex review PRRT_kwDORJXyws6ObgMJ.)
+  const { promise: racedTimeout, resolve: resolveTimeout } = Promise.withResolvers<true>();
   const timer = setTimeout(() => {
     timedOut = true;
     controller.abort();
+    resolveTimeout(true);
   }, timeoutMs);
 
   try {
-    const llmResult = await callFaithfulnessLlm(
+    const callPromise = callFaithfulnessLlm(
       FAITHFULNESS_SYSTEM_PROMPT,
       userPrompt,
       config,
@@ -458,7 +468,28 @@ export async function checkFaithfulnessBatch(
       timeoutMs,
       controller.signal,
     );
+    const settled = await Promise.race([
+      callPromise.then(
+        (r) => ({ done: true as const, result: r }),
+        // An unexpected throw is treated as "no content" (backend_unavailable)
+        // so the race never rejects and the outer catch is the final safety net.
+        () => ({ done: true as const, result: { content: null, modelUsed: null } }),
+      ),
+      racedTimeout.then(() => ({ done: false as const })),
+    ]);
     const elapsedMs = Date.now() - startedAt;
+
+    if (!settled.done) {
+      // The budget elapsed before any backend returned content. Fail open as
+      // timeout; the orphaned callPromise resolves/rejects harmlessly (the
+      // fallback was aborted; the local client aborts on its own timeoutMs).
+      for (const idx of checkableIndices) {
+        results[idx] = { ok: false, error: { code: "timeout" } };
+      }
+      return { results, elapsedMs };
+    }
+
+    const llmResult = settled.result;
 
     // Cursor review: if the LLM returned usable content, use it even when
     // the abort timer raced — a response that lands just as the timer fires

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -141,9 +141,13 @@ function buildBatchPrompt(inputs: FaithfulnessCheckInput[], contextChars: number
   for (let i = 0; i < inputs.length; i++) {
     const inp = inputs[i];
     if (!inp) continue;
-    const quote = inp.quote.slice(0, contextChars);
+    // The QUOTE is the primary entailment evidence and is already bounded
+    // upstream (provenance.maxQuoteChars / locateFactQuote). Send it whole
+    // so the verifier never judges entailment on a truncated span. Only the
+    // supplementary CONTEXT is bounded by contextChars (the config's "window
+    // around the quote" semantics — cursor review).
     parts.push(`--- Item ${i} ---
-QUOTE: "${quote}"`);
+QUOTE: "${inp.quote}"`);
     if (inp.context && inp.context.trim().length > 0) {
       parts.push(`CONTEXT: "${inp.context.slice(0, contextChars)}"`);
     }
@@ -565,6 +569,102 @@ export interface FaithfulnessGateFact {
  * so the caller records `unchecked`/`skipped_no_span` and proceeds — a gate
  * outage must never block memory writes (checklist §4).
  */
+// Common English stopwords — filtered before overlap scoring so function
+// words (the, a, is, ...) don't dilute the signal between a fact and its
+// source sentence.
+const STOPWORDS = new Set([
+  "the","a","an","and","or","but","is","are","was","were","be","been","being",
+  "to","of","in","on","at","for","with","from","by","as","it","its","this","that",
+  "these","those","i","you","he","she","we","they","my","your","his","her","our","their",
+  "has","have","had","do","does","did","will","would","can","could","should","not","no",
+  "s","very","really","just","so","than","then","there","here","about","into","over","under",
+]);
+
+/**
+ * Crude stemmer: strip common suffixes so "prefers"/"prefer",
+ * "using"/"use", "started"/"start" collapse to one token. Not a real
+ * stemmer — just enough to raise recall for the interim locator (#1575 will
+ * replace this with NLI-verified spans).
+ */
+function crudeStem(word: string): string {
+  if (word.length > 5 && word.endsWith("ing")) return word.slice(0, -3);
+  if (word.length > 4 && word.endsWith("ed")) return word.slice(0, -2);
+  if (word.length > 3 && (word.endsWith("s")) && !word.endsWith("ss")) return word.slice(0, -1);
+  return word;
+}
+
+/**
+ * Tokenize text into a lowercase, stopword-filtered, crudely-stemmed token
+ * set for overlap scoring.
+ */
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length <= 1) continue;
+    if (STOPWORDS.has(raw)) continue;
+    tokens.add(crudeStem(raw));
+  }
+  return tokens;
+}
+
+/**
+ * Overlap coefficient: |A ∩ B| / min(|A|, |B|). Robust for paraphrase
+ * matching where a short fact paraphrases a longer source sentence — a short
+ * fact fully supported by a long sentence scores high, unrelated text scores 0.
+ */
+function overlapCoefficient(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const t of small) if (large.has(t)) intersection++;
+  return intersection / small.size;
+}
+
+/**
+ * Minimum overlap for a located quote to be trusted as the fact's source span.
+ * Below this the fact is treated as having no located span (skipped_no_span)
+ * rather than judged against an unrelated sentence.
+ */
+const LOCATE_QUOTE_MIN_OVERLAP = 0.3;
+
+/**
+ * Locate the best-matching verbatim span (sentence) from the source turn text
+ * for an extracted fact, by token overlap. Returns the quote when a confident
+ * match is found, `undefined` otherwise (the gate then records
+ * skipped_no_span — never judged against an unrelated span).
+ *
+ * This is the interim source-text locator that makes the gate functional on
+ * real extraction output (where #1575 has not yet attached per-fact
+ * `sources`). It produces a genuine located quote per fact so the gate
+ * consumes a span, not the whole conversation (issue #1576 design constraint).
+ * #1575's NLI-verified per-fact locator will replace this when it lands.
+ */
+export function locateFactQuote(
+  factText: string,
+  sourceText: string,
+  maxQuoteChars = 600,
+): string | undefined {
+  if (!factText || !sourceText) return undefined;
+  const factTokens = tokenize(factText);
+  if (factTokens.size === 0) return undefined;
+  // Split source into candidate spans: sentences, then line segments as a
+  // fallback for transcripts without sentence punctuation.
+  const candidates: string[] = [];
+  for (const sentence of sourceText.split(/(?<=[.!?])\s+|\n+/)) {
+    const s = sentence.trim();
+    if (s.length > 0) candidates.push(s);
+  }
+  if (candidates.length === 0) return undefined;
+  let best: { quote: string; score: number } | null = null;
+  for (const candidate of candidates) {
+    const score = overlapCoefficient(factTokens, tokenize(candidate));
+    if (!best || score > best.score) best = { quote: candidate, score };
+  }
+  if (!best || best.score < LOCATE_QUOTE_MIN_OVERLAP) return undefined;
+  return best.quote.length > maxQuoteChars
+    ? best.quote.slice(0, maxQuoteChars)
+    : best.quote;
+}
 export async function runFaithfulnessGateBatch(
   facts: readonly FaithfulnessGateFact[],
   mode: "shadow" | "enforce",
@@ -572,6 +672,13 @@ export async function runFaithfulnessGateBatch(
   localLlm: LocalLlmClient | null,
   fallbackLlm: FallbackLlmClient | null,
   counters: FaithfulnessGateCounters,
+  /**
+   * The verbatim source turn text the facts were extracted from. When a fact
+   * has no #1575 `sources`, locateFactQuote finds a fallback span here so the
+   * gate runs on real extraction output. May be empty (replay/import paths
+   * with no source turns) — facts then get skipped_no_span.
+   */
+  sourceText = "",
 ): Promise<Map<number, FaithfulnessResult> | null> {
   const resultsByFactIndex = new Map<number, FaithfulnessResult>();
   try {
@@ -579,16 +686,17 @@ export async function runFaithfulnessGateBatch(
     for (let fi = 0; fi < facts.length; fi++) {
       const f = facts[fi];
       if (!f || typeof f.content !== "string" || !f.content.trim()) continue;
+      // Prefer a #1575 verified span; fall back to a located quote from the
+      // source turn text so the gate runs even before per-fact sources are
+      // attached. Without either, the fact is skipped_no_span (never gated).
       const sources = Array.isArray(f.sources) ? f.sources : [];
-      if (sources.length === 0) continue; // no verified span — skip, don't gate
       const firstSource = sources[0];
-      if (!firstSource || typeof firstSource.quote !== "string" || !firstSource.quote.trim()) {
-        continue;
-      }
-      inputs.push({
-        factIndex: fi,
-        input: { factText: f.content, quote: firstSource.quote },
-      });
+      const quote =
+        firstSource && typeof firstSource.quote === "string" && firstSource.quote.trim()
+          ? firstSource.quote
+          : locateFactQuote(f.content, sourceText);
+      if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
+      inputs.push({ factIndex: fi, input: { factText: f.content, quote } });
     }
     if (inputs.length === 0) return resultsByFactIndex;
     const batch = await checkFaithfulnessBatch(
@@ -601,20 +709,12 @@ export async function runFaithfulnessGateBatch(
       const entry = inputs[j];
       if (entry) resultsByFactIndex.set(entry.factIndex, batch.results[j]!);
     }
-    for (const result of batch.results) {
-      if (result.ok) {
-        if (result.verdict === "entailed") counters.entailed++;
-        else if (result.verdict === "contradicted") counters.contradicted++;
-        else if (result.verdict === "unsupported") counters.unsupported++;
-      } else {
-        counters.unchecked++;
-      }
-    }
+    // Verdict-distribution counters are bumped in applyFaithfulnessVerdict
+    // (at the per-fact apply point), NOT here, so console_state reflects
+    // facts that actually reached verdict application — not facts later
+    // dropped by dedup, importance, or judge gates (cursor review).
     log.info(
-      `extraction-faithfulness[${mode}]: ${inputs.length} facts checked, ` +
-        `entailed=${counters.entailed} contradicted=${counters.contradicted} ` +
-        `unsupported=${counters.unsupported} unchecked=${counters.unchecked}, ` +
-        `${batch.elapsedMs}ms`,
+      `extraction-faithfulness[${mode}]: ${inputs.length} facts checked, ${batch.elapsedMs}ms`,
     );
   } catch (err) {
     // Fail-open: a pipeline error never blocks writes (checklist §4). Return
@@ -664,6 +764,9 @@ export function applyFaithfulnessVerdict(
     };
   }
   if (result.ok) {
+    if (result.verdict === "entailed") counters.entailed++;
+    else if (result.verdict === "contradicted") counters.contradicted++;
+    else if (result.verdict === "unsupported") counters.unsupported++;
     const fm: FaithfulnessFrontmatter = {
       verdict: result.verdict,
       ...(result.model ? { model: result.model } : {}),
@@ -683,6 +786,7 @@ export function applyFaithfulnessVerdict(
     return { faithfulness: fm, enforceStatus };
   }
   // Backend failure — record as unchecked, fact proceeds (graceful degradation).
+  counters.unchecked++;
   return {
     faithfulness: { verdict: "unchecked", at: new Date().toISOString() },
     enforceStatus: undefined,

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -451,7 +451,13 @@ export async function checkFaithfulnessBatch(
   // both aborts the fallback (which honors the signal) and resolves the race
   // so the batch returns promptly; the in-flight local call aborts on its own
   // per-attempt timeoutMs. (codex review PRRT_kwDORJXyws6ObgMJ.)
-  const { promise: racedTimeout, resolve: resolveTimeout } = Promise.withResolvers<true>();
+  // Manual deferred instead of Promise.withResolvers (ES2024) — plugin-openclaw's
+  // standalone tsconfig targets ES2022 lib and this module is reachable from its
+  // type graph, so withResolvers would TS2550 there.
+  let resolveTimeout!: (value: true) => void;
+  const racedTimeout = new Promise<true>((resolve) => {
+    resolveTimeout = resolve;
+  });
   const timer = setTimeout(() => {
     timedOut = true;
     controller.abort();

--- a/packages/remnic-core/src/faithfulness-graph-guard.test.ts
+++ b/packages/remnic-core/src/faithfulness-graph-guard.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Issue #1576 — pending-review facts must NOT originate graph edges.
+ *
+ * When `extractionFaithfulnessGate="enforce"` routes an unsupported or
+ * contradicted fact to `pending_review`, the persist path still builds entity
+ * edges via `GraphIndex.onMemoryWritten`, so an unfaithful extraction in the
+ * review queue could change graph traversal/ranking for active memories even
+ * though direct recall filters later drop the pending file. The guard mirrors
+ * the existing supersession/promotion/artifact guards (codex P2
+ * PRRT_kwDORJXyws6OblI1's sibling thread PRRT_kwDORJXyws6OblI0).
+ *
+ * These tests exercise the real `persistExtraction` path end-to-end (no LLM
+ * network — the local LLM is stubbed to return controlled verdicts) and read
+ * the entity graph JSONL directly to prove the guard.
+ */
+
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { Orchestrator } from "./orchestrator.js";
+import { readEdges } from "./graph.js";
+import type { ExtractionResult, PluginConfig } from "./types.js";
+import type { LocalLlmClient } from "./local-llm.js";
+
+/**
+ * Stub local LLM whose `chatCompletion` only answers faithfulness-gate calls
+ * (operation === "extraction-faithfulness"). The verdict is chosen by a marker
+ * in the fact text so each persisted fact gets a deterministic, controllable
+ * verdict with no network. Non-faithfulness calls return null (fail-open skip).
+ */
+function faithfulnessStubLocalLlm(
+  verdictForFactContent: (factContent: string) => "entailed" | "unsupported",
+): LocalLlmClient {
+  return {
+    chatCompletion: async (
+      messages: Array<{ role: string; content: string }>,
+      options: { operation?: string } = {},
+    ) => {
+      if (options.operation !== "extraction-faithfulness") return null;
+      const userMsg = messages.find((m) => m.role === "user");
+      // The prompt emits `FACT: "<text>"` — fact text never contains a raw
+      // double-quote, so capture up to the closing quote.
+      const match = userMsg?.content.match(/FACT: "([^"]*)"/);
+      const factContent = match ? (match[1] ?? "") : "";
+      const verdict = verdictForFactContent(factContent);
+      return {
+        content: JSON.stringify([
+          { index: 0, verdict, rationale: "stub verdict" },
+        ]),
+      };
+    },
+  } as unknown as LocalLlmClient;
+}
+
+interface OrchHarness {
+  orchestrator: Orchestrator;
+  memoryDir: string;
+}
+
+async function makeHarness(): Promise<OrchHarness> {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-faithfulness-graph-"),
+  );
+  const config: PluginConfig = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    // Graph: entity only (isolate the assertion; time/causal off).
+    multiGraphMemoryEnabled: true,
+    entityGraphEnabled: true,
+    timeGraphEnabled: false,
+    causalGraphEnabled: false,
+    // Faithfulness gate in enforce mode.
+    extractionFaithfulnessGate: "enforce",
+    extractionFaithfulnessContextChars: 400,
+    extractionFaithfulnessTimeoutMs: 2000,
+    // Minimize competing gates so the fact reaches the write + graph stage.
+    extractionJudgeEnabled: false,
+    temporalSupersessionEnabled: false,
+    contradictionDetectionEnabled: false,
+    chunkingEnabled: false,
+    embeddingFallbackEnabled: false,
+    qmdEnabled: false,
+    extractionMinChars: 0,
+    extractionMinImportanceLevel: "trivial",
+    inlineSourceAttributionEnabled: false,
+  });
+  const orchestrator = new Orchestrator(config);
+  return { orchestrator, memoryDir };
+}
+
+function factResult(content: string, entityRef: string): ExtractionResult {
+  return {
+    facts: [
+      {
+        content,
+        category: "fact",
+        tags: [],
+        confidence: 0.9,
+        entityRef,
+      },
+    ],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as unknown as ExtractionResult;
+}
+
+test("pending_review fact gets no graph edge; an active fact with the same entityRef does (faithfulness #1576 guard)", async () => {
+  const { orchestrator, memoryDir } = await makeHarness();
+  try {
+    // fact0 → entailed (active). Establishes entityRef "widget-factory" so the
+    // next E1 fact has a sibling to edge to. Alone, fact0 has no sibling yet.
+    (orchestrator as unknown as { localLlm: LocalLlmClient }).localLlm =
+      faithfulnessStubLocalLlm((c) =>
+        c.includes("closed permanently") ? "unsupported" : "entailed",
+      );
+    const storage = await (orchestrator as unknown as {
+      getStorage: (ns: string) => Promise<{
+        ensureDirectories: () => Promise<void>;
+        readAllMemories: () => Promise<
+          Array<{
+            path: string;
+            frontmatter: { id: string; status?: string };
+          }>
+        >;
+      }>;
+    }).getStorage("default");
+    await storage.ensureDirectories();
+
+    const sourceText =
+      "The widget factory produces widgets. It launched last year. The team is small.";
+
+    const ids0 = await (orchestrator as unknown as {
+      persistExtraction: (
+        r: ExtractionResult,
+        s: unknown,
+        t: unknown,
+        ctx: unknown,
+        bn: unknown,
+        plan: unknown,
+        src: string,
+      ) => Promise<string[]>;
+    }).persistExtraction(
+      factResult("The widget factory produces widgets daily.", "widget-factory"),
+      storage,
+      null,
+      { sessionKey: "agent:test:main", principal: "test" },
+      undefined,
+      null,
+      sourceText,
+    );
+    const id0 = ids0[0];
+    assert.ok(id0, "fact0 persisted");
+
+    // fact1 → unsupported (pending_review). Under the bug it would originate an
+    // entity edge to fact0; under the guard it must NOT.
+    const ids1 = await (orchestrator as unknown as {
+      persistExtraction: (
+        r: ExtractionResult,
+        s: unknown,
+        t: unknown,
+        ctx: unknown,
+        bn: unknown,
+        plan: unknown,
+        src: string,
+      ) => Promise<string[]>;
+    }).persistExtraction(
+      factResult(
+        "The widget factory closed permanently.",
+        "widget-factory",
+      ),
+      storage,
+      null,
+      { sessionKey: "agent:test:main", principal: "test" },
+      undefined,
+      null,
+      sourceText,
+    );
+    const id1 = ids1[0];
+    assert.ok(id1, "fact1 persisted");
+
+    // fact1 must be written with status pending_review (the gate ran).
+    const memsAfter1 = await storage.readAllMemories();
+    const mem1 = memsAfter1.find((m) => m.frontmatter.id === id1);
+    assert.ok(mem1, "fact1 memory readable");
+    assert.equal(
+      mem1!.frontmatter.status,
+      "pending_review",
+      "unsupported fact must be pending_review under enforce",
+    );
+
+    // After fact0 + fact1: NO entity edges at all. fact0 had no E1 sibling when
+    // written; fact1 is pending_review and must be guarded out of the graph.
+    const edgesAfter1 = await readEdges(memoryDir, "entity");
+    assert.equal(
+      edgesAfter1.length,
+      0,
+      `pending_review fact must originate no graph edge (got ${edgesAfter1.length} entity edges)`,
+    );
+    assert.ok(
+      !edgesAfter1.some((e) => e.from.includes(id1!) || e.from.includes(id0!)),
+      "neither fact0 nor fact1 originates an entity edge",
+    );
+
+    // Control: an ACTIVE fact with the same entityRef DOES create entity edges
+    // (proving the graph is wired and only pending_review is excluded).
+    const ids2 = await (orchestrator as unknown as {
+      persistExtraction: (
+        r: ExtractionResult,
+        s: unknown,
+        t: unknown,
+        ctx: unknown,
+        bn: unknown,
+        plan: unknown,
+        src: string,
+      ) => Promise<string[]>;
+    }).persistExtraction(
+      factResult("The widget factory reopened this quarter.", "widget-factory"),
+      storage,
+      null,
+      { sessionKey: "agent:test:main", principal: "test" },
+      undefined,
+      null,
+      sourceText,
+    );
+    const id2 = ids2[0];
+    assert.ok(id2, "fact2 persisted");
+
+    const edgesAfter2 = await readEdges(memoryDir, "entity");
+    assert.ok(
+      edgesAfter2.length > 0,
+      "active fact with a shared entityRef must create entity edges (control)",
+    );
+    // fact2 (active) originates edges; fact1 (pending_review) never does.
+    assert.ok(
+      edgesAfter2.some((e) => e.from.includes(id2!)),
+      "active fact2 must be the source of an entity edge",
+    );
+    assert.ok(
+      !edgesAfter2.some((e) => e.from.includes(id1!)),
+      "pending_review fact1 must never originate an entity edge even after a later active fact",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -131,6 +131,7 @@ const THINKING_COMPATIBLE_BACKENDS: ReadonlySet<LocalLlmType> = new Set([
 const THINKING_SUPPRESSED_OPERATIONS: ReadonlySet<string> = new Set([
   "extraction",
   "extraction-judge",
+  "extraction-faithfulness",
   "contradiction-judge",
   "contradiction_verification",
   "link_suggestion",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -19059,7 +19059,18 @@ export class Orchestrator {
       }
       const memory = memoryByPath.get(r.path);
       if (memory) {
-        if (memory.frontmatter.status === "forgotten") {
+        // Review-lifecycle statuses never enter active recall injection
+        // (forgotten, pending_review, rejected, quarantined). Superseded and
+        // archived have dedicated filters below. #1576: the faithfulness gate
+        // routes unsupported/contradicted facts to pending_review — they must
+        // not leak back via the QMD/embedding path. chatgpt P2.
+        const recallStatus = memory.frontmatter.status;
+        if (
+          recallStatus === "forgotten" ||
+          recallStatus === "pending_review" ||
+          recallStatus === "rejected" ||
+          recallStatus === "quarantined"
+        ) {
           forgottenFilteredCount += 1;
           continue;
         }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1858,9 +1858,13 @@ export class Orchestrator {
    * Faithfulness gate verdict distribution (issue #1576). Consumed by the
    * console-state aggregator so `remnic doctor` can render how the gate is
    * performing. Returns a fresh object so callers cannot mutate the
-   * internal counters.
+   * internal counters. Returns `undefined` when the gate is off so the
+   * console-state snapshot omits the faithfulness block entirely (cursor
+   * review: an all-zero block would otherwise always be truthy and leak
+   * into snapshots that document it as absent-when-off).
    */
-  getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters {
+  getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters | undefined {
+    if (this.config.extractionFaithfulnessGate === "off") return undefined;
     return { ...this.faithfulnessCounters };
   }
   readonly modelRegistry: ModelRegistry;
@@ -15203,21 +15207,26 @@ export class Orchestrator {
           // PR #402 Thread 1 fix: run source-namespace temporal supersession for
           // chunked writes, matching the non-chunked path.  Without this the
           // source namespace retains stale facts that should have been superseded.
-          try {
-            const supersessionEntityRef =
-              typeof (fact as any).entityRef === "string"
-                ? ((fact as any).entityRef as string)
-                : undefined;
-            await applyTemporalSupersession({
-              storage: targetStorage,
-              newMemoryId: parentId,
-              entityRef: supersessionEntityRef,
-              structuredAttributes: fact.structuredAttributes,
-              createdAt: supersessionOrderingAt(sourceContext?.validAt),
-              enabled: this.config.temporalSupersessionEnabled,
-            });
-          } catch (err) {
-            log.warn(`temporal-supersession (chunked): unexpected error: ${err}`);
+          // Faithfulness gate (#1576, cursor High): skip supersession for a
+          // pending_review fact — an unfaithful extraction in the review queue
+          // must NOT retire older active memories.
+          if (faithfulnessEnforceStatus !== "pending_review") {
+            try {
+              const supersessionEntityRef =
+                typeof (fact as any).entityRef === "string"
+                  ? ((fact as any).entityRef as string)
+                  : undefined;
+              await applyTemporalSupersession({
+                storage: targetStorage,
+                newMemoryId: parentId,
+                entityRef: supersessionEntityRef,
+                structuredAttributes: fact.structuredAttributes,
+                createdAt: supersessionOrderingAt(sourceContext?.validAt),
+                enabled: this.config.temporalSupersessionEnabled,
+              });
+            } catch (err) {
+              log.warn(`temporal-supersession (chunked): unexpected error: ${err}`);
+            }
           }
           // Faithfulness gate (#1576, chatgpt P2): do not promote a
           // pending_review fact to shared/profile — it must enter the review
@@ -15420,22 +15429,26 @@ export class Orchestrator {
       }
       // Temporal supersession (issue #375): when the new fact has structured
       // attributes, retire any older fact with the same entity + attribute
-      // key that has a conflicting value.
-      try {
-        const supersessionEntityRef =
-          typeof (fact as any).entityRef === "string"
-            ? ((fact as any).entityRef as string)
-            : undefined;
-        await applyTemporalSupersession({
-          storage: targetStorage,
-          newMemoryId: memoryId,
-          entityRef: supersessionEntityRef,
-          structuredAttributes: fact.structuredAttributes,
-          createdAt: supersessionOrderingAt(sourceContext?.validAt),
-          enabled: this.config.temporalSupersessionEnabled,
-        });
-      } catch (err) {
-        log.warn(`temporal-supersession: unexpected error: ${err}`);
+      // key that has a conflicting value. Faithfulness gate (#1576, cursor
+      // High): skip for a pending_review fact — an unfaithful extraction in
+      // the review queue must NOT retire older active memories.
+      if (faithfulnessEnforceStatus !== "pending_review") {
+        try {
+          const supersessionEntityRef =
+            typeof (fact as any).entityRef === "string"
+              ? ((fact as any).entityRef as string)
+              : undefined;
+          await applyTemporalSupersession({
+            storage: targetStorage,
+            newMemoryId: memoryId,
+            entityRef: supersessionEntityRef,
+            structuredAttributes: fact.structuredAttributes,
+            createdAt: supersessionOrderingAt(sourceContext?.validAt),
+            enabled: this.config.temporalSupersessionEnabled,
+          });
+        } catch (err) {
+          log.warn(`temporal-supersession: unexpected error: ${err}`);
+        }
       }
       try {
         trackBehaviorSignals(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14970,7 +14970,14 @@ export class Orchestrator {
       // memory without user confirmation).
       let contradictionDetected = false;
 
-      if (this.config.contradictionDetectionEnabled && this.qmd.isAvailable()) {
+      // Faithfulness gate (#1576, chatgpt P2): skip contradiction detection
+      // for a pending_review fact — an unfaithful extraction in the review queue
+      // must not trigger auto-resolve and retire an existing active memory.
+      if (
+        this.config.contradictionDetectionEnabled &&
+        this.qmd.isAvailable() &&
+        faithfulnessEnforceStatus !== "pending_review"
+      ) {
         const targetNamespace = this.namespaceFromStorageDir(targetStorage.dir);
         const contradiction = await this.checkForContradiction(
           fact.content,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15213,7 +15213,9 @@ export class Orchestrator {
             `chunked memory ${parentId} into ${chunkResult.chunks.length} chunks`,
           );
           trackPersistedId(targetStorage, parentId);
+          // #1576 (cursor Medium): keep pending_review ids out of threadEpisodeIdsForGraph — else later active facts build thread-predecessor edges to an unfaithful memory.
           if (
+            faithfulnessEnforceStatus !== "pending_review" &&
             threadEpisodeIdsForGraph &&
             !threadEpisodeIdsForGraph.includes(parentId)
           ) {
@@ -15479,7 +15481,9 @@ export class Orchestrator {
           }),
         );
         trackPersistedId(targetStorage, memoryId);
+        // #1576 (cursor Medium): same thread-episode guard on the non-chunked path.
         if (
+          faithfulnessEnforceStatus !== "pending_review" &&
           threadEpisodeIdsForGraph &&
           !threadEpisodeIdsForGraph.includes(memoryId)
         ) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15035,7 +15035,16 @@ export class Orchestrator {
       // dropped, leaving a stale fact active. writeCategory (not fact.category)
       // is used because routing rules may have overridden the raw category.
       const isCorrection = writeCategory === "correction";
-      if (pendingSemanticSkip && !contradictionDetected && !isCorrection) {
+      // Faithfulness gate (#1576, cursor High): a pending_review fact must
+      // bypass the semantic-dedup skip so it reaches the review queue — the
+      // gate's contract is "persists with status: pending_review, never
+      // silently dropped" (issue #1576).
+      if (
+        pendingSemanticSkip &&
+        !contradictionDetected &&
+        !isCorrection &&
+        faithfulnessEnforceStatus !== "pending_review"
+      ) {
         log.debug(
           `dedup: skipping semantic near-duplicate fact "${fact.content
             .slice(0, 60)

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13269,6 +13269,9 @@ export class Orchestrator {
       // real namespace rather than a guess decoded from the storage dir.
       selfNamespace,
       scopeProfileGatePlan,
+      // Verbatim source turns for the faithfulness gate (#1576) so it can
+      // locate a quote per fact when #1575 spans are absent.
+      normalizedTurns.map((t) => t.content).join("\n\n"),
     );
     let postPersistMetadataFailed = false;
     meta ??= await storage.loadMeta();
@@ -13715,6 +13718,8 @@ export class Orchestrator {
     sourceContext?: { sessionKey?: string; principal?: string; validAt?: string },
     baseNamespace?: string,
     scopeProfileWritePlan?: ResolvedScopeProfilePlan | null,
+    /** Verbatim source turn text the facts were extracted from (faithfulness gate #1576). */
+    sourceText?: string,
     graphCaps: GraphConstructionCapabilitySet = resolveGraphConstructionCapabilities(this.config),
   ): Promise<string[]> {
     // Inline source attribution (issue #369). When enabled, every extracted
@@ -14618,6 +14623,7 @@ export class Orchestrator {
               fallbackLlmRuntimeContextFromConfig(this.config),
             ),
             this.faithfulnessCounters,
+            sourceText,
           )
         : null;
 
@@ -15162,6 +15168,11 @@ export class Orchestrator {
                   intentEntityTypes: inferredIntent?.entityTypes,
                   memoryKind,
                   validAt: sourceContext?.validAt,
+                  // Faithfulness gate (issue #1576): propagate the parent
+                  // fact's verdict + enforce status so a pending_review fact
+                  // is not indexed as active through its chunks (chatgpt P2).
+                  ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
+                  ...(faithfulnessEnforceStatus ? { status: faithfulnessEnforceStatus } : {}),
                 },
               );
             }
@@ -15208,7 +15219,10 @@ export class Orchestrator {
           } catch (err) {
             log.warn(`temporal-supersession (chunked): unexpected error: ${err}`);
           }
-          await promoteMemoryToShared({
+          // Faithfulness gate (#1576, chatgpt P2): do not promote a
+          // pending_review fact to shared/profile — it must enter the review
+          // queue without active copies that bypass the gate.
+          if (faithfulnessEnforceStatus !== "pending_review") await promoteMemoryToShared({
             sourceStorage: targetStorage,
             category: writeCategory,
             content: fact.content,
@@ -15253,7 +15267,8 @@ export class Orchestrator {
             if (
               this.config.verbatimArtifactsEnabled &&
               this.config.verbatimArtifactCategories.includes(writeCategory) &&
-              fact.confidence >= this.config.verbatimArtifactsMinConfidence
+              fact.confidence >= this.config.verbatimArtifactsMinConfidence &&
+              faithfulnessEnforceStatus !== "pending_review"
             ) {
               // Reuse citedChunkedContent so the artifact carries the same citation
               // timestamp as the parent memory write above (Fix #3 — duplicate-citation).
@@ -15442,7 +15457,9 @@ export class Orchestrator {
           threadEpisodeIdsForGraph.push(memoryId);
         }
         await this.indexPersistedMemory(targetStorage, memoryId);
-        await promoteMemoryToShared({
+        // Faithfulness gate (#1576, chatgpt P2): skip promotion for a
+        // pending_review fact so no active shared/profile copy bypasses the gate.
+        if (faithfulnessEnforceStatus !== "pending_review") await promoteMemoryToShared({
           sourceStorage: targetStorage,
           category: writeCategory,
           content: fact.content,
@@ -15506,7 +15523,8 @@ export class Orchestrator {
         if (
           this.config.verbatimArtifactsEnabled &&
           this.config.verbatimArtifactCategories.includes(writeCategory) &&
-          fact.confidence >= this.config.verbatimArtifactsMinConfidence
+          fact.confidence >= this.config.verbatimArtifactsMinConfidence &&
+          faithfulnessEnforceStatus !== "pending_review"
         ) {
           // Reuse citedFactContent so the artifact carries the same citation
           // timestamp as the memory write above (Fix #3 — duplicate-citation).

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15307,8 +15307,8 @@ export class Orchestrator {
                 intentEntityTypes: inferredIntent?.entityTypes,
               });
             }
-            // v8.2: graph edge building for chunked memories
-            if (graphCaps.multiGraphMemory) {
+            // v8.2: graph edge building for chunked memories. #1576: skip pending_review.
+            if (graphCaps.multiGraphMemory && faithfulnessEnforceStatus !== "pending_review") {
               try {
                 const graphContext = await ensureGraphContext(targetStorage);
                 const entityRef =
@@ -15508,8 +15508,8 @@ export class Orchestrator {
           validAt: sourceContext?.validAt,
           source: extractionWriteSource,
         });
-        // v8.2: graph edge building (fail-open — errors caught inside GraphIndex)
-        if (graphCaps.multiGraphMemory) {
+        // v8.2: graph edge building (fail-open). #1576: skip pending_review facts.
+        if (graphCaps.multiGraphMemory && faithfulnessEnforceStatus !== "pending_review") {
           try {
             const graphContext = await ensureGraphContext(targetStorage);
             const entityRef =

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16410,9 +16410,8 @@ export class Orchestrator {
         const tmtEntries = allMemories
           .filter(
             (m) =>
-              m.frontmatter.status !== "superseded" &&
-              m.frontmatter.status !== "archived" &&
-              m.frontmatter.status !== "forgotten",
+              m.frontmatter.status !== "superseded" && m.frontmatter.status !== "archived" &&
+              m.frontmatter.status !== "forgotten" && m.frontmatter.status !== "pending_review", // #1576: unfaithful queue items must not feed TMT clusters
           )
           .map((m) => ({
             path: m.path,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -36,6 +36,12 @@ import {
   type JudgeVerdict,
 } from "./extraction-judge.js";
 import {
+  applyFaithfulnessVerdict,
+  createFaithfulnessCounters,
+  runFaithfulnessGateBatch,
+} from "./extraction-faithfulness.js";
+import type { FaithfulnessGateCounters } from "./extraction-faithfulness.js";
+import {
   EXTRACTION_JUDGE_VERDICT_CATEGORY,
   recordJudgeVerdict,
 } from "./extraction-judge-telemetry.js";
@@ -1829,6 +1835,12 @@ export class Orchestrator {
    */
   private readonly judgeDeferCounts: Map<string, number>;
   /**
+   * Faithfulness gate distribution counters (issue #1576). Per-orchestrator
+   * running tally surfaced via console_state telemetry. No module-level state
+   * (rule 11) — these hang off the orchestrator instance.
+   */
+  private faithfulnessCounters: FaithfulnessGateCounters = createFaithfulnessCounters();
+  /**
    * Side-channel: number of facts deferred in the most recent
    * `persistExtraction` call (issue #562, PR 2). The caller reads this after
    * `persistExtraction` returns to decide whether to retain buffer turns for
@@ -1840,6 +1852,16 @@ export class Orchestrator {
 
   get fastGatewayLlm(): FallbackLlmClient | null {
     return this._fastGatewayLlm;
+  }
+
+  /**
+   * Faithfulness gate verdict distribution (issue #1576). Consumed by the
+   * console-state aggregator so `remnic doctor` can render how the gate is
+   * performing. Returns a fresh object so callers cannot mutate the
+   * internal counters.
+   */
+  getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters {
+    return { ...this.faithfulnessCounters };
   }
   readonly modelRegistry: ModelRegistry;
   readonly relevance: RelevanceStore;
@@ -14577,6 +14599,28 @@ export class Orchestrator {
       }
     }
 
+    // Faithfulness gate (issue #1576). Entailment-verification of extracted
+    // facts against their verified source spans from #1575. Placement: after
+    // parse + provenance validation, BEFORE persist/index (rule 44). The
+    // substantive batch logic lives in the pure module; this is thin
+    // delegation (ground rule 4). off → null map (byte-identical pre-feature
+    // pipeline, rule 39); shadow → record only; enforce → pending_review.
+    const faithfulnessMode = this.config.extractionFaithfulnessGate;
+    const faithfulnessResultsByFactIndex =
+      faithfulnessMode === "shadow" || faithfulnessMode === "enforce"
+        ? await runFaithfulnessGateBatch(
+            facts,
+            faithfulnessMode,
+            this.config,
+            this.localLlm,
+            new FallbackLlmClient(
+              this.config.gatewayConfig,
+              fallbackLlmRuntimeContextFromConfig(this.config),
+            ),
+            this.faithfulnessCounters,
+          )
+        : null;
+
     let factLoopIndex = -1;
     for (const fact of facts) {
       factLoopIndex++;
@@ -14812,6 +14856,19 @@ export class Orchestrator {
           continue;
         }
       }
+
+      // Faithfulness gate verdict application (issue #1576). Look up the
+      // pre-computed verdict for this fact and translate it to frontmatter +
+      // an optional enforce-mode pending_review status. Logic lives in the
+      // pure module; this is thin read-through (ground rule 4).
+      const { faithfulness: faithfulnessFm, enforceStatus: faithfulnessEnforceStatus } =
+        applyFaithfulnessVerdict(
+          faithfulnessResultsByFactIndex,
+          factLoopIndex,
+          faithfulnessMode,
+          fact.content,
+          this.faithfulnessCounters,
+        );
 
       // Issue #373 — write-time semantic similarity guard. Hook runs after
       // the exact content-hash miss and the importance gate so that:
@@ -15067,6 +15124,9 @@ export class Orchestrator {
               structuredAttributes: fact.structuredAttributes,
               validAt: sourceContext?.validAt,
               contentHashSource: rawChunkedContent,
+              // Faithfulness gate (issue #1576).
+              ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
+              ...(faithfulnessEnforceStatus ? { status: faithfulnessEnforceStatus } : {}),
             },
           );
           try {
@@ -15333,6 +15393,9 @@ export class Orchestrator {
           structuredAttributes: fact.structuredAttributes,
           validAt: sourceContext?.validAt,
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
+          // Faithfulness gate (issue #1576).
+          ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
+          ...(faithfulnessEnforceStatus ? { status: faithfulnessEnforceStatus } : {}),
         },
       );
       if (routedRuleId) {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -7029,6 +7029,10 @@ export class StorageManager {
       intentEntityTypes?: string[];
       memoryKind?: MemoryFrontmatter["memoryKind"];
       validAt?: string;
+      /** Lifecycle status (issue #1576): pending_review chunks stay out of active recall. */
+      status?: import("./types.js").MemoryStatus;
+      /** Faithfulness gate verdict (issue #1576), propagated from the parent fact. */
+      faithfulness?: import("./types.js").FaithfulnessFrontmatter;
     } = {},
   ): Promise<string> {
     await this.ensureDirectories();
@@ -7058,6 +7062,8 @@ export class StorageManager {
       intentEntityTypes: options.intentEntityTypes,
       memoryKind: options.memoryKind,
       valid_at: validAt,
+      ...(options.status ? { status: options.status } : {}),
+      ...(options.faithfulness ? { faithfulness: options.faithfulness } : {}),
     };
 
     const sanitized = sanitizeMemoryContent(content);

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -10,6 +10,7 @@ import { getCachedEntities, invalidateAllForDir, setCachedEntities } from "./mem
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { serializeProvenanceFields, parseProvenanceSources, parseProvenanceTag, reconcileProvenanceRead } from "./provenance.js";
+import { serializeFaithfulnessFields, parseFaithfulnessField } from "./extraction-faithfulness.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import { isValidTranscriptDate, WEARABLES_DIR_NAME } from "./wearables/day-store.js";
 import {
@@ -458,6 +459,7 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
     lines.push(`last_reinforced_at: ${fm.last_reinforced_at}`);
   }
   serializeProvenanceFields(fm, lines);
+  serializeFaithfulnessFields(fm, lines);
   lines.push("---");
   return lines.join("\n");
 }
@@ -872,6 +874,7 @@ function parseFrontmatter(
       last_reinforced_at: fm.last_reinforced_at || undefined,
       sources: parseProvenanceSources(fm.sources),
       provenance: reconcileProvenanceRead(parseProvenanceTag(fm.provenance), parseProvenanceSources(fm.sources)),
+      faithfulness: parseFaithfulnessField(fm.faithfulness),
     },
     content,
   };
@@ -3384,6 +3387,12 @@ export class StorageManager {
        */
       derivedFrom?: string[];
       derivedVia?: ConsolidationOperator;
+      /**
+       * Faithfulness gate verdict (issue #1576). When provided, persisted to
+       * frontmatter so downstream readers (TrustScore #1577, review queue)
+       * can consume it. Absent = gate was off or fact predates #1576.
+       */
+      faithfulness?: import("./types.js").FaithfulnessFrontmatter;
     } = {},
   ): Promise<string> {
     await this.ensureDirectories();
@@ -3452,6 +3461,10 @@ export class StorageManager {
     }
     if (options.derivedVia !== undefined) {
       fm.derived_via = options.derivedVia;
+    }
+    // Faithfulness gate frontmatter (issue #1576).
+    if (options.faithfulness !== undefined) {
+      fm.faithfulness = options.faithfulness;
     }
 
     // Append structured attributes as searchable suffix so QMD indexes them.

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1088,6 +1088,16 @@ export interface PluginConfig {
    * location.
    */
   judgeTrainingDir: string;
+  // Extraction faithfulness gate (issue #1576). Entailment-verification of
+  // extracted facts against their verified source spans from #1575.
+  /** Gate mode: "off" (default, byte-identical pre-feature), "shadow" (record only), "enforce" (route to pending_review). */
+  extractionFaithfulnessGate: "off" | "shadow" | "enforce";
+  /** Override model/endpoint; empty string = default routing chain. */
+  extractionFaithfulnessModel: string;
+  /** Context window (chars) around the quote sent to the verifier. Default 400. */
+  extractionFaithfulnessContextChars: number;
+  /** Per-batch timeout in ms; timeout → tagged error, never blocks writes. Default 8000. */
+  extractionFaithfulnessTimeoutMs: number;
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;
@@ -2617,6 +2627,35 @@ export interface MemoryFrontmatter {
    * recorded). Readers treat absent as `"none"` for legacy memories.
    */
   provenance?: "verified" | "unverified" | "none";
+
+  // Faithfulness gate (issue #1576). When the extraction faithfulness gate
+  // runs (mode "shadow" or "enforce"), this field records the verdict. Absent
+  // when the gate is off or the fact predates #1576 — readers MUST treat
+  // absent as "not checked" (rule 34 spirit).
+  //
+  // This field is its own frontmatter island — it never feeds mw_*/trust
+  // fields. Consumed by #1577 (TrustScore) as one input among many.
+  /** Entailment verdict from the faithfulness gate (issue #1576). */
+  faithfulness?: FaithfulnessFrontmatter;
+}
+
+/**
+ * Faithfulness gate frontmatter (issue #1576).
+ *
+ * Serialized as a single JSON line so it round-trips through the existing
+ * YAML parser. `verdict: "unchecked"` marks a fact that entered the gate but
+ * could not be evaluated (backend failure, timeout). `verdict:
+ * "skipped_no_span"` marks a legacy fact without a verified source span.
+ * Both are distinct from the field being absent (gate was off entirely).
+ */
+export interface FaithfulnessFrontmatter {
+  verdict: "entailed" | "contradicted" | "unsupported" | "unchecked" | "skipped_no_span";
+  /** Model/endpoint that produced the verdict, when known. */
+  model?: string;
+  /** One-sentence rationale from the verifier. */
+  rationale?: string;
+  /** ISO-8601 timestamp the check ran. */
+  at?: string;
 }
 
 /** Memory link relationship types */
@@ -2771,6 +2810,14 @@ export interface ExtractedFact {
   tags: string[];
   entityRef?: string;
   source?: ExtractionPassSource;
+  /**
+   * Claim-level provenance spans backing this fact (issue #1575).
+   * Populated by the PR 2 extraction validator when `provenance.enabled`
+   * is true. Absent for legacy extractions — downstream consumers (the
+   * faithfulness gate #1576, TrustScore #1577) MUST treat absent as
+   * "no verified span" and skip gracefully.
+   */
+  sources?: ProvenanceSource[];
   promptedByQuestion?: string;
   /**
    * Whether this fact is project-scoped or globally applicable.

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3658,6 +3658,27 @@
         "default": "",
         "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
       },
+      "extractionFaithfulnessGate": {
+        "type": "string",
+        "enum": ["off", "shadow", "enforce"],
+        "default": "off",
+        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+      },
+      "extractionFaithfulnessModel": {
+        "type": "string",
+        "default": "",
+        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+      },
+      "extractionFaithfulnessContextChars": {
+        "type": "number",
+        "default": 400,
+        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+      },
+      "extractionFaithfulnessTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19844,
+      "packages/remnic-core/src/orchestrator.ts": 19851,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
       "packages/remnic-core/src/storage.ts": 7359,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,10 +4,10 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19793,
+      "packages/remnic-core/src/orchestrator.ts": 19824,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
-      "packages/remnic-core/src/storage.ts": 7353,
+      "packages/remnic-core/src/storage.ts": 7359,
       "packages/remnic-core/src/config.ts": 4548
     },
     "oversizedFileCount": 10,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19835,
+      "packages/remnic-core/src/orchestrator.ts": 19844,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
       "packages/remnic-core/src/storage.ts": 7359,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19824,
+      "packages/remnic-core/src/orchestrator.ts": 19835,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
       "packages/remnic-core/src/storage.ts": 7359,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19851,
+      "packages/remnic-core/src/orchestrator.ts": 19855,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
       "packages/remnic-core/src/storage.ts": 7359,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19855,
+      "packages/remnic-core/src/orchestrator.ts": 19854,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
       "packages/remnic-core/src/storage.ts": 7359,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,11 +4,11 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19730,
+      "packages/remnic-core/src/orchestrator.ts": 19793,
       "packages/remnic-core/src/cli.ts": 9872,
       "packages/remnic-core/src/access-service.ts": 8549,
-      "packages/remnic-core/src/storage.ts": 7340,
-      "packages/remnic-core/src/config.ts": 4518
+      "packages/remnic-core/src/storage.ts": 7353,
+      "packages/remnic-core/src/config.ts": 4548
     },
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 559

--- a/tests/orchestrator-threading-fail-open.test.ts
+++ b/tests/orchestrator-threading-fail-open.test.ts
@@ -68,13 +68,13 @@ test("in-memory thread episode context updates for chunked and non-chunked write
   );
   assert.match(
     source,
-    /if \(\s*threadEpisodeIdsForGraph\s*&&\s*!threadEpisodeIdsForGraph\.includes\(memoryId\)\s*\) \{\s*threadEpisodeIdsForGraph\.push\(memoryId\);\s*\}/m,
-    "memoryId should be added to in-memory thread context during persistence",
+    /if \(\s*faithfulnessEnforceStatus !== "pending_review"\s*&&\s*threadEpisodeIdsForGraph\s*&&\s*!threadEpisodeIdsForGraph\.includes\(memoryId\)\s*\) \{\s*threadEpisodeIdsForGraph\.push\(memoryId\);\s*\}/m,
+    "memoryId is appended to thread context only when not pending_review (faithfulness graph guard, #1576)",
   );
   assert.match(
     source,
-    /if \(\s*threadEpisodeIdsForGraph\s*&&\s*!threadEpisodeIdsForGraph\.includes\(parentId\)\s*\) \{\s*threadEpisodeIdsForGraph\.push\(parentId\);\s*\}/m,
-    "parentId should be added to in-memory thread context during persistence",
+    /if \(\s*faithfulnessEnforceStatus !== "pending_review"\s*&&\s*threadEpisodeIdsForGraph\s*&&\s*!threadEpisodeIdsForGraph\.includes\(parentId\)\s*\) \{\s*threadEpisodeIdsForGraph\.push\(parentId\);\s*\}/m,
+    "parentId is appended to thread context only when not pending_review (faithfulness graph guard, #1576)",
   );
 });
 


### PR DESCRIPTION
Part of #1572 (glass-box memory). Depends on #1575 (provenance spans). Standards: #1520. Closes #1576.

## What

An extraction faithfulness gate that entailment-verifies extracted facts against their verified source spans (#1575) **before persist/index**, so hallucinated or mis-paraphrased extractions are caught at write time instead of becoming durable, high-confidence memories that poison downstream recall.

## Design

**Pure verdict module** (`extraction-faithfulness.ts`):
- Tagged `FaithfulnessResult` — `ok:true` carries a verdict + model + rationale; `ok:false` carries a distinguishable error code (`no_span` / `backend_unavailable` / `malformed_output` / `timeout`). Never conflates "failed" with "unsupported" (rule 34).
- Sealed classification prompt with a `FAITHFULNESS_PROMPT_HASH` (SHA-256) so #1573-style caching can key on it.
- `checkFaithfulnessBatch` — one LLM call per flush (bounded by `faithfulnessTimeoutMs`); timeout / malformed / null responses are all tagged, never crash.
- Frontmatter serialize/parse as a single-line JSON island; absent field = byte-identical pre-feature (rule 39).
- Orchestration helpers (`runFaithfulnessGateBatch`, `applyFaithfulnessVerdict`, `createFaithfulnessCounters`) extracted so the orchestrator holds only thin delegation (ground rule 4).

**Three modes** (`extraction.faithfulnessGate`, default `"off"`):

| Mode | Behavior |
|---|---|
| `off` (default) | Byte-identical pre-feature pipeline (rule 39). |
| `shadow` | Verdicts recorded in frontmatter + console_state counters only — no gating (measurement phase, rule 55). |
| `enforce` | `unsupported`/`contradicted` → `status: pending_review` (memory persists, enters the review queue, never silently dropped). Legacy facts without a span → `skipped_no_span`, NOT gated. Backend failure → `unchecked`, fact proceeds (graceful degradation, checklist §4). |

Gate placement: in `persistExtraction` after parse + provenance validation, **before** persist/index (rule 44). One batch call, consumed identically from every extraction entry path.

## Wiring
- `config.ts` — 4 keys with validation (invalid gate value rejected listing the valid options, rule 51); registered in all three `openclaw.plugin.json` configSchemas.
- `storage.ts` — serialize/parse the faithfulness frontmatter island; `writeMemory` `options.faithfulness` pass-through.
- `orchestrator.ts` — thin delegation in `persistExtraction` (batch before the fact loop; verdict applied per-fact); per-orchestrator counters + `getConsoleFaithfulnessDistribution()` getter. **No module-level state** (rule 11).
- `console/state.ts` — `ConsoleFaithfulnessDistribution` surfaced via `console_state` so `remnic doctor` renders the verdict distribution.

## Tests (46, all LLM-stubbed — no network/GPU)
entailed/contradicted/unsupported fixture triples (paraphrase, negation, entity-swap, date-shift, quantity-change, unrelated-quote), malformed output → `malformed_output`, timeout → tagged, batch index→fact mapping, whole-batch fail-open, `skipped_no_span`, enforce `pending_review` routing (done-when), frontmatter round-trip.

## Scope note
This delivers the gate + measurement plumbing (issue PRs 1–2 + the enforce-mode code of PR 3). Enforce stays **non-default** until the Tier-L LoCoMo adversarial ablation artifact lands (issue done-when) — that requires the lab 3090 and is tracked separately as the gate for flipping the default.

## Chokepoints used / not applicable
Not applicable — faithfulness has no scattered config flag reads (single `extractionFaithfulnessGate` read at the gate site) and adds no new MCP/HTTP/CLI surface.

## Ratchet
Baseline updated (justified thin wiring): orchestrator +63 (substantive batch/verdict logic extracted to the pure module; orchestrator holds only delegation + counter field + getter), storage +13 (frontmatter island), config +30 (4 parsed keys).

## Checklist
- [x] `npm run preflight:quick` → `[preflight] OK (quick)`
- [x] `npm run test:entity-hardening` → 246/246 pass
- [x] `npx tsc --noEmit` clean
- [x] `node scripts/check-ratchets.mjs` OK (baseline updated)
- [x] No `any` (tagged unions + structural types)
- [x] No host imports in @remnic/core
- [x] Mocked judge/LLM in tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core extraction persistence and recall filtering; enforce mode changes lifecycle status and blocks graph/supersession for flagged facts, though default remains off and failures degrade to unchecked rather than blocking writes.
> 
> **Overview**
> Adds an **extraction faithfulness gate** that LLM-checks whether each extracted fact is entailed by its source quote/span **before** persist/index. Default **`off`** keeps the pre-feature pipeline unchanged; **`shadow`** records verdicts in frontmatter and console telemetry; **`enforce`** sets **`pending_review`** on unsupported/contradicted facts while still persisting them.
> 
> New module **`extraction-faithfulness.ts`** implements batch entailment checks (tagged errors, timeouts fail open), quote fallback via **`locateFactQuote`**, multi-source spans, optional model override routing, and **`faithfulness`** frontmatter serialize/parse. **`persistExtraction`** runs one batch then applies per-fact verdicts; source turn text is passed through for quote location.
> 
> **`pending_review`** facts are walled off from active memory side effects: excluded from QMD recall, semantic dedup skip, contradiction auto-resolve, temporal supersession, shared promotion, graph/thread-episode edges, verbatim artifacts, and TMT rebuild (integration test **`faithfulness-graph-guard`**). Config adds four keys with strict validation; **`console_state`** exposes verdict distribution when the gate is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e786facc90f182bd21879d167cf6585ce84a1c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->