### PR TITLE
feat(ratchet): pin ad-hoc namespace-resolution call sites (#1521)

### DIFF
--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -14,6 +14,14 @@
  *                                comments/strings too, but the baseline is
  *                                measured with the same rule, so the ratchet
  *                                direction stays meaningful).
+ *   4. adHocNamespaceResolutions — call sites of the ad-hoc namespace-resolution
+ *                                helpers (`resolveWritableNamespace` /
+ *                                `namespaceFromStorageDir` /
+ *                                `configuredNamespaces`) outside the ScopePlan
+ *                                resolver module (scopes/scope-plan.ts). Every
+ *                                read/write path should consume a resolved
+ *                                ScopePlan instead (issue #1521); this ratchet
+ *                                pins the residual count so it can only shrink.
  *
  * Improvements pass and print a reminder to tighten the baseline with:
  *   node scripts/check-ratchets.mjs --update
@@ -51,6 +59,16 @@ const WATCHLIST = [
 ];
 
 const FLAG_READ_RE = /\bconfig\.[A-Za-z0-9_]+Enabled\b/g;
+/**
+ * Ad-hoc namespace-resolution call sites (issue #1521): occurrences of the
+ * three legacy resolution helpers outside the ScopePlan resolver module. The
+ * goal is zero — every path should resolve through `resolveScopePlan` instead.
+ * The `\s*\(` anchor targets call/definition sites, excluding local
+ * variables named `configuredNamespaces` (e.g. `const configuredNamespaces = …`).
+ */
+const ADHOC_RESOLUTION_RE =
+  /\b(resolveWritableNamespace|namespaceFromStorageDir|configuredNamespaces)\s*\(/g;
+const SCOPE_PLAN_REL = "packages/remnic-core/src/scopes/scope-plan.ts";
 const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".git"]);
 
 function usage() {
@@ -123,6 +141,7 @@ function collectMetrics(oversizeThresholdLoc) {
   const sourceFiles = walkSourceFiles(CORE_SRC).sort();
   const oversizedFiles = [];
   let scatteredConfigFlagReads = 0;
+  let adHocNamespaceResolutions = 0;
   for (const file of sourceFiles) {
     const relPosix = toPosix(path.relative(ROOT, file));
     const content = readFileSync(file, "utf8");
@@ -136,6 +155,12 @@ function collectMetrics(oversizeThresholdLoc) {
         scatteredConfigFlagReads += matches.length;
       }
     }
+    if (relPosix !== SCOPE_PLAN_REL) {
+      const adHocMatches = content.match(ADHOC_RESOLUTION_RE);
+      if (adHocMatches) {
+        adHocNamespaceResolutions += adHocMatches.length;
+      }
+    }
   }
 
   return {
@@ -144,6 +169,7 @@ function collectMetrics(oversizeThresholdLoc) {
     oversizedFiles,
     oversizedFileCount: oversizedFiles.length,
     scatteredConfigFlagReads,
+    adHocNamespaceResolutions,
   };
 }
 
@@ -178,7 +204,7 @@ function readBaseline() {
       fail(`baseline metrics.watchlistLoc entry ${file} must be a non-negative integer`);
     }
   }
-  for (const key of ["oversizedFileCount", "scatteredConfigFlagReads"]) {
+  for (const key of ["oversizedFileCount", "scatteredConfigFlagReads", "adHocNamespaceResolutions"]) {
     if (!Number.isInteger(metrics[key]) || metrics[key] < 0) {
       fail(`baseline metrics.${key} must be a non-negative integer`);
     }
@@ -201,6 +227,7 @@ function writeBaseline(metrics, oversizeThresholdLoc) {
       watchlistLoc: metrics.watchlistLoc,
       oversizedFileCount: metrics.oversizedFileCount,
       scatteredConfigFlagReads: metrics.scatteredConfigFlagReads,
+      adHocNamespaceResolutions: metrics.adHocNamespaceResolutions,
     },
   };
   writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
@@ -239,6 +266,7 @@ function main() {
     }
     console.log(`[ratchet]   oversizedFileCount (> ${DEFAULT_OVERSIZE_THRESHOLD_LOC} LOC): ${metrics.oversizedFileCount}`);
     console.log(`[ratchet]   scatteredConfigFlagReads: ${metrics.scatteredConfigFlagReads}`);
+    console.log(`[ratchet]   adHocNamespaceResolutions: ${metrics.adHocNamespaceResolutions}`);
     return;
   }
 
