### PR TITLE
fix(bench): make pnpm test self-sufficient on a fresh clone (#1609)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,17 +155,15 @@ jobs:
       - name: Rebuild native modules
         run: pnpm rebuild better-sqlite3
 
-      # Tests need @remnic/core AND @remnic/bench dist output. The bench dist
-      # requirement is load-bearing: tests/remnic-cli-dataset-resolution.test.ts
-      # loads @remnic/bench through the CLI's optional-bench loader, and when
-      # dist/ is absent the tsx/esm/api tsImport fallback breaks subsequent
-      # dynamic .ts imports in the same process (latent bug — main's serial
-      # quality job only passed because the recursive check-types step
-      # side-built bench/dist before Tests ran).
-      - name: Build workspace packages needed by tests
-        run: |
-          pnpm --filter @remnic/core build
-          pnpm --filter @remnic/bench build
+      # Tests need @remnic/core dist (the test runner links against it).
+      # @remnic/bench dist is NOT pre-built here on purpose: the root test
+      # runner (scripts/run-root-tests.mjs) now self-serves it via
+      # ensurePackageBuild, so a missing bench/dist no longer breaks the
+      # suite (issue #1609). Leaving it unbuilt here exercises the exact
+      # fresh-clone path on every CI run — if the runner's ensure regresses,
+      # CI fails loudly instead of passing via a side-effect.
+      - name: Build core
+        run: pnpm --filter @remnic/core build
 
       # CI hard-requires capability tests (#1541), which in turn hard-require
       # `uv` for the AMB runner scripts. Install it on the runner so the gate

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -23,6 +23,7 @@ import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { ensurePackageBuild } from "./build-staleness.mjs";
 import { appendNodeOption } from "./root-test-runner-env.mjs";
 import {
   chunkArgsByLength,
@@ -73,6 +74,28 @@ if (emptyPatterns.length > 0) {
   process.exit(1);
 }
 
+// Tests under packages/remnic-cli load @remnic/bench through the CLI's
+// optional-bench loader (packages/remnic-cli/src/optional-bench.ts). When
+// bench/dist is absent that loader falls back to tsx/esm/api's tsImport,
+// whose scoped-loader registration poisons subsequent dynamic .ts imports
+// in the same process — so tests/remnic-cli-dataset-resolution.test.ts
+// fails on a fresh clone that never built bench (#1609). Ensure bench dist
+// exists here so the fallback never fires in the test path. This makes the
+// runner self-sufficient: `pnpm test` and a direct
+// `node scripts/run-root-tests.mjs` both work without a prior
+// `check-types`/`build` side-effect. Idempotent — skips instantly when dist
+// exists and no source is newer.
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/bench",
+  join(repoRoot, "packages", "bench", "dist", "index.js"),
+  [
+    join(repoRoot, "packages", "bench", "src"),
+    join(repoRoot, "packages", "bench", "package.json"),
+    join(repoRoot, "packages", "bench", "tsup.config.ts"),
+    join(repoRoot, "packages", "bench", "tsconfig.json"),
+  ],
+);
 let filesToRun = files;
 let probe = probeBetterSqlite3(repoRoot);
 if (!probe.ok) {

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -64,3 +64,27 @@ test("root test runner applies remnic source conditions and test globs portably"
   assert.match(script, /process\.platform === "win32" \? "tsx\.cmd" : "tsx"/);
   assert.doesNotMatch(script, /shell:/);
 });
+
+test("root test runner ensures @remnic/bench dist before running tests (#1609)", () => {
+  // Regression guard for the fresh-clone failure: the runner MUST ensure
+  // @remnic/bench dist exists before spawning tsx --test, otherwise
+  // tests/remnic-cli-dataset-resolution.test.ts triggers the optional-bench
+  // tsImport fallback which poisons subsequent dynamic .ts imports.
+  // See issue #1609 and scripts/run-root-tests.mjs.
+  const script = readFileSync(join(repoRoot, "scripts", "run-root-tests.mjs"), "utf8");
+  assert.match(
+    script,
+    /ensurePackageBuild/,
+    "run-root-tests.mjs must call ensurePackageBuild so a fresh clone without a prior build still passes",
+  );
+  assert.match(
+    script,
+    /"@remnic\/bench"/,
+    "run-root-tests.mjs must ensure the @remnic/bench package specifically",
+  );
+  assert.match(
+    script,
+    /join\(repoRoot,\s*"packages",\s*"bench",\s*"dist",\s*"index\.js"\)/,
+    "run-root-tests.mjs must target the bench dist entry (packages/bench/dist/index.js) as the build artifact",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #1609.

On a fresh clone with no prior build, `pnpm test` failed 2 tests in `tests/remnic-cli-dataset-resolution.test.ts` (`runner-managed dry-run validates MemoryAgentBench ReDial mappings` and `MemoryAgentBench downloaded markers require ReDial mappings for split files`). Root cause: the CLI's optional-bench loader (`packages/remnic-cli/src/optional-bench.ts`) falls back to `tsx/esm/api`'s `tsImport` when `packages/bench/dist` is absent, and that scoped-loader registration poisons subsequent dynamic `.ts` imports in the same process. Main's CI only passed because the serial quality job's recursive `check-types` step side-built `bench/dist` before the Tests step ran.

## Change

**`scripts/run-root-tests.mjs`** now calls `ensurePackageBuild` for `@remnic/bench` before spawning `tsx --test`, so the `tsImport` fallback never fires in the test path. This makes both `pnpm test` and a direct `node scripts/run-root-tests.mjs` self-sufficient — no prior `check-types`/`build` side-effect required. The ensure is idempotent (skips instantly when dist exists and no source is newer), reusing the existing `build-staleness.mjs` helper.

## Proof of fresh-clone path

- **`.github/workflows/ci.yml`**: dropped the explicit `pnpm --filter @remnic/bench build` from the tests job so every CI run exercises the exact fresh-clone path. If the runner's ensure regresses, CI fails loudly instead of passing via a side-effect. (Core is still pre-built — that is not the bug here.)
- **`tests/root-test-build-contract.test.ts`**: added a contract test asserting the runner wires `ensurePackageBuild` for `@remnic/bench` targeting `packages/bench/dist/index.js`.
- Verified locally: deleted `packages/bench/dist`, ran `node scripts/run-root-tests.mjs --group misc` → the runner rebuilt bench dist (tsup output visible) then tests passed; the previously-failing 2 tests now pass with bench dist present.

## Scope

`@remnic/bench` + test wiring only. No core/cli changes (the second latent bug — `tsImport` poisoning the loader — is mitigated for the test path because the fallback never fires; deep-hardening of `optional-bench.ts` is out of scope for this issue's fresh-clone acceptance).

## Chokepoints used / not applicable

Not applicable — this is test-wiring + a CI workflow adjustment; no new feature gates, registries, or god-file edits.
