### PR TITLE
test(storage): contract suite over public storage surface (#1533 Phase A)

### DIFF
--- a/packages/remnic-core/src/storage-contract/atomicity.test.ts
+++ b/packages/remnic-core/src/storage-contract/atomicity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Issue #1533 — Phase A contract test: atomic write semantics.
+ *
+ * Rule 54 (CLAUDE.md): replace operations MUST write temp-then-rename, NEVER
+ * delete-before-write. This test pins that invariant by making rename fail
+ * (read-only target directory) and asserting the original file survives the
+ * failed overwrite.
+ *
+ * The atomic write primitive lives in secure-fs (`writeMaybeEncryptedFile`)
+ * and is consumed by StorageManager via `writeStorageSecureFile`. We test the
+ * primitive directly here because it is the single atomicity seam every write
+ * entry point depends on.
+ */
+
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { writeMaybeEncryptedFile, readMaybeEncryptedFile } from "../secure-store/secure-fs.js";
+
+test("atomicity: writeMaybeEncryptedFile writes temp-then-rename (no temp files left behind on success)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-atomic-"));
+  try {
+    const target = path.join(dir, "target.md");
+    await writeMaybeEncryptedFile(target, "first content", null, {}, dir);
+
+    // No temp files left behind
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(dir);
+    assert.deepEqual(entries.sort(), ["target.md"]);
+
+    // Overwrite — still only the target, no leftover temp
+    await writeMaybeEncryptedFile(target, "second content", null, {}, dir);
+    const entries2 = await readdir(dir);
+    assert.deepEqual(entries2.sort(), ["target.md"]);
+
+    const read = await readMaybeEncryptedFile(target, null, dir);
+    assert.equal(read, "second content");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("atomicity: a failed rename leaves the original file intact (never delete-before-write)", async (t) => {
+  // Skip on root — chmod restrictions don't apply.
+  if (process.getuid && process.getuid() === 0) {
+    t.skip("chmod-based test is unreliable when running as root");
+    return;
+  }
+
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-atomic-fail-"));
+  try {
+    const target = path.join(dir, "survivor.md");
+    await writeMaybeEncryptedFile(target, "original", null, {}, dir);
+
+    // Make the directory read-only so the rename into place fails.
+    await chmod(dir, 0o500);
+    try {
+      await assert.rejects(
+        () => writeMaybeEncryptedFile(target, "would-be-replacement", null, {}, dir),
+        // rename (or temp write) fails — the exact error varies by platform
+      );
+
+      // THE CONTRACT: the original file must still be readable with its
+      // original content. Delete-before-write would have destroyed it before
+      // the failed rename.
+      const survived = await readMaybeEncryptedFile(target, null, dir);
+      assert.equal(survived, "original", "original file must survive a failed atomic replace");
+    } finally {
+      // Restore perms so cleanup works.
+      await chmod(dir, 0o700);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("atomicity: StorageManager.updateMemory preserves the original on overwrite success", async (t) => {
+  const { StorageManager } = await import("../storage.js");
+  const { makeStorage } = await import("./harness.js");
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const id = await storage.writeMemory("fact", "version one");
+    const before = await storage.getMemoryById(id);
+    assert.ok(before);
+    assert.equal(before!.content, "version one");
+
+    const updated = await storage.updateMemory(id, "version two");
+    assert.equal(updated, true);
+
+    const after = await storage.getMemoryById(id);
+    assert.ok(after);
+    assert.equal(after!.content, "version two");
+    // The id is stable across the update (same file path, not a new memory)
+    assert.equal(after!.frontmatter.id, id);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("atomicity: mkdir is implicit — writeMaybeEncryptedFile creates parent dirs", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-atomic-mkdir-"));
+  try {
+    const target = path.join(dir, "nested", "deep", "file.md");
+    await writeMaybeEncryptedFile(target, "content", null, {}, dir);
+    const read = await readMaybeEncryptedFile(target, null, dir);
+    assert.equal(read, "content");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage-contract/cache-coherence.test.ts
+++ b/packages/remnic-core/src/storage-contract/cache-coherence.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #1533 — Phase A contract test: cache coherence across instances.
+ *
+ * Rule 37 (memory-cache): write via instance A, read via a FRESH instance B
+ * over the same dir → B sees the write. The module-level caches
+ * (readAllMemories in-flight, version sentinels) are keyed by baseDir and
+ * shared/static — this test pins that a write invalidates correctly so a
+ * second instance never serves stale data.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { StorageManager } from "../storage.js";
+import { resetStaticCaches } from "./harness.js";
+
+test("cache-coherence: write via instance A, read via fresh instance B → B sees the write", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-cache-coherence-"));
+  try {
+    resetStaticCaches();
+    const smA = new StorageManager(dir);
+    await smA.ensureDirectories();
+
+    const id = await smA.writeMemory("fact", "written by A");
+
+    // Fresh instance over the same dir
+    const smB = new StorageManager(dir);
+    await smB.ensureDirectories();
+    const found = await smB.getMemoryById(id);
+    assert.ok(found, "instance B must see the memory written by instance A");
+    assert.equal(found!.content, "written by A");
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("cache-coherence: delete via instance A is reflected in fresh instance B", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-cache-del-"));
+  try {
+    resetStaticCaches();
+    const smA = new StorageManager(dir);
+    await smA.ensureDirectories();
+    const id = await smA.writeMemory("fact", "to be deleted");
+
+    // Confirm B sees it
+    const smB = new StorageManager(dir);
+    await smB.ensureDirectories();
+    assert.ok(await smB.getMemoryById(id));
+
+    // A deletes
+    await smA.invalidateMemory(id);
+
+    // Fresh instance C must NOT see it
+    const smC = new StorageManager(dir);
+    await smC.ensureDirectories();
+    const found = await smC.getMemoryById(id);
+    assert.equal(found, null, "fresh instance must not see a deleted memory");
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("cache-coherence: readAllMemories reflects writes across instances after invalidation", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-cache-list-"));
+  try {
+    resetStaticCaches();
+    const smA = new StorageManager(dir);
+    await smA.ensureDirectories();
+    await smA.writeMemory("fact", "first");
+    await smA.writeMemory("decision", "second");
+
+    const smB = new StorageManager(dir);
+    await smB.ensureDirectories();
+    const all = await smB.readAllMemories();
+    assert.ok(all.length >= 2, "fresh instance must list all written memories");
+
+    // Write more via A
+    await smA.writeMemory("principle", "third");
+
+    const smC = new StorageManager(dir);
+    await smC.ensureDirectories();
+    const allAfter = await smC.readAllMemories();
+    assert.ok(allAfter.length >= 3, "fresh instance must see the additional write");
+    assert.ok(allAfter.some((m) => m.content === "third"));
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage-contract/content-hash.test.ts
+++ b/packages/remnic-core/src/storage-contract/content-hash.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Issue #1533 — Phase A contract test: content hash identity.
+ *
+ * Rule 23: the write-side and dedup-side MUST hash the same `rawContent`,
+ * never the timestamped/cited form. `writeMemory` persists a `contentHash` on
+ * the frontmatter for facts; `hasFactContentHash` queries the dedup index.
+ * This test pins that the two sides agree so subsequent extractions of the
+ * same logical fact are deduped correctly even when citation timestamps differ.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ContentHashIndex } from "../storage.js";
+import { makeStorage } from "./harness.js";
+
+test("content-hash: ContentHashIndex.computeHash is deterministic for the same input", () => {
+  const a = ContentHashIndex.computeHash("the sky is blue");
+  const b = ContentHashIndex.computeHash("the sky is blue");
+  assert.equal(a, b);
+  assert.notEqual(
+    ContentHashIndex.computeHash("the sky is blue"),
+    ContentHashIndex.computeHash("the sky is green"),
+  );
+});
+
+test("content-hash: writeMemory for fact registers the hash so hasFactContentHash returns true", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const rawFact = "PostgreSQL is our primary database";
+    await storage.writeMemory("fact", rawFact);
+
+    const has = await storage.hasFactContentHash(rawFact);
+    assert.equal(has, true, "hasFactContentHash must return true for a just-written fact");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("content-hash: contentHashSource overrides the persisted body for dedup (rule 23)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const rawFact = "We migrated to MySQL in March";
+    // Persist a citation-annotated body, but index the RAW fact text
+    await storage.writeMemory("fact", `${rawFact} [cited 2026-01-01]`, {
+      contentHashSource: rawFact,
+    });
+
+    // Querying with the RAW fact (not the cited form) must hit
+    assert.equal(
+      await storage.hasFactContentHash(rawFact),
+      true,
+      "hasFactContentHash must match on the raw fact, not the cited body",
+    );
+    // The cited form should NOT be separately indexed (it has the citation suffix)
+    assert.equal(
+      await storage.hasFactContentHash(`${rawFact} [cited 2026-01-01]`),
+      false,
+      "the cited/timestamped form must not be the indexed hash",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("content-hash: non-fact categories do not register a content hash", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    await storage.writeMemory("decision", "we chose option B");
+    assert.equal(
+      await storage.hasFactContentHash("we chose option B"),
+      false,
+      "non-fact categories must not enter the fact dedup index",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("content-hash: normalizeContent produces stable text for equivalent inputs", () => {
+  const a = ContentHashIndex.normalizeContent("  Hello   World  ");
+  const b = ContentHashIndex.normalizeContent("Hello World");
+  assert.equal(a, b, "normalizeContent must collapse whitespace consistently");
+});
+
+test("content-hash: the frontmatter contentHash matches computeHash of the raw content", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const rawFact = "deterministic hash check";
+    const id = await storage.writeMemory("fact", rawFact);
+    const memory = await storage.getMemoryById(id);
+    assert.ok(memory);
+    assert.ok(memory!.frontmatter.contentHash, "frontmatter must carry a contentHash for facts");
+    assert.equal(
+      memory!.frontmatter.contentHash,
+      ContentHashIndex.computeHash(rawFact),
+      "frontmatter contentHash must equal computeHash of the raw content",
+    );
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/storage-contract/failure-semantics.test.ts
+++ b/packages/remnic-core/src/storage-contract/failure-semantics.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Issue #1533 — Phase A contract test: failure semantics.
+ *
+ * Rule 34: reads distinguish empty-dir from unreadable-dir — `{ok:false}` vs
+ * `[]`. Where the current surface already does this, we pin it; where it
+ * doesn't, we record the gap (for the silent-failures issue) rather than
+ * change behavior here.
+ *
+ * Also pins containment: a FILE where a directory is expected is skipped via
+ * lstat().isDirectory(), not existsSync() (rule 24).
+ */
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { StorageManager } from "../storage.js";
+import { makeStorage } from "./harness.js";
+
+test("failure-semantics: readAllMemories on a fresh (empty) dir returns [] not null", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const result = await storage.readAllMemories();
+    assert.ok(Array.isArray(result), "readAllMemories must return an array");
+    assert.equal(result.length, 0, "empty store must return an empty array");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failure-semantics: getMemoryById on empty store returns null (not throw)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const result = await storage.getMemoryById("anything");
+    assert.equal(result, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failure-semantics: readMemoryByPath on a non-existent file returns null (not throw)", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    const result = await storage.readMemoryByPath(path.join(baseDir, "facts", "2026-01-01", "nope.md"));
+    assert.equal(result, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failure-semantics: readMemoryByPath on a malformed markdown file returns null", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    const dir = path.join(baseDir, "facts", "2026-01-01");
+    await mkdir(dir, { recursive: true });
+    const filePath = path.join(dir, "garbage.md");
+    await writeFile(filePath, "this has no frontmatter at all\njust random text", "utf-8");
+
+    const result = await storage.readMemoryByPath(filePath);
+    assert.equal(result, null, "malformed file (no frontmatter, not entity) must return null");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failure-semantics: a FILE where a category directory is expected does not crash readAllMemories", async () => {
+  // Create a FILE named "facts" (not a directory) at the base dir, then scan.
+  // collectActiveMemoryPaths uses lstat().isDirectory() (not existsSync) so a
+  // file-as-directory entry is skipped without crashing (rule 24 containment).
+  // We do NOT call ensureDirectories — it would try to mkdir facts/<today> and
+  // fail on the file. The scan path must be robust independently of dir creation.
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "remnic-fail-file-as-dir-"));
+  try {
+    StorageManager.clearAllStaticCaches();
+    await writeFile(path.join(baseDir, "facts"), "I am a file not a directory", "utf-8");
+    const storage = new StorageManager(baseDir);
+
+    const result = await storage.readAllMemories();
+    assert.ok(Array.isArray(result));
+    assert.equal(result.length, 0, "a file-as-directory must not produce spurious memories");
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("failure-semantics: invalidateMemory on a missing memory returns false (not throw)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const result = await storage.invalidateMemory("totally-missing-id-99999");
+    assert.equal(result, false);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("failure-semantics: ensureDirectories is idempotent (safe to call multiple times)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    await storage.ensureDirectories();
+    await storage.ensureDirectories();
+    await storage.ensureDirectories();
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/storage-contract/harness.ts
+++ b/packages/remnic-core/src/storage-contract/harness.ts
@@ -1,0 +1,148 @@
+/**
+ * Issue #1533 — Storage contract test harness.
+ *
+ * Shared fixture helpers for the storage public-surface contract suite AND
+ * the #1522 catalog-touch fitness test (both live under `storage-contract/`
+ * per the issue's coordination note: "build both on ONE shared harness so the
+ * write-entry-point enumeration lives in exactly one place").
+ *
+ * Every helper creates a fresh temp directory and returns a `cleanup` that
+ * tears it down — tests never share state. `StorageManager.clearAllStaticCaches()`
+ * is called on setup and teardown so the module-level caches (readAllMemories
+ * in-flight, version sentinels, secure-store entity cache) do not leak between
+ * tests.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { StorageManager } from "../storage.js";
+import {
+  NamespaceStorageRouter,
+} from "../namespaces/storage.js";
+import type { PluginConfig } from "../types.js";
+
+/** Clear every module-level cache so tests start from a known-empty state. */
+export function resetStaticCaches(): void {
+  StorageManager.clearAllStaticCaches();
+}
+
+/**
+ * Create a StorageManager backed by a fresh temp directory.
+ *
+ * Returns the manager, the on-disk base directory, and a `cleanup` that removes
+ * the directory and clears static caches. Callers MUST call `cleanup` in a
+ * `try/finally` (or via `node:test`'s `t.after`).
+ */
+export async function makeStorage(
+  prefix = "remnic-storage-contract-",
+): Promise<{
+  storage: StorageManager;
+  baseDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  resetStaticCaches();
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const storage = new StorageManager(baseDir);
+  await storage.ensureDirectories();
+  storage.invalidateAllMemoriesCacheForDir();
+  return {
+    storage,
+    baseDir,
+    cleanup: async () => {
+      resetStaticCaches();
+      await rm(baseDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Build a minimal valid memory markdown body for raw seeding (bypasses
+ * writeMemory so the test controls exact on-disk bytes).
+ */
+export function rawMemoryMarkdown(
+  id: string,
+  category: string,
+  content: string,
+  extra: Record<string, string> = {},
+): string {
+  const now = new Date().toISOString();
+  const lines = [
+    "---",
+    `id: ${id}`,
+    `category: ${category}`,
+    `created: ${now}`,
+    `updated: ${now}`,
+    "source: test",
+    "confidence: 0.9",
+    'tags: ["contract"]',
+  ];
+  for (const [key, value] of Object.entries(extra)) {
+    lines.push(`${key}: ${value}`);
+  }
+  lines.push("---", "", content, "");
+  return lines.join("\n");
+}
+
+/**
+ * Seed a raw markdown file at a path relative to `baseDir`. Used when a test
+ * needs to control exact placement (e.g. a specific category dir + date nest)
+ * without going through `writeMemory`.
+ */
+export async function seedRawFile(
+  baseDir: string,
+  relPath: string,
+  content: string,
+): Promise<string> {
+  const fullPath = path.join(baseDir, relPath);
+  await mkdir(path.dirname(fullPath), { recursive: true });
+  await writeFile(fullPath, content, "utf-8");
+  return fullPath;
+}
+
+/**
+ * Minimal PluginConfig for NamespaceStorageRouter tests. Only the fields the
+ * router reads are populated; the rest default to values that keep the router
+ * in the namespaces-enabled mode the tests exercise.
+ */
+export function makeNamespaceConfig(
+  memoryDir: string,
+  overrides: Record<string, unknown> = {},
+): PluginConfig {
+  return {
+    memoryDir,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    entitySchemas: {},
+    inlineSourceAttributionFormat: undefined,
+    ...overrides,
+  } as unknown as PluginConfig;
+}
+
+/**
+ * Create a NamespaceStorageRouter over a fresh temp dir with namespaces
+ * enabled. Returns the router, the memory dir, and a cleanup.
+ */
+export async function makeNamespaceRouter(
+  overrides: Partial<PluginConfig> = {},
+): Promise<{
+  router: NamespaceStorageRouter;
+  memoryDir: string;
+  config: PluginConfig;
+  cleanup: () => Promise<void>;
+}> {
+  resetStaticCaches();
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-contract-"));
+  const config = makeNamespaceConfig(memoryDir, overrides);
+  const router = new NamespaceStorageRouter(config);
+  return {
+    router,
+    memoryDir,
+    config,
+    cleanup: async () => {
+      resetStaticCaches();
+      await rm(memoryDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/remnic-core/src/storage-contract/namespace-routing.test.ts
+++ b/packages/remnic-core/src/storage-contract/namespace-routing.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Issue #1533 — Phase A contract test: namespace routing.
+ *
+ * NamespaceStorageRouter must route the SAME operation through the correct
+ * on-disk root for default vs named namespaces, while rejecting escaping paths
+ * (the containment invariants from #1506 — a FILE at the namespaces root or at
+ * a token dir is rejected via statSync().isDirectory(), not existsSync; rule 24).
+ *
+ * Contracts pinned:
+ *  - default namespace → memoryDir (legacy root)
+ *  - named namespace → memoryDir/namespaces/<token>
+ *  - unsafe namespace segments (/, \, .., absolute) are rejected
+ *  - writes in one namespace are invisible to another
+ */
+
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { makeStorage, makeNamespaceRouter } from "./harness.js";
+import { resolveNamespaceStorageRoot } from "../namespaces/storage.js";
+import { namespaceIdentityToken } from "../namespaces/identity.js";
+
+test("namespace-routing: default namespace resolves to the legacy memoryDir root", async () => {
+  const { router, memoryDir, config, cleanup } = await makeNamespaceRouter();
+  try {
+    const root = await resolveNamespaceStorageRoot(config, "default");
+    assert.equal(root, memoryDir);
+
+    const sm = await router.storageFor("default");
+    assert.equal(sm.dir, memoryDir);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: named namespace resolves to a tokenized subdirectory", async () => {
+  const { router, memoryDir, config, cleanup } = await makeNamespaceRouter();
+  try {
+    const ns = "team-alpha";
+    const root = await resolveNamespaceStorageRoot(config, ns);
+    const token = namespaceIdentityToken(ns);
+    assert.ok(
+      root.includes(path.join("namespaces", token)),
+      `named namespace root ${root} should include namespaces/${token}`,
+    );
+
+    const sm = await router.storageFor(ns);
+    assert.ok(sm.dir.startsWith(memoryDir), "named namespace must be under memoryDir");
+    assert.ok(sm.dir.includes("namespaces"), "named namespace must be under namespaces/");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: two named namespaces resolve to DIFFERENT roots", async () => {
+  const { router, cleanup } = await makeNamespaceRouter();
+  try {
+    const sm1 = await router.storageFor("team-alpha");
+    const sm2 = await router.storageFor("team-beta");
+    assert.notEqual(sm1.dir, sm2.dir, "different namespaces must have different roots");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: writes in one namespace are invisible to another (isolation)", async () => {
+  const { router, cleanup } = await makeNamespaceRouter();
+  try {
+    const sm1 = await router.storageFor("team-alpha");
+    const id = await sm1.writeMemory("fact", "alpha-only fact");
+
+    const sm2 = await router.storageFor("team-beta");
+    const found = await sm2.getMemoryById(id);
+    assert.equal(found, null, "beta namespace must not see alpha's memories");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: resolveNamespaceStorageRoot rejects traversal segments", async () => {
+  const { config, cleanup } = await makeNamespaceRouter();
+  try {
+    for (const bad of ["../escape", "a/b", "a\\b", "/abs"]) {
+      await assert.rejects(
+        () => resolveNamespaceStorageRoot(config, bad),
+        /unsafe namespace path segment/,
+        `should reject ${bad}`,
+      );
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: storageFor rejects unsafe non-default namespaces", async () => {
+  const { router, cleanup } = await makeNamespaceRouter();
+  try {
+    for (const bad of ["../escape", "a/b"]) {
+      await assert.rejects(
+        () => router.storageFor(bad),
+        /unsafe namespace/,
+        `should reject ${bad}`,
+      );
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: namespaces disabled → all namespaces use memoryDir", async () => {
+  const { router, memoryDir, cleanup } = await makeNamespaceRouter({
+    namespacesEnabled: false,
+  });
+  try {
+    const sm1 = await router.storageFor("default");
+    const sm2 = await router.storageFor("anything");
+    assert.equal(sm1.dir, memoryDir);
+    assert.equal(sm2.dir, memoryDir);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("namespace-routing: router caches StorageManager per namespace (same instance on repeat)", async () => {
+  const { router, cleanup } = await makeNamespaceRouter();
+  try {
+    const sm1 = await router.storageFor("team-alpha");
+    const sm2 = await router.storageFor("team-alpha");
+    assert.equal(sm1, sm2, "storageFor must return the cached instance for the same namespace");
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/storage-contract/round-trip.test.ts
+++ b/packages/remnic-core/src/storage-contract/round-trip.test.ts
@@ -19,6 +19,7 @@ import { StorageManager } from "../storage.js";
 import {
   ALL_CATEGORY_DIRS,
   ALL_CATEGORY_KEYS,
+  CATEGORY_DIR_MAP,
   RECALL_NON_MEMORY_DIRS,
   categoryDirName,
 } from "../utils/category-dir.js";
@@ -160,19 +161,18 @@ test("round-trip: readMemoryByPath returns null for a non-existent path", async 
   }
 });
 
-test("round-trip: every ALL_CATEGORY_DIRS entry is a real directory name, not a category key", () => {
+test("round-trip: ALL_CATEGORY_DIRS is exactly facts + every CATEGORY_DIR_MAP value", () => {
   // ALL_CATEGORY_DIRS must contain directory NAMES (facts, decisions, ...) not
   // singular keys (fact, decision, ...). This guards the parity between
-  // categoryDirName() and the scan roots.
+  // categoryDirName() and the scan roots — a divergence would silently drop
+  // a category from recall.
+  const expected = new Set(["facts", ...Object.values(CATEGORY_DIR_MAP)]);
+  assert.deepEqual(new Set(ALL_CATEGORY_DIRS), expected);
+  // No singular keys leaked in
   for (const dir of ALL_CATEGORY_DIRS) {
-    assert.ok(!dir.endsWith("s") || dir === "facts" || dir.endsWith("s"),
-      `sanity: ${dir} is a plural directory name`);
+    assert.ok(!Object.hasOwn(CATEGORY_DIR_MAP, dir),
+      `${dir} is a singular category key, not a directory name`);
   }
-  // The map covers every non-fact category key
-  const dirs = new Set(ALL_CATEGORY_DIRS);
-  assert.ok(dirs.has("facts"));
-  assert.ok(dirs.has("decisions"));
-  assert.ok(dirs.has("questions"));
 });
 
 test("round-trip: StorageManager.dir exposes the base directory", async () => {

--- a/packages/remnic-core/src/storage-contract/round-trip.test.ts
+++ b/packages/remnic-core/src/storage-contract/round-trip.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Issue #1533 — Phase A contract test: write/read/list/delete round-trips.
+ *
+ * For EVERY category directory (iterated from ALL_CATEGORY_DIRS, never hardcoded
+ * — rule 53's cousin), exercises the documented public surface end to end:
+ *
+ *   writeMemory → readMemoryByPath → getMemoryById → readAllMemories → invalidateMemory
+ *
+ * Asserts content fidelity, frontmatter integrity, hash identity, and that
+ * deleted memories disappear from every read path. This is the round-trip
+ * contract that the 51 importers depend on; Phase B moves MUST keep it green.
+ */
+
+import assert from "node:assert/strict";
+import type { MemoryCategory } from "../types.js";
+import test from "node:test";
+
+import { StorageManager } from "../storage.js";
+import {
+  ALL_CATEGORY_DIRS,
+  ALL_CATEGORY_KEYS,
+  RECALL_NON_MEMORY_DIRS,
+  categoryDirName,
+} from "../utils/category-dir.js";
+import { makeStorage } from "./harness.js";
+
+/**
+ * The singular category keys writeMemory accepts, minus "entity" (entities use
+ * a separate write path: writeEntity) and "question" (questions are a
+ * non-memory QUEUE dir — RECALL_NON_MEMORY_DIRS — surfaced through
+ * writeQuestion/readQuestions, NOT readAllMemories; see question-queue test).
+ */
+const ROUND_TRIP_CATEGORIES = ALL_CATEGORY_KEYS.filter(
+  (k) => k !== "entity" && k !== "question",
+) as MemoryCategory[];
+
+test("round-trip: writeMemory returns a stable id and persists to the category dir", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const id = await storage.writeMemory("fact", "The sky is blue", {
+      tags: ["contract"],
+    });
+    assert.equal(typeof id, "string");
+    assert.match(id, /^fact-/);
+
+    const byId = await storage.getMemoryById(id);
+    assert.ok(byId, "getMemoryById must find the just-written memory");
+    assert.equal(byId!.frontmatter.id, id);
+    assert.equal(byId!.content, "The sky is blue");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("round-trip: readAllMemories returns written memories from every category dir", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const written: string[] = [];
+    for (const category of ROUND_TRIP_CATEGORIES) {
+      const id = await storage.writeMemory(
+        category,
+        `content for ${category}`,
+        { confidence: 0.9 },
+      );
+      written.push(id);
+    }
+
+    const all = await storage.readAllMemories();
+    const ids = new Set(all.map((m) => m.frontmatter.id));
+    for (const id of written) {
+      assert.ok(ids.has(id), `readAllMemories missing memory ${id} (${ROUND_TRIP_CATEGORIES.find((c) => id.startsWith(c))})`);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+for (const category of ROUND_TRIP_CATEGORIES) {
+  test(`round-trip [${category}]: write → read-by-path → read-by-id → list → delete`, async () => {
+    const { storage, cleanup } = await makeStorage();
+    try {
+      const content = `fact body for category ${category}`;
+      const id = await storage.writeMemory(category, content, {
+        tags: ["round-trip"],
+      });
+
+      // getMemoryById
+      const byId = await storage.getMemoryById(id);
+      assert.ok(byId, "getMemoryById returned null");
+      assert.equal(byId!.content, content);
+      assert.equal(byId!.frontmatter.category, category);
+
+      // readMemoryByPath — the path comes from the byId result
+      const byPath = await storage.readMemoryByPath(byId!.path);
+      assert.ok(byPath, "readMemoryByPath returned null");
+      assert.equal(byPath!.content, content);
+      assert.equal(byPath!.frontmatter.id, id);
+
+      // The file landed under the right category dir
+      const expectedDir = categoryDirName(category);
+      assert.ok(
+        byId!.path.includes(`/${expectedDir}/`),
+        `${category} memory landed in ${byId!.path}, expected under ${expectedDir}/`,
+      );
+
+      // list contains it
+      const all = await storage.readAllMemories();
+      assert.ok(
+        all.some((m) => m.frontmatter.id === id),
+        "readAllMemories did not include the written memory",
+      );
+
+      // delete (invalidate) removes it from every read path
+      const deleted = await storage.invalidateMemory(id);
+      assert.equal(deleted, true, "invalidateMemory should return true on success");
+
+      const afterDelete = await storage.getMemoryById(id);
+      assert.equal(afterDelete, null, "getMemoryById must return null after invalidateMemory");
+
+      const allAfter = await storage.readAllMemories();
+      assert.ok(
+        !allAfter.some((m) => m.frontmatter.id === id),
+        "readAllMemories must not include deleted memory",
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+}
+
+test("round-trip: invalidateMemory returns false for a non-existent id (not a throw)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const result = await storage.invalidateMemory("does-not-exist-12345");
+    assert.equal(result, false);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("round-trip: getMemoryById returns null for a non-existent id", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const result = await storage.getMemoryById("missing-id");
+    assert.equal(result, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("round-trip: readMemoryByPath returns null for a non-existent path", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    const result = await storage.readMemoryByPath(
+      `${baseDir}/facts/2026-01-01/nonexistent.md`,
+    );
+    assert.equal(result, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("round-trip: every ALL_CATEGORY_DIRS entry is a real directory name, not a category key", () => {
+  // ALL_CATEGORY_DIRS must contain directory NAMES (facts, decisions, ...) not
+  // singular keys (fact, decision, ...). This guards the parity between
+  // categoryDirName() and the scan roots.
+  for (const dir of ALL_CATEGORY_DIRS) {
+    assert.ok(!dir.endsWith("s") || dir === "facts" || dir.endsWith("s"),
+      `sanity: ${dir} is a plural directory name`);
+  }
+  // The map covers every non-fact category key
+  const dirs = new Set(ALL_CATEGORY_DIRS);
+  assert.ok(dirs.has("facts"));
+  assert.ok(dirs.has("decisions"));
+  assert.ok(dirs.has("questions"));
+});
+
+test("round-trip: StorageManager.dir exposes the base directory", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    assert.equal(storage.dir, baseDir);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("question-queue: writeQuestion → readQuestions → resolveQuestion round-trip (questions are NOT in readAllMemories)", async () => {
+  const { storage, cleanup } = await makeStorage();
+  try {
+    const id = await storage.writeQuestion("What database are we on?", "infra context", 3);
+    assert.equal(typeof id, "string");
+    assert.match(id, /^q-/);
+
+    // readQuestions returns it
+    const questions = await storage.readQuestions();
+    const q = questions.find((x) => x.id === id);
+    assert.ok(q, "readQuestions must include the just-written question");
+    assert.equal(q!.question, "What database are we on?");
+    assert.equal(q!.resolved, false);
+
+    // questions/ is a RECALL_NON_MEMORY_DIRS entry — it must NOT appear in readAllMemories
+    const all = await storage.readAllMemories();
+    assert.ok(
+      !all.some((m) => m.frontmatter.id === id),
+      "questions must not leak into the memory corpus (readAllMemories)",
+    );
+
+    // unresolvedOnly filter works
+    const unresolved = await storage.readQuestions({ unresolvedOnly: true });
+    assert.ok(unresolved.some((x) => x.id === id));
+
+    // resolve marks it resolved
+    const resolved = await storage.resolveQuestion(id);
+    assert.equal(resolved, true);
+
+    const afterResolve = await storage.readQuestions({ unresolvedOnly: true });
+    assert.ok(!afterResolve.some((x) => x.id === id), "resolved question must not appear in unresolvedOnly");
+
+    const allAfter = await storage.readQuestions();
+    const resolvedQ = allAfter.find((x) => x.id === id);
+    assert.ok(resolvedQ, "resolved question should still be readable without the filter");
+    assert.equal(resolvedQ!.resolved, true);
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/storage-contract/surface.test.ts
+++ b/packages/remnic-core/src/storage-contract/surface.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Issue #1533 — Phase A contract test: public-surface enumeration.
+ *
+ * Phase A step 1: enumerate the public surface of storage.ts so the contract
+ * suite has an explicit inventory. This test pins the exported symbols the 51+
+ * importers depend on. When Phase B extracts seams, every entry here must still
+ * resolve — either on storage.ts or on the storage/* module that absorbed it.
+ *
+ * This is NOT a behavior test; it is a surface-stability guard. It documents
+ * what the MemoryStorage interface must cover.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as storageModule from "../storage.js";
+
+test("surface: StorageManager class is exported and constructible", () => {
+  assert.equal(typeof storageModule.StorageManager, "function");
+  assert.equal(storageModule.StorageManager.name, "StorageManager");
+});
+
+test("surface: ContentHashIndex class is exported", () => {
+  assert.equal(typeof storageModule.ContentHashIndex, "function");
+  assert.equal(storageModule.ContentHashIndex.name, "ContentHashIndex");
+});
+
+test("surface: entity helpers are exported (parseEntityFile, serializeEntityFile, normalizeEntityName)", () => {
+  assert.equal(typeof storageModule.parseEntityFile, "function");
+  assert.equal(typeof storageModule.serializeEntityFile, "function");
+  assert.equal(typeof storageModule.normalizeEntityName, "function");
+});
+
+test("surface: StorageManager exposes the documented memory CRUD methods", () => {
+  const proto = storageModule.StorageManager.prototype;
+  const required = [
+    "writeMemory",
+    "readAllMemories",
+    "readMemoryByPath",
+    "getMemoryById",
+    "invalidateMemory",
+    "updateMemory",
+    "ensureDirectories",
+    "setVersioningConfig",
+    "isSecureStoreUnlocked",
+    "getMemoryStatusVersion",
+  ];
+  for (const method of required) {
+    assert.equal(
+      typeof (proto as unknown as Record<string, unknown>)[method],
+      "function",
+      `StorageManager.prototype.${method} must be a function (documented public surface)`,
+    );
+  }
+});
+
+test("surface: StorageManager exposes the question-queue methods", () => {
+  const proto = storageModule.StorageManager.prototype;
+  assert.equal(typeof proto.writeQuestion, "function");
+  assert.equal(typeof proto.readQuestions, "function");
+  assert.equal(typeof proto.resolveQuestion, "function");
+});
+
+test("surface: StorageManager exposes cache invalidation methods (rule 37)", () => {
+  const proto = storageModule.StorageManager.prototype;
+  assert.equal(typeof proto.invalidateAllMemoriesCacheForDir, "function");
+  assert.equal(typeof proto.invalidateMemoryCachesForTiers, "function");
+});
+
+test("surface: StorageManager has a static clearAllStaticCaches for test isolation", () => {
+  assert.equal(
+    typeof storageModule.StorageManager.clearAllStaticCaches,
+    "function",
+    "clearAllStaticCaches is the test-isolation chokepoint",
+  );
+});
+
+test("surface: ContentHashIndex exposes computeHash and normalizeContent (rule 23)", () => {
+  assert.equal(typeof storageModule.ContentHashIndex.computeHash, "function");
+  assert.equal(typeof storageModule.ContentHashIndex.normalizeContent, "function");
+});
+
+test("surface: StorageManager.dir getter returns the base directory string", () => {
+  const desc = Object.getOwnPropertyDescriptor(
+    storageModule.StorageManager.prototype,
+    "dir",
+  );
+  assert.ok(desc, "dir must be a property on the prototype");
+  assert.equal(typeof desc?.get, "function", "dir must have a getter");
+});

--- a/packages/remnic-core/src/storage-contract/versioning.test.ts
+++ b/packages/remnic-core/src/storage-contract/versioning.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Issue #1533 — Phase A contract test: page versioning snapshots.
+ *
+ * When versioning is enabled, overwriting a FIXED-PATH file produces a numbered
+ * snapshot in the `.versions/` sidecar. Revert restores a prior version.
+ * This pins the versioning contract the consolidation/provenance paths rely on.
+ *
+ * NOTE: `writeMemory` generates a unique path per id, so the first write to a
+ * path never has pre-existing content to snapshot. The versioning integration
+ * is exercised through `writeProfile` — a fixed-path write that calls
+ * `snapshotBeforeWrite` before overwriting. The direct `createVersion`/
+ * `revertToVersion` API is tested separately.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createVersion,
+  listVersions,
+  revertToVersion,
+  getVersion,
+  type VersioningConfig,
+} from "../page-versioning.js";
+import { StorageManager } from "../storage.js";
+import { resetStaticCaches } from "./harness.js";
+
+const VERSIONING_CONFIG: VersioningConfig = {
+  enabled: true,
+  maxVersionsPerPage: 10,
+  sidecarDir: ".versions",
+};
+
+test("versioning: overwrite of a fixed-path file (writeProfile) produces a numbered snapshot", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-ver-snapshot-"));
+  try {
+    resetStaticCaches();
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    storage.setVersioningConfig(VERSIONING_CONFIG);
+
+    const profilePath = path.join(dir, "profile.md");
+    await storage.writeProfile("first version of profile");
+
+    // Overwrite the same fixed path → snapshotBeforeWrite fires
+    await storage.writeProfile("second version of profile");
+
+    const versions = await listVersions(profilePath, VERSIONING_CONFIG);
+    assert.ok(
+      versions.versions.length >= 1,
+      "at least one snapshot must exist after overwriting a fixed-path file",
+    );
+    assert.equal(versions.versions[0].trigger, "consolidation");
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("versioning: snapshot captures the PRE-overwrite content", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-ver-pre-"));
+  try {
+    resetStaticCaches();
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    storage.setVersioningConfig(VERSIONING_CONFIG);
+
+    const profilePath = path.join(dir, "profile.md");
+    await storage.writeProfile("ORIGINAL PROFILE");
+    await storage.writeProfile("REPLACEMENT PROFILE");
+
+    const versions = await listVersions(profilePath, VERSIONING_CONFIG);
+    assert.ok(versions.versions.length >= 1);
+
+    // Read the snapshot — it must contain the ORIGINAL, not the replacement
+    const snapshot = await getVersion(profilePath, versions.versions[0].versionId, VERSIONING_CONFIG);
+    assert.ok(snapshot, "snapshot content must be readable");
+    assert.ok(
+      snapshot!.includes("ORIGINAL PROFILE"),
+      "the snapshot must contain the pre-overwrite content",
+    );
+    assert.ok(
+      !snapshot!.includes("REPLACEMENT"),
+      "the snapshot must NOT contain the replacement content",
+    );
+
+    // The live file has the replacement
+    const live = await readFile(profilePath, "utf-8");
+    assert.ok(live.includes("REPLACEMENT PROFILE"));
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("versioning: disabled by default — no snapshots created", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-ver-disabled-"));
+  try {
+    resetStaticCaches();
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    // Do NOT call setVersioningConfig — default is disabled
+    await storage.writeProfile("v1");
+    await storage.writeProfile("v2");
+
+    const profilePath = path.join(dir, "profile.md");
+    const versions = await listVersions(profilePath, VERSIONING_CONFIG);
+    assert.equal(versions.versions.length, 0, "no snapshots when versioning was disabled at write time");
+  } finally {
+    resetStaticCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("versioning: createVersion → revertToVersion round-trip restores content", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-ver-revert-"));
+  try {
+    const filePath = path.join(dir, "doc.md");
+    await writeFile(filePath, "alpha", "utf-8");
+
+    await createVersion(filePath, "alpha", "manual", VERSIONING_CONFIG);
+    await writeFile(filePath, "beta", "utf-8");
+    await createVersion(filePath, "beta", "manual", VERSIONING_CONFIG);
+
+    const versions = await listVersions(filePath, VERSIONING_CONFIG);
+    assert.ok(versions.versions.length >= 2);
+
+    const firstVersionId = versions.versions[0].versionId;
+    await revertToVersion(filePath, firstVersionId, VERSIONING_CONFIG);
+
+    const restored = await readFile(filePath, "utf-8");
+    assert.equal(restored, "alpha", "revert must restore the version-1 content");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -70,6 +70,15 @@ const ADHOC_RESOLUTION_RE =
   /\b(resolveWritableNamespace|namespaceFromStorageDir|configuredNamespaces)\s*\(/g;
 const SCOPE_PLAN_REL = "packages/remnic-core/src/scopes/scope-plan.ts";
 const SKIPPED_DIR_NAMES = new Set(["node_modules", "dist", ".git"]);
+/**
+ * Direct imports of the main `storage.ts` module (issue #1533 Phase B): counts
+ * non-test source files that import from `./storage.js` or `../storage.js` (the
+ * 7.7k-LOC god file) rather than the extracted `storage/*` interface modules.
+ * The ratchet may only DECREASE as Phase B migrates the 51+ importers to the
+ * `MemoryStorage` interface. Matches relative imports ending in exactly
+ * `storage.js` — not sub-paths like `namespaces/storage.js` or `secure-fs.js`.
+ */
+const DIRECT_STORAGE_IMPORT_RE = /from\s+"(?:\.\.?\/)+storage\.js"/;
 
 function usage() {
   return [
@@ -142,6 +151,7 @@ function collectMetrics(oversizeThresholdLoc) {
   const oversizedFiles = [];
   let scatteredConfigFlagReads = 0;
   let adHocNamespaceResolutions = 0;
+  let directStorageImports = 0;
   for (const file of sourceFiles) {
     const relPosix = toPosix(path.relative(ROOT, file));
     const content = readFileSync(file, "utf8");
@@ -161,6 +171,15 @@ function collectMetrics(oversizeThresholdLoc) {
         adHocNamespaceResolutions += adHocMatches.length;
       }
     }
+    // Issue #1533: count files importing directly from the main storage.ts
+    // (exclude storage.ts itself). May only decrease as Phase B migrates
+    // importers to the MemoryStorage interface.
+    if (
+      relPosix !== "packages/remnic-core/src/storage.ts" &&
+      DIRECT_STORAGE_IMPORT_RE.test(content)
+    ) {
+      directStorageImports++;
+    }
   }
 
   return {
@@ -170,6 +189,7 @@ function collectMetrics(oversizeThresholdLoc) {
     oversizedFileCount: oversizedFiles.length,
     scatteredConfigFlagReads,
     adHocNamespaceResolutions,
+    directStorageImports,
   };
 }
 
@@ -204,7 +224,7 @@ function readBaseline() {
       fail(`baseline metrics.watchlistLoc entry ${file} must be a non-negative integer`);
     }
   }
-  for (const key of ["oversizedFileCount", "scatteredConfigFlagReads", "adHocNamespaceResolutions"]) {
+  for (const key of ["oversizedFileCount", "scatteredConfigFlagReads", "adHocNamespaceResolutions", "directStorageImports"]) {
     if (!Number.isInteger(metrics[key]) || metrics[key] < 0) {
       fail(`baseline metrics.${key} must be a non-negative integer`);
     }
@@ -228,6 +248,7 @@ function writeBaseline(metrics, oversizeThresholdLoc) {
       oversizedFileCount: metrics.oversizedFileCount,
       scatteredConfigFlagReads: metrics.scatteredConfigFlagReads,
       adHocNamespaceResolutions: metrics.adHocNamespaceResolutions,
+      directStorageImports: metrics.directStorageImports,
     },
   };
   writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
@@ -267,6 +288,7 @@ function main() {
     console.log(`[ratchet]   oversizedFileCount (> ${DEFAULT_OVERSIZE_THRESHOLD_LOC} LOC): ${metrics.oversizedFileCount}`);
     console.log(`[ratchet]   scatteredConfigFlagReads: ${metrics.scatteredConfigFlagReads}`);
     console.log(`[ratchet]   adHocNamespaceResolutions: ${metrics.adHocNamespaceResolutions}`);
+    console.log(`[ratchet]   directStorageImports: ${metrics.directStorageImports}`);
     return;
   }
 
@@ -338,6 +360,17 @@ function main() {
   } else if (current.adHocNamespaceResolutions < baseline.metrics.adHocNamespaceResolutions) {
     improvements.push(
       `ad-hoc namespace-resolution call sites: ${baseline.metrics.adHocNamespaceResolutions} -> ${current.adHocNamespaceResolutions}`,
+    );
+  }
+
+  if (current.directStorageImports > baseline.metrics.directStorageImports) {
+    failures.push(
+      `direct storage.ts imports grew from ${baseline.metrics.directStorageImports} ` +
+        `to ${current.directStorageImports} (migrate importers to the MemoryStorage interface; see #1533)`,
+    );
+  } else if (current.directStorageImports < baseline.metrics.directStorageImports) {
+    improvements.push(
+      `direct storage.ts imports: ${baseline.metrics.directStorageImports} -> ${current.directStorageImports}`,
     );
   }
 

--- a/scripts/check-ratchets.mjs
+++ b/scripts/check-ratchets.mjs
@@ -172,10 +172,13 @@ function collectMetrics(oversizeThresholdLoc) {
       }
     }
     // Issue #1533: count files importing directly from the main storage.ts
-    // (exclude storage.ts itself). May only decrease as Phase B migrates
-    // importers to the MemoryStorage interface.
+    // (exclude storage.ts itself, and exclude the test-only storage-contract/
+    // harness dir — it imports storage.js by design to exercise the public
+    // surface, not as a production caller). May only decrease as Phase B
+    // migrates real importers to the MemoryStorage interface.
     if (
       relPosix !== "packages/remnic-core/src/storage.ts" &&
+      !relPosix.includes("/storage-contract/") &&
       DIRECT_STORAGE_IMPORT_RE.test(content)
     ) {
       directStorageImports++;

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -13,6 +13,6 @@
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 561,
     "adHocNamespaceResolutions": 51,
-    "directStorageImports": 39
+    "directStorageImports": 38
   }
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -12,6 +12,7 @@
     },
     "oversizedFileCount": 10,
     "scatteredConfigFlagReads": 561,
-    "adHocNamespaceResolutions": 51
+    "adHocNamespaceResolutions": 51,
+    "directStorageImports": 39
   }
 }


### PR DESCRIPTION
## Summary

Phase A of #1533: pin the documented StorageManager API as a contract test suite, then enable Phase B with a direct-import ratchet.

## What

**Contract suite — 61 tests across 8 files** under `packages/remnic-core/src/storage-contract/`:

| File | Coverage |
|---|---|
| `round-trip.test.ts` | write→read→list→delete for EVERY `ALL_CATEGORY_DIRS` entry (iterated, never hardcoded); question-queue surface |
| `atomicity.test.ts` | temp-write+rename invariant (rule 54); original survives failed rename; mkdir implicit |
| `namespace-routing.test.ts` | `NamespaceStorageRouter` default vs named roots, isolation, traversal rejection |
| `versioning.test.ts` | overwrite snapshots pre-write content; createVersion/revertToVersion round-trip |
| `cache-coherence.test.ts` | write via instance A visible to fresh instance B (rule 37) |
| `content-hash.test.ts` | write-side/dedup-side hash same rawContent (rule 23); `contentHashSource` override |
| `failure-semantics.test.ts` | empty-dir→`[]` not null (rule 34); file-as-dir via `isDirectory()` not `existsSync` (rule 24) |
| `surface.test.ts` | public API enumeration — pins what the `MemoryStorage` interface must cover |

**Shared harness** (`harness.ts`): fixture helpers consumed by both this suite and the upcoming #1522 catalog-touch fitness test — one harness, per the issue coordination note.

**Phase B enabler**: `directStorageImports` ratchet metric in `scripts/check-ratchets.mjs` — counts non-test files importing from the main `storage.ts`. Baseline set to 39; may only decrease as Phase B migrates importers to the extracted `storage/*` interface modules.

## Why

`storage.ts` is 7,709 LOC with 39 direct importers and no direct test file. Every change is validated only indirectly through consumers. This suite pins the read/write/list/delete/status behavior as a contract so Phase B decomposition moves (io→layout→versioning→indexing seams) are behavior-preserving.

## Chokepoints used / not applicable
- storage chokepoint (#1522): **not applicable** (this PR adds tests only; #1522 catalog-touch fitness will reuse the shared harness)
- All other chokepoints: **not applicable** (no behavior changes)

## Test plan
- [x] `npx tsx --test 'src/storage-contract/**/*.test.ts'` — 61 pass, 0 fail
- [x] `npm run preflight:quick` — OK
- [x] `node scripts/check-ratchets.mjs` — OK
- [x] `npx tsc --noEmit` — clean
- [x] Config contract validation — OK

Closes #1533 (Phase A complete; Phase B decomposition follows in one-seam-per-PR PRs per the issue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and ratchet baseline updates; production storage code is unchanged, so risk is limited to CI/test maintenance.
> 
> **Overview**
> Adds **Phase A (#1533)** coverage for the `StorageManager` public API: a new `storage-contract/` suite (~61 tests) plus a structural ratchet for Phase B.
> 
> The contract tests pin behavior importers rely on—round-trips per category, atomic writes, namespace isolation, versioning snapshots, cross-instance cache coherence, fact content-hash dedup, failure/null semantics, and an exported API inventory—using a shared `harness.ts` (temp dirs, cache resets) intended for reuse by #1522.
> 
> `check-ratchets.mjs` gains **`directStorageImports`** (baseline **38**), counting non-test production files that import the monolithic `storage.ts`; the metric may only decrease as callers move to extracted `storage/*` modules. **No runtime storage behavior changes** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab203c54cfc2bbd31e008ef865d106e39ea81755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->