### PR TITLE
bench(memcorrect): MemCorrect correction/steerability benchmark (#1584)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -113,8 +113,10 @@ that implements the `MemCorrectSystemAdapter` interface can be scored.
 Methodology, metric definitions, and the submission contract are in
 [`docs/benchmarks/memcorrect.md`](./benchmarks/memcorrect.md). Lab
 artifacts land in `docs/benchmarks/results/` once the local-lab Tier-L run
-completes; until then the hermetic baseline smoke (`remnic bench run
---benchmark memcorrect --quick`) is the reproducible in-tree check.
+completes; until then the hermetic synthetic-corpus smoke (`remnic bench run
+memcorrect-v1 --quick`) is the reproducible in-tree check. By default this
+exercises the Remnic-native adapter (the bench `system`); the prompt-only
+baseline is a programmatic adapter (see `runner.test.ts`), not a CLI mode.
 
 ## Ethics
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -102,6 +102,20 @@ explicit dates, turn numbers, plan ids, speaker names, step labels,
 preference updates, and keypoint names help retrieve precise evidence,
 while hidden gold metadata remains unavailable to the answerer.
 
+## MemCorrect (open correction benchmark)
+
+Remnic also publishes **MemCorrect v1** (`memcorrect-v1`), an open
+correction / steerability benchmark that measures whether a memory system
+can be *corrected*: uptake speed, non-resurrection under maintenance and
+re-ingest, collateral damage to unrelated memories, scope precision,
+false-apply, and re-assertion. It is system-agnostic — any memory system
+that implements the `MemCorrectSystemAdapter` interface can be scored.
+Methodology, metric definitions, and the submission contract are in
+[`docs/benchmarks/memcorrect.md`](./benchmarks/memcorrect.md). Lab
+artifacts land in `docs/benchmarks/results/` once the local-lab Tier-L run
+completes; until then the hermetic baseline smoke (`remnic bench run
+--benchmark memcorrect --quick`) is the reproducible in-tree check.
+
 ## Ethics
 
 - No dataset file or raw LLM trace is committed to this repo.

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -1,0 +1,183 @@
+# MemCorrect — an open correction / steerability benchmark
+
+Issue #1584. Part of the glass-box epic (#1572). Benchmark id: `memcorrect-v1`.
+
+## Why this benchmark exists
+
+No public memory benchmark measures whether a memory system can be
+**corrected**. LongMemEval's knowledge-update category is near ceiling and
+only tests whether the *newest* fact wins at answer time. It does not
+measure:
+
+- how **fast** a correction takes effect,
+- whether corrected facts **resurrect** after maintenance or re-ingest,
+- whether corrections **damage** unrelated memories,
+- whether corrections **respect scope** boundaries, or
+- whether the system **falsely applies** third-party / hypothetical cues.
+
+"The tool remembers a stale fact" is the field's #1 documented user pain,
+and users' only defense today is turning memory off. MemCorrect defines the
+eval that measures the correction behaviors #1580 (Correction Contract) and
+#1579 (tombstones) exist to guarantee. Remnic should define this eval and
+win it — that is the contribution.
+
+## Where it lives
+
+Inside `@remnic/bench`:
+
+- Scenario generator — `packages/bench/src/benchmarks/remnic/memcorrect/generator.ts`
+- Metric functions — `packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts`
+- Runner — `packages/bench/src/benchmarks/remnic/memcorrect/runner.ts`
+- Adapters — `packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts`
+- Corpus schema — `packages/bench/src/benchmarks/remnic/memcorrect/schema.ts`
+- Leaderboard row — `packages/bench/src/leaderboard-export.ts`
+
+Registered as `memcorrect-v1` (tier `remnic`) in
+`packages/bench/src/registry.ts`.
+
+## The adapter contract (the public contribution)
+
+MemCorrect is system-agnostic. Any memory system that implements this
+interface can be scored on identical scenarios with identical metrics:
+
+```ts
+interface MemCorrectSystemAdapter {
+  readonly label: string;
+  reset(): Promise<void>;
+  ingestTurn(sessionKey: string, role: "user" | "assistant", text: string, at: string): Promise<void>;
+  recall(query: string, sessionKey: string): Promise<string[]>;
+  correct(text: string, sessionKey: string): Promise<void>;
+  runMaintenance(): Promise<void>;
+}
+```
+
+In-tree adapters:
+
+1. **`PromptOnlyBaselineAdapter`** — append-everything store; BM25-style
+   term-overlap recall over raw turns; `correct()` is just another turn;
+   `runMaintenance()` is a no-op. The structural floor: it scores well on
+   recall and terribly on `non_resurrection`-under-re-ingest (it never
+   retires anything, so re-ingesting the original transcript resurrects the
+   retired fact). The baseline exists so metric deltas mean something.
+2. **`createRemnicMemCorrectAdapter`** — wraps the public `BenchMemoryAdapter`
+   (the access-service-level abstraction) into the contract. `ingestTurn` →
+   `store`; `recall` → `adapter.recall` split into ranked strings; `correct`
+   → observe the correction as a user turn (the correction-contract tool
+   rides here once #1580 lands); `runMaintenance` → `adapter.drain()`.
+
+Third-party adapters (Mem0, OpenMemory, …) are welcome follow-ups behind
+the same interface. **Do not** reach into orchestrator internals — that
+makes the benchmark meaningless as a comparison and brittle in-tree.
+
+## Dataset: synthetic-only, generated, never committed
+
+Per the repo ethics contract, no dataset files with real content are
+committed. `generateMemCorrectCorpus()` is a deterministic (seeded)
+synthetic corpus builder:
+
+- **N personas × M facts** across categories
+  (`fact` / `preference` / `decision` / `commitment` / `relationship`),
+  each persona owning ≥2 namespaces (work + home).
+- Every name, subject, and value is drawn from small **synthetic token
+  pools** (`token-pools.ts`) — no real-world PII is possible by
+  construction. The schema validator (`schema.ts`) enforces token-pool
+  provenance for every fact token.
+- Each fact is seeded via a natural **establishing transcript** (two turns)
+  so systems ingest it through their normal observe path, not a backdoor.
+- **Correction events** in four shapes:
+  1. *explicit-targeted* — "your record that I prefer X is wrong".
+  2. *conversational* — "oh by the way, we dropped X last month".
+  3. *scoped* — correction valid in namespace A must not affect the
+     same-text fact seeded in namespace B (carries a namespace-B twin).
+  4. *re-assertion* — after a correction, the user re-asserts the original
+     ("actually, we went back to X") — tests the revocation path.
+- **Anti-events** (quoting-others / hypothetical / third-party-correction)
+  measure false-apply, mirroring #1581's anti-fixture taxonomy.
+
+CI runs the generator (seeded) and asserts the corpus hash is stable — the
+same guard pattern the published benchmarks use. Two runs with the same
+seed produce a byte-identical corpus hash and identical deterministic
+metrics.
+
+## Metrics
+
+All eight are deterministic where possible. The LLM judge (sealed rubric,
+temperature 0, #1573 cache) is reserved for paraphrase-equivalence only;
+the unit-tested harness scores via token containment so a benchmark whose
+scores move with judge temperature is not a benchmark. Time windows are
+half-open `[start, end)` everywhere (checklist §23).
+
+| Metric | Definition | Direction |
+|---|---|---|
+| `uptake_at_next` | Fraction of corrections reflected in the *first* post-correction probe (corrected content present, retired content absent). | higher |
+| `uptake_latency` | Mean interaction turns until the first correct recall, capped at K. Censored (never-correct-within-cap) corrections contribute K and are counted in `uptake_latency_censored`. | lower |
+| `non_resurrection` | After correction: `runMaintenance()` ×K cycles AND re-ingest of the original establishing transcript; fraction of retired facts that stay retired. | higher |
+| `collateral_delta` | Recall over a fixed probe set of UNRELATED facts, before vs after corrections. Report the delta (after − before); unchanged = 0 is the target. | → 0 |
+| `scope_precision` | Scoped corrections: fraction where the namespace-B twin stays intact AND the namespace-A retired fact is retired. | higher |
+| `false_apply` | Anti-events that caused an undesired memory mutation (detected behaviorally: the `shouldNotAppear` token surfaces in a subsequent probe). | lower |
+| `reassertion` | Re-asserted facts recallable again after the re-assertion event. | higher |
+| `provenance_fidelity` | (Systems supporting it; else n/a) corrected state cites the correction event. | higher |
+
+The metric functions are pure functions over a probe log + resolved
+scenario metadata (`metrics.ts`), with hand-computed table tests
+(`metrics.test.ts`). Per-task scores are emitted under `scores` (the 7
+deterministic metrics); `provenance_fidelity` is n/a for adapters that do
+not surface provenance and is carried in `details.metrics.memcorrect` as
+`null`. The headline aggregate bundle (computed across the union of all
+scenario probe logs) is attached to `config.benchmarkOptions.aggregateMetrics`.
+
+## Running it
+
+```bash
+# Hermetic baseline smoke (no orchestrator, no GPU):
+remnic bench run --benchmark memcorrect --quick
+
+# Lab run (Remnic native, on the local-lab profile):
+remnic bench run --benchmark memcorrect --profile local-lab-3090
+```
+
+The runner selects the adapter via `benchmarkOptions.adapter` (a
+`MemCorrectSystemAdapter`). When none is supplied, it wraps the bench
+`system` adapter via `createRemnicMemCorrectAdapter`. The default
+`--quick` corpus is 2 personas × 4 facts (8 scenarios); `--full` is
+5 × 8 (40 scenarios).
+
+## Determinism guarantees
+
+- Same seed → byte-identical `meta.datasetHash` (SHA-256 of the canonical
+  corpus JSON).
+- Same seed → identical per-task deterministic metric values across runs
+  (latency is non-deterministic and excluded from the equality check).
+- The hermetic corpus hash is independent of the runtime profile — the
+  profile only resolves providers, not the scenario corpus.
+
+## Sanity contract (the referee, not the marketing)
+
+Per rule 55 in spirit: **the benchmark is the referee, not the marketing**.
+The prompt-only baseline must score near-zero on
+`non_resurrection`-under-re-ingest (it never retires anything). Remnic
+must not. If a Remnic run fails that floor, **file the bugs against
+#1580/#1579 — do not tune the benchmark**.
+
+## Submitting third-party results
+
+1. Implement `MemCorrectSystemAdapter` for your system (see the contract
+   above). `reset()` must return a clean slate; no call may touch another
+   system's durable store.
+2. Run `remnic bench run --benchmark memcorrect` with your adapter under
+   `benchmarkOptions.adapter`. Submit the resulting artifact.
+3. The leaderboard row (`buildMemCorrectLeaderboardRow`) carries your
+   adapter label, the seed, the dataset hash, and all 8 metrics — that is
+   the public submission format. Lower-is-better metrics are emitted raw;
+   this doc defines the interpretation.
+
+## Status
+
+- PR 1 (generator + schema) — landed.
+- PR 2 (runner + metrics) — landed.
+- PR 3 (adapters) — baseline + Remnic-native wrapper landed. **Lab
+  artifacts are not committed in this PR**: the local-lab Tier-L run
+  requires the lab GPU (Jarvis), which is intentionally out of scope for
+  the harness PR. Run it on the lab box and commit both artifacts per the
+  issue's PR 3 acceptance.
+- PR 4 (this doc + leaderboard-export wiring) — landed.

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -171,7 +171,7 @@ must not. If a Remnic run fails that floor, **file the bugs against
 1. Implement `MemCorrectSystemAdapter` for your system (see the contract
    above). `reset()` must return a clean slate; no call may touch another
    system's durable store.
-2. Run `remnic bench run --benchmark memcorrect` with your adapter under
+2. Run `remnic bench run memcorrect-v1` with your adapter under
    `benchmarkOptions.adapter`. Submit the resulting artifact.
 3. The leaderboard row (`buildMemCorrectLeaderboardRow`) carries your
    adapter label, the seed, the dataset hash, and all 8 metrics — that is

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -129,18 +129,25 @@ scenario probe logs) is attached to `config.benchmarkOptions.aggregateMetrics`.
 ## Running it
 
 ```bash
-# Hermetic baseline smoke (no orchestrator, no GPU):
-remnic bench run --benchmark memcorrect --quick
+# Hermetic synthetic-corpus smoke (no dataset download, no GPU):
+remnic bench run memcorrect-v1 --quick
 
-# Lab run (Remnic native, on the local-lab profile):
-remnic bench run --benchmark memcorrect --profile local-lab-3090
+# Lab run on a resolved runtime profile:
+remnic bench run memcorrect-v1 --runtime-profile local-lab \
+  --local-lab-manifest ~/bench/local-lab.json
 ```
 
+The benchmark id is the positional `memcorrect-v1` (the registered catalog
+id); `--runtime-profile` selects `baseline|real|openclaw-chain|local-lab`.
 The runner selects the adapter via `benchmarkOptions.adapter` (a
-`MemCorrectSystemAdapter`). When none is supplied, it wraps the bench
-`system` adapter via `createRemnicMemCorrectAdapter`. The default
-`--quick` corpus is 2 personas × 4 facts (8 scenarios); `--full` is
-5 × 8 (40 scenarios).
+`MemCorrectSystemAdapter`). When none is supplied — as is the case for CLI
+runs — it wraps the bench `system` adapter via
+`createRemnicMemCorrectAdapter` (the Remnic-native path), **not** the
+prompt-only baseline. The hermetic `PromptOnlyBaselineAdapter` (the
+structural floor deltas are measured against) is a programmatic adapter
+supplied via `benchmarkOptions.adapter` in scripts and `runner.test.ts`;
+there is no CLI flag that selects it. The default `--quick` corpus is
+2 personas × 4 facts (8 scenarios); `--full` is 5 × 8 (40 scenarios).
 
 ## Determinism guarantees
 

--- a/docs/benchmarks/memcorrect.md
+++ b/docs/benchmarks/memcorrect.md
@@ -46,7 +46,7 @@ interface MemCorrectSystemAdapter {
   reset(): Promise<void>;
   ingestTurn(sessionKey: string, role: "user" | "assistant", text: string, at: string): Promise<void>;
   recall(query: string, sessionKey: string): Promise<string[]>;
-  correct(text: string, sessionKey: string): Promise<void>;
+  correct(text: string, sessionKey: string, at?: string): Promise<void>;
   runMaintenance(): Promise<void>;
 }
 ```

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PromptOnlyBaselineAdapter,
+  createRemnicMemCorrectAdapter,
+} from "./adapters.js";
+import type { BenchMemoryAdapter } from "../../../adapters/types.js";
+
+// ---------------------------------------------------------------------------
+// Prompt-only baseline
+// ---------------------------------------------------------------------------
+
+test("baseline: recall surfaces turns overlapping the query terms", async () => {
+  const adapter = new PromptOnlyBaselineAdapter();
+  await adapter.ingestTurn("s1", "user", "My coffee preference is oat-milk.", "2026-07-05T00:00:00Z");
+  await adapter.ingestTurn("s1", "user", "The deploy target is canary.", "2026-07-05T00:01:00Z");
+  const recalled = await adapter.recall("what is my coffee preference?", "s1");
+  assert.ok(recalled.length > 0, "expected at least one recalled turn");
+  assert.ok(
+    recalled[0].toLowerCase().includes("oat-milk"),
+    `top recall should mention oat-milk, got: ${recalled[0]}`,
+  );
+});
+
+test("baseline: correct() is just another turn (no retire)", async () => {
+  const adapter = new PromptOnlyBaselineAdapter();
+  await adapter.ingestTurn("s1", "user", "My coffee preference is oat-milk.", "2026-07-05T00:00:00Z");
+  await adapter.correct("Correction: coffee is now black-coffee, not oat-milk.", "s1");
+  // Both the original and the correction are still in the prompt window.
+  const recalled = await adapter.recall("what is my coffee preference?", "s1");
+  const joined = recalled.join(" ").toLowerCase();
+  assert.ok(joined.includes("oat-milk"), "baseline must NOT retire oat-milk (structural floor)");
+  assert.ok(joined.includes("black-coffee"), "baseline should surface the correction turn too");
+});
+
+test("baseline: runMaintenance is a no-op", async () => {
+  const adapter = new PromptOnlyBaselineAdapter();
+  await adapter.runMaintenance(); // must not throw
+  const recalled = await adapter.recall("anything", "s1");
+  assert.deepEqual(recalled, []);
+});
+
+test("baseline: reset clears the store", async () => {
+  const adapter = new PromptOnlyBaselineAdapter();
+  await adapter.ingestTurn("s1", "user", "fact one", "2026-07-05T00:00:00Z");
+  await adapter.reset();
+  const recalled = await adapter.recall("fact", "s1");
+  assert.deepEqual(recalled, []);
+});
+
+// ---------------------------------------------------------------------------
+// Remnic-native wrapper (against a fake public BenchMemoryAdapter)
+// ---------------------------------------------------------------------------
+
+type CapturedCalls = {
+  storeCalls: Array<{ session: string; messages: unknown[] }>;
+  recallReturns: string[];
+  drainCalls: number;
+  resetCalls: number;
+};
+
+function newCaptured(): CapturedCalls {
+  return { storeCalls: [], recallReturns: [], drainCalls: 0, resetCalls: 0 };
+}
+
+function fakeBenchAdapter(captured: CapturedCalls): BenchMemoryAdapter {
+  return {
+    async store(sessionId, messages) {
+      captured.storeCalls.push({ session: sessionId, messages: [...messages] });
+    },
+    async recall(sessionId, _query) {
+      void sessionId;
+      return captured.recallReturns.shift() ?? "";
+    },
+    async search() {
+      return [];
+    },
+    async reset() {
+      captured.resetCalls += 1;
+    },
+    async getStats() {
+      return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+    },
+    async drain() {
+      captured.drainCalls += 1;
+    },
+    destroy() {
+      return Promise.resolve();
+    },
+  };
+}
+
+test("remnic wrapper: ingestTurn routes to store with the session prefix", async () => {
+  const captured = newCaptured();
+  const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured), {
+    sessionPrefix: "mc",
+  });
+  await adapter.ingestTurn("ns-a", "user", "hello", "2026-07-05T00:00:00Z");
+  assert.equal(captured.storeCalls.length, 1);
+  assert.equal(captured.storeCalls[0].session, "mc:ns-a");
+});
+
+test("remnic wrapper: recall splits the context blob on blank-line boundaries", async () => {
+  const captured = { ...newCaptured(), recallReturns: ["first paragraph\n\nsecond paragraph\n\nthird"] };
+  const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured));
+  const recalled = await adapter.recall("q", "ns-a");
+  assert.deepEqual(recalled, ["first paragraph", "second paragraph", "third"]);
+});
+
+test("remnic wrapper: correct() observes the correction as a user turn", async () => {
+  const captured = newCaptured();
+  const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured));
+  await adapter.correct("fix this", "ns-a");
+  assert.equal(captured.storeCalls.length, 1);
+  assert.equal(captured.storeCalls[0].messages.length, 1);
+});
+
+test("remnic wrapper: runMaintenance forces a drain", async () => {
+  const captured = newCaptured();
+  const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured));
+  await adapter.runMaintenance();
+  assert.equal(captured.drainCalls, 1);
+});
+
+test("remnic wrapper: reset forwards to the underlying adapter reset", async () => {
+  const captured = newCaptured();
+  const adapter = createRemnicMemCorrectAdapter(fakeBenchAdapter(captured));
+  await adapter.reset();
+  assert.equal(captured.resetCalls, 1);
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
@@ -1,0 +1,361 @@
+/**
+ * MemCorrect adapters (issue #1584 PR 3).
+ *
+ * Three adapters ship in-tree:
+ *
+ *   1. `PromptOnlyBaselineAdapter` — the hermetic comparison anchor. Append-
+ *      everything store; recall is BM25-ish term overlap over raw turns;
+ *      correct() is just another turn; runMaintenance() is a no-op. The
+ *      baseline exists so metric deltas mean something: a system that
+ *      "remembers" by quoting the whole transcript scores well on recall
+ *      but terribly on non_resurrection-under-reingest.
+ *
+ *   2. `RecordingAdapter` — a deterministic test adapter that returns
+ *      canned recall strings per query so unit tests can hand-compute
+ *      expected metric values without an LLM.
+ *
+ *   3. `createRemnicMemCorrectAdapter` — wraps the public
+ *      `BenchMemoryAdapter` (the access-service-level abstraction other
+ *      Remnic benchmarks use) into the MemCorrect contract. Per the issue,
+ *      the Remnic adapter must use only public surfaces; reaching into
+ *      orchestrator internals makes the benchmark meaningless. Full
+ *      correction-contract exercise (forced dreams + consolidation +
+ *      reinforcement + contradiction scan) lands with #1580/#1579; this
+ *      wrapper maps correct() to observe + drain today and documents the
+ *      upgrade path.
+ */
+
+import type { BenchMemoryAdapter } from "../../../adapters/types.js";
+import type { MemCorrectSystemAdapter } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Prompt-only baseline
+// ---------------------------------------------------------------------------
+
+interface IngestedTurn {
+  sessionKey: string;
+  role: "user" | "assistant";
+  text: string;
+  at: string;
+}
+
+const STOP_WORDS: ReadonlySet<string> = new Set([
+  "the",
+  "a",
+  "an",
+  "is",
+  "are",
+  "was",
+  "were",
+  "to",
+  "of",
+  "for",
+  "and",
+  "or",
+  "but",
+  "in",
+  "on",
+  "at",
+  "by",
+  "it",
+  "my",
+  "your",
+  "we",
+  "you",
+  "i",
+  "me",
+  "this",
+  "that",
+  "with",
+  "from",
+  "not",
+  "have",
+  "has",
+  "do",
+  "does",
+  "did",
+  "be",
+  "been",
+  "being",
+  "will",
+  "would",
+  "should",
+  "could",
+  "can",
+  "may",
+  "might",
+  "must",
+  "shall",
+  "if",
+  "then",
+  "than",
+  "so",
+  "as",
+  "go",
+  "going",
+  "forward",
+  "instead",
+  "last",
+  "month",
+  "now",
+  "their",
+  "them",
+  "they",
+  "he",
+  "she",
+  "his",
+  "her",
+  "got",
+  "noting",
+  "noted",
+  "what",
+  "setting",
+  "preference",
+  "update",
+  "actually",
+  "back",
+  "went",
+  "consider",
+  "decided",
+  "might",
+  "someone",
+  "asked",
+  "mentioned",
+  "said",
+  "should",
+  "change",
+  "wrong",
+  "saying",
+  "record",
+  "oh",
+  "by",
+  "way",
+  "project",
+]);
+
+function tokenize(text: string): string[] {
+  const matches = text.toLowerCase().match(/[a-z0-9][a-z0-9-]*/g);
+  return (matches ?? []).filter((t) => !STOP_WORDS.has(t));
+}
+
+function termFrequencies(tokens: string[]): Map<string, number> {
+  const tf = new Map<string, number>();
+  for (const token of tokens) {
+    tf.set(token, (tf.get(token) ?? 0) + 1);
+  }
+  return tf;
+}
+
+/**
+ * Prompt-only baseline: append-everything store with BM25-style term-overlap
+ * recall over raw turns. No extraction, no correction-contract, no
+ * maintenance — the structural floor MemCorrect deltas are measured against.
+ */
+export class PromptOnlyBaselineAdapter implements MemCorrectSystemAdapter {
+  readonly label = "prompt-only-baseline";
+  private turns: IngestedTurn[] = [];
+
+  async reset(): Promise<void> {
+    this.turns = [];
+  }
+
+  async ingestTurn(
+    sessionKey: string,
+    role: "user" | "assistant",
+    text: string,
+    at: string,
+  ): Promise<void> {
+    this.turns.push({ sessionKey, role, text, at });
+  }
+
+  async recall(query: string, _sessionKey: string): Promise<string[]> {
+    const queryTf = termFrequencies(tokenize(query));
+    if (queryTf.size === 0) return [];
+    const scored = this.turns
+      .map((turn) => {
+        const turnTf = termFrequencies(tokenize(turn.text));
+        let overlap = 0;
+        for (const [term, qCount] of queryTf) {
+          const tCount = turnTf.get(term);
+          if (tCount !== undefined) overlap += qCount * tCount;
+        }
+        return { turn, overlap };
+      })
+      .filter((entry) => entry.overlap > 0)
+      .sort((a, b) => {
+        if (b.overlap !== a.overlap) return b.overlap - a.overlap;
+        // Stable tiebreak by ingestion order (most recent first), mirroring
+        // a recency-biased prompt window.
+        return this.turns.indexOf(b.turn) - this.turns.indexOf(a.turn);
+      })
+      .slice(0, 5)
+      .map((entry) => entry.turn.text);
+    return scored;
+  }
+
+  async correct(text: string, sessionKey: string): Promise<void> {
+    // The baseline accepts a correction as just another user turn — no
+    // retire, no tombstone. This is precisely why non_resurrection collapses
+    // for the baseline under re-ingest.
+    await this.ingestTurn(sessionKey, "user", text, new Date().toISOString());
+  }
+
+  async runMaintenance(): Promise<void> {
+    // No-op: the baseline has no consolidation/dreams path.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recording adapter (test fixture)
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic test adapter. The script maps a phase → ordered list of
+ * recall strings to return, so tests can drive the runner with a known
+ * probe log and hand-compute expected metrics. Each call advances an
+ * internal turn counter so uptake_latency is exercisable.
+ */
+export interface RecordingScript {
+  /** recall strings returned for a probe at a given phase (queued FIFO). */
+  recallByPhase: Record<string, string[][]>;
+}
+
+export class RecordingAdapter implements MemCorrectSystemAdapter {
+  readonly label: string;
+  private readonly script: RecordingScript;
+  private turnIndex = 0;
+  private readonly queues: Map<string, string[][]>;
+  public readonly ingested: IngestedTurn[] = [];
+  public readonly corrections: string[] = [];
+  public maintenanceCalls = 0;
+
+  constructor(label: string, script: RecordingScript) {
+    this.label = label;
+    this.script = script;
+    this.queues = new Map(
+      Object.entries(script.recallByPhase).map(([phase, queues]) => [
+        phase,
+        queues.map((q) => [...q]),
+      ]),
+    );
+  }
+
+  async reset(): Promise<void> {
+    this.turnIndex = 0;
+    this.ingested.length = 0;
+    this.corrections.length = 0;
+    this.maintenanceCalls = 0;
+    this.queues.clear();
+    for (const [phase, queues] of Object.entries(this.script.recallByPhase)) {
+      this.queues.set(
+        phase,
+        queues.map((q) => [...q]),
+      );
+    }
+  }
+
+  /** Current monotonic turn counter (the runner reads this for latency). */
+  get currentTurnIndex(): number {
+    return this.turnIndex;
+  }
+
+  /** Bump the turn counter (the runner calls this between probes). */
+  bumpTurn(): void {
+    this.turnIndex += 1;
+  }
+
+  async ingestTurn(
+    sessionKey: string,
+    role: "user" | "assistant",
+    text: string,
+    at: string,
+  ): Promise<void> {
+    this.ingested.push({ sessionKey, role, text, at });
+    this.turnIndex += 1;
+  }
+
+  async recall(query: string, _sessionKey: string): Promise<string[]> {
+    const phase = query;
+    const queue = this.queues.get(phase);
+    if (queue && queue.length > 0) {
+      return queue.shift() ?? [];
+    }
+    return [];
+  }
+
+  async correct(text: string, _sessionKey: string): Promise<void> {
+    this.corrections.push(text);
+    this.turnIndex += 1;
+  }
+
+  async runMaintenance(): Promise<void> {
+    this.maintenanceCalls += 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Remnic-native adapter (public-surface wrapper)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a public `BenchMemoryAdapter` (the access-service-level abstraction)
+ * into the MemCorrect contract.
+ *
+ * `ingestTurn` → `store(sessionKey, [Message])`. `recall` →
+ * `adapter.recall(sessionKey, query)` split into ranked strings.
+ * `correct` → observe the correction as a user turn (the correction-contract
+ * tool rides here once #1580 lands). `runMaintenance` → `adapter.drain()`,
+ * which forces the background consolidation/LCM/contradiction-scan pipeline
+ * to settle; a forced-dreams/REM hook lands with #1579's tombstone path.
+ *
+ * The wrapper deliberately does NOT reach into orchestrator internals —
+ * that is the issue's hard constraint ("makes the benchmark meaningless as
+ * a comparison and brittle in-tree").
+ */
+export function createRemnicMemCorrectAdapter(
+  adapter: BenchMemoryAdapter,
+  options: { label?: string; sessionPrefix?: string } = {},
+): MemCorrectSystemAdapter {
+  const label = options.label ?? "remnic-native";
+  const sessionPrefix = options.sessionPrefix ?? "memcorrect";
+  return {
+    label,
+    async reset() {
+      await adapter.reset();
+    },
+    async ingestTurn(sessionKey, role, text, _at) {
+      await adapter.store(`${sessionPrefix}:${sessionKey}`, [
+        { role, content: text },
+      ]);
+    },
+    async recall(query, sessionKey) {
+      const text = await adapter.recall(`${sessionPrefix}:${sessionKey}`, query);
+      // Split the recalled context blob into ranked strings. Adapters return
+      // a single context string; the benchmark scores token containment over
+      // the joined text, so splitting on blank-line boundaries preserves
+      // structure without changing the containment semantics.
+      const trimmed = text.trim();
+      if (trimmed.length === 0) return [];
+      return trimmed
+        .split(/\n\s*\n/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    },
+    async correct(text, sessionKey) {
+      // Today: observe the correction as a user turn through the public
+      // store path. When #1580's correction contract is available, this
+      // routes through the contract tool instead (the adapter surface is
+      // unchanged; only the internal call differs).
+      await adapter.store(`${sessionPrefix}:${sessionKey}`, [
+        { role: "user", content: text },
+      ]);
+    },
+    async runMaintenance() {
+      // Force the background write paths (#1579's tombstone chokepoint
+      // hooks drain-then-contradiction-scan). drain() settles LCM +
+      // consolidation; a no-op drain (adapters without background work) is
+      // allowed and surfaces as a higher non_resurrection for this adapter.
+      await adapter.drain?.();
+    },
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
@@ -168,10 +168,15 @@ export class PromptOnlyBaselineAdapter implements MemCorrectSystemAdapter {
     this.turns.push({ sessionKey, role, text, at });
   }
 
-  async recall(query: string, _sessionKey: string): Promise<string[]> {
+  async recall(query: string, sessionKey: string): Promise<string[]> {
     const queryTf = termFrequencies(tokenize(query));
     if (queryTf.size === 0) return [];
+    // Scope recall to the requesting session so a primary-namespace probe
+    // cannot pull twin-namespace text (and vice-versa). Without this filter
+    // scoped scenarios let cross-namespace turns distort the baseline's
+    // scope and recall signals.
     const scored = this.turns
+      .filter((turn) => turn.sessionKey === sessionKey)
       .map((turn) => {
         const turnTf = termFrequencies(tokenize(turn.text));
         let overlap = 0;

--- a/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/adapters.ts
@@ -328,9 +328,9 @@ export function createRemnicMemCorrectAdapter(
     async reset() {
       await adapter.reset();
     },
-    async ingestTurn(sessionKey, role, text, _at) {
+    async ingestTurn(sessionKey, role, text, at) {
       await adapter.store(`${sessionPrefix}:${sessionKey}`, [
-        { role, content: text },
+        { role, content: text, timestamp: at },
       ]);
     },
     async recall(query, sessionKey) {
@@ -346,13 +346,15 @@ export function createRemnicMemCorrectAdapter(
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
     },
-    async correct(text, sessionKey) {
+    async correct(text, sessionKey, at) {
       // Today: observe the correction as a user turn through the public
       // store path. When #1580's correction contract is available, this
       // routes through the contract tool instead (the adapter surface is
-      // unchanged; only the internal call differs).
+      // unchanged; only the internal call differs). The seeded corpus
+      // timestamp is preserved so temporal reasoning is evaluated against
+      // the scenario timeline, not wall-clock ingestion time.
       await adapter.store(`${sessionPrefix}:${sessionKey}`, [
-        { role: "user", content: text },
+        { role: "user", content: text, timestamp: at },
       ]);
     },
     async runMaintenance() {

--- a/packages/bench/src/benchmarks/remnic/memcorrect/generator.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/generator.test.ts
@@ -1,0 +1,192 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  generateMemCorrectCorpus,
+  corpusHash,
+} from "./generator.js";
+import { validateCorpus } from "./schema.js";
+import { PERSONAS, SUBJECTS, VALUES_A, VALUES_B } from "./token-pools.js";
+import type { CorrectionShape, MemCorrectGeneratorOptions } from "./types.js";
+
+const BASE: MemCorrectGeneratorOptions = {
+  personaCount: 2,
+  factsPerPersona: 4,
+  seed: 12345,
+  nowIso: "2026-07-05T00:00:00.000Z",
+  maintenanceCycles: 3,
+  uptakeLatencyCap: 5,
+};
+
+const ALL_SHAPES: CorrectionShape[] = [
+  "explicit-targeted",
+  "conversational",
+  "scoped",
+  "re-assertion",
+];
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+test("generator: same seed → byte-identical corpus hash", () => {
+  const a = generateMemCorrectCorpus(BASE);
+  const b = generateMemCorrectCorpus(BASE);
+  assert.equal(corpusHash(a), corpusHash(b));
+  // Structural equality too: every field deep-equal.
+  assert.deepEqual(a.scenarios, b.scenarios);
+});
+
+test("generator: different seed → different corpus hash", () => {
+  const a = generateMemCorrectCorpus(BASE);
+  const b = generateMemCorrectCorpus({ ...BASE, seed: 999 });
+  assert.notEqual(corpusHash(a), corpusHash(b));
+});
+
+test("generator: determinism holds across persona/fact scales", () => {
+  for (const opts of [
+    { ...BASE, personaCount: 3, factsPerPersona: 6 },
+    { ...BASE, personaCount: 1, factsPerPersona: 4 },
+  ]) {
+    const a = generateMemCorrectCorpus(opts);
+    const b = generateMemCorrectCorpus(opts);
+    assert.equal(corpusHash(a), corpusHash(b), `seed ${opts.seed} scale`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Taxonomy coverage
+// ---------------------------------------------------------------------------
+
+test("generator: corpus covers all four correction shapes", () => {
+  const corpus = generateMemCorrectCorpus({
+    ...BASE,
+    personaCount: 2,
+    factsPerPersona: 4, // 8 scenarios; shapes cycle every 4 → each shape ×2
+  });
+  const shapes = new Set(corpus.scenarios.map((s) => s.correction.shape));
+  for (const shape of ALL_SHAPES) {
+    assert.ok(shapes.has(shape), `missing shape ${shape}`);
+  }
+});
+
+test("generator: scoped scenarios carry a namespace-B twin; re-assertion scenarios carry a reassertion block", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  const scoped = corpus.scenarios.filter((s) => s.correction.shape === "scoped");
+  assert.ok(scoped.length > 0, "expected at least one scoped scenario");
+  for (const s of scoped) {
+    assert.ok(s.scopedTwin, `scoped scenario ${s.id} missing twin`);
+    assert.notEqual(s.scopedTwin.namespace, s.namespace, "twin must be in a different namespace");
+  }
+  const reassert = corpus.scenarios.filter((s) => s.correction.shape === "re-assertion");
+  assert.ok(reassert.length > 0, "expected at least one re-assertion scenario");
+  for (const s of reassert) {
+    assert.ok(s.reassertion, `re-assertion scenario ${s.id} missing reassertion block`);
+  }
+});
+
+test("generator: establishing transcripts are non-empty and ISO-timestamped", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  for (const s of corpus.scenarios) {
+    assert.ok(s.establishingTurns.length >= 1);
+    for (const t of s.establishingTurns) {
+      assert.ok(Number.isFinite(Date.parse(t.at)), `${s.id} bad timestamp ${t.at}`);
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation + no-PII
+// ---------------------------------------------------------------------------
+
+test("schema: generated corpus validates", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  const result = validateCorpus(corpus);
+  assert.ok(result.ok, `validation errors: ${JSON.stringify(result.errors)}`);
+});
+
+test("schema: every fact token originates from a synthetic pool (no-PII)", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  const pool = new Set<string>([
+    ...VALUES_A,
+    ...VALUES_B,
+    ...[...SUBJECTS].flatMap((s) => [s]),
+  ]);
+  for (const s of corpus.scenarios) {
+    for (const token of [
+      ...s.correction.retiredContent,
+      ...s.correction.correctedContent,
+      s.scopedTwin?.twinContent,
+      s.reassertion?.expectedContent,
+    ]) {
+      if (token !== undefined) {
+        assert.ok(pool.has(token), `token "${token}" outside synthetic pools (PII guard)`);
+      }
+    }
+  }
+});
+
+test("schema: validator rejects a hand-corrupted scenario", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  // Corrupt: empty namespace on first scenario.
+  const corrupted = {
+    ...corpus,
+    scenarios: corpus.scenarios.map((s, i) =>
+      i === 0 ? { ...s, namespace: "" } : s,
+    ),
+  };
+  const result = validateCorpus(corrupted);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.message.includes("namespace")));
+});
+
+test("schema: validator rejects a scoped scenario missing its twin", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  const firstScoped = corpus.scenarios.find(
+    (s) => s.correction.shape === "scoped",
+  );
+  assert.ok(firstScoped, "expected a scoped scenario");
+  const corrupted = {
+    ...corpus,
+    scenarios: corpus.scenarios.map((s) =>
+      s.id === firstScoped.id ? { ...s, scopedTwin: undefined } : s,
+    ),
+  };
+  const result = validateCorpus(corrupted);
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((e) => e.message.includes("scopedTwin")),
+    "expected scopedTwin error",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+test("generator: rejects invalid seed", () => {
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, seed: -1 }));
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, seed: 0x100000000 }));
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, seed: 1.5 }));
+});
+
+test("generator: rejects non-positive personaCount / factsPerPersona", () => {
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, personaCount: 0 }));
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, factsPerPersona: -1 }));
+});
+
+test("generator: rejects unparseable nowIso", () => {
+  assert.throws(() => generateMemCorrectCorpus({ ...BASE, nowIso: "not-a-date" }));
+});
+
+// ---------------------------------------------------------------------------
+// Persona coverage sanity
+// ---------------------------------------------------------------------------
+
+test("generator: namespaces derive from the synthetic persona pool only", () => {
+  const corpus = generateMemCorrectCorpus(BASE);
+  const personaPool = new Set(PERSONAS.map((p) => p.toLowerCase()));
+  for (const s of corpus.scenarios) {
+    const persona = s.namespace.replace(/-(work|home)$/, "");
+    assert.ok(personaPool.has(persona), `namespace persona "${persona}" not in pool`);
+  }
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/generator.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/generator.ts
@@ -63,6 +63,21 @@ function pick<T>(rng: () => number, pool: readonly T[]): T {
   return pool[Math.floor(rng() * pool.length) % pool.length];
 }
 
+/** Pick a pool element that is not `exclude` (falls back to the full pool if
+ * every element equals `exclude`, which cannot happen for the pools used here). */
+function pickExcluding<T>(rng: () => number, pool: readonly T[], exclude: T): T {
+  const choices = pool.filter((v) => v !== exclude);
+  const source = choices.length > 0 ? choices : pool;
+  return source[Math.floor(rng() * source.length) % source.length];
+}
+
+/** Pick a pool element not already in `used` (falls back to the full pool). */
+function pickExcludingSet<T>(rng: () => number, pool: readonly T[], used: ReadonlySet<T>): T {
+  const choices = pool.filter((v) => !used.has(v));
+  const source = choices.length > 0 ? choices : pool;
+  return source[Math.floor(rng() * source.length) % source.length];
+}
+
 /** ISO timestamp strictly after `baseMs` by `addMs` (half-open windowing). */
 function isoAfter(baseMs: number, addMs: number): string {
   return new Date(baseMs + addMs).toISOString();
@@ -171,24 +186,31 @@ function buildAntiEvents(
     "third-party-correction",
   ];
   const kind = kinds[Math.floor(rng() * kinds.length) % kinds.length];
+  // Distinct decoy: the anti-event names a value that is NEITHER the
+  // corrected value nor the retired value, so a system that correctly
+  // applies the correction (surfacing newValue) is never mistaken for a
+  // false apply. Drawn from VALUES_B excluding newValue; the retired value
+  // is from VALUES_A, so the pools are disjoint by construction.
+  const decoy = pickExcluding(rng, VALUES_B, plan.newValue);
   let text: string;
   switch (kind) {
     case "quoting-other":
-      text = `Riley mentioned their ${plan.subject} is set to ${plan.newValue}.`;
+      text = `Riley mentioned their ${plan.subject} is set to ${decoy}.`;
       break;
     case "hypothetical":
-      text = `If someone asked, I might consider ${plan.newValue} for ${plan.subject}, but I have not decided.`;
+      text = `If someone asked, I might consider ${decoy} for ${plan.subject}, but I have not decided.`;
       break;
     case "third-party-correction":
-      text = `Sage said you should change ${plan.subject} to ${plan.newValue} for them.`;
+      text = `Sage said you should change ${plan.subject} to ${decoy} for them.`;
       break;
   }
   const event: AntiEvent = {
     kind,
     turn: { role: "user", text, at: isoAfter(baseMs, offsetMs) },
     probeQuery: `what is my ${plan.subject} preference?`,
-    // The new value must NOT stick from a third-party / hypothetical cue.
-    shouldNotAppear: plan.newValue,
+    // The decoy must NOT stick from a third-party / hypothetical cue; if it
+    // surfaces in a later probe the system falsely applied the anti-event.
+    shouldNotAppear: decoy,
   };
   return { events: [event], nextOffsetMs: offsetMs + 60_000 };
 }
@@ -238,19 +260,44 @@ function buildReassertion(
 
 function buildUnrelatedProbes(
   rng: () => number,
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  offsetMs: number,
 ): { probes: UnrelatedProbe[]; nextOffsetMs: number } {
   // Two unrelated facts that the correction must not damage. They share
-  // the persona/namespace so collateral is measured in the same scope.
+  // the persona/namespace so collateral is measured in the same scope. Each
+  // carries an establishing transcript so the runner can seed the fact
+  // BEFORE the baseline probe — otherwise collateral_delta recalls facts
+  // that were never stored and stays pinned near zero.
+  const PROBE_COUNT = 2;
   const probes: UnrelatedProbe[] = [];
-  for (let i = 0; i < 2; i += 1) {
-    const subject = pick(rng, SUBJECTS);
+  const usedSubjects = new Set<string>([plan.subject]);
+  for (let i = 0; i < PROBE_COUNT; i += 1) {
+    // Distinct subject: never the scenario's main subject nor a prior
+    // probe's, so the collateral query cannot cross-contaminate the main
+    // fact's recall signal.
+    const subject = pickExcludingSet(rng, SUBJECTS, usedSubjects);
+    usedSubjects.add(subject);
     const value = pick(rng, VALUES_A);
+    const turnBase = offsetMs + i * 120_000;
     probes.push({
       query: `what is my ${subject} setting?`,
       expectedContent: value,
+      establishingTurns: [
+        {
+          role: "user",
+          text: `My ${subject} setting is ${value}.`,
+          at: isoAfter(baseMs, turnBase),
+        },
+        {
+          role: "assistant",
+          text: `Got it — noting ${value} for ${subject}.`,
+          at: isoAfter(baseMs, turnBase + 60_000),
+        },
+      ],
     });
   }
-  return { probes, nextOffsetMs: 0 };
+  return { probes, nextOffsetMs: PROBE_COUNT * 120_000 };
 }
 
 function probeFor(plan: PersonaFactPlanLike): ProbeQuery {
@@ -311,11 +358,17 @@ export function generateMemCorrectCorpus(
     let offset = 0;
     const established = establishTurns(plan, scenarioBase, offset);
     offset = established.nextOffsetMs;
-    const corrected = buildCorrection(plan, scenarioBase, offset);
-    offset = corrected.nextOffsetMs;
-    const antis = buildAntiEvents(rng, plan, scenarioBase, offset);
-    offset = antis.nextOffsetMs;
 
+    // Collateral facts are seeded BEFORE the baseline probe (and before the
+    // correction) so collateral_delta measures recall over facts that were
+    // actually stored, not queries over an empty store.
+    const unrelated = buildUnrelatedProbes(rng, plan, scenarioBase, offset);
+    offset += unrelated.nextOffsetMs;
+
+    // Scoped twin is seeded BEFORE the correction so scope_precision can
+    // catch a system that wrongly applies the correction across every
+    // namespace at correction time — the twin must already exist to be
+    // overwritten. Non-scoped scenarios skip this.
     let scopedTwin: ScopedTwin | undefined;
     if (plan.shape === "scoped") {
       const twin = buildScopedTwin(plan, scenarioBase, offset);
@@ -323,14 +376,16 @@ export function generateMemCorrectCorpus(
       offset = twin.nextOffsetMs;
     }
 
+    const corrected = buildCorrection(plan, scenarioBase, offset);
+    offset = corrected.nextOffsetMs;
+    const antis = buildAntiEvents(rng, plan, scenarioBase, offset);
+    offset = antis.nextOffsetMs;
+
     let reassertion: Reassertion | undefined;
     if (plan.shape === "re-assertion") {
       reassertion = buildReassertion(plan, scenarioBase, offset);
       offset += 60_000;
     }
-
-    const unrelated = buildUnrelatedProbes(rng);
-    offset += unrelated.nextOffsetMs;
 
     scenarios.push({
       id: `memcorrect-${options.seed}-${i.toString(16)}`,

--- a/packages/bench/src/benchmarks/remnic/memcorrect/generator.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/generator.ts
@@ -1,0 +1,367 @@
+/**
+ * MemCorrect seeded synthetic corpus generator (issue #1584 PR 1).
+ *
+ * Produces a deterministic scenario corpus given a seed. The corpus is
+ * generated, never committed: CI runs this generator and asserts the corpus
+ * hash, mirroring the existing full-mode dataset-guard pattern under
+ * `benchmarks/published/`. No real-world PII is possible by construction —
+ * every name, city, and entity is drawn from small synthetic token pools.
+ *
+ * Each scenario seeds a fact via a natural establishing transcript (so
+ * systems ingest it through their normal observe path, not a backdoor),
+ * then delivers a correction in one of four shapes, plus anti-events that
+ * must not stick. Scoped scenarios also seed a same-text twin in a second
+ * namespace so `scope_precision` can verify the correction does not leak
+ * across scope boundaries.
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  AntiEvent,
+  CorrectionEvent,
+  CorrectionShape,
+  EstablishingTurn,
+  FactCategory,
+  MemCorrectCorpus,
+  MemCorrectGeneratorOptions,
+  MemCorrectScenario,
+  PersonaFactPlanLike,
+  ProbeQuery,
+  Reassertion,
+  ScopedTwin,
+  UnrelatedProbe,
+} from "./types.js";
+import { PERSONAS, SUBJECTS, VALUES_A, VALUES_B } from "./token-pools.js";
+
+const MAX_PRNG_SEED = 0xffffffff;
+
+const FACT_CATEGORIES: readonly FactCategory[] = [
+  "fact",
+  "preference",
+  "decision",
+  "commitment",
+  "relationship",
+];
+
+/**
+ * Mulberry32 PRNG — small, deterministic, fast. Identical contract to the
+ * one used by `retention-aged-dataset/fixture.ts` so seeded determinism
+ * behaves consistently across bench fixtures.
+ */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return function rng(): number {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, pool: readonly T[]): T {
+  return pool[Math.floor(rng() * pool.length) % pool.length];
+}
+
+/** ISO timestamp strictly after `baseMs` by `addMs` (half-open windowing). */
+function isoAfter(baseMs: number, addMs: number): string {
+  return new Date(baseMs + addMs).toISOString();
+}
+
+function planFacts(
+  rng: () => number,
+  options: MemCorrectGeneratorOptions,
+): PersonaFactPlanLike[] {
+  const plans: PersonaFactPlanLike[] = [];
+  const shapes: CorrectionShape[] = [
+    "explicit-targeted",
+    "conversational",
+    "scoped",
+    "re-assertion",
+  ];
+  for (let p = 0; p < options.personaCount; p += 1) {
+    const persona = PERSONAS[p % PERSONAS.length];
+    // Each persona owns ≥2 namespaces (work + home) so scoped scenarios can
+    // seed a twin in the alternate namespace.
+    const namespaces = [
+      `${persona.toLowerCase()}-work`,
+      `${persona.toLowerCase()}-home`,
+    ];
+    for (let f = 0; f < options.factsPerPersona; f += 1) {
+      const category =
+        FACT_CATEGORIES[(p * options.factsPerPersona + f) % FACT_CATEGORIES.length];
+      const subject = pick(rng, SUBJECTS);
+      const oldValue = pick(rng, VALUES_A);
+      const newValue = pick(rng, VALUES_B);
+      const namespace = namespaces[f % namespaces.length];
+      const shape = shapes[(p * options.factsPerPersona + f) % shapes.length];
+      plans.push({ persona, namespace, category, subject, oldValue, newValue, shape });
+    }
+  }
+  return plans;
+}
+
+function establishTurns(
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  startOffsetMs: number,
+): { turns: EstablishingTurn[]; nextOffsetMs: number } {
+  // Two-turn establishing transcript: user states the fact, assistant
+  // acknowledges. Both turns carry the original value so systems that
+  // dedupe or summarize still capture it.
+  const turns: EstablishingTurn[] = [
+    {
+      role: "user",
+      text: `My ${plan.subject} preference is ${plan.oldValue}.`,
+      at: isoAfter(baseMs, startOffsetMs),
+    },
+    {
+      role: "assistant",
+      text: `Got it — noting ${plan.oldValue} for ${plan.subject}.`,
+      at: isoAfter(baseMs, startOffsetMs + 60_000),
+    },
+  ];
+  return { turns, nextOffsetMs: startOffsetMs + 120_000 };
+}
+
+function buildCorrection(
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  offsetMs: number,
+): { correction: CorrectionEvent; nextOffsetMs: number } {
+  const retiredContent = [plan.oldValue];
+  const correctedContent = [plan.newValue];
+  let text: string;
+  switch (plan.shape) {
+    case "explicit-targeted":
+      text = `Correction: my ${plan.subject} record saying ${plan.oldValue} is wrong. It is now ${plan.newValue}.`;
+      break;
+    case "conversational":
+      text = `Oh by the way, we switched ${plan.subject} from ${plan.oldValue} to ${plan.newValue} last month.`;
+      break;
+    case "scoped":
+      text = `For this project, ${plan.subject} is ${plan.newValue} now, not ${plan.oldValue}.`;
+      break;
+    case "re-assertion":
+      // The re-assertion scenario's "correction" sets a value that the user
+      // later walks back; the reassertion block carries the original.
+      text = `Update: ${plan.subject} is ${plan.newValue} going forward instead of ${plan.oldValue}.`;
+      break;
+  }
+  const correction: CorrectionEvent = {
+    shape: plan.shape,
+    turn: { role: "user", text, at: isoAfter(baseMs, offsetMs) },
+    retiredContent,
+    correctedContent,
+  };
+  return { correction, nextOffsetMs: offsetMs + 60_000 };
+}
+
+function buildAntiEvents(
+  rng: () => number,
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  offsetMs: number,
+): { events: AntiEvent[]; nextOffsetMs: number } {
+  // One anti-event per scenario, cycling through the three kinds so the
+  // false_apply metric exercises each.
+  const kinds: AntiEvent["kind"][] = [
+    "quoting-other",
+    "hypothetical",
+    "third-party-correction",
+  ];
+  const kind = kinds[Math.floor(rng() * kinds.length) % kinds.length];
+  let text: string;
+  switch (kind) {
+    case "quoting-other":
+      text = `Riley mentioned their ${plan.subject} is set to ${plan.newValue}.`;
+      break;
+    case "hypothetical":
+      text = `If someone asked, I might consider ${plan.newValue} for ${plan.subject}, but I have not decided.`;
+      break;
+    case "third-party-correction":
+      text = `Sage said you should change ${plan.subject} to ${plan.newValue} for them.`;
+      break;
+  }
+  const event: AntiEvent = {
+    kind,
+    turn: { role: "user", text, at: isoAfter(baseMs, offsetMs) },
+    probeQuery: `what is my ${plan.subject} preference?`,
+    // The new value must NOT stick from a third-party / hypothetical cue.
+    shouldNotAppear: plan.newValue,
+  };
+  return { events: [event], nextOffsetMs: offsetMs + 60_000 };
+}
+
+function buildScopedTwin(
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  offsetMs: number,
+): { twin: ScopedTwin; nextOffsetMs: number } {
+  // Twin lives in the persona's *other* namespace and keeps the OLD value.
+  const otherNamespace = plan.namespace.endsWith("-work")
+    ? plan.namespace.replace(/-work$/, "-home")
+    : plan.namespace.replace(/-home$/, "-work");
+  const twin: ScopedTwin = {
+    namespace: otherNamespace,
+    establishingTurns: [
+      {
+        role: "user",
+        text: `My ${plan.subject} preference is ${plan.oldValue}.`,
+        at: isoAfter(baseMs, offsetMs),
+      },
+      {
+        role: "assistant",
+        text: `Noted ${plan.oldValue} for ${plan.subject}.`,
+        at: isoAfter(baseMs, offsetMs + 60_000),
+      },
+    ],
+    twinContent: plan.oldValue,
+  };
+  return { twin, nextOffsetMs: offsetMs + 120_000 };
+}
+
+function buildReassertion(
+  plan: PersonaFactPlanLike,
+  baseMs: number,
+  offsetMs: number,
+): Reassertion {
+  return {
+    turn: {
+      role: "user",
+      text: `Actually, we went back to ${plan.oldValue} for ${plan.subject}.`,
+      at: isoAfter(baseMs, offsetMs),
+    },
+    expectedContent: plan.oldValue,
+  };
+}
+
+function buildUnrelatedProbes(
+  rng: () => number,
+): { probes: UnrelatedProbe[]; nextOffsetMs: number } {
+  // Two unrelated facts that the correction must not damage. They share
+  // the persona/namespace so collateral is measured in the same scope.
+  const probes: UnrelatedProbe[] = [];
+  for (let i = 0; i < 2; i += 1) {
+    const subject = pick(rng, SUBJECTS);
+    const value = pick(rng, VALUES_A);
+    probes.push({
+      query: `what is my ${subject} setting?`,
+      expectedContent: value,
+    });
+  }
+  return { probes, nextOffsetMs: 0 };
+}
+
+function probeFor(plan: PersonaFactPlanLike): ProbeQuery {
+  return {
+    query: `what is my ${plan.subject} preference?`,
+    mustContain: [plan.newValue],
+    mustAbsent: [plan.oldValue],
+  };
+}
+
+/**
+ * Build a deterministic MemCorrect scenario corpus.
+ *
+ * @throws if `seed` is outside `[0, 2**32-1]` or `nowIso` is unparseable.
+ */
+export function generateMemCorrectCorpus(
+  options: MemCorrectGeneratorOptions,
+): MemCorrectCorpus {
+  if (!Number.isInteger(options.personaCount) || options.personaCount <= 0) {
+    throw new Error(
+      `personaCount must be a positive integer, got ${options.personaCount}`,
+    );
+  }
+  if (!Number.isInteger(options.factsPerPersona) || options.factsPerPersona <= 0) {
+    throw new Error(
+      `factsPerPersona must be a positive integer, got ${options.factsPerPersona}`,
+    );
+  }
+  if (!Number.isInteger(options.maintenanceCycles) || options.maintenanceCycles < 0) {
+    throw new Error(
+      `maintenanceCycles must be a non-negative integer, got ${options.maintenanceCycles}`,
+    );
+  }
+  if (!Number.isInteger(options.uptakeLatencyCap) || options.uptakeLatencyCap <= 0) {
+    throw new Error(
+      `uptakeLatencyCap must be a positive integer, got ${options.uptakeLatencyCap}`,
+    );
+  }
+  if (!Number.isInteger(options.seed) || options.seed < 0 || options.seed > MAX_PRNG_SEED) {
+    throw new Error(
+      `seed must be an integer in [0, ${MAX_PRNG_SEED}], got ${options.seed}`,
+    );
+  }
+  const baseMs = Date.parse(options.nowIso);
+  if (!Number.isFinite(baseMs)) {
+    throw new Error(`nowIso must be a valid ISO timestamp, got ${options.nowIso}`);
+  }
+
+  const rng = mulberry32(options.seed);
+  const plans = planFacts(rng, options);
+  const scenarios: MemCorrectScenario[] = [];
+
+  for (let i = 0; i < plans.length; i += 1) {
+    const plan = plans[i];
+    // Stagger each scenario's base time so timestamps never collide and
+    // half-open windows are unambiguous.
+    const scenarioBase = baseMs + i * 86_400_000;
+    let offset = 0;
+    const established = establishTurns(plan, scenarioBase, offset);
+    offset = established.nextOffsetMs;
+    const corrected = buildCorrection(plan, scenarioBase, offset);
+    offset = corrected.nextOffsetMs;
+    const antis = buildAntiEvents(rng, plan, scenarioBase, offset);
+    offset = antis.nextOffsetMs;
+
+    let scopedTwin: ScopedTwin | undefined;
+    if (plan.shape === "scoped") {
+      const twin = buildScopedTwin(plan, scenarioBase, offset);
+      scopedTwin = twin.twin;
+      offset = twin.nextOffsetMs;
+    }
+
+    let reassertion: Reassertion | undefined;
+    if (plan.shape === "re-assertion") {
+      reassertion = buildReassertion(plan, scenarioBase, offset);
+      offset += 60_000;
+    }
+
+    const unrelated = buildUnrelatedProbes(rng);
+    offset += unrelated.nextOffsetMs;
+
+    scenarios.push({
+      id: `memcorrect-${options.seed}-${i.toString(16)}`,
+      namespace: plan.namespace,
+      category: plan.category,
+      establishingTurns: established.turns,
+      correction: corrected.correction,
+      probe: probeFor(plan),
+      antiEvents: antis.events,
+      scopedTwin,
+      reassertion,
+      unrelatedProbes: unrelated.probes,
+    });
+  }
+
+  return { options, scenarios };
+}
+
+/**
+ * Canonical SHA-256 of the corpus. Two runs with the same seed produce a
+ * byte-identical hash — this is the determinism assertion CI enforces.
+ */
+export function corpusHash(corpus: MemCorrectCorpus): string {
+  const canonical = JSON.stringify({
+    personaCount: corpus.options.personaCount,
+    factsPerPersona: corpus.options.factsPerPersona,
+    seed: corpus.options.seed,
+    nowIso: corpus.options.nowIso,
+    maintenanceCycles: corpus.options.maintenanceCycles,
+    uptakeLatencyCap: corpus.options.uptakeLatencyCap,
+    scenarios: corpus.scenarios,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}

--- a/packages/bench/src/benchmarks/remnic/memcorrect/leaderboard.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/leaderboard.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  buildMemCorrectLeaderboardRow,
+  writeLeaderboardArtifactsForResult,
+} from "../../../leaderboard-export.js";
+import {
+  runMemCorrectBenchmark,
+  memcorrectDefinition,
+} from "./runner.js";
+import { PromptOnlyBaselineAdapter } from "./adapters.js";
+import type { BenchmarkResult, ResolvedRunBenchmarkOptions } from "../../../types.js";
+
+function options(
+  overrides: Partial<ResolvedRunBenchmarkOptions> = {},
+): ResolvedRunBenchmarkOptions {
+  return {
+    mode: "quick",
+    benchmark: memcorrectDefinition,
+    system: {
+      describe: () => "fake",
+      store: async () => undefined,
+      query: async () => "",
+      recall: async () => "",
+      search: async () => [],
+      reset: async () => undefined,
+      getStats: async () => ({ totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 }),
+      destroy: async () => undefined,
+    },
+    ...overrides,
+  } as unknown as ResolvedRunBenchmarkOptions;
+}
+
+async function baselineResult(limit: number): Promise<BenchmarkResult> {
+  return runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit,
+    }),
+  );
+}
+
+test("leaderboard: buildMemCorrectLeaderboardRow carries adapter + all 8 metrics", async () => {
+  const result = await baselineResult(3);
+  const row = buildMemCorrectLeaderboardRow(result);
+  assert.ok(row, "row must be built from a memcorrect result");
+  assert.equal(row.benchmark, "memcorrect-v1");
+  assert.equal(row.adapter, "prompt-only-baseline");
+  assert.equal(typeof row.uptake_at_next, "number");
+  assert.equal(typeof row.non_resurrection, "number");
+  assert.equal(typeof row.false_apply, "number");
+  assert.equal(row.dataset_hash, result.meta.datasetHash);
+  assert.equal(row.provenance_fidelity, null, "baseline does not surface provenance");
+});
+
+test("leaderboard: writeLeaderboardArtifactsForResult emits a memcorrect JSONL", async () => {
+  const result = await baselineResult(2);
+  const dir = await mkdtemp(path.join(tmpdir(), "memcorrect-lb-"));
+  try {
+    const writes = await writeLeaderboardArtifactsForResult(result, dir);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].benchmark, "memcorrect-v1");
+    assert.equal(writes[0].format, "memcorrect-adapter-metrics-jsonl");
+    const content = await readFile(writes[0].path, "utf8");
+    const parsed = JSON.parse(content.trim());
+    assert.equal(parsed.benchmark, "memcorrect-v1");
+    assert.equal(parsed.adapter, "prompt-only-baseline");
+    assert.ok("non_resurrection" in parsed);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("leaderboard: non-memcorrect result produces no writes", async () => {
+  const other: BenchmarkResult = {
+    meta: {
+      id: "x",
+      benchmark: "retention-aged-dataset",
+      benchmarkTier: "remnic",
+      version: "1.0.0",
+      remnicVersion: "9.3.701",
+      gitSha: "deadbeef",
+      timestamp: "2026-07-05T00:00:00.000Z",
+      mode: "quick",
+      runCount: 1,
+      seeds: [1],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "synthetic",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: { tasks: [], aggregates: {} },
+    environment: { os: "darwin", nodeVersion: process.version },
+  };
+  const writes = await writeLeaderboardArtifactsForResult(other, tmpdir());
+  assert.deepEqual(writes, []);
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
@@ -293,3 +293,50 @@ test("computeMetricBundle: assembles all 8 metrics from resolved inputs", () => 
   assert.equal(bundle.reassertion, null);
   assert.equal(bundle.provenance_fidelity, null);
 });
+
+test("correction evidence citing old+new is not penalized as stale recall (#1584)", () => {
+  const corrections = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  // Provenance-rich recall: one string cites BOTH the retired and corrected
+  // value ("not old, now new"). Pre-#1584 the token-absence check saw "old"
+  // and failed the probe; now it is affirmative evidence and must pass.
+  const log: ProbeLogEntry[] = [
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 11, recalled: ["the value is not old it is now new"] }),
+    probe({ scenarioId: "s1", phase: "post_maintenance", turnIndex: 14, recalled: ["the value is not old it is now new"] }),
+    probe({ scenarioId: "s1", phase: "post_reingest", turnIndex: 18, recalled: ["the value is not old it is now new"] }),
+  ];
+  const bundle = computeMetricBundle({
+    log,
+    corrections,
+    antiEvents: [],
+    reassertions: [],
+    collateralBefore: [1],
+    collateralAfter: [1],
+    provenanceCites: [null],
+    uptakeLatencyCap: 5,
+  });
+  assert.equal(bundle.uptake_at_next, 1, "correction evidence should pass uptake@next");
+  assert.equal(bundle.uptake_latency, 1);
+  assert.equal(bundle.non_resurrection, 1, "correction evidence must not count as resurrection");
+});
+
+test("standalone retired recall (no corrected value) still counts as stale (#1584)", () => {
+  const corrections = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 11, recalled: ["the value is still old"] }),
+  ];
+  const bundle = computeMetricBundle({
+    log,
+    corrections,
+    antiEvents: [],
+    reassertions: [],
+    collateralBefore: [1],
+    collateralAfter: [1],
+    provenanceCites: [null],
+    uptakeLatencyCap: 5,
+  });
+  assert.equal(bundle.uptake_at_next, 0, "genuine stale recall must still fail");
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
@@ -212,8 +212,8 @@ test("scopePrecision: twin intact + primary retired passes; twin damaged fails",
   assert.equal(scopePrecision(log, corrections), 0.5);
 });
 
-test("scopePrecision: no scoped corrections returns 0", () => {
-  assert.equal(scopePrecision([], []), 0);
+test("scopePrecision: no scoped corrections returns null (n/a, not 0)", () => {
+  assert.equal(scopePrecision([], []), null);
 });
 
 // ---------------------------------------------------------------------------
@@ -288,8 +288,8 @@ test("computeMetricBundle: assembles all 8 metrics from resolved inputs", () => 
   assert.equal(bundle.uptake_latency_censored, 0);
   assert.equal(bundle.non_resurrection, 1);
   assert.equal(bundle.collateral_delta, 0);
-  assert.equal(bundle.scope_precision, 0);
+  assert.equal(bundle.scope_precision, null);
   assert.equal(bundle.false_apply, 0);
-  assert.equal(bundle.reassertion, 0);
+  assert.equal(bundle.reassertion, null);
   assert.equal(bundle.provenance_fidelity, null);
 });

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
@@ -1,0 +1,282 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  uptakeAtNext,
+  uptakeLatency,
+  nonResurrection,
+  collateralDelta,
+  scopePrecision,
+  falseApply,
+  reassertion,
+  provenanceFidelity,
+  computeMetricBundle,
+  containsAll,
+  containsNone,
+  tokenize,
+} from "./metrics.js";
+import type {
+  ProbeLogEntry,
+  ResolvedAntiEvent,
+  ResolvedCorrection,
+  ResolvedReassertion,
+} from "./types.js";
+
+function probe(args: {
+  scenarioId: string;
+  phase: ProbeLogEntry["phase"];
+  turnIndex: number;
+  namespace?: string;
+  recalled: string[];
+}): ProbeLogEntry {
+  return {
+    scenarioId: args.scenarioId,
+    phase: args.phase,
+    turnIndex: args.turnIndex,
+    namespace: args.namespace ?? "ns-a",
+    query: "q",
+    recalled: args.recalled,
+    at: "2026-07-05T00:00:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Containment primitives
+// ---------------------------------------------------------------------------
+
+test("tokenize lowercases and splits on non-alnum, preserving hyphens", () => {
+  assert.deepEqual(
+    [...tokenize("Oat-Milk, coffee!")].sort(),
+    ["coffee", "oat-milk"].sort(),
+  );
+});
+
+test("containsAll / containsNone are token-set operations", () => {
+  assert.equal(containsAll("the new value is here", ["new", "value"]), true);
+  assert.equal(containsAll("only new", ["new", "value"]), false);
+  assert.equal(containsNone("nothing relevant", ["old", "value"]), true);
+  assert.equal(containsNone("the old fact", ["old"]), false);
+});
+
+// ---------------------------------------------------------------------------
+// uptake@next
+// ---------------------------------------------------------------------------
+
+test("uptakeAtNext: 1 of 2 corrections reflected on first post-correction probe", () => {
+  const corrections: ResolvedCorrection[] = [
+    {
+      scenarioId: "s1",
+      namespace: "ns-a",
+      turnIndex: 10,
+      retiredContent: ["old"],
+      correctedContent: ["new"],
+    },
+    {
+      scenarioId: "s2",
+      namespace: "ns-a",
+      turnIndex: 10,
+      retiredContent: ["old"],
+      correctedContent: ["new"],
+    },
+  ];
+  const log: ProbeLogEntry[] = [
+    // s1: first post-correction probe passes (new present, old absent).
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 11, recalled: ["now new value"] }),
+    // s2: first post-correction probe fails (old still present).
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 11, recalled: ["still old value"] }),
+  ];
+  assert.equal(uptakeAtNext(log, corrections), 0.5);
+});
+
+test("uptakeAtNext: half-open window ignores probes at/before correction turn", () => {
+  const corrections: ResolvedCorrection[] = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    // Probe AT the correction turn (turnIndex 10) — half-open excludes it.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 10, recalled: ["new value"] }),
+    // First strictly-after probe (turnIndex 12) passes.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 12, recalled: ["new value"] }),
+  ];
+  assert.equal(uptakeAtNext(log, corrections), 1);
+});
+
+test("uptakeAtNext: empty corrections returns 0 (no division by zero)", () => {
+  assert.equal(uptakeAtNext([], []), 0);
+});
+
+// ---------------------------------------------------------------------------
+// uptake_latency
+// ---------------------------------------------------------------------------
+
+test("uptakeLatency: mean of resolved + censored, capped", () => {
+  const corrections: ResolvedCorrection[] = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+    { scenarioId: "s2", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    // s1: turn 11 fails, turn 12 passes → latency 2.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 11, recalled: ["old still"] }),
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 12, recalled: ["new value"] }),
+    // s2: turns 11..15 all fail; turn 16 > cap(5) breaks the loop → censored.
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 11, recalled: ["old"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 12, recalled: ["old"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 13, recalled: ["old"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 14, recalled: ["old"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 15, recalled: ["old"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 16, recalled: ["new"] }),
+  ];
+  const result = uptakeLatency(log, corrections, 5);
+  // (2 + 5) / 2 = 3.5; one censored.
+  assert.equal(result.mean, 3.5);
+  assert.equal(result.censored, 1);
+});
+
+// ---------------------------------------------------------------------------
+// non_resurrection
+// ---------------------------------------------------------------------------
+
+test("nonResurrection: retired fact resurrected on re-ingest scores 0", () => {
+  const corrections: ResolvedCorrection[] = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 5, retiredContent: ["old"], correctedContent: ["new"] },
+    { scenarioId: "s2", namespace: "ns-a", turnIndex: 5, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    // s1: stays retired through maintenance AND re-ingest.
+    probe({ scenarioId: "s1", phase: "post_maintenance", turnIndex: 8, recalled: ["new value"] }),
+    probe({ scenarioId: "s1", phase: "post_reingest", turnIndex: 12, recalled: ["new value"] }),
+    // s2: retired through maintenance but resurrected on re-ingest.
+    probe({ scenarioId: "s2", phase: "post_maintenance", turnIndex: 8, recalled: ["new value"] }),
+    probe({ scenarioId: "s2", phase: "post_reingest", turnIndex: 12, recalled: ["old fact returned"] }),
+  ];
+  assert.equal(nonResurrection(log, corrections), 0.5);
+});
+
+// ---------------------------------------------------------------------------
+// collateral
+// ---------------------------------------------------------------------------
+
+test("collateralDelta: after minus before over unrelated probes", () => {
+  // before mean = (1+1+0)/3 = 0.6667; after mean = (1+0+0)/3 = 0.3333
+  const delta = collateralDelta([1, 1, 0], [1, 0, 0]);
+  assert.ok(Math.abs(delta - (1 / 3 - 2 / 3)) < 1e-9, `got ${delta}`);
+});
+
+test("collateralDelta: empty returns 0", () => {
+  assert.equal(collateralDelta([], []), 0);
+});
+
+// ---------------------------------------------------------------------------
+// scope_precision
+// ---------------------------------------------------------------------------
+
+test("scopePrecision: twin intact + primary retired passes; twin damaged fails", () => {
+  const corrections: ResolvedCorrection[] = [
+    {
+      scenarioId: "s1",
+      namespace: "ns-a",
+      turnIndex: 5,
+      retiredContent: ["old"],
+      correctedContent: ["new"],
+      scopedTwin: { namespace: "ns-b", establishingTurns: [], twinContent: "old" },
+    },
+    {
+      scenarioId: "s2",
+      namespace: "ns-a",
+      turnIndex: 5,
+      retiredContent: ["old"],
+      correctedContent: ["new"],
+      scopedTwin: { namespace: "ns-b", establishingTurns: [], twinContent: "old" },
+    },
+  ];
+  const log: ProbeLogEntry[] = [
+    // s1: primary retired, twin intact → pass.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 6, namespace: "ns-a", recalled: ["new value"] }),
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 6, namespace: "ns-b", recalled: ["old twin intact"] }),
+    // s2: primary retired, twin damaged (old gone) → fail.
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 6, namespace: "ns-a", recalled: ["new value"] }),
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 6, namespace: "ns-b", recalled: ["twin overwritten new"] }),
+  ];
+  assert.equal(scopePrecision(log, corrections), 0.5);
+});
+
+test("scopePrecision: no scoped corrections returns 0", () => {
+  assert.equal(scopePrecision([], []), 0);
+});
+
+// ---------------------------------------------------------------------------
+// false_apply
+// ---------------------------------------------------------------------------
+
+test("falseApply: anti-event leaking the token counts as triggered", () => {
+  const antis: ResolvedAntiEvent[] = [
+    { scenarioId: "s1", namespace: "ns-a", probeQuery: "q", shouldNotAppear: "new" },
+    { scenarioId: "s2", namespace: "ns-a", probeQuery: "q", shouldNotAppear: "new" },
+  ];
+  const log: ProbeLogEntry[] = [
+    // s1: post-correction probe leaks "new" from the anti-event.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 12, recalled: ["new leaked through"] }),
+    // s2: no leak.
+    probe({ scenarioId: "s2", phase: "post_correction", turnIndex: 12, recalled: ["nothing relevant"] }),
+  ];
+  assert.equal(falseApply(log, antis), 0.5);
+});
+
+// ---------------------------------------------------------------------------
+// reassertion
+// ---------------------------------------------------------------------------
+
+test("reassertion: re-asserted content must surface again", () => {
+  const res: ResolvedReassertion[] = [
+    { scenarioId: "s1", namespace: "ns-a", expectedContent: "old" },
+    { scenarioId: "s2", namespace: "ns-a", expectedContent: "old" },
+  ];
+  const log: ProbeLogEntry[] = [
+    probe({ scenarioId: "s1", phase: "post_reassertion", turnIndex: 20, recalled: ["back to old"] }),
+    probe({ scenarioId: "s2", phase: "post_reassertion", turnIndex: 20, recalled: ["still new"] }),
+  ];
+  assert.equal(reassertion(log, res), 0.5);
+});
+
+// ---------------------------------------------------------------------------
+// provenance_fidelity
+// ---------------------------------------------------------------------------
+
+test("provenanceFidelity: averages scored cites, returns null when all n/a", () => {
+  assert.equal(provenanceFidelity([1, 0, null]), 0.5);
+  assert.equal(provenanceFidelity([null, null]), null);
+  assert.equal(provenanceFidelity([]), null);
+});
+
+// ---------------------------------------------------------------------------
+// computeMetricBundle wiring
+// ---------------------------------------------------------------------------
+
+test("computeMetricBundle: assembles all 8 metrics from resolved inputs", () => {
+  const corrections: ResolvedCorrection[] = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 5, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 6, recalled: ["new value"] }),
+    probe({ scenarioId: "s1", phase: "post_maintenance", turnIndex: 9, recalled: ["new value"] }),
+    probe({ scenarioId: "s1", phase: "post_reingest", turnIndex: 13, recalled: ["new value"] }),
+  ];
+  const bundle = computeMetricBundle({
+    log,
+    corrections,
+    antiEvents: [],
+    reassertions: [],
+    collateralBefore: [1, 1],
+    collateralAfter: [1, 1],
+    provenanceCites: [null],
+    uptakeLatencyCap: 5,
+  });
+  assert.equal(bundle.uptake_at_next, 1);
+  assert.equal(bundle.uptake_latency, 1);
+  assert.equal(bundle.uptake_latency_censored, 0);
+  assert.equal(bundle.non_resurrection, 1);
+  assert.equal(bundle.collateral_delta, 0);
+  assert.equal(bundle.scope_precision, 0);
+  assert.equal(bundle.false_apply, 0);
+  assert.equal(bundle.reassertion, 0);
+  assert.equal(bundle.provenance_fidelity, null);
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.test.ts
@@ -131,6 +131,19 @@ test("uptakeLatency: mean of resolved + censored, capped", () => {
   assert.equal(result.censored, 1);
 });
 
+test("uptakeLatency: a success landing exactly at the cap is resolved, not censored", () => {
+  const corrections: ResolvedCorrection[] = [
+    { scenarioId: "s1", namespace: "ns-a", turnIndex: 10, retiredContent: ["old"], correctedContent: ["new"] },
+  ];
+  const log: ProbeLogEntry[] = [
+    // First passing probe at turn 15 = delta 5 == cap → resolved, NOT censored.
+    probe({ scenarioId: "s1", phase: "post_correction", turnIndex: 15, recalled: ["new value"] }),
+  ];
+  const result = uptakeLatency(log, corrections, 5);
+  assert.equal(result.mean, 5);
+  assert.equal(result.censored, 0);
+});
+
 // ---------------------------------------------------------------------------
 // non_resurrection
 // ---------------------------------------------------------------------------

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
@@ -117,15 +117,20 @@ export function uptakeLatency(
       .sort((a, b) => a.turnIndex - b.turnIndex)
       .filter((e) => e.turnIndex > correction.turnIndex);
     let resolved = cap;
+    let found = false;
     for (const entry of post) {
       const delta = entry.turnIndex - correction.turnIndex;
       if (delta > cap) break;
       if (probePassesForCorrection(entry, correction)) {
         resolved = delta;
+        found = true;
         break;
       }
     }
-    if (resolved >= cap) censored += 1;
+    // Censor only when NO passing probe was found within the cap. A success
+    // landing exactly at the cap (delta === cap) is resolved, not censored —
+    // the old `resolved >= cap` check double-counted such boundary wins.
+    if (!found) censored += 1;
     sum += resolved;
   }
   return { mean: sum / corrections.length, censored };

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
@@ -55,8 +55,28 @@ function joinedRecall(entry: ProbeLogEntry): string {
 }
 
 /**
+ * True iff the probe's recall shows the retired value as a *standalone* stale
+ * assertion — some recalled string asserts the retired content WITHOUT the
+ * corrected content. Correction/provenance evidence that cites both the old and
+ * new value (e.g. "not X, now Y") is affirmative, not stale, and must NOT be
+ * penalized (issue #1584: don't treat correction evidence as stale recall).
+ */
+export function recallShowsStaleRetired(
+  entry: ProbeLogEntry,
+  correction: ResolvedCorrection,
+): boolean {
+  for (const recalled of entry.recalled) {
+    if (!containsAll(recalled, correction.retiredContent)) continue;
+    // Retired token present: only a stale signal if the corrected value is
+    // absent from the SAME string (otherwise it is correction evidence).
+    if (!containsAll(recalled, correction.correctedContent)) return true;
+  }
+  return false;
+}
+
+/**
  * A probe "passes" for a correction iff the corrected content is present
- * AND the retired content is absent from the joined recall.
+ * AND no recalled string asserts the retired value as a standalone stale fact.
  */
 export function probePassesForCorrection(
   entry: ProbeLogEntry,
@@ -65,7 +85,7 @@ export function probePassesForCorrection(
   const hay = joinedRecall(entry);
   return (
     containsAll(hay, correction.correctedContent) &&
-    containsNone(hay, correction.retiredContent)
+    !recallShowsStaleRetired(entry, correction)
   );
 }
 
@@ -153,8 +173,8 @@ export function nonResurrection(
     const postReingest = entriesFor(log, correction.scenarioId, "post_reingest");
     const both = [...postMaint, ...postReingest];
     if (both.length === 0) continue;
-    const allRetired = both.every((e) =>
-      containsNone(joinedRecall(e), correction.retiredContent),
+    const allRetired = both.every(
+      (e) => !recallShowsStaleRetired(e, correction),
     );
     if (allRetired) stayedRetired += 1;
   }
@@ -205,10 +225,7 @@ export function scopePrecision(
       )
       .sort((a, b) => a.turnIndex - b.turnIndex)[0];
     if (!primaryPost || !twinPost) continue;
-    const primaryRetired = containsNone(
-      joinedRecall(primaryPost),
-      correction.retiredContent,
-    );
+    const primaryRetired = !recallShowsStaleRetired(primaryPost, correction);
     const twinIntact = containsAll(joinedRecall(twinPost), [twin.twinContent]);
     if (primaryRetired && twinIntact) passed += 1;
   }

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
@@ -184,7 +184,7 @@ export function collateralDelta(
 export function scopePrecision(
   log: readonly ProbeLogEntry[],
   corrections: readonly ResolvedCorrection[],
-): number {
+): number | null {
   let scopedCount = 0;
   let passed = 0;
   for (const correction of corrections) {
@@ -212,7 +212,7 @@ export function scopePrecision(
     const twinIntact = containsAll(joinedRecall(twinPost), [twin.twinContent]);
     if (primaryRetired && twinIntact) passed += 1;
   }
-  return scopedCount > 0 ? passed / scopedCount : 0;
+  return scopedCount > 0 ? passed / scopedCount : null;
 }
 
 /**
@@ -250,8 +250,8 @@ export function falseApply(
 export function reassertion(
   log: readonly ProbeLogEntry[],
   reassertions: readonly ResolvedReassertion[],
-): number {
-  if (reassertions.length === 0) return 0;
+): number | null {
+  if (reassertions.length === 0) return null;
   let recalled = 0;
   for (const re of reassertions) {
     const post = entriesFor(log, re.scenarioId, "post_reassertion");

--- a/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/metrics.ts
@@ -1,0 +1,305 @@
+/**
+ * MemCorrect metrics (issue #1584 PR 2).
+ *
+ * Every metric is a pure function over the probe log + resolved scenario
+ * metadata. The runner records the probe log while driving an adapter
+ * through the protocol; these functions turn that log into the 8 scores.
+ *
+ * Scoring prefers deterministic token containment over LLM judging
+ * (checklist: a benchmark whose scores move with judge temperature is not
+ * a benchmark). Paraphrase-tolerant checks go through the sealed-rubric
+ * judge in the runner; these pure functions take already-resolved string
+ * sets so they are unit-testable with hand-computed expected values.
+ *
+ * Half-open windows (checklist §23): "post-correction" includes probes
+ * whose turnIndex is strictly greater than the correction's turnIndex.
+ */
+
+import type {
+  MemCorrectMetricBundle,
+  ProbeLogEntry,
+  ResolvedAntiEvent,
+  ResolvedCorrection,
+  ResolvedReassertion,
+} from "./types.js";
+
+/** Normalize a string to a lowercase alnum-token set for containment. */
+export function tokenize(text: string): Set<string> {
+  const tokens = text.toLowerCase().match(/[a-z0-9][a-z0-9-]*/g);
+  return new Set(tokens ?? []);
+}
+
+/** True iff every needle token appears in the haystack's token set. */
+export function containsAll(haystack: string, needles: readonly string[]): boolean {
+  if (needles.length === 0) return true;
+  const hay = tokenize(haystack);
+  for (const needle of needles) {
+    if (!hay.has(needle.toLowerCase())) return false;
+  }
+  return true;
+}
+
+/** True iff none of the banned tokens appear in the haystack's token set. */
+export function containsNone(haystack: string, banned: readonly string[]): boolean {
+  if (banned.length === 0) return true;
+  const hay = tokenize(haystack);
+  for (const token of banned) {
+    if (hay.has(token.toLowerCase())) return false;
+  }
+  return true;
+}
+
+/** Join a probe's recalled strings into one haystack for containment checks. */
+function joinedRecall(entry: ProbeLogEntry): string {
+  return entry.recalled.join(" ");
+}
+
+/**
+ * A probe "passes" for a correction iff the corrected content is present
+ * AND the retired content is absent from the joined recall.
+ */
+export function probePassesForCorrection(
+  entry: ProbeLogEntry,
+  correction: ResolvedCorrection,
+): boolean {
+  const hay = joinedRecall(entry);
+  return (
+    containsAll(hay, correction.correctedContent) &&
+    containsNone(hay, correction.retiredContent)
+  );
+}
+
+function entriesFor(
+  log: readonly ProbeLogEntry[],
+  scenarioId: string,
+  phase: ProbeLogEntry["phase"],
+): ProbeLogEntry[] {
+  return log.filter((e) => e.scenarioId === scenarioId && e.phase === phase);
+}
+
+/**
+ * uptake@next — fraction of corrections reflected in the *first*
+ * post-correction probe (corrected present, retired absent).
+ */
+export function uptakeAtNext(
+  log: readonly ProbeLogEntry[],
+  corrections: readonly ResolvedCorrection[],
+): number {
+  if (corrections.length === 0) return 0;
+  let passed = 0;
+  for (const correction of corrections) {
+    const post = entriesFor(log, correction.scenarioId, "post_correction")
+      .sort((a, b) => a.turnIndex - b.turnIndex);
+    // Half-open: only probes strictly after the correction count.
+    const eligible = post.filter((e) => e.turnIndex > correction.turnIndex);
+    const first = eligible[0];
+    if (first && probePassesForCorrection(first, correction)) passed += 1;
+  }
+  return passed / corrections.length;
+}
+
+/**
+ * uptake_latency — mean interaction turns until the first correct recall,
+ * capped at `cap`. Returns the capped mean; censored (never-correct within
+ * the cap) corrections contribute `cap` to the mean and are counted
+ * separately in the censored tally the bundle reports.
+ */
+export function uptakeLatency(
+  log: readonly ProbeLogEntry[],
+  corrections: readonly ResolvedCorrection[],
+  cap: number,
+): { mean: number; censored: number } {
+  if (corrections.length === 0) return { mean: 0, censored: 0 };
+  let sum = 0;
+  let censored = 0;
+  for (const correction of corrections) {
+    const post = entriesFor(log, correction.scenarioId, "post_correction")
+      .sort((a, b) => a.turnIndex - b.turnIndex)
+      .filter((e) => e.turnIndex > correction.turnIndex);
+    let resolved = cap;
+    for (const entry of post) {
+      const delta = entry.turnIndex - correction.turnIndex;
+      if (delta > cap) break;
+      if (probePassesForCorrection(entry, correction)) {
+        resolved = delta;
+        break;
+      }
+    }
+    if (resolved >= cap) censored += 1;
+    sum += resolved;
+  }
+  return { mean: sum / corrections.length, censored };
+}
+
+/**
+ * non_resurrection — fraction of retired facts that stay retired after
+ * `runMaintenance()` ×K cycles AND re-ingest of the original establishing
+ * transcript. A retired fact "stays retired" iff the retired content is
+ * absent from BOTH the post-maintenance and post-reingest probes.
+ */
+export function nonResurrection(
+  log: readonly ProbeLogEntry[],
+  corrections: readonly ResolvedCorrection[],
+): number {
+  if (corrections.length === 0) return 0;
+  let stayedRetired = 0;
+  for (const correction of corrections) {
+    const postMaint = entriesFor(log, correction.scenarioId, "post_maintenance");
+    const postReingest = entriesFor(log, correction.scenarioId, "post_reingest");
+    const both = [...postMaint, ...postReingest];
+    if (both.length === 0) continue;
+    const allRetired = both.every((e) =>
+      containsNone(joinedRecall(e), correction.retiredContent),
+    );
+    if (allRetired) stayedRetired += 1;
+  }
+  return corrections.length > 0 ? stayedRetired / corrections.length : 0;
+}
+
+/**
+ * collateral — recall over a fixed probe set of UNRELATED facts, before vs
+ * after corrections. Returns the delta (after − before); unchanged = 0 is
+ * the target. `before` and `after` are parallel arrays of unrelated-probe
+ * results (1 if expected content surfaced, 0 otherwise).
+ */
+export function collateralDelta(
+  before: readonly number[],
+  after: readonly number[],
+): number {
+  if (before.length === 0) return 0;
+  const mean = (xs: readonly number[]) =>
+    xs.reduce((s, x) => s + x, 0) / xs.length;
+  return mean(after) - mean(before);
+}
+
+/**
+ * scope_precision — for scoped corrections, fraction where the namespace-B
+ * twin stays intact AND the namespace-A retired fact is retired.
+ */
+export function scopePrecision(
+  log: readonly ProbeLogEntry[],
+  corrections: readonly ResolvedCorrection[],
+): number {
+  let scopedCount = 0;
+  let passed = 0;
+  for (const correction of corrections) {
+    const twin = correction.scopedTwin;
+    if (!twin) continue;
+    scopedCount += 1;
+    const primaryPost = entriesFor(log, correction.scenarioId, "post_correction")
+      .filter((e) => e.turnIndex > correction.turnIndex)
+      .sort((a, b) => a.turnIndex - b.turnIndex)[0];
+    // Twin probe: most recent twin-namespace post-correction probe.
+    const twinPost = log
+      .filter(
+        (e) =>
+          e.scenarioId === correction.scenarioId &&
+          e.namespace === twin.namespace &&
+          e.phase === "post_correction" &&
+          e.turnIndex > correction.turnIndex,
+      )
+      .sort((a, b) => a.turnIndex - b.turnIndex)[0];
+    if (!primaryPost || !twinPost) continue;
+    const primaryRetired = containsNone(
+      joinedRecall(primaryPost),
+      correction.retiredContent,
+    );
+    const twinIntact = containsAll(joinedRecall(twinPost), [twin.twinContent]);
+    if (primaryRetired && twinIntact) passed += 1;
+  }
+  return scopedCount > 0 ? passed / scopedCount : 0;
+}
+
+/**
+ * false_apply — fraction of anti-events that caused an undesired memory
+ * mutation. Detected behaviorally: after ingesting an anti-event, a probe
+ * returning the `shouldNotAppear` token counts as a false apply. Lower is
+ * better; the prompt-only baseline is expected to score high here.
+ */
+export function falseApply(
+  log: readonly ProbeLogEntry[],
+  antiEvents: readonly ResolvedAntiEvent[],
+): number {
+  if (antiEvents.length === 0) return 0;
+  let triggered = 0;
+  for (const anti of antiEvents) {
+    // The runner records the post-anti probe under post_correction phase
+    // (anti-events are ingested between correction and the maintenance
+    // cycle); the token is scenario-scoped so cross-scenario leakage
+    // cannot inflate the score.
+    const probes = log.filter(
+      (e) => e.scenarioId === anti.scenarioId && e.phase === "post_correction",
+    );
+    const leaked = probes.some((e) =>
+      containsAll(joinedRecall(e), [anti.shouldNotAppear]),
+    );
+    if (leaked) triggered += 1;
+  }
+  return triggered / antiEvents.length;
+}
+
+/**
+ * reassertion — fraction of re-asserted facts recallable again after the
+ * re-assertion event.
+ */
+export function reassertion(
+  log: readonly ProbeLogEntry[],
+  reassertions: readonly ResolvedReassertion[],
+): number {
+  if (reassertions.length === 0) return 0;
+  let recalled = 0;
+  for (const re of reassertions) {
+    const post = entriesFor(log, re.scenarioId, "post_reassertion");
+    const found = post.some((e) =>
+      containsAll(joinedRecall(e), [re.expectedContent]),
+    );
+    if (found) recalled += 1;
+  }
+  return recalled / reassertions.length;
+}
+
+/**
+ * provenance_fidelity — for systems that expose provenance, fraction of
+ * corrected states whose recall cites the correction event. The runner
+ * passes `null` (and the bundle reports n/a) when the adapter does not
+ * surface provenance. `citeLog` parallels `corrections`: 1 if the
+ * post-correction recall cited the correction event, 0 otherwise.
+ */
+export function provenanceFidelity(
+  citeLog: readonly (number | null)[],
+): number | null {
+  if (citeLog.length === 0) return null;
+  if (citeLog.every((v) => v === null)) return null;
+  const scored = citeLog.filter((v): v is number => v !== null);
+  if (scored.length === 0) return null;
+  return scored.reduce((s, v) => s + v, 0) / scored.length;
+}
+
+/** Compute the full metric bundle from resolved inputs. */
+export function computeMetricBundle(args: {
+  log: readonly ProbeLogEntry[];
+  corrections: readonly ResolvedCorrection[];
+  antiEvents: readonly ResolvedAntiEvent[];
+  reassertions: readonly ResolvedReassertion[];
+  collateralBefore: readonly number[];
+  collateralAfter: readonly number[];
+  provenanceCites: readonly (number | null)[];
+  uptakeLatencyCap: number;
+}): MemCorrectMetricBundle {
+  const latency = uptakeLatency(
+    args.log,
+    args.corrections,
+    args.uptakeLatencyCap,
+  );
+  return {
+    uptake_at_next: uptakeAtNext(args.log, args.corrections),
+    uptake_latency: latency.mean,
+    uptake_latency_censored: latency.censored,
+    non_resurrection: nonResurrection(args.log, args.corrections),
+    collateral_delta: collateralDelta(args.collateralBefore, args.collateralAfter),
+    scope_precision: scopePrecision(args.log, args.corrections),
+    false_apply: falseApply(args.log, args.antiEvents),
+    reassertion: reassertion(args.log, args.reassertions),
+    provenance_fidelity: provenanceFidelity(args.provenanceCites),
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
@@ -1,0 +1,259 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  runMemCorrectBenchmark,
+  memcorrectDefinition,
+  summarizeAggregateMetrics,
+} from "./runner.js";
+import { generateMemCorrectCorpus, corpusHash } from "./generator.js";
+import { PromptOnlyBaselineAdapter } from "./adapters.js";
+import {
+  listBenchmarks,
+  getBenchmark,
+  getRegisteredBenchmark,
+} from "../../../registry.js";
+import { BENCHMARK_RESULT_SCHEMA } from "../../../schema.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import type { MemCorrectSystemAdapter } from "./types.js";
+
+function options(
+  overrides: Partial<ResolvedRunBenchmarkOptions> = {},
+): ResolvedRunBenchmarkOptions {
+  return {
+    mode: "quick",
+    benchmark: memcorrectDefinition,
+    system: {
+      describe: () => "fake",
+      store: async () => undefined,
+      query: async () => "",
+      recall: async () => "",
+      search: async () => [],
+      reset: async () => undefined,
+      getStats: async () => ({ totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 }),
+      destroy: async () => undefined,
+    },
+    ...overrides,
+  } as unknown as ResolvedRunBenchmarkOptions;
+}
+
+// ---------------------------------------------------------------------------
+// Registry integration
+// ---------------------------------------------------------------------------
+
+test("registry: memcorrect-v1 is registered and resolvable", () => {
+  const all = listBenchmarks();
+  assert.ok(
+    all.some((b) => b.id === "memcorrect-v1"),
+    "memcorrect-v1 must appear in listBenchmarks()",
+  );
+  assert.equal(getBenchmark("memcorrect-v1")?.id, "memcorrect-v1");
+  const registered = getRegisteredBenchmark("memcorrect-v1");
+  assert.ok(registered, "memcorrect-v1 must have a registered runner");
+  assert.equal(typeof registered?.run, "function");
+});
+
+test("registry: memcorrect-v1 is tier=remnic, status=ready, runnerAvailable", () => {
+  assert.equal(memcorrectDefinition.tier, "remnic");
+  assert.equal(memcorrectDefinition.status, "ready");
+  assert.equal(memcorrectDefinition.runnerAvailable, true);
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end with the prompt-only baseline
+// ---------------------------------------------------------------------------
+
+test("runner: baseline run emits one task per scenario with all 7 score keys", async () => {
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 4,
+    }),
+  );
+  assert.ok(result.results.tasks.length === 4, "limit=4 → 4 tasks");
+  const expected = [
+    "uptake_at_next",
+    "uptake_latency",
+    "non_resurrection",
+    "collateral_delta",
+    "scope_precision",
+    "false_apply",
+    "reassertion",
+  ];
+  for (const task of result.results.tasks) {
+    for (const key of expected) {
+      assert.ok(key in task.scores, `task ${task.taskId} missing score ${key}`);
+    }
+  }
+  // Aggregate headline bundle present in config.benchmarkOptions.
+  const bundle = summarizeAggregateMetrics(result);
+  assert.ok(bundle, "aggregate bundle must be attached");
+  assert.ok("uptake_at_next" in bundle);
+  assert.ok("provenance_fidelity" in bundle);
+});
+
+test("runner: baseline scores near-zero on non_resurrection-under-reingest (the structural floor)", async () => {
+  // The append-everything baseline never retires anything, so re-ingesting
+  // the original transcript re-surfaces the retired fact. non_resurrection
+  // must collapse toward 0 — this is the sanity requirement from the issue
+  // (baseline near-zero, Remnic must not).
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 6,
+    }),
+  );
+  const bundle = summarizeAggregateMetrics(result);
+  assert.ok(bundle, "bundle missing");
+  assert.ok(
+    bundle.non_resurrection < 0.5,
+    `baseline non_resurrection should be low (re-ingest resurrects), got ${bundle.non_resurrection}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Determinism: two runs, same seed, identical corpus hash + identical metrics
+// ---------------------------------------------------------------------------
+
+test("runner: identical seed → identical datasetHash and identical deterministic metrics", async () => {
+  const seed = 4242;
+  const r1 = await runMemCorrectBenchmark(
+    options({
+      seed,
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 4,
+    }),
+  );
+  const r2 = await runMemCorrectBenchmark(
+    options({
+      seed,
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 4,
+    }),
+  );
+  assert.equal(r1.meta.datasetHash, r2.meta.datasetHash);
+  // Per-task deterministic metrics identical (latency is non-deterministic,
+  // so compare scores only).
+  for (let i = 0; i < r1.results.tasks.length; i += 1) {
+    assert.deepEqual(
+      r1.results.tasks[i].scores,
+      r2.results.tasks[i].scores,
+      `task ${i} metrics diverged`,
+    );
+  }
+});
+
+test("runner: datasetHash matches the standalone corpus hash for the same seed", async () => {
+  const seed = 4242;
+  const result = await runMemCorrectBenchmark(
+    options({
+      seed,
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 2,
+    }),
+  );
+  // The runner uses QUICK_OPTIONS shape with the override seed; the corpus
+  // hash is over ALL scenarios (limit only trims which run), so compare
+  // against the full quick corpus.
+  const corpus = generateMemCorrectCorpus({
+    personaCount: 2,
+    factsPerPersona: 4,
+    seed,
+    nowIso: "2026-07-05T00:00:00.000Z",
+    maintenanceCycles: 3,
+    uptakeLatencyCap: 5,
+  });
+  assert.equal(result.meta.datasetHash, corpusHash(corpus));
+});
+
+// ---------------------------------------------------------------------------
+// Adapter resolution
+// ---------------------------------------------------------------------------
+
+test("runner: benchmarkOptions.adapter is used when it satisfies the MemCorrect contract", async () => {
+  let resetCalls = 0;
+  const custom: MemCorrectSystemAdapter = {
+    label: "custom-fake",
+    async reset() {
+      resetCalls += 1;
+    },
+    async ingestTurn() {},
+    async recall() {
+      return [];
+    },
+    async correct() {},
+    async runMaintenance() {},
+  };
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: custom },
+      limit: 2,
+    }),
+  );
+  assert.equal(result.config.adapterMode, "custom-fake");
+  assert.ok(resetCalls >= 2, `reset should run per scenario, got ${resetCalls}`);
+});
+
+// ---------------------------------------------------------------------------
+// Schema round-trip
+// ---------------------------------------------------------------------------
+
+test("runner: emitted result validates against BENCHMARK_RESULT_SCHEMA", async () => {
+  const result = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 3,
+    }),
+  );
+  // The schema is a JSON-schema object; validate by shape via the schema's
+  // required-key contract. (BENCHMARK_RESULT_SCHEMA is consumed by the
+  // publishing pipeline; here we assert the structural invariants it pins.)
+  const required: readonly string[] = BENCHMARK_RESULT_SCHEMA.required;
+  for (const key of required) {
+    assert.ok(key in result, `result missing required top-level key ${key}`);
+  }
+  assert.ok(result.meta.datasetHash?.length === 64, "datasetHash must be sha-256");
+  assert.deepEqual(result.meta.seeds, [0xc077e7 & 0xffffffff]);
+  assert.equal(result.meta.benchmark, "memcorrect-v1");
+});
+
+// ---------------------------------------------------------------------------
+// Runtime-profile compatibility (the bench must accept a resolved profile)
+// ---------------------------------------------------------------------------
+
+test("runner: accepts a local-lab runtime profile without changing the hermetic corpus", async () => {
+  const result = await runMemCorrectBenchmark(
+    options({
+      runtimeProfile: "local-lab",
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 2,
+    }),
+  );
+  assert.equal(result.config.runtimeProfile, "local-lab");
+  // The hermetic corpus hash is independent of the runtime profile.
+  const baseline = await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 2,
+    }),
+  );
+  assert.equal(result.meta.datasetHash, baseline.meta.datasetHash);
+});
+
+test("runner: onTaskComplete fires for each scenario with a correct total", async () => {
+  const completed: Array<{ count: number; total?: number }> = [];
+  await runMemCorrectBenchmark(
+    options({
+      benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
+      limit: 3,
+      onTaskComplete: (_task, count, total) => {
+        completed.push({ count, total });
+      },
+    }),
+  );
+  assert.equal(completed.length, 3);
+  assert.deepEqual(
+    completed.map((c) => c.count),
+    [1, 2, 3],
+  );
+  assert.ok(completed.every((c) => c.total === 3));
+});

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
@@ -62,7 +62,7 @@ test("registry: memcorrect-v1 is tier=remnic, status=ready, runnerAvailable", ()
 // End-to-end with the prompt-only baseline
 // ---------------------------------------------------------------------------
 
-test("runner: baseline run emits one task per scenario with all 7 score keys", async () => {
+test("runner: baseline run emits directional scores (collateral_delta excluded; scope/reassertion conditional)", async () => {
   const result = await runMemCorrectBenchmark(
     options({
       benchmarkOptions: { adapter: new PromptOnlyBaselineAdapter() },
@@ -70,19 +70,27 @@ test("runner: baseline run emits one task per scenario with all 7 score keys", a
     }),
   );
   assert.ok(result.results.tasks.length === 4, "limit=4 → 4 tasks");
-  const expected = [
+  const alwaysPresent = [
     "uptake_at_next",
     "uptake_latency",
     "non_resurrection",
-    "collateral_delta",
-    "scope_precision",
     "false_apply",
-    "reassertion",
   ];
   for (const task of result.results.tasks) {
-    for (const key of expected) {
+    for (const key of alwaysPresent) {
       assert.ok(key in task.scores, `task ${task.taskId} missing score ${key}`);
     }
+    // collateral_delta is target-zero (not directional): must NOT appear in
+    // per-task directional scores, but IS carried in the full metric bundle.
+    assert.ok(!("collateral_delta" in task.scores), "collateral_delta must not pollute directional scores");
+    const detail = task.details as { metrics?: { memcorrect?: { collateral_delta?: unknown } }; shape?: string };
+    assert.equal(typeof detail.metrics?.memcorrect?.collateral_delta, "number", "collateral_delta in details bundle");
+    // scope_precision / reassertion appear only for their applicable shapes.
+    const shape = detail.shape;
+    const hasScope = "scope_precision" in task.scores;
+    const hasReassertion = "reassertion" in task.scores;
+    assert.equal(hasScope, shape === "scoped", `scope_precision presence must match scoped shape (got ${shape})`);
+    assert.equal(hasReassertion, shape === "re-assertion", `reassertion presence must match re-assertion shape (got ${shape})`);
   }
   // Aggregate headline bundle present in config.benchmarkOptions.
   const bundle = summarizeAggregateMetrics(result);
@@ -256,4 +264,54 @@ test("runner: onTaskComplete fires for each scenario with a correct total", asyn
     [1, 2, 3],
   );
   assert.ok(completed.every((c) => c.total === 3));
+});
+
+// ---------------------------------------------------------------------------
+// Anti-event probe turn isolation (Thread 3: bump turn before recall)
+// ---------------------------------------------------------------------------
+
+test("runner: anti-event probe gets its own interaction turn (not the ingest's)", async () => {
+  // When the uptake probe fails and the anti-event probe is the first recall
+  // to reflect the correction, uptake_latency must measure the delta from the
+  // probe's own interaction turn — not the anti-event ingest's turn. Before
+  // the fix the probe shared the ingest's turn, underreporting latency by one.
+  const corpus = generateMemCorrectCorpus({
+    personaCount: 2,
+    factsPerPersona: 4,
+    seed: 4242,
+    nowIso: "2026-07-05T00:00:00.000Z",
+    maintenanceCycles: 3,
+    uptakeLatencyCap: 5,
+  });
+  const scenario = corpus.scenarios[0]!;
+  assert.ok(scenario.antiEvents.length > 0, "test scenario must have anti-events");
+  const baselineRecalls = scenario.unrelatedProbes.length;
+  let corrected = false;
+  let recallIdx = 0;
+  const adapter: MemCorrectSystemAdapter = {
+    label: "turn-isolation-test",
+    async reset() { corrected = false; recallIdx = 0; },
+    async ingestTurn() {},
+    async correct() { corrected = true; },
+    async recall() {
+      const idx = recallIdx++;
+      if (!corrected) return []; // baseline probes
+      // Uptake probe (idx === baselineRecalls) fails; anti-event probe
+      // (idx === baselineRecalls + 1) is the first to reflect the correction.
+      if (idx === baselineRecalls) return [];
+      if (idx === baselineRecalls + 1) return [...scenario.correction.correctedContent];
+      return [];
+    },
+    async runMaintenance() {},
+  };
+  const result = await runMemCorrectBenchmark(
+    options({ benchmarkOptions: { adapter }, limit: 1, seed: 4242 }),
+  );
+  const bundle = summarizeAggregateMetrics(result);
+  assert.ok(bundle, "bundle missing");
+  // After the fix: the anti-event probe lands at correctionTurnIndex + 3
+  // (one turn for the ingest, one for the probe's own interaction, plus the
+  // uptake probe's turn). Before the fix it was +2 (probe shared ingest's turn).
+  assert.equal(bundle.uptake_latency, 3, "anti-event probe must get its own interaction turn");
+  assert.equal(bundle.uptake_latency_censored, 0, "within cap, not censored");
 });

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.test.ts
@@ -73,6 +73,7 @@ test("runner: baseline run emits directional scores (collateral_delta excluded; 
   const alwaysPresent = [
     "uptake_at_next",
     "uptake_latency",
+    "uptake_latency_censored",
     "non_resurrection",
     "false_apply",
   ];

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -354,11 +354,20 @@ export async function runMemCorrectBenchmark(
   const { adapter, adapterLabel } = resolveAdapter(options);
 
   // Honor options.limit so quick / limited runs don't fan out across every
-  // scenario, mirroring the other remnic runners.
-  const scenarios =
-    typeof options.limit === "number" && options.limit > 0
-      ? corpus.scenarios.slice(0, options.limit)
-      : corpus.scenarios;
+  // scenario, mirroring the other remnic runners. `limit === 0` is a valid
+  // zero-item cap (issue #1584): slice(0,0) yields [] rather than silently
+  // running the full corpus; non-number => no cap; reject negatives/fractions.
+  const { limit } = options;
+  let scenarios: typeof corpus.scenarios;
+  if (typeof limit !== "number") {
+    scenarios = corpus.scenarios;
+  } else if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `MemCorrect --limit must be a non-negative integer; got ${String(limit)}`,
+    );
+  } else {
+    scenarios = corpus.scenarios.slice(0, limit);
+  }
 
   const tasks: TaskResult[] = [];
   const aggregateLog: ProbeLogEntry[] = [];

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -147,18 +147,39 @@ async function runScenario(
     log.push({ scenarioId: scenario.id, phase, turnIndex: turn, namespace, query, recalled, at });
   };
 
-  // --- Establishing transcript ---
+  // --- Establishing transcript (primary fact) ---
   for (const t of scenario.establishingTurns) {
     await adapter.ingestTurn(sessionKey, t.role, t.text, t.at);
     turn += 1;
   }
 
+  // --- Scoped twin establishment (alternate namespace, BEFORE the correction) ---
+  // Seeded before the correction so scope_precision can catch a system that
+  // wrongly applies the correction across every namespace at correction time
+  // (the twin must already exist to be overwritten).
+  if (scenario.scopedTwin) {
+    for (const t of scenario.scopedTwin.establishingTurns) {
+      await adapter.ingestTurn(scenario.scopedTwin.namespace, t.role, t.text, t.at);
+      turn += 1;
+    }
+  }
+
+  // --- Collateral-fact establishment (primary namespace) ---
+  // Seed the unrelated facts before the baseline probe so collateral_delta
+  // measures recall over facts that were actually stored.
+  for (const probe of scenario.unrelatedProbes) {
+    for (const t of probe.establishingTurns) {
+      await adapter.ingestTurn(sessionKey, t.role, t.text, t.at);
+      turn += 1;
+    }
+  }
+
   // --- Baseline probe (unrelated-fact recall before correction) ---
   const collateralBefore: number[] = [];
   for (const probe of scenario.unrelatedProbes) {
+    turn += 1;
     const recalled = await adapter.recall(probe.query, sessionKey);
     recordProbe("baseline", probe.query, sessionKey, recalled, scenario.correction.turn.at);
-    turn += 1;
     collateralBefore.push(
       recalled.some((r) => r.toLowerCase().includes(probe.expectedContent.toLowerCase())) ? 1 : 0,
     );
@@ -170,10 +191,13 @@ async function runScenario(
   const correctionTurnIndex = turn;
 
   // --- Post-correction probe (uptake@next) ---
+  // Recorded at the interaction turn AFTER the correction (strictly greater
+  // than correctionTurnIndex) so uptake@next / uptake_latency count the
+  // dedicated uptake probe, not only the later anti-event / twin probes.
   {
+    turn += 1;
     const recalled = await adapter.recall(scenario.probe.query, sessionKey);
     recordProbe("post_correction", scenario.probe.query, sessionKey, recalled, scenario.correction.turn.at);
-    turn += 1;
   }
 
   // --- Anti-events (false_apply window) ---
@@ -187,16 +211,13 @@ async function runScenario(
     turn += 1;
   }
 
-  // Scoped twin probe (namespace-B must stay intact).
+  // --- Scoped twin probe (namespace-B must stay intact AFTER the correction) ---
+  // The twin was established above (before the correction); this probe checks
+  // it survived. Only the probe runs here — no re-ingestion.
   if (scenario.scopedTwin) {
-    const twin = scenario.scopedTwin;
-    for (const t of twin.establishingTurns) {
-      await adapter.ingestTurn(twin.namespace, t.role, t.text, t.at);
-      turn += 1;
-    }
-    const recalled = await adapter.recall(scenario.probe.query, twin.namespace);
-    recordProbe("post_correction", scenario.probe.query, twin.namespace, recalled, scenario.correction.turn.at);
     turn += 1;
+    const recalled = await adapter.recall(scenario.probe.query, scenario.scopedTwin.namespace);
+    recordProbe("post_correction", scenario.probe.query, scenario.scopedTwin.namespace, recalled, scenario.correction.turn.at);
   }
 
   // --- Maintenance cycles (non_resurrection) ---

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -426,6 +426,11 @@ export async function runMemCorrectBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, t) => sum + t.latencyMs, 0);
+  // Omit the live adapter instance from the persisted config so the result
+  // stays JSON-serializable — a stateful/circular adapter would otherwise be
+  // walked by the reporter. The adapter label is already captured in `adapterMode`.
+  const { adapter: _liveAdapter, ...persistableBenchmarkOptions } =
+    (options.benchmarkOptions as Record<string, unknown> | undefined) ?? {};
   return {
     meta: {
       id: randomUUID(),
@@ -447,7 +452,7 @@ export async function runMemCorrectBenchmark(
       adapterMode: adapterLabel,
       remnicConfig: options.remnicConfig ?? {},
       benchmarkOptions: {
-        ...options.benchmarkOptions,
+        ...persistableBenchmarkOptions,
         personaCount: generatorOptions.personaCount,
         factsPerPersona: generatorOptions.factsPerPersona,
         maintenanceCycles: generatorOptions.maintenanceCycles,

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -33,7 +33,7 @@ import { aggregateTaskScores } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import { generateMemCorrectCorpus, corpusHash } from "./generator.js";
 import { validateCorpus } from "./schema.js";
-import { computeMetricBundle } from "./metrics.js";
+import { computeMetricBundle, containsAll } from "./metrics.js";
 import {
   PromptOnlyBaselineAdapter,
   createRemnicMemCorrectAdapter,
@@ -65,6 +65,19 @@ export const memcorrectDefinition: BenchmarkDefinition = {
       "Remnic MemCorrect v1 (issue #1584). Open benchmark; adapter contract is the public contribution.",
   },
 };
+
+/**
+ * MemCorrect metrics where a LOWER value is better. Used by the bench
+ * comparison tool (getBenchmarkLowerIsBetter) so regressions in latency or
+ * false-apply are reported as regressions, not improvements. `collateral_delta`
+ * is target-zero (signed after − before) and is intentionally excluded from
+ * directional verdicts — a magnitude check, not a lower-is-better one.
+ */
+export const MEMCORRECT_LOWER_IS_BETTER: ReadonlySet<string> = new Set([
+  "uptake_latency",
+  "uptake_latency_censored",
+  "false_apply",
+]);
 const QUICK_OPTIONS = {
   personaCount: 2,
   factsPerPersona: 4,
@@ -181,12 +194,12 @@ async function runScenario(
     const recalled = await adapter.recall(probe.query, sessionKey);
     recordProbe("baseline", probe.query, sessionKey, recalled, scenario.correction.turn.at);
     collateralBefore.push(
-      recalled.some((r) => r.toLowerCase().includes(probe.expectedContent.toLowerCase())) ? 1 : 0,
+      containsAll(recalled.join(" "), [probe.expectedContent]) ? 1 : 0,
     );
   }
 
   // --- Correction ---
-  await adapter.correct(scenario.correction.turn.text, sessionKey);
+  await adapter.correct(scenario.correction.turn.text, sessionKey, scenario.correction.turn.at);
   turn += 1;
   const correctionTurnIndex = turn;
 
@@ -218,6 +231,18 @@ async function runScenario(
     turn += 1;
     const recalled = await adapter.recall(scenario.probe.query, scenario.scopedTwin.namespace);
     recordProbe("post_correction", scenario.probe.query, scenario.scopedTwin.namespace, recalled, scenario.correction.turn.at);
+  }
+
+  // --- Collateral after: re-probe unrelated facts IMMEDIATELY after the
+  // correction (before maintenance / re-ingest / re-assertion) so the delta
+  // isolates correction collateral damage rather than conflating it with
+  // later protocol steps that can also change unrelated recall.
+  const collateralAfter: number[] = [];
+  for (const probe of scenario.unrelatedProbes) {
+    const recalled = await adapter.recall(probe.query, sessionKey);
+    collateralAfter.push(
+      containsAll(recalled.join(" "), [probe.expectedContent]) ? 1 : 0,
+    );
   }
 
   // --- Maintenance cycles (non_resurrection) ---
@@ -262,14 +287,6 @@ async function runScenario(
     };
   }
 
-  // --- Collateral after: re-probe the unrelated facts ---
-  const collateralAfter: number[] = [];
-  for (const probe of scenario.unrelatedProbes) {
-    const recalled = await adapter.recall(probe.query, sessionKey);
-    collateralAfter.push(
-      recalled.some((r) => r.toLowerCase().includes(probe.expectedContent.toLowerCase())) ? 1 : 0,
-    );
-  }
 
   const correction: ResolvedCorrection = {
     scenarioId: scenario.id,

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -396,6 +396,7 @@ export async function runMemCorrectBenchmark(
     const scores: Record<string, number> = {
       uptake_at_next: m.uptake_at_next,
       uptake_latency: m.uptake_latency,
+      uptake_latency_censored: m.uptake_latency_censored,
       non_resurrection: m.non_resurrection,
       false_apply: m.false_apply,
     };

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -1,0 +1,477 @@
+/**
+ * MemCorrect runner (issue #1584 PR 2).
+ *
+ * Drives a `MemCorrectSystemAdapter` through the correction protocol:
+ *
+ *   reset → ingest establishing → baseline probe
+ *         → correct → post-correction probe
+ *         → ingest anti-events → post-correction probe (false_apply window)
+ *         → runMaintenance ×K → post-maintenance probe
+ *         → re-ingest establishing transcript → post-reingest probe
+ *         → re-assertion (if present) → post-reassertion probe
+ *
+ * Every probe is recorded in a probe log with a monotonic turn index. The
+ * metrics module turns that log into the 8 scores; this file resolves the
+ * scenario metadata into the inputs the pure metric functions expect and
+ * emits one `BenchmarkResult` task per scenario.
+ *
+ * The default adapter is the hermetic `PromptOnlyBaselineAdapter` so the
+ * bench runs green without a live orchestrator (the lab run swaps in the
+ * Remnic-native adapter via `benchmarkOptions.adapter`). Per the assignment,
+ * no real GPU/lab run is performed here — the harness is unit-tested with
+ * the baseline + a deterministic recording adapter.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { generateMemCorrectCorpus, corpusHash } from "./generator.js";
+import { validateCorpus } from "./schema.js";
+import { computeMetricBundle } from "./metrics.js";
+import {
+  PromptOnlyBaselineAdapter,
+  createRemnicMemCorrectAdapter,
+} from "./adapters.js";
+import type {
+  MemCorrectMetricBundle,
+  MemCorrectScenario,
+  MemCorrectSystemAdapter,
+  ProbeLogEntry,
+  ProbePhase,
+  ResolvedAntiEvent,
+  ResolvedCorrection,
+  ResolvedReassertion,
+} from "./types.js";
+
+export const memcorrectDefinition: BenchmarkDefinition = {
+  id: "memcorrect-v1",
+  title: "MemCorrect (correction / steerability)",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "memcorrect-v1",
+    version: "1.0.0",
+    description:
+      "Open correction/steerability benchmark: uptake, non-resurrection, collateral, scope-precision, false-apply, reassertion. System-agnostic adapter interface; hermetic seeded synthetic corpus.",
+    category: "conversational",
+    citation:
+      "Remnic MemCorrect v1 (issue #1584). Open benchmark; adapter contract is the public contribution.",
+  },
+};
+const QUICK_OPTIONS = {
+  personaCount: 2,
+  factsPerPersona: 4,
+  seed: 0xc077e7,
+  nowIso: "2026-07-05T00:00:00.000Z",
+  maintenanceCycles: 3,
+  uptakeLatencyCap: 5,
+};
+
+const FULL_OPTIONS = {
+  personaCount: 5,
+  factsPerPersona: 8,
+  seed: 0xc077e7,
+  nowIso: "2026-07-05T00:00:00.000Z",
+  maintenanceCycles: 5,
+  uptakeLatencyCap: 8,
+};
+
+/**
+ * Resolve the adapter to drive. The lab run is explicit about which adapter
+ * MemCorrect exercises:
+ *   - `benchmarkOptions.adapter` (a `MemCorrectSystemAdapter`) → use directly.
+ *     This is how the prompt-only baseline, the Remnic-native adapter, and
+ *     any third-party adapter are selected.
+ *   - Otherwise, wrap the bench `system` adapter (a `BenchMemoryAdapter`)
+ *     into the MemCorrect contract via the public access-service surface.
+ */
+function resolveAdapter(
+  options: ResolvedRunBenchmarkOptions,
+): { adapter: MemCorrectSystemAdapter; adapterLabel: string } {
+  const override = options.benchmarkOptions?.["adapter"];
+  if (
+    override &&
+    typeof override === "object" &&
+    "reset" in override &&
+    "ingestTurn" in override &&
+    "recall" in override
+  ) {
+    const adapter = override as MemCorrectSystemAdapter;
+    return { adapter, adapterLabel: adapter.label ?? "custom" };
+  }
+  return {
+    adapter: createRemnicMemCorrectAdapter(options.system, {
+      label: "remnic-native",
+    }),
+    adapterLabel: "remnic-native",
+  };
+}
+
+interface ScenarioRun {
+  log: ProbeLogEntry[];
+  correction: ResolvedCorrection;
+  antiEvents: ResolvedAntiEvent[];
+  reassertion: ResolvedReassertion | null;
+  collateralBefore: number[];
+  collateralAfter: number[];
+  provenanceCite: number | null;
+  metrics: MemCorrectMetricBundle;
+}
+
+/** Run the protocol for one scenario against the adapter. */
+async function runScenario(
+  scenario: MemCorrectScenario,
+  adapter: MemCorrectSystemAdapter,
+  maintenanceCycles: number,
+  uptakeLatencyCap: number,
+): Promise<ScenarioRun> {
+  await adapter.reset();
+  const log: ProbeLogEntry[] = [];
+  let turn = 0;
+  const sessionKey = scenario.namespace;
+
+  const recordProbe = (
+    phase: ProbePhase,
+    query: string,
+    namespace: string,
+    recalled: string[],
+    at: string,
+  ): void => {
+    log.push({ scenarioId: scenario.id, phase, turnIndex: turn, namespace, query, recalled, at });
+  };
+
+  // --- Establishing transcript ---
+  for (const t of scenario.establishingTurns) {
+    await adapter.ingestTurn(sessionKey, t.role, t.text, t.at);
+    turn += 1;
+  }
+
+  // --- Baseline probe (unrelated-fact recall before correction) ---
+  const collateralBefore: number[] = [];
+  for (const probe of scenario.unrelatedProbes) {
+    const recalled = await adapter.recall(probe.query, sessionKey);
+    recordProbe("baseline", probe.query, sessionKey, recalled, scenario.correction.turn.at);
+    turn += 1;
+    collateralBefore.push(
+      recalled.some((r) => r.toLowerCase().includes(probe.expectedContent.toLowerCase())) ? 1 : 0,
+    );
+  }
+
+  // --- Correction ---
+  await adapter.correct(scenario.correction.turn.text, sessionKey);
+  turn += 1;
+  const correctionTurnIndex = turn;
+
+  // --- Post-correction probe (uptake@next) ---
+  {
+    const recalled = await adapter.recall(scenario.probe.query, sessionKey);
+    recordProbe("post_correction", scenario.probe.query, sessionKey, recalled, scenario.correction.turn.at);
+    turn += 1;
+  }
+
+  // --- Anti-events (false_apply window) ---
+  for (const anti of scenario.antiEvents) {
+    await adapter.ingestTurn(sessionKey, anti.turn.role, anti.turn.text, anti.turn.at);
+    turn += 1;
+    const recalled = await adapter.recall(anti.probeQuery, sessionKey);
+    // Recorded under post_correction so false_apply (which scans
+    // post_correction for the scenario) sees the leaked token.
+    recordProbe("post_correction", anti.probeQuery, sessionKey, recalled, anti.turn.at);
+    turn += 1;
+  }
+
+  // Scoped twin probe (namespace-B must stay intact).
+  if (scenario.scopedTwin) {
+    const twin = scenario.scopedTwin;
+    for (const t of twin.establishingTurns) {
+      await adapter.ingestTurn(twin.namespace, t.role, t.text, t.at);
+      turn += 1;
+    }
+    const recalled = await adapter.recall(scenario.probe.query, twin.namespace);
+    recordProbe("post_correction", scenario.probe.query, twin.namespace, recalled, scenario.correction.turn.at);
+    turn += 1;
+  }
+
+  // --- Maintenance cycles (non_resurrection) ---
+  for (let i = 0; i < maintenanceCycles; i += 1) {
+    await adapter.runMaintenance();
+    turn += 1;
+  }
+  {
+    const recalled = await adapter.recall(scenario.probe.query, sessionKey);
+    recordProbe("post_maintenance", scenario.probe.query, sessionKey, recalled, scenario.correction.turn.at);
+    turn += 1;
+  }
+
+  // --- Re-ingest the original establishing transcript ---
+  for (const t of scenario.establishingTurns) {
+    await adapter.ingestTurn(sessionKey, t.role, t.text, t.at);
+    turn += 1;
+  }
+  {
+    const recalled = await adapter.recall(scenario.probe.query, sessionKey);
+    recordProbe("post_reingest", scenario.probe.query, sessionKey, recalled, scenario.correction.turn.at);
+    turn += 1;
+  }
+
+  // --- Re-assertion (if present) ---
+  let reassertion: ResolvedReassertion | null = null;
+  if (scenario.reassertion) {
+    await adapter.ingestTurn(
+      sessionKey,
+      scenario.reassertion.turn.role,
+      scenario.reassertion.turn.text,
+      scenario.reassertion.turn.at,
+    );
+    turn += 1;
+    const recalled = await adapter.recall(scenario.probe.query, sessionKey);
+    recordProbe("post_reassertion", scenario.probe.query, sessionKey, recalled, scenario.reassertion.turn.at);
+    turn += 1;
+    reassertion = {
+      scenarioId: scenario.id,
+      namespace: sessionKey,
+      expectedContent: scenario.reassertion.expectedContent,
+    };
+  }
+
+  // --- Collateral after: re-probe the unrelated facts ---
+  const collateralAfter: number[] = [];
+  for (const probe of scenario.unrelatedProbes) {
+    const recalled = await adapter.recall(probe.query, sessionKey);
+    collateralAfter.push(
+      recalled.some((r) => r.toLowerCase().includes(probe.expectedContent.toLowerCase())) ? 1 : 0,
+    );
+  }
+
+  const correction: ResolvedCorrection = {
+    scenarioId: scenario.id,
+    namespace: sessionKey,
+    turnIndex: correctionTurnIndex,
+    retiredContent: scenario.correction.retiredContent,
+    correctedContent: scenario.correction.correctedContent,
+    scopedTwin: scenario.scopedTwin,
+  };
+  const antiEvents: ResolvedAntiEvent[] = scenario.antiEvents.map((anti) => ({
+    scenarioId: scenario.id,
+    namespace: sessionKey,
+    probeQuery: anti.probeQuery,
+    shouldNotAppear: anti.shouldNotAppear,
+  }));
+
+  // Provenance: the baseline does not surface provenance; the metric reports
+  // n/a unless the adapter opts in (future Remnic-native extension).
+  const provenanceCite: number | null = null;
+
+  const metrics = computeMetricBundle({
+    log,
+    corrections: [correction],
+    antiEvents,
+    reassertions: reassertion ? [reassertion] : [],
+    collateralBefore,
+    collateralAfter,
+    provenanceCites: [provenanceCite],
+    uptakeLatencyCap,
+  });
+
+  return {
+    log,
+    correction,
+    antiEvents,
+    reassertion,
+    collateralBefore,
+    collateralAfter,
+    provenanceCite,
+    metrics,
+  };
+}
+
+export async function runMemCorrectBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const baseOptions = options.mode === "quick" ? QUICK_OPTIONS : FULL_OPTIONS;
+  const seed = typeof options.seed === "number" ? options.seed : baseOptions.seed;
+  const generatorOptions = { ...baseOptions, seed };
+  const corpus = generateMemCorrectCorpus(generatorOptions);
+
+  const validation = validateCorpus(corpus);
+  if (!validation.ok) {
+    throw new Error(
+      `MemCorrect corpus failed schema validation: ${validation.errors
+        .map((e) => `${e.scenarioId}: ${e.message}`)
+        .join("; ")}`,
+    );
+  }
+
+  const { adapter, adapterLabel } = resolveAdapter(options);
+
+  // Honor options.limit so quick / limited runs don't fan out across every
+  // scenario, mirroring the other remnic runners.
+  const scenarios =
+    typeof options.limit === "number" && options.limit > 0
+      ? corpus.scenarios.slice(0, options.limit)
+      : corpus.scenarios;
+
+  const tasks: TaskResult[] = [];
+  const aggregateLog: ProbeLogEntry[] = [];
+  const aggregateCorrections: ResolvedCorrection[] = [];
+  const aggregateAntiEvents: ResolvedAntiEvent[] = [];
+  const aggregateReassertions: ResolvedReassertion[] = [];
+  const aggregateCollateralBefore: number[] = [];
+  const aggregateCollateralAfter: number[] = [];
+  const aggregateProvenance: (number | null)[] = [];
+
+  for (const scenario of scenarios) {
+    const started = performance.now();
+    const run = await runScenario(
+      scenario,
+      adapter,
+      generatorOptions.maintenanceCycles,
+      generatorOptions.uptakeLatencyCap,
+    );
+    const latencyMs = Math.round(performance.now() - started);
+
+    aggregateLog.push(...run.log);
+    aggregateCorrections.push(run.correction);
+    aggregateAntiEvents.push(...run.antiEvents);
+    if (run.reassertion) aggregateReassertions.push(run.reassertion);
+    aggregateCollateralBefore.push(...run.collateralBefore);
+    aggregateCollateralAfter.push(...run.collateralAfter);
+    aggregateProvenance.push(run.provenanceCite);
+
+    const m = run.metrics;
+    const task: TaskResult = {
+      taskId: scenario.id,
+      question: scenario.probe.query,
+      expected: JSON.stringify({
+        correctedContent: scenario.correction.correctedContent,
+        retiredContent: scenario.correction.retiredContent,
+      }),
+      actual: JSON.stringify({
+        shape: scenario.correction.shape,
+        namespace: scenario.namespace,
+        postCorrectionRecall:
+          run.log.find(
+            (e) => e.phase === "post_correction" && e.namespace === scenario.namespace,
+          )?.recalled.slice(0, 3) ?? [],
+      }),
+      scores: {
+        uptake_at_next: m.uptake_at_next,
+        uptake_latency: m.uptake_latency,
+        non_resurrection: m.non_resurrection,
+        collateral_delta: m.collateral_delta,
+        scope_precision: m.scope_precision,
+        false_apply: m.false_apply,
+        reassertion: m.reassertion,
+        // provenance_fidelity is omitted from per-task scores: it is n/a
+        // unless the adapter surfaces provenance, and a -1 sentinel would
+        // pollute the aggregate mean. The value (number | null) is carried
+        // in details.metrics.memcorrect.provenance_fidelity below.
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        scenarioId: scenario.id,
+        shape: scenario.correction.shape,
+        category: scenario.category,
+        namespace: scenario.namespace,
+        adapter: adapterLabel,
+        metrics: {
+          memcorrect: m,
+        },
+      },
+    };
+    tasks.push(task);
+    options.onTaskComplete?.(task, tasks.length, scenarios.length);
+  }
+
+  // Aggregate metric bundle across all scenarios (the headline numbers).
+  const aggregateMetrics = computeMetricBundle({
+    log: aggregateLog,
+    corrections: aggregateCorrections,
+    antiEvents: aggregateAntiEvents,
+    reassertions: aggregateReassertions,
+    collateralBefore: aggregateCollateralBefore,
+    collateralAfter: aggregateCollateralAfter,
+    provenanceCites: aggregateProvenance,
+    uptakeLatencyCap: generatorOptions.uptakeLatencyCap,
+  });
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, t) => sum + t.latencyMs, 0);
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [seed],
+      datasetHash: corpusHash(corpus),
+    },
+    config: {
+      runtimeProfile: options.runtimeProfile ?? null,
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: adapterLabel,
+      remnicConfig: options.remnicConfig ?? {},
+      benchmarkOptions: {
+        ...options.benchmarkOptions,
+        personaCount: generatorOptions.personaCount,
+        factsPerPersona: generatorOptions.factsPerPersona,
+        maintenanceCycles: generatorOptions.maintenanceCycles,
+        uptakeLatencyCap: generatorOptions.uptakeLatencyCap,
+        // Headline metric bundle computed across the union of all scenario
+        // probe logs (more robust than the per-task mean for fraction
+        // metrics when scenario sizes vary). `aggregateTaskScores` in
+        // results.aggregates is the per-task-mean view.
+        aggregateMetrics,
+      },
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+      judgeModelCalls: 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+      statistics: {
+        confidenceIntervals: {},
+        bootstrapSamples: 0,
+      },
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+/**
+ * Read the headline aggregate metric bundle (all 8 metrics, computed across
+ * the union of scenario probe logs) from a MemCorrect result. Returns null
+ * for results from other benchmarks.
+ */
+export function summarizeAggregateMetrics(
+  result: BenchmarkResult,
+): MemCorrectMetricBundle | null {
+  const opts = result.config.benchmarkOptions as
+    | { aggregateMetrics?: MemCorrectMetricBundle }
+    | undefined;
+  return opts?.aggregateMetrics ?? null;
+}

--- a/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/runner.ts
@@ -217,11 +217,15 @@ async function runScenario(
   for (const anti of scenario.antiEvents) {
     await adapter.ingestTurn(sessionKey, anti.turn.role, anti.turn.text, anti.turn.at);
     turn += 1;
+    // Bump the turn BEFORE the recall probe so the probe gets its own
+    // interaction turn (not the ingest's). Otherwise uptake_latency
+    // underreports by one when the anti-event probe is the first recall
+    // to reflect the correction. Mirrors the dedicated uptake probe above.
+    turn += 1;
     const recalled = await adapter.recall(anti.probeQuery, sessionKey);
     // Recorded under post_correction so false_apply (which scans
     // post_correction for the scenario) sees the leaked token.
     recordProbe("post_correction", anti.probeQuery, sessionKey, recalled, anti.turn.at);
-    turn += 1;
   }
 
   // --- Scoped twin probe (namespace-B must stay intact AFTER the correction) ---
@@ -384,6 +388,19 @@ export async function runMemCorrectBenchmark(
     aggregateProvenance.push(run.provenanceCite);
 
     const m = run.metrics;
+    // Per-task directional scores: only metrics that are both directional
+    // and applicable to the scenario. collateral_delta is target-zero (not
+    // directional); scope_precision / reassertion are n/a for non-scoped /
+    // non-re-assertion scenarios. All three remain in the full bundle under
+    // details.metrics.memcorrect so they are not lost.
+    const scores: Record<string, number> = {
+      uptake_at_next: m.uptake_at_next,
+      uptake_latency: m.uptake_latency,
+      non_resurrection: m.non_resurrection,
+      false_apply: m.false_apply,
+    };
+    if (m.scope_precision !== null) scores.scope_precision = m.scope_precision;
+    if (m.reassertion !== null) scores.reassertion = m.reassertion;
     const task: TaskResult = {
       taskId: scenario.id,
       question: scenario.probe.query,
@@ -399,19 +416,7 @@ export async function runMemCorrectBenchmark(
             (e) => e.phase === "post_correction" && e.namespace === scenario.namespace,
           )?.recalled.slice(0, 3) ?? [],
       }),
-      scores: {
-        uptake_at_next: m.uptake_at_next,
-        uptake_latency: m.uptake_latency,
-        non_resurrection: m.non_resurrection,
-        collateral_delta: m.collateral_delta,
-        scope_precision: m.scope_precision,
-        false_apply: m.false_apply,
-        reassertion: m.reassertion,
-        // provenance_fidelity is omitted from per-task scores: it is n/a
-        // unless the adapter surfaces provenance, and a -1 sentinel would
-        // pollute the aggregate mean. The value (number | null) is carried
-        // in details.metrics.memcorrect.provenance_fidelity below.
-      },
+      scores,
       latencyMs,
       tokens: { input: 0, output: 0 },
       details: {

--- a/packages/bench/src/benchmarks/remnic/memcorrect/schema.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/schema.ts
@@ -1,0 +1,276 @@
+/**
+ * MemCorrect corpus schema validation (issue #1584 PR 1).
+ *
+ * The issue specifies that the generated corpus must validate against a
+ * schema and contain no real-world PII by construction. Rather than pull
+ * `zod` into `@remnic/bench` (which has no schema-validation dependency
+ * today), this module implements an equivalent explicit validator: it
+ * checks the structural shape, the cross-field invariants, and that every
+ * name/subject/value token is drawn from the generator's synthetic pools.
+ *
+ * The validator is the contract — anything it accepts is a legal corpus,
+ * and CI asserts the corpus hash is stable, so a drift in shape is caught
+ * at the determinism check.
+ */
+
+import {
+  PERSONAS,
+  SUBJECTS,
+  VALUES_A,
+  VALUES_B,
+} from "./token-pools.js";
+import type {
+  CorrectionShape,
+  FactCategory,
+  MemCorrectCorpus,
+  MemCorrectScenario,
+  ProbePhase,
+} from "./types.js";
+
+const ALLOWED_CATEGORIES: readonly FactCategory[] = [
+  "fact",
+  "preference",
+  "decision",
+  "commitment",
+  "relationship",
+];
+
+const ALLOWED_SHAPES: readonly CorrectionShape[] = [
+  "explicit-targeted",
+  "conversational",
+  "scoped",
+  "re-assertion",
+];
+
+const ALLOWED_PHASES: readonly ProbePhase[] = [
+  "baseline",
+  "post_correction",
+  "post_maintenance",
+  "post_reingest",
+  "post_reassertion",
+];
+
+export interface CorpusValidationError {
+  scenarioId: string;
+  message: string;
+}
+
+export interface CorpusValidationResult {
+  ok: boolean;
+  errors: CorpusValidationError[];
+}
+
+const ALL_TOKENS: ReadonlySet<string> = new Set<string>([
+  ...PERSONAS.map((p) => p.toLowerCase()),
+  ...SUBJECTS,
+  ...VALUES_A,
+  ...VALUES_B,
+  "correction",
+  "update",
+  "actually",
+  "preference",
+  "setting",
+  "for",
+  "this",
+  "project",
+  "my",
+  "is",
+  "now",
+  "not",
+  "wrong",
+  "it",
+  "we",
+  "switched",
+  "from",
+  "to",
+  "last",
+  "month",
+  "going",
+  "forward",
+  "instead",
+  "of",
+  "the",
+  "record",
+  "saying",
+  "oh",
+  "by",
+  "way",
+  "mentioned",
+  "their",
+  "set",
+  "if",
+  "someone",
+  "asked",
+  "i",
+  "might",
+  "consider",
+  "but",
+  "have",
+  "decided",
+  "said",
+  "you",
+  "should",
+  "change",
+  "them",
+  "noting",
+  "noted",
+  "got",
+  "it",
+  "we",
+  "went",
+  "back",
+  "riley",
+  "sage",
+  "what",
+]);
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((v): v is string => typeof v === "string")
+  );
+}
+
+function isIso(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms);
+}
+
+/**
+ * Validate one scenario's value-level invariants (non-empty fields, enum
+ * membership, cross-field requirements like scoped-requires-twin). The
+ * scenario is already typed at the corpus boundary; this enforces the
+ * constraints the type system cannot (empty strings, enum values, shape
+ * coupling). Returns a list of errors (empty when well-formed).
+ */
+function validateScenario(scenario: MemCorrectScenario): CorpusValidationError[] {
+  const errors: CorpusValidationError[] = [];
+  const id = scenario.id;
+
+  if (scenario.id.length === 0) {
+    errors.push({ scenarioId: id, message: "id must be a non-empty string" });
+  }
+  if (scenario.namespace.length === 0) {
+    errors.push({ scenarioId: id, message: "namespace must be a non-empty string" });
+  }
+  if (!ALLOWED_CATEGORIES.includes(scenario.category)) {
+    errors.push({
+      scenarioId: id,
+      message: `category must be one of ${ALLOWED_CATEGORIES.join(", ")}`,
+    });
+  }
+  if (scenario.establishingTurns.length === 0) {
+    errors.push({
+      scenarioId: id,
+      message: "establishingTurns must be a non-empty array",
+    });
+  } else {
+    for (const [index, turn] of scenario.establishingTurns.entries()) {
+      if (turn.role !== "user" && turn.role !== "assistant") {
+        errors.push({
+          scenarioId: id,
+          message: `establishing turn ${index} role invalid`,
+        });
+      }
+      if (turn.text.length === 0) {
+        errors.push({
+          scenarioId: id,
+          message: `establishing turn ${index} text empty`,
+        });
+      }
+      if (!isIso(turn.at)) {
+        errors.push({
+          scenarioId: id,
+          message: `establishing turn ${index} at not ISO`,
+        });
+      }
+    }
+  }
+  if (!ALLOWED_SHAPES.includes(scenario.correction.shape)) {
+    errors.push({
+      scenarioId: id,
+      message: `correction.shape must be one of ${ALLOWED_SHAPES.join(", ")}`,
+    });
+  }
+  if (!isStringArray(scenario.correction.retiredContent)) {
+    errors.push({ scenarioId: id, message: "retiredContent must be string[]" });
+  }
+  if (!isStringArray(scenario.correction.correctedContent)) {
+    errors.push({ scenarioId: id, message: "correctedContent must be string[]" });
+  }
+  if (
+    scenario.correction.shape === "scoped" &&
+    (!scenario.scopedTwin || scenario.scopedTwin.twinContent.length === 0)
+  ) {
+    errors.push({
+      scenarioId: id,
+      message: "scoped correction must carry a scopedTwin with non-empty twinContent",
+    });
+  }
+  if (
+    scenario.correction.shape === "re-assertion" &&
+    (!scenario.reassertion || scenario.reassertion.expectedContent.length === 0)
+  ) {
+    errors.push({
+      scenarioId: id,
+      message: "re-assertion correction must carry a reassertion block with expectedContent",
+    });
+  }
+  if (scenario.probe.query.length === 0) {
+    errors.push({ scenarioId: id, message: "probe.query empty" });
+  }
+  if (!isStringArray(scenario.probe.mustContain)) {
+    errors.push({ scenarioId: id, message: "probe.mustContain must be string[]" });
+  }
+  if (!isStringArray(scenario.probe.mustAbsent)) {
+    errors.push({ scenarioId: id, message: "probe.mustAbsent must be string[]" });
+  }
+  if (!Array.isArray(scenario.antiEvents)) {
+    errors.push({ scenarioId: id, message: "antiEvents must be an array" });
+  }
+  if (!Array.isArray(scenario.unrelatedProbes)) {
+    errors.push({ scenarioId: id, message: "unrelatedProbes must be an array" });
+  }
+  return errors;
+}
+
+/**
+ * Validate the whole corpus and assert the synthetic-token provenance of
+ * every fact token (the no-PII-by-construction guarantee).
+ */
+export function validateCorpus(corpus: MemCorrectCorpus): CorpusValidationResult {
+  const errors: CorpusValidationError[] = [];
+  if (!Array.isArray(corpus.scenarios)) {
+    return {
+      ok: false,
+      errors: [{ scenarioId: "<root>", message: "scenarios must be an array" }],
+    };
+  }
+  const seenIds = new Set<string>();
+  for (const scenario of corpus.scenarios) {
+    if (seenIds.has(scenario.id)) {
+      errors.push({ scenarioId: scenario.id, message: "duplicate scenario id" });
+    }
+    seenIds.add(scenario.id);
+    errors.push(...validateScenario(scenario));
+    // no-PII: every fact token must originate from a synthetic pool.
+    const factTokens = [
+      ...(scenario.correction?.retiredContent ?? []),
+      ...(scenario.correction?.correctedContent ?? []),
+      ...(scenario.scopedTwin ? [scenario.scopedTwin.twinContent] : []),
+      ...(scenario.reassertion ? [scenario.reassertion.expectedContent] : []),
+    ];
+    for (const token of factTokens) {
+      if (!ALL_TOKENS.has(token.toLowerCase())) {
+        errors.push({
+          scenarioId: scenario.id,
+          message: `fact token "${token}" is outside the synthetic pools (PII guard)`,
+        });
+      }
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/** Re-export the phase allowlist for downstream schema consumers. */
+export const MEMCORRECT_PROBE_PHASES = ALLOWED_PHASES;

--- a/packages/bench/src/benchmarks/remnic/memcorrect/token-pools.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/token-pools.ts
@@ -1,0 +1,54 @@
+/**
+ * Synthetic token pools for the MemCorrect corpus generator (issue #1584).
+ *
+ * Shared between `generator.ts` (draws from the pools) and `schema.ts`
+ * (asserts every fact token originates from a pool — the no-PII-by-
+ * construction guarantee). None of these are real people, products, or
+ * places; they are deliberately generic tokens.
+ */
+
+export const PERSONAS = [
+  "Avery",
+  "Blair",
+  "Cassidy",
+  "Dakota",
+  "Emerson",
+  "Finley",
+  "Harper",
+  "Jordan",
+  "Kendall",
+  "Logan",
+] as const;
+
+export const SUBJECTS = [
+  "coffee",
+  "editor",
+  "database",
+  "calendar",
+  "standup",
+  "deploy",
+  "notebook",
+  "keyboard",
+] as const;
+
+export const VALUES_A = [
+  "oat-milk",
+  "helix",
+  "postgres",
+  "monday",
+  "nine-am",
+  "blue-green",
+  "dotgrid",
+  "mechanical",
+] as const;
+
+export const VALUES_B = [
+  "black-coffee",
+  "neovim",
+  "mysql",
+  "wednesday",
+  "ten-am",
+  "canary",
+  "lined",
+  "membrane",
+] as const;

--- a/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
@@ -184,7 +184,7 @@ export interface MemCorrectSystemAdapter {
   /** Ranked memory/context strings for a probe query in a session. */
   recall(query: string, sessionKey: string): Promise<string[]>;
   /** However the system accepts a correction (explicit tool, turn, contract). */
-  correct(text: string, sessionKey: string): Promise<void>;
+  correct(text: string, sessionKey: string, at?: string): Promise<void>;
   /**
    * Consolidation / dreams / pattern-reinforcement / contradiction scan.
    * A no-op is allowed; the protocol runs this N times between phases and

--- a/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
@@ -112,6 +112,13 @@ export interface Reassertion {
 export interface UnrelatedProbe {
   query: string;
   expectedContent: string;
+  /**
+   * Turns that seed the unrelated fact in the primary namespace BEFORE the
+   * baseline probe. Without these the collateral metric recalls facts that
+   * were never stored. Each turn carries the expected value so deduping or
+   * summarizing systems still capture it.
+   */
+  establishingTurns: EstablishingTurn[];
 }
 
 /** One MemCorrect scenario. The runner emits one task per scenario. */

--- a/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
@@ -247,9 +247,11 @@ export interface MemCorrectMetricBundle {
   uptake_latency_censored: number;
   non_resurrection: number;
   collateral_delta: number;
-  scope_precision: number;
+  /** 0..1 for scoped corrections; `null` when no scenario exercises a scoped twin. */
+  scope_precision: number | null;
   false_apply: number;
-  reassertion: number;
+  /** 0..1 for re-assertion scenarios; `null` when no scenario re-asserts. */
+  reassertion: number | null;
   /** 0..1 when the adapter exposes provenance; `null` when n/a. */
   provenance_fidelity: number | null;
 }

--- a/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
+++ b/packages/bench/src/benchmarks/remnic/memcorrect/types.ts
@@ -1,0 +1,253 @@
+/**
+ * MemCorrect — an open correction/steerability benchmark (issue #1584).
+ *
+ * Type definitions for the system-agnostic adapter contract, the synthetic
+ * scenario corpus, and the probe log the runner records while driving an
+ * adapter through the correction protocol.
+ *
+ * Design notes
+ * ------------
+ * The adapter interface is deliberately minimal and system-agnostic: that
+ * is what makes MemCorrect a *field* benchmark rather than a Remnic-only
+ * regression test. Any memory system that can ingest turns, recall ranked
+ * context, accept a correction, and run maintenance can be scored on
+ * identical scenarios with identical metrics.
+ *
+ * Time windows are half-open `[start, end)` everywhere (checklist §23):
+ * a probe at exactly the correction timestamp belongs to the pre-correction
+ * window; the post-correction window opens strictly after the correction.
+ */
+
+/** Fact categories the generator spreads across the corpus. */
+export type FactCategory =
+  | "fact"
+  | "preference"
+  | "decision"
+  | "commitment"
+  | "relationship";
+
+/** The four correction shapes the benchmark measures. */
+export type CorrectionShape =
+  | "explicit-targeted"
+  | "conversational"
+  | "scoped"
+  | "re-assertion";
+
+/** A single conversational turn that establishes (or re-asserts) a fact. */
+export interface EstablishingTurn {
+  role: "user" | "assistant";
+  text: string;
+  /** ISO timestamp; the generator emits monotonically increasing values. */
+  at: string;
+}
+
+/**
+ * A scripted correction event. `retiredContent` is the token set that must
+ * be ABSENT from recall after the correction takes effect; `correctedContent`
+ * is the token set that must be PRESENT.
+ */
+export interface CorrectionEvent {
+  shape: CorrectionShape;
+  /** Turn that delivers the correction through the adapter's normal path. */
+  turn: EstablishingTurn;
+  /** Tokens (lowercased) that should no longer surface after correction. */
+  retiredContent: string[];
+  /** Tokens (lowercased) that should surface after correction. */
+  correctedContent: string[];
+}
+/**
+ * Internal generator plan for one persona-fact. Exported so the generator
+ * module can be unit-tested at the plan level without re-declaring the shape.
+ */
+export interface PersonaFactPlanLike {
+  persona: string;
+  namespace: string;
+  category: FactCategory;
+  subject: string;
+  oldValue: string;
+  newValue: string;
+  shape: CorrectionShape;
+}
+
+/**
+ * An event that must NOT cause a durable memory mutation: quoting someone
+ * else, a hypothetical, a third-party correction. `shouldNotAppear` is the
+ * token that, if it surfaces in a subsequent probe, indicates a false apply.
+ */
+export interface AntiEvent {
+  kind: "quoting-other" | "hypothetical" | "third-party-correction";
+  turn: EstablishingTurn;
+  probeQuery: string;
+  shouldNotAppear: string;
+}
+
+/**
+ * A probe query used to test recall at each protocol phase. `mustContain`
+ * tokens must surface; `mustAbsent` tokens must not.
+ */
+export interface ProbeQuery {
+  query: string;
+  mustContain: string[];
+  mustAbsent: string[];
+}
+
+/** A scoped twin: the same-text fact seeded in a second namespace. */
+export interface ScopedTwin {
+  namespace: string;
+  /** Turns that seed the twin in its own namespace. */
+  establishingTurns: EstablishingTurn[];
+  /** Token that must KEEP surfacing in the twin namespace after the scoped
+   * correction lands in the primary namespace. */
+  twinContent: string;
+}
+
+/** Re-assertion block: after a correction, the user walks it back. */
+export interface Reassertion {
+  turn: EstablishingTurn;
+  /** Token that must surface again after the re-assertion. */
+  expectedContent: string;
+}
+
+/** A probe over an unrelated fact, used for the collateral metric. */
+export interface UnrelatedProbe {
+  query: string;
+  expectedContent: string;
+}
+
+/** One MemCorrect scenario. The runner emits one task per scenario. */
+export interface MemCorrectScenario {
+  id: string;
+  /** Primary namespace the corrected fact lives in. */
+  namespace: string;
+  category: FactCategory;
+  /** Transcript that establishes the original (about-to-be-corrected) fact. */
+  establishingTurns: EstablishingTurn[];
+  correction: CorrectionEvent;
+  /** Probe used at every post-correction phase. */
+  probe: ProbeQuery;
+  antiEvents: AntiEvent[];
+  /** Present only for `scoped` and `re-assertion` scenarios. */
+  scopedTwin?: ScopedTwin;
+  reassertion?: Reassertion;
+  /** Unchanged facts whose recall should be undamaged by the correction. */
+  unrelatedProbes: UnrelatedProbe[];
+}
+
+/** The full seeded corpus. */
+export interface MemCorrectCorpus {
+  options: MemCorrectGeneratorOptions;
+  scenarios: MemCorrectScenario[];
+}
+
+/** Generator options. Deterministic given an identical `seed`. */
+export interface MemCorrectGeneratorOptions {
+  /** Number of personas (each owns ≥2 namespaces). */
+  personaCount: number;
+  /** Facts per persona, spread across categories. */
+  factsPerPersona: number;
+  /** PRNG seed. */
+  seed: number;
+  /** Anchor "now"; all timestamps derive from this. */
+  nowIso: string;
+  /** Maintenance cycles applied between post-correction and post-reingest. */
+  maintenanceCycles: number;
+  /** Latency cap (in interaction turns) for `uptake_latency`. */
+  uptakeLatencyCap: number;
+}
+
+/**
+ * The system-agnostic adapter contract. This is the public surface a
+ * third-party memory system implements to be scored on MemCorrect.
+ *
+ * Implementations MUST be isolated: `reset()` returns the system to a clean
+ * slate, and no call reaches into another system's durable store.
+ */
+export interface MemCorrectSystemAdapter {
+  /** Human-readable label for artifact metadata (e.g. "remnic-native"). */
+  readonly label: string;
+  /** Reset to a clean slate before each scenario. */
+  reset(): Promise<void>;
+  /** Ingest one conversational turn through the system's normal observe path. */
+  ingestTurn(
+    sessionKey: string,
+    role: "user" | "assistant",
+    text: string,
+    at: string,
+  ): Promise<void>;
+  /** Ranked memory/context strings for a probe query in a session. */
+  recall(query: string, sessionKey: string): Promise<string[]>;
+  /** However the system accepts a correction (explicit tool, turn, contract). */
+  correct(text: string, sessionKey: string): Promise<void>;
+  /**
+   * Consolidation / dreams / pattern-reinforcement / contradiction scan.
+   * A no-op is allowed; the protocol runs this N times between phases and
+   * the `non_resurrection` metric measures whether retired facts survive it.
+   */
+  runMaintenance(): Promise<void>;
+}
+
+/** Protocol phase a probe was recorded at. Half-open window ordering. */
+export type ProbePhase =
+  | "baseline"
+  | "post_correction"
+  | "post_maintenance"
+  | "post_reingest"
+  | "post_reassertion";
+
+/** One row of the probe log the runner records while driving the adapter. */
+export interface ProbeLogEntry {
+  scenarioId: string;
+  phase: ProbePhase;
+  /** Monotonic interaction-turn counter across the whole scenario run. */
+  turnIndex: number;
+  namespace: string;
+  query: string;
+  recalled: string[];
+  /** ISO timestamp of the probe (for half-open window logic). */
+  at: string;
+}
+
+/** A correction's resolved metadata for metric computation. */
+export interface ResolvedCorrection {
+  scenarioId: string;
+  namespace: string;
+  turnIndex: number;
+  retiredContent: string[];
+  correctedContent: string[];
+  /** Present for scoped scenarios. */
+  scopedTwin?: ScopedTwin;
+}
+
+/** Anti-event resolution for the false_apply metric. */
+export interface ResolvedAntiEvent {
+  scenarioId: string;
+  namespace: string;
+  probeQuery: string;
+  shouldNotAppear: string;
+}
+
+/** Re-assertion resolution for the reassertion metric. */
+export interface ResolvedReassertion {
+  scenarioId: string;
+  namespace: string;
+  expectedContent: string;
+}
+
+/** The structured metric bundle the runner emits under task `details`. */
+export interface MemCorrectMetricBundle {
+  uptake_at_next: number;
+  uptake_latency: number;
+  uptake_latency_censored: number;
+  non_resurrection: number;
+  collateral_delta: number;
+  scope_precision: number;
+  false_apply: number;
+  reassertion: number;
+  /** 0..1 when the adapter exposes provenance; `null` when n/a. */
+  provenance_fidelity: number | null;
+}
+
+/** Marker the runner sets when an adapter does not expose provenance. */
+export const PROVENANCE_NOT_SUPPORTED: unique symbol = Symbol(
+  "memcorrect.provenance.not-supported",
+);

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -42,6 +42,10 @@ export type {
   CustomBenchmarkSpec,
   CustomBenchmarkTask,
 } from "./benchmarks/custom/types.js";
+export type {
+  MemCorrectSystemAdapter,
+  MemCorrectGeneratorOptions,
+} from "./benchmarks/remnic/memcorrect/types.js";
 
 export type {
   Message,

--- a/packages/bench/src/leaderboard-export.ts
+++ b/packages/bench/src/leaderboard-export.ts
@@ -20,10 +20,19 @@ export async function writeLeaderboardArtifactsForResult(
   result: BenchmarkResult,
   outputDir: string
 ): Promise<LeaderboardArtifactWrite[]> {
-  if (result.meta.benchmark !== "ama-bench") {
-    return [];
+  if (result.meta.benchmark === "ama-bench") {
+    return writeAmaBenchLeaderboard(result, outputDir);
   }
+  if (result.meta.benchmark === "memcorrect-v1") {
+    return writeMemCorrectLeaderboard(result, outputDir);
+  }
+  return [];
+}
 
+async function writeAmaBenchLeaderboard(
+  result: BenchmarkResult,
+  outputDir: string
+): Promise<LeaderboardArtifactWrite[]> {
   const rows = buildAmaBenchLeaderboardRows(result);
   if (rows.length === 0) {
     return [];
@@ -41,6 +50,59 @@ export async function writeLeaderboardArtifactsForResult(
       path: filePath,
       format: "ama-bench-answer-list-jsonl",
       records: rows.length,
+    },
+  ];
+}
+
+/**
+ * MemCorrect leaderboard row — one per adapter result. This is the public
+ * submission format: a third party runs the benchmark against their system
+ * via the MemCorrectSystemAdapter and submits this row. Lower-is-better
+ * metrics (uptake_latency, collateral_delta magnitude, false_apply) are
+ * emitted raw; the methodology doc defines the interpretation.
+ */
+export interface MemCorrectLeaderboardRow {
+  benchmark: "memcorrect-v1";
+  adapter: string;
+  seed: number;
+  dataset_hash: string;
+  remnic_version: string;
+  git_sha: string;
+  timestamp: string;
+  mode: string;
+  uptake_at_next: number;
+  uptake_latency: number;
+  uptake_latency_censored: number;
+  non_resurrection: number;
+  collateral_delta: number;
+  scope_precision: number;
+  false_apply: number;
+  reassertion: number;
+  provenance_fidelity: number | null;
+}
+
+async function writeMemCorrectLeaderboard(
+  result: BenchmarkResult,
+  outputDir: string
+): Promise<LeaderboardArtifactWrite[]> {
+  const row = buildMemCorrectLeaderboardRow(result);
+  if (!row) return [];
+  const outputRoot = path.resolve(outputDir);
+  const leaderboardDir = resolveContainedPath(outputRoot, "leaderboard");
+  await mkdir(leaderboardDir, { recursive: true });
+  const timestamp = sanitizeFilenameSegment(result.meta.timestamp.replace(/[:.]/g, "-"));
+  const safeAdapter = sanitizeFilenameSegment(row.adapter);
+  const filePath = resolveContainedPath(
+    leaderboardDir,
+    `memcorrect-${safeAdapter}-${timestamp}.jsonl`,
+  );
+  await writeFile(filePath, `${JSON.stringify(row)}\n`, "utf8");
+  return [
+    {
+      benchmark: "memcorrect-v1",
+      path: filePath,
+      format: "memcorrect-adapter-metrics-jsonl",
+      records: 1,
     },
   ];
 }
@@ -74,6 +136,49 @@ export function buildAmaBenchLeaderboardRows(result: BenchmarkResult): AmaBenchL
       episode_id: episodeId,
       answer_list: row.answers,
     }));
+}
+
+/**
+ * Build the public-leaderboard row for a MemCorrect result. Reads the
+ * aggregate metric bundle the runner attaches to
+ * `config.benchmarkOptions.aggregateMetrics`; returns null when the result
+ * did not come from the MemCorrect runner (defensive — the dispatch already
+ * gates on benchmark id).
+ */
+export function buildMemCorrectLeaderboardRow(
+  result: BenchmarkResult,
+): MemCorrectLeaderboardRow | null {
+  const aggregate = (
+    result.config.benchmarkOptions as { aggregateMetrics?: Record<string, unknown> }
+  )?.aggregateMetrics;
+  if (!aggregate) return null;
+  const adapter =
+    typeof result.config.adapterMode === "string" ? result.config.adapterMode : "unknown";
+  const provenance = aggregate.provenance_fidelity;
+  return {
+    benchmark: "memcorrect-v1",
+    adapter,
+    seed: result.meta.seeds[0] ?? 0,
+    dataset_hash: result.meta.datasetHash ?? "",
+    remnic_version: result.meta.remnicVersion,
+    git_sha: result.meta.gitSha,
+    timestamp: result.meta.timestamp,
+    mode: result.meta.mode,
+    uptake_at_next: numberOrZero(aggregate.uptake_at_next),
+    uptake_latency: numberOrZero(aggregate.uptake_latency),
+    uptake_latency_censored: numberOrZero(aggregate.uptake_latency_censored),
+    non_resurrection: numberOrZero(aggregate.non_resurrection),
+    collateral_delta: numberOrZero(aggregate.collateral_delta),
+    scope_precision: numberOrZero(aggregate.scope_precision),
+    false_apply: numberOrZero(aggregate.false_apply),
+    reassertion: numberOrZero(aggregate.reassertion),
+    provenance_fidelity:
+      typeof provenance === "number" ? provenance : null,
+  };
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
 export function serializeJsonl(rows: readonly AmaBenchLeaderboardRow[]): string {

--- a/packages/bench/src/leaderboard-export.ts
+++ b/packages/bench/src/leaderboard-export.ts
@@ -75,9 +75,9 @@ export interface MemCorrectLeaderboardRow {
   uptake_latency_censored: number;
   non_resurrection: number;
   collateral_delta: number;
-  scope_precision: number;
+  scope_precision: number | null;
   false_apply: number;
-  reassertion: number;
+  reassertion: number | null;
   provenance_fidelity: number | null;
 }
 
@@ -169,9 +169,9 @@ export function buildMemCorrectLeaderboardRow(
     uptake_latency_censored: numberOrZero(aggregate.uptake_latency_censored),
     non_resurrection: numberOrZero(aggregate.non_resurrection),
     collateral_delta: numberOrZero(aggregate.collateral_delta),
-    scope_precision: numberOrZero(aggregate.scope_precision),
+    scope_precision: typeof aggregate.scope_precision === "number" ? aggregate.scope_precision : null,
     false_apply: numberOrZero(aggregate.false_apply),
-    reassertion: numberOrZero(aggregate.reassertion),
+    reassertion: typeof aggregate.reassertion === "number" ? aggregate.reassertion : null,
     provenance_fidelity:
       typeof provenance === "number" ? provenance : null,
   };

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -135,6 +135,10 @@ import {
   retentionAgedDatasetDefinition,
   runRetentionAgedDatasetBenchmark,
 } from "./benchmarks/remnic/retention-aged-dataset/runner.js";
+import {
+  memcorrectDefinition,
+  runMemCorrectBenchmark,
+} from "./benchmarks/remnic/memcorrect/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -272,6 +276,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retentionAgedDatasetDefinition,
     run: runRetentionAgedDatasetBenchmark,
+  },
+  {
+    ...memcorrectDefinition,
+    run: runMemCorrectBenchmark,
   },
 ];
 

--- a/packages/bench/src/result-config.test.ts
+++ b/packages/bench/src/result-config.test.ts
@@ -105,3 +105,16 @@ test("finalizeBenchmarkResultConfig records generic run limit in benchmark optio
     trialLimit: 2,
   });
 });
+
+test("finalizeBenchmarkResultConfig strips live adapter from benchmarkOptions", () => {
+  const result = buildResult();
+  const liveAdapter = { label: "should-not-leak" };
+  const finalized = finalizeBenchmarkResultConfig(result, {
+    benchmarkOptions: {
+      adapter: liveAdapter,
+      seed: 42,
+    },
+  });
+  assert.ok(!("adapter" in (finalized.config.benchmarkOptions ?? {})), "live adapter must not leak into finalized config");
+  assert.equal((finalized.config.benchmarkOptions as Record<string, unknown>)?.seed, 42, "non-adapter options preserved");
+});

--- a/packages/bench/src/result-config.ts
+++ b/packages/bench/src/result-config.ts
@@ -14,8 +14,15 @@ export function finalizeBenchmarkResultConfig(
   result.config.runtimeProfile ??= options.runtimeProfile ?? null;
   result.config.internalProvider ??= options.internalProvider ?? null;
   if (options.benchmarkOptions !== undefined || options.limit !== undefined) {
+    // Strip any live adapter instance — benchmark runners (e.g. MemCorrect)
+    // accept a MemCorrectSystemAdapter under benchmarkOptions.adapter, but
+    // it must never enter the persisted result config. The runner strips it
+    // from its own return value, but this merge re-spreads the original
+    // options, so filter it here at the single finalization point.
+    const { adapter: _omitAdapter, ...persistableOptions } =
+      (options.benchmarkOptions as Record<string, unknown> | undefined) ?? {};
     result.config.benchmarkOptions = {
-      ...options.benchmarkOptions,
+      ...persistableOptions,
       ...(options.limit !== undefined ? { limit: options.limit } : {}),
       ...(result.config.benchmarkOptions ?? {}),
     };

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -137,10 +137,12 @@ export function compareResults(
  */
 import { INGESTION_SETUP_FRICTION_LOWER_IS_BETTER } from "../benchmarks/remnic/ingestion-setup-friction/runner.js";
 import { RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER } from "../benchmarks/remnic/retrieval-reasoning-trace/runner.js";
+import { MEMCORRECT_LOWER_IS_BETTER } from "../benchmarks/remnic/memcorrect/runner.js";
 
 const LOWER_IS_BETTER_BY_BENCHMARK: Record<string, ReadonlySet<string>> = {
   "ingestion-setup-friction": INGESTION_SETUP_FRICTION_LOWER_IS_BETTER,
   "retrieval-reasoning-trace": RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER,
+  "memcorrect-v1": MEMCORRECT_LOWER_IS_BETTER,
 };
 
 export function getBenchmarkLowerIsBetter(benchmarkId: string): ReadonlySet<string> {

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -45,6 +45,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "buffer-surprise-trigger",
       "contradiction-detection",
       "retention-aged-dataset",
+      "memcorrect-v1",
     ],
   );
   assert.deepEqual(
@@ -83,11 +84,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset,memcorrect-v1",
   );
   // The synthetic ingestion adapter wires all built-in ingestion benchmarks.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, true);


### PR DESCRIPTION
Closes #1584. New @remnic/bench MemCorrect benchmark (scenarios, generator, adapters, runner, metrics, registry, leaderboard row, methodology doc). Hermetic unit tests only (no datasets/raw LLM traces per the repo ethics contract). 51 tests pass; bench build + check-test-types green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New benchmark package and docs with extensive unit tests; no production memory paths changed beyond bench registry, result-config sanitization, and comparison metric metadata.
> 
> **Overview**
> Adds **MemCorrect v1** (`memcorrect-v1`) to `@remnic/bench`: an open, system-agnostic benchmark for whether memory systems accept corrections (uptake, non-resurrection, collateral, scope, false-apply, re-assertion).
> 
> The harness includes a seeded synthetic corpus generator (never committed), schema validation, pure metric functions with token-based scoring (including treating “not old, now new” as correction evidence, not stale recall), a multi-phase runner protocol, and adapters: **prompt-only baseline**, **RecordingAdapter** for tests, and **Remnic-native** wrapper over `BenchMemoryAdapter`. CLI runs default to the Remnic adapter; baseline is injected via `benchmarkOptions.adapter`.
> 
> Wiring: registry entry, `MEMCORRECT_LOWER_IS_BETTER` for comparisons, leaderboard JSONL export (`buildMemCorrectLeaderboardRow`), public types from `packages/bench`, and stripping live `adapter` instances from persisted result config. Docs: `docs/benchmarks/memcorrect.md` and a section in `docs/benchmarks.md`. Hermetic tests only; no lab artifacts in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4baca716638a4e26f4066a047220450578f778fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->