### PR TITLE
feat(config): strict-integer validation for faithfulness numeric knobs (#1634)

### DIFF
--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -2050,3 +2050,35 @@ test("parseConfig rejects a present-but-non-string extractionFaithfulnessGate (s
   // A present-but-unknown string still rejects (pre-existing behavior preserved).
   assert.throws(() => parseConfig({ extractionFaithfulnessGate: "on" }), /extractionFaithfulnessGate must be one of/);
 });
+
+test("parseConfig extractionFaithfulnessContextChars rejects non-numeric and non-integer input (#1634)", () => {
+  // Issue #1634 (#1576 follow-up): migrate from coerce+clamp/default to the
+  // strict-integer validator used by qmdDaemonTimeoutMs / commitmentDecayDays.
+  // A malformed budget must reject, not silently default or round.
+  assert.equal(parseConfig({}).extractionFaithfulnessContextChars, 400);
+  assert.equal(parseConfig({ extractionFaithfulnessContextChars: null }).extractionFaithfulnessContextChars, 400);
+  assert.equal(parseConfig({ extractionFaithfulnessContextChars: "2400" }).extractionFaithfulnessContextChars, 2400);
+  assert.equal(parseConfig({ extractionFaithfulnessContextChars: 5000 }).extractionFaithfulnessContextChars, 4000);
+  for (const value of ["abc", "", 0, 1.5, "1.5", Number.NaN, Infinity, true, {}] as unknown[]) {
+    assert.throws(
+      () => parseConfig({ extractionFaithfulnessContextChars: value } as Record<string, unknown>),
+      /extractionFaithfulnessContextChars must be an integer/,
+      `invalid extractionFaithfulnessContextChars ${String(value)} should throw`,
+    );
+  }
+});
+
+test("parseConfig extractionFaithfulnessTimeoutMs rejects non-numeric and non-integer input (#1634)", () => {
+  // Issue #1634: same strict-integer contract as extractionFaithfulnessContextChars.
+  assert.equal(parseConfig({}).extractionFaithfulnessTimeoutMs, 8000);
+  assert.equal(parseConfig({ extractionFaithfulnessTimeoutMs: null }).extractionFaithfulnessTimeoutMs, 8000);
+  assert.equal(parseConfig({ extractionFaithfulnessTimeoutMs: "12000" }).extractionFaithfulnessTimeoutMs, 12_000);
+  assert.equal(parseConfig({ extractionFaithfulnessTimeoutMs: 999_999 }).extractionFaithfulnessTimeoutMs, 60_000);
+  for (const value of ["abc", "", 0, 1.5, "1.5", Number.NaN, Infinity, true, {}] as unknown[]) {
+    assert.throws(
+      () => parseConfig({ extractionFaithfulnessTimeoutMs: value } as Record<string, unknown>),
+      /extractionFaithfulnessTimeoutMs must be an integer/,
+      `invalid extractionFaithfulnessTimeoutMs ${String(value)} should throw`,
+    );
+  }
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2927,18 +2927,18 @@ export function parseConfig(
       typeof cfg.extractionFaithfulnessModel === "string"
         ? cfg.extractionFaithfulnessModel
         : "",
-    // Numeric knobs go through coerceNumber so CLI operators can pass
-    // --config extractionFaithfulnessTimeoutMs=4000 without the string
-    // silently dropping to the default. Matches the coercion contract applied
-    // to other numeric config keys (CLAUDE.md rule #28 / gotcha #36).
-    extractionFaithfulnessContextChars: (() => {
-      const n = coerceNumber(cfg.extractionFaithfulnessContextChars);
-      return n !== undefined && n > 0 ? Math.min(Math.round(n), 4000) : 400;
-    })(),
-    extractionFaithfulnessTimeoutMs: (() => {
-      const n = coerceNumber(cfg.extractionFaithfulnessTimeoutMs);
-      return n !== undefined && n > 0 ? Math.min(Math.round(n), 60_000) : 8000;
-    })(),
+    // Issue #1634 (#1576 follow-up): strict-integer validation via
+    // parseIntegerAtLeast — reject non-numeric, <=0, non-integer, NaN,
+    // Infinity, booleans, objects (gotcha #51). Mirrors qmdDaemonTimeoutMs.
+    // Valid CLI-string integers still coerce and clamp to the budget cap.
+    extractionFaithfulnessContextChars: Math.min(
+      parseIntegerAtLeast(cfg.extractionFaithfulnessContextChars, 400, 1, "extractionFaithfulnessContextChars"),
+      4000,
+    ),
+    extractionFaithfulnessTimeoutMs: Math.min(
+      parseIntegerAtLeast(cfg.extractionFaithfulnessTimeoutMs, 8000, 1, "extractionFaithfulnessTimeoutMs"),
+      60_000,
+    ),
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,


### PR DESCRIPTION
## Summary

Follow-up from #1629 (#1576). Codex P2 `PRRT_kwDORJXyws6Ob4RR`.

The two faithfulness numeric knobs (`extractionFaithfulnessContextChars`, `extractionFaithfulnessTimeoutMs`) previously used the **coerce + clamp/default** style: `coerceNumber` → `n > 0 ? min(round(n), cap) : default`. This meant `--config extractionFaithfulnessTimeoutMs=abc` silently defaulted, `=0` silently defaulted, and `=1.5` silently rounded — a malformed budget looked accepted.

This PR migrates both knobs to the **strict-integer validator** (`parseIntegerAtLeast`) already used by `qmdDaemonTimeoutMs` and `commitmentDecayDays`. Both now reject non-numeric, `<=0`, non-integer, `NaN`, `Infinity`, booleans, and objects with a clear error. Valid CLI-string integers still coerce and clamp to the budget cap.

## Changes

- **`packages/remnic-core/src/config.ts`**: replaced the two inline `coerceNumber` IIFEs with `parseIntegerAtLeast` + `Math.min` clamp. Ratchet-neutral (file stays at 4547 lines vs 4548 baseline).
- **`packages/remnic-core/src/config.test.ts`**: added two tests mirroring the `qmdDaemonTimeoutMs rejects non-numeric and non-integer input` case, covering the full failure class (`"abc"`, `""`, `0`, `1.5`, `"1.5"`, `NaN`, `Infinity`, `true`, `{}`) plus happy-path defaults, null→default, CLI-string coercion, and clamp behavior.

## Chokepoints used

`parseIntegerAtLeast` (existing strict-integer validator, same as `qmdDaemonTimeoutMs` / `commitmentDecayDays`).

## Verification

- `npm run preflight:quick` — lint ✓, check-types ✓, ratchet ✓, docs-parity ✓
- `npm run test:entity-hardening` — 246/246 pass
- `tsx --test src/config.test.ts` — 152/152 pass (150 existing + 2 new)

Closes #1634

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config parsing behavior change only: invalid operator input now fails fast instead of silently using defaults, which may surface misconfiguration earlier but does not alter runtime extraction paths when config is valid.
> 
> **Overview**
> **`extractionFaithfulnessContextChars`** and **`extractionFaithfulnessTimeoutMs`** no longer use `coerceNumber` with silent defaults or rounding. They now go through **`parseIntegerAtLeast`** (same contract as **`qmdDaemonTimeoutMs`** / **`commitmentDecayDays`**), then clamp to caps (4000 and 60_000).
> 
> Malformed or out-of-contract values (non-numeric, `<=0`, floats, `NaN`, `Infinity`, booleans, objects) **throw** with a clear message instead of falling back to 400 / 8000 or rounding. Omitted/`null` still use defaults; valid CLI string integers still coerce; values above the cap still clamp.
> 
> Two new **`config.test.ts`** cases lock in defaults, null→default, string coercion, clamping, and the full rejection matrix for both keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f92aec7c5712ed8262181dcda2a9d488f81dc0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->