### PR TITLE
fix(coding): uncapped session-delta totals + read-only-caller state gate (#1630)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4665,11 +4665,22 @@ export class EngramAccessService {
         // non-default namespaces route to memoryDir/namespaces/<token>, so
         // session-delta markers must read/write from the routed tree, mirroring
         // the decision/architecture siblings (cursor review).
-        // Issue #1630 fix 2: the marker write is a write side-effect, so gate
-        // it on canWriteNamespace — read-only callers get the delta but don't
-        // advance state (the READ ACL let them reach here, e.g. shared ns).
-        const principal = this.resolveRequestPrincipal(req.sessionKey, authenticatedPrincipal);
-        const canAdvanceState = canWriteNamespace(principal, ns, this.orchestrator.config);
+        // Issue #1630 fix 2: gate the marker write on the WRITE-path resolver
+        // — it mirrors memory_store's exact authorization (base ACL for coding
+        // overlays, selectedLayer.writable for scope-profiles), not the raw
+        // canWriteNamespace which misses overlay/profile grants (cursor+codex
+        // review). A throw = read-only caller; delta computed but no advance.
+        let canAdvanceState = false;
+        try {
+          await this.resolveCodingScopedWriteNamespace({
+            namespace: req.namespace,
+            sessionKey: req.sessionKey,
+            authenticatedPrincipal,
+          });
+          canAdvanceState = true;
+        } catch {
+          canAdvanceState = false;
+        }
         return {
           memoryDir: storage.dir,
           namespace: ns,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4665,9 +4665,15 @@ export class EngramAccessService {
         // non-default namespaces route to memoryDir/namespaces/<token>, so
         // session-delta markers must read/write from the routed tree, mirroring
         // the decision/architecture siblings (cursor review).
+        // Issue #1630 fix 2: the marker write is a write side-effect, so gate
+        // it on canWriteNamespace — read-only callers get the delta but don't
+        // advance state (the READ ACL let them reach here, e.g. shared ns).
+        const principal = this.resolveRequestPrincipal(req.sessionKey, authenticatedPrincipal);
+        const canAdvanceState = canWriteNamespace(principal, ns, this.orchestrator.config);
         return {
           memoryDir: storage.dir,
           namespace: ns,
+          canAdvanceState,
         } satisfies DeltaSurfaceStorage;
       },
       gitInvoker: (cwd, args) => {

--- a/packages/remnic-core/src/coding/session-delta-surfaces.test.ts
+++ b/packages/remnic-core/src/coding/session-delta-surfaces.test.ts
@@ -81,9 +81,10 @@ function makeContext(overrides: Partial<DeltaSurfaceContext> = {}): DeltaSurface
 // shimming its filesystem. The handler imports readLastSeenState / writeLastSeenState
 // from ./session-delta.js, which hit the real fs. We point memoryDir at a
 // temp dir per-test.
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { sessionDeltaStatePath } from "./session-delta.js";
 
 async function makeTempStorage(): Promise<{ storage: DeltaSurfaceStorage; cleanup: () => Promise<void> }> {
   const dir = await mkdtemp(path.join(tmpdir(), "delta-surface-"));
@@ -379,6 +380,189 @@ test("handler/get: state file is created after a successful first_run", async ()
     const parsed = JSON.parse(raw);
     assert.equal(parsed.head, "head1");
     assert.ok(parsed.at);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #1630 fix 1 — uncapped totals surface in the changed response
+// ──────────────────────────────────────────────────────────────────────────
+
+test("handler/get: changed response surfaces uncapped totals alongside capped slices (issue #1630 fix 1)", async () => {
+  const { storage, cleanup } = await makeTempStorage();
+  try {
+    // Seed: first run on headA.
+    const invoker1 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headA\n" },
+    ]);
+    await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({ resolveStorage: async () => storage, gitInvoker: invoker1 }),
+    );
+
+    // Now head moved to headB with 25 commits / 60 files — both exceed the
+    // caps (MAX_DELTA_COMMITS=20, MAX_DELTA_FILES=50).
+    const sep = "\x1f";
+    const commitBlocks = Array.from({ length: 25 }, (_, i) => [
+      `sha${i}${sep}fix ${i}`,
+      "",
+      `src/file${i}.ts`,
+      "",
+    ].join("\n"));
+    // Add 35 more distinct files so the total crosses the file cap.
+    const extraFiles = Array.from({ length: 35 }, (_, i) => `extra${i}.ts`);
+    const lastBlock = [
+      `shaExtra${sep}extra`,
+      "",
+      ...extraFiles,
+      "",
+    ].join("\n");
+    const log = [...commitBlocks, lastBlock].join("\n");
+    const invoker2 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headB\n" },
+      { args: ["log", "--reverse", "--pretty=format:%H\x1f%s", "--name-only", "headA..headB"], stdout: log },
+    ]);
+    const result = await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({ resolveStorage: async () => storage, gitInvoker: invoker2 }),
+    );
+    if (!("ok" in result) || !result.ok || result.kind !== "changed") {
+      assert.fail(`expected changed, got ${JSON.stringify(result)}`);
+      return;
+    }
+    // Capped display slices.
+    assert.equal(result.delta.commits.length, 20, "commits slice must be capped to MAX_DELTA_COMMITS");
+    assert.equal(result.delta.touchedFiles.length, 50, "touchedFiles slice must be capped to MAX_DELTA_FILES");
+    // Uncapped totals — the TRUE delta size, NOT the capped length.
+    assert.equal(result.delta.totalCommits, 26, "totalCommits must report the uncapped commit count");
+    assert.ok(
+      result.delta.totalTouchedFiles > 50,
+      `totalTouchedFiles must report the uncapped file count (got ${result.delta.totalTouchedFiles})`,
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Issue #1630 fix 2 — read-only callers do NOT advance the state marker
+// ──────────────────────────────────────────────────────────────────────────
+
+test("handler/get: read-only caller (canAdvanceState=false) does NOT advance the state marker (issue #1630 fix 2)", async () => {
+  const { storage, cleanup } = await makeTempStorage();
+  try {
+    // Seed headA with a WRITE-capable caller (default canAdvanceState=true).
+    const invoker1 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headA\n" },
+    ]);
+    await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({
+        resolveStorage: async () => ({ ...storage, canAdvanceState: true }),
+        gitInvoker: invoker1,
+      }),
+    );
+    // Confirm the marker landed at headA.
+    const statePath = sessionDeltaStatePath(storage.memoryDir, storage.namespace);
+    const seeded = JSON.parse(await readFile(statePath, "utf8"));
+    assert.equal(seeded.head, "headA");
+
+    // A READ-ONLY caller (canAdvanceState=false) on headB. The delta is
+    // computed and returned, but the marker MUST NOT advance.
+    const sep = "\x1f";
+    const log = [
+      `shaRO${sep}read only commit`,
+      "",
+      "src/ro.ts",
+      "",
+    ].join("\n");
+    const invoker2 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headB\n" },
+      { args: ["log", "--reverse", "--pretty=format:%H\x1f%s", "--name-only", "headA..headB"], stdout: log },
+    ]);
+    const result = await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({
+        resolveStorage: async () => ({ ...storage, canAdvanceState: false }),
+        gitInvoker: invoker2,
+      }),
+    );
+    // The delta is still computed and returned — read-only callers see the data.
+    if (!("ok" in result) || !result.ok || result.kind !== "changed") {
+      assert.fail(`expected changed, got ${JSON.stringify(result)}`);
+      return;
+    }
+    assert.equal(result.delta.commits.length, 1);
+    // But the persisted marker stayed at headA — read-only did not advance it.
+    const persisted = JSON.parse(await readFile(statePath, "utf8"));
+    assert.equal(persisted.head, "headA", "read-only caller must NOT advance the state marker");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handler/get: write-capable caller (canAdvanceState=true) DOES advance the state marker (issue #1630 fix 2)", async () => {
+  const { storage, cleanup } = await makeTempStorage();
+  try {
+    // Seed headA.
+    const invoker1 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headA\n" },
+    ]);
+    await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({
+        resolveStorage: async () => ({ ...storage, canAdvanceState: true }),
+        gitInvoker: invoker1,
+      }),
+    );
+
+    // A WRITE-capable caller on headB — the marker MUST advance.
+    const sep = "\x1f";
+    const log = [
+      `shaW${sep}write commit`,
+      "",
+      "src/w.ts",
+      "",
+    ].join("\n");
+    const invoker2 = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headB\n" },
+      { args: ["log", "--reverse", "--pretty=format:%H\x1f%s", "--name-only", "headA..headB"], stdout: log },
+    ]);
+    await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({
+        resolveStorage: async () => ({ ...storage, canAdvanceState: true }),
+        gitInvoker: invoker2,
+      }),
+    );
+    const statePath = sessionDeltaStatePath(storage.memoryDir, storage.namespace);
+    const persisted = JSON.parse(await readFile(statePath, "utf8"));
+    assert.equal(persisted.head, "headB", "write-capable caller must advance the state marker");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("handler/get: canAdvanceState defaults to true when omitted (back-compat) (issue #1630 fix 2)", async () => {
+  // Legacy callers that don't set canAdvanceState keep pre-fix behavior:
+  // the marker advances. This protects the existing surface contract.
+  const { storage, cleanup } = await makeTempStorage();
+  try {
+    const invoker = makeInvoker([
+      { args: ["rev-parse", "HEAD"], stdout: "headDefault\n" },
+    ]);
+    await handleCodingDelta(
+      { subcommand: "get", sessionKey: "s1" },
+      makeContext({
+        // canAdvanceState intentionally omitted.
+        resolveStorage: async () => storage,
+        gitInvoker: invoker,
+      }),
+    );
+    const statePath = sessionDeltaStatePath(storage.memoryDir, storage.namespace);
+    const persisted = JSON.parse(await readFile(statePath, "utf8"));
+    assert.equal(persisted.head, "headDefault", "omitted canAdvanceState defaults to true (back-compat)");
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/coding/session-delta-surfaces.ts
+++ b/packages/remnic-core/src/coding/session-delta-surfaces.ts
@@ -117,6 +117,16 @@ export type DeltaSurfaceResponse =
       delta: {
         commits: ReadonlyArray<{ sha: string; subject: string }>;
         touchedFiles: readonly string[];
+        /**
+         * Uncapped total commit count (the {@link commits} slice is capped
+         * for transport). Issue #1630 fix 1.
+         */
+        totalCommits: number;
+        /**
+         * Uncapped total touched-file count (the {@link touchedFiles} slice
+         * is capped for transport). Issue #1630 fix 1.
+         */
+        totalTouchedFiles: number;
         summaryLine: string;
       };
       nextState: LastSeenState;
@@ -161,6 +171,15 @@ export interface DeltaSurfaceStorage {
   readonly memoryDir: string;
   /** The resolved coding-scoped namespace — basis for the state filename. */
   readonly namespace: string;
+  /**
+   * Whether the calling principal may WRITE the namespace — i.e. advance the
+   * last-seen-head marker. Read-only callers (e.g. a principal with read-but-
+   * not-write on the shared namespace) receive the computed delta but the
+   * state file is NOT advanced, so they cannot move another principal's
+   * baseline (issue #1630 fix 2). Defaults to `true` when omitted so existing
+   * callers (and the surface contract tests) keep their pre-fix behavior.
+   */
+  readonly canAdvanceState?: boolean;
 }
 
 /**
@@ -265,13 +284,21 @@ async function deltaGet(
   // 5. Persist the new state (rule 25 + rule 54). Failures here are logged
   //    but do NOT fail the operation — the delta was computed; the next
   //    session may re-derive it. A write failure surfaces in doctor/xray.
+  //
+  //    Issue #1630 fix 2: the marker write is gated on a write-capable
+  //    principal. A read-only caller (e.g. read-but-not-write on the shared
+  //    namespace) receives the computed delta but does NOT advance the state
+  //    marker, so it cannot move another principal's baseline. The default
+  //    is `true` so legacy callers and the surface contract tests keep their
+  //    pre-fix behavior.
+  const canAdvanceState = storage.canAdvanceState !== false;
   let nextState: LastSeenState | null = null;
   if (result.ok) {
     nextState = result.nextState;
   } else if (result.code === "unreachable_head") {
     nextState = result.nextState;
   }
-  if (nextState) {
+  if (nextState && canAdvanceState) {
     try {
       await writeLastSeenState(statePath, nextState);
     } catch (err) {
@@ -312,6 +339,8 @@ async function deltaGet(
         delta: {
           commits: result.delta.commits,
           touchedFiles: result.delta.touchedFiles,
+          totalCommits: result.delta.totalCommits,
+          totalTouchedFiles: result.delta.totalTouchedFiles,
           summaryLine: result.delta.summaryLine,
         },
         nextState: result.nextState,

--- a/packages/remnic-core/src/coding/session-delta.test.ts
+++ b/packages/remnic-core/src/coding/session-delta.test.ts
@@ -193,6 +193,10 @@ test("computeSessionDelta reports uncapped totals alongside capped slices (issue
   // Uncapped totals — the true delta size, NOT the capped slice length.
   assert.equal(result.delta.totalCommits, commitCount);
   assert.equal(result.delta.totalTouchedFiles, fileCount);
+  // The summary line must report the UNCAPPED totals, not the capped slice
+  // length — otherwise the briefing under-reports the delta size (codex review).
+  assert.match(result.delta.summaryLine, /100 commits, 200 files touched/);
+  assert.ok(!result.delta.summaryLine.match(/^.*20 commits, 50 files/), "summary must NOT use capped counts");
 });
 
 test("computeSessionDelta totals equal slice lengths when under the cap (issue #1630 fix 1)", () => {

--- a/packages/remnic-core/src/coding/session-delta.test.ts
+++ b/packages/remnic-core/src/coding/session-delta.test.ts
@@ -171,6 +171,48 @@ test("computeSessionDelta caps a large delta to MAX constants", () => {
   assert.equal(result.delta.touchedFiles.length, MAX_DELTA_FILES);
 });
 
+test("computeSessionDelta reports uncapped totals alongside capped slices (issue #1630 fix 1)", () => {
+  // A repo exceeding both caps: 100 commits / 200 files. The slices are
+  // capped for transport, but totalCommits/totalTouchedFiles must report
+  // the TRUE delta size so summaries never under-report.
+  const commitCount = 100;
+  const fileCount = 200;
+  const commits: GitCommit[] = Array.from({ length: commitCount }, (_, i) => ({
+    sha: `c${i}`,
+    subject: `s ${i}`,
+  }));
+  const files = Array.from({ length: fileCount }, (_, i) => `f${i}.ts`);
+  const result = computeSessionDelta(PRIOR, slice("head", commits, files));
+  if (!result.ok || result.kind !== "changed") {
+    assert.fail(`expected changed, got ${JSON.stringify(result)}`);
+    return;
+  }
+  // Capped display lists — transport-sized.
+  assert.equal(result.delta.commits.length, MAX_DELTA_COMMITS);
+  assert.equal(result.delta.touchedFiles.length, MAX_DELTA_FILES);
+  // Uncapped totals — the true delta size, NOT the capped slice length.
+  assert.equal(result.delta.totalCommits, commitCount);
+  assert.equal(result.delta.totalTouchedFiles, fileCount);
+});
+
+test("computeSessionDelta totals equal slice lengths when under the cap (issue #1630 fix 1)", () => {
+  // Below the caps, totals === slice lengths (no information lost).
+  const commits: GitCommit[] = [
+    { sha: "u1", subject: "under cap 1" },
+    { sha: "u2", subject: "under cap 2" },
+  ];
+  const files = ["a.ts", "b.ts", "c.ts"];
+  const result = computeSessionDelta(PRIOR, slice("head", commits, files));
+  if (!result.ok || result.kind !== "changed") {
+    assert.fail(`expected changed, got ${JSON.stringify(result)}`);
+    return;
+  }
+  assert.equal(result.delta.totalCommits, 2);
+  assert.equal(result.delta.totalTouchedFiles, 3);
+  assert.equal(result.delta.totalCommits, result.delta.commits.length);
+  assert.equal(result.delta.totalTouchedFiles, result.delta.touchedFiles.length);
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // State persistence — rule 25 (write after compute) + rule 54 (temp+rename)
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/session-delta.ts
+++ b/packages/remnic-core/src/coding/session-delta.ts
@@ -72,6 +72,18 @@ export interface SessionDelta {
   commits: GitCommit[];
   /** Touched files since last seen, capped to {@link MAX_DELTA_FILES}. */
   touchedFiles: string[];
+  /**
+   * Uncapped total commit count. The {@link commits} slice is capped for
+   * transport; this total reports the true delta size so summaries and
+   * metrics never under-report on large repos (issue #1630 fix 1).
+   */
+  totalCommits: number;
+  /**
+   * Uncapped total touched-file count. The {@link touchedFiles} slice is
+   * capped for transport; this total reports the true delta size (issue
+   * #1630 fix 1).
+   */
+  totalTouchedFiles: number;
   /** A single human-readable summary line for briefing injection. */
   summaryLine: string;
 }
@@ -159,6 +171,11 @@ export function computeSessionDelta(
     delta: {
       commits,
       touchedFiles,
+      // Uncapped totals — the slices above are capped for transport, but
+      // the summary/metrics must report the true delta size so callers
+      // never under-report on large repos (issue #1630 fix 1).
+      totalCommits: current.commits.length,
+      totalTouchedFiles: current.touchedFiles.length,
       summaryLine: buildSummaryLine(commits.length, touchedFiles.length, lastSeen.at),
     },
     nextState,

--- a/packages/remnic-core/src/coding/session-delta.ts
+++ b/packages/remnic-core/src/coding/session-delta.ts
@@ -176,7 +176,7 @@ export function computeSessionDelta(
       // never under-report on large repos (issue #1630 fix 1).
       totalCommits: current.commits.length,
       totalTouchedFiles: current.touchedFiles.length,
-      summaryLine: buildSummaryLine(commits.length, touchedFiles.length, lastSeen.at),
+      summaryLine: buildSummaryLine(current.commits.length, current.touchedFiles.length, lastSeen.at),
     },
     nextState,
   };

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -6,7 +6,7 @@
     "watchlistLoc": {
       "packages/remnic-core/src/orchestrator.ts": 19854,
       "packages/remnic-core/src/cli.ts": 9872,
-      "packages/remnic-core/src/access-service.ts": 8555,
+      "packages/remnic-core/src/access-service.ts": 8566,
       "packages/remnic-core/src/storage.ts": 7359,
       "packages/remnic-core/src/config.ts": 4548
     },

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -6,7 +6,7 @@
     "watchlistLoc": {
       "packages/remnic-core/src/orchestrator.ts": 19854,
       "packages/remnic-core/src/cli.ts": 9872,
-      "packages/remnic-core/src/access-service.ts": 8549,
+      "packages/remnic-core/src/access-service.ts": 8555,
       "packages/remnic-core/src/storage.ts": 7359,
       "packages/remnic-core/src/config.ts": 4548
     },


### PR DESCRIPTION
## Summary

Closes #1630 — the two P2 review findings deferred from #1627 (Track A PR4).

### Fix 1 — Report uncapped delta totals in the summary
`packages/remnic-core/src/coding/session-delta.ts`: when a repo exceeds `MAX_DELTA_COMMITS` / `MAX_DELTA_FILES`, the `commits` and `touchedFiles` arrays are capped and the summary reported the capped `length`, under-reporting the true delta size. `computeSessionDelta` now tracks the uncapped totals separately and surfaces `totalCommits` / `totalTouchedFiles` in the `SessionDelta` alongside the capped slices. The surface response (`DeltaSurfaceResponse`) mirrors the two new fields.

### Fix 2 — Prevent read-only callers from advancing delta state
`packages/remnic-core/src/access-service.ts` (`codingDelta` delegate): the read resolver (`resolveCodingScopedReadableNamespace`) was used, but the handler persisted the last-seen HEAD marker as a write side-effect. A caller with read-but-not-write on a namespace (e.g. the built-in shared namespace) could therefore advance the delta state marker. The marker write is now gated behind a write-capable principal via a new `DeltaSurfaceStorage.canAdvanceState` flag (set from `canWriteNamespace` in the access-service delegate). The handler only calls `writeLastSeenState` when `canAdvanceState` is true. The flag defaults to `true` when omitted so legacy callers and existing surface-contract tests keep pre-fix behavior.

## Files changed
- `packages/remnic-core/src/coding/session-delta.ts` — `SessionDelta` gains `totalCommits`/`totalTouchedFiles`; `computeSessionDelta` populates them from the uncapped `current.commits.length` / `current.touchedFiles.length`.
- `packages/remnic-core/src/coding/session-delta-surfaces.ts` — `DeltaSurfaceResponse` changed-delta gains the two totals; `DeltaSurfaceStorage` gains optional `canAdvanceState`; `deltaGet` gates the state write on `canAdvanceState !== false`.
- `packages/remnic-core/src/access-service.ts` — `codingDelta` delegate resolves the principal and sets `canAdvanceState = canWriteNamespace(...)`.
- `packages/remnic-core/src/coding/session-delta.test.ts` — uncapped-totals assertions (over-cap + under-cap parity).
- `packages/remnic-core/src/coding/session-delta-surfaces.test.ts` — read-only caller does NOT advance state; write-capable does; omitted-flag back-compat; uncapped totals surface in changed response.
- `scripts/ratchet-baseline.json` — `access-service.ts` 8549→8555 (+6; the security gate is substantive and issue-required).

## Tests
- `npm run preflight:quick` ✅ (review-pattern check PASSED)
- `npm run test:entity-hardening` ✅ (246/246, touches access-service.ts)
- `node scripts/check-ratchets.mjs` ✅ (baseline updated w/ justification above)
- Pure differ: 31/31 ✅ | Surface contract: 21/21 ✅

## Chokepoints used / not applicable
- `canWriteNamespace` (existing write ACL) — the gate, not a new chokepoint.
- No new config flags, no new MCP tools/routes, no hand-rolled validation.

## Checklist
- [x] All tests pass (entity-hardening 246/246; session-delta 31/31; surfaces 21/21)
- [x] New logic covered by tests (uncapped totals + read-only gate)
- [x] No secrets committed
- [x] PR diff ≤ 400 LOC (281 insertions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who may persist shared coding-delta state and alters API response fields; behavior is gated on the existing write resolver with new contract tests.
> 
> **Overview**
> Addresses **#1630** for coding session deltas: large repos no longer under-report change size, and read-only principals can no longer move the shared last-seen HEAD marker.
> 
> **Uncapped totals:** `computeSessionDelta` now exposes `totalCommits` and `totalTouchedFiles` (true counts) while `commits` / `touchedFiles` stay capped for transport. The summary line and `changed` API payload use the uncapped totals so briefings reflect repos above `MAX_DELTA_COMMITS` / `MAX_DELTA_FILES`.
> 
> **Read-only gate:** `DeltaSurfaceStorage` adds optional `canAdvanceState`. The `codingDelta` delegate sets it by probing `resolveCodingScopedWriteNamespace` (same write path as `memory_store`). `deltaGet` only persists `writeLastSeenState` when `canAdvanceState` is true; omitted flag defaults to true for backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b867787d332832efd64deb4efc929f1a0bd4a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->