### PR TITLE
feat(plugin-pi): pre-bundle omp extension to fix loader resolution (#1598)

### DIFF
--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -1,7 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import { expandTildePath } from "@remnic/core";
+// Leaf submodule (not the `@remnic/core` barrel) so the omp pre-bundle's
+// `bun build` does not pull the rest of core — including the LanceDB native
+// asset — into the extension bundle. See PR #1641.
+import { expandTildePath } from "@remnic/core/utils/path";
 
 import { REMNIC_PI_EXTENSION_DIR_NAME, resolvePiAgentHome } from "./paths.js";
 

--- a/packages/plugin-pi/src/messages.ts
+++ b/packages/plugin-pi/src/messages.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 
-import { parsePiMessageParts, type LcmMessagePartInput } from "@remnic/core";
+// Leaf submodule (not the `@remnic/core` barrel) so the omp pre-bundle's
+// `bun build` does not pull the rest of core into the extension bundle.
+// `message-parts` is a pure parser with no storage/native deps. See PR #1641.
+import { parsePiMessageParts, type LcmMessagePartInput } from "@remnic/core/message-parts";
 
 import type { ObserveMessage, ObserveMessagePart } from "./client.js";
 

--- a/packages/plugin-pi/src/paths.ts
+++ b/packages/plugin-pi/src/paths.ts
@@ -1,7 +1,9 @@
 import os from "node:os";
 import path from "node:path";
 
-import { expandTildePath } from "@remnic/core";
+// Leaf submodule (not the `@remnic/core` barrel) so the omp pre-bundle's
+// `bun build` does not pull the rest of core into the extension bundle.
+import { expandTildePath } from "@remnic/core/utils/path";
 
 export const REMNIC_PI_EXTENSION_DIR_NAME = "remnic";
 

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -63,7 +63,7 @@ function restoreEnv(name: string, value: string | undefined): void {
 function createFakeBun(root: string): string {
   const binPath = path.join(root, "fake-bun");
   const script = [
-    "#!/usr/bin/env node",
+    `#!${process.execPath}`,
     'const fs = require("node:fs");',
     'const path = require("node:path");',
     "const args = process.argv.slice(2);",
@@ -921,3 +921,236 @@ test("omp publisher loader.js embeds the plugin-pi dist path for mtime self-heal
     `loader must embed the plugin-pi dist path (${wrapperPath}) for mtime comparison`,
   );
 });
+
+// ── Regression (PR #1641 / #1598): the pre-existing dist-bundle must survive a
+// failed final swap. runBundleBuild renames the old bundle aside, moves the new
+// one in, and restores the backup if the final rename fails — it never removes
+// the working bundle before the new one is in place.
+test("omp publisher preserves the existing dist-bundle when the final bundle swap fails", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bundle-swap-fail-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  // Stand up an extension root whose existing dist-bundle holds a working bundle.
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  fs.mkdirSync(extensionRoot, { recursive: true });
+  fs.mkdirSync(path.join(extensionRoot, "dist-bundle"), { recursive: true });
+  fs.writeFileSync(
+    path.join(extensionRoot, "dist-bundle", "index.js"),
+    "export default async function prior() { return \"prior-bundle\"; }\n",
+  );
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  // Sabotage only the final tmp->dist-bundle rename so the new build succeeds
+  // but the swap fails. The backup rename (dist-bundle -> .bak-*) still works.
+  const realRenameSync = fs.renameSync;
+  let swapFailed = false;
+  fs.renameSync = function sabotagedRenameSync(from, to) {
+    if (typeof to === "string" && to.endsWith(path.join(extensionRoot, "dist-bundle")) &&
+        typeof from === "string" && from.includes(".dist-bundle.tmp-")) {
+      swapFailed = true;
+      throw Object.assign(new Error("simulated swap failure"), { code: "EUNKNOWN" });
+    }
+    return realRenameSync.call(fs, from, to);
+  };
+  t.after(() => { fs.renameSync = realRenameSync; });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /failed to finalize bundle output/i,
+  );
+
+  assert.ok(swapFailed, "the final swap must have been attempted and failed");
+  // The working bundle must still be in place — the install is never left bundle-less.
+  assert.equal(
+    fs.readFileSync(path.join(extensionRoot, "dist-bundle", "index.js"), "utf8"),
+    'export default async function prior() { return "prior-bundle"; }\n',
+    "pre-existing dist-bundle must be restored after a failed swap",
+  );
+  // No leftover tmp or backup dirs.
+  for (const entry of fs.readdirSync(extensionRoot)) {
+    assert.ok(
+      !entry.startsWith(".dist-bundle.tmp-") && !entry.startsWith(".dist-bundle.bak-"),
+      `leftover bundle temp/backup dir not cleaned: ${entry}`,
+    );
+  }
+});
+
+// ── Regression (PR #1641 / #1598): the generated loader.js must reuse the bun
+// path resolved at install time so self-healing works when bun is reachable
+// only via REMNIC_OMP_BUN_BIN or a common absolute path that is not on omp's
+// runtime PATH.
+test("omp publisher loader.js embeds the resolved bun path for self-healing rebuilds", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-loader-bun-path-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  const resolvedBun = createFakeBun(root);
+  process.env.REMNIC_OMP_BUN_BIN = resolvedBun;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  const loader = fs.readFileSync(path.join(extensionRoot, "loader.js"), "utf8");
+
+  // The resolved absolute bun path must be embedded and used by the rebuild.
+  assert.ok(
+    loader.includes(JSON.stringify(resolvedBun)),
+    `loader must embed the resolved bun path (${resolvedBun}) for self-healing`,
+  );
+  assert.match(loader, /resolvedBunBin/, "loader must declare resolvedBunBin");
+  assert.match(
+    loader,
+    /spawnSync\(bunForRebuild/,
+    "loader's rebuildBundle must spawn bunForRebuild, not a hardcoded \"bun\"",
+  );
+  assert.doesNotMatch(
+    loader,
+    /spawnSync\(\"bun\"/,
+    "loader must not hardcode spawnSync(\"bun\", ...) for rebuilds",
+  );
+});
+
+// ── Regression (PR #1641 / #1598): resolveBunBinary must honour USERPROFILE
+// (matching omp's path helpers) so the ~/.bun/bin/bun fallback resolves on
+// Windows installs where HOME is unset.
+test("omp publisher resolveBunBinary falls back to USERPROFILE/.bun when HOME is unset", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bun-userprofile-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  // Plant a bun binary under the USERPROFILE home so the candidate lookup finds it.
+  fs.mkdirSync(path.join(home, ".bun", "bin"), { recursive: true });
+  const userprofileBun = path.join(home, ".bun", "bin", "bun");
+  fs.writeFileSync(
+    userprofileBun,
+    createFakeBunScript(),
+    { mode: 0o755 },
+  );
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  const previousPath = process.env.PATH;
+  // Force the PATH probe to fail so resolveBunBinary must use the USERPROFILE
+  // candidate. Empty PATH only affects spawnSync("bun") (ENOENT); the candidate
+  // is invoked as an absolute path and needs no PATH.
+  delete process.env.HOME;
+  process.env.USERPROFILE = home;
+  delete process.env.REMNIC_OMP_BUN_BIN;
+  process.env.PATH = "/usr/bin";
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    restoreEnv("PATH", previousPath);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  // Publish must succeed: resolveBunBinary found the USERPROFILE-relative bun,
+  // pre-bundled, and wrote loader.js + dist-bundle.
+  const result = await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = result.extensionRoot;
+  assert.ok(fs.existsSync(path.join(extensionRoot, "dist-bundle", "index.js")), "dist-bundle produced via USERPROFILE-resolved bun");
+  const loader = fs.readFileSync(path.join(extensionRoot, "loader.js"), "utf8");
+  assert.ok(
+    loader.includes(JSON.stringify(userprofileBun)),
+    "loader must embed the USERPROFILE-resolved bun path",
+  );
+});
+
+/**
+ * Returns the fake-bun script body (writes a stub index.js into --outdir),
+ * matching createFakeBun but without writing to disk. Used by tests that need
+ * to plant the binary at a specific absolute path (e.g. ~/.bun/bin/bun).
+ */
+function createFakeBunScript(): string {
+  return [
+    `#!${process.execPath}`,
+    'const fs = require("node:fs");',
+    'const path = require("node:path");',
+    "const args = process.argv.slice(2);",
+    'const outdirArg = args.find((a) => a.startsWith("--outdir="));',
+    'if (!outdirArg) { console.error("fake-bun: --outdir missing"); process.exit(1); }',
+    'const outdir = outdirArg.slice("--outdir=".length);',
+    "fs.mkdirSync(outdir, { recursive: true });",
+    'fs.writeFileSync(path.join(outdir, "index.js"), "export default async function remnicPiExtension() {}\\n");',
+    "",
+  ].join("\n");
+}

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -10,6 +10,7 @@ import { type PublishContext, loadTokenStore, saveTokenStore } from "@remnic/cor
 import {
   OmpMemoryExtensionPublisher,
   PiMemoryExtensionPublisher,
+  resolveBunBinary,
   resolveBunOnPath,
   resolveOmpWrapperImportSpecifier,
 } from "./publisher.js";
@@ -1619,4 +1620,54 @@ test("resolveBunOnPath skips a non-executable bun earlier on PATH and resolves t
   });
   const resolved = resolveBunOnPath();
   assert.equal(resolved, fs.realpathSync(goodBun));
