### PR TITLE
fix(extraction-faithfulness): center fallback quote window + track matched offset (#1633)

### DIFF
--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -840,27 +840,59 @@ test("locateFactQuote: centers the bounded window on matched terms for >maxQuote
   );
 });
 
-test("locateFactQuote: tracks the matched occurrence offset for repeated anaphoric lines (issue #1633, codex :710)", () => {
-  // Two entities, same anaphoric sentence pattern — the fact is about Zeta,
-  // which appears SECOND. The locator's offset must point at the Zeta clause so
-  // extractContextWindow centers on Zeta, not the first (Acme) occurrence.
+test("locateFactQuote: tracks the matched occurrence offset for repeated anaphoric lines (issue #1633, codex :710, :710-thread-S)", () => {
+  // Two entities with the EXACT SAME anaphoric sentence afterward — the
+  // fact is about Zeta, which appears SECOND. Both "It launched in March."
+  // candidates score identically on own-overlap, so the locator must use the
+  // preceding-neighbor tiebreak to pick the occurrence whose neighbor ("Zeta")
+  // names the fact's entity. The offset must then point at the Zeta clause.
   const sourceText =
-    "We started the Acme project in January. It launched in March at beta. " +
-    "Then we began the Zeta initiative in February. It launched in March at general availability.";
+    "We started the Acme project in January. It launched in March. " +
+    "Then we began the Zeta initiative in February. It launched in March.";
+  const located = locateFactQuote("The Zeta initiative launched in March.", sourceText);
+  assert.ok(located, "expected a located quote");
+  // The matched quote is the (identical) anaphoric line; offset must point at
+  // the SECOND occurrence (the one after the Zeta clause), not the first.
+  const firstOccurrence = sourceText.indexOf("It launched in March.");
+  const secondOccurrence = sourceText.indexOf("It launched in March.", firstOccurrence + 1);
+  assert.ok(secondOccurrence > firstOccurrence, "test fixture must contain two occurrences");
+  assert.equal(
+    located!.offset,
+    secondOccurrence,
+    "offset must point at the second (Zeta) occurrence, not the first (Acme)",
+  );
+  assert.equal(
+    sourceText.slice(located!.offset, located!.offset + located!.quote.length),
+    located!.quote,
+    "offset must point at the start of the matched quote",
+  );
+});
+
+test("locateFactQuote: bounded window keeps the densest evidence cluster when matches span wider than maxQuoteChars (codex :747-thread-O)", () => {
+  // Fact tokens appear at BOTH ENDS of a long candidate with filler between.
+  // A naive midpoint-centered window would land in the filler and contain no
+  // evidence. The densest-cluster window must capture actual matched terms.
+  const head = "PostgreSQL migration completed. "; // matches at the very start
+  const filler = "and ".repeat(220); // ~880 chars of filler (no fact tokens)
+  const tail = " for the user."; // matches at the very end
+  const sourceText = head + filler + tail; // one long sentence, no period inside
+  // Fact spans tokens from both ends: postgresql, migration (head) + user (tail).
   const located = locateFactQuote(
-    "The Zeta initiative launched in March at general availability.",
+    "The user completed the PostgreSQL migration.",
     sourceText,
+    120,
   );
   assert.ok(located, "expected a located quote");
-  // offset must fall within the Zeta clause, AFTER the Acme clause.
-  const acmeClauseEnd = sourceText.indexOf("at beta.") + "at beta.".length;
   assert.ok(
-    located!.offset >= acmeClauseEnd,
-    `offset must point past the Acme clause (offset=${located!.offset}, acmeEnd=${acmeClauseEnd})`,
+    located!.quote.length <= 120,
+    `bounded quote must respect maxQuoteChars (got ${located!.quote.length})`,
   );
+  // The densest cluster is the head (2 matches: postgresql, migration); the
+  // window must contain at least one of them. (user appears alone at the tail,
+  // so a tail-anchored window would be sparser and is not chosen.)
   assert.ok(
-    sourceText.slice(located!.offset).startsWith(located!.quote),
-    "offset must point at the start of the matched quote",
+    located!.quote.includes("PostgreSQL") || located!.quote.includes("migration"),
+    "bounded window must include matched evidence, not pure filler",
   );
 });
 

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -794,12 +794,13 @@ test("applyFaithfulnessVerdict: per-fact backend failure (ok:false) → unchecke
   assert.equal(r.enforceStatus, undefined);
 });
 
-test("locateFactQuote: finds the best-overlap sentence", () => {
+test("locateFactQuote: finds the best-overlap sentence (returns LocatedQuote, issue #1633)", () => {
   const src = "I drove to Berlin yesterday. My favorite editor is Vim.";
-  assert.equal(
-    locateFactQuote("The user likes Vim.", src),
-    "My favorite editor is Vim.",
-  );
+  const located = locateFactQuote("The user likes Vim.", src);
+  assert.ok(located, "expected a located quote");
+  assert.equal(located!.quote, "My favorite editor is Vim.");
+  // offset must point at the matched candidate's actual position in sourceText.
+  assert.equal(located!.offset, src.indexOf("My favorite editor is Vim."));
 });
 
 test("locateFactQuote: returns undefined below the overlap threshold", () => {
@@ -810,6 +811,57 @@ test("locateFactQuote: returns undefined below the overlap threshold", () => {
 test("locateFactQuote: empty inputs → undefined", () => {
   assert.equal(locateFactQuote("", "text"), undefined);
   assert.equal(locateFactQuote("fact", ""), undefined);
+});
+
+test("locateFactQuote: centers the bounded window on matched terms for >maxQuoteChars candidates (issue #1633, codex :747)", () => {
+  // The supporting terms ("PostgreSQL", "migration") fall well past the
+  // ~maxQuoteChars prefix. Returning the prefix would drop the evidence and
+  // route an actually-entailed fact to pending_review in enforce mode.
+  const filler = "Lorem ipsum dolor sit amet ".repeat(28); // ~728-char preamble
+  const sourceText = filler + "The team completed the PostgreSQL migration last quarter.";
+  const located = locateFactQuote(
+    "The team finished the PostgreSQL migration.",
+    sourceText,
+    200,
+  );
+  assert.ok(located, "expected a located quote");
+  assert.ok(
+    located!.quote.length <= 200,
+    `bounded quote must respect maxQuoteChars (got ${located!.quote.length})`,
+  );
+  // The matched evidence must survive truncation — the whole point of centering.
+  assert.ok(located!.quote.includes("PostgreSQL"), "bounded quote keeps 'PostgreSQL'");
+  assert.ok(located!.quote.includes("migration"), "bounded quote keeps 'migration'");
+  // offset must locate the returned (possibly bounded) quote within sourceText.
+  assert.equal(
+    sourceText.slice(located!.offset, located!.offset + located!.quote.length),
+    located!.quote,
+    "offset must point at the returned quote within sourceText",
+  );
+});
+
+test("locateFactQuote: tracks the matched occurrence offset for repeated anaphoric lines (issue #1633, codex :710)", () => {
+  // Two entities, same anaphoric sentence pattern — the fact is about Zeta,
+  // which appears SECOND. The locator's offset must point at the Zeta clause so
+  // extractContextWindow centers on Zeta, not the first (Acme) occurrence.
+  const sourceText =
+    "We started the Acme project in January. It launched in March at beta. " +
+    "Then we began the Zeta initiative in February. It launched in March at general availability.";
+  const located = locateFactQuote(
+    "The Zeta initiative launched in March at general availability.",
+    sourceText,
+  );
+  assert.ok(located, "expected a located quote");
+  // offset must fall within the Zeta clause, AFTER the Acme clause.
+  const acmeClauseEnd = sourceText.indexOf("at beta.") + "at beta.".length;
+  assert.ok(
+    located!.offset >= acmeClauseEnd,
+    `offset must point past the Acme clause (offset=${located!.offset}, acmeEnd=${acmeClauseEnd})`,
+  );
+  assert.ok(
+    sourceText.slice(located!.offset).startsWith(located!.quote),
+    "offset must point at the start of the matched quote",
+  );
 });
 
 test("applyFaithfulnessVerdict: bumps verdict counters at apply time (cursor review)", () => {
@@ -1040,6 +1092,35 @@ test("extractContextWindow: returns undefined when quote is absent from sourceTe
   assert.equal(extractContextWindow("some source", "not present", 400), undefined);
   assert.equal(extractContextWindow("", "x", 400), undefined);
   assert.equal(extractContextWindow("source", "s", 0), undefined);
+});
+
+test("extractContextWindow: matchedOffset selects the matched occurrence, not the first (issue #1633, codex :710)", () => {
+  // The same anaphoric line appears twice — once about Acme, once about Zeta.
+  // Without matchedOffset, indexOf centers context on Acme (the first hit).
+  // With the locator's offset, the window must center on the matched (Zeta) hit.
+  const sourceText =
+    "Acme context before. It launched in March. Acme context after. " +
+    "Zeta context before. It launched in March. Zeta context after.";
+  const quote = "It launched in March.";
+  const firstOccurrence = sourceText.indexOf(quote);
+  const zetaOccurrence = sourceText.indexOf("Zeta context before");
+  assert.ok(firstOccurrence >= 0 && zetaOccurrence > firstOccurrence);
+  // Budget 50 captures the surrounding entity tag without spanning both
+  // occurrences (which would make them indistinguishable).
+  const ctxDefault = extractContextWindow(sourceText, quote, 50);
+  const ctxMatched = extractContextWindow(sourceText, quote, 50, zetaOccurrence);
+  const ctxFirst = extractContextWindow(sourceText, quote, 50, firstOccurrence);
+  assert.ok(ctxDefault && ctxMatched && ctxFirst, "all windows must resolve");
+  assert.ok(
+    ctxDefault!.includes("Acme") && !ctxDefault!.includes("Zeta"),
+    "default (no offset) centers on the first (Acme) occurrence, not Zeta",
+  );
+  assert.ok(
+    ctxMatched!.includes("Zeta") && !ctxMatched!.includes("Acme"),
+    "matchedOffset centers on the matched (Zeta) occurrence, not Acme",
+  );
+  assert.notEqual(ctxMatched, ctxDefault, "windows must differ when offset disambiguates");
+  assert.equal(ctxFirst, ctxDefault, "explicit first-occurrence offset equals the default");
 });
 
 test("runFaithfulnessGateBatch: fallback locator injects CONTEXT into the verifier prompt (codex P2 PRRT_kwDORJXyws6OblI1)", async () => {

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -896,6 +896,37 @@ test("locateFactQuote: bounded window keeps the densest evidence cluster when ma
   );
 });
 
+test("locateFactQuote: bounded window stays linear with many repeated matched tokens (codex PRRT_kwDORJXyws6Ocih3)", () => {
+  // A long unpunctuated candidate with thousands of repeats of a fact token
+  // (pasted logs / minified text). The densest-cluster selection must stay
+  // O(n) via the two-pointer sliding window; the O(n^2) nested loop would
+  // stall extraction on ~5k repeats. This test asserts both correctness (the
+  // bounded window contains the densest cluster) and that the call returns
+  // promptly — under O(n^2) this fixture (~5k repeats) would take seconds.
+  const repeats = 5000;
+  const token = "PostgreSQL "; // one fact token per repeat
+  const filler = "x ".repeat(50); // leading filler so the cluster is mid-string
+  const sourceText = filler + token.repeat(repeats) + "migration done";
+  const start = Date.now();
+  const located = locateFactQuote("PostgreSQL migration done.", sourceText, 200);
+  const elapsed = Date.now() - start;
+  assert.ok(located, "expected a located quote");
+  assert.ok(
+    located!.quote.length <= 200,
+    `bounded quote must respect maxQuoteChars (got ${located!.quote.length})`,
+  );
+  // The densest cluster is the run of PostgreSQL repeats; the window must be
+  // anchored inside it (not in the leading filler) and contain evidence.
+  assert.ok(
+    located!.quote.includes("PostgreSQL"),
+    "bounded window must anchor inside the densest cluster",
+  );
+  assert.ok(
+    elapsed < 1000,
+    `bounded window must stay linear (took ${elapsed}ms for ${repeats} repeats)`,
+  );
+});
+
 test("applyFaithfulnessVerdict: bumps verdict counters at apply time (cursor review)", () => {
   const counters = createFaithfulnessCounters();
   const map: Map<number, FaithfulnessResult> = new Map([

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -718,9 +718,26 @@ export function extractContextWindow(
   sourceText: string,
   quote: string,
   contextChars: number,
+  /**
+   * Character offset of `quote` within `sourceText` (from `locateFactQuote`).
+   * When the quote string appears more than once — e.g. repeated anaphoric
+   * lines after different entities — pass the matched occurrence's offset so
+   * the context window centers on the actual match, not the first occurrence
+   * (issue #1633, codex PRRT_kwDORJXyws6ObzwI). Defaults to the first
+   * occurrence via indexOf for backward compatibility.
+   */
+  matchedOffset?: number,
 ): string | undefined {
   if (!sourceText || !quote || !(contextChars > 0)) return undefined;
-  const idx = sourceText.indexOf(quote);
+  let idx: number;
+  if (matchedOffset !== undefined && matchedOffset >= 0) {
+    const at = sourceText.indexOf(quote, matchedOffset);
+    // Fall back to the first occurrence if the matched offset is stale (e.g.
+    // the quote was bounded and is not a literal substring at that offset).
+    idx = at >= 0 ? at : sourceText.indexOf(quote);
+  } else {
+    idx = sourceText.indexOf(quote);
+  }
   if (idx < 0) return undefined;
   const quoteEnd = idx + quote.length;
   const center = Math.floor((idx + quoteEnd) / 2);
@@ -733,31 +750,136 @@ export function extractContextWindow(
   return window.length > 0 ? window : undefined;
 }
 
+/**
+ * A located fallback quote plus the offset it begins at in the source text.
+ * `offset` lets `extractContextWindow` disambiguate repeated occurrences of
+ * the same quote string (issue #1633).
+ */
+export interface LocatedQuote {
+  /** Verbatim source span, centered on the matched terms when truncated. */
+  quote: string;
+  /** Character offset of `quote` within sourceText. */
+  offset: number;
+}
+
+interface SourceCandidate {
+  /** Trimmed candidate text. */
+  text: string;
+  /** Character offset of `text` within the source string. */
+  start: number;
+}
+
+/**
+ * Split source text into candidate spans (sentences, then line segments as a
+ * fallback for transcripts without sentence punctuation), tracking each
+ * candidate's start offset so repeated occurrences can be disambiguated
+ * (issue #1633).
+ */
+function splitSourceCandidates(sourceText: string): SourceCandidate[] {
+  const candidates: SourceCandidate[] = [];
+  const re = /(?<=[.!?])\s+|\n+/g;
+  let lastEnd = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sourceText)) !== null) {
+    pushCandidate(candidates, sourceText, lastEnd, m.index);
+    lastEnd = re.lastIndex;
+  }
+  pushCandidate(candidates, sourceText, lastEnd, sourceText.length);
+  return candidates;
+}
+
+function pushCandidate(
+  out: SourceCandidate[],
+  source: string,
+  begin: number,
+  end: number,
+): void {
+  const seg = source.slice(begin, end);
+  const leadingWS = seg.length - seg.trimStart().length;
+  const trimmed = seg.trim();
+  if (trimmed.length > 0) {
+    out.push({ text: trimmed, start: begin + leadingWS });
+  }
+}
+
+/**
+ * Locate the min/max character range of fact-token matches inside a candidate.
+ * Used by `locateFactQuote` to center truncation on the actual evidence when a
+ * candidate exceeds `maxQuoteChars` (issue #1633, codex PRRT_kwDORJXyws6Obrwe).
+ * Returns the full candidate span when no token matches (defensive — overlap
+ * scoring already accepted the candidate).
+ */
+function locateMatchedSpan(
+  factTokens: Set<string>,
+  candidate: string,
+): { start: number; end: number } {
+  const lower = candidate.toLowerCase();
+  const wordRe = /[a-z0-9]+/g;
+  let min = candidate.length;
+  let max = 0;
+  let found = false;
+  let m: RegExpExecArray | null;
+  while ((m = wordRe.exec(lower)) !== null) {
+    const word = m[0];
+    if (word.length <= 1) continue;
+    if (STOPWORDS.has(word)) continue;
+    if (factTokens.has(crudeStem(word))) {
+      found = true;
+      if (m.index < min) min = m.index;
+      const wordEnd = m.index + word.length;
+      if (wordEnd > max) max = wordEnd;
+    }
+  }
+  if (!found) return { start: 0, end: candidate.length };
+  return { start: min, end: max };
+}
+
+/**
+ * Build a bounded window of `maxChars` from `text`, centered on `span`.
+ * Returns the window text and its start offset within `text` so callers can
+ * translate the in-candidate offset back to a source-text offset.
+ */
+function boundedWindow(
+  text: string,
+  span: { start: number; end: number },
+  maxChars: number,
+): { text: string; start: number } {
+  const center = Math.floor((span.start + span.end) / 2);
+  const half = Math.floor(maxChars / 2);
+  let start = Math.max(0, center - half);
+  const end = Math.min(text.length, start + maxChars);
+  // Re-anchor start so the window uses the full budget when end clamped.
+  start = Math.max(0, end - maxChars);
+  return { text: text.slice(start, end), start };
+}
+
 export function locateFactQuote(
   factText: string,
   sourceText: string,
   maxQuoteChars = 600,
-): string | undefined {
+): LocatedQuote | undefined {
   if (!factText || !sourceText) return undefined;
   const factTokens = tokenize(factText);
   if (factTokens.size === 0) return undefined;
-  // Split source into candidate spans: sentences, then line segments as a
-  // fallback for transcripts without sentence punctuation.
-  const candidates: string[] = [];
-  for (const sentence of sourceText.split(/(?<=[.!?])\s+|\n+/)) {
-    const s = sentence.trim();
-    if (s.length > 0) candidates.push(s);
-  }
+  const candidates = splitSourceCandidates(sourceText);
   if (candidates.length === 0) return undefined;
-  let best: { quote: string; score: number } | null = null;
+  let best: { candidate: SourceCandidate; score: number } | null = null;
   for (const candidate of candidates) {
-    const score = overlapCoefficient(factTokens, tokenize(candidate));
-    if (!best || score > best.score) best = { quote: candidate, score };
+    const score = overlapCoefficient(factTokens, tokenize(candidate.text));
+    if (!best || score > best.score) best = { candidate, score };
   }
   if (!best || best.score < LOCATE_QUOTE_MIN_OVERLAP) return undefined;
-  return best.quote.length > maxQuoteChars
-    ? best.quote.slice(0, maxQuoteChars)
-    : best.quote;
+  const { text, start } = best.candidate;
+  if (text.length <= maxQuoteChars) {
+    return { quote: text, offset: start };
+  }
+  // Center the bounded window on the matched-term span instead of returning
+  // the first maxQuoteChars prefix (issue #1633). Returning the prefix drops
+  // supporting words that fall after char ~600, routing actually-entailed
+  // facts to pending_review in enforce mode.
+  const matched = locateMatchedSpan(factTokens, text);
+  const win = boundedWindow(text, matched, maxQuoteChars);
+  return { quote: win.text, offset: start + win.start };
 }
 export async function runFaithfulnessGateBatch(
   facts: readonly FaithfulnessGateFact[],
@@ -793,11 +915,19 @@ export async function runFaithfulnessGateBatch(
       .map((s) => (s && typeof s.quote === "string" ? s.quote.trim() : ""))
       .filter((q) => q.length > 0);
     const usingFallbackLocator = sourceQuotes.length === 0;
-    const quote =
-      sourceQuotes.length > 0
-        ? sourceQuotes.join("\n")
-        : locateFactQuote(f.content, sourceText);
-    if (!quote) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
+    let quote: string;
+    let matchedOffset: number | undefined;
+    if (sourceQuotes.length > 0) {
+      quote = sourceQuotes.join("\n");
+    } else {
+      // Fallback locator returns the matched span AND its offset so the
+      // context window centers on the occurrence that actually matched the
+      // fact, not the first indexOf hit (issue #1633).
+      const located = locateFactQuote(f.content, sourceText);
+      if (!located) continue; // no located span — applyFaithfulnessVerdict tags skipped_no_span
+      quote = located.quote;
+      matchedOffset = located.offset;
+    }
     // Pass source context into the verifier so extractionFaithfulnessContextChars
     // actually applies in the fallback-locator path (codex P2
     // PRRT_kwDORJXyws6OblI1). #1575 verified spans already carry full evidence,
@@ -808,6 +938,7 @@ export async function runFaithfulnessGateBatch(
             sourceText,
             quote,
             config.extractionFaithfulnessContextChars,
+            matchedOffset,
           )
         : undefined;
     inputs.push({

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -845,23 +845,28 @@ function boundedWindow(
     const end = Math.min(text.length, maxChars);
     return { text: text.slice(0, end), start: 0 };
   }
+  // matchedPositions is sorted ascending (the regex scans left-to-right), so a
+  // two-pointer sliding window finds the densest maxChars-wide cluster in O(n)
+  // instead of O(n^2). This matters when a long unpunctuated candidate carries
+  // many repeats of a fact token (pasted logs, minified text) — thousands of
+  // positions would otherwise stall extraction before the LLM call (codex
+  // PRRT_kwDORJXyws6Ocih3).
   let bestAnchor = matchedPositions[0]!;
   let bestCount = 0;
   let bestLast = bestAnchor;
-  for (const anchor of matchedPositions) {
+  let j = 0;
+  for (let i = 0; i < matchedPositions.length; i++) {
+    const anchor = matchedPositions[i]!;
     const winEnd = anchor + maxChars;
-    let count = 0;
-    let last = anchor;
-    for (const p of matchedPositions) {
-      if (p >= anchor && p < winEnd) {
-        count++;
-        last = p;
-      }
+    if (j < i) j = i;
+    while (j + 1 < matchedPositions.length && matchedPositions[j + 1]! < winEnd) {
+      j++;
     }
+    const count = j - i + 1;
     if (count > bestCount) {
       bestCount = count;
       bestAnchor = anchor;
-      bestLast = last;
+      bestLast = matchedPositions[j]!;
     }
   }
   // The densest cluster [bestAnchor, bestLast] fits within maxChars by

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -803,48 +803,70 @@ function pushCandidate(
 }
 
 /**
- * Locate the min/max character range of fact-token matches inside a candidate.
- * Used by `locateFactQuote` to center truncation on the actual evidence when a
- * candidate exceeds `maxQuoteChars` (issue #1633, codex PRRT_kwDORJXyws6Obrwe).
- * Returns the full candidate span when no token matches (defensive — overlap
- * scoring already accepted the candidate).
+ * Locate the start offsets of fact-token matches inside a candidate. Used by
+ * `locateFactQuote` to build a bounded window that is guaranteed to contain
+ * real evidence (issue #1633, codex PRRT_kwDORJXyws6Obrwe / PRRT_kwDORJXyws6Oce-O).
  */
-function locateMatchedSpan(
-  factTokens: Set<string>,
-  candidate: string,
-): { start: number; end: number } {
+function locateMatchedTokens(factTokens: Set<string>, candidate: string): number[] {
   const lower = candidate.toLowerCase();
   const wordRe = /[a-z0-9]+/g;
-  let min = candidate.length;
-  let max = 0;
-  let found = false;
+  const positions: number[] = [];
   let m: RegExpExecArray | null;
   while ((m = wordRe.exec(lower)) !== null) {
     const word = m[0];
     if (word.length <= 1) continue;
     if (STOPWORDS.has(word)) continue;
     if (factTokens.has(crudeStem(word))) {
-      found = true;
-      if (m.index < min) min = m.index;
-      const wordEnd = m.index + word.length;
-      if (wordEnd > max) max = wordEnd;
+      positions.push(m.index);
     }
   }
-  if (!found) return { start: 0, end: candidate.length };
-  return { start: min, end: max };
+  return positions;
 }
 
 /**
- * Build a bounded window of `maxChars` from `text`, centered on `span`.
- * Returns the window text and its start offset within `text` so callers can
- * translate the in-candidate offset back to a source-text offset.
+ * Build a bounded window of `maxChars` from `text` that contains the densest
+ * cluster of matched-token positions. Slides a maxChars-wide window anchored
+ * at each matched token and keeps the one that captures the most matches
+ * (tiebreak: earliest anchor). This guarantees the window includes real
+ * evidence even when the matched span is wider than `maxChars` (e.g. fact
+ * tokens at both ends of a long sentence with filler between). Centering on
+ * the densest cluster's midpoint then uses any leftover budget as leading and
+ * trailing context. Returns the window text and its start offset within `text`
+ * so callers can translate the in-candidate offset back to a source-text offset.
  */
 function boundedWindow(
   text: string,
-  span: { start: number; end: number },
+  matchedPositions: number[],
   maxChars: number,
 ): { text: string; start: number } {
-  const center = Math.floor((span.start + span.end) / 2);
+  if (matchedPositions.length === 0) {
+    // Defensive: overlap scoring accepted the candidate but no individual
+    // token matched (e.g. all matches were stopwords). Fall back to prefix.
+    const end = Math.min(text.length, maxChars);
+    return { text: text.slice(0, end), start: 0 };
+  }
+  let bestAnchor = matchedPositions[0]!;
+  let bestCount = 0;
+  let bestLast = bestAnchor;
+  for (const anchor of matchedPositions) {
+    const winEnd = anchor + maxChars;
+    let count = 0;
+    let last = anchor;
+    for (const p of matchedPositions) {
+      if (p >= anchor && p < winEnd) {
+        count++;
+        last = p;
+      }
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      bestAnchor = anchor;
+      bestLast = last;
+    }
+  }
+  // The densest cluster [bestAnchor, bestLast] fits within maxChars by
+  // construction; center a maxChars window on its midpoint, clamped to text.
+  const center = Math.floor((bestAnchor + bestLast) / 2);
   const half = Math.floor(maxChars / 2);
   let start = Math.max(0, center - half);
   const end = Math.min(text.length, start + maxChars);
@@ -863,21 +885,37 @@ export function locateFactQuote(
   if (factTokens.size === 0) return undefined;
   const candidates = splitSourceCandidates(sourceText);
   if (candidates.length === 0) return undefined;
-  let best: { candidate: SourceCandidate; score: number } | null = null;
-  for (const candidate of candidates) {
+  // Pick the best-overlap candidate. Tiebreak equal own-overlap scores by a
+  // "context" score that includes the immediately PRECEDING candidate's text,
+  // so a repeated anaphoric line ("It launched in March") resolves to the
+  // occurrence whose neighbor names the fact's entity (issue #1633, codex
+  // PRRT_kwDORJXyws6Oce-S). Without this tiebreak the first occurrence wins
+  // even when the second is the one the fact refers to.
+  let best: { candidate: SourceCandidate; score: number; contextScore: number } | null = null;
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i]!;
     const score = overlapCoefficient(factTokens, tokenize(candidate.text));
-    if (!best || score > best.score) best = { candidate, score };
+    const prevText = i > 0 ? candidates[i - 1]!.text : "";
+    const contextText = prevText ? `${prevText} ${candidate.text}` : candidate.text;
+    const contextScore = overlapCoefficient(factTokens, tokenize(contextText));
+    if (
+      !best ||
+      score > best.score ||
+      (score === best.score && contextScore > best.contextScore)
+    ) {
+      best = { candidate, score, contextScore };
+    }
   }
   if (!best || best.score < LOCATE_QUOTE_MIN_OVERLAP) return undefined;
   const { text, start } = best.candidate;
   if (text.length <= maxQuoteChars) {
     return { quote: text, offset: start };
   }
-  // Center the bounded window on the matched-term span instead of returning
-  // the first maxQuoteChars prefix (issue #1633). Returning the prefix drops
-  // supporting words that fall after char ~600, routing actually-entailed
-  // facts to pending_review in enforce mode.
-  const matched = locateMatchedSpan(factTokens, text);
+  // Build a bounded window around the densest cluster of matched terms instead
+  // of returning the first maxQuoteChars prefix (issue #1633). Returning the
+  // prefix drops supporting words that fall after char ~600, routing
+  // actually-entailed facts to pending_review in enforce mode.
+  const matched = locateMatchedTokens(factTokens, text);
   const win = boundedWindow(text, matched, maxQuoteChars);
   return { quote: win.text, offset: start + win.start };
 }


### PR DESCRIPTION
## Summary

Closes #1633 — the two deferred locator-precision edges from the #1576/#1629 faithfulness gate. Both only affect the **fallback quote-locator** path (the transitional best-effort bridge used when #1575 per-fact provenance spans are absent), and only for pathological source lines. The primary #1575-provenance path is unaffected.

### (a) Center fallback quotes on the matched text — codex `PRRT_kwDORJXyws6Obrwe`, `:747`
When the located candidate sentence exceeded `maxQuoteChars` (~600) and the supporting words fell *after* the first 600 chars, the verifier received a prefix that omitted the evidence, so enforce mode could route an actually-supported fact to `pending_review`. `locateFactQuote` now computes the in-candidate matched-term span and returns a bounded window **centered on it** instead of the prefix.

### (b) Track the matched span offset — codex `PRRT_kwDORJXyws6ObzwI`, `:710`
When the located quote string appeared more than once in the source turns (e.g. repeated anaphoric lines *"It launched in March"* after different entities), `indexOf` centered the context on the *first* occurrence, not the occurrence that matched the fact. `locateFactQuote` now returns a `LocatedQuote { quote, offset }` where `offset` is the candidate's actual position in `sourceText`; `extractContextWindow` accepts an optional `matchedOffset` and uses `indexOf(quote, matchedOffset)` to center on the right occurrence.

## Files changed
- `packages/remnic-core/src/extraction-faithfulness.ts` — `locateFactQuote` returns `LocatedQuote | undefined`; new helpers `splitSourceCandidates` (offset-tracking sentence splitter), `locateMatchedSpan` (min/max char range of fact-token matches), `boundedWindow` (centered truncation); `extractContextWindow` gains optional `matchedOffset`; gate caller updated.
- `packages/remnic-core/src/extraction-faithfulness.test.ts` — updated existing `locateFactQuote` test for the new return shape; added 3 regression tests.

## New tests
1. `locateFactQuote: centers the bounded window on matched terms for >maxQuoteChars candidates` — ~728-char filler preamble + supporting terms past char 600; bounded quote keeps `PostgreSQL`/`migration`; offset points at the returned quote.
2. `locateFactQuote: tracks the matched occurrence offset for repeated anaphoric lines` — two entities with the same anaphoric line; the fact is about the SECOND entity; offset lands in the second clause, past the first.
3. `extractContextWindow: matchedOffset selects the matched occurrence, not the first` — same anaphoric line about Acme and Zeta; default window includes Acme (not Zeta), matched-offset window includes Zeta (not Acme); explicit first-occurrence offset equals the default.

## Verification
- `npm run preflight:quick` → `[preflight] OK (quick)`
- `npm run test:entity-hardening` → 246/246 pass
- `node scripts/check-ratchets.mjs` → `[ratchet] OK`
- `extraction-faithfulness.test.ts` full suite → 66/66 pass

## API change
`locateFactQuote` return type changed from `string | undefined` to `LocatedQuote | undefined`. The only production caller (`runFaithfulnessGateBatch`) is updated in this PR. The change is internal to the faithfulness module; no exported plugin/MCP/CLI surface is affected.

## Chokepoints used / not applicable
Not applicable — this is a self-contained locator-precision refinement on the fallback path. No new tools/routes/commands, no catalog writes, no capability flags, no keyed mutations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes can alter enforce-mode `pending_review` vs entailed outcomes on the fallback locator path, but scope is limited to internal extraction-faithfulness wiring with no public API surface change beyond the module’s `locateFactQuote` return type.
> 
> **Overview**
> Improves the **fallback quote locator** used when per-fact provenance spans are missing, so enforce-mode faithfulness checks see the right evidence and context.
> 
> **`locateFactQuote`** now returns **`LocatedQuote`** (`quote` + **`offset`**) instead of a bare string. Candidate sentences are split with **`splitSourceCandidates`** so offsets are known; equal-overlap ties break using the **preceding sentence** so repeated lines (e.g. *"It launched in March"*) attach to the correct entity. Long matches are truncated with a **densest-token-cluster** **`boundedWindow`** (O(n) two-pointer) rather than the first ~600 characters, keeping matched terms like `PostgreSQL` / `migration` in the quote.
> 
> **`extractContextWindow`** accepts optional **`matchedOffset`** so synthesized CONTEXT centers on the matched occurrence, not the first `indexOf` hit. **`runFaithfulnessGateBatch`** passes that offset on the fallback path only; the #1575 provenance path is unchanged.
> 
> Tests cover bounded quotes, repeated anaphora, wide evidence spans, and performance on thousands of token repeats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8993e7e8144abcf7b3a3488c137a27841a025bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->