@@ -299,6 +327,17 @@ function main() {
   } else if (current.scatteredConfigFlagReads < baseline.metrics.scatteredConfigFlagReads) {
     improvements.push(
       `scattered config.*Enabled reads: ${baseline.metrics.scatteredConfigFlagReads} -> ${current.scatteredConfigFlagReads}`,
+    );
+  }
+
+  if (current.adHocNamespaceResolutions > baseline.metrics.adHocNamespaceResolutions) {
+    failures.push(
+      `ad-hoc namespace-resolution call sites grew from ${baseline.metrics.adHocNamespaceResolutions} ` +
+        `to ${current.adHocNamespaceResolutions} (resolve through the ScopePlan resolver instead; see #1521)`,
+    );
+  } else if (current.adHocNamespaceResolutions < baseline.metrics.adHocNamespaceResolutions) {
+    improvements.push(
+      `ad-hoc namespace-resolution call sites: ${baseline.metrics.adHocNamespaceResolutions} -> ${current.adHocNamespaceResolutions}`,
     );
   }
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -11,6 +11,7 @@
       "packages/remnic-core/src/config.ts": 4558
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 559
+    "scatteredConfigFlagReads": 559,
+    "adHocNamespaceResolutions": 51
   }
 }

--- a/tests/check-ratchets.test.mjs
+++ b/tests/check-ratchets.test.mjs
@@ -189,6 +189,49 @@ test("watchlist/baseline drift fails in both directions", () => {
   });
 });
 