+});
+
+// ── Regression (PR #1641 / #1598): when the PATH `bun --version` probe fails,
+// resolveBunBinary's filesystem fallback must also skip a stale,
+// non-executable ~/.bun/bin/bun instead of returning it over a later working
+// binary. Same executable-file check as the PATH walk (isExecutableFile),
+// centralised so both candidate-selection sites stay in lockstep.
+test("resolveBunBinary fallback skips a stale non-executable ~/.bun/bin/bun", (t) => {
+  if (process.platform === "win32") {
+    // POSIX executable-bit semantics; skip on Windows (PATHEXT/.exe differ).
+    t.skip();
+    return;
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bun-fallback-"));
+  const home = path.join(root, "home");
+  const bunBinDir = path.join(home, ".bun", "bin");
+  fs.mkdirSync(bunBinDir, { recursive: true });
+  // Stale, non-executable regular file at the first fallback candidate.
+  fs.writeFileSync(path.join(bunBinDir, "bun"), "broken\n", { mode: 0o644 });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  const previousPath = process.env.PATH;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.REMNIC_OMP_BUN_BIN;
+  // Empty PATH so the spawnSync("bun", ["--version"]) probe fails and the
+  // filesystem fallback candidate list is exercised.
+  process.env.PATH = "";
+  t.after(() => {
+    process.env.HOME = previousHome;
+    process.env.USERPROFILE = previousUserProfile;
+    process.env.PATH = previousPath;
+    if (previousBunBin === undefined) delete process.env.REMNIC_OMP_BUN_BIN;
+    else process.env.REMNIC_OMP_BUN_BIN = previousBunBin;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const resolved = resolveBunBinary();
+  // The stale non-executable ~/.bun/bin/bun must NOT be returned. If the host
+  // has a real bun at a later candidate (/usr/local/bin/bun, /opt/homebrew/bin/
+  // bun) the resolver returns that working binary instead — either way the
+  // non-executable file is skipped, which is the bug fix's intent. When a
+  // binary is returned it must itself be executable (a working bun, not just a
+  // file that exists).
+  assert.notEqual(resolved, path.join(bunBinDir, "bun"));
+  if (resolved !== null) {
+    fs.accessSync(resolved, fs.constants.X_OK);
+  }
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -54,6 +54,30 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
+/**
+ * Creates a fake `bun` binary that mimics `bun build <entry> --outdir=<dir>`
+ * by writing a stub `index.js` (valid ESM default export) into the outdir.
+ * Returned path is meant for `process.env.REMNIC_OMP_BUN_BIN` so tests can
+ * exercise the omp pre-bundle path without a real bun on PATH.
+ */
+function createFakeBun(root: string): string {
+  const binPath = path.join(root, "fake-bun");
+  const script = [
+    "#!/usr/bin/env node",
+    'const fs = require("node:fs");',
+    'const path = require("node:path");',
+    "const args = process.argv.slice(2);",
+    'const outdirArg = args.find((a) => a.startsWith("--outdir="));',
+    'if (!outdirArg) { console.error("fake-bun: --outdir missing"); process.exit(1); }',
+    'const outdir = outdirArg.slice("--outdir=".length);',
+    "fs.mkdirSync(outdir, { recursive: true });",
+    'fs.writeFileSync(path.join(outdir, "index.js"), "export default async function remnicPiExtension() {}\\n");',
+    "",
+  ].join("\n");
+  fs.writeFileSync(binPath, script, { mode: 0o755 });
+  return binPath;
+}
+
 test("Pi publisher honors PI_CODING_AGENT_DIR for extension root", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-publisher-dir-test-"));
   try {
@@ -549,7 +573,7 @@ test("omp publisher honors PI_CODING_AGENT_DIR for extension root", async () => 
   );
 });
 
-test("omp publisher publishes config, wrapper, and readme with the omp connector token", async (t) => {
+test("omp publisher publishes config, wrapper, readme, pre-bundle loader, and manifest with the omp connector token", async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-publisher-test-"));
   const home = path.join(root, "home");
   fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
@@ -559,17 +583,20 @@ test("omp publisher publishes config, wrapper, and readme with the omp connector
   const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
   const previousOmpProfile = process.env.OMP_PROFILE;
   const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   delete process.env.PI_CODING_AGENT_DIR;
   delete process.env.OMP_PROFILE;
   delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
   t.after(() => {
     restoreEnv("HOME", previousHome);
     restoreEnv("USERPROFILE", previousUserProfile);
     restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
     restoreEnv("OMP_PROFILE", previousOmpProfile);
     restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -602,6 +629,24 @@ test("omp publisher publishes config, wrapper, and readme with the omp connector
   assert.ok(fs.existsSync(path.join(extensionRoot, "index.ts")));
   const readme = fs.readFileSync(path.join(extensionRoot, "README.md"), "utf8");
   assert.match(readme, /omp/i);
+
+  // Pre-bundle infrastructure (issue #1598): loader.js + package.json + dist-bundle.
+  const loaderPath = path.join(extensionRoot, "loader.js");
+  const packageJsonPath = path.join(extensionRoot, "package.json");
+  const bundleEntry = path.join(extensionRoot, "dist-bundle", "index.js");
+  assert.ok(fs.existsSync(loaderPath), "loader.js was not written");
+  assert.ok(fs.existsSync(packageJsonPath), "package.json was not written");
+  assert.ok(fs.existsSync(bundleEntry), "dist-bundle/index.js was not produced");
+
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as Record<string, unknown>;
+  const ompManifest = pkg.omp as { extensions?: string[] } | undefined;
+  assert.deepEqual(ompManifest?.extensions, ["./loader.js"]);
+  const scripts = pkg.scripts as { postinstall?: string } | undefined;
+  assert.ok(scripts?.postinstall?.includes("bun build"), "postinstall must run bun build");
+
+  const loader = fs.readFileSync(loaderPath, "utf8");
+  assert.match(loader, /omp\.extensions/);
+  assert.match(loader, /bun build/);
 });
 
 test("omp publisher refuses a symlinked extension root", async (t) => {
@@ -664,11 +709,13 @@ test("omp publisher unpublish removes a profile-scoped install even without the 
   const previousConfigDir = process.env.PI_CONFIG_DIR;
   const previousOmpProfile = process.env.OMP_PROFILE;
   const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   delete process.env.PI_CODING_AGENT_DIR;
   delete process.env.PI_CONFIG_DIR;
   delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
   t.after(() => {
     restoreEnv("HOME", previousHome);
     restoreEnv("USERPROFILE", previousUserProfile);
@@ -676,6 +723,7 @@ test("omp publisher unpublish removes a profile-scoped install even without the 
     restoreEnv("PI_CONFIG_DIR", previousConfigDir);
     restoreEnv("OMP_PROFILE", previousOmpProfile);
     restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -693,6 +741,8 @@ test("omp publisher unpublish removes a profile-scoped install even without the 
   });
   assert.equal(installResult.extensionRoot, profileRoot);
   assert.ok(fs.existsSync(path.join(profileRoot, "remnic.config.json")));
+  assert.ok(fs.existsSync(path.join(profileRoot, "loader.js")), "loader.js was not installed");
+  assert.ok(fs.existsSync(path.join(profileRoot, "dist-bundle", "index.js")), "bundle was not installed");
 
   // Remove WITHOUT the profile env set — must still find and remove the
   // profile-scoped install instead of no-oping on the default agent dir.
@@ -702,4 +752,172 @@ test("omp publisher unpublish removes a profile-scoped install even without the 
   assert.equal(fs.existsSync(path.join(profileRoot, "remnic.config.json")), false);
   assert.equal(fs.existsSync(path.join(profileRoot, "index.ts")), false);
   assert.equal(fs.existsSync(path.join(profileRoot, "README.md")), false);
+  assert.equal(fs.existsSync(path.join(profileRoot, "loader.js")), false, "loader.js was not removed");
+  assert.equal(fs.existsSync(path.join(profileRoot, "package.json")), false, "package.json was not removed");
+  assert.equal(fs.existsSync(path.join(profileRoot, "dist-bundle")), false, "dist-bundle was not removed");
+});
+
+test("omp publisher fails with a clear message when bun is absent", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-no-bun-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  // Point to a nonexistent binary so resolveBunBinary returns null.
+  process.env.REMNIC_OMP_BUN_BIN = path.join(root, "does-not-exist");
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /requires `bun`.*omp/i,
+  );
+
+  // Rollback: the extension root was newly created, so it must be cleaned up.
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  assert.equal(fs.existsSync(extensionRoot), false, "extension root must be cleaned up on rollback");
+});
+
+test("omp publisher rolls back shared files when bun build fails", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bundle-fail-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  // Pre-populate the extension root with prior files so we can verify rollback
+  // restores them rather than deleting the root.
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  fs.mkdirSync(extensionRoot, { recursive: true });
+  fs.writeFileSync(path.join(extensionRoot, "remnic.config.json"), '{"prior":true}\n');
+  fs.writeFileSync(path.join(extensionRoot, "index.ts"), "// prior wrapper\n");
+  fs.writeFileSync(path.join(extensionRoot, "README.md"), "prior readme\n");
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  // Fake bun that always fails.
+  const failingBun = path.join(root, "failing-bun");
+  fs.writeFileSync(
+    failingBun,
+    ['#!/usr/bin/env node', 'console.error("simulated bun build failure"); process.exit(1);', ""].join("\n"),
+    { mode: 0o755 },
+  );
+  process.env.REMNIC_OMP_BUN_BIN = failingBun;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /bun build failed/i,
+  );
+
+  // Prior files must be restored to their original content.
+  assert.equal(fs.readFileSync(path.join(extensionRoot, "remnic.config.json"), "utf8"), '{"prior":true}\n');
+  assert.equal(fs.readFileSync(path.join(extensionRoot, "index.ts"), "utf8"), "// prior wrapper\n");
+  assert.equal(fs.readFileSync(path.join(extensionRoot, "README.md"), "utf8"), "prior readme\n");
+  // dist-bundle must not exist (rollback cleans newly created dirs).
+  assert.equal(fs.existsSync(path.join(extensionRoot, "dist-bundle")), false, "dist-bundle must be cleaned up on rollback");
+});
+
+test("omp publisher loader.js embeds the plugin-pi dist path for mtime self-healing", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-loader-path-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  const loader = fs.readFileSync(path.join(extensionRoot, "loader.js"), "utf8");
+  const wrapper = fs.readFileSync(path.join(extensionRoot, "index.ts"), "utf8");
+
+  // The loader must reference the same plugin-pi dist path that the wrapper imports from,
+  // so mtime self-healing detects npm updates of @remnic/plugin-pi.
+  const wrapperImportMatch = wrapper.match(/from\s+"(file:\/\/.+plugin-pi\/dist\/index\.js)"/);
+  assert.ok(wrapperImportMatch, "wrapper must import from plugin-pi dist");
+  const wrapperPath = wrapperImportMatch[1].replace(/^file:\/\//, "");
+  assert.ok(
+    loader.includes(JSON.stringify(wrapperPath)),
+    `loader must embed the plugin-pi dist path (${wrapperPath}) for mtime comparison`,
+  );
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -10,6 +10,7 @@ import { type PublishContext, loadTokenStore, saveTokenStore } from "@remnic/cor
 import {
   OmpMemoryExtensionPublisher,
   PiMemoryExtensionPublisher,
+  resolveBunOnPath,
   resolveOmpWrapperImportSpecifier,
 } from "./publisher.js";
 
@@ -1584,4 +1585,38 @@ test("omp publisher resolveBunBinary resolves the PATH-found bun to an absolute 
     /var bunForRebuild\s*=\s*"bun"\s*;/,
     "loader must not fall back to the bare 'bun' string when an absolute binary was available on PATH",
   );
+});
+
+// ── Regression (PR #1641 / #1598): resolveBunOnPath must skip non-executable
+// PATH candidates so it matches `which(1)` and the spawnSync("bun", …) version
+// probe. When a stale, non-executable `bun` file appears earlier on PATH than
+// the real executable, the OS exec lookup in the version probe skips it and
+// succeeds against the later binary; returning the non-executable file here
+// would diverge and embed a path that fails with EACCES at bundle time.
+test("resolveBunOnPath skips a non-executable bun earlier on PATH and resolves the later executable one", (t) => {
+  if (process.platform === "win32") {
+    // The POSIX executable-bit check that this regression guards against is
+    // not meaningful on Windows (PATHEXT/.exe semantics differ); skip there.
+    t.skip();
+    return;
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bun-nonexec-"));
+  const staleDir = path.join(root, "stale");
+  const goodDir = path.join(root, "good");
+  fs.mkdirSync(staleDir, { recursive: true });
+  fs.mkdirSync(goodDir, { recursive: true });
+  const staleBun = path.join(staleDir, "bun");
+  const goodBun = path.join(goodDir, "bun");
+  // Stale: a regular, non-executable file named `bun` earlier on PATH.
+  fs.writeFileSync(staleBun, "#!/bin/sh\nold broken bun\n", { mode: 0o644 });
+  // Good: an executable `bun` later on PATH.
+  fs.writeFileSync(goodBun, "#!/bin/sh\necho bun\n", { mode: 0o755 });
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${staleDir}:${goodDir}`;
+  t.after(() => {
+    process.env.PATH = previousPath;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  const resolved = resolveBunOnPath();
+  assert.equal(resolved, fs.realpathSync(goodBun));
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -877,6 +877,61 @@ test("omp publisher rolls back shared files when bun build fails", async (t) => 
   assert.equal(fs.existsSync(path.join(extensionRoot, "dist-bundle")), false, "dist-bundle must be cleaned up on rollback");
 });
 
+// ── Regression (PR #1641 / #1598): a failed omp pre-bundle (bun missing or
+// `bun build` failing) must NOT roll back the connector token. The CLI commits
+// the new token before publishing and the loader self-heals dist-bundle on
+// first load; destroying the token leaves the connector installed with no
+// credential and blocks a non-`--force` reinstall (AGENTS.md #14).
+test("omp publisher keeps the connector token when pre-bundling fails", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-token-preserve-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  // No bun available → resolveBunBinary returns null → pre-bundle fails.
+  process.env.REMNIC_OMP_BUN_BIN = path.join(root, "does-not-exist");
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  // The CLI has already committed the new omp token; there was no prior token.
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new OmpMemoryExtensionPublisher();
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        rollbackTokenEntry: null,
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /requires `bun`.*omp/i,
+  );
+
+  // The committed token must survive the pre-bundle failure.
+  const ompToken = loadTokenStore().tokens.find((entry) => entry.connector === "omp");
+  assert.equal(ompToken?.token, "omp-token", "omp token must be preserved when pre-bundling fails");
+});
+
 test("omp publisher loader.js embeds the plugin-pi dist path for mtime self-healing", async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-loader-path-"));
   const home = path.join(root, "home");

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -642,7 +643,7 @@ test("omp publisher publishes config, wrapper, readme, pre-bundle loader, and ma
   const ompManifest = pkg.omp as { extensions?: string[] } | undefined;
   assert.deepEqual(ompManifest?.extensions, ["./loader.js"]);
   const scripts = pkg.scripts as { postinstall?: string } | undefined;
-  assert.ok(scripts?.postinstall?.includes("bun build"), "postinstall must run bun build");
+  assert.ok(scripts?.postinstall?.includes("build index.ts"), "postinstall must run bun build");
 
   const loader = fs.readFileSync(loaderPath, "utf8");
   assert.match(loader, /bundleIsStale/, "loader must have staleness check");
@@ -911,14 +912,21 @@ test("omp publisher loader.js embeds the plugin-pi dist path for mtime self-heal
   const loader = fs.readFileSync(path.join(extensionRoot, "loader.js"), "utf8");
   const wrapper = fs.readFileSync(path.join(extensionRoot, "index.ts"), "utf8");
 
-  // The loader must reference the same plugin-pi dist path that the wrapper imports from,
-  // so mtime self-healing detects npm updates of @remnic/plugin-pi.
-  const wrapperImportMatch = wrapper.match(/from\s+"(file:\/\/.+plugin-pi\/(?:src|dist)\/index\.(?:ts|js))"/);
-  assert.ok(wrapperImportMatch, "wrapper must import from plugin-pi dist");
-  const wrapperPath = wrapperImportMatch[1].replace(/^file:\/\//, "");
+  // omp pre-bundles the wrapper with `bun build`, whose bundler cannot resolve
+  // file:// specifiers (verified Bun 1.2–1.3: "Could not resolve: file://...").
+  // The wrapper must therefore use a relative import specifier; the loader
+  // still embeds the absolute plugin-pi dist path for mtime self-healing.
+  assert.doesNotMatch(
+    wrapper,
+    /from\s+"file:\/\//,
+    "omp wrapper must not use a file:// import (bun build cannot resolve it)",
+  );
+  const relMatch = wrapper.match(/from\s+"(\.\.?\/[^"]+)"/);
+  assert.ok(relMatch, "omp wrapper must use a relative import specifier for bun build");
+  const resolvedPluginPiEntry = path.resolve(extensionRoot, relMatch[1]);
   assert.ok(
-    loader.includes(JSON.stringify(wrapperPath)),
-    `loader must embed the plugin-pi dist path (${wrapperPath}) for mtime comparison`,
+    loader.includes(JSON.stringify(resolvedPluginPiEntry)),
+    `loader must embed the plugin-pi dist path (${resolvedPluginPiEntry}) for mtime comparison`,
   );
 });
 
@@ -1154,3 +1162,127 @@ function createFakeBunScript(): string {
     "",
   ].join("\n");
 }
+
+// ── Regression (PR #1641 / #1598, P1): omp pre-bundles index.ts with
+// `bun build`, whose bundler cannot resolve file:// import specifiers. The
+// generated wrapper must use a relative specifier so a real bun build produces
+// dist-bundle (the fake-bun tests never parse the entry, so this is the only
+// guard against the file:// regression).
+test("omp publisher wrapper is bun-buildable (relative import, not file://)", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-wrapper-bunbuild-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  const wrapperPath = path.join(extensionRoot, "index.ts");
+  const wrapper = fs.readFileSync(wrapperPath, "utf8");
+  assert.doesNotMatch(
+    wrapper,
+    /from\s+"file:\/\//,
+    "omp wrapper must not use a file:// import (bun build cannot resolve it)",
+  );
+  assert.match(wrapper, /from\s+"\.\.?\//, "omp wrapper must use a relative import specifier");
+
+  // Live `bun build` of the generated wrapper is not feasible in this
+  // isolated test: plugin-pi's transitive bare-specifier imports (e.g.
+  // `@remnic/core`) need the real omp node_modules layout to resolve. The
+  // specifier fix itself was verified during development with a self-contained
+  // target — `file://` fails with "Could not resolve" on Bun 1.2–1.3 while a
+  // relative specifier produces the bundle — so here we guard the mechanism
+  // (relative, not file://) that makes a real install buildable.
+});
+
+// ── Regression (PR #1641 / #1598): package.json postinstall must reuse the
+// resolved bun path so `npm install` re-bundles on systems where bun is not on
+// the PATH npm inherits.
+test("omp publisher package.json postinstall uses the resolved bun path", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-postinstall-bun-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  const resolvedBun = createFakeBun(root);
+  process.env.REMNIC_OMP_BUN_BIN = resolvedBun;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const extensionRoot = path.join(home, ".omp", "agent", "extensions", "remnic");
+  const pkg = JSON.parse(fs.readFileSync(path.join(extensionRoot, "package.json"), "utf8")) as {
+    scripts: { postinstall: string };
+  };
+  const postinstall = pkg.scripts.postinstall;
+  assert.ok(
+    postinstall.includes(resolvedBun),
+    `postinstall must reference the resolved bun path (${resolvedBun})`,
+  );
+  assert.ok(postinstall.includes("build index.ts"), "postinstall must run bun build");
+  assert.match(
+    postinstall,
+    /\|\|\s*BUN=bun/,
+    "postinstall must fall back to PATH bun when the resolved binary is missing",
+  );
+  assert.doesNotMatch(
+    postinstall,
+    /^bun build\s/,
+    "postinstall must not invoke a bare bun (would fail when bun is not on PATH)",
+  );
+});

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -645,8 +645,8 @@ test("omp publisher publishes config, wrapper, readme, pre-bundle loader, and ma
   assert.ok(scripts?.postinstall?.includes("bun build"), "postinstall must run bun build");
 
   const loader = fs.readFileSync(loaderPath, "utf8");
-  assert.match(loader, /omp\.extensions/);
-  assert.match(loader, /bun build/);
+  assert.match(loader, /bundleIsStale/, "loader must have staleness check");
+  assert.match(loader, /dist-bundle/, "loader must reference dist-bundle");
 });
 
 test("omp publisher refuses a symlinked extension root", async (t) => {
@@ -913,7 +913,7 @@ test("omp publisher loader.js embeds the plugin-pi dist path for mtime self-heal
 
   // The loader must reference the same plugin-pi dist path that the wrapper imports from,
   // so mtime self-healing detects npm updates of @remnic/plugin-pi.
-  const wrapperImportMatch = wrapper.match(/from\s+"(file:\/\/.+plugin-pi\/dist\/index\.js)"/);
+  const wrapperImportMatch = wrapper.match(/from\s+"(file:\/\/.+plugin-pi\/(?:src|dist)\/index\.(?:ts|js))"/);
   assert.ok(wrapperImportMatch, "wrapper must import from plugin-pi dist");
   const wrapperPath = wrapperImportMatch[1].replace(/^file:\/\//, "");
   assert.ok(

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -1483,6 +1483,27 @@ test("resolveOmpWrapperImportSpecifier fails fast with an actionable error for c
     "cross-drive omp layout must fail fast instead of emitting an invalid ./D:\\… specifier",
   );
 });
+test("resolveOmpWrapperImportSpecifier treats Windows drive-letter casing as the same drive", () => {
+  // Windows drive roots are case-insensitive: the omp agent home and the
+  // plugin-pi install may report the drive letter in different casing (e.g.
+  // C:\ from the home env var, c:\ from fileURLToPath(import.meta.url)). Such a
+  // layout is same-drive and path.win32.relative yields a valid specifier, so
+  // the guard must NOT reject it.
+  const wrapperDir = "C:\\Users\\me\\.omp\\agent\\extensions\\remnic";
+  const modulePath = "c:\\remnic\\plugin-pi\\dist\\index.js";
+  // Sanity-check: raw roots differ in casing but the drive is the same.
+  assert.notEqual(win32.parse(wrapperDir).root, win32.parse(modulePath).root);
+  assert.equal(
+    win32.parse(wrapperDir).root.toLowerCase(),
+    win32.parse(modulePath).root.toLowerCase(),
+  );
+  const specifier = resolveOmpWrapperImportSpecifier(modulePath, wrapperDir, win32);
+  assert.ok(
+    specifier.startsWith("./") || specifier.startsWith("../"),
+    `expected a relative specifier for same-drive different-casing roots, got ${specifier}`,
+  );
+  assert.doesNotMatch(specifier, /^[A-Za-z]:[\\/]/, "specifier must not be a bare absolute drive path");
+});
 
 // ── Regression (PR #1641 / #1598): when bun is found via the PATH probe,
 // resolveBunBinary must resolve it to an absolute executable path so the

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -2,12 +2,16 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import os from "node:os";
-import path from "node:path";
+import path, { win32 } from "node:path";
 import test from "node:test";
 
 import { type PublishContext, loadTokenStore, saveTokenStore } from "@remnic/core";
 
-import { OmpMemoryExtensionPublisher, PiMemoryExtensionPublisher } from "./publisher.js";
+import {
+  OmpMemoryExtensionPublisher,
+  PiMemoryExtensionPublisher,
+  resolveOmpWrapperImportSpecifier,
+} from "./publisher.js";
 
 class FailingPiPublisher extends PiMemoryExtensionPublisher {
   async renderInstructions(ctx: PublishContext): Promise<string> {
@@ -1446,5 +1450,36 @@ test("omp extension runtime closure imports core only via leaf submodules, not t
       "not the @remnic/core barrel — the barrel pulls the search backends " +
       "(LanceDB native asset) into the omp extension bundle. Offenders: " +
       offenders.join(", "),
+  );
+});
+
+// ── Regression (PR #1641 / #1598): the omp wrapper import specifier must stay
+// a valid relative module specifier even on Windows cross-drive layouts. When
+// the extension dir and the plugin-pi install are on different drives,
+// path.relative returns an absolute drive path; prefixing "./" then yields an
+// invalid specifier that fails `bun build` cryptically. `bun build` also
+// cannot resolve a `file://` specifier (verified on Bun 1.3), so the only safe
+// response is to fail fast with an actionable error.
+test("resolveOmpWrapperImportSpecifier emits a ./ relative specifier for same-drive paths", () => {
+  const specifier = resolveOmpWrapperImportSpecifier(
+    path.join(path.sep, "opt", "remnic", "plugin-pi", "dist", "index.js"),
+    path.join(path.sep, "home", "me", ".omp", "agent", "extensions", "remnic"),
+  );
+  assert.ok(
+    specifier.startsWith("./") || specifier.startsWith("../"),
+    `expected a relative (./ or ../) specifier, got ${specifier}`,
+  );
+  assert.doesNotMatch(specifier, /^[A-Za-z]:[\\/]/, "specifier must not be a bare absolute drive path");
+  assert.doesNotMatch(specifier, /^\/[^/]/, "specifier must not be a bare absolute posix path");
+});
+test("resolveOmpWrapperImportSpecifier fails fast with an actionable error for cross-drive Windows layouts", () => {
+  const wrapperDir = "C:\\Users\\me\\.omp\\agent\\extensions\\remnic";
+  const modulePath = "D:\\remnic\\plugin-pi\\dist\\index.js";
+  // Sanity-check the cross-drive premise: different roots under win32 semantics.
+  assert.notEqual(win32.parse(wrapperDir).root, win32.parse(modulePath).root);
+  assert.throws(
+    () => resolveOmpWrapperImportSpecifier(modulePath, wrapperDir, win32),
+    /different drives/i,
+    "cross-drive omp layout must fail fast instead of emitting an invalid ./D:\\… specifier",
   );
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -1483,3 +1483,84 @@ test("resolveOmpWrapperImportSpecifier fails fast with an actionable error for c
     "cross-drive omp layout must fail fast instead of emitting an invalid ./D:\\… specifier",
   );
 });
+
+// ── Regression (PR #1641 / #1598): when bun is found via the PATH probe,
+// resolveBunBinary must resolve it to an absolute executable path so the
+// embedded loader/postinstall don't depend on omp's runtime PATH (GUI/service
+// launches often strip PATH, which would make a bare "bun" self-heal spawn
+// fail even though install found a working binary).
+test("omp publisher resolveBunBinary resolves the PATH-found bun to an absolute path", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bun-path-resolve-"));
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  // Fake bun that satisfies BOTH the `--version` PATH probe (exit 0) and the
+  // `build --outdir` bundle step (writes a stub index.js).
+  const fakeBun = path.join(binDir, "bun");
+  fs.writeFileSync(
+    fakeBun,
+    [
+      `#!${process.execPath}`,
+      'const fs = require("node:fs");',
+      'const path = require("node:path");',
+      "const args = process.argv.slice(2);",
+      'if (args[0] === "--version") process.exit(0);',
+      'const outdirArg = args.find((a) => a.startsWith("--outdir="));',
+      'if (!outdirArg) { console.error("fake-bun: --outdir missing"); process.exit(1); }',
+      'const outdir = outdirArg.slice("--outdir=".length);',
+      "fs.mkdirSync(outdir, { recursive: true });",
+      'fs.writeFileSync(path.join(outdir, "index.js"), "export default async function remnicPiExtension() {}\\n");',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  const previousPath = process.env.PATH;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  delete process.env.REMNIC_OMP_BUN_BIN;
+  // Only the fake bun is on PATH, so the PATH probe resolves to it.
+  process.env.PATH = binDir;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    restoreEnv("PATH", previousPath);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const result = await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const loader = fs.readFileSync(path.join(result.extensionRoot, "loader.js"), "utf8");
+  const resolvedFakeBun = fs.realpathSync(fakeBun);
+  assert.ok(
+    loader.includes(JSON.stringify(resolvedFakeBun)),
+    `loader must embed the absolute PATH-resolved bun path (${resolvedFakeBun}), not the bare string "bun"`,
+  );
+  assert.doesNotMatch(
+    loader,
+    /var bunForRebuild\s*=\s*"bun"\s*;/,
+    "loader must not fall back to the bare 'bun' string when an absolute binary was available on PATH",
+  );
+});

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -643,7 +643,7 @@ test("omp publisher publishes config, wrapper, readme, pre-bundle loader, and ma
   const ompManifest = pkg.omp as { extensions?: string[] } | undefined;
   assert.deepEqual(ompManifest?.extensions, ["./loader.js"]);
   const scripts = pkg.scripts as { postinstall?: string } | undefined;
-  assert.ok(scripts?.postinstall?.includes("build index.ts"), "postinstall must run bun build");
+  assert.equal(scripts?.postinstall, "node postinstall-bundle.cjs", "postinstall must run the cross-platform Node helper");
 
   const loader = fs.readFileSync(loaderPath, "utf8");
   assert.match(loader, /bundleIsStale/, "loader must have staleness check");
@@ -1227,8 +1227,8 @@ test("omp publisher wrapper is bun-buildable (relative import, not file://)", as
 // ── Regression (PR #1641 / #1598): package.json postinstall must reuse the
 // resolved bun path so `npm install` re-bundles on systems where bun is not on
 // the PATH npm inherits.
-test("omp publisher package.json postinstall uses the resolved bun path", async (t) => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-postinstall-bun-"));
+test("omp publisher writes a cross-platform postinstall-bundle.cjs that embeds the resolved bun path", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-postinstall-cjs-"));
   const home = path.join(root, "home");
   fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
 
@@ -1269,20 +1269,148 @@ test("omp publisher package.json postinstall uses the resolved bun path", async 
   const pkg = JSON.parse(fs.readFileSync(path.join(extensionRoot, "package.json"), "utf8")) as {
     scripts: { postinstall: string };
   };
-  const postinstall = pkg.scripts.postinstall;
+  // npm runs scripts via cmd.exe on Windows by default; a Node-only helper is
+  // the only cross-platform shape, so package.json just invokes it.
+  assert.equal(pkg.scripts.postinstall, "node postinstall-bundle.cjs");
+
+  const helperPath = path.join(extensionRoot, "postinstall-bundle.cjs");
+  assert.ok(fs.existsSync(helperPath), "postinstall-bundle.cjs must be written");
+  const helper = fs.readFileSync(helperPath, "utf8");
   assert.ok(
-    postinstall.includes(resolvedBun),
-    `postinstall must reference the resolved bun path (${resolvedBun})`,
+    helper.includes(resolvedBun),
+    `postinstall helper must embed the resolved bun path (${resolvedBun})`,
   );
-  assert.ok(postinstall.includes("build index.ts"), "postinstall must run bun build");
-  assert.match(
-    postinstall,
-    /\|\|\s*BUN=bun/,
-    "postinstall must fall back to PATH bun when the resolved binary is missing",
+  assert.match(helper, /function pickBun/, "helper must resolve bun with a PATH fallback");
+  assert.match(helper, /\.dist-bundle\.bak-/, "helper must swap bundles atomically (backup dir)");
+
+  // The helper must be syntactically valid Node (no shell-specific syntax).
+  const syntaxCheck = spawnSync(process.execPath, ["--check", helperPath], { encoding: "utf-8" });
+  assert.equal(syntaxCheck.status, 0, `postinstall-bundle.cjs fails node --check: ${syntaxCheck.stderr}`);
+
+  // Running the helper must rebuild dist-bundle via the embedded bun path.
+  fs.rmSync(path.join(extensionRoot, "dist-bundle"), { recursive: true, force: true });
+  const run = spawnSync(process.execPath, [helperPath], {
+    cwd: extensionRoot,
+    encoding: "utf-8",
+  });
+  assert.equal(run.status, 0, `postinstall helper failed to rebuild: ${run.stderr ?? run.stdout}`);
+  assert.ok(
+    fs.existsSync(path.join(extensionRoot, "dist-bundle", "index.js")),
+    "postinstall helper must regenerate dist-bundle/index.js",
   );
+});
+
+// ── Regression (PR #1641 / #1598): the official Bun Windows installer ships
+// bun.exe; resolveBunBinary must probe it (fs.existsSync does not apply PATHEXT).
+test("omp publisher resolveBunBinary finds ~/.bun/bin/bun.exe (Windows installer layout)", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-bun-exe-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  // Plant ONLY bun.exe (no bun) under the home, mirroring the Windows installer.
+  fs.mkdirSync(path.join(home, ".bun", "bin"), { recursive: true });
+  const bunExe = path.join(home, ".bun", "bin", "bun.exe");
+  fs.writeFileSync(bunExe, createFakeBunScript(), { mode: 0o755 });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  const previousPath = process.env.PATH;
+  delete process.env.HOME;
+  process.env.USERPROFILE = home;
+  delete process.env.REMNIC_OMP_BUN_BIN;
+  process.env.PATH = "/usr/bin"; // force the PATH probe to fail → candidate lookup
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    restoreEnv("PATH", previousPath);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const result = await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+  assert.ok(
+    fs.existsSync(path.join(result.extensionRoot, "dist-bundle", "index.js")),
+    "publish must succeed via the ~/.bun/bin/bun.exe candidate",
+  );
+});
+
+// ── Regression (PR #1641 / #1598): the loader's self-heal rebuild must build to
+// a temp dir and swap (mirroring runBundleBuild), never writing --outdir
+// straight into dist-bundle where a failure could corrupt the working bundle.
+test("omp publisher loader rebuilds via a temp dir swap, not an in-place build", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-omp-loader-swap-"));
+  const home = path.join(root, "home");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousOmpProfile = process.env.OMP_PROFILE;
+  const previousPiProfile = process.env.PI_PROFILE;
+  const previousBunBin = process.env.REMNIC_OMP_BUN_BIN;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.PI_CODING_AGENT_DIR;
+  delete process.env.OMP_PROFILE;
+  delete process.env.PI_PROFILE;
+  process.env.REMNIC_OMP_BUN_BIN = createFakeBun(root);
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_CODING_AGENT_DIR", previousCodingAgentDir);
+    restoreEnv("OMP_PROFILE", previousOmpProfile);
+    restoreEnv("PI_PROFILE", previousPiProfile);
+    restoreEnv("REMNIC_OMP_BUN_BIN", previousBunBin);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "omp", token: "omp-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  await new OmpMemoryExtensionPublisher().publish({
+    config: { memoryDir: path.join(root, "memory") },
+    skillsRoot: path.join(root, "memory", "skills"),
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  });
+
+  const loader = fs.readFileSync(
+    path.join(home, ".omp", "agent", "extensions", "remnic", "loader.js"),
+    "utf8",
+  );
+  assert.match(loader, /\.dist-bundle\.tmp-/, "loader rebuild must build to a temp dir");
+  assert.match(loader, /\.dist-bundle\.bak-/, "loader rebuild must rename the old bundle aside");
+  assert.match(loader, /renameSync\(tmp, bundleDir\)/, "loader rebuild must swap the temp into place");
+  // The spawn call must target the temp dir, not dist-bundle directly
+  // (the literal "--outdir=dist-bundle" still appears in error-guidance text,
+  // so assert the call site specifically).
   assert.doesNotMatch(
-    postinstall,
-    /^bun build\s/,
-    "postinstall must not invoke a bare bun (would fail when bun is not on PATH)",
+    loader,
+    /spawnSync\(bunForRebuild.*--outdir=dist-bundle/,
+    "loader rebuild spawn must not target dist-bundle directly",
   );
+  // Must still be valid JS.
+  const syntaxCheck = spawnSync(
+    process.execPath,
+    ["--check", path.join(home, ".omp", "agent", "extensions", "remnic", "loader.js")],
+    { encoding: "utf-8" },
+  );
+  assert.equal(syntaxCheck.status, 0, `loader.js fails node --check: ${syntaxCheck.stderr}`);
 });

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -1414,3 +1414,37 @@ test("omp publisher loader rebuilds via a temp dir swap, not an in-place build",
   );
   assert.equal(syntaxCheck.status, 0, `loader.js fails node --check: ${syntaxCheck.stderr}`);
 });
+
+// ── Regression (PR #1641 / #1598): the omp pre-bundle must not pull all of
+// @remnic/core (and the LanceDB native asset) into the extension bundle.
+// The omp wrapper is `bun build`-ed from the generated index.ts, which imports
+// `createRemnicPiExtension`. Every file transitively reachable from that entry
+// must reach core through leaf submodules (`@remnic/core/<submodule>`), never
+// the `@remnic/core` barrel — the barrel eagerly imports the search backends
+// (LanceDB/Orama/Meilisearch), and since the package has no `sideEffects`
+// field, bundlers cannot tree-shake them out. Measured before this fix: a real
+// `bun build` emitted 917 modules + the ~100 MB lancedb .node asset; after, 209
+// modules / ~0.16 MB with zero native refs.
+test("omp extension runtime closure imports core only via leaf submodules, not the barrel", () => {
+  const srcDir = path.join(path.dirname(new URL(import.meta.url).pathname), "..", "src");
+  // publisher.ts is build/install-time only — it is never in the omp-bundled
+  // runtime graph (the wrapper imports createRemnicPiExtension from index.ts),
+  // so its barrel import is exempt.
+  const exempt: Record<string, true> = { "publisher.ts": true };
+  const barrelRe = /from\s+["@']@remnic\/core["@']/;
+  const offenders: string[] = [];
+  for (const file of fs.readdirSync(srcDir)) {
+    if (!file.endsWith(".ts") || file.endsWith(".test.ts") || exempt[file]) continue;
+    const text = fs.readFileSync(path.join(srcDir, file), "utf8");
+    if (barrelRe.test(text)) offenders.push(file);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    "omp-bundled runtime files must import @remnic/core helpers from leaf " +
+      "submodules (e.g. @remnic/core/utils/path, @remnic/core/message-parts), " +
+      "not the @remnic/core barrel — the barrel pulls the search backends " +
+      "(LanceDB native asset) into the omp extension bundle. Offenders: " +
+      offenders.join(", "),
+  );
+});

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -561,7 +561,10 @@ function resolveExtensionModulePath(): string {
  * prefixing `./` then yields an invalid module specifier that fails `bun build`
  * with a cryptic error. Detect that layout and fail fast with an actionable
  * message instead. (Cross-drive omp installs are unsupported because neither a
- * relative specifier nor a `file://` URL is acceptable to `bun build`.)
+ * relative specifier nor a `file://` URL is acceptable to `bun build`.) Drive
+ * roots are compared case-insensitively so a same-drive Windows install is not
+ * falsely rejected when the agent home and the plugin-pi install report the
+ * drive letter in different casing (`C:\\` vs `c:\\`).
  *
  * Exported so the cross-drive guard can be exercised on non-Windows hosts via
  * `path.win32`.
@@ -571,7 +574,13 @@ export function resolveOmpWrapperImportSpecifier(
   wrapperDir: string,
   pathApi: typeof path = path,
 ): string {
-  if (pathApi.parse(wrapperDir).root !== pathApi.parse(extensionModulePath).root) {
+  // Windows drive roots are case-insensitive: `C:\\…` (e.g. from the omp agent
+  // home) and `c:\\…` (e.g. from fileURLToPath(import.meta.url)) are the SAME
+  // drive, and path.win32.relative yields a valid relative specifier between
+  // them. Compare the parsed roots case-insensitively so a same-drive install
+  // isn't falsely rejected as "different drives". posix roots (`/`) are
+  // unaffected by toLowerCase().
+  if (pathApi.parse(wrapperDir).root.toLowerCase() !== pathApi.parse(extensionModulePath).root.toLowerCase()) {
     throw new Error(
       "Remnic omp extension cannot pre-bundle: the extension directory " +
         `(${wrapperDir}) and the @remnic/plugin-pi install (${extensionModulePath}) ` +

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -153,6 +153,16 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
   }
 
   /**
+   * Whether the generated wrapper must use a bun-buildable import specifier
+   * (relative path) instead of a file:// URL. omp pre-bundles the wrapper with
+   * `bun build`, which cannot resolve file:// specifiers; pi loads the wrapper
+   * directly via tsx and keeps the file:// URL.
+   */
+  protected get usesBundledWrapper(): boolean {
+    return false;
+  }
+
+  /**
    * Hook for subclasses to write host-specific files and run install-time
    * build steps after the shared config/wrapper/readme are written. Runs
    * inside the publish try-block: a throw triggers full rollback.
@@ -266,7 +276,15 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       atomicWriteFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
       filesWritten.push(configPath);
 
-      atomicWriteFile(wrapperPath, renderWrapper(pluginPiDistPath, configPath), 0o644);
+      atomicWriteFile(
+        wrapperPath,
+        renderWrapper(
+          pluginPiDistPath,
+          configPath,
+          this.usesBundledWrapper ? extensionRoot : undefined,
+        ),
+        0o644,
+      );
       filesWritten.push(wrapperPath);
 
       atomicWriteFile(readmePath, `${await this.renderInstructions(ctx)}\n`, 0o644);
@@ -278,8 +296,12 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       }
     } catch (err) {
       try {
-        restorePublishSnapshot(extensionRoot, rootExisted, fileSnapshots);
+        // Remove newly created owned dirs (e.g. dist-bundle) BEFORE
+        // restorePublishSnapshot's removeEmptyDirectory check, otherwise a
+        // first-time publish that created dist-bundle would leave an empty
+        // extension root behind on rollback.
         restoreDirSnapshots(dirSnapshots);
+        restorePublishSnapshot(extensionRoot, rootExisted, fileSnapshots);
       } catch (restoreErr) {
         ctx.log.warn(
           `${this.host.displayName} extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
@@ -366,6 +388,12 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     return ["dist-bundle"];
   }
 
+  // omp pre-bundles index.ts with `bun build`; the wrapper must use a relative
+  // import specifier (bun's bundler cannot resolve file:// URLs).
+  protected get usesBundledWrapper(): boolean {
+    return true;
+  }
+
   protected finalizePublish(
     ctx: PublishContext,
     extensionRoot: string,
@@ -388,7 +416,7 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     const packageJsonPath = path.join(extensionRoot, "package.json");
 
     atomicWriteFile(loaderPath, renderOmpLoader(paths.pluginPiDistPath, bunBin), 0o644);
-    atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
+    atomicWriteFile(packageJsonPath, renderOmpPackageJson(bunBin), 0o644);
 
     this.runBundleBuild(ctx, extensionRoot, bunBin);
   }
@@ -516,10 +544,27 @@ function resolveExtensionModulePath(): string {
   return built;
 }
 
-function renderWrapper(extensionModulePath: string, configPath: string): string {
-  const moduleUrl = pathToFileURL(extensionModulePath).href;
+function renderWrapper(
+  extensionModulePath: string,
+  configPath: string,
+  wrapperDir?: string,
+): string {
+  // omp pre-bundles this entry with `bun build`, whose bundler cannot resolve
+  // `file://` specifiers — it exits with "Could not resolve: file://..." on
+  // Bun 1.2–1.3 (verified). When the wrapper will be bun-built, emit a relative
+  // specifier resolved against the wrapper's directory; bun, tsx, and Node ESM
+  // all resolve relative specifiers. For tsx-loaded wrappers (pi) the file://
+  // URL is retained.
+  let importSpecifier: string;
+  if (wrapperDir) {
+    let rel = path.relative(wrapperDir, extensionModulePath);
+    if (process.platform === "win32") rel = rel.split(path.sep).join("/");
+    importSpecifier = rel.startsWith(".") ? rel : `./${rel}`;
+  } else {
+    importSpecifier = pathToFileURL(extensionModulePath).href;
+  }
   return [
-    `import { createRemnicPiExtension } from ${JSON.stringify(moduleUrl)};`,
+    `import { createRemnicPiExtension } from ${JSON.stringify(importSpecifier)};`,
     "",
     `export default createRemnicPiExtension({ configPath: ${JSON.stringify(configPath)} });`,
     "",
@@ -593,7 +638,16 @@ function renderOmpLoader(pluginPiDistPath: string, bunBin: string): string {
  * Generates the `package.json` that tells omp to load `loader.js` (not
  * auto-discover `index.ts`) and re-bundles after `npm install` via postinstall.
  */
-function renderOmpPackageJson(): string {
+function renderOmpPackageJson(bunBin: string): string {
+  // Postinstall re-bundles after `npm install` (e.g. a plugin-pi upgrade moved
+  // the dist mtime past the bundle). Reuse the bun path resolved at install
+  // time so postinstall succeeds on systems where bun is reachable only via
+  // REMNIC_OMP_BUN_BIN or a common absolute path that is not on the PATH npm
+  // spawns postinstall with. Fall back to PATH "bun" if the resolved binary no
+  // longer exists (e.g. the extension tree was relocated).
+  const safeBun = bunBin.replace(/'/g, "'\\''");
+  const postinstall =
+    `BUN='${safeBun}'; [ -x "$BUN" ] 2>/dev/null || BUN=bun; "$BUN" build index.ts --target=bun --outdir=dist-bundle`;
   const manifest = {
     name: "remnic-omp-extension",
     version: "0.0.0",
@@ -603,9 +657,7 @@ function renderOmpPackageJson(): string {
     // Legacy key so older omp builds that only read `pi.extensions` also
     // resolve loader.js instead of falling through to index.ts.
     pi: { extensions: ["./loader.js"] },
-    scripts: {
-      postinstall: "bun build index.ts --target=bun --outdir=dist-bundle",
-    },
+    scripts: { postinstall },
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import os from "node:os";
 
 import {
   type MemoryExtensionPublisher,
@@ -370,25 +371,10 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     extensionRoot: string,
     paths: { configPath: string; wrapperPath: string; pluginPiDistPath: string },
   ): void {
-    const loaderPath = path.join(extensionRoot, "loader.js");
-    const packageJsonPath = path.join(extensionRoot, "package.json");
-
-    atomicWriteFile(loaderPath, renderOmpLoader(paths.pluginPiDistPath), 0o644);
-    atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
-
-    this.runBundleBuild(ctx, extensionRoot);
-  }
-
-  /**
-   * Pre-bundles the omp extension with `bun build` so omp's embedded runtime
-   * never resolves bare npm specifiers (e.g. @sinclair/typebox) from the
-   * extension's node_modules at load time. The bundle is written to a temp
-   * directory and atomically swapped into dist-bundle/ on success; a failure
-   * leaves any pre-existing dist-bundle untouched.
-   *
-   * Override in tests to skip the real bun invocation.
-   */
-  protected runBundleBuild(ctx: PublishContext, extensionRoot: string): void {
+    // Resolve once so the install-time build and the generated loader share the
+    // same bun path — a loader that hardcodes "bun" cannot self-heal when bun
+    // is reachable only via REMNIC_OMP_BUN_BIN or a common absolute install
+    // path that is not on omp's PATH at runtime.
     const bunBin = resolveBunBinary();
     if (!bunBin) {
       throw new Error(
@@ -398,6 +384,27 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
       );
     }
 
+    const loaderPath = path.join(extensionRoot, "loader.js");
+    const packageJsonPath = path.join(extensionRoot, "package.json");
+
+    atomicWriteFile(loaderPath, renderOmpLoader(paths.pluginPiDistPath, bunBin), 0o644);
+    atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
+
+    this.runBundleBuild(ctx, extensionRoot, bunBin);
+  }
+
+  /**
+   * Pre-bundles the omp extension with `bun build` so omp's embedded runtime
+   * never resolves bare npm specifiers (e.g. @sinclair/typebox) from the
+   * extension's node_modules at load time. The bundle is written to a temp
+   * directory and swapped into dist-bundle/ on success. The pre-existing
+   * dist-bundle is renamed aside (not removed) before the swap, so a failure
+   * during the final rename restores the previously working bundle rather than
+   * leaving the install with no bundle at all.
+   *
+   * Override in tests to skip the real bun invocation.
+   */
+  protected runBundleBuild(ctx: PublishContext, extensionRoot: string, bunBin: string): void {
     const sourceEntry = path.join(extensionRoot, "index.ts");
     const tmpOutDir = path.join(extensionRoot, `.dist-bundle.tmp-${process.pid}-${Date.now()}`);
     const finalOutDir = path.join(extensionRoot, "dist-bundle");
@@ -425,16 +432,40 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
       );
     }
 
+    // Swap the freshly built bundle into place without ever leaving the install
+    // bundle-less. Rename the existing dist-bundle aside, move the new one in,
+    // and only then discard the backup. On any failure mid-swap, restore the
+    // backup so the previously working bundle survives (the publish-level
+    // rollback only removes newly created dirs — it never restores a removed
+    // dist-bundle, so we must not remove it here).
+    let backupDir: string | null = null;
     try {
       if (fs.existsSync(finalOutDir)) {
-        fs.rmSync(finalOutDir, { recursive: true, force: true });
+        backupDir = path.join(extensionRoot, `.dist-bundle.bak-${process.pid}-${Date.now()}`);
+        fs.renameSync(finalOutDir, backupDir);
       }
       fs.renameSync(tmpOutDir, finalOutDir);
+      if (backupDir) {
+        try {
+          fs.rmSync(backupDir, { recursive: true, force: true });
+        } catch {
+          // best-effort backup cleanup; leaving it does not break the install
+        }
+      }
     } catch (err) {
       try {
-        fs.rmSync(tmpOutDir, { recursive: true, force: true });
+        if (fs.existsSync(tmpOutDir)) fs.rmSync(tmpOutDir, { recursive: true, force: true });
       } catch {
         // best-effort tmp cleanup
+      }
+      // Restore the previously working bundle if we moved it aside and the
+      // final swap did not land.
+      if (backupDir && fs.existsSync(backupDir) && !fs.existsSync(finalOutDir)) {
+        try {
+          fs.renameSync(backupDir, finalOutDir);
+        } catch {
+          // best-effort restore; the loader's self-heal rebuilds on next start
+        }
       }
       throw new Error(
         `Remnic omp extension: failed to finalize bundle output — ${err instanceof Error ? err.message : String(err)}.`,
@@ -503,7 +534,7 @@ function renderWrapper(extensionModulePath: string, configPath: string): string 
  * imports the self-contained bundle so omp's embedded runtime never resolves
  * bare npm specifiers at load time.
  */
-function renderOmpLoader(pluginPiDistPath: string): string {
+function renderOmpLoader(pluginPiDistPath: string, bunBin: string): string {
   return [
     "// Auto-generated by Remnic's OmpMemoryExtensionPublisher.",
     "// omp's embedded runtime cannot resolve bare npm specifiers from this",
@@ -520,6 +551,12 @@ function renderOmpLoader(pluginPiDistPath: string): string {
     'const bundleEntry = join(here, "dist-bundle", "index.js");',
     'const sourceEntry = join(here, "index.ts");',
     `const pluginPiEntry = ${JSON.stringify(pluginPiDistPath)};`,
+    // Reuse the bun path resolved at install time (REMNIC_OMP_BUN_BIN, PATH,
+    // or a common absolute location). Fall back to "bun" on PATH if the
+    // resolved path no longer exists (e.g. the extension tree was moved), so
+    // self-healing still works when bun is reachable only via PATH.
+    `const resolvedBunBin = ${JSON.stringify(bunBin)};`,
+    'const bunForRebuild = resolvedBunBin && existsSync(resolvedBunBin) ? resolvedBunBin : "bun";',
     "",
     "function bundleIsStale() {",
     "  if (!existsSync(bundleEntry)) return true;",
@@ -530,7 +567,7 @@ function renderOmpLoader(pluginPiDistPath: string): string {
     "}",
     "",
     "function rebuildBundle() {",
-    '  const result = spawnSync("bun", ["build", sourceEntry, "--target=bun", "--outdir=dist-bundle"], {',
+    '  const result = spawnSync(bunForRebuild, ["build", sourceEntry, "--target=bun", "--outdir=dist-bundle"], {',
     "    cwd: here,",
     '    stdio: "inherit",',
     "  });",
@@ -587,8 +624,12 @@ function resolveBunBinary(): string | null {
   const pathProbe = spawnSync("bun", ["--version"], { encoding: "utf-8" });
   if (!pathProbe.error && pathProbe.status === 0) return "bun";
 
+  // Mirror omp's path helpers, which resolve the agent home as
+  // HOME ?? USERPROFILE ?? os.homedir(). Relying on HOME alone breaks the
+  // ~/.bun/bin/bun fallback on Windows installs where HOME is unset.
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
   const candidates = [
-    path.join(process.env.HOME ?? "", ".bun", "bin", "bun"),
+    path.join(home ?? "", ".bun", "bin", "bun"),
     "/usr/local/bin/bun",
     "/opt/homebrew/bin/bun",
   ];

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -789,6 +789,36 @@ try {
 }
 
 /**
+ * Walks `PATH` the way a shell does and returns the first `bun` executable it
+ * finds, as a realpath-resolved absolute path (or null when nothing on PATH
+ * is an executable `bun`). Used so the install-time PATH probe can embed an
+ * absolute bun path in the generated loader/postinstall instead of the bare
+ * string `"bun"`, which would break self-heal rebuilds under a stripped
+ * runtime PATH (GUI/service launches). Mirrors `which(1)`; no dependency.
+ */
+function resolveBunOnPath(): string | null {
+  const pathVar = process.env.PATH ?? process.env.Path ?? process.env.path ?? "";
+  const separator = process.platform === "win32" ? ";" : ":";
+  const candidateNames =
+    process.platform === "win32" ? ["bun.exe", "bun"] : ["bun"];
+  for (const dir of pathVar.split(separator)) {
+    if (!dir) continue;
+    for (const name of candidateNames) {
+      const candidate = path.isAbsolute(dir)
+        ? path.join(dir, name)
+        : path.resolve(dir, name);
+      try {
+        const stat = fs.statSync(candidate);
+        if (stat.isFile()) return fs.realpathSync(candidate);
+      } catch {
+        // Missing dir or permission error — try the next candidate.
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Resolves the `bun` binary for the install-time pre-bundle. Honours
  * `REMNIC_OMP_BUN_BIN` (test/override seam), then PATH, then common locations.
  * Returns null when bun is unavailable so the caller can fail with guidance.
@@ -800,7 +830,15 @@ function resolveBunBinary(): string | null {
   }
 
   const pathProbe = spawnSync("bun", ["--version"], { encoding: "utf-8" });
-  if (!pathProbe.error && pathProbe.status === 0) return "bun";
+  if (!pathProbe.error && pathProbe.status === 0) {
+    // Resolve the PATH-found bun to an absolute executable so the embedded
+    // loader/postinstall don't depend on omp's runtime PATH — GUI/service
+    // launches commonly inherit a stripped PATH, which would make a bare
+    // "bun" self-heal spawn fail even though install found a working binary.
+    // Fall back to "bun" only if the PATH walk can't locate it (e.g. a shell
+    // function/alias that isn't an actual file on PATH).
+    return resolveBunOnPath() ?? "bun";
+  }
 
   // Mirror omp's path helpers, which resolve the agent home as
   // HOME ?? USERPROFILE ?? os.homedir(). Relying on HOME alone breaks the

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -307,12 +307,21 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
           `${this.host.displayName} extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
         );
       }
-      try {
-        restoreTokenEntry(priorTokenEntry, this.host.connectorId);
-      } catch (tokenErr) {
-        ctx.log.warn(
-          `${this.host.displayName} connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`,
-        );
+      // A failed omp pre-bundle (bun missing or `bun build` failing) is
+      // recoverable: the runtime loader self-heals dist-bundle on first load,
+      // and the connector token is already committed by the CLI. Rolling it
+      // back here would leave the connector registered with no credential and
+      // block a non-`--force` reinstall (AGENTS.md #14 — don't destroy
+      // committed state before the new state is confirmed). File/dir rollback
+      // above still runs, so a failed first-time publish still cleans its root.
+      if (!(err instanceof OmpPreBundleError)) {
+        try {
+          restoreTokenEntry(priorTokenEntry, this.host.connectorId);
+        } catch (tokenErr) {
+          ctx.log.warn(
+            `${this.host.displayName} connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`,
+          );
+        }
       }
       throw err;
     }
@@ -374,6 +383,20 @@ export class PiMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
   }
 }
 
+/**
+ * Marks a failure originating from the omp pre-bundle step (bun missing, or the
+ * `bun build` itself failing). {@link HostMemoryExtensionPublisher.publish}
+ * catches this and rolls back the written files but SKIPS the connector-token
+ * rollback: the pre-bundle runs after the install (config + wrapper + token) is
+ * already committed, and the runtime loader self-heals `dist-bundle` on first
+ * load, so destroying the just-generated token would leave the connector
+ * registered with no credential and block a non-`--force` reinstall
+ * (AGENTS.md #14 — don't destroy committed state before the new state is
+ * confirmed). The message is preserved verbatim so existing `/requires \`bun\`/`
+ * and `/bun build failed/` assertions still match.
+ */
+class OmpPreBundleError extends Error {}
+
 /** Publisher for Oh My Pi / omp (`~/.omp/agent/extensions/remnic`). */
 export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
   constructor() {
@@ -405,7 +428,10 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     // path that is not on omp's PATH at runtime.
     const bunBin = resolveBunBinary();
     if (!bunBin) {
-      throw new Error(
+      // OmpPreBundleError so publish() keeps the connector token intact (see
+      // the class doc); the runtime loader self-heals the bundle once bun is
+      // installed.
+      throw new OmpPreBundleError(
         "Remnic omp extension requires `bun` to pre-bundle the extension: omp's embedded " +
           "runtime cannot resolve bare npm specifiers from the extension's node_modules. " +
           "Install bun from https://bun.sh, then re-run `remnic connectors install omp`.",
@@ -424,7 +450,14 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     atomicWriteFile(postinstallPath, renderOmpPostinstall(bunBin), 0o644);
     atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
 
-    this.runBundleBuild(ctx, extensionRoot, bunBin);
+    try {
+      this.runBundleBuild(ctx, extensionRoot, bunBin);
+    } catch (err) {
+      // OmpPreBundleError so publish() keeps the connector token intact (see
+      // the class doc); the runtime loader self-heals the bundle on next load.
+      const message = err instanceof Error ? err.message : String(err);
+      throw new OmpPreBundleError(message);
+    }
   }
 
   /**

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -550,6 +550,41 @@ function resolveExtensionModulePath(): string {
   return built;
 }
 
+/**
+ * Resolves the import specifier the omp wrapper uses to reach the
+ * `@remnic/plugin-pi` dist entry from the generated `index.ts`. omp pre-bundles
+ * that wrapper with `bun build`, whose bundler cannot resolve `file://`
+ * specifiers ("Could not resolve: file://…" on Bun 1.2–1.3, verified), so the
+ * specifier must be a relative path. On Windows, when the extension directory
+ * and the plugin-pi install sit on different drives, `path.relative` cannot
+ * express a relative path and returns an absolute drive path (e.g. `D:\…`);
+ * prefixing `./` then yields an invalid module specifier that fails `bun build`
+ * with a cryptic error. Detect that layout and fail fast with an actionable
+ * message instead. (Cross-drive omp installs are unsupported because neither a
+ * relative specifier nor a `file://` URL is acceptable to `bun build`.)
+ *
+ * Exported so the cross-drive guard can be exercised on non-Windows hosts via
+ * `path.win32`.
+ */
+export function resolveOmpWrapperImportSpecifier(
+  extensionModulePath: string,
+  wrapperDir: string,
+  pathApi: typeof path = path,
+): string {
+  if (pathApi.parse(wrapperDir).root !== pathApi.parse(extensionModulePath).root) {
+    throw new Error(
+      "Remnic omp extension cannot pre-bundle: the extension directory " +
+        `(${wrapperDir}) and the @remnic/plugin-pi install (${extensionModulePath}) ` +
+        "are on different drives, so no relative import specifier can be generated " +
+        "for `bun build` (and `bun build` cannot resolve a `file://` specifier). " +
+        "Move the omp agent home and the Remnic install onto the same drive.",
+    );
+  }
+  let rel = pathApi.relative(wrapperDir, extensionModulePath);
+  rel = rel.split(pathApi.sep).join("/");
+  return rel.startsWith(".") ? rel : `./${rel}`;
+}
+
 function renderWrapper(
   extensionModulePath: string,
   configPath: string,
@@ -563,9 +598,7 @@ function renderWrapper(
   // URL is retained.
   let importSpecifier: string;
   if (wrapperDir) {
-    let rel = path.relative(wrapperDir, extensionModulePath);
-    if (process.platform === "win32") rel = rel.split(path.sep).join("/");
-    importSpecifier = rel.startsWith(".") ? rel : `./${rel}`;
+    importSpecifier = resolveOmpWrapperImportSpecifier(extensionModulePath, wrapperDir);
   } else {
     importSpecifier = pathToFileURL(extensionModulePath).href;
   }

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -381,7 +381,7 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
   }
 
   protected get ownedFileNames(): readonly string[] {
-    return [...BASE_OWNED_FILES, "loader.js", "package.json"];
+    return [...BASE_OWNED_FILES, "loader.js", "package.json", "postinstall-bundle.cjs"];
   }
 
   protected get ownedDirNames(): readonly string[] {
@@ -415,8 +415,14 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
     const loaderPath = path.join(extensionRoot, "loader.js");
     const packageJsonPath = path.join(extensionRoot, "package.json");
 
+    const postinstallPath = path.join(extensionRoot, "postinstall-bundle.cjs");
+
     atomicWriteFile(loaderPath, renderOmpLoader(paths.pluginPiDistPath, bunBin), 0o644);
-    atomicWriteFile(packageJsonPath, renderOmpPackageJson(bunBin), 0o644);
+    // Cross-platform postinstall helper (Node-only) so npm's default cmd.exe
+    // shell on Windows re-bundles after `npm install`; the POSIX one-liner it
+    // replaces only ran under bash.
+    atomicWriteFile(postinstallPath, renderOmpPostinstall(bunBin), 0o644);
+    atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
 
     this.runBundleBuild(ctx, extensionRoot, bunBin);
   }
@@ -587,13 +593,14 @@ function renderOmpLoader(pluginPiDistPath: string, bunBin: string): string {
     "// the self-contained bundle here. Rebuilt automatically when index.ts or",
     "// the underlying @remnic/plugin-pi dist changes.",
     "",
-    'import { existsSync, statSync } from "node:fs";',
+    'import { existsSync, renameSync, rmSync, statSync } from "node:fs";',
     'import { spawnSync } from "node:child_process";',
     'import { dirname, join } from "node:path";',
     'import { fileURLToPath, pathToFileURL } from "node:url";',
     "",
     'const here = dirname(fileURLToPath(import.meta.url));',
-    'const bundleEntry = join(here, "dist-bundle", "index.js");',
+    'const bundleDir = join(here, "dist-bundle");',
+    'const bundleEntry = join(bundleDir, "index.js");',
     'const sourceEntry = join(here, "index.ts");',
     `const pluginPiEntry = ${JSON.stringify(pluginPiDistPath)};`,
     // Reuse the bun path resolved at install time (REMNIC_OMP_BUN_BIN, PATH,
@@ -612,18 +619,43 @@ function renderOmpLoader(pluginPiDistPath: string, bunBin: string): string {
     "}",
     "",
     "function rebuildBundle() {",
-    '  const result = spawnSync(bunForRebuild, ["build", sourceEntry, "--target=bun", "--outdir=dist-bundle"], {',
+    "  // Build to a temp dir and swap, mirroring the install-time build, so a",
+    "  // failed self-heal rebuild never corrupts the working bundle.",
+    '  var tmp = join(here, ".dist-bundle.tmp-" + process.pid + "-" + Date.now());',
+    "  var result = spawnSync(bunForRebuild, [",
+    '    "build",',
+    "    sourceEntry,",
+    '    "--target=bun",',
+    '    "--outdir=" + tmp',
+    "  ], {",
     "    cwd: here,",
     '    stdio: "inherit",',
     "  });",
     "  if (result.status !== 0 || result.error) {",
+    "    try { rmSync(tmp, { recursive: true, force: true }); } catch (e) {}",
     "    throw new Error(",
     '      "Remnic omp extension: bundle is stale or missing and could not be rebuilt. " +',
     '      "Install bun (https://bun.sh), then run " +',
     '      "`bun build index.ts --target=bun --outdir=dist-bundle` inside " + here',
     "    );",
     "  }",
+    "  var backup = null;",
+    "  try {",
+    "    if (existsSync(bundleDir)) {",
+    '      backup = join(here, ".dist-bundle.bak-" + process.pid + "-" + Date.now());',
+    "      renameSync(bundleDir, backup);",
+    "    }",
+    "    renameSync(tmp, bundleDir);",
+    "    if (backup) { try { rmSync(backup, { recursive: true, force: true }); } catch (e) {} }",
+    "  } catch (err) {",
+    "    try { rmSync(tmp, { recursive: true, force: true }); } catch (e) {}",
+    "    if (backup && existsSync(backup) && !existsSync(bundleDir)) { try { renameSync(backup, bundleDir); } catch (e) {} }",
+    "    throw new Error(",
+    '      "Remnic omp extension: failed to finalize rebuilt bundle - " + (err && err.message ? err.message : err)',
+    "    );",
+    "  }",
     "}",
+
     "",
     "if (bundleIsStale()) rebuildBundle();",
     "",
@@ -638,16 +670,12 @@ function renderOmpLoader(pluginPiDistPath: string, bunBin: string): string {
  * Generates the `package.json` that tells omp to load `loader.js` (not
  * auto-discover `index.ts`) and re-bundles after `npm install` via postinstall.
  */
-function renderOmpPackageJson(bunBin: string): string {
+function renderOmpPackageJson(): string {
   // Postinstall re-bundles after `npm install` (e.g. a plugin-pi upgrade moved
-  // the dist mtime past the bundle). Reuse the bun path resolved at install
-  // time so postinstall succeeds on systems where bun is reachable only via
-  // REMNIC_OMP_BUN_BIN or a common absolute path that is not on the PATH npm
-  // spawns postinstall with. Fall back to PATH "bun" if the resolved binary no
-  // longer exists (e.g. the extension tree was relocated).
-  const safeBun = bunBin.replace(/'/g, "'\\''");
-  const postinstall =
-    `BUN='${safeBun}'; [ -x "$BUN" ] 2>/dev/null || BUN=bun; "$BUN" build index.ts --target=bun --outdir=dist-bundle`;
+  // the dist mtime past the bundle). It delegates to postinstall-bundle.cjs — a
+  // Node-only helper — so npm's default cmd.exe shell on Windows runs it just as
+  // well as POSIX bash. The helper embeds the resolved bun path with a PATH
+  // fallback and swaps the bundle atomically.
   const manifest = {
     name: "remnic-omp-extension",
     version: "0.0.0",
@@ -657,9 +685,74 @@ function renderOmpPackageJson(bunBin: string): string {
     // Legacy key so older omp builds that only read `pi.extensions` also
     // resolve loader.js instead of falling through to index.ts.
     pi: { extensions: ["./loader.js"] },
-    scripts: { postinstall },
+    scripts: { postinstall: "node postinstall-bundle.cjs" },
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/**
+ * Generates the cross-platform `postinstall-bundle.cjs` helper. Node-only, so
+ * npm's default cmd.exe shell on Windows re-bundles after `npm install` just as
+ * well as POSIX bash. Embeds the bun path resolved at install time with a PATH
+ * fallback and writes the new bundle via a temp-dir swap so a failed rebuild
+ * never corrupts the working bundle. The emitted script uses string
+ * concatenation (no template literals) so it stays parseable everywhere.
+ */
+function renderOmpPostinstall(bunBin: string): string {
+  // Single template literal: the emitted .cjs uses string concatenation (no
+  // template literals of its own), so this body has no backticks and the one
+  // ${JSON.stringify(bunBin)} interpolation is unambiguous.
+  return `// Auto-generated by Remnic's OmpMemoryExtensionPublisher.
+// Re-bundles the omp extension after npm install (e.g. a plugin-pi upgrade)
+// using the bun path resolved at install time, with a PATH fallback. Node-only
+// so it runs under npm's default cmd.exe shell on Windows as well as POSIX bash.
+"use strict";
+var fs = require("node:fs");
+var cp = require("node:child_process");
+var path = require("node:path");
+
+var RESOLVED_BUN = ${JSON.stringify(bunBin)};
+var dir = __dirname;
+var entry = path.join(dir, "index.ts");
+var out = path.join(dir, "dist-bundle");
+
+function pickBun() {
+  var env = process.env.REMNIC_OMP_BUN_BIN;
+  if (env && fs.existsSync(env)) return env;
+  if (RESOLVED_BUN && fs.existsSync(RESOLVED_BUN)) return RESOLVED_BUN;
+  return "bun";
+}
+
+function rebuild() {
+  var bun = pickBun();
+  var tmp = path.join(dir, ".dist-bundle.tmp-" + process.pid + "-" + Date.now());
+  var r = cp.spawnSync(bun, ["build", entry, "--target=bun", "--outdir=" + tmp], { cwd: dir, stdio: "inherit" });
+  if (r.error || r.status !== 0) {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}
+    throw new Error("Remnic omp extension: postinstall bun build failed (bun=" + bun + "). Run bun build index.ts --target=bun --outdir=dist-bundle manually inside " + dir);
+  }
+  var backup = null;
+  try {
+    if (fs.existsSync(out)) {
+      backup = path.join(dir, ".dist-bundle.bak-" + process.pid + "-" + Date.now());
+      fs.renameSync(out, backup);
+    }
+    fs.renameSync(tmp, out);
+    if (backup) { try { fs.rmSync(backup, { recursive: true, force: true }); } catch (e) {} }
+  } catch (err) {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) {}
+    if (backup && fs.existsSync(backup) && !fs.existsSync(out)) { try { fs.renameSync(backup, out); } catch (e) {} }
+    throw err;
+  }
+}
+
+try {
+  rebuild();
+} catch (err) {
+  console.error(err && err.message ? err.message : err);
+  process.exit(1);
+}
+`;
 }
 
 /**
@@ -680,8 +773,12 @@ function resolveBunBinary(): string | null {
   // HOME ?? USERPROFILE ?? os.homedir(). Relying on HOME alone breaks the
   // ~/.bun/bin/bun fallback on Windows installs where HOME is unset.
   const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  // The official Bun installer writes ~/.bun/bin/bun on POSIX and
+  // ~/.bun/bin/bun.exe on Windows; fs.existsSync does not apply PATHEXT, so we
+  // probe both names. The .exe candidate is a harmless no-op on POSIX.
   const candidates = [
     path.join(home ?? "", ".bun", "bin", "bun"),
+    path.join(home ?? "", ".bun", "bin", "bun.exe"),
     "/usr/local/bin/bun",
     "/opt/homebrew/bin/bun",
   ];

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -805,7 +805,7 @@ try {
  * string `"bun"`, which would break self-heal rebuilds under a stripped
  * runtime PATH (GUI/service launches). Mirrors `which(1)`; no dependency.
  */
-function resolveBunOnPath(): string | null {
+export function resolveBunOnPath(): string | null {
   const pathVar = process.env.PATH ?? process.env.Path ?? process.env.path ?? "";
   const separator = process.platform === "win32" ? ";" : ":";
   const candidateNames =
@@ -818,9 +818,18 @@ function resolveBunOnPath(): string | null {
         : path.resolve(dir, name);
       try {
         const stat = fs.statSync(candidate);
-        if (stat.isFile()) return fs.realpathSync(candidate);
+        // Match `which(1)`: skip non-executable candidates. The PATH version
+        // probe (spawnSync("bun", ["--version"])) uses the OS exec lookup, which
+        // skips non-executable files, so returning a non-executable `bun` here
+        // would diverge from the probe and embed a path that fails with EACCES
+        // at bundle time. fs.accessSync with X_OK is a no-op check on Windows
+        // for real .exe files (it verifies read access there).
+        if (stat.isFile()) {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          return fs.realpathSync(candidate);
+        }
       } catch {
-        // Missing dir or permission error — try the next candidate.
+        // Missing dir, non-executable file, or permission error — next candidate.
       }
     }
   }

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -798,6 +798,26 @@ try {
 }
 
 /**
+ * True when `candidate` is a regular file that the current process can
+ * execute. Used by every `bun`-binary candidate selection site so a stale,
+ * non-executable file named `bun` (or `bun.exe`) cannot win over a later
+ * working binary — matching `which(1)` and the `spawnSync("bun", ["--version"])`
+ * version probe, which both skip non-executable files. On Windows
+ * `fs.accessSync(X_OK)` verifies read access, which holds for real `.exe`
+ * files, so the check is a harmless no-op there.
+ */
+function isExecutableFile(candidate: string): boolean {
+  try {
+    const stat = fs.statSync(candidate);
+    if (!stat.isFile()) return false;
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Walks `PATH` the way a shell does and returns the first `bun` executable it
  * finds, as a realpath-resolved absolute path (or null when nothing on PATH
  * is an executable `bun`). Used so the install-time PATH probe can embed an
@@ -816,20 +836,8 @@ export function resolveBunOnPath(): string | null {
       const candidate = path.isAbsolute(dir)
         ? path.join(dir, name)
         : path.resolve(dir, name);
-      try {
-        const stat = fs.statSync(candidate);
-        // Match `which(1)`: skip non-executable candidates. The PATH version
-        // probe (spawnSync("bun", ["--version"])) uses the OS exec lookup, which
-        // skips non-executable files, so returning a non-executable `bun` here
-        // would diverge from the probe and embed a path that fails with EACCES
-        // at bundle time. fs.accessSync with X_OK is a no-op check on Windows
-        // for real .exe files (it verifies read access there).
-        if (stat.isFile()) {
-          fs.accessSync(candidate, fs.constants.X_OK);
-          return fs.realpathSync(candidate);
-        }
-      } catch {
-        // Missing dir, non-executable file, or permission error — next candidate.
+      if (isExecutableFile(candidate)) {
+        return fs.realpathSync(candidate);
       }
     }
   }
@@ -841,7 +849,7 @@ export function resolveBunOnPath(): string | null {
  * `REMNIC_OMP_BUN_BIN` (test/override seam), then PATH, then common locations.
  * Returns null when bun is unavailable so the caller can fail with guidance.
  */
-function resolveBunBinary(): string | null {
+export function resolveBunBinary(): string | null {
   const override = process.env.REMNIC_OMP_BUN_BIN;
   if (override !== undefined) {
     return fs.existsSync(override) ? override : null;
@@ -863,8 +871,11 @@ function resolveBunBinary(): string | null {
   // ~/.bun/bin/bun fallback on Windows installs where HOME is unset.
   const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
   // The official Bun installer writes ~/.bun/bin/bun on POSIX and
-  // ~/.bun/bin/bun.exe on Windows; fs.existsSync does not apply PATHEXT, so we
-  // probe both names. The .exe candidate is a harmless no-op on POSIX.
+  // ~/.bun/bin/bun.exe on Windows. Select the first candidate that is an
+  // executable regular file (not merely one that exists) so a stale,
+  // non-executable ~/.bun/bin/bun cannot win over a later working binary
+  // (e.g. /usr/local/bin/bun or /opt/homebrew/bin/bun) — same `which(1)`
+  // semantics as the PATH walk above.
   const candidates = [
     path.join(home ?? "", ".bun", "bin", "bun"),
     path.join(home ?? "", ".bun", "bin", "bun.exe"),
@@ -872,7 +883,7 @@ function resolveBunBinary(): string | null {
     "/opt/homebrew/bin/bun",
   ];
   for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) return candidate;
+    if (isExecutableFile(candidate)) return candidate;
   }
   return null;
 }

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -22,14 +23,19 @@ import {
 } from "./paths.js";
 
 const DEFAULT_DAEMON_PORT = 4318;
-const EXTENSION_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
-const EXTENSION_OWNED_TEMP_FILE_PATTERN = /^(?:remnic\.config\.json|index\.ts|README\.md)\.tmp-\d+-\d+$/u;
+const BASE_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
+const EXTENSION_OWNED_TEMP_FILE_SUFFIX = /\.tmp-\d+-\d+$/u;
 
 type FileSnapshot = {
   path: string;
   existed: boolean;
   content?: Buffer;
   mode?: number;
+};
+
+type DirSnapshot = {
+  path: string;
+  existed: boolean;
 };
 
 /**
@@ -126,6 +132,38 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
   protected constructor(private readonly host: HostPublisherDescriptor) {}
 
+  /**
+   * File basenames this publisher owns inside the extension root. The shared
+   * set is config + wrapper + readme; subclasses add host-specific files
+   * (e.g. omp's pre-bundle loader + package manifest). Used for snapshot,
+   * atomic-write rollback, and unpublish cleanup.
+   */
+  protected get ownedFileNames(): readonly string[] {
+    return BASE_OWNED_FILES;
+  }
+
+  /**
+   * Directory names this publisher owns inside the extension root (build
+   * outputs). Recursively removed on unpublish and on publish rollback when
+   * newly created.
+   */
+  protected get ownedDirNames(): readonly string[] {
+    return [];
+  }
+
+  /**
+   * Hook for subclasses to write host-specific files and run install-time
+   * build steps after the shared config/wrapper/readme are written. Runs
+   * inside the publish try-block: a throw triggers full rollback.
+   */
+  protected finalizePublish(
+    _ctx: PublishContext,
+    _extensionRoot: string,
+    _paths: { configPath: string; wrapperPath: string; pluginPiDistPath: string },
+  ): void {
+    // No-op by default; subclasses override.
+  }
+
   get hostId(): string {
     return this.host.hostId;
   }
@@ -176,9 +214,16 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
     ctx.log.info(`Publishing ${this.host.displayName} memory extension to ${extensionRoot}`);
 
-    const [configPath, wrapperPath, readmePath] = extensionOwnedPaths(extensionRoot);
+    const ownedFilePaths = this.ownedFileNames.map((fileName) => path.join(extensionRoot, fileName));
+    const configPath = ownedFilePaths[0];
+    const wrapperPath = ownedFilePaths[1];
+    const readmePath = ownedFilePaths[2];
+    const pluginPiDistPath = resolveExtensionModulePath();
     const rootExisted = fs.existsSync(extensionRoot);
-    const snapshots = snapshotFiles([configPath, wrapperPath, readmePath]);
+    const fileSnapshots = snapshotFiles(ownedFilePaths);
+    const dirSnapshots = snapshotDirs(
+      this.ownedDirNames.map((dirName) => path.join(extensionRoot, dirName)),
+    );
     const priorTokenEntry =
       ctx.rollbackTokenEntry === undefined
         ? snapshotTokenEntry(this.host.connectorId)
@@ -220,14 +265,20 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       atomicWriteFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
       filesWritten.push(configPath);
 
-      atomicWriteFile(wrapperPath, renderWrapper(resolveExtensionModulePath(), configPath), 0o644);
+      atomicWriteFile(wrapperPath, renderWrapper(pluginPiDistPath, configPath), 0o644);
       filesWritten.push(wrapperPath);
 
       atomicWriteFile(readmePath, `${await this.renderInstructions(ctx)}\n`, 0o644);
       filesWritten.push(readmePath);
+
+      this.finalizePublish(ctx, extensionRoot, { configPath, wrapperPath, pluginPiDistPath });
+      for (let i = BASE_OWNED_FILES.length; i < ownedFilePaths.length; i++) {
+        filesWritten.push(ownedFilePaths[i]);
+      }
     } catch (err) {
       try {
-        restorePublishSnapshot(extensionRoot, rootExisted, snapshots);
+        restorePublishSnapshot(extensionRoot, rootExisted, fileSnapshots);
+        restoreDirSnapshots(dirSnapshots);
       } catch (restoreErr) {
         ctx.log.warn(
           `${this.host.displayName} extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
@@ -256,6 +307,8 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       ? this.host.listRemovalAgentHomes(process.env)
       : [this.host.resolveAgentHome(process.env)];
 
+    const ownedFileNames = this.ownedFileNames;
+    const ownedDirNames = this.ownedDirNames;
     const seen = new Set<string>();
     for (const agentHome of agentHomes) {
       const extensionRoot = path.join(path.resolve(agentHome), "extensions", "remnic");
@@ -264,9 +317,27 @@ export class HostMemoryExtensionPublisher implements MemoryExtensionPublisher {
       if (!fs.existsSync(extensionRoot)) continue;
 
       assertSafeExtensionRoot(extensionRoot, agentHome);
-      const removableFiles = removableOwnedExtensionFiles(extensionOwnedUnpublishPaths(extensionRoot));
+      const removableFiles = removableOwnedExtensionFiles(
+        extensionOwnedUnpublishPaths(extensionRoot, ownedFileNames),
+      );
       for (const filePath of removableFiles) {
         fs.rmSync(filePath, { force: true });
+      }
+      for (const dirName of ownedDirNames) {
+        const dirPath = path.join(extensionRoot, dirName);
+        let stat: fs.Stats;
+        try {
+          stat = fs.lstatSync(dirPath);
+        } catch (err) {
+          if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") continue;
+          throw err;
+        }
+        if (stat.isSymbolicLink()) {
+          throw new Error(`Extension path must not be a symlink: ${dirPath}`);
+        }
+        if (stat.isDirectory()) {
+          fs.rmSync(dirPath, { recursive: true, force: true });
+        }
       }
       removeEmptyDirectory(extensionRoot);
     }
@@ -285,16 +356,105 @@ export class OmpMemoryExtensionPublisher extends HostMemoryExtensionPublisher {
   constructor() {
     super(OMP_HOST);
   }
+
+  protected get ownedFileNames(): readonly string[] {
+    return [...BASE_OWNED_FILES, "loader.js", "package.json"];
+  }
+
+  protected get ownedDirNames(): readonly string[] {
+    return ["dist-bundle"];
+  }
+
+  protected finalizePublish(
+    ctx: PublishContext,
+    extensionRoot: string,
+    paths: { configPath: string; wrapperPath: string; pluginPiDistPath: string },
+  ): void {
+    const loaderPath = path.join(extensionRoot, "loader.js");
+    const packageJsonPath = path.join(extensionRoot, "package.json");
+
+    atomicWriteFile(loaderPath, renderOmpLoader(paths.pluginPiDistPath), 0o644);
+    atomicWriteFile(packageJsonPath, renderOmpPackageJson(), 0o644);
+
+    this.runBundleBuild(ctx, extensionRoot);
+  }
+
+  /**
+   * Pre-bundles the omp extension with `bun build` so omp's embedded runtime
+   * never resolves bare npm specifiers (e.g. @sinclair/typebox) from the
+   * extension's node_modules at load time. The bundle is written to a temp
+   * directory and atomically swapped into dist-bundle/ on success; a failure
+   * leaves any pre-existing dist-bundle untouched.
+   *
+   * Override in tests to skip the real bun invocation.
+   */
+  protected runBundleBuild(ctx: PublishContext, extensionRoot: string): void {
+    const bunBin = resolveBunBinary();
+    if (!bunBin) {
+      throw new Error(
+        "Remnic omp extension requires `bun` to pre-bundle the extension: omp's embedded " +
+          "runtime cannot resolve bare npm specifiers from the extension's node_modules. " +
+          "Install bun from https://bun.sh, then re-run `remnic connectors install omp`.",
+      );
+    }
+
+    const sourceEntry = path.join(extensionRoot, "index.ts");
+    const tmpOutDir = path.join(extensionRoot, `.dist-bundle.tmp-${process.pid}-${Date.now()}`);
+    const finalOutDir = path.join(extensionRoot, "dist-bundle");
+
+    const result = spawnSync(bunBin, ["build", sourceEntry, "--target=bun", `--outdir=${tmpOutDir}`], {
+      cwd: extensionRoot,
+      encoding: "utf-8",
+    });
+
+    if (result.error || result.status !== 0) {
+      try {
+        fs.rmSync(tmpOutDir, { recursive: true, force: true });
+      } catch {
+        // best-effort tmp cleanup
+      }
+      const detail =
+        (typeof result.stderr === "string" ? result.stderr.trim() : "") ||
+        (result.error instanceof Error ? result.error.message : "") ||
+        `bun exited with status ${result.status ?? "null"}`;
+      throw new Error(
+        `Remnic omp extension: bun build failed (${detail}). Resolve the error and re-run ` +
+          "`remnic connectors install omp`, or build manually with " +
+          "`bun build index.ts --target=bun --outdir=dist-bundle` inside " +
+          `${extensionRoot}.`,
+      );
+    }
+
+    try {
+      if (fs.existsSync(finalOutDir)) {
+        fs.rmSync(finalOutDir, { recursive: true, force: true });
+      }
+      fs.renameSync(tmpOutDir, finalOutDir);
+    } catch (err) {
+      try {
+        fs.rmSync(tmpOutDir, { recursive: true, force: true });
+      } catch {
+        // best-effort tmp cleanup
+      }
+      throw new Error(
+        `Remnic omp extension: failed to finalize bundle output — ${err instanceof Error ? err.message : String(err)}.`,
+      );
+    }
+
+    ctx.log.info(`Pre-bundled omp extension into ${finalOutDir}`);
+  }
 }
 
-function extensionOwnedPaths(extensionRoot: string): string[] {
-  return EXTENSION_OWNED_FILES.map((fileName) => path.join(extensionRoot, fileName));
+function extensionOwnedPaths(extensionRoot: string, ownedFileNames: readonly string[]): string[] {
+  return ownedFileNames.map((fileName) => path.join(extensionRoot, fileName));
 }
 
-function extensionOwnedUnpublishPaths(extensionRoot: string): string[] {
-  const ownedPaths = extensionOwnedPaths(extensionRoot);
+function extensionOwnedUnpublishPaths(extensionRoot: string, ownedFileNames: readonly string[]): string[] {
+  const ownedBaseNames = new Set(ownedFileNames);
+  const ownedPaths = extensionOwnedPaths(extensionRoot, ownedFileNames);
   for (const fileName of fs.readdirSync(extensionRoot)) {
-    if (EXTENSION_OWNED_TEMP_FILE_PATTERN.test(fileName)) {
+    const match = EXTENSION_OWNED_TEMP_FILE_SUFFIX.exec(fileName);
+    if (match && ownedBaseNames.has(fileName.slice(0, match.index))) {
       ownedPaths.push(path.join(extensionRoot, fileName));
     }
   }
@@ -333,6 +493,109 @@ function renderWrapper(extensionModulePath: string, configPath: string): string 
     `export default createRemnicPiExtension({ configPath: ${JSON.stringify(configPath)} });`,
     "",
   ].join("\n");
+}
+
+/**
+ * Generates the self-healing `loader.js` that omp loads via the package
+ * manifest's `omp.extensions` entry. It mtime-compares the pre-bundled
+ * `dist-bundle/index.js` against `index.ts` and the underlying @remnic/plugin-pi
+ * dist, rebuilds via `bun build` when stale (e.g. after an `npm update`), then
+ * imports the self-contained bundle so omp's embedded runtime never resolves
+ * bare npm specifiers at load time.
+ */
+function renderOmpLoader(pluginPiDistPath: string): string {
+  return [
+    "// Auto-generated by Remnic's OmpMemoryExtensionPublisher.",
+    "// omp's embedded runtime cannot resolve bare npm specifiers from this",
+    "// extension's node_modules, so we pre-bundle with `bun build` and import",
+    "// the self-contained bundle here. Rebuilt automatically when index.ts or",
+    "// the underlying @remnic/plugin-pi dist changes.",
+    "",
+    'import { existsSync, statSync } from "node:fs";',
+    'import { spawnSync } from "node:child_process";',
+    'import { dirname, join } from "node:path";',
+    'import { fileURLToPath, pathToFileURL } from "node:url";',
+    "",
+    'const here = dirname(fileURLToPath(import.meta.url));',
+    'const bundleEntry = join(here, "dist-bundle", "index.js");',
+    'const sourceEntry = join(here, "index.ts");',
+    `const pluginPiEntry = ${JSON.stringify(pluginPiDistPath)};`,
+    "",
+    "function bundleIsStale() {",
+    "  if (!existsSync(bundleEntry)) return true;",
+    "  const bundleMtime = statSync(bundleEntry).mtimeMs;",
+    "  if (existsSync(sourceEntry) && bundleMtime < statSync(sourceEntry).mtimeMs) return true;",
+    "  if (pluginPiEntry && existsSync(pluginPiEntry) && bundleMtime < statSync(pluginPiEntry).mtimeMs) return true;",
+    "  return false;",
+    "}",
+    "",
+    "function rebuildBundle() {",
+    '  const result = spawnSync("bun", ["build", sourceEntry, "--target=bun", "--outdir=dist-bundle"], {',
+    "    cwd: here,",
+    '    stdio: "inherit",',
+    "  });",
+    "  if (result.status !== 0 || result.error) {",
+    "    throw new Error(",
+    '      "Remnic omp extension: bundle is stale or missing and could not be rebuilt. " +',
+    '      "Install bun (https://bun.sh), then run " +',
+    '      "`bun build index.ts --target=bun --outdir=dist-bundle` inside " + here',
+    "    );",
+    "  }",
+    "}",
+    "",
+    "if (bundleIsStale()) rebuildBundle();",
+    "",
+    "// Cache-bust so a freshly rebuilt bundle is loaded instead of a stale cached copy.",
+    'const bundle = await import(pathToFileURL(bundleEntry).href + "?t=" + Date.now());',
+    "export default bundle.default;",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Generates the `package.json` that tells omp to load `loader.js` (not
+ * auto-discover `index.ts`) and re-bundles after `npm install` via postinstall.
+ */
+function renderOmpPackageJson(): string {
+  const manifest = {
+    name: "remnic-omp-extension",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    omp: { extensions: ["./loader.js"] },
+    // Legacy key so older omp builds that only read `pi.extensions` also
+    // resolve loader.js instead of falling through to index.ts.
+    pi: { extensions: ["./loader.js"] },
+    scripts: {
+      postinstall: "bun build index.ts --target=bun --outdir=dist-bundle",
+    },
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/**
+ * Resolves the `bun` binary for the install-time pre-bundle. Honours
+ * `REMNIC_OMP_BUN_BIN` (test/override seam), then PATH, then common locations.
+ * Returns null when bun is unavailable so the caller can fail with guidance.
+ */
+function resolveBunBinary(): string | null {
+  const override = process.env.REMNIC_OMP_BUN_BIN;
+  if (override !== undefined) {
+    return fs.existsSync(override) ? override : null;
+  }
+
+  const pathProbe = spawnSync("bun", ["--version"], { encoding: "utf-8" });
+  if (!pathProbe.error && pathProbe.status === 0) return "bun";
+
+  const candidates = [
+    path.join(process.env.HOME ?? "", ".bun", "bin", "bun"),
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 function atomicWriteFile(filePath: string, content: string, mode: number): void {
@@ -397,6 +660,38 @@ function restorePublishSnapshot(extensionRoot: string, rootExisted: boolean, sna
     removeEmptyDirectory(extensionRoot);
   }
 }
+
+function snapshotDirs(paths: string[]): DirSnapshot[] {
+  return paths.map((dirPath) => {
+    let existed = false;
+    try {
+      const stat = fs.lstatSync(dirPath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Extension path must not be a symlink: ${dirPath}`);
+      }
+      existed = stat.isDirectory();
+    } catch (err) {
+      if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+        existed = false;
+      } else {
+        throw err;
+      }
+    }
+    return { path: dirPath, existed };
+  });
+}
+
+function restoreDirSnapshots(snapshots: DirSnapshot[]): void {
+  for (const snapshot of snapshots) {
+    if (snapshot.existed) continue;
+    try {
+      fs.rmSync(snapshot.path, { recursive: true, force: true });
+    } catch {
+      // best-effort — the loader self-heals at runtime if the dir lingers
+    }
+  }
+}
+
 
 function canCleanNewExtensionRoot(extensionRoot: string): boolean {
   let stat: fs.Stats;

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1476,6 +1476,21 @@
       "remnic-source": "./src/memory-worth.ts",
       "import": "./dist/memory-worth.js"
     },
+    "./message-parts": {
+      "types": "./dist/message-parts/index.d.ts",
+      "remnic-source": "./src/message-parts/index.ts",
+      "import": "./dist/message-parts/index.js"
+    },
+    "./message-parts/index": {
+      "types": "./dist/message-parts/index.d.ts",
+      "remnic-source": "./src/message-parts/index.ts",
+      "import": "./dist/message-parts/index.js"
+    },
+    "./message-parts/index.js": {
+      "types": "./dist/message-parts/index.d.ts",
+      "remnic-source": "./src/message-parts/index.ts",
+      "import": "./dist/message-parts/index.js"
+    },
     "./migrate/from-engram": {
       "types": "./dist/migrate/from-engram.d.ts",
       "remnic-source": "./src/migrate/from-engram.ts",
@@ -2805,6 +2820,16 @@
       "types": "./dist/utils/serialize-mutations.d.ts",
       "remnic-source": "./src/utils/serialize-mutations.ts",
       "import": "./dist/utils/serialize-mutations.js"
+    },
+    "./utils/path": {
+      "types": "./dist/utils/path.d.ts",
+      "remnic-source": "./src/utils/path.ts",
+      "import": "./dist/utils/path.js"
+    },
+    "./utils/path.js": {
+      "types": "./dist/utils/path.d.ts",
+      "remnic-source": "./src/utils/path.ts",
+      "import": "./dist/utils/path.js"
     },
     "./verified-recall": {
       "types": "./dist/verified-recall.d.ts",


### PR DESCRIPTION
Fixes #1598. omp's embedded runtime cannot resolve bare npm specifiers from the extension's node_modules, silently breaking extension load. OmpMemoryExtensionPublisher now writes a pre-bundled layout: loader.js (self-healing wrapper), package.json (omp.extensions manifest + postinstall), and dist-bundle/ (bun build output at install time). HostMemoryExtensionPublisher gains protected ownedFileNames/ownedDirNames/finalizePublish hooks. 96 tests pass (93 existing + 3 new).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connector install, credential rollback semantics, and generated on-disk extension artifacts across platforms; behaviour is heavily regression-tested but install failures can still leave a token without a bundle until bun/self-heal runs.
> 
> **Overview**
> Fixes omp extension load failures by **pre-bundling** the Remnic Pi extension at connector install time so omp’s embedded runtime never resolves bare npm specifiers from `node_modules`.
> 
> **Omp install layout:** `OmpMemoryExtensionPublisher` now writes `loader.js` (mtime-based self-heal + `bun build` into `dist-bundle/`), `package.json` (`omp.extensions` → loader, Node `postinstall-bundle.cjs`), and runs install-time `bun build` with **atomic temp-dir swap** so a failed rebuild does not wipe a working bundle. Unpublish/rollback track extra owned files and `dist-bundle/`.
> 
> **Bundler / import fixes:** The generated omp wrapper uses a **relative** import (not `file://`, which `bun build` cannot resolve). Runtime code in `plugin-pi` imports **`@remnic/core` leaf subpaths** (`utils/path`, `message-parts`) instead of the barrel so the bundle does not pull LanceDB/native search backends (~100MB). `remnic-core` gains matching package exports.
> 
> **Bun resolution:** `resolveBunBinary` / `resolveBunOnPath` honour `REMNIC_OMP_BUN_BIN`, PATH (absolute embed for loader/postinstall), `USERPROFILE`/`~/.bun/bin/bun(.exe)`, and skip non-executable PATH candidates. Cross-drive Windows layouts fail fast when no relative specifier exists.
> 
> **Rollback policy:** `OmpPreBundleError` rolls back written files/dirs but **does not** roll back the omp connector token after the CLI has committed it—the loader can self-heal the bundle on next load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6092ae8171a9615beb663e8fe803742ef0bd9da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->