### PR TITLE
refactor(recall): unify four recall pipelines behind one staged spine (#1539 PRs 3-6)

### DIFF
--- a/packages/remnic-core/src/event-order-recall.test.ts
+++ b/packages/remnic-core/src/event-order-recall.test.ts
@@ -216,6 +216,59 @@ test("event order recall keeps summary within the section budget", async () => {
   assert.match(recalled, /^## Chronological event evidence/);
 });
 
+test("event order recall budgets the outline BEFORE evidence so the total never exceeds maxChars (#1539 fix)", async () => {
+  // Issue #1539 step 4 (the ONE declared behavior change): pre-fix, event-order
+  // built the evidence pack at the FULL budget, then appended the chronology
+  // outline + summary, then clipped — which could silently exceed maxChars
+  // (the outline consumed space the evidence pack had already filled). Post-fix,
+  // the summary (incl. outline) is computed FIRST and its length subtracted from
+  // the evidence budget, so evidence + summary = budget exactly.
+  //
+  // This test uses a fixture rich enough to produce a non-empty chronology
+  // outline, then asserts the total fits the budget with the outline present.
+  const sessionId = "event-order-outline-budget-fix";
+  const engine = new FakeEventOrderEngine(sessionId, [
+    {
+      turn_index: 10,
+      role: "user",
+      content:
+        "I first brought up passive voice reduction and checklist in my writing process.",
+    },
+    {
+      turn_index: 30,
+      role: "user",
+      content:
+        "Later I discussed webinar planning and promotion for the workshop series.",
+    },
+    {
+      turn_index: 50,
+      role: "user",
+      content:
+        "After that I focused on engagement and incentives discussion with the team.",
+    },
+  ]);
+
+  const maxChars = 600;
+  const recalled = await buildEventOrderRecallSection({
+    engine,
+    sessionId,
+    query:
+      "Can you walk me through the order in which I brought up different aspects of my personal and professional progress throughout our conversations, in order? Mention ONLY and ONLY three items.",
+    maxChars,
+    maxScanWindowTurns: 4,
+  });
+
+  assert.ok(recalled.length > 0);
+  // The fix guarantees the total (evidence + summary + outline) fits the budget.
+  assert.ok(
+    recalled.length <= maxChars,
+    `expected recalled section length ${recalled.length} to fit ${maxChars}`,
+  );
+  // The outline must be present — the fix guarantees it is budgeted for, not
+  // clipped away by evidence that consumed the full budget.
+  assert.match(recalled, /Chronology outline:/);
+});
+
 test("event order recall returns relevant user turns in chronological order", async () => {
   const sessionId = "event-order-core";
   const engine = new FakeEventOrderEngine(sessionId, [

--- a/packages/remnic-core/src/event-order-recall.ts
+++ b/packages/remnic-core/src/event-order-recall.ts
@@ -1,6 +1,11 @@
 import { buildEvidencePack, type EvidencePackItem } from "./evidence-pack.js";
 import type { ExplicitCueRecallEngine } from "./explicit-cue-recall.js";
 
+import {
+  unifiedDedupeAndRank,
+  type RankedEvidenceItem,
+} from "./recall-pipeline-stages.js";
+
 export interface EventOrderRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   // event-order reads a SINGLE LCM session key. Unlike the relevance-ranked
@@ -16,10 +21,6 @@ export interface EventOrderRecallOptions {
   maxScanWindowTokens?: number;
   maxItems?: number;
   title?: string;
-}
-
-interface RankedEventItem extends EvidencePackItem {
-  rank: number;
 }
 
 const DEFAULT_SCAN_WINDOW_TURNS = 12;
@@ -67,15 +68,14 @@ export async function buildEventOrderRecallSection(
   }
 
   const title = options.title ?? "Chronological event evidence";
-  const evidence = buildEvidencePack(ranked, {
-    title,
-    maxChars: budget,
-    maxItemChars: options.maxItemChars,
-  });
-  if (!evidence) {
-    return "";
-  }
 
+  // Issue #1539 step 4 (the ONE declared behavior change): budget the outline
+  // BEFORE building evidence, matching guidance/targeted-fact. Previously
+  // event-order built the evidence pack at the FULL budget, then appended the
+  // chronology outline, then clipped the total — which could silently exceed
+  // maxChars (the outline consumed space the evidence pack had already filled).
+  // Now the summary (incl. outline) is computed first and its length subtracted
+  // from the evidence budget, so evidence + summary = budget exactly.
   const requested = parseRequestedItemCount(options.query);
   const outlineSource = requested
     ? rankEventOrderItemsForOutline(items, options.query).slice(0, maxItems)
@@ -87,8 +87,20 @@ export async function buildEventOrderRecallSection(
     outline,
     "Use these turns to preserve the order in which the user raised the topics.",
   ].filter(Boolean).join(" ");
+  const summaryInsert = `\n\n${summary}`;
+  const evidenceBudget = Math.max(0, budget - summaryInsert.length);
+  const evidence = buildEvidencePack(ranked, {
+    title,
+    maxChars: evidenceBudget,
+    maxItemChars: options.maxItemChars,
+  });
+  if (!evidence) {
+    // If no evidence fit the residual budget, still emit the summary clipped to
+    // budget (matches targeted-fact's empty-evidence-with-summary fallback).
+    return clipSectionToBudget(`## ${title}${summaryInsert}`, budget);
+  }
   return clipSectionToBudget(
-    evidence.replace(`## ${title}`, `## ${title}\n\n${summary}`),
+    evidence.replace(`## ${title}`, `## ${title}${summaryInsert}`),
     budget,
   );
 }
@@ -148,23 +160,28 @@ function rankAndSelectEventOrderItems(
   items: EvidencePackItem[],
   options: EventOrderRecallOptions,
   maxItems: number,
-): RankedEventItem[] {
+): RankedEvidenceItem[] {
   const requested = parseRequestedItemCount(options.query);
-  const rankedByScore = items
-    .map((item) => ({
-      ...item,
-      rank: scoreEventOrderItem(item, options.query),
-    }))
-    .filter((item) => item.rank >= 6)
-    .sort((left, right) => {
-      if (right.rank !== left.rank) return right.rank - left.rank;
-      const leftTurn = typeof left.turnIndex === "number" ? left.turnIndex : Number.MAX_SAFE_INTEGER;
-      const rightTurn = typeof right.turnIndex === "number" ? right.turnIndex : Number.MAX_SAFE_INTEGER;
-      if (leftTurn !== rightTurn) return leftTurn - rightTurn;
-      return left.content.localeCompare(right.content);
-    });
+  // Issue #1539 PR6: rank + threshold-filter + sort now route through the
+  // unified spine. Event-order's three declared divergences are named config
+  // fields: rankThreshold:6 (was an undocumented inline .filter), ASC sort
+  // direction (was a byte-identical comparator copy with flipped direction),
+  // and dedupByContent:false (event-order keeps distinct turns — turn_index is
+  // local to each session_id, so chronology must not collapse same-body turns).
+  // The spine's id-dedup is a no-op here: event-order reads a single session
+  // with unique per-turn ids (no cross-key merge, per the #1505 opt-out).
+  // Content is already cue-appended during collection; the spine scores on the
+  // (already-transformed) item.content, matching the prior inline behavior.
+  const rankedByScore = unifiedDedupeAndRank(items, {
+    query: options.query,
+    intents: [],
+    scoreEvidence: (item, q) => scoreEventOrderItem(item, q),
+    rankThreshold: 6,
+    dedupByContent: false,
+    turnIndexSortDirection: "asc",
+  });
 
-  const selectedById = new Map<string, RankedEventItem>();
+  const selectedById = new Map<string, RankedEvidenceItem>();
   if (requested) {
     const queryTerms = extractEventOrderTerms(options.query);
     const tailReserve = Math.min(
@@ -254,13 +271,20 @@ function rankAndSelectEventOrderItems(
 function rankEventOrderItemsForOutline(
   items: readonly EvidencePackItem[],
   query: string,
-): RankedEventItem[] {
-  return items
-    .map((item) => ({
-      ...item,
-      rank: scoreEventOrderItem(item, query),
-    }))
-    .filter((item) => item.rank >= 6);
+): RankedEvidenceItem[] {
+  // Issue #1539 PR6: the outline source uses the same declared config as the
+  // main rank pass (rankThreshold:6, dedupByContent:false) but preserves
+  // collection order via preserveInsertionOrder — the outline renders turns in
+  // the order they were collected (chronological by session scan), not in
+  // rank-sorted order.
+  return unifiedDedupeAndRank(items, {
+    query,
+    intents: [],
+    scoreEvidence: (item, q) => scoreEventOrderItem(item, q),
+    rankThreshold: 6,
+    dedupByContent: false,
+    preserveInsertionOrder: true,
+  });
 }
 
 function eventItemSelectionKey(item: EvidencePackItem): string {
@@ -527,7 +551,7 @@ function appendChronologicalCues(content: string, query: string): string {
 }
 
 function buildChronologyOutline(
-  items: readonly RankedEventItem[],
+  items: readonly RankedEvidenceItem[],
   query: string,
   requested?: number,
 ): string {
@@ -584,7 +608,7 @@ function buildChronologyOutline(
 }
 
 function collectChronologyOutlineCandidates(
-  items: readonly RankedEventItem[],
+  items: readonly RankedEvidenceItem[],
   query: string,
 ): Array<{ turn: number; label: string; priority: number }> {
   const terms = extractEventOrderTerms(query);

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -3,6 +3,7 @@ import {
   gatherAcrossReadSessions,
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
+import { unifiedDedupeAndRank } from "./recall-pipeline-stages.js";
 
 export interface ExplicitCueRecallEngine {
   expandContext(
@@ -410,7 +411,26 @@ export async function buildExplicitCueRecallSection(
     includeContentLexicalCues: options.includeContentLexicalCues,
     includeStructuredPlanCues: options.includeStructuredPlanCues,
   });
-  return buildEvidencePack(evidenceItems, {
+  // Issue #1539 PR5: route through the unified spine to declare explicit-cue's
+  // policy explicitly. The call is behavior-idempotent — items are already
+  // deduped by `seenTurns` during collection (so the spine's id-dedup matches
+  // exactly), the constant scorer assigns rank=0 which `buildEvidencePack`
+  // ignores, and `preserveInsertionOrder` skips the sort so the deliberate
+  // value ordering (turn references -> content cues -> lexical cues, by evidence
+  // type then read-key priority) is preserved byte-for-byte.
+  //
+  // The value is the DECLARED config: a fifth recall pipeline would be a config
+  // file, and this config documents explicit-cue's opt-outs (no scoring, id-only
+  // dedup, insertion-order preservation) as named fields instead of embedded
+  // code. See recall-pipeline-stages.ts for the spine contract.
+  const rankedEvidenceItems = unifiedDedupeAndRank(evidenceItems, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 0,
+    dedupByContent: false,
+    preserveInsertionOrder: true,
+  });
+  return buildEvidencePack(rankedEvidenceItems, {
     title: "Explicit Cue Evidence",
     query: evidenceFocusQuery,
     maxChars,

--- a/packages/remnic-core/src/recall-pipeline-parity.test.ts
+++ b/packages/remnic-core/src/recall-pipeline-parity.test.ts
@@ -139,25 +139,48 @@ test("parity response-guidance: rank primary key always DESC regardless of turnI
 });
 
 // ---------------------------------------------------------------------------
-// PR5 — explicit-cue shape: no scoring (constant scorer — the "intentional
-// no-scoring behavior" made explicit by the config), DESC default, content-dedup.
+// PR5 — explicit-cue shape: the pipeline that OPTS OUT of scoring AND sorting.
+// Its deliberate value ordering (turn references -> content cues -> lexical
+// cues, by evidence type then read-key priority) is the highest-value design
+// choice — preserved verbatim via preserveInsertionOrder + constant scorer +
+// id-only dedup (the spine call is behavior-idempotent; items are already
+// deduped by seenTurns during collection).
 // ---------------------------------------------------------------------------
 
-test("parity explicit-cue: constant scorer reduces to turnIndex DESC ordering", () => {
+test("parity explicit-cue: preserveInsertionOrder keeps collection order intact", () => {
+  // Insertion order is 2, 4, 1. A default sort would reorder to 4, 2, 1.
+  // explicit-cue must NOT reorder — the collection order IS the value order.
   const items = [
-    item(2, "explicit cue b"),
-    item(4, "explicit cue a"),
-    item(1, "explicit cue c"),
+    item(2, "explicit cue b", { id: "s:2" }),
+    item(4, "explicit cue a", { id: "s:4" }),
+    item(1, "explicit cue c", { id: "s:1" }),
   ];
   const ranked = unifiedDedupeAndRank(items, {
     query: "",
     intents: [],
-    scoreEvidence: () => 1, // explicit-cue does not score
+    scoreEvidence: () => 0,
+    dedupByContent: false,
+    preserveInsertionOrder: true,
   });
   assert.deepEqual(
     ranked.map((r) => r.turnIndex),
-    [4, 2, 1],
+    [2, 4, 1],
   );
+});
+
+test("parity explicit-cue: id-only dedup (dedupByContent false) keeps distinct turns", () => {
+  const items = [
+    item(1, "same body", { id: "s:1" }),
+    item(2, "same body", { id: "s:2" }),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 0,
+    dedupByContent: false,
+    preserveInsertionOrder: true,
+  });
+  assert.equal(ranked.length, 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/recall-pipeline-parity.test.ts
+++ b/packages/remnic-core/src/recall-pipeline-parity.test.ts
@@ -1,0 +1,265 @@
+// Issue #1539 PRs 3–6 — migration parity guards.
+//
+// Each recall pipeline (targeted-fact, response-guidance, explicit-cue,
+// event-order) was migrated from an inline dedup/score/threshold/sort block to
+// a thin config object handed to `unifiedDedupeAndRank` (the spine). The
+// per-tier test files (targeted-fact-recall.test.ts etc.) are the end-to-end
+// characterization — they exercise buildXxxRecallSection on full fixtures. This
+// file is the SEAM guard: it pins, per pipeline, that the declared config shape
+// routes through the spine with the correct divergence (sort direction,
+// content-dedup on/off, rank threshold, transform-applied-to-output-but-not-
+// score). If a future refactor flips one of these silently, the matching test
+// here fails BEFORE the end-to-end suites have a chance to mask it.
+//
+// These tests do NOT re-implement the per-tier scorers — those are genuinely
+// per-tier policy and stay in the per-tier test files. Here we use small
+// representative scorers that exercise the divergence dimension each pipeline
+// declares on the spine.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { EvidencePackItem } from "./evidence-pack.js";
+import { unifiedDedupeAndRank } from "./recall-pipeline-stages.js";
+
+function item(
+  turnIndex: number,
+  content: string,
+  overrides: Partial<EvidencePackItem> = {},
+): EvidencePackItem {
+  return {
+    id: `s1:${turnIndex}`,
+    sessionId: "s1",
+    turnIndex,
+    role: "user",
+    content,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PR3 — targeted-fact shape: DESC, content-dedup, transform-applied-to-output,
+// score-on-original. No rank threshold.
+// ---------------------------------------------------------------------------
+
+test("parity targeted-fact: DESC ordering on score ties (latest turnIndex first)", () => {
+  const items = [
+    item(1, "early turn"),
+    item(5, "late turn"),
+    item(3, "middle turn"),
+  ];
+  // Constant scorer forces score ties so turnIndex DESC is the deciding key.
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+  });
+  assert.equal(ranked[0].turnIndex, 5);
+  assert.equal(ranked[1].turnIndex, 3);
+  assert.equal(ranked[2].turnIndex, 1);
+});
+
+test("parity targeted-fact: content transform applied to output, NOT to scorer input", () => {
+  const items = [item(2, "Revenue was $500")];
+  // A scorer that reads ORIGINAL content must NOT see the appended cue suffix.
+  let scorerObserved = "";
+  unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: (original) => {
+      scorerObserved = original.content;
+      return 1;
+    },
+    transformContent: (content) => `${content} [CUE]`,
+  });
+  assert.equal(scorerObserved, "Revenue was $500");
+  // ...and the output content carries the transform:
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 1,
+    transformContent: (content) => `${content} [CUE]`,
+  });
+  assert.equal(ranked[0].content, "Revenue was $500 [CUE]");
+});
+
+test("parity targeted-fact: duplicate normalized content collapses (default dedupByContent)", () => {
+  const items = [
+    item(1, "Same content"),
+    item(2, "same   content"), // whitespace/case differences normalize equal
+    item(3, "Distinct"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+  });
+  assert.equal(ranked.length, 2);
+  // First-seen wins: turnIndex 1 is kept, turnIndex 2 (same normalized content)
+  // is dropped. Output is then sorted DESC by turnIndex on the score tie.
+  assert.deepEqual(
+    ranked.map((r) => r.turnIndex),
+    [3, 1],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// PR4 — response-guidance shape: same as targeted-fact (DESC + content-dedup +
+// transform + score-on-original) but with guidance-cue transform. Pin the shape
+// matches; the guidance-specific transform is exercised end-to-end in
+// response-guidance-recall.test.ts.
+// ---------------------------------------------------------------------------
+
+test("parity response-guidance: DESC ordering on score ties", () => {
+  const items = [
+    item(2, "guidance b"),
+    item(7, "guidance a"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 5,
+  });
+  assert.equal(ranked[0].turnIndex, 7);
+  assert.equal(ranked[1].turnIndex, 2);
+});
+
+test("parity response-guidance: rank primary key always DESC regardless of turnIndex", () => {
+  const items = [
+    item(1, "low rank high turnIndex"),
+    item(9, "high rank low turnIndex"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: (original) => (original.content.includes("high rank") ? 20 : 1),
+  });
+  assert.equal(ranked[0].turnIndex, 9);
+  assert.equal(ranked[1].turnIndex, 1);
+});
+
+// ---------------------------------------------------------------------------
+// PR5 — explicit-cue shape: no scoring (constant scorer — the "intentional
+// no-scoring behavior" made explicit by the config), DESC default, content-dedup.
+// ---------------------------------------------------------------------------
+
+test("parity explicit-cue: constant scorer reduces to turnIndex DESC ordering", () => {
+  const items = [
+    item(2, "explicit cue b"),
+    item(4, "explicit cue a"),
+    item(1, "explicit cue c"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 1, // explicit-cue does not score
+  });
+  assert.deepEqual(
+    ranked.map((r) => r.turnIndex),
+    [4, 2, 1],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// PR6 — event-order shape: ASC ordering, NO content-dedup (dedupByContent:false
+// keeps distinct turns even when cue-appended bodies match), declared
+// rankThreshold of 6, transform applied to output.
+// ---------------------------------------------------------------------------
+
+test("parity event-order: ASC ordering on rank ties (earliest turnIndex first)", () => {
+  const items = [
+    item(5, "turn five"),
+    item(1, "turn one"),
+    item(3, "turn three"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+    turnIndexSortDirection: "asc",
+  });
+  assert.deepEqual(
+    ranked.map((r) => r.turnIndex),
+    [1, 3, 5],
+  );
+});
+
+test("parity event-order: dedupByContent false keeps distinct turns with identical bodies", () => {
+  // Two distinct turns (different ids/turnIndex) but identical cue-appended body.
+  // Event-order MUST keep both — they are legitimate repeated turns in a
+  // chronological transcript. This is the cursor-bugbot a4299851 regression guard.
+  const items = [
+    item(1, "the user asked again"),
+    item(4, "the user asked again"),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+    dedupByContent: false,
+    turnIndexSortDirection: "asc",
+  });
+  assert.equal(ranked.length, 2);
+  assert.deepEqual(
+    ranked.map((r) => r.turnIndex),
+    [1, 4],
+  );
+});
+
+test("parity event-order: declared rankThreshold (6) drops below-threshold items", () => {
+  const items = [
+    item(1, "strong", { id: "s:1" }),
+    item(2, "weak", { id: "s:2" }),
+    item(3, "borderline", { id: "s:3" }),
+  ];
+  const ranked = unifiedDedupeAndRank(items, {
+    query: "",
+    intents: [],
+    scoreEvidence: (original) => {
+      if (original.content === "strong") return 10;
+      if (original.content === "borderline") return 6; // exactly threshold -> kept (>=)
+      return 5; // weak -> dropped
+    },
+    rankThreshold: 6,
+    turnIndexSortDirection: "asc",
+  });
+  // rank is ALWAYS DESC primary: strong (10) outranks borderline (6).
+  // turnIndex ASC only breaks ties within the same rank.
+  assert.deepEqual(
+    ranked.map((r) => r.content),
+    ["strong", "borderline"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Cross-pipeline divergence guard: the SAME corpus produces DIFFERENT orderings
+// under DESC vs ASC config. This is the core #1539 defect class — copy-pasting
+// the comparator into a chronological pipeline silently inverts ordering.
+// ---------------------------------------------------------------------------
+
+test("parity divergence: DESC vs ASC configs on the same corpus invert turnIndex ordering", () => {
+  const corpus = [
+    item(1, "a", { id: "x:1" }),
+    item(2, "b", { id: "x:2" }),
+    item(3, "c", { id: "x:3" }),
+  ];
+  const desc = unifiedDedupeAndRank(corpus, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+  });
+  const asc = unifiedDedupeAndRank(corpus, {
+    query: "",
+    intents: [],
+    scoreEvidence: () => 10,
+    turnIndexSortDirection: "asc",
+  });
+  assert.deepEqual(
+    desc.map((r) => r.turnIndex),
+    [3, 2, 1],
+  );
+  assert.deepEqual(
+    asc.map((r) => r.turnIndex),
+    [1, 2, 3],
+  );
+});

--- a/packages/remnic-core/src/recall-pipeline-stages.test.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.test.ts
@@ -267,3 +267,46 @@ test("unifiedDedupeAndRank: dedupByContent true (default) still collapses identi
   });
   assert.equal(resultExplicit.length, 1, "explicit dedupByContent: true collapses identical content");
 });
+
+test("unifiedDedupeAndRank: preserveInsertionOrder skips the sort stage (explicit-cue shape)", () => {
+  // Insertion order is turn-index 3, 1, 2. A DESC sort would reorder to 3, 2, 1.
+  // preserveInsertionOrder must keep the original (post-dedup) order: 3, 1, 2.
+  const items: EvidencePackItem[] = [
+    item(3, "turn ref", { id: "s:3" }),
+    item(1, "content cue", { id: "s:1" }),
+    item(2, "lexical hit", { id: "s:2" }),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: () => 0, // explicit-cue does not score
+    dedupByContent: false, // explicit-cue dedupes by id only (seenTurns)
+    preserveInsertionOrder: true,
+  });
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["s:3", "s:1", "s:2"],
+    "insertion order is preserved — no sort applied",
+  );
+});
+
+test("unifiedDedupeAndRank: preserveInsertionOrder still applies threshold filter", () => {
+  const items: EvidencePackItem[] = [
+    item(1, "strong", { id: "s:1" }),
+    item(2, "weak", { id: "s:2" }),
+    item(3, "medium", { id: "s:3" }),
+  ];
+  const result = unifiedDedupeAndRank(items, {
+    query: "q",
+    intents: NO_INTENTS,
+    scoreEvidence: (original) => (original.content === "strong" ? 10 : original.content === "medium" ? 5 : 1),
+    rankThreshold: 5,
+    dedupByContent: false,
+    preserveInsertionOrder: true,
+  });
+  // threshold drops "weak" (rank 1); insertion order of survivors preserved.
+  assert.deepEqual(
+    result.map((r) => r.id),
+    ["s:1", "s:3"],
+  );
+});

--- a/packages/remnic-core/src/recall-pipeline-stages.ts
+++ b/packages/remnic-core/src/recall-pipeline-stages.ts
@@ -125,6 +125,21 @@ export interface UnifiedRankConfig<TIntent> {
    * The rank primary key is ALWAYS DESC regardless of this setting.
    */
   turnIndexSortDirection?: TurnIndexSortDirection;
+  /**
+   * When `true`, skip the sort stage entirely and return items in their
+   * post-dedup insertion order (first-seen first). Used by explicit-cue,
+   * whose deliberate value ordering — turn references → content cues →
+   * lexical cues, gathered by evidence TYPE then read-key priority — is the
+   * pipeline's highest-value design choice. A rank-based sort would invert
+   * it (turn references are deliberately UNSCORED while lexical hits carry
+   * numeric scores; sorting by score would demote turn references below
+   * weak lexical hits — cursor[bot] / codex P2 on #1505).
+   *
+   * Score and threshold-filter still apply when declared; only the sort is
+   * skipped. The constant scorer (`scoreEvidence: () => 0`) makes the
+   * no-scoring policy explicit alongside this flag.
+   */
+  preserveInsertionOrder?: boolean;
 }
 
 /**
@@ -232,6 +247,13 @@ export function unifiedDedupeAndRank<TIntent>(
   // turnIndex direction is configurable: DESC (relevance) or ASC (chronology).
   // The tertiary tiebreaker follows the direction:
   //   DESC → score DESC; ASC → content.localeCompare.
+  //
+  // explicit-cue opts out of sorting entirely (preserveInsertionOrder) — its
+  // deliberate value ordering is the collection order (turn references →
+  // content cues → lexical cues), and a rank-based sort would invert it.
+  if (config.preserveInsertionOrder) {
+    return filtered;
+  }
   return filtered.sort(makeComparator(direction));
 }
 

--- a/packages/remnic-core/src/response-guidance-recall.ts
+++ b/packages/remnic-core/src/response-guidance-recall.ts
@@ -5,6 +5,11 @@ import {
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
 
+import {
+  unifiedDedupeAndRank,
+  type RankedEvidenceItem,
+} from "./recall-pipeline-stages.js";
+
 export interface ResponseGuidanceRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
@@ -22,10 +27,6 @@ export interface ResponseGuidanceRecallOptions {
   maxScanWindowTokens?: number;
   title?: string;
   forceGeneric?: boolean;
-}
-
-interface RankedGuidanceItem extends EvidencePackItem {
-  rank: number;
 }
 
 type GuidanceIntent =
@@ -341,42 +342,37 @@ async function collectGuidanceScanItems(
   return items;
 }
 
+/**
+ * Issue #1539 PR4: response-guidance now routes dedup/score/threshold/sort through
+ * the unified spine (`unifiedDedupeAndRank`). The divergence that lived inline
+ * here — append-guidance-cues content transform (two-arg: content + intents),
+ * relevance scoring on ORIGINAL content, default DESC turn-index ordering with
+ * -1 sentinel for missing turns — is now declared config on the spine. The score
+ * and appendGuidanceCues helpers stay in this module because they are genuinely
+ * per-tier policy; only the duplicated dedup/sort/threshold machinery moved out.
+ *
+ * Behavior is byte-for-byte identical to the inline implementation it replaces
+ * (the spine was extracted to match it exactly; see recall-pipeline-stages.ts).
+ * The response-guidance-recall.test.ts suite is the characterization.
+ *
+ * Note: response-guidance (like the pre-migration code) dedups on the TRANSFORMED
+ * (cue-appended) content, not the original — this matches the spine's default
+ * (transform-then-dedup) exactly. No divergence from prior behavior.
+ */
 function rankAndDedupeGuidanceItems(
   items: EvidencePackItem[],
   query: string,
   intents: readonly GuidanceIntent[],
-): RankedGuidanceItem[] {
-  const seenIds = new Set<string>();
-  const seenContent = new Set<string>();
-  const ranked: RankedGuidanceItem[] = [];
-
-  for (const item of items) {
-    const id = item.id ?? (
-      item.sessionId && typeof item.turnIndex === "number"
-        ? `${item.sessionId}:${item.turnIndex}`
-        : undefined
-    );
-    if (id && seenIds.has(id)) continue;
-
-    const enhancedContent = appendGuidanceCues(item.content, intents);
-    const contentKey = enhancedContent.toLowerCase().replace(/\s+/g, " ").trim();
-    if (seenContent.has(contentKey)) continue;
-
-    if (id) seenIds.add(id);
-    seenContent.add(contentKey);
-    ranked.push({
-      ...item,
-      content: enhancedContent,
-      rank: scoreGuidanceEvidence(item, query, intents),
-    });
-  }
-
-  return ranked.sort((left, right) => {
-    if (right.rank !== left.rank) return right.rank - left.rank;
-    const leftTurn = typeof left.turnIndex === "number" ? left.turnIndex : -1;
-    const rightTurn = typeof right.turnIndex === "number" ? right.turnIndex : -1;
-    if (rightTurn !== leftTurn) return rightTurn - leftTurn;
-    return (right.score ?? 0) - (left.score ?? 0);
+): RankedEvidenceItem[] {
+  // The spine's config.intents is typed TIntent[] (readability contract — it is
+  // never mutated). Cast the readonly array through; safe because the spine only
+  // forwards intents to the score/transform callbacks.
+  const mutableIntents = intents as GuidanceIntent[];
+  return unifiedDedupeAndRank(items, {
+    query,
+    intents: mutableIntents,
+    scoreEvidence: (item, q, intentArr) => scoreGuidanceEvidence(item, q, intentArr),
+    transformContent: (content, intentArr) => appendGuidanceCues(content, intentArr),
   });
 }
 

--- a/packages/remnic-core/src/targeted-fact-recall.ts
+++ b/packages/remnic-core/src/targeted-fact-recall.ts
@@ -9,6 +9,11 @@ import {
   resolveLcmReadSessionIds,
 } from "./lcm-fallback-read.js";
 
+import {
+  unifiedDedupeAndRank,
+  type RankedEvidenceItem,
+} from "./recall-pipeline-stages.js";
+
 export interface TargetedFactRecallOptions {
   engine: ExplicitCueRecallEngine | null | undefined;
   sessionId?: string;
@@ -25,10 +30,6 @@ export interface TargetedFactRecallOptions {
   maxScanWindowTurns?: number;
   maxScanWindowTokens?: number;
   title?: string;
-}
-
-interface RankedEvidenceItem extends EvidencePackItem {
-  rank: number;
 }
 
 const DEFAULT_MAX_SEARCH_RESULTS = 48;
@@ -210,38 +211,30 @@ async function collectTargetedFactScanItems(
   return items;
 }
 
+/**
+ * Issue #1539 PR3: targeted-fact now routes dedup/score/threshold/sort through
+ * the unified spine (`unifiedDedupeAndRank`). The divergence that lived inline
+ * here — append-normalized-numeric-cues content transform, relevance scoring on
+ * ORIGINAL content, default DESC turn-index ordering with -1 sentinel for
+ * missing turns — is now declared config on the spine. The score and
+ * appendNormalizedNumericCues helpers stay in this module because they are
+ * genuinely per-tier policy; only the duplicated dedup/sort/threshold machinery
+ * moved out.
+ *
+ * Behavior is byte-for-byte identical to the inline implementation it replaces
+ * (the spine was extracted to match it exactly; see recall-pipeline-stages.ts).
+ * The targeted-fact-recall.test.ts suite (42 cases, incl. the search/scan
+ * ordering and summary insertion tests) is the characterization.
+ */
 function rankAndDedupeTargetedFactItems(
   items: EvidencePackItem[],
   query: string,
 ): RankedEvidenceItem[] {
-  const seenIds = new Set<string>();
-  const seenContent = new Set<string>();
-  const ranked: RankedEvidenceItem[] = [];
-
-  for (const item of items) {
-    const id = item.id ?? (
-      item.sessionId && typeof item.turnIndex === "number"
-        ? `${item.sessionId}:${item.turnIndex}`
-        : undefined
-    );
-    if (id && seenIds.has(id)) continue;
-    const contentKey = item.content.toLowerCase().replace(/\s+/g, " ").trim();
-    if (seenContent.has(contentKey)) continue;
-    if (id) seenIds.add(id);
-    seenContent.add(contentKey);
-    ranked.push({
-      ...item,
-      content: appendNormalizedNumericCues(item.content),
-      rank: scoreTargetedFactEvidence(item, query),
-    });
-  }
-
-  return ranked.sort((left, right) => {
-    if (right.rank !== left.rank) return right.rank - left.rank;
-    const leftTurn = typeof left.turnIndex === "number" ? left.turnIndex : -1;
-    const rightTurn = typeof right.turnIndex === "number" ? right.turnIndex : -1;
-    if (rightTurn !== leftTurn) return rightTurn - leftTurn;
-    return (right.score ?? 0) - (left.score ?? 0);
+  return unifiedDedupeAndRank(items, {
+    query,
+    intents: [],
+    scoreEvidence: (item, q) => scoreTargetedFactEvidence(item, q),
+    transformContent: (content) => appendNormalizedNumericCues(content),
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #1539 (PRs 3–6 of 6). The four recall pipelines (`targeted-fact`, `response-guidance`, `explicit-cue`, `event-order`) now route their dedup/score/threshold/sort stages through `unifiedDedupeAndRank` (the spine extracted in PR2, already on main). Each pipeline is now a thin config + collection module; the spine owns the dedup/rank/budget/merge policy.

## What changed

### PR3 — targeted-fact (`targeted-fact-recall.ts`)
- `rankAndDedupeTargetedFactItems` → delegates to `unifiedDedupeAndRank` with: numeric-cues transform, original-content scoring, default DESC ordering.
- Behavior byte-for-byte identical (transform is injective, so dedup-on-original ≡ dedup-on-transformed).

### PR4 — response-guidance (`response-guidance-recall.ts`)
- `rankAndDedupeGuidanceItems` → delegates to spine with: two-arg guidance-cues transform (content + intents), original-content scoring, DESC ordering, dedup on transformed content (matching prior behavior).
- `readonly GuidanceIntent[]` cast through to spine `TIntent[]` (spine never mutates).

### PR5 — explicit-cue (`explicit-cue-recall.ts`)
- **New spine field**: `preserveInsertionOrder: boolean` — skips the sort stage entirely.
- explicit-cue opts out of both scoring AND sorting (its deliberate value ordering: turn refs → content cues → lexical cues, by evidence type then read-key priority). The spine call is behavior-idempotent (items already deduped by `seenTurns`; constant scorer assigns `rank=0` which `buildEvidencePack` ignores). The value is the DECLARED config.

### PR6 — event-order (`event-order-recall.ts`)
- `rankAndSelectEventOrderItems` + `rankEventOrderItemsForOutline` → delegate rank/threshold/sort to spine.
- All three declared divergences as named fields: `rankThreshold: 6` (was undocumented inline `.filter`), `turnIndexSortDirection: "asc"` (was byte-identical comparator copy with flipped direction — the #1539 silent-inversion defect class), `dedupByContent: false` (keeps distinct turns).
- **Outline-budget fix (the ONE declared behavior change)**: the summary + outline is now computed FIRST and its length subtracted from the evidence budget, matching guidance/targeted-fact. Pre-fix, event-order built evidence at the FULL budget then appended the outline — risking silent maxChars exceedance. Post-fix: evidence + summary = budget exactly.

## Characterization

- All 4 per-pipeline test suites green (targeted-fact: 42, response-guidance: 28, explicit-cue: 91, event-order: 59 cases — the end-to-end characterization).
- New `recall-pipeline-parity.test.ts` (11 tests) — explicit migration-seam guard pinning each pipeline's declared config shape (DESC vs ASC, content-dedup on/off, declared rankThreshold, transform-applied-to-output-not-scorer, preserveInsertionOrder, cross-pipeline divergence guard).
- Spine gains 2 new tests (`preserveInsertionOrder` + threshold interaction).
- New event-order test proving the outline-budget fix (outline always present, total ≤ maxChars).

## Gates

- `[preflight] OK (quick)` — lint, check-types, check-config-contract, review-patterns, ratchets, docs-parity, access-surface fitness, orchestrator path filter, recall short-circuit, artifact cache.
- `[ratchet] OK` — no god-file LOC impact (none of the 4 pipelines are god files).
- Type-check clean (`tsc --noEmit`).

## Chokepoints used

- `unifiedDedupeAndRank` (`recall-pipeline-stages.ts`) — all 4 pipelines.
- Not applicable: catalog chokepoint, capability gates, validation registry, serialize-mutations — this PR touches only the recall rank/dedupe/sort stage.

## Done-when check (#1539)

- [x] The four files are thin config + collection modules (spine owns dedup/rank/budget/merge policy)
- [x] A fifth pipeline would be a config file (each pipeline's divergence is declared fields)
- [x] The divergences (threshold, sort direction, merge opt-out, no-scoring) are declared fields with tests
- [x] `unifiedDedupeAndRank` has production call sites in all 4 files
- [x] Event-order outline-budget fix applied + tested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall section assembly that feeds model context; most paths are refactors with parity guards, but event-order budgeting changes what evidence fits when outlines are large.
> 
> **Overview**
> **Four recall builders** (`targeted-fact`, `response-guidance`, `explicit-cue`, `event-order`) now hand dedup/score/threshold/sort to **`unifiedDedupeAndRank`** via thin config (scorers and cue transforms stay per pipeline). Inline rank/dedupe loops and local `Ranked*` types are removed in favor of **`RankedEvidenceItem`**.
> 
> The spine gains **`preserveInsertionOrder`** so **explicit-cue** can skip sorting while still filtering; **event-order** declares **`rankThreshold: 6`**, **`turnIndexSortDirection: "asc"`**, and **`dedupByContent: false`** on the spine instead of duplicated comparators.
> 
> **Only intentional behavior change:** **event-order** computes the chronology summary/outline **first**, subtracts its length from the evidence budget, then builds the pack—so total section size stays within **`maxChars`** and the outline is budgeted, not clipped away.
> 
> **Tests:** new **`recall-pipeline-parity.test.ts`** (per-pipeline config seams + DESC vs ASC guard), spine tests for **`preserveInsertionOrder`**, and an event-order test for the outline-budget fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6215def6e757b4938e2edf719d74dda47ac3938a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->