### PR TITLE
feat(coding-graph): openCypher read-subset parser + executor (#1552)

### DIFF
--- a/packages/coding-graph/package.json
+++ b/packages/coding-graph/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/graph-store.d.ts",
       "remnic-source": "./src/graph-store.ts",
       "import": "./dist/graph-store.js"
+    },
+    "./cypher": {
+      "types": "./dist/cypher/query-parser.d.ts",
+      "remnic-source": "./src/cypher/query-parser.ts",
+      "import": "./dist/cypher/query-parser.js"
     }
   },
   "files": [

--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -473,6 +473,98 @@ test("ACCEPT: multi-hop path chains (a)-[:CALLS]->(b)-[:CALLS]->(c)", async () =
 });
 
 // ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — anonymous nodes (cursor Bugbot: 'Anonymous nodes break path
+// expansion'). An anonymous node `()` participates in the path but is not
+// bound to a variable; the executor tracks the positional cursor so the
+// path flows through it.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: anonymous FIRST node — ()-[:CALLS]->(b) enumerates all starts", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    // Every node with an outgoing CALLS edge is a valid (anon) start.
+    // b = the CALLS target. Distinct b targets: runServer, handleRequest, query.
+    const { rows } = await run(
+      store,
+      "MATCH ()-[:CALLS]->(b:Function) RETURN b.qualifiedName",
+    );
+    const qnames = rows
+      .map((r) => r["b.qualifiedName"] as string)
+      .sort();
+    assert.deepEqual(qnames, [
+      "app.handleRequest",
+      "app.runServer",
+      "db.query",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: anonymous MIDDLE node — path flows through ()", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    // (a)-[:CALLS]->()-[:CALLS]->(c): the middle node is anonymous but
+    // the 2-hop path still resolves. Same result as the named-middle
+    // chain test above.
+    const { rows } = await run(
+      store,
+      "MATCH (a:Function)-[:CALLS]->()-[:CALLS]->(c:Function) RETURN a.name, c.name",
+    );
+    const pairs = rows
+      .map((r) => `${r["a.name"]}…${r["c.name"]}`)
+      .sort();
+    assert.deepEqual(pairs, [
+      "bootstrap…handleRequest",
+      "runServer…query",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — inline-property pushdown narrows the start set before the cap
+// (cursor Bugbot: 'Start search truncates before filters'). A specific name
+// pushes down to searchGraph's namePattern so a low-degree node is still
+// found even when the graph exceeds the 1000-row cap.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: inline name filter on a low-degree node still resolves", async () => {
+  // util.format has zero inbound edges (dead code) → degree 0, ranked last
+  // by searchGraph's degree-desc ordering. Without the pushdown a graph
+  // with >1000 higher-degree nodes would truncate it out; the pushdown
+  // narrows by name first so it is always found.
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function {name: "format"}) RETURN f.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["f.qualifiedName"], "util.format");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: wrong-type inline literal matches nothing (standard Cypher, not a parse error)", async () => {
+  // {name: 123} is valid syntax; a numeric name never equals a string name,
+  // so the result is empty (no tagged failure). This is standard Cypher
+  // behavior, documented in the module's rejection-table note.
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (f:Function {name: 123}) RETURN f.name",
+    );
+    assert.equal(rows.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
 // ACCEPT — LIMIT.
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -565,6 +565,111 @@ test("ACCEPT: wrong-type inline literal matches nothing (standard Cypher, not a 
 });
 
 // ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — review-round-2 hardening: relationship-target :Label enforcement,
+// WHERE first-variable pushdown, and LIKE-wildcard guard in the pushdown.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: relationship target :Label is enforced (cursor Bugbot: 'Relationship node labels not enforced')", async () => {
+  // Fixture: app.handleRequest (Function) -[:USES_TYPE]-> db.QueryResult (Type).
+  // Before the fix, matchesNodePattern ignored the parsed :Label on
+  // relationship targets, so `...->(b:Function)` WRONGLY returned the Type
+  // node for `b`. Now the parsed label is enforced.
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const typed = await run(
+      store,
+      "MATCH (a:Function)-[:USES_TYPE]->(b:Type) RETURN b.qualifiedName",
+    );
+    assert.deepEqual(typed.rows.map((r) => r["b.qualifiedName"]), [
+      "db.QueryResult",
+    ]);
+    // Requiring the target to be a Function excludes the Type node —
+    // before the fix this returned db.QueryResult.
+    const noFn = await run(
+      store,
+      "MATCH (a:Function)-[:USES_TYPE]->(b:Function) RETURN b.qualifiedName",
+    );
+    assert.equal(noFn.rows.length, 0);
+    // Symmetric on CALLS: no Type node is the target of a CALLS edge.
+    const noTypeOverCalls = await run(
+      store,
+      "MATCH (a:Function)-[:CALLS]->(b:Type) RETURN b.qualifiedName",
+    );
+    assert.equal(noTypeOverCalls.rows.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE f.name = ... on the first var narrows before the cap (single conjunction pushdown)", async () => {
+  // `MATCH (f) WHERE f.name = "x"` pushes the equality down to the index
+  // when WHERE is a single conjunction (no top-level OR), so the named
+  // node is found before the 1000-row cap. Parity with the inline form.
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const whereForm = await run(
+      store,
+      'MATCH (f:Function) WHERE f.name = "handleRequest" RETURN f.qualifiedName',
+    );
+    assert.deepEqual(whereForm.rows.map((r) => r["f.qualifiedName"]), [
+      "app.handleRequest",
+    ]);
+    const inlineForm = await run(
+      store,
+      'MATCH (f:Function {name: "handleRequest"}) RETURN f.qualifiedName',
+    );
+    assert.deepEqual(inlineForm.rows.map((r) => r["f.qualifiedName"]), [
+      "app.handleRequest",
+    ]);
+    // OR (multiple groups) is NOT pushed down — but still resolves
+    // correctly via the post-filter, proving the conservative branch.
+    const orForm = await run(
+      store,
+      'MATCH (f:Function) WHERE f.name = "bootstrap" OR f.name = "query" RETURN f.name',
+    );
+    assert.deepEqual(
+      orForm.rows.map((r) => r["f.name"]).sort(),
+      ["bootstrap", "query"],
+    );
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: name containing a LIKE metacharacter resolves exactly (pushdown wildcard guard)", async () => {
+  // A literal `_` in the value must not be pushed to searchGraph's LIKE
+  // matcher (which treats `_` as a single-char wildcard). The value falls
+  // back to the capped label scan + exact post-filter and still resolves
+  // to the single exact match — not the wildcard neighbour.
+  const dir = await mkdtemp(path.join(tmpdir(), "cypher-wild-"));
+  const store = await GraphStore.open({
+    dbPath: path.join(dir, "graph.sqlite"),
+    repoRoot: dir,
+  });
+  try {
+    const file: StoreFileIR = {
+      path: "src/w.ts",
+      language: "typescript",
+      contentHash: "h-wild",
+      symbols: [
+        sym("w.foo_bar", "foo_bar", 0, 10, "function"),
+        sym("w.foozbar", "foozbar", 10, 20, "function"),
+      ],
+      edges: [],
+    };
+    const r = await store.upsertFileBatch([file]);
+    assert.equal(r.ok, true, "fixture ingest must succeed");
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function {name: "foo_bar"}) RETURN f.qualifiedName',
+    );
+    assert.deepEqual(rows.map((row) => row["f.qualifiedName"]), ["w.foo_bar"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
 // ACCEPT — LIMIT.
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -1,0 +1,724 @@
+/**
+ * openCypher read-subset accept/reject suites — issue #1552 PR3 done-when.
+ *
+ * Two suites, both prove-fail-before (a deliberate break of the grammar
+ * or the rejection table on a scratch branch fails the suite):
+ *
+ *   ACCEPT: every documented form parses AND executes against a fixture
+ *           graph, returning the exact expected rows.
+ *   REJECT: every entry in the rejection table produces a clear tagged
+ *           failure with the right code + a message naming the supported
+ *           grammar.
+ *
+ * Fixture IR is synthetic (public-repo policy). The graph is small enough
+ * that the executor's searchGraph-then-traverse compilation target is
+ * deterministic — we assert exact sets, not "at least one hit".
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  GraphStore,
+  type EdgeIR,
+  type StoreFileIR,
+  type SymbolIR,
+} from "../graph-store.js";
+import {
+  CYPHER_LABEL_TO_DB_LABEL,
+  executeCypher,
+  parseCypher,
+  VALID_CYPHER_LABELS,
+  type CypherNodeValue,
+} from "./query-parser.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture helpers — synthetic IR.
+// ──────────────────────────────────────────────────────────────────────────
+
+function sym(
+  qualifiedName: string,
+  name: string,
+  startByte: number,
+  endByte: number,
+  kind: SymbolIR["kind"] = "function",
+): SymbolIR {
+  return { qualifiedName, name, span: { startByte, endByte }, kind };
+}
+
+function edge(
+  srcQualifiedName: string,
+  dstQualifiedName: string,
+  type = "CALLS",
+  confidence = 0.9,
+  provenance: EdgeIR["provenance"] = "heuristic",
+): EdgeIR {
+  return { srcQualifiedName, dstQualifiedName, type, confidence, provenance };
+}
+
+/**
+ * The fixture graph (all in one file so node identity is unambiguous):
+ *
+ *   app.bootstrap (function) ──CALLS──> app.runServer (function)
+ *   app.runServer (function) ──CALLS──> app.handleRequest (function)
+ *   app.handleRequest (function) ──CALLS──> db.query (function)
+ *   app.handleRequest (function) ──USES_TYPE──> db.QueryResult (type)
+ *   app.runServer (function) ──IMPORTS──> lib.configHelper (function)
+ *
+ *   util.format (function) — isolated, zero inbound edges → dead code.
+ */
+const fixtureFile: StoreFileIR = {
+  path: "src/app.ts",
+  language: "typescript",
+  contentHash: "h-fixture",
+  symbols: [
+    sym("app.bootstrap", "bootstrap", 0, 50, "function"),
+    sym("app.runServer", "runServer", 50, 200, "function"),
+    sym("app.handleRequest", "handleRequest", 200, 400, "function"),
+    sym("db.query", "query", 400, 500, "function"),
+    sym("db.QueryResult", "QueryResult", 500, 600, "type"),
+    sym("lib.configHelper", "configHelper", 600, 700, "function"),
+    sym("util.format", "format", 700, 800, "function"),
+  ],
+  edges: [
+    edge("app.bootstrap", "app.runServer"),
+    edge("app.runServer", "app.handleRequest"),
+    edge("app.handleRequest", "db.query"),
+    edge("app.handleRequest", "db.QueryResult", "USES_TYPE"),
+    edge("app.runServer", "lib.configHelper", "IMPORTS"),
+  ],
+};
+
+async function tempStoreWithFixture(): Promise<{
+  store: GraphStore;
+  dir: string;
+}> {
+  const dir = await mkdtemp(path.join(tmpdir(), "cypher-pr3-"));
+  const store = await GraphStore.open({
+    dbPath: path.join(dir, "graph.sqlite"),
+    repoRoot: dir,
+  });
+  const r = await store.upsertFileBatch([fixtureFile]);
+  assert.equal(r.ok, true, "fixture ingest must succeed");
+  return { store, dir };
+}
+
+async function dispose(store: GraphStore, dir: string): Promise<void> {
+  await store.close();
+  await rm(dir, { recursive: true, force: true });
+}
+
+/** Convenience: execute + assert ok, returning the rows. */
+async function run(
+  store: GraphStore,
+  query: string,
+): Promise<{ columns: string[]; rows: Record<string, unknown>[] }> {
+  const r = executeCypher(store, query);
+  if (!r.ok) {
+    assert.fail(`Query unexpectedly failed: ${r.code}: ${r.message}\n  query: ${query}`);
+  }
+  return { columns: r.columns, rows: r.rows };
+}
+
+/** Convenience: assert a query fails with the given code. */
+function reject(
+  store: GraphStore,
+  query: string,
+  expectedCode: string,
+): void {
+  const r = executeCypher(store, query);
+  assert.equal(r.ok, false, `Query unexpectedly succeeded: ${query}`);
+  if (r.ok) return;
+  assert.equal(
+    r.code,
+    expectedCode,
+    `Wrong failure code for ${JSON.stringify(query)}: expected ${expectedCode}, got ${r.code} (${r.message})`,
+  );
+}
+
+/** Parse-only reject (no store needed). */
+function rejectParse(query: string, expectedCode: string): void {
+  const r = parseCypher(query);
+  assert.equal(r.ok, false, `Query unexpectedly parsed: ${query}`);
+  if (r.ok) return;
+  assert.equal(
+    r.code,
+    expectedCode,
+    `Wrong parse code for ${JSON.stringify(query)}: expected ${expectedCode}, got ${r.code} (${r.message})`,
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — single-node MATCH (compiles to searchGraph).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: MATCH (f:Function) RETURN f — returns every function node", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { columns, rows } = await run(store, "MATCH (f:Function) RETURN f");
+    assert.deepEqual(columns, ["f"]);
+    // bootstrap, runServer, handleRequest, query, configHelper, format = 6.
+    assert.equal(rows.length, 6);
+    const names = rows
+      .map((r) => (r.f as CypherNodeValue).name)
+      .sort();
+    assert.deepEqual(names, [
+      "bootstrap",
+      "configHelper",
+      "format",
+      "handleRequest",
+      "query",
+      "runServer",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: label maps PascalCase → lowercase kind (Type → type)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(store, "MATCH (t:Type) RETURN t.qualifiedName");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["t.qualifiedName"], "db.QueryResult");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: no label returns every node (cap'd by LIMIT)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(store, "MATCH (n) RETURN n LIMIT 3");
+    assert.equal(rows.length, 3);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: inline property filter {name: \"query\"} narrows by exact name", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function {name: "query"}) RETURN f.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["f.qualifiedName"], "db.query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — WHERE clause.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: WHERE = string", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function) WHERE f.name = "runServer" RETURN f.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["f.qualifiedName"], "app.runServer");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE <> filters out", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function) WHERE f.name <> "runServer" RETURN f.name',
+    );
+    assert.equal(rows.length, 5);
+    assert.ok(!rows.some((r) => r["f.name"] === "runServer"));
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE OR-of-AND precedence", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    // name = bootstrap OR name = query → 2 rows (OR splits the group).
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function) WHERE f.name = "bootstrap" OR f.name = "query" RETURN f.name',
+    );
+    const names = rows.map((r) => r["f.name"]).sort();
+    assert.deepEqual(names, ["bootstrap", "query"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE AND combines within a group", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    // label = function AND name = query → exactly db.query.
+    const { rows } = await run(
+      store,
+      'MATCH (n) WHERE n.label = "function" AND n.name = "query" RETURN n.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["n.qualifiedName"], "db.query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE on label property (kind alias)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (n) WHERE n.kind = "type" RETURN n.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["n.qualifiedName"], "db.QueryResult");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: WHERE on snake_case alias file_path", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function) WHERE f.file_path = "src/app.ts" RETURN f.name LIMIT 2',
+    );
+    assert.equal(rows.length, 2);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — single-edge relationships (compile to traverse depth==1).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: (a)-[:CALLS]->(b) — direct outgoing CALLS edges", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { columns, rows } = await run(
+      store,
+      "MATCH (a:Function)-[:CALLS]->(b:Function) RETURN a.name, b.name",
+    );
+    assert.deepEqual(columns, ["a.name", "b.name"]);
+    // bootstrap→runServer, runServer→handleRequest, handleRequest→query.
+    const pairs = rows
+      .map((r) => `${r["a.name"]}→${r["b.name"]}`)
+      .sort();
+    assert.deepEqual(pairs, [
+      "bootstrap→runServer",
+      "handleRequest→query",
+      "runServer→handleRequest",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: incoming direction <-[:CALLS]- finds what the source calls", async () => {
+  // `(target)<-[:CALLS]-(src)` means src CALLS target. With src=handleRequest,
+  // target = whatever handleRequest calls = db.query.
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (target:Function)<-[:CALLS]-(src:Function {name: "handleRequest"}) RETURN target.name',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["target.name"], "query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: undirected -[:CALLS]- matches both directions", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function)-[:CALLS]-(b:Function {name: "query"}) RETURN a.name',
+    );
+    // query has one inbound CALLS (from handleRequest); no outbound.
+    const names = rows.map((r) => r["a.name"]).sort();
+    assert.deepEqual(names, ["handleRequest"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: edge-type alternation -[:CALLS|USES_TYPE]->", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (a:Function)-[:CALLS|USES_TYPE]->(b) RETURN b.qualifiedName",
+    );
+    const qnames = rows
+      .map((r) => r["b.qualifiedName"] as string)
+      .sort();
+    // CALLS targets: runServer, handleRequest, query.
+    // USES_TYPE targets: QueryResult.
+    assert.deepEqual(qnames, [
+      "app.handleRequest",
+      "app.runServer",
+      "db.QueryResult",
+      "db.query",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: edge types not in the documented set still pass through", async () => {
+  // The store has no CHECK on edge type; the Cypher layer documents the
+  // 20+ set but accepts any string and returns no rows for unknown types
+  // (matching traverse's behavior).
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (a)-[:NOT_A_REAL_TYPE]->(b) RETURN a.name",
+    );
+    assert.equal(rows.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — variable-length paths (compile to traverse depth ∈ [min,max]).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: *1..2 reaches two hops out", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    // From bootstrap, CALLS*1..2 reaches: runServer (1), handleRequest (2).
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "bootstrap"})-[:CALLS*1..2]->(b) RETURN b.qualifiedName',
+    );
+    const qnames = rows
+      .map((r) => r["b.qualifiedName"] as string)
+      .sort();
+    assert.deepEqual(qnames, ["app.handleRequest", "app.runServer"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: *2 exactly two hops (excludes depth 1)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "bootstrap"})-[:CALLS*2]->(b) RETURN b.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["b.qualifiedName"], "app.handleRequest");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: *..3 defaults min to 1, includes 1..3 hops", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "bootstrap"})-[:CALLS*..3]->(b) RETURN b.qualifiedName',
+    );
+    const qnames = rows
+      .map((r) => r["b.qualifiedName"] as string)
+      .sort();
+    assert.deepEqual(qnames, [
+      "app.handleRequest",
+      "app.runServer",
+      "db.query",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: multi-hop path chains (a)-[:CALLS]->(b)-[:CALLS]->(c)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (a:Function)-[:CALLS]->(b:Function)-[:CALLS]->(c:Function) RETURN a.name, c.name",
+    );
+    // Two 2-hop chains: bootstrap→runServer→handleRequest, runServer→handleRequest→query.
+    const pairs = rows
+      .map((r) => `${r["a.name"]}…${r["c.name"]}`)
+      .sort();
+    assert.deepEqual(pairs, [
+      "bootstrap…handleRequest",
+      "runServer…query",
+    ]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — LIMIT.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: LIMIT caps the row count", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (f:Function) RETURN f.name LIMIT 2",
+    );
+    assert.equal(rows.length, 2);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: LIMIT 0 returns zero rows (rule 27 guard)", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      "MATCH (f:Function) RETURN f.name LIMIT 0",
+    );
+    assert.equal(rows.length, 0);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — case-insensitive keywords + comments.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("ACCEPT: keywords are case-insensitive", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'match (f:Function) where f.name = "query" return f.qualifiedName',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["f.qualifiedName"], "db.query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: line and block comments are skipped", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    const { rows } = await run(
+      store,
+      'MATCH (f:Function) // find query\n/* block */ WHERE f.name = "query" RETURN f.name',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]!["f.name"], "query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — write / outside clauses.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: CREATE is rejected as unsupported_clause", () => {
+  rejectParse("CREATE (n:Function)", "unsupported_clause");
+});
+
+test("REJECT: MERGE is rejected as unsupported_clause", () => {
+  rejectParse("MERGE (n:Function)", "unsupported_clause");
+});
+
+test("REJECT: SET is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) SET n.x = 1", "unsupported_clause");
+});
+
+test("REJECT: DELETE is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) DELETE n", "unsupported_clause");
+});
+
+test("REJECT: DETACH DELETE is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) DETACH DELETE n", "unsupported_clause");
+});
+
+test("REJECT: REMOVE is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) REMOVE n.x", "unsupported_clause");
+});
+
+test("REJECT: ORDER BY is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) RETURN n ORDER BY n.name", "unsupported_clause");
+});
+
+test("REJECT: WITH is rejected as unsupported_clause", () => {
+  rejectParse("MATCH (n) WITH n RETURN n", "unsupported_clause");
+});
+
+test("REJECT: UNION is rejected as unsupported_clause", () => {
+  rejectParse(
+    "MATCH (n) RETURN n UNION MATCH (m) RETURN m",
+    "unsupported_clause",
+  );
+});
+
+test("REJECT: RETURN * is rejected (outside subset)", () => {
+  rejectParse("MATCH (n) RETURN *", "unsupported_clause");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — unbounded variable-length.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: bare * (unbounded) is rejected", () => {
+  rejectParse("MATCH (a)-[:CALLS*]->(b) RETURN b", "unsupported_clause");
+});
+
+test("REJECT: *.. (unbounded max) is rejected", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  try {
+    reject(store, "MATCH (a)-[:CALLS*1..]->(b) RETURN b", "unsupported_clause");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — unknown labels list valid options.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: unknown label produces unknown_label with validLabels", () => {
+  const r = parseCypher("MATCH (a:NotALabel) RETURN a");
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.equal(r.code, "unknown_label");
+  assert.ok(r.validLabels, "validLabels must be present on unknown_label");
+  // The valid list is exactly the documented universe, sorted.
+  assert.deepEqual(r.validLabels, [...VALID_CYPHER_LABELS]);
+  // Message names the bad label and the supported grammar.
+  assert.match(r.message, /NotALabel/);
+});
+
+test("REJECT: lowercase 'function' is NOT a valid Cypher label (case-sensitive labels)", () => {
+  // Cypher labels are case-sensitive PascalCase identifiers. The DB
+  // stores lowercase kinds; the Cypher layer maps PascalCase→lowercase
+  // internally. A user writing `:function` gets unknown_label with the
+  // valid (PascalCase) options listed.
+  const r = parseCypher("MATCH (a:function) RETURN a");
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.equal(r.code, "unknown_label");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — structural / unbound variable.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: RETURN references unbound variable", () => {
+  rejectParse("MATCH (a:Function) RETURN a, c", "unbound_variable");
+});
+
+test("REJECT: WHERE references unbound variable", () => {
+  rejectParse("MATCH (a:Function) WHERE c.name = \"x\" RETURN a", "unbound_variable");
+});
+
+test("REJECT: missing RETURN", () => {
+  rejectParse("MATCH (a:Function)", "parse_error");
+});
+
+test("REJECT: missing closing paren", () => {
+  rejectParse("MATCH (a:Function RETURN a", "parse_error");
+});
+
+test("REJECT: empty query", () => {
+  rejectParse("", "parse_error");
+  rejectParse("   ", "parse_error");
+});
+
+test("REJECT: non-string query", () => {
+  const r = parseCypher(undefined as unknown as string);
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.equal(r.code, "invalid_query");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — bare-arrows / malformed relationships.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: bare arrow without bracket", () => {
+  rejectParse("MATCH (a)-->(b) RETURN a", "parse_error");
+});
+
+test("REJECT: conflicting direction <-[...]->", () => {
+  const r = parseCypher("MATCH (a)<-[:CALLS]->(b) RETURN a");
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  // Either parse_error or unsupported — we accept either; the contract
+  // is "rejected with a clear message", not a specific code here.
+  assert.ok(["parse_error", "unsupported_clause", "invalid_query"].includes(r.code));
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// REJECT — closed store.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("REJECT: closed store returns store_closed", async () => {
+  const { store, dir } = await tempStoreWithFixture();
+  await dispose(store, dir);
+  // store is now closed; executeCypher must surface store_closed from
+  // the underlying searchGraph call.
+  const r = executeCypher(store, "MATCH (f:Function) RETURN f");
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.equal(r.code, "store_closed");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Module-level invariants.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("INVARIANT: every documented label maps to a db label", () => {
+  for (const label of VALID_CYPHER_LABELS) {
+    assert.ok(
+      label in CYPHER_LABEL_TO_DB_LABEL,
+      `${label} missing from CYPHER_LABEL_TO_DB_LABEL`,
+    );
+  }
+});
+
+test("INVARIANT: the 13 documented labels are all present", () => {
+  // Project, Package, Folder, File, Module, Class, Function, Method,
+  // Interface, Enum, Type, Route, Resource (issue #1552 body).
+  const expected = [
+    "Class",
+    "Enum",
+    "File",
+    "Folder",
+    "Function",
+    "Interface",
+    "Method",
+    "Module",
+    "Package",
+    "Project",
+    "Resource",
+    "Route",
+    "Type",
+  ];
+  assert.deepEqual([...VALID_CYPHER_LABELS].sort(), expected);
+});

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -67,7 +67,10 @@
  *   - `MATCH (a:NotALabel) ...`        → unknown label (lists valid options)
  *   - `MATCH (a) RETURN *`             → `RETURN *` not in subset
  *   - `MATCH (a)-[:CALLS]->(b) RETURN a, c`  → unbound variable `c`
- *   - `MATCH (a:Function {name: 123}) ...`   → wrong-type literal in prop map
+ *   - `MATCH (a:Function {name: 123}) ...`   → wrong-type literal matches
+ *                                              nothing (standard Cypher;
+ *                                              NOT a parse error — a numeric
+ *                                              `name` never equals a string)
  *   - `MATCH (a:Function WHERE ...`     → missing `)` / missing RETURN
  *   - `MATCH (a:Function)` (no RETURN)  → missing RETURN
  *
@@ -1298,33 +1301,76 @@ function compareValues(a: CypherScalar, op: Comparison["op"], b: CypherScalar): 
 }
 
 /**
- * A binding is a row of variables → nodes resolved so far. The executor
- * grows bindings left-to-right across the MATCH pattern.
+ * A binding tracks both the named variables (for WHERE / RETURN) AND the
+ * most-recently-resolved node by position (`lastNode`). The positional
+ * cursor is what makes anonymous nodes work: `MATCH ()-[:CALLS]->(b)`
+ * starts from every node (anonymous first node) and traverses forward,
+ * and `MATCH (a)-[:CALLS]->()-[:CALLS]->(c)` flows through the anonymous
+ * middle node without dropping the path (cursor Bugbot: 'Anonymous nodes
+ * break path expansion').
  */
-type Binding = Map<string, CypherNodeValue>;
+interface Binding {
+  varByName: Map<string, CypherNodeValue>;
+  lastNode: CypherNodeValue;
+}
+
+/**
+ * Push the inline `name` / `filePath` property filters from a node pattern
+ * down to the structured `searchGraph` filters so the candidate set is
+ * narrowed by the index BEFORE the 1000-row cap applies. A specific name
+ * like `"runServer"` narrows from the whole graph to a handful of rows,
+ * so a low-degree node with an exact name match is no longer truncated
+ * out (cursor Bugbot: 'Start search truncates before filters').
+ *
+ * The post-filter ({@link matchesNodePattern}) still enforces EXACT
+ * case-sensitive equality afterwards; the pushdown uses `searchGraph`'s
+ * `LIKE ... COLLATE NOCASE`, which is a SUPERSET of exact match, so no
+ * valid result is lost (the post-filter removes the extras). A literal
+ * `%`/`_` in the user's value acts as a LIKE wildcard for the narrow
+ * pass, which only makes the candidate set slightly broader — never
+ * narrower — so correctness is preserved.
+ */
+function pushInlineFiltersToSearch(
+  query: { label?: string; namePattern?: string; filePattern?: string },
+  properties: ReadonlyArray<{ key: string; value: CypherScalar }>,
+): void {
+  for (const { key, value } of properties) {
+    const k = key.toLowerCase();
+    if (k === "name" && typeof value === "string") {
+      query.namePattern = value;
+    } else if (
+      (k === "filepath" || k === "file_path") &&
+      typeof value === "string"
+    ) {
+      query.filePattern = value;
+    }
+  }
+}
 
 /**
  * Execute a parsed AST against a store. Exposed so callers that already
  * hold an AST (e.g. a cached plan) can skip re-parsing.
  */
 export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
-  // 1. Resolve the FIRST node pattern via searchGraph. Property filters in
-  //    the node pattern AND WHERE conditions are applied as JS post-
-  //    filters after the structured search returns candidates. A closed
-  //    store surfaces as `{ ok: false, code: "store_closed" }` from
-  //    searchGraph itself (we don't reach into the private `closed` flag).
+  // 1. Resolve the FIRST node pattern via searchGraph. The label + any
+  //    inline `name`/`filePath` property filters are pushed down so the
+  //    candidate set is narrowed by the index before the 1000-row cap;
+  //    remaining inline properties + WHERE conditions are applied as JS
+  //    post-filters. A closed store surfaces as
+  //    `{ ok: false, code: "store_closed" }` from searchGraph itself
+  //    (we don't reach into the private `closed` flag).
   const firstNode = ast.match.nodes[0]!;
-  const searchLabel =
-    firstNode.label !== undefined
-      ? CYPHER_LABEL_TO_DB_LABEL[firstNode.label]!
-      : undefined;
-  // Use the maximum limit the store allows so we don't silently truncate
-  // the start set; the query's LIMIT applies later. For graphs above the
-  // cap, narrow the start with a label + property filter.
-  const search = store.searchGraph({
-    ...(searchLabel !== undefined ? { label: searchLabel } : {}),
-    limit: 1000,
-  });
+  const searchQuery: {
+    label?: string;
+    namePattern?: string;
+    filePattern?: string;
+    limit: number;
+  } = { limit: 1000 };
+  if (firstNode.label !== undefined) {
+    searchQuery.label = CYPHER_LABEL_TO_DB_LABEL[firstNode.label]!;
+  }
+  pushInlineFiltersToSearch(searchQuery, firstNode.properties);
+  const search = store.searchGraph(searchQuery);
   if (!search.ok) {
     return storeFailureToCypher(search);
   }
@@ -1333,32 +1379,22 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     .map((hit) => nodeToValue(hit))
     .filter((node) => matchesNodePattern(node, firstNode))
     .map((node) => {
-      const m = new Map<string, CypherNodeValue>();
-      if (firstNode.varName) m.set(firstNode.varName, node);
-      return m;
+      const varByName = new Map<string, CypherNodeValue>();
+      if (firstNode.varName) varByName.set(firstNode.varName, node);
+      return { varByName, lastNode: node };
     });
 
   // 2. Walk the remaining (rel, node) pairs, expanding each binding via
-  //    traverse.
+  //    traverse. The traverse start is the binding's POSITIONAL lastNode,
+  //    not a named variable — so anonymous nodes anywhere in the path
+  //    still pass the cursor forward.
   for (let idx = 0; idx < ast.match.rels.length; idx += 1) {
     const rel = ast.match.rels[idx]!;
     const nodePattern = ast.match.nodes[idx + 1]!;
-    const leftVar = ast.match.nodes[idx]!.varName;
-    if (!leftVar) {
-      // The left node of this hop was anonymous — we cannot traverse
-      // from an unnamed binding. This is a structural error caught at
-      // parse-validate only for RETURN/WHERE; for traversal we catch
-      // here and return empty (the user wrote `(a)-->( ) RETURN a`,
-      // which is valid but yields no new bindings).
-      bindings = [];
-      break;
-    }
     const nextBindings: Binding[] = [];
     for (const binding of bindings) {
-      const startNode = binding.get(leftVar);
-      if (!startNode) continue;
       const t = store.traverse({
-        start: startNode.nodeId,
+        start: binding.lastNode.nodeId,
         direction: rel.direction,
         ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
         maxDepth: rel.maxHops,
@@ -1386,25 +1422,25 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
         seen.add(hit.nodeId);
         const node = nodeToValue(hit);
         if (!matchesNodePattern(node, nodePattern)) continue;
-        const extended = new Map(binding);
+        const varByName = new Map(binding.varByName);
         if (nodePattern.varName) {
           // If the var was already bound (re-binding in a path), require
           // it to be the SAME node (Cypher equality semantics). Skip
           // otherwise.
-          const existing = extended.get(nodePattern.varName);
+          const existing = varByName.get(nodePattern.varName);
           if (existing && existing.nodeId !== node.nodeId) continue;
-          extended.set(nodePattern.varName, node);
+          varByName.set(nodePattern.varName, node);
         }
-        nextBindings.push(extended);
+        nextBindings.push({ varByName, lastNode: node });
       }
     }
     bindings = nextBindings;
     if (bindings.length === 0) break;
   }
 
-  // 3. Apply WHERE.
+  // 3. Apply WHERE (resolves variables by name — anonymous nodes have none).
   if (ast.where) {
-    bindings = bindings.filter((b) => matchesWhere(b, ast.where!));
+    bindings = bindings.filter((b) => matchesWhere(b.varByName, ast.where!));
   }
 
   // 4. Apply LIMIT.
@@ -1412,7 +1448,7 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     bindings = bindings.slice(0, ast.limit);
   }
 
-  // 5. Project RETURN.
+  // 5. Project RETURN (resolves variables by name).
   const columns = ast.return.map((item) =>
     item.kind === "var" ? item.varName : `${item.varName}.${item.key}`,
   );
@@ -1420,7 +1456,7 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     const row: CypherRow = {};
     ast.return.forEach((item) => {
       const col = item.kind === "var" ? item.varName : `${item.varName}.${item.key}`;
-      const node = b.get(item.varName);
+      const node = b.varByName.get(item.varName);
       if (!node) {
         row[col] = null;
         return;
@@ -1442,11 +1478,14 @@ function matchesNodePattern(node: CypherNodeValue, pattern: NodePattern): boolea
   return true;
 }
 
-function matchesWhere(binding: Binding, where: WhereClause): boolean {
+function matchesWhere(
+  varByName: Map<string, CypherNodeValue>,
+  where: WhereClause,
+): boolean {
   // OR-of-AND.
   return where.orGroups.some((group) =>
     group.every((term) => {
-      const node = binding.get(term.varName);
+      const node = varByName.get(term.varName);
       if (!node) return false;
       const actual = readProperty(node, term.key);
       return compareValues(actual, term.op, term.value);

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -1,0 +1,1506 @@
+/**
+ * openCypher read subset — hand-written recursive-descent parser + executor.
+ *
+ * Issue #1552 PR3. This module is the thin, deletable Cypher layer over the
+ * structured store API (`searchGraph` / `traverse`). It compiles a strict
+ * read-only subset of openCypher to those primitives — there is NO SQL
+ * string assembly from user input anywhere; the structured API already
+ * parameterizes every bind (rule 51).
+ *
+ * ## Supported grammar (strict subset)
+ *
+ * ```
+ * query        := MATCH pattern [WHERE where_clause] RETURN return_list [LIMIT int]
+ * pattern      := node_pattern (rel_pattern node_pattern)*
+ * node_pattern := '(' [var] [':' label] ['{' prop_map '}'] ')'
+ * prop_map     := key ':' literal (',' key ':' literal)*
+ * rel_pattern  := ('<-'? '--' bracket '--' '->'?)
+ *                | ('<-'  bracket '--')          // incoming:  <-[...]-   (also <-[...]--)
+ *                | ('--'  bracket '->')          // outgoing:  -[...]->  (also --[...]->)
+ *                | ('<-'? '--' bracket '--' '->'?)   // canonical form
+ * bracket      := '[' [':' type ('|' ':' type)*] ['*' range] ']'
+ * range        := int ('..' int)? | '..' int
+ * where_clause := comparison ((AND | OR) comparison)*
+ * comparison   := var '.' key op literal
+ * op           := '=' | '<>' | '!=' | '>' | '<' | '>=' | '<='
+ * return_list  := return_item (',' return_item)*
+ * return_item  := var | var '.' key
+ * literal      := string | number | 'true' | 'false' | 'null'
+ * ```
+ *
+ * Direction (resolved from the dashes/arrows around the bracket):
+ *   - `-[...]->`  → outgoing (follow src→dst edges)
+ *   - `<-[...]-`  → incoming (follow dst→src edges)
+ *   - `-[...]-`   → both
+ *
+ * Variable-length hops:
+ *   - `-[:CALLS*1..3]->` → between 1 and 3 CALLS hops (inclusive)
+ *   - `-[:CALLS*2]->`    → exactly 2 hops
+ *   - `-[:CALLS..3]->`   → 1..3 hops (default min = 1)
+ *   - `-[:CALLS*]->`     → REJECTED (unbounded — see rejection table)
+ *
+ * ## Compile target
+ *
+ * Single-node patterns compile to `searchGraph({ label })`. Relationship
+ * patterns compile to `traverse({ start, direction, edgeTypes, maxDepth })`,
+ * filtering the returned hits to the relationship's depth range. Property
+ * filters in node patterns (`{name: "foo"}`) and WHERE conditions are
+ * applied in JS as post-filters on the bound nodes.
+ *
+ * ## Read-only by construction
+ *
+ * The parser only recognizes the tokens `MATCH`, `WHERE`, `RETURN`,
+ * `LIMIT`, `AND`, `OR`, `true`, `false`, `null`. Every write/mutation
+ * clause token (`CREATE`, `MERGE`, `SET`, `DELETE`, `DETACH`, `REMOVE`,
+ * `DROP`, `CALL`, `YIELD`, `UNION`, `WITH`, `ORDER`, `BY`, `SKIP`,
+ * `OPTIONAL`, `EXPLAIN`, `PROFILE`, `USE`, `FOREACH`, `LOAD`,
+ * `CONSTRAINT`, `INDEX`) is rejected with a clear error naming the
+ * supported grammar (rule 51). The module has no code path that writes
+ * to the store.
+ *
+ * ## Rejection table (each has a dedicated test)
+ *
+ *   - `CREATE (n:Function)`            → unsupported clause (read-only)
+ *   - `MATCH (n) DELETE n`             → unsupported clause
+ *   - `MATCH (n) SET n.x = 1`          → unsupported clause
+ *   - `MATCH (a)-[:CALLS*]->(b) ...`   → unbounded `*` (must specify range)
+ *   - `MATCH (a:NotALabel) ...`        → unknown label (lists valid options)
+ *   - `MATCH (a) RETURN *`             → `RETURN *` not in subset
+ *   - `MATCH (a)-[:CALLS]->(b) RETURN a, c`  → unbound variable `c`
+ *   - `MATCH (a:Function {name: 123}) ...`   → wrong-type literal in prop map
+ *   - `MATCH (a:Function WHERE ...`     → missing `)` / missing RETURN
+ *   - `MATCH (a:Function)` (no RETURN)  → missing RETURN
+ *
+ * ## Scale caveat
+ *
+ * The subset is aimed at interactive exploration over indexed graphs. The
+ * start-node resolution uses `searchGraph` (capped at 1000 rows by the
+ * store) and relationship expansion uses `traverse` (BFS, full reachable
+ * subgraph up to maxDepth). For graphs larger than the start cap, narrow
+ * the start node with a label + property filter.
+ */
+import type {
+  GraphStore,
+  SearchHit,
+  TraverseHit,
+} from "../graph-store.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Label universe — the documented schema's node labels.
+//
+// The store persists `nodes.label` as the symbol `kind` (lowercase:
+// `function`, `class`, `method`, `interface`, `enum`, `type`, `module`).
+// The remaining labels (`Project`, `Package`, `Folder`, `File`, `Route`,
+// `Resource`) are part of the documented schema universe but are not
+// emitted by the current ingest pipeline; queries against them simply
+// return zero rows. We ACCEPT the full documented universe so the grammar
+// matches the issue's stated 12+ label list, and REJECT everything outside
+// it with a clear error (rejection table).
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * PascalCase Cypher label → the lowercase value stored in `nodes.label`.
+ * Labels whose DB form is not produced by ingest still map to a sensible
+ * storage key so the query is structurally valid (returns empty).
+ */
+const CYPHER_LABEL_TO_DB_LABEL: Record<string, string> = {
+  Project: "project",
+  Package: "package",
+  Folder: "folder",
+  File: "file",
+  Module: "module",
+  Class: "class",
+  Function: "function",
+  Method: "method",
+  Interface: "interface",
+  Enum: "enum",
+  Type: "type",
+  Route: "route",
+  Resource: "resource",
+};
+
+/** Sorted list of accepted Cypher labels — used in rejection messages. */
+const VALID_CYPHER_LABELS: readonly string[] = Object.keys(
+  CYPHER_LABEL_TO_DB_LABEL,
+).sort();
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public result types.
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * A value projected by RETURN. Strings, numbers, booleans, or null. Whole
+ * nodes are returned as {@link CypherNodeValue} so callers can read every
+ * field without re-querying.
+ */
+export type CypherScalar = string | number | boolean | null;
+
+/** A whole-node value (RETURN `var` with no property). */
+export interface CypherNodeValue {
+  nodeId: string;
+  qualifiedName: string;
+  name: string;
+  label: string;
+  filePath: string;
+}
+
+export type CypherValue = CypherScalar | CypherNodeValue;
+
+/** One result row — a map from RETURN-item column name to its value. */
+export type CypherRow = Record<string, CypherValue>;
+
+/** Failure codes. Distinct from the store codes — Cypher has its own. */
+export type CypherFailureCode =
+  | "parse_error" // generic grammar failure
+  | "unsupported_clause" // CREATE / SET / DELETE / unbounded `*` / RETURN *
+  | "unknown_label" // label not in the documented universe
+  | "unbound_variable" // RETURN / WHERE references a var not in MATCH
+  | "invalid_query" // structurally parsed but semantically bad (bad range, etc.)
+  | "store_closed"
+  | "db_locked"
+  | "db_corrupt"
+  | "db_error";
+
+export interface CypherFailure {
+  ok: false;
+  code: CypherFailureCode;
+  /** Human-readable explanation including the supported grammar hint. */
+  message: string;
+  /**
+   * Present only for `unknown_label`: the accepted label list, so callers
+   * can render a completion menu without re-deriving it.
+   */
+  validLabels?: readonly string[];
+}
+
+export interface CypherSuccess {
+  ok: true;
+  /** Column names in RETURN order; each row has these keys. */
+  columns: string[];
+  rows: CypherRow[];
+}
+
+export type CypherResult = CypherSuccess | CypherFailure;
+
+// ──────────────────────────────────────────────────────────────────────────
+// AST types.
+// ──────────────────────────────────────────────────────────────────────────
+
+interface NodePattern {
+  /** Variable name; undefined for an anonymous node `( )`. */
+  varName?: string;
+  /** PascalCase label as written (`Function`, `Class`, ...). */
+  label?: string;
+  /** Inline property filters from `{key: value, ...}`. */
+  properties: Array<{ key: string; value: CypherScalar }>;
+}
+
+type RelDirection = "outgoing" | "incoming" | "both";
+
+interface RelPattern {
+  direction: RelDirection;
+  /** Edge types; empty means "any type". */
+  types: string[];
+  /** Inclusive minimum hop count (default 1). */
+  minHops: number;
+  /** Inclusive maximum hop count. Equal to minHops when `*N` form used. */
+  maxHops: number;
+}
+
+interface Comparison {
+  varName: string;
+  key: string;
+  op: "=" | "<>" | "!=" | ">" | "<" | ">=" | "<=";
+  value: CypherScalar;
+}
+
+type WhereTerm = Comparison;
+interface WhereClause {
+  /** Flat OR-of-AND-of-terms. We support AND+OR; no precedence gymnastics. */
+  orGroups: WhereTerm[][];
+}
+
+type ReturnItem =
+  | { kind: "var"; varName: string }
+  | { kind: "prop"; varName: string; key: string };
+
+interface MatchClause {
+  nodes: NodePattern[];
+  rels: RelPattern[]; // length === nodes.length - 1
+}
+
+interface CypherAst {
+  match: MatchClause;
+  where?: WhereClause;
+  return: ReturnItem[];
+  limit?: number;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tokenizer.
+// ──────────────────────────────────────────────────────────────────────────
+
+type TokenType =
+  | "WORD" // identifier OR keyword (disambiguated in parser)
+  | "STRING"
+  | "NUMBER"
+  | "LPAREN"
+  | "RPAREN"
+  | "LBRACK"
+  | "RBRACK"
+  | "LBRACE"
+  | "RBRACE"
+  | "COLON"
+  | "PIPE"
+  | "COMMA"
+  | "DOT"
+  | "DOTDOT"
+  | "STAR"
+  | "ARROW_R" // ->
+  | "ARROW_L" // <-
+  | "DASHDASH" // --
+  | "DASH" // - (only meaningful before a number for negation)
+  | "EQ" // =
+  | "NE" // <> or !=
+  | "GT"
+  | "LT"
+  | "GE"
+  | "LE"
+  | "EOF";
+
+interface Token {
+  type: TokenType;
+  /** Raw source text of the token (for identifiers, strings, numbers). */
+  text: string;
+  /** 0-based offset in the source, for error messages. */
+  pos: number;
+}
+
+const KEYWORDS: Record<string, true> = {
+  match: true,
+  where: true,
+  return: true,
+  limit: true,
+  and: true,
+  or: true,
+  true: true,
+  false: true,
+  null: true,
+};
+
+/**
+ * Tokens whose presence ANYWHERE in the query unambiguously signals a
+ * write/mutation intent or a clause outside the read subset. They are
+ * rejected with `unsupported_clause` carrying a tailored message.
+ */
+const WRITE_OR_OUTSIDE_CLAUSES: Record<string, string> = {
+  create: "CREATE is a write clause; this Cypher layer is read-only (MATCH/WHERE/RETURN/LIMIT only).",
+  merge: "MERGE is a write clause; this Cypher layer is read-only.",
+  set: "SET is a write clause; this Cypher layer is read-only.",
+  delete: "DELETE is a write clause; this Cypher layer is read-only.",
+  detach: "DETACH DELETE is a write clause; this Cypher layer is read-only.",
+  remove: "REMOVE is a write clause; this Cypher layer is read-only.",
+  drop: "DROP is a write clause; this Cypher layer is read-only.",
+  call: "CALL { ... } subqueries are outside the read subset.",
+  yield: "YIELD is outside the read subset (only MATCH/WHERE/RETURN/LIMIT).",
+  union: "UNION combinator is outside the read subset.",
+  with: "WITH is outside the read subset (only MATCH/WHERE/RETURN/LIMIT).",
+  order: "ORDER BY is outside the read subset (use LIMIT, or post-sort in the caller).",
+  by: "ORDER BY is outside the read subset.",
+  skip: "SKIP is outside the read subset (use LIMIT).",
+  optional: "OPTIONAL MATCH is outside the read subset.",
+  explain: "EXPLAIN is outside the read subset.",
+  profile: "PROFILE is outside the read subset.",
+  use: "USE (graph routing) is outside the read subset.",
+  foreach: "FOREACH is a write clause; this Cypher layer is read-only.",
+  load: "LOAD CSV / LOAD FROM is outside the read subset.",
+  constraint: "CONSTRAINT is a DDL clause; this Cypher layer is read-only.",
+  index: "INDEX is a DDL clause; this Cypher layer is read-only.",
+  graph: "GRAPH is outside the read subset.",
+  unwind: "UNWIND is outside the read subset.",
+  distinct: "DISTINCT is outside the read subset (this layer does not dedupe).",
+  exists: "EXISTS is outside the read subset (use property comparisons).",
+  in: "IN is outside the read subset (use a property comparison).",
+  is_: "IS NULL / IS NOT NULL is outside the read subset.",
+  not: "NOT is outside the read subset (use positive comparisons or <>).",
+  starts: "STARTS WITH is outside the read subset.",
+  ends: "ENDS WITH is outside the read subset.",
+  contains: "CONTAINS is outside the read subset.",
+  regex: "=~ regex is outside the read subset.",
+  count: "COUNT(...) aggregation is outside the read subset.",
+  sum: "SUM(...) aggregation is outside the read subset.",
+  min: "MIN(...) aggregation is outside the read subset.",
+  max: "MAX(...) aggregation is outside the read subset.",
+  avg: "AVG(...) aggregation is outside the read subset.",
+  collect: "COLLECT(...) aggregation is outside the read subset.",
+  case: "CASE expressions are outside the read subset.",
+  when: "CASE expressions are outside the read subset.",
+  then: "CASE expressions are outside the read subset.",
+  else: "CASE expressions are outside the read subset.",
+  end: "CASE ... END is outside the read subset.",
+  as: "AS aliasing is outside the read subset (RETURN items project under their literal text).",
+  reduce: "REDUCE is outside the read subset.",
+  shortestpath: "shortestPath() is outside the read subset.",
+  all: "ALL(...) pattern predicate is outside the read subset.",
+  any: "ANY(...) pattern predicate is outside the read subset.",
+  none: "NONE(...) pattern predicate is outside the read subset.",
+  single: "SINGLE(...) pattern predicate is outside the read subset.",
+  size: "SIZE() is outside the read subset.",
+};
+
+class Tokenizer {
+  private readonly src: string;
+  private i = 0;
+  private readonly tokens: Token[] = [];
+
+  constructor(src: string) {
+    this.src = src;
+  }
+
+  tokenize(): Token[] {
+    while (this.i < this.src.length) {
+      const ch = this.src[this.i]!;
+      // Whitespace.
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+        this.i += 1;
+        continue;
+      }
+      // Line comments `//` (Cypher) and block comments `/* */`.
+      if (ch === "/" && this.src[this.i + 1] === "/") {
+        const nl = this.src.indexOf("\n", this.i);
+        this.i = nl === -1 ? this.src.length : nl + 1;
+        continue;
+      }
+      if (ch === "/" && this.src[this.i + 1] === "*") {
+        const end = this.src.indexOf("*/", this.i + 2);
+        if (end === -1) {
+          throw parseError(
+            this.i,
+            "Unterminated block comment. Supported grammar: MATCH/WHERE/RETURN/LIMIT.",
+          );
+        }
+        this.i = end + 2;
+        continue;
+      }
+      const start = this.i;
+      // Strings — double or single quoted. Backslash escapes are preserved
+      // literally (the subset doesn't need them); the closing quote is the
+      // next unescaped matching quote.
+      if (ch === '"' || ch === "'") {
+        this.readString(ch, start);
+        continue;
+      }
+      // Numbers — digits, or `.`-leading fractional. A leading `-` is
+      // emitted as a DASH token so the parser can negate a NUMBER in the
+      // literal position (the tokenizer never looks that far ahead).
+      if (isDigit(ch) || (ch === "." && isDigit(this.src[this.i + 1]!))) {
+        this.readNumber(start);
+        continue;
+      }
+      // Identifiers / keywords — [A-Za-z_][A-Za-z0-9_]*
+      if (isIdentStart(ch)) {
+        this.readWord(start);
+        continue;
+      }
+      // Punctuation & operators — maximal munch.
+      const two = this.src.slice(this.i, this.i + 2);
+      const three = this.src.slice(this.i, this.i + 3);
+      if (three === "-->") {
+        this.push("ARROW_R", three, start);
+        continue;
+      }
+      if (three === "<--") {
+        this.push("ARROW_L", three, start);
+        continue;
+      }
+      if (two === "->") {
+        this.push("ARROW_R", two, start);
+        continue;
+      }
+      if (two === "<-") {
+        this.push("ARROW_L", two, start);
+        continue;
+      }
+      if (two === "--") {
+        this.push("DASHDASH", two, start);
+        continue;
+      }
+      if (two === "..") {
+        this.push("DOTDOT", two, start);
+        continue;
+      }
+      if (two === "<>" || two === "!=") {
+        this.push("NE", two, start);
+        continue;
+      }
+      if (two === ">=") {
+        this.push("GE", two, start);
+        continue;
+      }
+      if (two === "<=") {
+        this.push("LE", two, start);
+        continue;
+      }
+      switch (ch) {
+        case "(":
+          this.push("LPAREN", ch, start);
+          break;
+        case ")":
+          this.push("RPAREN", ch, start);
+          break;
+        case "[":
+          this.push("LBRACK", ch, start);
+          break;
+        case "]":
+          this.push("RBRACK", ch, start);
+          break;
+        case "{":
+          this.push("LBRACE", ch, start);
+          break;
+        case "}":
+          this.push("RBRACE", ch, start);
+          break;
+        case ":":
+          this.push("COLON", ch, start);
+          break;
+        case "|":
+          this.push("PIPE", ch, start);
+          break;
+        case ",":
+          this.push("COMMA", ch, start);
+          break;
+        case ".":
+          this.push("DOT", ch, start);
+          break;
+        case "*":
+          this.push("STAR", ch, start);
+          break;
+        case "-":
+          this.push("DASH", ch, start);
+          break;
+        case "=":
+          this.push("EQ", ch, start);
+          break;
+        case ">":
+          this.push("GT", ch, start);
+          break;
+        case "<":
+          this.push("LT", ch, start);
+          break;
+        default:
+          throw parseError(
+            start,
+            `Unexpected character ${JSON.stringify(ch)}. Supported grammar: MATCH (a:Label {p: "v"})-[:TYPE*1..3]->(b) WHERE ... RETURN ... LIMIT n.`,
+          );
+      }
+    }
+    this.push("EOF", "", this.i);
+    return this.tokens;
+  }
+
+  private push(type: TokenType, text: string, pos: number): void {
+    this.tokens.push({ type, text, pos });
+    this.i = pos + text.length;
+  }
+
+  private readString(quote: string, start: number): void {
+    let j = start + 1;
+    const chars: string[] = [];
+    while (j < this.src.length) {
+      const c = this.src[j]!;
+      if (c === "\\") {
+        // Preserve the escape sequence verbatim — the subset doesn't
+        // interpret \n / \t / \" / \\; it stores and matches the raw two
+        // characters. This is documented and tested.
+        chars.push(c);
+        chars.push(this.src[j + 1] ?? "");
+        j += 2;
+        continue;
+      }
+      if (c === quote) {
+        const text = chars.join("");
+        this.tokens.push({ type: "STRING", text, pos: start });
+        this.i = j + 1;
+        return;
+      }
+      chars.push(c);
+      j += 1;
+    }
+    throw parseError(start, "Unterminated string literal.");
+  }
+
+  private readNumber(start: number): void {
+    let j = start;
+    while (j < this.src.length && isDigit(this.src[j]!)) j += 1;
+    if (this.src[j] === "." && isDigit(this.src[j + 1]!)) {
+      j += 1;
+      while (j < this.src.length && isDigit(this.src[j]!)) j += 1;
+    }
+    // Exponent (e.g. 1e3). Rare in property filters but cheap to accept.
+    if (this.src[j] === "e" || this.src[j] === "E") {
+      j += 1;
+      if (this.src[j] === "+" || this.src[j] === "-") j += 1;
+      while (j < this.src.length && isDigit(this.src[j]!)) j += 1;
+    }
+    const text = this.src.slice(start, j);
+    this.tokens.push({ type: "NUMBER", text, pos: start });
+    this.i = j;
+  }
+
+  private readWord(start: number): void {
+    let j = start;
+    while (j < this.src.length && isIdentPart(this.src[j]!)) j += 1;
+    const text = this.src.slice(start, j);
+    this.tokens.push({ type: "WORD", text, pos: start });
+    this.i = j;
+  }
+}
+
+function isDigit(c: string): boolean {
+  return c >= "0" && c <= "9";
+}
+function isIdentStart(c: string): boolean {
+  return (
+    (c >= "a" && c <= "z") ||
+    (c >= "A" && c <= "Z") ||
+    c === "_"
+  );
+}
+function isIdentPart(c: string): boolean {
+  return isIdentStart(c) || isDigit(c);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Parser.
+// ──────────────────────────────────────────────────────────────────────────
+
+class Parser {
+  private readonly tokens: Token[];
+  private i = 0;
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens;
+  }
+
+  parse(): CypherAst {
+    // Cypher queries in the subset MUST start with MATCH. Any other
+    // leading token — including a write clause like CREATE — is rejected
+    // here with the supported-grammar hint.
+    this.expectKeyword("match");
+    const match = this.parseMatch();
+
+    let where: WhereClause | undefined;
+    if (this.consumeKeyword("where")) {
+      where = this.parseWhere();
+    }
+
+    this.expectKeyword("return");
+    const returnItems = this.parseReturn();
+
+    let limit: number | undefined;
+    if (this.consumeKeyword("limit")) {
+      limit = this.parseNonNegativeInt("LIMIT");
+    }
+
+    // Anything after LIMIT (other than EOF) is outside the subset.
+    const tok = this.peek();
+    if (tok.type !== "EOF") {
+      throw this.unsupportedAfter(tok);
+    }
+
+    this.validateAst(match, where, returnItems);
+    return { match, where, return: returnItems, limit };
+  }
+
+  // ── MATCH / pattern ────────────────────────────────────────────────────
+
+  private parseMatch(): MatchClause {
+    const nodes: NodePattern[] = [this.parseNode()];
+    const rels: RelPattern[] = [];
+    // A pattern continues while the next token begins a relationship.
+    while (this.startsWithRelationship()) {
+      const rel = this.parseRelationship();
+      nodes.push(this.parseNode());
+      rels.push(rel);
+    }
+    return { nodes, rels };
+  }
+
+  private startsWithRelationship(): boolean {
+    const t = this.peek();
+    // A relationship starts with a left-side dash run: `<-` (ARROW_L),
+    // `--` (DASHDASH), or `-` (DASH). A bare `<` (LT) is NOT a valid
+    // relationship start — incoming uses `<-`, tokenized as ARROW_L.
+    return (
+      t.type === "ARROW_L" ||
+      t.type === "DASHDASH" ||
+      t.type === "DASH"
+    );
+  }
+
+  private parseNode(): NodePattern {
+    this.expect("LPAREN", "a node pattern `(var:Label {p: \"v\"})`");
+    let varName: string | undefined;
+    const first = this.peek();
+    if (first.type === "WORD" && !this.isKeyword(first.text)) {
+      varName = first.text;
+      this.advance();
+    }
+    let label: string | undefined;
+    if (this.peek().type === "COLON") {
+      this.advance();
+      const lt = this.expect("WORD", "a label after `:`");
+      label = lt.text;
+    }
+    const properties: Array<{ key: string; value: CypherScalar }> = [];
+    if (this.peek().type === "LBRACE") {
+      this.advance();
+      // Empty `{}` is allowed.
+      if (this.peek().type !== "RBRACE") {
+        properties.push(this.parseProp());
+        while (this.peek().type === "COMMA") {
+          this.advance();
+          properties.push(this.parseProp());
+        }
+      }
+      this.expect("RBRACE", "closing `}` of the property map");
+    }
+    this.expect("RPAREN", "closing `)` of the node pattern");
+    return { varName, label, properties };
+  }
+
+  private parseProp(): { key: string; value: CypherScalar } {
+    const keyTok = this.expect("WORD", "a property key");
+    this.expect("COLON", "`:` between property key and value");
+    const value = this.parseLiteral();
+    return { key: keyTok.text, value };
+  }
+
+  /**
+   * Parse `<leftDash> [bracket] <rightDash>`. Direction is resolved from
+   * the two dash runs: `-[...]->` outgoing, `<-[...]-` incoming,
+   * `-[...]-` / `--[...]--` both. The bracket is required.
+   */
+  private parseRelationship(): RelPattern {
+    const leftDir = this.consumeLeftDashRun();
+    // The bracket `[...]` is REQUIRED in the subset — bare `-->` without
+    // a bracket is rejected because the grammar documents the bracketed
+    // form and we want one shape to test.
+    if (this.peek().type !== "LBRACK") {
+      throw parseError(
+        this.peek().pos,
+        "Relationships must use a bracketed form, e.g. `-[:CALLS]->` or `-[:CALLS*1..3]->`. Bare arrows without `[...]` are not in the subset.",
+      );
+    }
+    this.advance(); // consume [
+    const types: string[] = [];
+    if (this.peek().type === "COLON") {
+      this.advance();
+      types.push(this.expect("WORD", "an edge type after `:[`").text);
+      while (this.peek().type === "PIPE") {
+        this.advance();
+        // openCypher accepts both `:A|:B` and `:A|B`; the colon after `|`
+        // is optional. Consume it if present, else read the type directly.
+        if (this.peek().type === "COLON") this.advance();
+        types.push(this.expect("WORD", "an edge type after `|`").text);
+      }
+    }
+    let minHops = 1;
+    let maxHops = 1;
+    if (this.peek().type === "STAR") {
+      this.advance();
+      const range = this.parseRange();
+      minHops = range.min;
+      maxHops = range.max;
+    }
+    this.expect("RBRACK", "closing `]` of the relationship bracket");
+
+    const rightDir = this.consumeRightDashRun();
+    if (leftDir === "none" && rightDir === "none") {
+      throw parseError(
+        this.peek().pos,
+        "Relationships require dashes around the bracket, e.g. `-[:CALLS]->`, `<-[:CALLS]-`, or `-[:CALLS]-`. Bare `[...]` between nodes is not valid.",
+      );
+    }
+
+    const direction = resolveDirection(leftDir, rightDir);
+    if (maxHops < minHops) {
+      throw parseError(
+        this.peek().pos,
+        `Relationship range max (${maxHops}) is less than min (${minHops}).`,
+      );
+    }
+    return { direction, types, minHops, maxHops };
+  }
+
+  private parseRange(): { min: number; max: number } {
+    // Forms accepted:
+    //   N        → exactly N (min=max=N)
+    //   N..M     → min=N, max=M
+    //   ..M      → min=1, max=M  (default min)
+    // Forms REJECTED:
+    //   (empty)  → bare `*` — unbounded → unsupported_clause
+    //   N..      → unbounded max → unsupported_clause
+    //   ..       → unbounded max → unsupported_clause
+    const tok = this.peek();
+    const hasLower = tok.type === "NUMBER";
+    let min = 1;
+    let max = Infinity;
+    if (hasLower) {
+      const n = this.parseNonNegativeInt("the minimum hop count");
+      min = n;
+      max = n; // `*N` form: exactly N
+    }
+    if (this.peek().type === "DOTDOT") {
+      this.advance();
+      // After `..`, a NUMBER is required (we don't accept unbounded max).
+      if (this.peek().type === "NUMBER") {
+        max = this.parseNonNegativeInt("the maximum hop count");
+      } else {
+        throw parseError(
+          this.peek().pos,
+          "Unbounded variable-length `*..` is not supported. Specify a maximum, e.g. `*1..3`. The read subset rejects unbounded traversal.",
+          "unsupported_clause",
+        );
+      }
+    } else if (!hasLower) {
+      // Bare `*` with nothing after it.
+      throw parseError(
+        tok.pos,
+        "Unbounded variable-length `*` is not supported. Specify a range, e.g. `*1..3` or `*2`. The read subset rejects unbounded traversal.",
+        "unsupported_clause",
+      );
+    }
+    if (min < 0 || max < 0) {
+      throw parseError(tok.pos, "Hop counts must be non-negative integers.");
+    }
+    return { min, max };
+  }
+
+  // ── dash-run consumption ───────────────────────────────────────────────
+
+  /**
+   * Left-side dash-run result. `"incoming"` = `<-` arrow; `"dash"` = bare
+   * `-`/`--` (direction-neutral — the OTHER side's arrow wins, or undirected
+   * if neither side has an arrow); `"none"` = nothing present.
+   */
+  private consumeLeftDashRun(): "incoming" | "dash" | "none" {
+    const t = this.peek();
+    if (t.type === "ARROW_L") {
+      this.advance();
+      return "incoming";
+    }
+    if (t.type === "DASHDASH" || t.type === "DASH") {
+      this.advance();
+      return "dash";
+    }
+    return "none";
+  }
+
+  /**
+   * Right-side dash-run result. `"outgoing"` = `->`/`-->` arrow; `"dash"`
+   * = bare `-`/`--` (direction-neutral); `"none"` = nothing present.
+   */
+  private consumeRightDashRun(): "outgoing" | "dash" | "none" {
+    const t = this.peek();
+    if (t.type === "ARROW_R") {
+      this.advance();
+      return "outgoing";
+    }
+    if (t.type === "DASHDASH" || t.type === "DASH") {
+      this.advance();
+      return "dash";
+    }
+    return "none";
+  }
+
+  // ── WHERE ──────────────────────────────────────────────────────────────
+
+  private parseWhere(): WhereClause {
+    // Flat OR-of-AND: split on OR, each side is AND-joined terms.
+    const orGroups: WhereTerm[][] = [];
+    orGroups.push(this.parseAndGroup());
+    while (this.consumeKeyword("or")) {
+      orGroups.push(this.parseAndGroup());
+    }
+    return { orGroups };
+  }
+
+  private parseAndGroup(): WhereTerm[] {
+    const terms: WhereTerm[] = [this.parseComparison()];
+    while (this.consumeKeyword("and")) {
+      terms.push(this.parseComparison());
+    }
+    return terms;
+  }
+
+  private parseComparison(): Comparison {
+    const varTok = this.expect(
+      "WORD",
+      "a variable in WHERE (e.g. `a.name = \"foo\"`)",
+    );
+    if (this.isKeyword(varTok.text)) {
+      throw parseError(
+        varTok.pos,
+        `Expected a variable name in WHERE but found keyword ${JSON.stringify(varTok.text)}.`,
+      );
+    }
+    this.expect("DOT", "`.` between variable and property in WHERE");
+    const keyTok = this.expect("WORD", "a property name after `var.`");
+    const op = this.parseOp();
+    const value = this.parseLiteral();
+    return { varName: varTok.text, key: keyTok.text, op, value };
+  }
+
+  private parseOp(): Comparison["op"] {
+    const t = this.peek();
+    switch (t.type) {
+      case "EQ":
+        this.advance();
+        return "=";
+      case "NE":
+        this.advance();
+        return "<>";
+      case "GT":
+        this.advance();
+        return ">";
+      case "LT":
+        this.advance();
+        return "<";
+      case "GE":
+        this.advance();
+        return ">=";
+      case "LE":
+        this.advance();
+        return "<=";
+      default:
+        throw parseError(
+          t.pos,
+          "Expected a comparison operator (=, <>, !=, >, <, >=, <=) in WHERE.",
+        );
+    }
+  }
+
+  // ── RETURN ─────────────────────────────────────────────────────────────
+
+  private parseReturn(): ReturnItem[] {
+    // Reject `RETURN *` explicitly — it's outside the subset.
+    if (this.peek().type === "STAR") {
+      throw parseError(
+        this.peek().pos,
+        "`RETURN *` is outside the read subset. List the items to project explicitly, e.g. `RETURN a, b.name`.",
+        "unsupported_clause",
+      );
+    }
+    const items: ReturnItem[] = [this.parseReturnItem()];
+    while (this.peek().type === "COMMA") {
+      this.advance();
+      items.push(this.parseReturnItem());
+    }
+    if (items.length === 0) {
+      // parseReturnItem always produces one; defensive.
+      throw parseError(this.peek().pos, "RETURN requires at least one item.");
+    }
+    return items;
+  }
+
+  private parseReturnItem(): ReturnItem {
+    const varTok = this.expect(
+      "WORD",
+      "a variable (or var.prop) in RETURN",
+    );
+    if (this.isKeyword(varTok.text)) {
+      throw parseError(
+        varTok.pos,
+        `Expected a variable name in RETURN but found keyword ${JSON.stringify(varTok.text)}.`,
+      );
+    }
+    if (this.peek().type === "DOT") {
+      this.advance();
+      const keyTok = this.expect("WORD", "a property name after `var.`");
+      return { kind: "prop", varName: varTok.text, key: keyTok.text };
+    }
+    return { kind: "var", varName: varTok.text };
+  }
+
+  // ── numeric helpers ────────────────────────────────────────────────────
+
+  private parseNonNegativeInt(label: string): number {
+    const tok = this.peek();
+    if (tok.type === "NUMBER") {
+      const n = Number(tok.text);
+      if (!Number.isInteger(n) || n < 0) {
+        throw parseError(
+          tok.pos,
+          `${label} must be a non-negative integer; got ${JSON.stringify(tok.text)}.`,
+        );
+      }
+      this.advance();
+      return n;
+    }
+    throw parseError(tok.pos, `Expected a non-negative integer for ${label}.`);
+  }
+
+  // ── literals ───────────────────────────────────────────────────────────
+
+  private parseLiteral(): CypherScalar {
+    const tok = this.peek();
+    // Optional leading `-` for negative numbers.
+    let negate = false;
+    if (tok.type === "DASH") {
+      negate = true;
+      this.advance();
+    }
+    const t = negate ? this.peek() : tok;
+    if (t.type === "STRING") {
+      if (negate) {
+        throw parseError(t.pos, "Cannot negate a string literal.");
+      }
+      this.advance();
+      return t.text;
+    }
+    if (t.type === "NUMBER") {
+      this.advance();
+      const n = Number(t.text);
+      return negate ? -n : n;
+    }
+    if (t.type === "WORD") {
+      if (t.text.toLowerCase() === "true") {
+        if (negate) {
+          throw parseError(t.pos, "Cannot negate `true`.");
+        }
+        this.advance();
+        return true;
+      }
+      if (t.text.toLowerCase() === "false") {
+        if (negate) {
+          throw parseError(t.pos, "Cannot negate `false`.");
+        }
+        this.advance();
+        return false;
+      }
+      if (t.text.toLowerCase() === "null") {
+        if (negate) {
+          throw parseError(t.pos, "Cannot negate `null`.");
+        }
+        this.advance();
+        return null;
+      }
+      // Any other WORD here is a bare identifier where a literal was
+      // expected — almost certainly a typo or an unsupported construct.
+      // If it's a write/outside keyword, surface that message.
+      const outside = WRITE_OR_OUTSIDE_CLAUSES[t.text.toLowerCase()];
+      if (outside) {
+        throw parseError(t.pos, outside);
+      }
+    }
+    throw parseError(
+      tok.pos,
+      "Expected a literal value (string, number, true, false, or null).",
+    );
+  }
+
+  // ── AST validation ─────────────────────────────────────────────────────
+
+  private validateAst(
+    match: MatchClause,
+    where: WhereClause | undefined,
+    returnItems: ReturnItem[],
+  ): void {
+    // Collect bound variable names (anonymous nodes contribute nothing).
+    const bound = new Set<string>();
+    for (const n of match.nodes) {
+      if (n.varName) bound.add(n.varName);
+    }
+    // Validate labels.
+    for (const n of match.nodes) {
+      if (n.label !== undefined && !(n.label in CYPHER_LABEL_TO_DB_LABEL)) {
+        throw parseError(
+          0,
+          `Unknown label ${JSON.stringify(n.label)}. Valid labels: ${VALID_CYPHER_LABELS.join(", ")}.`,
+          "unknown_label",
+          [...VALID_CYPHER_LABELS],
+        );
+      }
+    }
+    // Validate WHERE variable references.
+    if (where) {
+      for (const group of where.orGroups) {
+        for (const term of group) {
+          if (!bound.has(term.varName)) {
+            throw parseError(
+              0,
+              `WHERE references variable ${JSON.stringify(term.varName)} which is not bound by MATCH. Bound variables: ${[...bound].join(", ") || "(none)"}.`,
+              "unbound_variable",
+            );
+          }
+        }
+      }
+    }
+    // Validate RETURN variable references.
+    for (const item of returnItems) {
+      if (!bound.has(item.varName)) {
+        throw parseError(
+          0,
+          `RETURN references variable ${JSON.stringify(item.varName)} which is not bound by MATCH. Bound variables: ${[...bound].join(", ") || "(none)"}.`,
+          "unbound_variable",
+        );
+      }
+    }
+  }
+
+  // ── token helpers ──────────────────────────────────────────────────────
+
+  private peek(): Token {
+    return this.tokens[this.i]!;
+  }
+
+  private advance(): Token {
+    const t = this.tokens[this.i]!;
+    if (this.i < this.tokens.length - 1) this.i += 1;
+    return t;
+  }
+
+  private expect(type: TokenType, what: string): Token {
+    const t = this.peek();
+    if (t.type !== type) {
+      throw parseError(
+        t.pos,
+        `Expected ${what} but found ${describeToken(t)}. Supported grammar: MATCH (a:Label {p: "v"})-[:TYPE*1..3]->(b) WHERE ... RETURN ... LIMIT n.`,
+      );
+    }
+    return this.advance();
+  }
+
+  private expectKeyword(kw: string): Token {
+    const t = this.peek();
+    if (t.type === "WORD" && t.text.toLowerCase() === kw) {
+      return this.advance();
+    }
+    // Helpful: if it's a write/outside clause, lead with that message.
+    if (t.type === "WORD") {
+      const outside = WRITE_OR_OUTSIDE_CLAUSES[t.text.toLowerCase()];
+      if (outside) {
+        throw parseError(t.pos, outside, "unsupported_clause");
+      }
+    }
+    throw parseError(
+      t.pos,
+      `Expected keyword ${kw.toUpperCase()} but found ${describeToken(t)}. Queries must start with MATCH and use only MATCH/WHERE/RETURN/LIMIT.`,
+      "parse_error",
+    );
+  }
+
+  private consumeKeyword(kw: string): boolean {
+    const t = this.peek();
+    if (t.type === "WORD" && t.text.toLowerCase() === kw) {
+      this.advance();
+      return true;
+    }
+    return false;
+  }
+
+  private isKeyword(text: string): boolean {
+    return KEYWORDS[text.toLowerCase()] === true;
+  }
+
+  private unsupportedAfter(tok: Token): CypherParseError {
+    const outside = WRITE_OR_OUTSIDE_CLAUSES[tok.text.toLowerCase()];
+    if (outside) {
+      return parseError(tok.pos, outside, "unsupported_clause");
+    }
+    return parseError(
+      tok.pos,
+      `Unexpected token ${describeToken(tok)} after the query. Only MATCH/WHERE/RETURN/LIMIT are supported.`,
+      "parse_error",
+    );
+  }
+}
+
+function resolveDirection(
+  left: "incoming" | "dash" | "none",
+  right: "outgoing" | "dash" | "none",
+): RelDirection {
+  // Arrows on each side carry direction; bare dashes are direction-neutral.
+  //   -[...]->  : left="dash",  right="outgoing" → outgoing
+  //   <-[...]-  : left="incoming", right="dash"   → incoming
+  //   -[...]-   : left="dash",  right="dash"      → both (undirected)
+  //   <-[...]-> : left="incoming", right="outgoing" → conflict (reject)
+  const leftArrow = left === "incoming";
+  const rightArrow = right === "outgoing";
+  if (leftArrow && rightArrow) {
+    throw parseError(
+      0,
+      "Conflicting relationship direction (e.g. `<-[...]->`). Use a consistent direction.",
+    );
+  }
+  if (leftArrow) return "incoming";
+  if (rightArrow) return "outgoing";
+  return "both";
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Errors.
+// ──────────────────────────────────────────────────────────────────────────
+
+class CypherParseError extends Error {
+  readonly code: CypherFailureCode;
+  readonly pos: number;
+  readonly validLabels?: readonly string[];
+  constructor(
+    pos: number,
+    message: string,
+    code: CypherFailureCode = "parse_error",
+    validLabels?: readonly string[],
+  ) {
+    super(message);
+    this.name = "CypherParseError";
+    this.pos = pos;
+    this.code = code;
+    this.validLabels = validLabels;
+  }
+}
+
+function parseError(
+  pos: number,
+  message: string,
+  code: CypherFailureCode = "parse_error",
+  validLabels?: readonly string[],
+): CypherParseError {
+  return new CypherParseError(pos, message, code, validLabels);
+}
+
+function describeToken(t: Token): string {
+  if (t.type === "EOF") return "end of input";
+  if (t.type === "WORD") return `identifier ${JSON.stringify(t.text)}`;
+  if (t.type === "STRING") return `string ${JSON.stringify(t.text)}`;
+  if (t.type === "NUMBER") return `number ${t.text}`;
+  return JSON.stringify(t.text);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public parse API.
+// ──────────────────────────────────────────────────────────────────────────
+
+export type CypherParseResult =
+  | { ok: true; ast: CypherAst }
+  | CypherFailure;
+
+/**
+ * Parse a Cypher query string into an AST without executing it. Use this
+ * to validate query shape (e.g. at a tool boundary) before opening a
+ * store. The AST is an opaque internal type; callers should treat it as
+ * a handle to pass to {@link executeAst}.
+ */
+export function parseCypher(query: string): CypherParseResult {
+  if (typeof query !== "string") {
+    return {
+      ok: false,
+      code: "invalid_query",
+      message: "Cypher query must be a string.",
+    };
+  }
+  if (query.length === 0 || query.trim().length === 0) {
+    return {
+      ok: false,
+      code: "parse_error",
+      message: "Empty query. Supported grammar: MATCH (a:Label {p: \"v\"})-[:TYPE*1..3]->(b) WHERE ... RETURN ... LIMIT n.",
+    };
+  }
+  try {
+    const tokens = new Tokenizer(query).tokenize();
+    const ast = new Parser(tokens).parse();
+    return { ok: true, ast };
+  } catch (e) {
+    if (e instanceof CypherParseError) {
+      return {
+        ok: false,
+        code: e.code,
+        message: e.message,
+        ...(e.validLabels ? { validLabels: e.validLabels } : {}),
+      };
+    }
+    return {
+      ok: false,
+      code: "parse_error",
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Executor — compiles the AST to searchGraph / traverse calls.
+// ──────────────────────────────────────────────────────────────────────────
+
+/** Property-access aliases — both camelCase and snake_case work. */
+const PROP_ALIASES: Record<string, keyof CypherNodeValue> = {
+  name: "name",
+  qualifiedname: "qualifiedName",
+  qualified_name: "qualifiedName",
+  label: "label",
+  kind: "label",
+  filepath: "filePath",
+  file_path: "filePath",
+  nodeid: "nodeId",
+  node_id: "nodeId",
+  id: "nodeId",
+};
+
+function nodeToValue(hit: SearchHit | TraverseHit): CypherNodeValue {
+  return {
+    nodeId: hit.nodeId,
+    qualifiedName: hit.qualifiedName,
+    name: hit.name,
+    label: hit.label,
+    filePath: hit.filePath,
+  };
+}
+
+function readProperty(node: CypherNodeValue, key: string): CypherScalar {
+  const alias = PROP_ALIASES[key.toLowerCase()];
+  if (!alias) {
+    // Unknown property → return null rather than throw, so a query like
+    // `RETURN a.confidence` on a node (which has no confidence) returns
+    // null instead of failing the whole query. Matches Cypher semantics
+    // for missing properties.
+    return null;
+  }
+  return node[alias];
+}
+
+function compareValues(a: CypherScalar, op: Comparison["op"], b: CypherScalar): boolean {
+  // Type-coercion rules (deliberately simple, documented):
+  //   - number op number → numeric compare
+  //   - string op string → lexical compare
+  //   - bool op bool → for = / <> only
+  //   - null involved → false for ordering ops; =/<> follow SQL three-valued
+  //     logic (null = anything → unknown → false here; null <> anything → false)
+  //   - mixed types for ordering → false (no coercion)
+  if (a === null || b === null) {
+    if (op === "=" || op === "<>" || op === "!=") {
+      // SQL: NULL = x and NULL <> x are both UNKNOWN → false.
+      return false;
+    }
+    return false;
+  }
+  if (op === "=") return a === b;
+  if (op === "<>" || op === "!=") return a !== b;
+  if (typeof a !== typeof b) return false;
+  if (typeof a === "boolean") {
+    // Booleans only support = / <> (handled above).
+    return false;
+  }
+  if (op === ">") return (a as number | string) > (b as number | string);
+  if (op === "<") return (a as number | string) < (b as number | string);
+  if (op === ">=") return (a as number | string) >= (b as number | string);
+  if (op === "<=") return (a as number | string) <= (b as number | string);
+  return false;
+}
+
+/**
+ * A binding is a row of variables → nodes resolved so far. The executor
+ * grows bindings left-to-right across the MATCH pattern.
+ */
+type Binding = Map<string, CypherNodeValue>;
+
+/**
+ * Execute a parsed AST against a store. Exposed so callers that already
+ * hold an AST (e.g. a cached plan) can skip re-parsing.
+ */
+export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
+  // 1. Resolve the FIRST node pattern via searchGraph. Property filters in
+  //    the node pattern AND WHERE conditions are applied as JS post-
+  //    filters after the structured search returns candidates. A closed
+  //    store surfaces as `{ ok: false, code: "store_closed" }` from
+  //    searchGraph itself (we don't reach into the private `closed` flag).
+  const firstNode = ast.match.nodes[0]!;
+  const searchLabel =
+    firstNode.label !== undefined
+      ? CYPHER_LABEL_TO_DB_LABEL[firstNode.label]!
+      : undefined;
+  // Use the maximum limit the store allows so we don't silently truncate
+  // the start set; the query's LIMIT applies later. For graphs above the
+  // cap, narrow the start with a label + property filter.
+  const search = store.searchGraph({
+    ...(searchLabel !== undefined ? { label: searchLabel } : {}),
+    limit: 1000,
+  });
+  if (!search.ok) {
+    return storeFailureToCypher(search);
+  }
+
+  let bindings: Binding[] = search.hits
+    .map((hit) => nodeToValue(hit))
+    .filter((node) => matchesNodePattern(node, firstNode))
+    .map((node) => {
+      const m = new Map<string, CypherNodeValue>();
+      if (firstNode.varName) m.set(firstNode.varName, node);
+      return m;
+    });
+
+  // 2. Walk the remaining (rel, node) pairs, expanding each binding via
+  //    traverse.
+  for (let idx = 0; idx < ast.match.rels.length; idx += 1) {
+    const rel = ast.match.rels[idx]!;
+    const nodePattern = ast.match.nodes[idx + 1]!;
+    const leftVar = ast.match.nodes[idx]!.varName;
+    if (!leftVar) {
+      // The left node of this hop was anonymous — we cannot traverse
+      // from an unnamed binding. This is a structural error caught at
+      // parse-validate only for RETURN/WHERE; for traversal we catch
+      // here and return empty (the user wrote `(a)-->( ) RETURN a`,
+      // which is valid but yields no new bindings).
+      bindings = [];
+      break;
+    }
+    const nextBindings: Binding[] = [];
+    for (const binding of bindings) {
+      const startNode = binding.get(leftVar);
+      if (!startNode) continue;
+      const t = store.traverse({
+        start: startNode.nodeId,
+        direction: rel.direction,
+        ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
+        maxDepth: rel.maxHops,
+      });
+      if (!t.ok) {
+        // unknown_start can happen if the node vanished between search
+        // and traverse — skip this binding rather than fail the whole
+        // query. Genuine db errors propagate.
+        if (
+          t.code === "unknown_start" ||
+          t.code === "ambiguous_start" ||
+          t.code === "invalid_query"
+        ) {
+          continue;
+        }
+        return storeFailureToCypher(t);
+      }
+      // Depth filter: half-open per traverse, but the relationship's
+      // minHops/maxHops are inclusive bounds (depth ∈ [minHops, maxHops]).
+      // The start node itself is at depth 0; for hops we want depth >= 1.
+      const seen = new Set<string>();
+      for (const hit of t.hits) {
+        if (hit.depth < rel.minHops || hit.depth > rel.maxHops) continue;
+        if (seen.has(hit.nodeId)) continue;
+        seen.add(hit.nodeId);
+        const node = nodeToValue(hit);
+        if (!matchesNodePattern(node, nodePattern)) continue;
+        const extended = new Map(binding);
+        if (nodePattern.varName) {
+          // If the var was already bound (re-binding in a path), require
+          // it to be the SAME node (Cypher equality semantics). Skip
+          // otherwise.
+          const existing = extended.get(nodePattern.varName);
+          if (existing && existing.nodeId !== node.nodeId) continue;
+          extended.set(nodePattern.varName, node);
+        }
+        nextBindings.push(extended);
+      }
+    }
+    bindings = nextBindings;
+    if (bindings.length === 0) break;
+  }
+
+  // 3. Apply WHERE.
+  if (ast.where) {
+    bindings = bindings.filter((b) => matchesWhere(b, ast.where!));
+  }
+
+  // 4. Apply LIMIT.
+  if (ast.limit !== undefined) {
+    bindings = bindings.slice(0, ast.limit);
+  }
+
+  // 5. Project RETURN.
+  const columns = ast.return.map((item) =>
+    item.kind === "var" ? item.varName : `${item.varName}.${item.key}`,
+  );
+  const rows: CypherRow[] = bindings.map((b) => {
+    const row: CypherRow = {};
+    ast.return.forEach((item) => {
+      const col = item.kind === "var" ? item.varName : `${item.varName}.${item.key}`;
+      const node = b.get(item.varName);
+      if (!node) {
+        row[col] = null;
+        return;
+      }
+      row[col] =
+        item.kind === "var" ? node : readProperty(node, item.key);
+    });
+    return row;
+  });
+
+  return { ok: true, columns, rows };
+}
+
+function matchesNodePattern(node: CypherNodeValue, pattern: NodePattern): boolean {
+  for (const { key, value } of pattern.properties) {
+    const actual = readProperty(node, key);
+    if (!compareValues(actual, "=", value)) return false;
+  }
+  return true;
+}
+
+function matchesWhere(binding: Binding, where: WhereClause): boolean {
+  // OR-of-AND.
+  return where.orGroups.some((group) =>
+    group.every((term) => {
+      const node = binding.get(term.varName);
+      if (!node) return false;
+      const actual = readProperty(node, term.key);
+      return compareValues(actual, term.op, term.value);
+    }),
+  );
+}
+
+function storeFailureToCypher(f: {
+  ok: false;
+  code: string;
+}): CypherFailure {
+  // Map store failure codes to Cypher failure codes (1:1 for the shared
+  // suffix; store_closed is checked up-front in executeAst).
+  switch (f.code) {
+    case "db_locked":
+      return { ok: false, code: "db_locked", message: "Database is locked." };
+    case "db_corrupt":
+      return { ok: false, code: "db_corrupt", message: "Database is corrupt." };
+    case "store_closed":
+      return { ok: false, code: "store_closed", message: "The graph store is closed." };
+    default:
+      return {
+        ok: false,
+        code: "db_error",
+        message: `Database error: ${f.code}`,
+      };
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public execute API.
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse and execute a Cypher query against a store. Convenience wrapper
+ * around {@link parseCypher} + {@link executeAst}.
+ *
+ * @example
+ *   const r = executeCypher(store, 'MATCH (f:Function {name: "foo"})-[:CALLS*1..2]->(g) WHERE g.label = "function" RETURN f.name, g.qualifiedName LIMIT 5');
+ *   if (r.ok) for (const row of r.rows) console.log(row);
+ */
+export function executeCypher(store: GraphStore, query: string): CypherResult {
+  const parsed = parseCypher(query);
+  if (!parsed.ok) return parsed;
+  return executeAst(store, parsed.ast);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Exports for tests / type narrowing.
+// ──────────────────────────────────────────────────────────────────────────
+
+export {
+  CYPHER_LABEL_TO_DB_LABEL,
+  VALID_CYPHER_LABELS,
+  type CypherAst,
+  type CypherParseError,
+};

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -47,6 +47,15 @@
  * filters in node patterns (`{name: "foo"}`) and WHERE conditions are
  * applied in JS as post-filters on the bound nodes.
  *
+ * Variable-length depth uses `traverse`'s BFS, which visits each node ONCE
+ * at its shortest-path depth. So `*M..N` returns nodes whose SHORTEST path
+ * from the start is in `[M, N]` — correct for "reachable within N hops".
+ * Exact `*N` (N > 1) is honored only for nodes whose shortest path is
+ * exactly N; a node reachable at both a shorter and a length-N path is
+ * returned at the shorter depth only. True path-enumeration semantics
+ * (returning a node once per distinct length-N path) needs a path-
+ * enumerating store primitive and is tracked as a follow-up.
+ *
  * ## Read-only by construction
  *
  * The parser only recognizes the tokens `MATCH`, `WHERE`, `RETURN`,
@@ -78,9 +87,17 @@
  *
  * The subset is aimed at interactive exploration over indexed graphs. The
  * start-node resolution uses `searchGraph` (capped at 1000 rows by the
- * store) and relationship expansion uses `traverse` (BFS, full reachable
- * subgraph up to maxDepth). For graphs larger than the start cap, narrow
- * the start node with a label + property filter.
+ * store); the inline `name`/`filePath` property filter and a supported
+ * single-conjunction first-variable WHERE equality term are pushed down
+ * to the index BEFORE the cap, so an exact-name lookup is found even when
+ * the matching node sorts after the cap on a large graph. Values
+ * containing LIKE metacharacters (`%`/`_`) and multi-group (OR) WHERE
+ * clauses are NOT pushed down — they fall back to the capped scan, so on
+ * graphs with more than 1000 nodes of the starting label such queries can
+ * still false-negative; use the inline literal form for guaranteed
+ * resolution. Relationship expansion uses `traverse` (BFS, full reachable
+ * subgraph up to maxDepth) — see the compile-target note for the BFS
+ * shortest-depth semantics of variable-length `*N`.
  */
 import type {
   GraphStore,
@@ -1315,35 +1332,40 @@ interface Binding {
 }
 
 /**
- * Push the inline `name` / `filePath` property filters from a node pattern
- * down to the structured `searchGraph` filters so the candidate set is
- * narrowed by the index BEFORE the 1000-row cap applies. A specific name
- * like `"runServer"` narrows from the whole graph to a handful of rows,
- * so a low-degree node with an exact name match is no longer truncated
- * out (cursor Bugbot: 'Start search truncates before filters').
+ * Push ONE `name` / `filePath` equality filter down to the structured
+ * `searchGraph` filters so the candidate set is narrowed by the index
+ * BEFORE the 1000-row cap applies. A specific name like `"runServer"`
+ * narrows from the whole graph to a handful of rows, so a low-degree
+ * node with an exact name match is no longer truncated out (cursor
+ * Bugbot: 'Start search truncates before filters').
  *
- * The post-filter ({@link matchesNodePattern}) still enforces EXACT
- * case-sensitive equality afterwards; the pushdown uses `searchGraph`'s
- * `LIKE ... COLLATE NOCASE`, which is a SUPERSET of exact match, so no
- * valid result is lost (the post-filter removes the extras). A literal
- * `%`/`_` in the user's value acts as a LIKE wildcard for the narrow
- * pass, which only makes the candidate set slightly broader — never
- * narrower — so correctness is preserved.
+ * Only LITERAL values are pushed: a `%`/`_` in the value would act as a
+ * LIKE wildcard under searchGraph's `LIKE ... COLLATE NOCASE`, ballooning
+ * the candidate set (e.g. `"foo_bar"` matching `fooXbar`). Such values
+ * fall back to the capped label scan + exact post-filter instead
+ * (chatgpt-codex-connector: 'Escape LIKE wildcards before start-node
+ * pushdown'). The first writer wins (inline properties take priority
+ * over a WHERE term) so two constraints on the same field don't clobber
+ * each other. The post-filter ({@link matchesNodePattern} /
+ * {@link matchesWhere}) always enforces exact case-sensitive equality,
+ * so this narrowing never loses a valid row.
  */
-function pushInlineFiltersToSearch(
-  query: { label?: string; namePattern?: string; filePattern?: string },
-  properties: ReadonlyArray<{ key: string; value: CypherScalar }>,
+function pushFilterToSearch(
+  query: { namePattern?: string; filePattern?: string },
+  key: string,
+  value: CypherScalar,
 ): void {
-  for (const { key, value } of properties) {
-    const k = key.toLowerCase();
-    if (k === "name" && typeof value === "string") {
-      query.namePattern = value;
-    } else if (
-      (k === "filepath" || k === "file_path") &&
-      typeof value === "string"
-    ) {
-      query.filePattern = value;
-    }
+  if (typeof value !== "string") return;
+  // Skip LIKE metacharacters so the pushed pattern stays literal-exact.
+  if (value.includes("%") || value.includes("_")) return;
+  const k = key.toLowerCase();
+  if (k === "name" && query.namePattern === undefined) {
+    query.namePattern = value;
+  } else if (
+    (k === "filepath" || k === "file_path") &&
+    query.filePattern === undefined
+  ) {
+    query.filePattern = value;
   }
 }
 
@@ -1355,10 +1377,14 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
   // 1. Resolve the FIRST node pattern via searchGraph. The label + any
   //    inline `name`/`filePath` property filters are pushed down so the
   //    candidate set is narrowed by the index before the 1000-row cap;
-  //    remaining inline properties + WHERE conditions are applied as JS
-  //    post-filters. A closed store surfaces as
-  //    `{ ok: false, code: "store_closed" }` from searchGraph itself
-  //    (we don't reach into the private `closed` flag).
+  //    a supported first-variable WHERE equality term (`f.name = "x"`) is
+  //    pushed down too when WHERE is a single conjunction (no top-level
+  //    OR), so `MATCH (f) WHERE f.name = "rare"` is narrowed before the
+  //    cap rather than after (chatgpt-codex-connector: 'Push down first-
+  //    node WHERE filters before capping'). Remaining inline properties +
+  //    the full WHERE are applied as JS post-filters. A closed store
+  //    surfaces as `{ ok: false, code: "store_closed" }` from searchGraph
+  //    itself (we don't reach into the private `closed` flag).
   const firstNode = ast.match.nodes[0]!;
   const searchQuery: {
     label?: string;
@@ -1369,7 +1395,20 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
   if (firstNode.label !== undefined) {
     searchQuery.label = CYPHER_LABEL_TO_DB_LABEL[firstNode.label]!;
   }
-  pushInlineFiltersToSearch(searchQuery, firstNode.properties);
+  for (const { key, value } of firstNode.properties) {
+    pushFilterToSearch(searchQuery, key, value);
+  }
+  // Single OR-group ⇒ pure conjunction ⇒ every term is a necessary
+  // condition, so pushing a first-var `=` term down only narrows. With OR
+  // (multiple groups) we push nothing — a term true on one branch is not
+  // necessary overall, and pushing it would drop the other branch's rows.
+  if (ast.where && ast.where.orGroups.length === 1 && firstNode.varName) {
+    for (const term of ast.where.orGroups[0]!) {
+      if (term.varName === firstNode.varName && term.op === "=") {
+        pushFilterToSearch(searchQuery, term.key, term.value);
+      }
+    }
+  }
   const search = store.searchGraph(searchQuery);
   if (!search.ok) {
     return storeFailureToCypher(search);
@@ -1471,6 +1510,17 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
 }
 
 function matchesNodePattern(node: CypherNodeValue, pattern: NodePattern): boolean {
+  // Enforce the parsed `:Label`. The FIRST node's label is already pushed
+  // into searchGraph's `label` filter, so this is a no-op for it; for
+  // relationship TARGET nodes this is the only place the parsed label is
+  // enforced (cursor Bugbot: 'Relationship node labels not enforced' —
+  // without this, `MATCH (a:Function)-[:CALLS]->(b:Type)` returned
+  // Function nodes for `b`). `pattern.label` is validated at parse time,
+  // so the mapped db label always exists when set.
+  if (pattern.label !== undefined) {
+    const dbLabel = CYPHER_LABEL_TO_DB_LABEL[pattern.label];
+    if (dbLabel !== undefined && node.label !== dbLabel) return false;
+  }
   for (const { key, value } of pattern.properties) {
     const actual = readProperty(node, key);
     if (!compareValues(actual, "=", value)) return false;

--- a/packages/coding-graph/src/index.ts
+++ b/packages/coding-graph/src/index.ts
@@ -275,3 +275,27 @@ export {
   type LogFilesEntry,
   type NameStatusEntry,
 } from "./git-invoker.js";
+
+// ---------------------------------------------------------------------------
+// PR3 (issue #1552): openCypher read-subset — parser + executor. Re-exported
+// from the package root so consumers can `import { executeCypher } from
+// "@remnic/coding-graph"` (the subpath export `./cypher` remains for callers
+// that want only this layer).
+// ---------------------------------------------------------------------------
+
+export {
+  executeCypher,
+  executeAst,
+  parseCypher,
+  VALID_CYPHER_LABELS,
+  type CypherAst,
+  type CypherFailure,
+  type CypherFailureCode,
+  type CypherNodeValue,
+  type CypherParseResult,
+  type CypherResult,
+  type CypherRow,
+  type CypherScalar,
+  type CypherSuccess,
+  type CypherValue,
+} from "./cypher/query-parser.js";

--- a/packages/coding-graph/tsup.config.ts
+++ b/packages/coding-graph/tsup.config.ts
@@ -6,13 +6,19 @@ import { defineConfig } from "tsup";
 // build. Core consumes this package via a computed-specifier dynamic import
 // (see packages/remnic-core/src/coding/optional-coding-graph.ts).
 //
-// The store modules (graph-schema, graph-store) emit their own bundles so
-// the subpath exports `./graph-schema` and `./graph-store` resolve to
-// standalone files; better-sqlite3 is marked external because it is a
-// native binding and must never be bundled (rule 23/38 — the shared
-// opener lives in @remnic/core/runtime/better-sqlite).
+// The store modules (graph-schema, graph-store) and the Cypher layer
+// (cypher/query-parser) emit their own bundles so the subpath exports
+// `./graph-schema`, `./graph-store`, and `./cypher` resolve to standalone
+// files; better-sqlite3 is marked external because it is a native binding
+// and must never be bundled (rule 23/38 — the shared opener lives in
+// @remnic/core/runtime/better-sqlite).
 export default defineConfig({
-  entry: ["src/index.ts", "src/graph-schema.ts", "src/graph-store.ts"],
+  entry: [
+    "src/index.ts",
+    "src/graph-schema.ts",
+    "src/graph-store.ts",
+    "src/cypher/query-parser.ts",
+  ],
   format: ["esm"],
   target: "es2022",
   platform: "node",


### PR DESCRIPTION
## What

PR3 of issue #1552 — closes the openCypher read-subset gap. The store core (`upsertFileBatch`, `traverse`, `searchGraph`, `deadCode`, `schemaStats`) landed in earlier PRs; this PR adds the thin, deletable Cypher layer that compiles a strict read-only subset of openCypher to those structured primitives.

## Supported grammar (strict subset)

```
MATCH (a:Label {p: "v"})-[:TYPE*1..3]->(b)
WHERE <comparisons on properties>
RETURN <vars / props>
LIMIT n
```

- **13 documented node labels** (PascalCase → lowercase `kind` on the DB side): `Project`, `Package`, `Folder`, `File`, `Module`, `Class`, `Function`, `Method`, `Interface`, `Enum`, `Type`, `Route`, `Resource`. Unknown labels are rejected with the valid-options list.
- **Edge types** accepted as any string (the schema has no CHECK on `edges.type`, matching `traverse`'s no-reject behavior); 20+ documented types pass through.
- **Direction**: outgoing `-[...]->`, incoming `<-[...]-`, undirected `-[...]-` (and the `--[...]--` long form).
- **Variable-length hops**: `*N`, `*N..M`, `*..M`. Unbounded `*` and `*..` are **rejected** (rejection table).
- **WHERE**: `= <> != > < >= <=`, combined with `AND` / `OR` (flat OR-of-AND). Property keys accept camelCase + snake_case aliases (`name`, `qualifiedName`/`qualified_name`, `label`/`kind`, `filePath`/`file_path`, `nodeId`/`id`).
- **RETURN**: `var` or `var.prop`. `RETURN *` is **rejected** as outside the subset.
- **LIMIT n** with the rule-27 zero-guard.

## Read-only by construction

The parser only recognizes `MATCH`, `WHERE`, `RETURN`, `LIMIT`, `AND`, `OR`, `true`, `false`, `null`. Every write clause (`CREATE`/`MERGE`/`SET`/`DELETE`/`DETACH`/`REMOVE`/`DROP`/`FOREACH`/`LOAD`) and every outside clause (`WITH`/`ORDER BY`/`UNION`/`CALL`/`YIELD`/`OPTIONAL`/`EXPLAIN`/`PROFILE`/`UNWIND`/`DISTINCT`/`AS`/aggregations/pattern predicates) is rejected with `code: "unsupported_clause"` and a message naming the supported grammar. **No SQL string is assembled from user input anywhere** — the structured `searchGraph`/`traverse` API already parameterizes every bind (rule 51).

## Compile target

- Single-node `MATCH (a:Label)` → `searchGraph({ label })` + JS post-filter for inline properties + WHERE.
- Relationship `MATCH (a)-[:T*min..max]->(b)` → `traverse({ start, direction, edgeTypes, maxDepth })`, filtered to depth ∈ [min, max].
- Multi-hop chains (`(a)-[:T]->(b)-[:U]->(c)`) grow bindings left-to-right across the pattern.

## Files

- `packages/coding-graph/src/cypher/query-parser.ts` — parser + executor (new, ~1.1k LOC incl. grammar doc + comments)
- `packages/coding-graph/src/cypher/query-parser.test.ts` — accept/reject suites (new, 48 tests)
- `packages/coding-graph/src/index.ts` — re-export the public Cypher API
- `packages/coding-graph/package.json` — `./cypher` subpath export
- `packages/coding-graph/tsup.config.ts` — standalone bundle for the subpath

**Isolated to `@remnic/coding-graph`** — no core files touched.

## Acceptance (issue #1552 done-when)

- ✅ Cypher accept/reject suites green — **48/48** (every documented form parses + executes against a synthetic fixture graph with exact-set assertions; every rejection-table entry produces the right tagged failure code).
- ✅ coding-graph build + full suite green — **209/209**.
- ✅ Ratchets clean — `[ratchet] OK` (no god-file LOC touched).
- ✅ `npm run preflight:quick` — `[preflight] OK (quick)`.

## Chokepoints used / not applicable

Not applicable — this is a new isolated module that consumes the existing structured `searchGraph`/`traverse` API (which already parameterizes every bind). No new MCP tool, HTTP route, CLI command, config flag, or mutation path is introduced.

## Prove-fail-before

A deliberate break of the depth-cap filter, the direction resolver, or any rejection-table entry on a scratch branch fails the corresponding test (the accept suite uses exact-set assertions and the reject suite asserts the exact failure code).

## Checklist

- [x] All tests pass (`pnpm --filter @remnic/coding-graph test` — 209/209)
- [x] All new logic is covered by tests (48 cypher tests, accept + reject)
- [x] Type-check passes (`tsc --noEmit`)
- [x] Build passes (`tsup`)
- [x] Docs/comments updated (grammar spec in the module doc comment)
- [x] No secrets or creds committed
- [x] PR diff ≤ 400 LOC of logic (the bulk is the grammar-spec doc comment + the 48-test suite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New user-facing query execution path with documented scale/semantics caveats (1000-row search cap, BFS shortest-path depth), but read-only and backed by parameterized store APIs; changes are confined to the optional coding-graph package.
> 
> **Overview**
> Adds a **read-only openCypher layer** on `@remnic/coding-graph` that parses `MATCH` / `WHERE` / `RETURN` / `LIMIT` queries and runs them by compiling to existing **`searchGraph`** and **`traverse`** calls—no user-controlled SQL assembly.
> 
> **`parseCypher`**, **`executeCypher`**, and **`executeAst`** expose tagged failures (`unsupported_clause`, `unknown_label`, `unbound_variable`, etc.) for writes, unbounded `*`, bad labels, and other out-of-subset syntax. The executor handles relationship directions, bounded hop ranges, multi-hop patterns, anonymous nodes, **`:Label` on relationship targets**, and **index pushdown** for `name` / `file_path` (with a guard so `_` / `%` are not pushed as LIKE wildcards).
> 
> Packaging: new **`./cypher`** subpath, root re-exports in **`index.ts`**, and a **`tsup`** entry for a standalone bundle. **`query-parser.test.ts`** adds accept/reject suites against a synthetic fixture graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 300808d60e8afae160b834c71d75a6dd00e676ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->