+test("--update counts ad-hoc namespace-resolution call sites outside scope-plan.ts", () => {
+  withFixture((fixture) => {
+    // Add a file with two ad-hoc resolution call sites.
+    writeFileSync(
+      path.join(fixture.src, "gadget.ts"),
+      "const a = this.resolveWritableNamespace(ns);\n" +
+        "const b = this.namespaceFromStorageDir(dir);\n" +
+        "const c = this.configuredNamespaces();\n",
+    );
+    // scope-plan.ts is excluded — its call sites must NOT count.
+    mkdirSync(path.join(fixture.src, "scopes"), { recursive: true });
+    writeFileSync(
+      path.join(fixture.src, "scopes", "scope-plan.ts"),
+      "const x = this.resolveWritableNamespace(ns);\n",
+    );
+
+    const update = runRatchets(["--update"], fixture);
+    assert.equal(update.status, 0, update.stderr);
+    const baseline = JSON.parse(readFileSync(fixture.baseline, "utf8"));
+    assert.equal(baseline.metrics.adHocNamespaceResolutions, 3);
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 0, check.stderr);
+    assert.match(check.stdout, /\[ratchet\] OK/);
+  });
+});
+
+test("new ad-hoc namespace-resolution call sites fail the check", () => {
+  withFixture((fixture) => {
+    writeFileSync(
+      path.join(fixture.src, "gadget.ts"),
+      "const a = this.resolveWritableNamespace(ns);\n",
+    );
+    assert.equal(runRatchets(["--update"], fixture).status, 0);
+
+    appendFileSync(path.join(fixture.src, "gadget.ts"), "const b = this.configuredNamespaces();\n");
+
+    const check = runRatchets([], fixture);
+    assert.equal(check.status, 1);
+    assert.match(check.stderr, /ad-hoc namespace-resolution call sites grew from 1 to 2/);
+  });
+});
+
 test("unknown arguments are rejected with usage", () => {
   withFixture((fixture) => {
     const result = runRatchets(["--bogus"], fixture);


### PR DESCRIPTION
## Summary

Closes done-when **criterion 4** of #1521: *"a new ratchet metric pins the count."*

Criteria 1–3 are already met on main:
- ✅ `resolveScopePlan` adopted across recall tiers (read paths migrated)
- ✅ Ad-hoc resolvers have zero **new** call sites outside `scope-plan.ts`
- ✅ Parity test exists in `scopes/scope-plan.test.ts`

This PR adds the missing ratchet: a new `adHocNamespaceResolutions` metric in `scripts/check-ratchets.mjs` that counts call sites of the three ad-hoc namespace-resolution helpers (`resolveWritableNamespace` / `namespaceFromStorageDir` / `configuredNamespaces`) **outside** the ScopePlan resolver module (`scopes/scope-plan.ts`), and pins the count at the current floor so a regression that reintroduces ad-hoc resolution fails the ratchet.

## Changes

| File | Change |
|---|---|
| `scripts/check-ratchets.mjs` | New `adHocNamespaceResolutions` metric: regex counts `\b(resolveWritableNamespace\|namespaceFromStorageDir\|configuredNamespaces)\s*\(` in non-test `.ts` source files excluding `scopes/scope-plan.ts`. Added to `collectMetrics`, `readBaseline` validation, `writeBaseline`, `--update` output, and the comparison/failure logic. |
| `scripts/ratchet-baseline.json` | Pinned at **51** (current floor): 33 in `access-service.ts`, 16 in `orchestrator.ts`, 2 in `maintenance/namespace-planner.ts`). |
| `tests/check-ratchets.test.mjs` | 2 new tests: (1) `--update` counts ad-hoc call sites and excludes `scope-plan.ts`; (2) a new call site fails the check. |

## Design notes

- The `\s*\(` anchor targets call/definition sites, correctly **excluding** local variables named `configuredNamespaces` (e.g. `const configuredNamespaces = new Set<string>()` in `access-service.ts`).
- Test files excluded by `walkSourceFiles` (`.test.ts` filter); `scope-plan.ts` excluded as the resolver module where delegation to these helpers is legitimate.
- Same heuristic-noise tolerance as the existing `scatteredConfigFlagReads` metric: comments mentioning the function names with parens count, but the baseline is measured with the same rule so the ratchet direction stays meaningful.
- Future PRs migrating the write-side boundary and maintenance paths to `resolveScopePlan` will **reduce** this count and tighten the baseline.

## Prove-fail

Seeded a violating call site (`this.resolveWritableNamespace(request.namespace)` in a comment in `types.ts`), ran the ratchet:

```
[ratchet] structural ratchet exceeded — this change grows debt tracked in #1520:
[ratchet]   - ad-hoc namespace-resolution call sites grew from 51 to 52 (resolve through the ScopePlan resolver instead; see #1521)
```

Exit code 1. ✅ Removed the violation → exit code 0, `[ratchet] OK`.

## Verification

- `node scripts/check-ratchets.mjs` → `[ratchet] OK`
- `node --test tests/check-ratchets.test.mjs` → 12/12 pass (including 2 new tests)
- Prove-fail: violation detected and rejected

**Chokepoints used:** ratchet baseline (`scripts/check-ratchets.mjs`).
**Chokepoints not applicable:** ScopePlan resolver, catalog write chokepoint, CapabilitySet, operation registry, serialize-mutations — this PR is ratchet-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only ratchet script, baseline JSON, and tests; no runtime or production code paths change.
> 
> **Overview**
> Adds a fourth structural ratchet metric, **`adHocNamespaceResolutions`**, so CI fails if new call sites appear for the legacy namespace helpers (`resolveWritableNamespace`, `namespaceFromStorageDir`, `configuredNamespaces`) outside `scopes/scope-plan.ts` (#1521).
> 
> `check-ratchets.mjs` counts matches via regex (call sites only, not `const configuredNamespaces = …`), wires the metric through baseline read/write, `--update` logging, and grow/shrink comparison like the existing flag-read ratchet. **`ratchet-baseline.json`** is pinned at **51** current call sites. **`tests/check-ratchets.test.mjs`** adds coverage for exclusion of `scope-plan.ts` and for regression when the count increases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78a66e77dbde8c73fcfccdab67947fb28ec0009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->