### PR TITLE
fix(plugin-pi): chunk large turns, retry transient closes, bound per-turn timeout (#1600 #1602 #1626)

### DIFF
--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -428,3 +428,20 @@ test("requestWithRetry bails before the backoff sleep when the budget is smaller
   assert.ok(elapsed < 150, `bailed before the 200ms backoff (elapsed ${elapsed}ms)`);
   assert.equal(calls, 1);
 });
+
+test("recall shares a per-turn deadline across retries even when the caller omits timeoutMs (review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), turnRequestTimeoutMs: 50, observeMaxRetries: 3 });
+  await assert.rejects(
+    () => client.recall("query", "sess", "/cwd"),
+    /exceeded the 50ms budget before retry/,
+  );
+  assert.equal(calls, 1, "recall defaulted to the turn budget and stopped retries instead of looping unbounded");
+});

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -337,3 +337,52 @@ test("chunkObservePayload never overshoots the cap once array commas are counted
     assert.ok(bytes <= 3000, `chunk ${bytes} bytes exceeds 3000 cap`);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Review (cursor + codex): retries must share one deadline; single-chunk
+// observe must use the turn budget, not the 60s general budget (#1602/#1626).
+// ---------------------------------------------------------------------------
+
+test("requestWithRetry keeps retries within the shared per-turn budget instead of a fresh timeout per attempt (#1602/#1626, review cursor+codex)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  // Budget (50ms) is smaller than the first exponential backoff (200ms), so a
+  // retry would already be past the deadline. The old code retried with a fresh
+  // full timeout each attempt; the new code aborts before the retry.
+  const client = new RemnicClient({ ...baseConfig(), observeMaxRetries: 3 });
+  await assert.rejects(
+    () => client.recall("query", "sess", "/cwd", { timeoutMs: 50, maxRetries: 3 }),
+    /exceeded the 50ms budget before retry/,
+  );
+  assert.equal(calls, 1, "the shared deadline stopped further retries instead of looping");
+});
+
+test("single-chunk observe is bounded by the turn budget, not the general request budget (#1626, review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (_input, init) => {
+    calls += 1;
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  // General budget 60s, turn budget 30ms. A single small message must time out
+  // at the TURN budget (30ms), proving the single-chunk path no longer falls
+  // back to the 60s general budget the way the multi-chunk path never did.
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 60000, turnRequestTimeoutMs: 30 });
+  await assert.rejects(
+    () => client.observe("sess", "/cwd", [{ role: "user", content: "hi" }]),
+    /Remnic request timed out after 30ms/,
+  );
+  assert.equal(calls, 1);
+});

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { RemnicClient, RemnicHttpError } from "./client.js";
+import { RemnicClient, RemnicHttpError, chunkObservePayload, isTransientNetworkError, type ObserveMessage } from "./client.js";
 import type { RemnicPiConfig } from "./config.js";
 
 test("RemnicClient reports request timeouts with actionable context", async (t) => {
@@ -74,6 +74,10 @@ function baseConfig(): RemnicPiConfig {
     statusEnabled: true,
     requestTimeoutMs: 60000,
     startupRequestTimeoutMs: 1000,
+    turnRequestTimeoutMs: 20000,
+    observeMaxBytes: 102400,
+    observeMaxRetries: 2,
+    daemonCooldownMs: 5000,
   };
 }
 
@@ -131,4 +135,168 @@ test("RemnicClient reports invalid JSON clearly for successful daemon responses"
     () => client.health(),
     /Invalid JSON response from Remnic daemon/,
   );
+});
+
+
+// ---------------------------------------------------------------------------
+// Issue #1600: 413 on large turns — observe chunking & truncation
+// ---------------------------------------------------------------------------
+
+test("chunkObservePayload splits a batch that exceeds the byte cap", () => {
+  const config = baseConfig();
+  const messages: ObserveMessage[] = [
+    { role: "assistant", content: "x".repeat(40000) },
+    { role: "user", content: "y".repeat(40000) },
+    { role: "user", content: "z".repeat(40000) },
+  ];
+  const chunks = chunkObservePayload(config, "sess", "/cwd", messages, 50000);
+  assert.ok(chunks.length >= 2, `expected chunking, got ${chunks.length}`);
+  for (const chunk of chunks) {
+    const bytes = new TextEncoder().encode(JSON.stringify(chunk)).length;
+    assert.ok(bytes <= 50000, `chunk ${bytes} bytes exceeds 50000 cap`);
+  }
+});
+
+test("chunkObservePayload truncates a single oversized message instead of dropping it", () => {
+  const config = baseConfig();
+  const huge: ObserveMessage = { role: "assistant", content: "a".repeat(200000) };
+  const chunks = chunkObservePayload(config, "sess", "/cwd", [huge], 50000);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].messages.length, 1);
+  assert.match(chunks[0].messages[0].content, /\[Remnic observe truncated/);
+  const bytes = new TextEncoder().encode(JSON.stringify(chunks[0])).length;
+  assert.ok(bytes <= 50000, `truncated chunk ${bytes} exceeds cap`);
+});
+
+test("observe chunks an oversize batch into multiple POSTs under the cap (#1600)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const bodyBytes: number[] = [];
+  globalThis.fetch = async (_input, init) => {
+    const body = typeof init?.body === "string" ? init.body : "";
+    bodyBytes.push(new TextEncoder().encode(body).length);
+    return new Response(JSON.stringify({ count: 1 }), { status: 200 });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), observeMaxBytes: 50000 });
+  const messages = Array.from({ length: 5 }, (_, i) => ({
+    role: "user" as const,
+    content: "x".repeat(20000) + String(i),
+  }));
+  const result = await client.observe("sess", "/cwd", messages);
+
+  assert.ok(bodyBytes.length >= 2, `expected chunking into multiple POSTs, got ${bodyBytes.length}`);
+  for (const b of bodyBytes) assert.ok(b <= 50000, `chunk ${b} exceeds cap`);
+  assert.equal(result.count, bodyBytes.length);
+});
+
+test("observe 413 error message includes the body size for operator tuning (#1600)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("request_body_too_large", { status: 413, statusText: "Request Entity Too Large" });
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient(baseConfig());
+  await assert.rejects(
+    () => client.observe("sess", "/cwd", [{ role: "user", content: "big" }]),
+    (err: unknown) => {
+      assert.ok(err instanceof RemnicHttpError, "expected RemnicHttpError");
+      assert.equal((err as RemnicHttpError).status, 413);
+      assert.match((err as RemnicHttpError).message, /observed body \d+ bytes/);
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1602: transient socket close — observe retries instead of dropping
+// ---------------------------------------------------------------------------
+
+test("isTransientNetworkError classifies connection-level failures", () => {
+  assert.ok(isTransientNetworkError(new Error("The socket connection was closed unexpectedly.")));
+  assert.ok(isTransientNetworkError(new Error("fetch failed: ECONNRESET")));
+  assert.ok(isTransientNetworkError(new Error("write EPIPE")));
+  assert.ok(!isTransientNetworkError(new RemnicHttpError(500, "boom")));
+  assert.ok(!isTransientNetworkError(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+  assert.ok(!isTransientNetworkError(new Error("offline")));
+  assert.ok(!isTransientNetworkError("string error"));
+});
+
+test("observe retries on transient socket close and succeeds (#1602)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      throw new Error("The socket connection was closed unexpectedly. For more information, pass \`verbose: true\` in the second argument to fetch()");
+    }
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), observeMaxRetries: 2 });
+  const result = await client.observe("sess", "/cwd", [{ role: "user", content: "hello" }]);
+
+  assert.equal(calls, 2, "first attempt failed transiently, second succeeded");
+  assert.deepEqual(result, { ok: true });
+});
+
+test("observe does not retry on HTTP 500 (only transient connection errors)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), observeMaxRetries: 3 });
+  await assert.rejects(() => client.observe("sess", "/cwd", [{ role: "user", content: "hi" }]));
+  assert.equal(calls, 1, "HTTP errors are not retried");
+});
+
+test("observe gives up after exhausting the retry budget on repeated transient failures", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), observeMaxRetries: 2 });
+  await assert.rejects(
+    () => client.observe("sess", "/cwd", [{ role: "user", content: "hi" }]),
+    /socket connection was closed/,
+  );
+  assert.equal(calls, 3, "1 initial + 2 retries");
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1626: bounded per-turn timeout + daemon-reachability circuit breaker
+// ---------------------------------------------------------------------------
+
+test("recall honors a turn-scoped timeout override below the general budget (#1626)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 60000 });
+  await assert.rejects(
+    () => client.recall("query", "sess", "/cwd", { timeoutMs: 40 }),
+    /Remnic request timed out after 40ms/,
+  );
+});
+
+test("circuit breaker reports unreachable during cooldown and recovers (#1626)", () => {
+  const client = new RemnicClient(baseConfig());
+  assert.ok(client.isReachable(), "fresh client is reachable");
+  client.markUnreachable(5000);
+  assert.ok(!client.isReachable(), "in cooldown after failure");
+  client.markReachable();
+  assert.ok(client.isReachable(), "reachable again after success");
 });

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -405,3 +405,26 @@ test("chunkObservePayload truncates oversize messages even when the per-message 
     "oversize message was truncated rather than passed through",
   );
 });
+
+test("requestWithRetry bails before the backoff sleep when the budget is smaller than the backoff (review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const client = new RemnicClient({ ...baseConfig(), observeMaxRetries: 3 });
+  // Budget (50ms) is far below the first 200ms exponential backoff. The old
+  // code slept the full 200ms before detecting the overshoot; the fix checks
+  // before sleeping, so we bail in well under the backoff.
+  const start = Date.now();
+  await assert.rejects(
+    () => client.recall("query", "sess", "/cwd", { timeoutMs: 50, maxRetries: 3 }),
+    /exceeded the 50ms budget before retry/,
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 150, `bailed before the 200ms backoff (elapsed ${elapsed}ms)`);
+  assert.equal(calls, 1);
+});

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -386,3 +386,22 @@ test("single-chunk observe is bounded by the turn budget, not the general reques
   );
   assert.equal(calls, 1);
 });
+
+test("chunkObservePayload truncates oversize messages even when the per-message budget is tiny (review cursor)", () => {
+  const config = baseConfig();
+  // Tight cap chosen so the envelope overhead leaves a small-but-positive
+  // per-message budget (<=1024). Previously this returned ONE untruncated
+  // envelope and could overshoot the cap; now each message is truncated/packed.
+  const huge: ObserveMessage = { role: "assistant", content: "a".repeat(50000) };
+  const chunks = chunkObservePayload(config, "sess", "/cwd", [huge], 800);
+  assert.ok(chunks.length >= 1);
+  for (const chunk of chunks) {
+    const bytes = new TextEncoder().encode(JSON.stringify(chunk)).length;
+    assert.ok(bytes <= 800, `truncated chunk ${bytes} bytes exceeds 800 cap`);
+  }
+  assert.match(
+    chunks[0].messages[0].content,
+    /\[Remnic observe truncated/,
+    "oversize message was truncated rather than passed through",
+  );
+});

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -300,3 +300,40 @@ test("circuit breaker reports unreachable during cooldown and recovers (#1626)",
   client.markReachable();
   assert.ok(client.isReachable(), "reachable again after success");
 });
+
+
+test("truncateObserveMessage drops bulky rawContent and parts so the chunk fits (#1600, review cursor+codex)", () => {
+  const config = baseConfig();
+  // A live Pi observe message carries the full original payload in rawContent
+  // and parsed parts — both dominate the serialized size.
+  const huge: ObserveMessage = {
+    role: "assistant",
+    content: "small rendered text",
+    rawContent: { big: "x".repeat(200000) },
+    parts: [{ kind: "tool_result", payload: { output: "y".repeat(200000) } }],
+  };
+  const chunks = chunkObservePayload(config, "sess", "/cwd", [huge], 50000);
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].messages.length, 1);
+  const out = chunks[0].messages[0];
+  assert.match(out.content, /\[Remnic observe truncated/);
+  assert.equal(out.rawContent, undefined, "rawContent must be dropped on truncation");
+  assert.equal(out.parts, undefined, "parts must be dropped on truncation");
+  const bytes = new TextEncoder().encode(JSON.stringify(chunks[0])).length;
+  assert.ok(bytes <= 50000, `truncated chunk ${bytes} exceeds cap even after dropping raw fields`);
+});
+
+test("chunkObservePayload never overshoots the cap once array commas are counted (review cursor)", () => {
+  const config = baseConfig();
+  // Many small messages near the cap boundary exercise the comma accounting.
+  const messages: ObserveMessage[] = Array.from({ length: 200 }, (_, i) => ({
+    role: "user" as const,
+    content: "m" + String(i).padStart(3, "0"),
+  }));
+  const chunks = chunkObservePayload(config, "sess", "/cwd", messages, 3000);
+  assert.ok(chunks.length > 1);
+  for (const chunk of chunks) {
+    const bytes = new TextEncoder().encode(JSON.stringify(chunk)).length;
+    assert.ok(bytes <= 3000, `chunk ${bytes} bytes exceeds 3000 cap`);
+  }
+});

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -449,9 +449,13 @@ export function chunkObservePayload(
 ): ObserveBody[] {
   const envelopeOverhead = jsonBytes(buildObserveEnvelope(config, sessionKey, cwd, []));
   const messageBudget = maxBytes - envelopeOverhead;
-  if (messageBudget <= 1024) {
-    // The envelope itself is too large to fit a meaningful message; return a
-    // single chunk and let the daemon/server reject it visibly.
+  if (messageBudget <= 0) {
+    // The envelope overhead alone meets/exceeds the cap, so no valid body can
+    // fit — return a single chunk and let the daemon reject it visibly (this is
+    // a degenerate/misconfigured cap, not the common case). A small-but-positive
+    // budget (<=1024) is NOT degenerate: truncate/pack normally so oversized
+    // messages are shrunk to fit instead of bypassing the #1600 safeguards
+    // (cursor review).
     return [buildObserveEnvelope(config, sessionKey, cwd, messages)];
   }
   const chunks: ObserveMessage[][] = [];

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -435,9 +435,9 @@ export function isTransientNetworkError(err: unknown): boolean {
 }
 
 function sleep(ms: number): Promise<void> {
-  const { promise, resolve } = Promise.withResolvers<void>();
-  setTimeout(resolve, ms);
-  return promise;
+  // Plain Promise constructor: avoids Promise.withResolvers (ES2024 / Node 22+),
+  // so retry backoff works on Node 20 and other runtimes that load plugin-pi.
+  return new Promise<void>(resolve => setTimeout(resolve, ms));
 }
 
 function jsonBytes(value: unknown): number {

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -29,6 +29,17 @@ export interface McpTool {
   inputSchema?: Record<string, unknown>;
 }
 
+export interface RequestOptions {
+  timeoutMs?: number;
+  /** Transient-retry budget for connection-level failures (socket close, ECONNRESET). */
+  maxRetries?: number;
+}
+
+export interface ObserveOptions extends RequestOptions {
+  /** Soft cap on a single observe POST body in bytes; oversize batches are chunked. */
+  maxBytes?: number;
+}
+
 export class RemnicHttpError extends Error {
   constructor(
     readonly status: number,
@@ -38,55 +49,137 @@ export class RemnicHttpError extends Error {
   }
 }
 
+interface ObserveBody {
+  sessionKey: string;
+  cwd: string;
+  namespace?: string;
+  skipExtraction: boolean;
+  messages: ObserveMessage[];
+}
+
+const encoder = new TextEncoder();
+const RETRY_BASE_DELAY_MS = 200;
+const MAX_COOLDOWN_MS = 60_000;
+const TRUNCATION_MARKER = "\n\n[Remnic observe truncated: payload exceeded client size cap]";
+
 export class RemnicClient {
   private requestId = 0;
+  // Circuit-breaker state: when the daemon is known-unreachable, observe/recall
+  // callers skip fast instead of blocking every turn on a doomed request (#1626).
+  private unreachableUntil = 0;
+  private consecutiveFailures = 0;
 
   constructor(private readonly config: RemnicPiConfig) {}
+
+  /** True when the daemon is not in a known-unreachable cooldown. */
+  isReachable(): boolean {
+    return Date.now() >= this.unreachableUntil;
+  }
+
+  /** Clear the circuit breaker — call after any successful daemon interaction. */
+  markReachable(): void {
+    this.consecutiveFailures = 0;
+    this.unreachableUntil = 0;
+  }
+
+  /**
+   * Enter (or extend) an unreachable cooldown. The cooldown grows exponentially
+   * with consecutive failures (base, 2×base, 4×base, …) capped at 60 s, so a
+   * flapping daemon is retried gently while a hard-down host backs off hard.
+   */
+  markUnreachable(baseCooldownMs: number): void {
+    this.consecutiveFailures += 1;
+    const factor = 2 ** Math.min(this.consecutiveFailures - 1, 4);
+    const cooldown = Math.min(baseCooldownMs * factor, MAX_COOLDOWN_MS);
+    this.unreachableUntil = Date.now() + cooldown;
+  }
 
   async health(options: RequestOptions = {}): Promise<Record<string, unknown>> {
     return this.request("GET", "/engram/v1/health", undefined, options);
   }
 
-  async recall(query: string, sessionKey: string, cwd: string): Promise<RecallResponse> {
-    return this.request("POST", "/engram/v1/recall", {
-      query,
-      sessionKey,
-      cwd,
-      namespace: this.config.namespace,
-      topK: this.config.recallTopK,
-      mode: this.config.recallMode,
-    });
+  async recall(
+    query: string,
+    sessionKey: string,
+    cwd: string,
+    options: RequestOptions = {},
+  ): Promise<RecallResponse> {
+    // Recall is a read-only query; retry transient connection failures with the
+    // same budget as observe (#1602).
+    const merged: RequestOptions = { ...options, maxRetries: options.maxRetries ?? this.config.observeMaxRetries };
+    return this.requestWithRetry(
+      "POST",
+      "/engram/v1/recall",
+      {
+        query,
+        sessionKey,
+        cwd,
+        namespace: this.config.namespace,
+        topK: this.config.recallTopK,
+        mode: this.config.recallMode,
+      },
+      merged,
+    );
   }
 
-  async recallExplain(sessionKey: string): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/recall/explain", {
-      sessionKey,
-      namespace: this.config.namespace,
-    });
+  async recallExplain(sessionKey: string, options: RequestOptions = {}): Promise<Record<string, unknown>> {
+    return this.requestWithRetry(
+      "POST",
+      "/engram/v1/recall/explain",
+      {
+        sessionKey,
+        namespace: this.config.namespace,
+      },
+      options,
+    );
   }
 
-  async observe(sessionKey: string, cwd: string, messages: ObserveMessage[]): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/observe", {
-      sessionKey,
-      cwd,
-      namespace: this.config.namespace,
-      skipExtraction: this.config.observeSkipExtraction,
-      messages,
-    });
+  async observe(
+    sessionKey: string,
+    cwd: string,
+    messages: ObserveMessage[],
+    options: ObserveOptions = {},
+  ): Promise<Record<string, unknown>> {
+    const maxBytes = options.maxBytes ?? this.config.observeMaxBytes;
+    const retryOptions: RequestOptions = {
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries ?? this.config.observeMaxRetries,
+    };
+    const chunks = chunkObservePayload(this.config, sessionKey, cwd, messages, maxBytes);
+    if (chunks.length === 1) {
+      return this.requestWithRetry("POST", "/engram/v1/observe", chunks[0], retryOptions);
+    }
+    // Multiple chunks: send sequentially so a single slow daemon connection is
+    // not stressed by parallel writes. Each chunk is retried independently on
+    // transient connection failures. Observe is dedupe-safe, so a partial
+    // failure just re-sends (redundantly) on the next turn.
+    const results: Record<string, unknown>[] = [];
+    for (const chunk of chunks) {
+      const result = await this.requestWithRetry<Record<string, unknown>>(
+        "POST",
+        "/engram/v1/observe",
+        chunk,
+        retryOptions,
+      );
+      if (result && typeof result === "object") {
+        results.push(result);
+      }
+    }
+    return mergeObserveResults(results);
   }
 
-  async storeMemory(content: string, sessionKey: string): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/memories", {
+  async storeMemory(content: string, sessionKey: string, options: RequestOptions = {}): Promise<Record<string, unknown>> {
+    return this.requestWithRetry("POST", "/engram/v1/memories", {
       content,
       category: "fact",
       sourceReason: "Captured from Pi via Remnic extension",
       sessionKey,
       namespace: this.config.namespace,
-    });
+    }, options);
   }
 
   async lcmSearch(query: string, sessionKey: string, limit = 10): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/lcm/search", {
+    return this.requestWithRetry("POST", "/engram/v1/lcm/search", {
       query,
       sessionKey,
       namespace: this.config.namespace,
@@ -95,14 +188,14 @@ export class RemnicClient {
   }
 
   async lcmCompactionFlush(sessionKey: string): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/lcm/compaction/flush", {
+    return this.requestWithRetry("POST", "/engram/v1/lcm/compaction/flush", {
       sessionKey,
       namespace: this.config.namespace,
     });
   }
 
   async lcmCompactionRecord(sessionKey: string, tokensBefore: number, tokensAfter: number): Promise<Record<string, unknown>> {
-    return this.request("POST", "/engram/v1/lcm/compaction/record", {
+    return this.requestWithRetry("POST", "/engram/v1/lcm/compaction/record", {
       sessionKey,
       namespace: this.config.namespace,
       tokensBefore,
@@ -120,7 +213,7 @@ export class RemnicClient {
 
   async mcpListTools(options: RequestOptions = {}): Promise<McpTool[]> {
     const result = await this.mcpRequest("tools/list", {}, options);
-    const tools = (result as { tools?: unknown }).tools;
+    const tools = result.tools;
     return Array.isArray(tools) ? tools.filter(isMcpTool) : [];
   }
 
@@ -131,6 +224,10 @@ export class RemnicClient {
     });
   }
 
+  /**
+   * Single HTTP attempt with the configured timeout. No retry — retry of
+   * transient connection failures lives in {@link requestWithRetry}.
+   */
   private async request<T = Record<string, unknown>>(
     method: string,
     pathname: string,
@@ -142,8 +239,8 @@ export class RemnicClient {
     // 0, negative, NaN, or non-finite values would make setTimeout abort
     // immediately (or behave erratically), so fall back to the general budget.
     // In practice the override is always sourced from the validated
-    // `startupRequestTimeoutMs` config, but this keeps the client robust to any
-    // future caller (Copilot review).
+    // `startupRequestTimeoutMs` / `turnRequestTimeoutMs` config, but this keeps
+    // the client robust to any future caller (Copilot review).
     const override = options.timeoutMs;
     const timeoutMs =
       typeof override === "number" && Number.isFinite(override) && override > 0
@@ -172,7 +269,13 @@ export class RemnicClient {
         }
       }
       if (!response.ok) {
-        throw new RemnicHttpError(response.status, responseErrorMessage(response, text, payload, parseError));
+        const message = responseErrorMessage(response, text, payload, parseError);
+        if (response.status === 413) {
+          // Surface the body size so operators can tune the cap (#1600).
+          const bodyBytes = body === undefined ? 0 : jsonBytes(body);
+          throw new RemnicHttpError(response.status, `${message} (observed body ${bodyBytes} bytes; cap via observeMaxBytes)`);
+        }
+        throw new RemnicHttpError(response.status, message);
       }
       if (parseError) {
         const reason = parseError instanceof Error ? parseError.message : String(parseError);
@@ -186,6 +289,35 @@ export class RemnicClient {
       throw err;
     } finally {
       clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Wrap {@link request} with a small bounded retry loop for transient
+   * connection-level failures (socket close mid-request, ECONNRESET, EPIPE).
+   * Timeouts (our own AbortController) and HTTP responses (4xx/5xx) are NOT
+   * retried here — timeouts already burned the full budget, and HTTP errors
+   * carry semantic meaning the caller must handle. Observe/recall are
+   * dedupe-safe so retrying a transiently-failed POST is harmless (#1602).
+   */
+  private async requestWithRetry<T = Record<string, unknown>>(
+    method: string,
+    pathname: string,
+    body: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const maxRetries = options.maxRetries ?? 0;
+    let attempt = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        return await this.request<T>(method, pathname, body, options);
+      } catch (err) {
+        if (attempt >= maxRetries || !isTransientNetworkError(err)) throw err;
+        const delayMs = RETRY_BASE_DELAY_MS * 2 ** attempt;
+        await sleep(delayMs);
+        attempt += 1;
+      }
     }
   }
 
@@ -208,27 +340,178 @@ export class RemnicClient {
   }
 }
 
-interface RequestOptions {
-  timeoutMs?: number;
-}
-
 function isMcpTool(value: unknown): value is McpTool {
-  return !!value && typeof value === "object" && typeof (value as { name?: unknown }).name === "string";
+  return !!value && typeof value === "object" && "name" in value && typeof value.name === "string";
 }
 
 function isAbortError(err: unknown): boolean {
   return err instanceof Error && (err.name === "AbortError" || err.message === "This operation was aborted");
 }
 
+/**
+ * Classify connection-level failures that are safe to retry: the request never
+ * reached the daemon (or died mid-flight), so a retry is idempotent. Excludes
+ * our own AbortController timeouts and HTTP responses (those carry meaning).
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (isAbortError(err)) return false;
+  if (err instanceof RemnicHttpError) return false;
+  const lower = (err.message ?? "").toLowerCase();
+  // Bun fetch: "The socket connection was closed unexpectedly."
+  if (lower.includes("socket connection was closed")) return true;
+  if (lower.includes("socket closed")) return true;
+  // Node undici / OS codes surfaced in the message.
+  if (lower.includes("econnreset")) return true;
+  if (lower.includes("epipe")) return true;
+  if (lower.includes("und_err_socket")) return true;
+  // Node wraps the real cause in err.cause (TypeError: fetch failed).
+  if (lower.includes("fetch failed")) return true;
+  // Inspect the cause chain without an unchecked cast. Error.cause is
+  // `unknown` in the ES2022 lib; narrow it before reading `.code`.
+  const cause = err.cause;
+  if (cause && typeof cause === "object" && "code" in cause) {
+    const code = cause.code;
+    if (typeof code === "string" && (code === "ECONNRESET" || code === "EPIPE" || code === "UND_ERR_SOCKET")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function jsonBytes(value: unknown): number {
+  return encoder.encode(JSON.stringify(value)).length;
+}
+
+function buildObserveEnvelope(config: RemnicPiConfig, sessionKey: string, cwd: string, messages: ObserveMessage[]): ObserveBody {
+  return {
+    sessionKey,
+    cwd,
+    namespace: config.namespace,
+    skipExtraction: config.observeSkipExtraction,
+    messages,
+  };
+}
+
+/**
+ * Split an observe batch into POST bodies whose serialized JSON stays under
+ * `maxBytes`. Single messages that alone exceed the per-message budget are
+ * truncated with a marker rather than dropped, so large tool outputs still
+ * leave a trace in memory (#1600).
+ */
+export function chunkObservePayload(
+  config: RemnicPiConfig,
+  sessionKey: string,
+  cwd: string,
+  messages: ObserveMessage[],
+  maxBytes: number,
+): ObserveBody[] {
+  const envelopeOverhead = jsonBytes(buildObserveEnvelope(config, sessionKey, cwd, []));
+  const messageBudget = maxBytes - envelopeOverhead;
+  if (messageBudget <= 1024) {
+    // The envelope itself is too large to fit a meaningful message; return a
+    // single chunk and let the daemon/server reject it visibly.
+    return [buildObserveEnvelope(config, sessionKey, cwd, messages)];
+  }
+  const chunks: ObserveMessage[][] = [];
+  let current: ObserveMessage[] = [];
+  let currentSize = 0;
+  const flush = (): void => {
+    if (current.length > 0) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+  };
+  for (const message of messages) {
+    const size = jsonBytes(message);
+    if (size > messageBudget) {
+      flush();
+      chunks.push([truncateObserveMessage(message, messageBudget)]);
+      continue;
+    }
+    if (currentSize + size > messageBudget) {
+      flush();
+    }
+    current.push(message);
+    currentSize += size;
+  }
+  flush();
+  if (chunks.length === 0) {
+    return [buildObserveEnvelope(config, sessionKey, cwd, [])];
+  }
+  return chunks.map((msgs) => buildObserveEnvelope(config, sessionKey, cwd, msgs));
+}
+
+const decoder = new TextDecoder();
+
+function truncateObserveMessage(message: ObserveMessage, budgetBytes: number): ObserveMessage {
+  // Measure the ACTUAL JSON bytes of candidate messages so JSON escaping (which
+  // turns the marker's \n into \\\\n, doubling its size) can't make the
+  // final body overshoot the budget.
+  const fullBytes = jsonBytes({ ...message, content: message.content + TRUNCATION_MARKER });
+  if (fullBytes <= budgetBytes) {
+    return { ...message, content: message.content + TRUNCATION_MARKER };
+  }
+  const markerOnly = jsonBytes({ ...message, content: TRUNCATION_MARKER });
+  if (markerOnly > budgetBytes) {
+    // Pathological: even the marker alone doesn't fit. Keep it anyway so the
+    // turn isn't silently dropped.
+    return { ...message, content: TRUNCATION_MARKER };
+  }
+  // Binary-search the largest content slice whose full message fits. Slicing by
+  // encoded bytes keeps multi-byte sequences intact where possible; the decoder
+  // replaces any dangling tail with the replacement char.
+  const encoded = encoder.encode(message.content);
+  let lo = 0;
+  let hi = encoded.length;
+  while (lo < hi) {
+    const mid = hi - Math.floor((hi - lo) / 2);
+    const candidate = decoder.decode(encoded.subarray(0, mid)) + TRUNCATION_MARKER;
+    if (jsonBytes({ ...message, content: candidate }) <= budgetBytes) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  const truncated = lo > 0 ? decoder.decode(encoded.subarray(0, lo)) : "";
+  return { ...message, content: truncated + TRUNCATION_MARKER };
+}
+
+function mergeObserveResults(results: Record<string, unknown>[]): Record<string, unknown> {
+  if (results.length === 0) return {};
+  if (results.length === 1) return results[0];
+  const merged: Record<string, unknown> = {};
+  let countSum = 0;
+  let hasCount = false;
+  for (const result of results) {
+    for (const key of Object.keys(result)) {
+      const value = result[key];
+      if (key === "count" && typeof value === "number" && Number.isFinite(value)) {
+        countSum += value;
+        hasCount = true;
+      } else {
+        merged[key] = value;
+      }
+    }
+  }
+  if (hasCount) merged.count = countSum;
+  return merged;
+}
+
 function responseErrorMessage(response: Response, text: string, payload: unknown, parseError: unknown): string {
   if (!parseError && payload && typeof payload === "object") {
-    const error = (payload as { error?: unknown }).error;
-    if (typeof error === "string" && error.trim().length > 0) {
-      return error;
+    if ("error" in payload && typeof payload.error === "string" && payload.error.trim().length > 0) {
+      return payload.error;
     }
-    const message = (payload as { message?: unknown }).message;
-    if (typeof message === "string" && message.trim().length > 0) {
-      return message;
+    if ("message" in payload && typeof payload.message === "string" && payload.message.trim().length > 0) {
+      return payload.message;
     }
   }
 

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -341,6 +341,18 @@ export class RemnicClient {
       } catch (err) {
         if (attempt >= maxRetries || !isTransientNetworkError(err)) throw err;
         const delayMs = RETRY_BASE_DELAY_MS * 2 ** attempt;
+        if (hasDeadline) {
+          // The backoff sleep counts against the shared deadline; bail BEFORE
+          // sleeping if the sleep alone would overshoot the remaining budget,
+          // so a sub-backoff timeoutMs never blocks for the full backoff only
+          // to then throw (cursor review).
+          const remainingBeforeSleep = deadline - Date.now();
+          if (remainingBeforeSleep <= delayMs) {
+            throw new Error(
+              `Remnic request exceeded the ${budgetMs}ms budget before retry ${attempt + 1} (${method} ${pathname})`,
+            );
+          }
+        }
         await sleep(delayMs);
         attempt += 1;
         if (hasDeadline) {

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -105,8 +105,16 @@ export class RemnicClient {
     options: RequestOptions = {},
   ): Promise<RecallResponse> {
     // Recall is a read-only query; retry transient connection failures with the
-    // same budget as observe (#1602).
-    const merged: RequestOptions = { ...options, maxRetries: options.maxRetries ?? this.config.observeMaxRetries };
+    // same budget as observe (#1602). Default to the per-turn budget when the
+    // caller omits timeoutMs so the retries share one deadline (like observe)
+    // instead of each attempt reusing the full general request timeout (cursor
+    // review). Callers that need more (e.g. the manual /remnic-recall command)
+    // pass an explicit timeoutMs.
+    const merged: RequestOptions = {
+      ...options,
+      timeoutMs: options.timeoutMs ?? this.config.turnRequestTimeoutMs,
+      maxRetries: options.maxRetries ?? this.config.observeMaxRetries,
+    };
     return this.requestWithRetry(
       "POST",
       "/engram/v1/recall",

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -141,20 +141,26 @@ export class RemnicClient {
     options: ObserveOptions = {},
   ): Promise<Record<string, unknown>> {
     const maxBytes = options.maxBytes ?? this.config.observeMaxBytes;
+    // Observe runs on the live turn hooks, so bound it by the per-turn budget
+    // (#1626) regardless of how many chunks the payload splits into. A missing
+    // override previously let single-chunk observe fall back to the 60s general
+    // budget while multi-chunk used the 20s turn budget (cursor review). An
+    // explicit override is honored so callers outside the turn (shutdown replay,
+    // tests) can extend it.
+    const turnBudgetMs = options.timeoutMs ?? this.config.turnRequestTimeoutMs;
     const retryOptions: RequestOptions = {
-      timeoutMs: options.timeoutMs,
+      timeoutMs: turnBudgetMs,
       maxRetries: options.maxRetries ?? this.config.observeMaxRetries,
     };
     const chunks = chunkObservePayload(this.config, sessionKey, cwd, messages, maxBytes);
     if (chunks.length === 1) {
       return this.requestWithRetry("POST", "/engram/v1/observe", chunks[0], retryOptions);
     }
-    // Multiple chunks: send sequentially within a single per-turn deadline so
-    // the TOTAL observe time stays under turnRequestTimeoutMs (not per-chunk),
-    // which keeps it inside the host's ~30s handler budget (#1626). Each chunk
-    // is retried independently on transient connection failures; observe is
+    // Multiple chunks: send sequentially within the SAME per-turn deadline so
+    // the TOTAL observe time stays under turnBudgetMs (not per-chunk), which
+    // keeps it inside the host's ~30s handler budget (#1626). Each chunk is
+    // retried independently on transient connection failures; observe is
     // dedupe-safe, so a partial failure just re-sends on the next turn.
-    const turnBudgetMs = options.timeoutMs ?? this.config.turnRequestTimeoutMs;
     const deadline = Date.now() + turnBudgetMs;
     const results: Record<string, unknown>[] = [];
     for (let i = 0; i < chunks.length; i++) {
@@ -317,16 +323,35 @@ export class RemnicClient {
     options: RequestOptions = {},
   ): Promise<T> {
     const maxRetries = options.maxRetries ?? 0;
+    // Share ONE deadline across all attempts (including backoff sleeps) when the
+    // caller passes a per-turn/per-operation budget, so a late transient failure
+    // cannot burn a full timeout on every retry and overshoot the host's ~30s
+    // handler window (#1602/#1626 — cursor + codex reviews). The first attempt
+    // keeps the original timeoutMs verbatim (preserving error messages/timing);
+    // only retries are tightened to the remaining budget.
+    const budgetMs = options.timeoutMs;
+    const hasDeadline = typeof budgetMs === "number" && Number.isFinite(budgetMs) && budgetMs > 0;
+    const deadline = hasDeadline ? Date.now() + budgetMs : Number.POSITIVE_INFINITY;
     let attempt = 0;
+    let attemptOptions = options;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
-        return await this.request<T>(method, pathname, body, options);
+        return await this.request<T>(method, pathname, body, attemptOptions);
       } catch (err) {
         if (attempt >= maxRetries || !isTransientNetworkError(err)) throw err;
         const delayMs = RETRY_BASE_DELAY_MS * 2 ** attempt;
         await sleep(delayMs);
         attempt += 1;
+        if (hasDeadline) {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) {
+            throw new Error(
+              `Remnic request exceeded the ${budgetMs}ms budget before retry ${attempt} (${method} ${pathname})`,
+            );
+          }
+          attemptOptions = { ...options, timeoutMs: remaining };
+        }
       }
     }
   }

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -149,17 +149,27 @@ export class RemnicClient {
     if (chunks.length === 1) {
       return this.requestWithRetry("POST", "/engram/v1/observe", chunks[0], retryOptions);
     }
-    // Multiple chunks: send sequentially so a single slow daemon connection is
-    // not stressed by parallel writes. Each chunk is retried independently on
-    // transient connection failures. Observe is dedupe-safe, so a partial
-    // failure just re-sends (redundantly) on the next turn.
+    // Multiple chunks: send sequentially within a single per-turn deadline so
+    // the TOTAL observe time stays under turnRequestTimeoutMs (not per-chunk),
+    // which keeps it inside the host's ~30s handler budget (#1626). Each chunk
+    // is retried independently on transient connection failures; observe is
+    // dedupe-safe, so a partial failure just re-sends on the next turn.
+    const turnBudgetMs = options.timeoutMs ?? this.config.turnRequestTimeoutMs;
+    const deadline = Date.now() + turnBudgetMs;
     const results: Record<string, unknown>[] = [];
-    for (const chunk of chunks) {
+    for (let i = 0; i < chunks.length; i++) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(
+          `Remnic observe exceeded the per-turn budget of ${turnBudgetMs}ms across ${chunks.length} chunks (completed ${i})`,
+        );
+      }
+      const chunkOptions: RequestOptions = { ...retryOptions, timeoutMs: remaining };
       const result = await this.requestWithRetry<Record<string, unknown>>(
         "POST",
         "/engram/v1/observe",
-        chunk,
-        retryOptions,
+        chunks[i],
+        chunkOptions,
       );
       if (result && typeof result === "object") {
         results.push(result);
@@ -436,9 +446,13 @@ export function chunkObservePayload(
       chunks.push([truncateObserveMessage(message, messageBudget)]);
       continue;
     }
-    if (currentSize + size > messageBudget) {
+    // Account for the JSON array comma separator before this message when it is
+    // not the first in the chunk, so the serialized body never overshoots the
+    // cap (review: cursor).
+    if (current.length > 0 && currentSize + 1 + size > messageBudget) {
       flush();
     }
+    if (current.length > 0) currentSize += 1;
     current.push(message);
     currentSize += size;
   }
@@ -452,20 +466,24 @@ export function chunkObservePayload(
 const decoder = new TextDecoder();
 
 function truncateObserveMessage(message: ObserveMessage, budgetBytes: number): ObserveMessage {
-  // Measure the ACTUAL JSON bytes of candidate messages so JSON escaping (which
-  // turns the marker's \n into \\\\n, doubling its size) can't make the
-  // final body overshoot the budget.
-  const fullBytes = jsonBytes({ ...message, content: message.content + TRUNCATION_MARKER });
-  if (fullBytes <= budgetBytes) {
-    return { ...message, content: message.content + TRUNCATION_MARKER };
-  }
-  const markerOnly = jsonBytes({ ...message, content: TRUNCATION_MARKER });
+  // A truncated observe keeps ONLY role + a content marker, dropping rawContent
+  // and parts. Live Pi turns carry the full original message in rawContent and
+  // parsed parts; those fields dominate the serialized size and would keep the
+  // chunk over the cap (defeating #1600), so they are removed — the daemon
+  // extracts from content. JSON-escape-aware: measures ACTUAL jsonBytes of each
+  // candidate so escaping (\n -> \\\\n) can't overshoot.
+  const slim: ObserveMessage = { role: message.role, content: "" };
+  const markerOnly = jsonBytes({ ...slim, content: TRUNCATION_MARKER });
   if (markerOnly > budgetBytes) {
     // Pathological: even the marker alone doesn't fit. Keep it anyway so the
     // turn isn't silently dropped.
-    return { ...message, content: TRUNCATION_MARKER };
+    return { role: message.role, content: TRUNCATION_MARKER };
   }
-  // Binary-search the largest content slice whose full message fits. Slicing by
+  const fullContent = message.content + TRUNCATION_MARKER;
+  if (jsonBytes({ ...slim, content: fullContent }) <= budgetBytes) {
+    return { role: message.role, content: fullContent };
+  }
+  // Binary-search the largest content slice whose slim message fits. Slicing by
   // encoded bytes keeps multi-byte sequences intact where possible; the decoder
   // replaces any dangling tail with the replacement char.
   const encoded = encoder.encode(message.content);
@@ -474,14 +492,14 @@ function truncateObserveMessage(message: ObserveMessage, budgetBytes: number): O
   while (lo < hi) {
     const mid = hi - Math.floor((hi - lo) / 2);
     const candidate = decoder.decode(encoded.subarray(0, mid)) + TRUNCATION_MARKER;
-    if (jsonBytes({ ...message, content: candidate }) <= budgetBytes) {
+    if (jsonBytes({ ...slim, content: candidate }) <= budgetBytes) {
       lo = mid;
     } else {
       hi = mid - 1;
     }
   }
   const truncated = lo > 0 ? decoder.decode(encoded.subarray(0, lo)) : "";
-  return { ...message, content: truncated + TRUNCATION_MARKER };
+  return { role: message.role, content: truncated + TRUNCATION_MARKER };
 }
 
 function mergeObserveResults(results: Record<string, unknown>[]): Record<string, unknown> {

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -332,3 +332,46 @@ test("loadConfig fails closed on invalid namespace values", () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("loadConfig derives turnRequestTimeoutMs from requestTimeoutMs when unset (review codex)", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-config-turn-derive-"));
+  const configPath = path.join(root, "remnic.config.json");
+  try {
+    // Existing install that lowered requestTimeoutMs below the 20s turn default.
+    fs.writeFileSync(configPath, JSON.stringify({ requestTimeoutMs: 5000 }));
+    const cfg = loadConfig({ configPath, env: {} });
+    assert.equal(cfg.requestTimeoutMs, 5000);
+    assert.equal(cfg.turnRequestTimeoutMs, 5000, "turn budget tracks the lowered request timeout, not the 20s default");
+
+    // Default requestTimeoutMs (60000) keeps the 20s turn default.
+    fs.writeFileSync(configPath, JSON.stringify({}));
+    const def = loadConfig({ configPath, env: {} });
+    assert.equal(def.turnRequestTimeoutMs, 20000, "default turn budget stays 20s when request timeout is default");
+
+    // An explicit turnRequestTimeoutMs always wins.
+    fs.writeFileSync(configPath, JSON.stringify({ requestTimeoutMs: 5000, turnRequestTimeoutMs: 8000 }));
+    const explicit = loadConfig({ configPath, env: {} });
+    assert.equal(explicit.turnRequestTimeoutMs, 8000, "explicit turn budget is honored over the derived fallback");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loadConfig accepts observeMaxRetries: 0 to disable retries (review codex)", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-config-zero-retries-"));
+  const configPath = path.join(root, "remnic.config.json");
+  try {
+    fs.writeFileSync(configPath, JSON.stringify({ observeMaxRetries: 0 }));
+    const cfg = loadConfig({ configPath, env: {} });
+    assert.equal(cfg.observeMaxRetries, 0, "zero is a valid 'disable retries' value");
+
+    // A negative value is still rejected.
+    fs.writeFileSync(configPath, JSON.stringify({ observeMaxRetries: -1 }));
+    assert.throws(
+      () => loadConfig({ configPath, env: {} }),
+      /Invalid numeric value for Remnic Pi config field observeMaxRetries/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -20,6 +20,32 @@ export interface RemnicPiConfig {
   statusEnabled: boolean;
   requestTimeoutMs: number;
   startupRequestTimeoutMs: number;
+  /**
+   * Per-turn request budget for observe/recall. MUST stay below the host's
+   * in-handler kill budget (Pi/omp kills handlers at 30 s). Defaults to 20 s,
+   * capped at 25 s so a misconfiguration can never produce a structurally
+   * unsatisfiable timeout (issue #1626).
+   */
+  turnRequestTimeoutMs: number;
+  /**
+   * Soft cap on a single observe POST body in bytes. The client chunks observe
+   * batches to stay under this; individual oversized messages are truncated
+   * with a marker. Defaults to 100 KiB, safely under the daemon's default
+   * 128 KiB `maxBodyBytes` (issue #1600).
+   */
+  observeMaxBytes: number;
+  /**
+   * Maximum retry attempts for observe/recall on transient connection-level
+   * failures (socket close, ECONNRESET, EPIPE). Observe is dedupe-safe so
+   * retrying is harmless (issue #1602).
+   */
+  observeMaxRetries: number;
+  /**
+   * Cooldown base for the daemon-reachability circuit breaker. When observe/
+   * recall fails on a timeout or connection error, subsequent turns skip fast
+   * for an exponentially growing window starting at this value (issue #1626).
+   */
+  daemonCooldownMs: number;
 }
 
 export interface LoadConfigOptions {
@@ -40,6 +66,13 @@ const DEFAULT_CONFIG: RemnicPiConfig = {
   statusEnabled: true,
   requestTimeoutMs: 60000,
   startupRequestTimeoutMs: 1000,
+  // Default 20 s is comfortably under the Pi/omp 30 s handler budget (#1626).
+  turnRequestTimeoutMs: 20000,
+  // Default 100 KiB leaves headroom under the daemon's 128 KiB default (#1600).
+  observeMaxBytes: 102400,
+  observeMaxRetries: 2,
+  // Base cooldown for the circuit breaker; doubles on consecutive failures (#1626).
+  daemonCooldownMs: 5000,
 };
 
 function defaultConfigPath(env: NodeJS.ProcessEnv): string {
@@ -187,5 +220,19 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
       60_000,
       "startupRequestTimeoutMs",
     ),
+    turnRequestTimeoutMs: coercePositiveInt(
+      fileConfig.turnRequestTimeoutMs,
+      DEFAULT_CONFIG.turnRequestTimeoutMs,
+      25_000,
+      "turnRequestTimeoutMs",
+    ),
+    observeMaxBytes: coercePositiveInt(
+      fileConfig.observeMaxBytes,
+      DEFAULT_CONFIG.observeMaxBytes,
+      8_388_608,
+      "observeMaxBytes",
+    ),
+    observeMaxRetries: coercePositiveInt(fileConfig.observeMaxRetries, DEFAULT_CONFIG.observeMaxRetries, 5, "observeMaxRetries"),
+    daemonCooldownMs: coercePositiveInt(fileConfig.daemonCooldownMs, DEFAULT_CONFIG.daemonCooldownMs, 60_000, "daemonCooldownMs"),
   };
 }

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -111,6 +111,32 @@ function coercePositiveInt(value: unknown, fallback: number, max: number, fieldN
   return parsed;
 }
 
+/**
+ * Like {@link coercePositiveInt} but allows 0, for knobs where 0 is a
+ * meaningful "disabled" value (e.g. observeMaxRetries). Still rejects
+ * negatives, non-integers, and values above the cap.
+ */
+function coerceNonNegativeInt(value: unknown, fallback: number, max: number, fieldName: string): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  let parsed: number;
+  if (typeof value === "number") {
+    parsed = value;
+  } else if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return fallback;
+    if (!/^[+-]?\d+$/.test(trimmed)) {
+      throw new Error(`Invalid numeric value for Remnic Pi config field ${fieldName}: expected an integer from 0 to ${max}`);
+    }
+    parsed = Number(trimmed);
+  } else {
+    throw new Error(`Invalid numeric value for Remnic Pi config field ${fieldName}: expected an integer from 0 to ${max}`);
+  }
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > max) {
+    throw new Error(`Invalid numeric value for Remnic Pi config field ${fieldName}: expected an integer from 0 to ${max}`);
+  }
+  return parsed;
+}
+
 function coerceOptionalNonEmptyString(value: unknown, fieldName: string): string | undefined {
   if (value === undefined || value === null) return undefined;
   if (typeof value === "string" && value.trim().length > 0) return value.trim();
@@ -200,6 +226,24 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
     coerceOptionalString(env.REMNIC_PI_AUTH_TOKEN, "REMNIC_PI_AUTH_TOKEN");
   const namespace = coerceOptionalNonEmptyString(fileConfig.namespace, "namespace");
 
+  const requestTimeoutMs = coercePositiveInt(
+    fileConfig.requestTimeoutMs,
+    DEFAULT_CONFIG.requestTimeoutMs,
+    60_000,
+    "requestTimeoutMs",
+  );
+  // When turnRequestTimeoutMs is not explicitly set, derive it from the
+  // configured requestTimeoutMs (capped at the default turn budget) so an
+  // existing install that lowered requestTimeoutMs below 20s keeps its tighter
+  // per-turn budget instead of being silently raised back to 20s (codex review).
+  const turnFallback = Math.min(requestTimeoutMs, DEFAULT_CONFIG.turnRequestTimeoutMs);
+  const turnRequestTimeoutMs = coercePositiveInt(
+    fileConfig.turnRequestTimeoutMs,
+    turnFallback,
+    25_000,
+    "turnRequestTimeoutMs",
+  );
+
   return {
     remnicDaemonUrl: daemonUrl,
     authToken,
@@ -213,26 +257,21 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
     compactionEnabled: coerceBoolean(fileConfig.compactionEnabled, DEFAULT_CONFIG.compactionEnabled, "compactionEnabled"),
     mcpToolsEnabled: coerceBoolean(fileConfig.mcpToolsEnabled, DEFAULT_CONFIG.mcpToolsEnabled, "mcpToolsEnabled"),
     statusEnabled: coerceBoolean(fileConfig.statusEnabled, DEFAULT_CONFIG.statusEnabled, "statusEnabled"),
-    requestTimeoutMs: coercePositiveInt(fileConfig.requestTimeoutMs, DEFAULT_CONFIG.requestTimeoutMs, 60_000, "requestTimeoutMs"),
+    requestTimeoutMs,
     startupRequestTimeoutMs: coercePositiveInt(
       fileConfig.startupRequestTimeoutMs,
       DEFAULT_CONFIG.startupRequestTimeoutMs,
       60_000,
       "startupRequestTimeoutMs",
     ),
-    turnRequestTimeoutMs: coercePositiveInt(
-      fileConfig.turnRequestTimeoutMs,
-      DEFAULT_CONFIG.turnRequestTimeoutMs,
-      25_000,
-      "turnRequestTimeoutMs",
-    ),
+    turnRequestTimeoutMs,
     observeMaxBytes: coercePositiveInt(
       fileConfig.observeMaxBytes,
       DEFAULT_CONFIG.observeMaxBytes,
       8_388_608,
       "observeMaxBytes",
     ),
-    observeMaxRetries: coercePositiveInt(fileConfig.observeMaxRetries, DEFAULT_CONFIG.observeMaxRetries, 5, "observeMaxRetries"),
+    observeMaxRetries: coerceNonNegativeInt(fileConfig.observeMaxRetries, DEFAULT_CONFIG.observeMaxRetries, 5, "observeMaxRetries"),
     daemonCooldownMs: coercePositiveInt(fileConfig.daemonCooldownMs, DEFAULT_CONFIG.daemonCooldownMs, 60_000, "daemonCooldownMs"),
   };
 }

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -9,6 +9,7 @@ import { Kind } from "@sinclair/typebox";
 import remnicPiExtension, {
   buildCompactionSummary,
   createRemnicPiExtension,
+  isDaemonUnreachableError,
   observeMessages,
   stripSessionOwnedSchemaFields,
   stripSessionOwnedRuntimeFields,
@@ -1515,4 +1516,69 @@ test("retry-budget exhaustion trips the circuit breaker so the next turn cools d
   // Second turn: breaker is in cooldown -> observe is skipped, no new fetch.
   await emit("turn_end", { message }, ctx);
   assert.equal(calls, callsAfterFirst, "breaker skipped the second turn after budget exhaustion");
+});
+
+test("isDaemonUnreachableError recognizes both budget-exceeded wordings so the breaker trips (review cursor)", () => {
+  // requestWithRetry retry-budget exhaustion:
+  assert.ok(
+    isDaemonUnreachableError(new Error("Remnic request exceeded the 50ms budget before retry 1 (POST /engram/v1/observe)")),
+    "retry-budget exhaustion is unreachable",
+  );
+  // Multi-chunk observe per-turn budget exhaustion:
+  assert.ok(
+    isDaemonUnreachableError(new Error("Remnic observe exceeded the per-turn budget of 20ms across 3 chunks (completed 1)")),
+    "multi-chunk observe budget exhaustion is unreachable",
+  );
+  // A semantic HTTP-style error is NOT classified as unreachable:
+  assert.ok(!isDaemonUnreachableError(new Error("Internal Server Error")), "HTTP errors stay reachable");
+});
+
+test("a successful startup health probe clears a stale circuit breaker (review codex)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (input, init) => {
+    calls += 1;
+    const url = String(input);
+    if (url.endsWith("/engram/v1/health")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    // recall hangs until the AbortController fires, simulating an unreachable daemon.
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: true,
+      turnRequestTimeoutMs: 30,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as any);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "status-clear-breaker" },
+  };
+  const event = { messages: [{ role: "user", content: "hi" }] };
+
+  // 1) recall times out -> breaker tripped.
+  await emit("context", event, ctx);
+  // 2) session_start health succeeds -> clears the stale breaker.
+  await emit("session_start", {}, ctx);
+  // 3) recall now runs instead of fast-skipping.
+  const callsBeforeSecondRecall = calls;
+  await emit("context", event, ctx);
+  assert.ok(calls > callsBeforeSecondRecall, "recall ran after the health probe cleared the breaker");
 });

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1431,3 +1431,44 @@ test("session_shutdown replays the branch even when the daemon breaker is trippe
   await emit("session_shutdown", {}, ctx);
   assert.equal(observeBodies.length, 1, "shutdown bypassed the breaker and observed the branch");
 });
+
+test("session_shutdown observe uses the general request budget, not the per-turn budget (review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      turnRequestTimeoutMs: 30,
+      requestTimeoutMs: 150,
+    },
+  });
+  await extension(pi as any);
+
+  const stale = makeStaleCtx({
+    sessionId: "shutdown-budget-test",
+    branch: [{ id: "entry-1", message: { role: "user", content: "x".repeat(50) } }],
+  });
+
+  await emit("session_shutdown", {}, stale.ctx);
+
+  // Shutdown replay is teardown (no host handler window), so it must use the
+  // general request budget (150ms), NOT the per-turn budget (30ms). The timeout
+  // error embeds the budget actually used, so this deterministically proves
+  // which budget governed the forced replay.
+  const observeFail = stale.notifications.find((n) => /Remnic observe failed/.test(n.message));
+  assert.ok(observeFail, "shutdown observe ran and timed out");
+  assert.match(observeFail!.message, /timed out after 150ms/);
+});

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1582,3 +1582,46 @@ test("a successful startup health probe clears a stale circuit breaker (review c
   await emit("context", event, ctx);
   assert.ok(calls > callsBeforeSecondRecall, "recall ran after the health probe cleared the breaker");
 });
+
+test("/remnic-recall bounds retry to the general request budget instead of unbounded retries (review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, runCommand } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      requestTimeoutMs: 40,
+      observeMaxRetries: 2,
+    },
+  });
+  await extension(pi as any);
+
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { notify: (m: string, l: string) => notifications.push({ message: m, level: l }) },
+    sessionManager: { getSessionId: () => "recall-command-budget" },
+  };
+
+  await runCommand("remnic-recall", "any query", ctx);
+  // The command passes the general request budget as a shared deadline, so the
+  // 40ms budget (below the first 200ms backoff) stops retries after one call
+  // instead of looping through the full retry chain unbounded.
+  assert.equal(calls, 1, "manual recall did not loop through unbounded retries");
+  assert.ok(
+    notifications.some((n) => /Remnic command failed/.test(n.message)),
+    "command reported the bounded failure",
+  );
+});

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1583,6 +1583,55 @@ test("a successful startup health probe clears a stale circuit breaker (review c
   assert.ok(calls > callsBeforeSecondRecall, "recall ran after the health probe cleared the breaker");
 });
 
+test("an offline startup health probe trips the circuit breaker so the first turn fast-skips (review codex)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let recallCalls = 0;
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.endsWith("/engram/v1/health")) {
+      // Daemon is offline: a connection-level failure fails fast (health() does not retry).
+      throw new Error("The socket connection was closed unexpectedly.");
+    }
+    // If the breaker let recall through, this would hang until the AbortController fires.
+    recallCalls += 1;
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: true,
+      turnRequestTimeoutMs: 30,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as any);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "status-trip-breaker" },
+  };
+  const event = { messages: [{ role: "user", content: "hi" }] };
+
+  // 1) session_start health fails because the daemon is offline -> trips the breaker.
+  await emit("session_start", {}, ctx);
+  // 2) context (recall) fast-skips because the breaker is tripped, so the doomed
+  //    recall never costs the full turn budget.
+  await emit("context", event, ctx);
+  assert.equal(recallCalls, 0, "recall fast-skipped after the offline startup probe tripped the breaker");
+});
+
 test("/remnic-recall bounds retry to the general request budget instead of unbounded retries (review cursor)", async (t) => {
   const originalFetch = globalThis.fetch;
   let calls = 0;

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1472,3 +1472,47 @@ test("session_shutdown observe uses the general request budget, not the per-turn
   assert.ok(observeFail, "shutdown observe ran and timed out");
   assert.match(observeFail!.message, /timed out after 150ms/);
 });
+
+test("retry-budget exhaustion trips the circuit breaker so the next turn cools down (review codex)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new Error("The socket connection was closed unexpectedly.");
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      // Per-turn budget below the first 200ms backoff, so a transient failure
+      // exhausts the retry budget and throws the budget-exceeded error.
+      turnRequestTimeoutMs: 30,
+      observeMaxRetries: 2,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as any);
+
+  const message = { role: "assistant", content: "done" };
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "budget-breaker-test", getEntries: () => [], getBranch: () => [] },
+  };
+
+  // First turn: transient socket close exhausts the retry budget. The
+  // budget-exceeded error must trip the breaker (not fall through silently).
+  await emit("turn_end", { message }, ctx);
+  const callsAfterFirst = calls;
+  assert.ok(callsAfterFirst >= 1, "first turn attempted an observe");
+
+  // Second turn: breaker is in cooldown -> observe is skipped, no new fetch.
+  await emit("turn_end", { message }, ctx);
+  assert.equal(calls, callsAfterFirst, "breaker skipped the second turn after budget exhaustion");
+});

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1625,3 +1625,53 @@ test("/remnic-recall bounds retry to the general request budget instead of unbou
     "command reported the bounded failure",
   );
 });
+
+test("a successful /remnic-recall clears a stale circuit breaker (review cursor)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (input, init) => {
+    calls += 1;
+    const url = String(input);
+    // Manual recall responds OK; automatic context recall hangs until abort.
+    if (url.endsWith("/engram/v1/recall") && init?.body && JSON.parse(String(init.body)).query === "manual") {
+      return new Response(JSON.stringify({ context: "manual context" }), { status: 200 });
+    }
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit, runCommand } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      turnRequestTimeoutMs: 30,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as any);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    ui: { setStatus: () => {}, notify: () => {} },
+    sessionManager: { getSessionId: () => "manual-recall-clears-breaker" },
+  };
+  const autoEvent = { messages: [{ role: "user", content: "auto" }] };
+
+  // 1) automatic context recall times out -> breaker tripped.
+  await emit("context", autoEvent, ctx);
+  // 2) a successful manual /remnic-recall clears the stale breaker.
+  await runCommand("remnic-recall", "manual", ctx);
+  // 3) automatic context recall now runs instead of fast-skipping.
+  const callsBeforeSecondAuto = calls;
+  await emit("context", { messages: [{ role: "user", content: "auto2" }] }, ctx);
+  assert.ok(calls > callsBeforeSecondAuto, "automatic recall ran after the manual recall cleared the breaker");
+});

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1379,3 +1379,55 @@ test("recall circuit breaker skips subsequent turns after a timeout against an u
   await emit("context", event, ctx);
   assert.equal(fetchCalls, 1, "circuit breaker skipped recall during cooldown");
 });
+
+test("session_shutdown replays the branch even when the daemon breaker is tripped (#1626, review codex)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const observeBodies: Array<Record<string, any>> = [];
+  let call = 0;
+  globalThis.fetch = async (input, init) => {
+    call += 1;
+    if (String(input).endsWith("/engram/v1/observe")) {
+      // Fail the ENTIRE turn_end retry chain (1 initial + observeMaxRetries=2
+      // retries = 3 calls) so the breaker actually trips; the next observe
+      // (shutdown) then succeeds, proving shutdown bypasses the breaker.
+      if (call <= 3) {
+        throw new Error("The socket connection was closed unexpectedly.");
+      }
+      observeBodies.push(JSON.parse(String(init?.body ?? "{}")));
+    }
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  const message = { role: "assistant", content: "done" };
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: {
+      getSessionId: () => "shutdown-breaker-test",
+      getEntries: () => [],
+      getBranch: () => [{ id: "entry-1", message }],
+    },
+  };
+
+  // turn_end observe fails transiently -> breaker tripped, nothing recorded.
+  await emit("turn_end", { message }, ctx);
+  assert.equal(observeBodies.length, 0, "turn_end observe failed and recorded nothing");
+
+  // shutdown runs while the breaker is in cooldown; forceAttempt must still
+  // replay the branch (the last chance to observe before teardown).
+  await emit("session_shutdown", {}, ctx);
+  assert.equal(observeBodies.length, 1, "shutdown bypassed the breaker and observed the branch");
+});

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -1231,6 +1231,10 @@ function baseConfig(): RemnicPiConfig {
     statusEnabled: true,
     requestTimeoutMs: 60000,
     startupRequestTimeoutMs: 1000,
+    turnRequestTimeoutMs: 20000,
+    observeMaxBytes: 102400,
+    observeMaxRetries: 2,
+    daemonCooldownMs: 5000,
   };
 }
 
@@ -1330,3 +1334,48 @@ function makeStaleCtx(options: {
     statuses,
   };
 }
+
+
+test("recall circuit breaker skips subsequent turns after a timeout against an unreachable daemon (#1626)", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  // fetch hangs until the AbortController fires, simulating an unreachable host.
+  globalThis.fetch = async (_input, init) => {
+    fetchCalls += 1;
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () =>
+        reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })),
+      );
+    });
+  };
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+      turnRequestTimeoutMs: 30,
+      daemonCooldownMs: 60000,
+    },
+  });
+  await extension(pi as unknown as Parameters<typeof extension>[0]);
+
+  const ctx = {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "cb-session" },
+  };
+  const event = { messages: [{ role: "user", content: "any prompt" }] };
+
+  // First turn: recall times out → daemon enters cooldown.
+  await emit("context", event, ctx);
+  assert.equal(fetchCalls, 1, "first turn issued a recall that timed out");
+
+  // Second turn: daemon is known-down → recall is skipped fast, no fetch.
+  await emit("context", event, ctx);
+  assert.equal(fetchCalls, 1, "circuit breaker skipped recall during cooldown");
+});

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -211,7 +211,13 @@ function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfi
         session.notify("Usage: /remnic-recall <query>", "warning");
         return;
       }
-      const result = await client.recall(query, session.sessionKey, session.cwd);
+      // Pass the general request budget so requestWithRetry shares ONE deadline
+      // across retries (total <= requestTimeoutMs) instead of looping through
+      // observeMaxRetries full timeouts and blocking the interactive command
+      // for several minutes on a flaky connection (cursor review).
+      const result = await client.recall(query, session.sessionKey, session.cwd, {
+        timeoutMs: config.requestTimeoutMs,
+      });
       session.notify(trimContext(result.context ?? "(no Remnic context)", MAX_CONTEXT_CHARS), "info");
     }),
   });

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -133,7 +133,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         const branchMessages = branchMessagesWithEntryIdentity(session.branch);
         const unobservedBranchMessages = skipLiveObservedReplayMessages(session.sessionKey, branchMessages, state.liveObservedReplayKeys);
         if (unobservedBranchMessages.length > 0) {
-          await observeMessagesForSession(session, client, unobservedBranchMessages, state.observedHashes, undefined, config);
+          await observeMessagesForSession(session, client, unobservedBranchMessages, state.observedHashes, undefined, config, true);
         }
       }
       persistObservedState(pi, state.observedHashes);
@@ -421,6 +421,7 @@ async function observeMessagesForSession(
   observedHashes: Set<string>,
   liveObservedReplayKeys?: Map<string, number>,
   config?: RemnicPiConfig,
+  forceAttempt = false,
 ): Promise<void> {
   const messages: ObserveMessage[] = [];
   const pendingHashes = new Set<string>();
@@ -435,8 +436,11 @@ async function observeMessagesForSession(
   if (messages.length === 0) return;
   // Circuit breaker: when config is wired (the live Pi handlers always pass
   // it), skip observe fast while the daemon is known-down so a dead host
-  // doesn't burn the full per-turn budget on every turn (#1626).
-  if (config && !client.isReachable()) return;
+  // doesn't burn the full per-turn budget on every turn (#1626). Shutdown is
+  // the exception — it is the last chance to observe the branch before the
+  // session tears down, so force the attempt even mid-cooldown; a failure
+  // still trips the breaker normally (codex review).
+  if (config && !forceAttempt && !client.isReachable()) return;
   const observeOptions = config ? { timeoutMs: config.turnRequestTimeoutMs } : undefined;
   try {
     await client.observe(session.sessionKey, session.cwd, messages, observeOptions);

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -441,7 +441,14 @@ async function observeMessagesForSession(
   // session tears down, so force the attempt even mid-cooldown; a failure
   // still trips the breaker normally (codex review).
   if (config && !forceAttempt && !client.isReachable()) return;
-  const observeOptions = config ? { timeoutMs: config.turnRequestTimeoutMs } : undefined;
+  // Live turn hooks are bounded by the per-turn budget to protect the host's
+  // ~30s handler window (#1626). Shutdown is teardown with no such constraint,
+  // so the forced replay uses the general request budget — otherwise a large
+  // unobserved branch would time out exactly when forceAttempt tried to save it
+  // (cursor review).
+  const observeOptions = config
+    ? { timeoutMs: forceAttempt ? config.requestTimeoutMs : config.turnRequestTimeoutMs }
+    : undefined;
   try {
     await client.observe(session.sessionKey, session.cwd, messages, observeOptions);
     if (config) client.markReachable();

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -574,6 +574,11 @@ function persistObservedState(pi: PiApi, observedHashes: Set<string>): void {
 async function setStatus(session: PiContextSnapshot, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
   try {
     await client.health({ timeoutMs: config.startupRequestTimeoutMs });
+    // A successful health probe means the daemon is reachable, so clear any
+    // stale cooldown a prior recall/observe timeout left on the shared client —
+    // otherwise the next live hook fast-skips even though the daemon is up
+    // (codex review).
+    client.markReachable();
     session.setStatus("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
   } catch {
     session.setStatus("remnic", "Remnic offline");
@@ -706,7 +711,7 @@ function trimContext(value: string, budget: number): string {
 }
 
 
-function isDaemonUnreachableError(err: unknown): boolean {
+export function isDaemonUnreachableError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (/Remnic request timed out/.test(err.message)) return true;
   // Retry-budget exhaustion means transient failures ate the whole per-turn
@@ -715,6 +720,11 @@ function isDaemonUnreachableError(err: unknown): boolean {
   // full budget on the next hook (codex review). This error only arises from
   // transient connection failures, never from a semantic HTTP response.
   if (/Remnic request exceeded the \d+ms budget before retry/.test(err.message)) return true;
+  // Multi-chunk observe throws its own budget-exceeded message when the shared
+  // per-turn deadline is exhausted across chunks; that is also an effectively-
+  // unreachable condition for the turn, so trip the breaker and fast-skip
+  // subsequent turns instead of piling on more doomed chunked observes (cursor).
+  if (/Remnic observe exceeded the per-turn budget of \d+ms/.test(err.message)) return true;
   return isTransientNetworkError(err);
 }
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -1,7 +1,7 @@
 import { Type, type TSchema } from "@sinclair/typebox";
 
 import { loadConfig, type LoadConfigOptions, type RemnicPiConfig } from "./config.js";
-import { RemnicClient, type McpTool, type ObserveMessage } from "./client.js";
+import { RemnicClient, isTransientNetworkError, type McpTool, type ObserveMessage } from "./client.js";
 import {
   hashObservedMessage,
   latestUserRecallTarget,
@@ -71,6 +71,9 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       const session = snapshotPiContext(ctx);
       if (!session) return;
       if (!config.recallEnabled || !config.authToken) return;
+      // Circuit breaker: skip recall fast while the daemon is known-down so a
+      // dead host doesn't block every turn on a doomed request (#1626).
+      if (!client.isReachable()) return;
       const recallTarget = latestUserRecallTarget(Array.isArray(event.messages) ? event.messages : []);
       if (!recallTarget) return;
       const { query } = recallTarget;
@@ -78,7 +81,10 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (recallTarget.dedupeKey === state.lastInjectedRecallKey) return;
 
       try {
-        const recalled = await client.recall(query, session.sessionKey, session.cwd);
+        const recalled = await client.recall(query, session.sessionKey, session.cwd, {
+          timeoutMs: config.turnRequestTimeoutMs,
+        });
+        client.markReachable();
         const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
         if (!context) return;
         state.lastInjectedRecallKey = recallTarget.dedupeKey;
@@ -94,6 +100,10 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
           ],
         };
       } catch (err) {
+        // Only trip the breaker when the daemon is genuinely unreachable
+        // (timeout or connection-level failure) — not on a transient HTTP
+        // error, so a one-off failure still retries on the next turn (#1626).
+        if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
         session.notify(`Remnic recall unavailable: ${errorMessage(err)}`, "warning");
       }
     });
@@ -103,7 +113,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!session) return;
       if (!config.observeEnabled || !isUserMessage(event.message)) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
-      await observeMessagesForSession(session, client, [event.message], state.observedHashes, state.liveObservedReplayKeys);
+      await observeMessagesForSession(session, client, [event.message], state.observedHashes, state.liveObservedReplayKeys, config);
     });
 
     pi.on("turn_end", async (event, ctx) => {
@@ -112,7 +122,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       if (!config.observeEnabled) return;
       const messages = [event.message, ...(Array.isArray(event.toolResults) ? event.toolResults : [])];
       const { state } = getSessionState(session.sessionKey, sessionStates);
-      await observeMessagesForSession(session, client, messages, state.observedHashes, state.liveObservedReplayKeys);
+      await observeMessagesForSession(session, client, messages, state.observedHashes, state.liveObservedReplayKeys, config);
     });
 
     pi.on("session_shutdown", async (_event, ctx) => {
@@ -123,7 +133,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
         const branchMessages = branchMessagesWithEntryIdentity(session.branch);
         const unobservedBranchMessages = skipLiveObservedReplayMessages(session.sessionKey, branchMessages, state.liveObservedReplayKeys);
         if (unobservedBranchMessages.length > 0) {
-          await observeMessagesForSession(session, client, unobservedBranchMessages, state.observedHashes);
+          await observeMessagesForSession(session, client, unobservedBranchMessages, state.observedHashes, undefined, config);
         }
       }
       persistObservedState(pi, state.observedHashes);
@@ -410,6 +420,7 @@ async function observeMessagesForSession(
   rawMessages: unknown[],
   observedHashes: Set<string>,
   liveObservedReplayKeys?: Map<string, number>,
+  config?: RemnicPiConfig,
 ): Promise<void> {
   const messages: ObserveMessage[] = [];
   const pendingHashes = new Set<string>();
@@ -422,8 +433,14 @@ async function observeMessagesForSession(
     messages.push(message);
   }
   if (messages.length === 0) return;
+  // Circuit breaker: when config is wired (the live Pi handlers always pass
+  // it), skip observe fast while the daemon is known-down so a dead host
+  // doesn't burn the full per-turn budget on every turn (#1626).
+  if (config && !client.isReachable()) return;
+  const observeOptions = config ? { timeoutMs: config.turnRequestTimeoutMs } : undefined;
   try {
-    await client.observe(session.sessionKey, session.cwd, messages);
+    await client.observe(session.sessionKey, session.cwd, messages, observeOptions);
+    if (config) client.markReachable();
     for (const hash of pendingHashes) rememberObservedHash(observedHashes, hash);
     if (liveObservedReplayKeys) {
       for (const message of messages) {
@@ -431,6 +448,7 @@ async function observeMessagesForSession(
       }
     }
   } catch (err) {
+    if (config && isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
     session.notify(`Remnic observe failed: ${errorMessage(err)}`, "warning");
   }
 }
@@ -674,6 +692,13 @@ function trimContext(value: string, budget: number): string {
   if (value.length <= budget) return value;
   if (budget <= TRUNCATION_NOTICE.length) return TRUNCATION_NOTICE.slice(0, budget);
   return `${value.slice(0, budget - TRUNCATION_NOTICE.length)}${TRUNCATION_NOTICE}`;
+}
+
+
+function isDaemonUnreachableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (/Remnic request timed out/.test(err.message)) return true;
+  return isTransientNetworkError(err);
 }
 
 function errorMessage(err: unknown): string {

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -199,6 +199,9 @@ function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfi
     description: "Check Remnic daemon status",
     handler: commandHandler(async (_args, _ctx, session) => {
       const health = await client.health();
+      // The daemon responded (any HTTP result), so clear any stale cooldown a
+      // prior timeout left on the shared client (cursor review).
+      client.markReachable();
       session.notify(`Remnic ${health.ok ? "healthy" : "unhealthy"} at ${config.remnicDaemonUrl}`, health.ok ? "success" : "warning");
     }),
   });
@@ -218,6 +221,9 @@ function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfi
       const result = await client.recall(query, session.sessionKey, session.cwd, {
         timeoutMs: config.requestTimeoutMs,
       });
+      // The daemon responded, so clear any stale cooldown a prior timeout left
+      // on the shared client (cursor review).
+      client.markReachable();
       session.notify(trimContext(result.context ?? "(no Remnic context)", MAX_CONTEXT_CHARS), "info");
     }),
   });

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -592,7 +592,12 @@ async function setStatus(session: PiContextSnapshot, client: RemnicClient, confi
     // (codex review).
     client.markReachable();
     session.setStatus("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
-  } catch {
+  } catch (err) {
+    // Startup just proved the daemon is unreachable, so trip the fast-skip
+    // breaker too — otherwise the first live context/observe hook still spends
+    // the full turn budget on a doomed request before the breaker would trip
+    // on its own (codex review).
+    if (isDaemonUnreachableError(err)) client.markUnreachable(config.daemonCooldownMs);
     session.setStatus("remnic", "Remnic offline");
   }
 }

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -709,6 +709,12 @@ function trimContext(value: string, budget: number): string {
 function isDaemonUnreachableError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (/Remnic request timed out/.test(err.message)) return true;
+  // Retry-budget exhaustion means transient failures ate the whole per-turn
+  // deadline inside requestWithRetry — the daemon is effectively unreachable
+  // for this turn, so trip the breaker and cool down instead of burning another
+  // full budget on the next hook (codex review). This error only arises from
+  // transient connection failures, never from a semantic HTTP response.
+  if (/Remnic request exceeded the .* budget before retry/.test(err.message)) return true;
   return isTransientNetworkError(err);
 }
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -714,7 +714,7 @@ function isDaemonUnreachableError(err: unknown): boolean {
   // for this turn, so trip the breaker and cool down instead of burning another
   // full budget on the next hook (codex review). This error only arises from
   // transient connection failures, never from a semantic HTTP response.
-  if (/Remnic request exceeded the .* budget before retry/.test(err.message)) return true;
+  if (/Remnic request exceeded the \d+ms budget before retry/.test(err.message)) return true;
   return isTransientNetworkError(err);
 }
 

--- a/packages/plugin-pi/tsconfig.json
+++ b/packages/plugin-pi/tsconfig.json
@@ -9,7 +9,16 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ]
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
## What

`@remnic/plugin-pi` observe dropped turns on three failure classes; all three share the same fire-and-forget observe/recall path that warned once and discarded the payload. This PR fixes the shared client path so no failure class silently loses memory. **Isolated to plugin-pi** — no core changes.

- Closes #1600 — daemon 413 request_body_too_large on large turns
- Closes #1602 — turns dropped on transient socket close, no retry
- Closes #1626 — observe/recall block the full 60s requestTimeoutMs past the host's 30s handler budget

## How

**#1600 — 413 on large turns:**
- `observe()` now chunks the message batch so each POST body stays under a configurable `observeMaxBytes` cap (default 100 KiB, under the daemon's 128 KiB `maxBodyBytes` default). Single oversized messages are truncated with a marker (byte-accurate, JSON-escape-aware binary search) instead of dropped.
- A 413 response surfaces the attempted body size in the error message so operators can tune the cap.

**#1602 — transient socket close, no retry:**
- New `requestWithRetry()` wraps the HTTP call with a bounded retry loop for connection-level failures (Bun `socket connection was closed`, `ECONNRESET`, `EPIPE`, undici `fetch failed`). Timeouts (our own AbortController) and HTTP responses are **not** retried.
- `observe` and `recall` use the retry budget (`observeMaxRetries`, default 2); observe is dedupe-safe so retrying a transiently-failed POST is harmless.

**#1626 — observe/recall block the full 60s:**
- `observe`/`recall` now pass an explicit `turnRequestTimeoutMs` (default 20s, capped at 25s) which is structurally satisfiable under the host's 30s handler budget — the previous 60s default could never fire inside the 30s window, so the host always force-killed the handler first.
- A daemon-reachability **circuit breaker** (`isReachable`/`markReachable`/`markUnreachable`) skips observe/recall fast while the daemon is known-down, with exponential cooldown so a hard-down host backs off instead of blocking every turn. The breaker only trips on timeout / connection-level errors (not HTTP errors), so a one-off failure still retries next turn.

## Config

New optional fields (all have safe defaults):
- `turnRequestTimeoutMs` — default 20000, max 25000 (< 30s host budget)
- `observeMaxBytes` — default 102400 (100 KiB)
- `observeMaxRetries` — default 2, max 5
- `daemonCooldownMs` — default 5000, max 60000

`tsconfig.json` lib bumped to ES2024 for `Promise.withResolvers`.

## Tests

11 new tests covering each failure class:
- **#1600:** chunking splits an oversize batch into multiple POSTs under the cap; single oversized message is truncated (not dropped); 413 error message includes the body size.
- **#1602:** `isTransientNetworkError` classification; observe retries on transient socket close and succeeds; observe does NOT retry HTTP 500; observe gives up after exhausting the retry budget.
- **#1626:** recall honors a turn-scoped timeout override below the general budget; circuit-breaker state machine (reachable → cooldown → recovered); end-to-end recall skips subsequent turns after a timeout against an unreachable daemon.

104/104 plugin-pi tests green; `preflight:quick` green; ratchets OK.

## Chokepoints

Not applicable — plugin-pi-only; no core chokepoints touched. No watchlisted god files changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live turn-path observe/recall timing, retry, and payload shaping; mis-tuned caps could truncate memory content, but scope is plugin-pi only with broad test coverage and safe defaults.
> 
> **Overview**
> Hardens **@remnic/plugin-pi** daemon traffic so large turns, flaky connections, and long timeouts no longer drop observe/recall work on live Pi hooks.
> 
> **Large observe bodies (#1600):** `observe()` splits batches with `chunkObservePayload` under `observeMaxBytes` (default 100 KiB). Oversized messages are truncated (drops bulky `rawContent`/`parts`, JSON-size-aware) instead of omitted; 413 responses report attempted body size.
> 
> **Transient failures (#1602):** `requestWithRetry` retries only connection-level errors via `isTransientNetworkError`, not HTTP or abort timeouts. Retries share one deadline (including backoff), so turn hooks cannot stack multiple full 60s attempts.
> 
> **Per-turn limits & fast-fail (#1626):** New config (`turnRequestTimeoutMs`, `observeMaxRetries`, `daemonCooldownMs`) bounds live recall/observe; `turnRequestTimeoutMs` can derive from a lowered `requestTimeoutMs`. Extension uses a reachability circuit breaker—skip recall/observe during cooldown after timeouts/unreachable errors, with exponential backoff; health/status/manual recall and shutdown replay (`forceAttempt`) clear or bypass the breaker where appropriate. Multi-chunk observe shares a single per-turn deadline across sequential POSTs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb234e63aea1172798fd7b63eac99042003a89d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->