### PR TITLE
feat(temporal): wire extraction eventTime to anchored bi-temporal validAt (#1578 PR2)

### DIFF
--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -286,6 +286,14 @@ function resolveQuarter(
  */
 function resolveAbsolute(raw: string): number | null {
   const trimmed = raw.trim();
+  // YYYY-MM (ISO year-month, no day) → first day of that month, UTC
+  // (#1578 review r3: the prompt example "until 2025-06" must resolve, not
+  // fall back to "assumed").
+  const ym = /^(\d{4})-(\d{2})$/.exec(trimmed);
+  if (ym) {
+    const ms = buildDateMs(Number(ym[1]), Number(ym[2]), 1);
+    return ms === null ? null : startOfDayUtc(ms);
+  }
   const ms = parseFlexibleIsoTimestamp(trimmed);
   if (ms === null) return null;
   // Date-only inputs (no T) anchor to start-of-day UTC.
@@ -467,6 +475,17 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
   // Bare four-digit year: exclusive end = January 1 of the FOLLOWING year.
   if (/^\d{4}$/.test(trimmed)) {
     return buildDateMs(Number(trimmed) + 1, 1, 1);
+  }
+
+  // YYYY-MM (year-month) end bound: exclusive end = start of the FOLLOWING
+  // month, so "until 2025-06" spans all of June (#1578 review r3).
+  const ymEnd = /^(\d{4})-(\d{2})$/.exec(trimmed);
+  if (ymEnd) {
+    const startMs = buildDateMs(Number(ymEnd[1]), Number(ymEnd[2]), 1);
+    if (startMs === null) return null;
+    const nd = new Date(startMs);
+    nd.setUTCMonth(nd.getUTCMonth() + 1);
+    return startOfDayUtc(nd.getTime());
   }
 
   // Absolute date/datetime end bound.

--- a/packages/remnic-core/src/event-time.ts
+++ b/packages/remnic-core/src/event-time.ts
@@ -546,3 +546,57 @@ function resolveEndBound(anchorMs: number, period: string): number | null {
   }
   return null;
 }
+
+/**
+ * Resolved bi-temporal fields for a single extracted fact (issue #1578 PR2).
+ *
+ * - `validFrom` / `validUntil` — the event-time `[from, until)` interval.
+ *   When `eventTimeSource === "assumed"`, `validFrom` is copied from
+ *   `observedAt` (the ingestion anchor) so every bi-temporal-on fact carries
+ *   at least a start bound.
+ * - `observedAt` — always the ingestion anchor (the source turn timestamp).
+ * - `eventTimeSource` — `"extracted"` when the expression resolved to a real
+ *   event-time interval; `"assumed"` when the expression was absent or
+ *   unresolvable.
+ *
+ * This is the single write-time helper every extraction entry path calls
+ * (rule 39). It is pure: (expression, anchor) in, interval out. Resolution
+ * never touches `Date.now()` — replay/import of old transcripts resolves
+ * against the old anchor.
+ */
+export interface FactEventTime {
+  validFrom?: string;
+  validUntil?: string;
+  observedAt: string;
+  eventTimeSource: "extracted" | "assumed";
+}
+
+/**
+ * Resolve a single fact's event-time expression against the ingestion anchor.
+ *
+ * Returns the bi-temporal interval to persist alongside the fact. When the
+ * expression is absent, empty, or unresolvable, falls back to
+ * `eventTimeSource: "assumed"` with `validFrom = observedAt` — per the
+ * #1578 frontmatter contract. When the expression resolves but only pins one
+ * bound ("since 2024" → validFrom only; "until 2025-06" → validUntil only),
+ * only the resolved bound is returned.
+ */
+export function resolveFactEventTime(
+  expression: string | undefined | null,
+  anchorIso: string,
+): FactEventTime {
+  const resolved = resolveEventTime(expression, anchorIso);
+  if (resolved.ok && (resolved.validFrom !== undefined || resolved.validUntil !== undefined)) {
+    return {
+      ...(resolved.validFrom !== undefined ? { validFrom: resolved.validFrom } : {}),
+      ...(resolved.validUntil !== undefined ? { validUntil: resolved.validUntil } : {}),
+      observedAt: anchorIso,
+      eventTimeSource: "extracted",
+    };
+  }
+  return {
+    validFrom: anchorIso,
+    observedAt: anchorIso,
+    eventTimeSource: "assumed",
+  };
+}

--- a/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
+++ b/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
@@ -186,3 +186,42 @@ test("resolveFactEventTime: 'through 2026' → validUntil only (open-ended end b
   // "through 2026" → exclusive end = start of 2027.
   assert.equal(result.validUntil, "2027-01-01T00:00:00.000Z");
 });
+test("storage: writeChunk propagates invalidAt/observedAt/eventTimeSource from the parent fact (#1578 PR2)", async () => {
+  // Proves the cursor-bugbot fix: an independently-surfaced chunk expires at the
+  // same invalid_at window as its parent so recall's isValidityExpiredNow check
+  // fires on chunks too, not just the chunked parent write.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-et-chunk-invalid-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const parentId = await storage.writeMemory("fact", "We used MongoDB until June 2025.", {
+      validAt: "2024-01-01T00:00:00.000Z",
+      invalidAt: "2025-06-01T00:00:00.000Z",
+      observedAt: "2025-06-20T00:00:00.000Z",
+      eventTimeSource: "extracted",
+    });
+    const chunkId = await storage.writeChunk(
+      parentId,
+      0,
+      1,
+      "fact",
+      "We used MongoDB until June 2025.",
+      {
+        validAt: "2024-01-01T00:00:00.000Z",
+        invalidAt: "2025-06-01T00:00:00.000Z",
+        observedAt: "2025-06-20T00:00:00.000Z",
+        eventTimeSource: "extracted",
+      },
+    );
+    const mems = await storage.readAllMemories();
+    const chunk = mems.find((m) => m.frontmatter.id === chunkId);
+    assert.ok(chunk, "chunk must be readable");
+    assert.equal(chunk!.frontmatter.valid_at, "2024-01-01T00:00:00.000Z");
+    assert.equal(chunk!.frontmatter.invalid_at, "2025-06-01T00:00:00.000Z",
+      "chunk must carry the parent's end bound so it expires independently");
+    assert.equal(chunk!.frontmatter.observedAt, "2025-06-20T00:00:00.000Z");
+    assert.equal(chunk!.frontmatter.eventTimeSource, "extracted");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
+++ b/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
@@ -225,3 +225,17 @@ test("storage: writeChunk propagates invalidAt/observedAt/eventTimeSource from t
     await rm(dir, { recursive: true, force: true });
   }
 });
+test("resolveFactEventTime: 'until 2025-06' (YYYY-MM) → invalidAt = start of following month (#1578 r3)", () => {
+  const result = resolveFactEventTime("until 2025-06", "2025-06-20T00:00:00.000Z");
+  assert.equal(result.eventTimeSource, "extracted");
+  assert.equal(result.validFrom, undefined);
+  assert.equal(result.validUntil, "2025-07-01T00:00:00.000Z",
+    "YYYY-MM end bound must span the whole month, not fall back to assumed");
+});
+
+test("resolveFactEventTime: bare '2025-03' (YYYY-MM) → validFrom = first of month (#1578 r3)", () => {
+  const result = resolveFactEventTime("2025-03", "2025-06-20T00:00:00.000Z");
+  assert.equal(result.eventTimeSource, "extracted");
+  assert.equal(result.validFrom, "2025-03-01T00:00:00.000Z");
+  assert.equal(result.validUntil, undefined);
+});

--- a/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
+++ b/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
@@ -152,3 +152,37 @@ test("storage: invalid_at round-trips through writeMemoryFrontmatter → readAll
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("storage: writeMemory accepts invalidAt directly (end-bound at extraction write time)", async () => {
+  // Proves Fix C: writeMemory now accepts invalidAt so "until X" expressions
+  // persist invalid_at at write time without a separate updateMemoryFrontmatter call.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-et-writeMem-invalid-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const id = await storage.writeMemory("fact", "We used MongoDB until June 2025.", {
+      validAt: "2024-01-01T00:00:00.000Z",
+      invalidAt: "2025-06-01T00:00:00.000Z",
+      observedAt: "2025-06-20T00:00:00.000Z",
+      eventTimeSource: "extracted",
+    });
+    const mems = await storage.readAllMemories();
+    const mem = mems.find((m) => m.frontmatter.id === id);
+    assert.ok(mem);
+    assert.equal(mem!.frontmatter.valid_at, "2024-01-01T00:00:00.000Z");
+    assert.equal(mem!.frontmatter.invalid_at, "2025-06-01T00:00:00.000Z");
+    assert.equal(mem!.frontmatter.observedAt, "2025-06-20T00:00:00.000Z");
+    assert.equal(mem!.frontmatter.eventTimeSource, "extracted");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveFactEventTime: 'through 2026' → validUntil only (open-ended end bound)", () => {
+  const result = resolveFactEventTime("through 2026", "2025-06-20T00:00:00.000Z");
+  assert.equal(result.eventTimeSource, "extracted");
+  assert.equal(result.validFrom, undefined);
+  assert.ok(result.validUntil, "validUntil must be set for an end-bound expression");
+  // "through 2026" → exclusive end = start of 2027.
+  assert.equal(result.validUntil, "2027-01-01T00:00:00.000Z");
+});

--- a/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
+++ b/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 
 import { resolveFactEventTime } from "./event-time.js";
 import { ExtractionEngine } from "./extraction.js";
+import { ExtractedFactSchema } from "./schemas.js";
 import { StorageManager } from "./storage.js";
 
 /**
@@ -115,6 +116,33 @@ test("extraction normalization: absent eventTime → undefined (assumed deferred
     entities: [],
   });
   assert.equal(result.facts[0].eventTime, undefined);
+});
+
+// ── 2b. Schema preserves snake_case event_time (gateway fix, chatgpt-codex) ─
+
+test("ExtractedFactSchema: snake_case event_time survives schema parse (gateway strip-unknown fix)", () => {
+  // Zod .object() strips unknown keys by default. Before the event_time alias
+  // was added, the gateway fallback path (parseWithSchemaDetailed → schema.parse)
+  // silently dropped event_time, losing the temporal bound (#1578).
+  const parsed = ExtractedFactSchema.parse({
+    content: "Switched to PostgreSQL.",
+    category: "fact",
+    confidence: 0.9,
+    tags: [],
+    event_time: "2025-01-15",
+  });
+  assert.equal(parsed.event_time, "2025-01-15");
+});
+
+test("ExtractedFactSchema: camelCase eventTime also survives schema parse (no regression)", () => {
+  const parsed = ExtractedFactSchema.parse({
+    content: "We moved offices in March.",
+    category: "fact",
+    confidence: 0.8,
+    tags: [],
+    eventTime: "2025-03",
+  });
+  assert.equal(parsed.eventTime, "2025-03");
 });
 
 // ── 3. Storage round-trips invalid_at ────────────────────────────────────

--- a/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
+++ b/packages/remnic-core/src/extraction-eventtime-wiring.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { resolveFactEventTime } from "./event-time.js";
+import { ExtractionEngine } from "./extraction.js";
+import { StorageManager } from "./storage.js";
+
+/**
+ * Issue #1578 PR 2 — extraction event-time wiring.
+ *
+ * Proves three contracts:
+ *  1. resolveFactEventTime anchors to the SOURCE TURN timestamp, never
+ *     wall-clock — replay/import of an old transcript yields old-era event
+ *     times (the core bi-temporal invariant from the #1578 design).
+ *  2. Extraction normalization passes the per-fact `eventTime` expression
+ *     through from raw LLM JSON (camelCase and snake_case payloads) so the
+ *     persist path can resolve it at write time.
+ *  3. Storage round-trips `invalid_at` so the bi-temporal interval survives
+ *     write → read (complementing PR 1's observedAt/eventTimeSource test).
+ */
+
+// ── 1. Replay anchoring ──────────────────────────────────────────────────
+
+test("resolveFactEventTime: replay of a 2025 transcript anchors 'last March' to 2025-03, not today", () => {
+  // The anchor is the source turn timestamp from an old (2025) transcript.
+  const anchor2025 = "2025-04-10T12:00:00.000Z";
+  const result = resolveFactEventTime("last March", anchor2025);
+  assert.equal(result.eventTimeSource, "extracted");
+  assert.ok(result.validFrom, "validFrom must be set for a resolvable expression");
+  // "last March" relative to April 2025 → March 2025.
+  assert.ok(result.validFrom!.startsWith("2025-03"), `expected 2025-03, got ${result.validFrom}`);
+  // Critical bi-temporal invariant: NOT anchored to today's wall-clock.
+  assert.ok(!result.validFrom!.startsWith("2026"), "must not anchor to wall-clock");
+  assert.equal(result.observedAt, anchor2025);
+});
+
+test("resolveFactEventTime: same expression, different anchors → different validFrom", () => {
+  // The identical phrase resolves differently depending on the anchor —
+  // proving the resolver is anchor-driven, not Date.now()-driven.
+  const old = resolveFactEventTime("yesterday", "2025-01-15T10:00:00.000Z");
+  const recent = resolveFactEventTime("yesterday", "2026-07-05T10:00:00.000Z");
+  assert.ok(old.validFrom!.startsWith("2025-01-14"), `got ${old.validFrom}`);
+  assert.ok(recent.validFrom!.startsWith("2026-07-04"), `got ${recent.validFrom}`);
+  assert.notEqual(old.validFrom, recent.validFrom);
+});
+
+test("resolveFactEventTime: absent expression → 'assumed' with validFrom = anchor", () => {
+  const anchor = "2025-06-01T00:00:00.000Z";
+  const result = resolveFactEventTime(undefined, anchor);
+  assert.equal(result.eventTimeSource, "assumed");
+  assert.equal(result.validFrom, anchor);
+  assert.equal(result.observedAt, anchor);
+  assert.equal(result.validUntil, undefined);
+});
+
+test("resolveFactEventTime: 'since 2024' → validFrom only (open-ended start)", () => {
+  const result = resolveFactEventTime("since 2024", "2025-06-01T00:00:00.000Z");
+  assert.equal(result.eventTimeSource, "extracted");
+  assert.ok(result.validFrom!.startsWith("2024-01-01"));
+  assert.equal(result.validUntil, undefined);
+});
+
+test("resolveFactEventTime: unresolvable garbage → 'assumed' fallback", () => {
+  const anchor = "2025-06-01T00:00:00.000Z";
+  const result = resolveFactEventTime("sometime maybe???", anchor);
+  assert.equal(result.eventTimeSource, "assumed");
+  assert.equal(result.validFrom, anchor);
+});
+
+// ── 2. Extraction normalization passes eventTime through ─────────────────
+
+function makeEngine(): ExtractionEngine {
+  // Minimal construction: the facts normalizer is a pure data transform
+  // (no LLM / I/O). Stub the optional deps so the constructor doesn't
+  // spin up real clients.
+  return new ExtractionEngine(
+    { memoryDir: "/tmp" } as any,
+    undefined, // profiler → safe default
+    {} as any, // localLlm stub
+    undefined, // gatewayConfig
+    {} as any, // modelRegistry stub
+  );
+}
+
+test("extraction normalization: camelCase 'eventTime' passes through to ExtractedFact", () => {
+  const engine = makeEngine();
+  const result = (engine as any).normalizeExtractionResultPayload({
+    facts: [
+      { content: "We moved offices in March.", category: "fact", eventTime: "last March" },
+    ],
+    entities: [],
+  });
+  assert.equal(result.facts.length, 1);
+  assert.equal(result.facts[0].eventTime, "last March");
+});
+
+test("extraction normalization: snake_case 'event_time' also captured", () => {
+  const engine = makeEngine();
+  const result = (engine as any).normalizeExtractionResultPayload({
+    facts: [
+      { content: "Switched to PostgreSQL.", category: "fact", event_time: "2025-01-15" },
+    ],
+    entities: [],
+  });
+  assert.equal(result.facts[0].eventTime, "2025-01-15");
+});
+
+test("extraction normalization: absent eventTime → undefined (assumed deferred to write time)", () => {
+  const engine = makeEngine();
+  const result = (engine as any).normalizeExtractionResultPayload({
+    facts: [{ content: "The sky is blue.", category: "fact" }],
+    entities: [],
+  });
+  assert.equal(result.facts[0].eventTime, undefined);
+});
+
+// ── 3. Storage round-trips invalid_at ────────────────────────────────────
+
+test("storage: invalid_at round-trips through writeMemoryFrontmatter → readAllMemories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-et-invalidAt-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "Old stack was Node 18.", {
+      validAt: "2025-01-01T00:00:00.000Z",
+      observedAt: "2025-06-01T00:00:00.000Z",
+      eventTimeSource: "extracted",
+    });
+
+    const before = await storage.readAllMemories();
+    const mem = before.find((m) => m.frontmatter.id === id);
+    assert.ok(mem);
+
+    const ok = await storage.writeMemoryFrontmatter(mem!, {
+      invalid_at: "2025-06-15T00:00:00.000Z",
+    });
+    assert.equal(ok, true);
+
+    const after = await storage.readAllMemories();
+    const patched = after.find((m) => m.frontmatter.id === id);
+    assert.ok(patched, "patched fact must be readable");
+    assert.equal(patched!.frontmatter.invalid_at, "2025-06-15T00:00:00.000Z");
+    // Bi-temporal provenance preserved through the frontmatter patch.
+    assert.equal(patched!.frontmatter.observedAt, "2025-06-01T00:00:00.000Z");
+    assert.equal(patched!.frontmatter.eventTimeSource, "extracted");
+    assert.equal(patched!.frontmatter.valid_at, "2025-01-01T00:00:00.000Z");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1261,10 +1261,23 @@ export class ExtractionEngine {
         // reasoningTrace through normalizeReasoningTrace before passing it on so
         // gateway output matches the shape local/direct-client paths produce.
         const normalizedFacts = result.facts.map((f: any) => {
-          if (!f?.reasoningTrace) return f;
+          if (!f) return f;
+          // Gateway tolerance: collapse snake_case event_time → camelCase
+          // eventTime so the gateway path matches the local/direct/proactive
+          // normalization (#1578 r3 — cursor bugbot).
+          const eventTime =
+            typeof f.eventTime === "string" && f.eventTime.trim().length > 0
+              ? f.eventTime.trim()
+              : typeof f.event_time === "string" && f.event_time.trim().length > 0
+                ? f.event_time.trim()
+                : undefined;
+          if (!f.reasoningTrace && eventTime === undefined) return f;
           return {
             ...f,
-            reasoningTrace: normalizeReasoningTrace(f.reasoningTrace) ?? undefined,
+            ...(f.reasoningTrace
+              ? { reasoningTrace: normalizeReasoningTrace(f.reasoningTrace) ?? undefined }
+              : {}),
+            ...(eventTime !== undefined ? { eventTime } : {}),
           };
         });
         const sanitized = this.sanitizeExtractionResult({

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1691,6 +1691,7 @@ ${existingEntities.join(", ")}
 
 When you see something that matches a known entity, use THAT name exactly. Only create a NEW entity if nothing in this list represents it.
 ` : ""}
+${this.eventTimePromptInstruction()}
 Also extract relationships between entities mentioned in the conversation.
 - Format: {source: "entity-name", target: "entity-name", label: "relationship description"}
 - Max 5 relationships per extraction

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -756,6 +756,11 @@ export class ExtractionEngine {
       this.config.provenance?.enabled
         ? '- Source quotes: For each fact, include a "quote" field with the EXACT verbatim words from the conversation that support the fact (a contiguous span from a single turn, not a paraphrase). Cap at ~300 chars.'
         : "",
+      // #1578: emit the same event-time guidance as the primary extraction
+      // paths so proactive-recovered facts also carry an optional eventTime
+      // (chatgpt-codex thread on extraction.ts:1607). Returns "" when the
+      // bi-temporal gate is off, keeping the prompt unchanged by default.
+      this.eventTimePromptInstruction(),
       "",
       "Base extracted facts (do not repeat):",
       factsPreview || "(none)",

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -279,6 +279,12 @@ export class ExtractionEngine {
               typeof f?.quote === "string" && f.quote.trim().length > 0
                 ? f.quote
                 : undefined,
+            eventTime:
+              typeof f?.eventTime === "string" && f.eventTime.trim().length > 0
+                ? f.eventTime.trim()
+                : typeof f?.event_time === "string" && f.event_time.trim().length > 0
+                  ? f.event_time.trim()
+                  : undefined,
           }))
           .filter((f: any) => f.content.length > 0)
       : [];
@@ -1394,7 +1400,7 @@ Examples of when to add structuredAttributes:
 - Decisions: {"chosen": "PostgreSQL", "rejected": "MongoDB", "reason": "ACID compliance"}
 - Quantities/measurements: {"budget": "50000", "team_size": "5", "deadline": "2024-06-01"}
 Only add structuredAttributes when there are concrete values. Skip for abstract or narrative facts.
-
+${this.eventTimePromptInstruction()}
 Also generate:
 1. 1-3 genuine questions you're curious about from this conversation
 2. Profile updates about user patterns/behaviors (if any)
@@ -1593,6 +1599,28 @@ ${truncatedConversation}`;
     }
 
     return { facts, entities, profileUpdates: [], questions: [] };
+  }
+
+  /**
+   * Bi-temporal event-time extraction instruction (#1578 PR2). Emitted on
+   * every extraction entry path when `temporal.biTemporal` is on so the LLM
+   * emits an optional per-fact `eventTime` expression. The expression is
+   * resolved against the source turn timestamp at write time — never
+   * wall-clock — so replay/import of old transcripts anchors correctly.
+   * Returns an empty string when the gate is off (byte-identical prompt).
+   */
+  private eventTimePromptInstruction(): string {
+    if (!this.config.temporalBiTemporal) return "";
+    return `
+=== Event Time (bi-temporal) ===
+When a fact has an explicit temporal anchor — a date, month, season, or relative time expression stating WHEN the fact became (or stopped being) true — capture it verbatim in an "eventTime" field on that fact. Examples:
+- "We moved offices in March" → "eventTime": "last March"
+- "The API has been rate-limited since 2024" → "eventTime": "since 2024"
+- "I switched to PostgreSQL on 2025-01-15" → "eventTime": "2025-01-15"
+- "We used MongoDB until June 2025" → "eventTime": "until 2025-06"
+Accepted forms: ISO dates ("2025-03-01"), month/season + year ("March 2025", "summer 2024"), relative ("yesterday", "last week", "this month", "next year", "last December"), and open-ended ("since 2024", "until 2025-06-01").
+Omit "eventTime" when the fact has no explicit temporal anchor — do NOT guess or infer dates. The system resolves the expression against the conversation's own timestamp, not today's date.
+`;
   }
 
   /**

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1618,7 +1618,7 @@ When a fact has an explicit temporal anchor — a date, month, season, or relati
 - "The API has been rate-limited since 2024" → "eventTime": "since 2024"
 - "I switched to PostgreSQL on 2025-01-15" → "eventTime": "2025-01-15"
 - "We used MongoDB until June 2025" → "eventTime": "until 2025-06"
-Accepted forms: ISO dates ("2025-03-01"), month/season + year ("March 2025", "summer 2024"), relative ("yesterday", "last week", "this month", "next year", "last December"), and open-ended ("since 2024", "until 2025-06-01").
+Accepted forms: ISO dates ("2025-03-01"), year-month ("2025-03"), month/season + year ("March 2025", "summer 2024"), relative ("yesterday", "last week", "this month", "next year", "last December"), and open-ended ("since 2024", "until 2025-06").
 Omit "eventTime" when the fact has no explicit temporal anchor — do NOT guess or infer dates. The system resolves the expression against the conversation's own timestamp, not today's date.
 `;
   }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12156,12 +12156,8 @@ export class Orchestrator {
       role,
       content,
       timestamp: captureTimestamp,
-      // #1578: anchor live-capture turns to their wall-clock timestamp when
-      // bi-temporal extraction is on, so resolveFactEventTime has an observed-
-      // time reference for facts captured in the normal processTurn path.
-      // Replay/import turns carry sourceValidAt explicitly (or omit it to stay
-      // intentionally undated); only live capture reuses the timestamp as the
-      // anchor — undated replay batches must remain valid_at-free (codex P1).
+      // #1578: anchor live-capture turns to wall-clock when bi-temporal is on;
+      // replay/import turns carry sourceValidAt explicitly (codex P1).
       ...(this.config.temporalBiTemporal
         ? { sourceValidAt: captureTimestamp }
         : {}),
@@ -15260,9 +15256,7 @@ export class Orchestrator {
                   intentEntityTypes: inferredIntent?.entityTypes,
                   memoryKind,
                   validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
-                  // #1578: propagate bi-temporal end bound + ingestion provenance
-                  // to chunks so an independently-surfaced chunk expires at the
-                  // same invalid_at as its parent (cursor bugbot).
+                  // #1578: propagate end bound + provenance to chunks (cursor bugbot).
                   ...(biTemporal
                     ? {
                         observedAt: biTemporal.observedAt,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15329,7 +15329,7 @@ export class Orchestrator {
                 newMemoryId: parentId,
                 entityRef: supersessionEntityRef,
                 structuredAttributes: fact.structuredAttributes,
-                createdAt: supersessionOrderingAt(sourceContext?.validAt),
+                createdAt: supersessionOrderingAt(biTemporal?.validFrom ?? sourceContext?.validAt),
                 // #1578 r3: an extracted end-only bound (validFrom absent) is
                 // historical, not a new authoritative state — never let it
                 // supersede a later active fact (codex P1 on :15534).
@@ -15568,7 +15568,7 @@ export class Orchestrator {
             newMemoryId: memoryId,
             entityRef: supersessionEntityRef,
             structuredAttributes: fact.structuredAttributes,
-            createdAt: supersessionOrderingAt(sourceContext?.validAt),
+            createdAt: supersessionOrderingAt(biTemporal?.validFrom ?? sourceContext?.validAt),
             enabled: this.config.temporalSupersessionEnabled &&
               !(biTemporal && !biTemporal.validFrom),
           });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15216,7 +15216,7 @@ export class Orchestrator {
               intentEntityTypes: inferredIntent?.entityTypes,
               memoryKind,
               structuredAttributes: fact.structuredAttributes,
-              validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+              validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
               ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource, ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}) } : {}),
               contentHashSource: rawChunkedContent,
               // Faithfulness gate (issue #1576).
@@ -15259,7 +15259,7 @@ export class Orchestrator {
                   intentActionType: inferredIntent?.actionType,
                   intentEntityTypes: inferredIntent?.entityTypes,
                   memoryKind,
-                  validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+                  validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
                   // #1578: propagate bi-temporal end bound + ingestion provenance
                   // to chunks so an independently-surfaced chunk expires at the
                   // same invalid_at as its parent (cursor bugbot).
@@ -15353,7 +15353,7 @@ export class Orchestrator {
             intentActionType: inferredIntent?.actionType,
             intentEntityTypes: inferredIntent?.entityTypes,
             memoryKind,
-            validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+            validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
             ...(biTemporal
               ? {
                   observedAt: biTemporal.observedAt,
@@ -15530,7 +15530,7 @@ export class Orchestrator {
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
           structuredAttributes: fact.structuredAttributes,
-          validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+          validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
           ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource, ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}) } : {}),
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
           // Faithfulness gate (issue #1576).
@@ -15612,7 +15612,7 @@ export class Orchestrator {
           intentActionType: inferredIntent?.actionType,
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
-          validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+          validAt: biTemporal ? biTemporal.validFrom : sourceContext?.validAt,
           ...(biTemporal
             ? {
                 observedAt: biTemporal.observedAt,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1021,8 +1021,8 @@ function latestSourceValidAtFromTurns(turns: readonly BufferTurn[]): string | un
   let latestMs: number | null = null;
   for (const turn of turns) {
     if (turn.extractionContextOnly === true) continue;
-    const candidate = turn.sourceValidAt ?? turn.timestamp; // #1578: fall back so live extractions anchor too
-    const parsed = parseFlexibleIsoTimestamp(candidate.trim());
+    if (typeof turn.sourceValidAt !== "string") continue;
+    const parsed = parseFlexibleIsoTimestamp(turn.sourceValidAt.trim());
     if (parsed === null) continue;
     if (latestMs === null || parsed > latestMs) {
       latestMs = parsed;
@@ -12151,10 +12151,20 @@ export class Orchestrator {
         : typeof sessionKey === "string" && sessionKey.length > 0
           ? sessionKey
           : "default";
+    const captureTimestamp = new Date().toISOString();
     const turn: BufferTurn = {
       role,
       content,
-      timestamp: new Date().toISOString(),
+      timestamp: captureTimestamp,
+      // #1578: anchor live-capture turns to their wall-clock timestamp when
+      // bi-temporal extraction is on, so resolveFactEventTime has an observed-
+      // time reference for facts captured in the normal processTurn path.
+      // Replay/import turns carry sourceValidAt explicitly (or omit it to stay
+      // intentionally undated); only live capture reuses the timestamp as the
+      // anchor — undated replay batches must remain valid_at-free (codex P1).
+      ...(this.config.temporalBiTemporal
+        ? { sourceValidAt: captureTimestamp }
+        : {}),
       sessionKey,
       logicalSessionKey: options.logicalSessionKey ?? bufferKey,
       providerThreadId: options.providerThreadId ?? null,
@@ -13923,6 +13933,11 @@ export class Orchestrator {
       intentEntityTypes?: string[];
       memoryKind?: MemoryFrontmatter["memoryKind"];
       validAt?: string;
+      // #1578 — bi-temporal bounds + ingestion provenance forwarded to profile-
+      // target copies (same defect class as shared promotion; cursor bugbot).
+      invalidAt?: string;
+      observedAt?: string;
+      eventTimeSource?: "extracted" | "assumed";
       source: string;
       sources?: ProvenanceSource[];
       provenance?: "verified" | "unverified" | "none";
@@ -13981,6 +13996,10 @@ export class Orchestrator {
               intentEntityTypes: options.intentEntityTypes,
               memoryKind: options.memoryKind,
               validAt: options.validAt,
+              // #1578 — forward bi-temporal bounds + ingestion provenance.
+              ...(options.invalidAt ? { invalidAt: options.invalidAt } : {}),
+              ...(options.observedAt ? { observedAt: options.observedAt } : {}),
+              ...(options.eventTimeSource ? { eventTimeSource: options.eventTimeSource } : {}),
               contentHashSource: options.category === "fact" ? dedupContent : rawContent,
               ...(options.sources && options.sources.length > 0 ? { sources: options.sources } : {}),
               ...(options.provenance ? { provenance: options.provenance } : {}),
@@ -14043,6 +14062,12 @@ export class Orchestrator {
       intentEntityTypes?: string[];
       memoryKind?: MemoryFrontmatter["memoryKind"];
       validAt?: string;
+      // #1578 — bi-temporal bounds + ingestion provenance forwarded to the
+      // shared-namespace copy so shared recall honours the same invalid_at
+      // window as the source fact (cursor bugbot).
+      invalidAt?: string;
+      observedAt?: string;
+      eventTimeSource?: "extracted" | "assumed";
       source: string;
       /** Claim-level provenance spans (issue #1575 PR 2). */
       sources?: ProvenanceSource[];
@@ -14272,6 +14297,10 @@ export class Orchestrator {
             intentEntityTypes: options.intentEntityTypes,
             memoryKind: options.memoryKind,
             validAt: options.validAt,
+            // #1578 — forward bi-temporal bounds + ingestion provenance.
+            ...(options.invalidAt ? { invalidAt: options.invalidAt } : {}),
+            ...(options.observedAt ? { observedAt: options.observedAt } : {}),
+            ...(options.eventTimeSource ? { eventTimeSource: options.eventTimeSource } : {}),
             contentHashSource: options.category === "fact" ? dedupContent : rawContent,
             // Claim-level provenance spans (issue #1575 PR 2).
             ...(options.sources && options.sources.length > 0 ? { sources: options.sources } : {}),
@@ -15231,6 +15260,18 @@ export class Orchestrator {
                   intentEntityTypes: inferredIntent?.entityTypes,
                   memoryKind,
                   validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+                  // #1578: propagate bi-temporal end bound + ingestion provenance
+                  // to chunks so an independently-surfaced chunk expires at the
+                  // same invalid_at as its parent (cursor bugbot).
+                  ...(biTemporal
+                    ? {
+                        observedAt: biTemporal.observedAt,
+                        eventTimeSource: biTemporal.eventTimeSource,
+                        ...(biTemporal.validUntil
+                          ? { invalidAt: biTemporal.validUntil }
+                          : {}),
+                      }
+                    : {}),
                   // Faithfulness gate (issue #1576): propagate the parent
                   // fact's verdict + enforce status so a pending_review fact
                   // is not indexed as active through its chunks (chatgpt P2).
@@ -15313,6 +15354,13 @@ export class Orchestrator {
             intentEntityTypes: inferredIntent?.entityTypes,
             memoryKind,
             validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+            ...(biTemporal
+              ? {
+                  observedAt: biTemporal.observedAt,
+                  eventTimeSource: biTemporal.eventTimeSource,
+                  ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}),
+                }
+              : {}),
             source: extractionWriteSource,
             ...(fact.sources && fact.sources.length > 0 ? { sources: fact.sources } : {}),
             ...(fact.provenance ? { provenance: fact.provenance } : {}),
@@ -15565,6 +15613,13 @@ export class Orchestrator {
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
           validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+          ...(biTemporal
+            ? {
+                observedAt: biTemporal.observedAt,
+                eventTimeSource: biTemporal.eventTimeSource,
+                ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}),
+              }
+            : {}),
           source: extractionWriteSource,
           ...(fact.sources && fact.sources.length > 0 ? { sources: fact.sources } : {}),
           ...(fact.provenance ? { provenance: fact.provenance } : {}),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1021,8 +1021,8 @@ function latestSourceValidAtFromTurns(turns: readonly BufferTurn[]): string | un
   let latestMs: number | null = null;
   for (const turn of turns) {
     if (turn.extractionContextOnly === true) continue;
-    if (typeof turn.sourceValidAt !== "string") continue;
-    const parsed = parseFlexibleIsoTimestamp(turn.sourceValidAt.trim());
+    const candidate = turn.sourceValidAt ?? turn.timestamp; // #1578: fall back so live extractions anchor too
+    const parsed = parseFlexibleIsoTimestamp(candidate.trim());
     if (parsed === null) continue;
     if (latestMs === null || parsed > latestMs) {
       latestMs = parsed;
@@ -15188,7 +15188,7 @@ export class Orchestrator {
               memoryKind,
               structuredAttributes: fact.structuredAttributes,
               validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
-              ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource } : {}),
+              ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource, ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}) } : {}),
               contentHashSource: rawChunkedContent,
               // Faithfulness gate (issue #1576).
               ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
@@ -15483,7 +15483,7 @@ export class Orchestrator {
           memoryKind,
           structuredAttributes: fact.structuredAttributes,
           validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
-          ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource } : {}),
+          ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource, ...(biTemporal.validUntil ? { invalidAt: biTemporal.validUntil } : {}) } : {}),
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
           // Faithfulness gate (issue #1576).
           ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -121,6 +121,7 @@ import {
   shouldFilterSupersededFromRecall,
 } from "./temporal-supersession.js";
 import { isValidAsOf, isValidityExpiredNow } from "./temporal-validity.js";
+import { resolveFactEventTime } from "./event-time.js";
 import { RelevanceStore } from "./relevance.js";
 import { NegativeExampleStore } from "./negative.js";
 import {
@@ -14677,7 +14678,7 @@ export class Orchestrator {
         typeof (fact as any).confidence === "number"
           ? (fact as any).confidence
           : 0.7;
-
+      const biTemporal = this.config.temporalBiTemporal && sourceContext?.validAt ? resolveFactEventTime(fact.eventTime, sourceContext.validAt) : undefined;
       // Content-hash dedup check (v6.0)
       //
       // Canonicalize pre-tagged facts before hashing (Codex P2 — issue #369).
@@ -15159,7 +15160,6 @@ export class Orchestrator {
           // back, leaving a dangling deindex with no replacement reference.
           // Child chunks intentionally do NOT carry supersedes; only the
           // parent represents the logical memory unit.
-          //
           // Canonicalize contentHashSource before writing (Thread 3 — Codex P2,
           // issue #369). If fact.content already carries an inline citation
           // (e.g. re-processed or relayed fact), strip it so contentHashSource
@@ -15187,7 +15187,8 @@ export class Orchestrator {
               intentEntityTypes: inferredIntent?.entityTypes,
               memoryKind,
               structuredAttributes: fact.structuredAttributes,
-              validAt: sourceContext?.validAt,
+              validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+              ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource } : {}),
               contentHashSource: rawChunkedContent,
               // Faithfulness gate (issue #1576).
               ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
@@ -15229,7 +15230,7 @@ export class Orchestrator {
                   intentActionType: inferredIntent?.actionType,
                   intentEntityTypes: inferredIntent?.entityTypes,
                   memoryKind,
-                  validAt: sourceContext?.validAt,
+                  validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
                   // Faithfulness gate (issue #1576): propagate the parent
                   // fact's verdict + enforce status so a pending_review fact
                   // is not indexed as active through its chunks (chatgpt P2).
@@ -15311,7 +15312,7 @@ export class Orchestrator {
             intentActionType: inferredIntent?.actionType,
             intentEntityTypes: inferredIntent?.entityTypes,
             memoryKind,
-            validAt: sourceContext?.validAt,
+            validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
             source: extractionWriteSource,
             ...(fact.sources && fact.sources.length > 0 ? { sources: fact.sources } : {}),
             ...(fact.provenance ? { provenance: fact.provenance } : {}),
@@ -15444,13 +15445,11 @@ export class Orchestrator {
             : undefined;
 
       // Normal write (no chunking)
-      //
       // Compute the cited content once so that writeMemory and writeArtifact
       // (when verbatim artifacts are enabled) share the same citation timestamp.
       // Calling applyInlineCitation twice on the same raw content would produce
       // two different timestamps, creating duplicate citations with divergent
       // provenance metadata on the memory and artifact copies of the same fact.
-      //
       // Pass the RAW (pre-citation) fact as `contentHashSource` so the
       // fact-content hash index records the hash of the canonical fact text
       // rather than the citation-annotated variant. When inline attribution is
@@ -15483,7 +15482,8 @@ export class Orchestrator {
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
           structuredAttributes: fact.structuredAttributes,
-          validAt: sourceContext?.validAt,
+          validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
+          ...(biTemporal ? { observedAt: biTemporal.observedAt, eventTimeSource: biTemporal.eventTimeSource } : {}),
           contentHashSource: writeCategory === "fact" ? fact.content : undefined,
           // Faithfulness gate (issue #1576).
           ...(faithfulnessFm ? { faithfulness: faithfulnessFm } : {}),
@@ -15564,7 +15564,7 @@ export class Orchestrator {
           intentActionType: inferredIntent?.actionType,
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
-          validAt: sourceContext?.validAt,
+          validAt: biTemporal?.validFrom ?? sourceContext?.validAt,
           source: extractionWriteSource,
           ...(fact.sources && fact.sources.length > 0 ? { sources: fact.sources } : {}),
           ...(fact.provenance ? { provenance: fact.provenance } : {}),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14019,7 +14019,7 @@ export class Orchestrator {
                 entityRef: options.entityRef,
                 structuredAttributes: options.structuredAttributes,
                 createdAt: supersessionOrderingAt(options.validAt),
-                enabled: true,
+                enabled: !(options.eventTimeSource === "extracted" && !options.validAt),
               });
             } catch (profileSupersessionErr) {
               log.warn(
@@ -14222,7 +14222,7 @@ export class Orchestrator {
                   entityRef: options.entityRef,
                   structuredAttributes: options.structuredAttributes,
                   createdAt: supersessionOrderingAt(options.validAt),
-                  enabled: true,
+                  enabled: !(options.eventTimeSource === "extracted" && !options.validAt),
                   useCallerTimestamp: true,
                 });
                 // Catalog touch (issue #1499 — codex P2 NElSf): this dedup branch
@@ -14326,7 +14326,7 @@ export class Orchestrator {
               entityRef: options.entityRef,
               structuredAttributes: options.structuredAttributes,
               createdAt: supersessionOrderingAt(options.validAt),
-              enabled: true,
+              enabled: !(options.eventTimeSource === "extracted" && !options.validAt),
             });
           } catch (sharedSupersessionErr) {
             log.warn(
@@ -15330,7 +15330,11 @@ export class Orchestrator {
                 entityRef: supersessionEntityRef,
                 structuredAttributes: fact.structuredAttributes,
                 createdAt: supersessionOrderingAt(sourceContext?.validAt),
-                enabled: this.config.temporalSupersessionEnabled,
+                // #1578 r3: an extracted end-only bound (validFrom absent) is
+                // historical, not a new authoritative state — never let it
+                // supersede a later active fact (codex P1 on :15534).
+                enabled: this.config.temporalSupersessionEnabled &&
+                  !(biTemporal && !biTemporal.validFrom),
               });
             } catch (err) {
               log.warn(`temporal-supersession (chunked): unexpected error: ${err}`);
@@ -15565,7 +15569,8 @@ export class Orchestrator {
             entityRef: supersessionEntityRef,
             structuredAttributes: fact.structuredAttributes,
             createdAt: supersessionOrderingAt(sourceContext?.validAt),
-            enabled: this.config.temporalSupersessionEnabled,
+            enabled: this.config.temporalSupersessionEnabled &&
+              !(biTemporal && !biTemporal.validFrom),
           });
         } catch (err) {
           log.warn(`temporal-supersession: unexpected error: ${err}`);

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -173,6 +173,11 @@ export const ExtractedFactSchema = z.object({
     .describe(
       'Optional event-time expression for bi-temporal validity (#1578). An ISO date ("2025-03-01") or a relative expression verbatim ("last March", "yesterday", "since 2024", "until 2025-06-01"). Resolved against the source turn timestamp at write time — NOT wall-clock. Omit when the fact has no explicit temporal anchor.',
     ),
+  event_time: z
+    .string()
+    .optional()
+    .nullable()
+    .describe("Alias for eventTime (snake_case). Gateway-tolerance shim (#1578)."),
 }).superRefine((value, ctx) => {
   if (value.category === "procedure" && (!Array.isArray(value.procedureSteps) || value.procedureSteps.length < 2)) {
     ctx.addIssue({

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -166,6 +166,13 @@ export const ExtractedFactSchema = z.object({
     .describe(
       'For category "reasoning_trace" only: a stored solution chain with ordered steps, a final answer, and an optional observed outcome. Require at least two steps.',
     ),
+  eventTime: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      'Optional event-time expression for bi-temporal validity (#1578). An ISO date ("2025-03-01") or a relative expression verbatim ("last March", "yesterday", "since 2024", "until 2025-06-01"). Resolved against the source turn timestamp at write time — NOT wall-clock. Omit when the fact has no explicit temporal anchor.',
+    ),
 }).superRefine((value, ctx) => {
   if (value.category === "procedure" && (!Array.isArray(value.procedureSteps) || value.procedureSteps.length < 2)) {
     ctx.addIssue({

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3580,6 +3580,7 @@ export class StorageManager {
       // or assumed from the ingestion anchor.  Both validate on serialize.
       observedAt?: string;
       eventTimeSource?: "extracted" | "assumed";
+      invalidAt?: string;
       structuredAttributes?: Record<string, string>;
       /**
        * When provided, this string is used as the source for the fact-content
@@ -3665,6 +3666,7 @@ export class StorageManager {
       valid_at: validAt,
       observedAt,
       eventTimeSource: options.eventTimeSource,
+      invalid_at: normalizeMemoryWriteTimestamp("invalidAt", options.invalidAt),
       structuredAttributes: options.structuredAttributes,
     };
     if (options.status !== undefined) {
@@ -4504,12 +4506,10 @@ export class StorageManager {
     // is disabled, missing, or unhealthy. RECALL_FALLBACK_DIRS is the single
     // source of truth derived from ALL_CATEGORY_DIRS (shared with
     // ensureDirectories() and the write routing in utils/category-dir.ts).
-    //
     // These paths resolve identically to the legacy this.factsDir /
     // this.correctionsDir / this.proceduresDir / this.reasoningTracesDir
     // getters (all `path.join(this.baseDir, <dir>)`), so the scan stays
     // namespace-aware: this.baseDir is per-namespace, set by the storage router.
-    //
     // Deliberately EXCLUDED (issue #1497 + PR #1503 review): the non-category
     // content dirs that ensureDirectories() also creates — entities/, state/,
     // artifacts/, identity/, config/ — plus the root profile.md, AND the

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -7359,6 +7359,12 @@ export class StorageManager {
       sources?: ProvenanceSource[];
       /** Coarse provenance tag (issue #1575 PR 2), propagated from the parent. */
       provenance?: "verified" | "unverified" | "none";
+      // Issue #1578 — bi-temporal bounds + ingestion provenance propagated from
+      // the parent fact so an independently-surfaced chunk expires at the same
+      // invalid_at window and carries the same observed-at anchor.
+      invalidAt?: string;
+      observedAt?: string;
+      eventTimeSource?: "extracted" | "assumed";
     } = {},
   ): Promise<string> {
     await this.ensureDirectories();
@@ -7368,6 +7374,8 @@ export class StorageManager {
     const conf = options.confidence ?? 0.8;
     const tier = confidenceTier(conf);
     const validAt = normalizeMemoryWriteTimestamp("validAt", options.validAt);
+    const chunkInvalidAt = normalizeMemoryWriteTimestamp("invalidAt", options.invalidAt);
+    const chunkObservedAt = normalizeMemoryWriteTimestamp("observedAt", options.observedAt);
 
     const fm: MemoryFrontmatter = {
       id,
@@ -7388,6 +7396,9 @@ export class StorageManager {
       intentEntityTypes: options.intentEntityTypes,
       memoryKind: options.memoryKind,
       valid_at: validAt,
+      invalid_at: chunkInvalidAt,
+      observedAt: chunkObservedAt,
+      eventTimeSource: options.eventTimeSource,
       ...(options.status ? { status: options.status } : {}),
       ...(options.faithfulness ? { faithfulness: options.faithfulness } : {}),
       ...(options.sources ? { sources: options.sources } : {}),

--- a/packages/remnic-core/src/temporal-validity.test.ts
+++ b/packages/remnic-core/src/temporal-validity.test.ts
@@ -410,6 +410,39 @@ test("isValidAsOf: half-open interval [valid_at, invalid_at)", () => {
   assert.equal(isValidAsOf(fm, Date.parse("2026-01-01T00:00:00.000Z")), false);
 });
 
+test("isValidAsOf: extracted end-only bound is open-start (-inf, invalid_at] (#1578 r3)", () => {
+  // An extracted fact like "we used MongoDB until June 2025" resolves to
+  // validUntil only (no validFrom); valid_at is absent, eventTimeSource is
+  // "extracted". The interval must be open-start so historical as_of queries
+  // before ingestion still see it, rather than defaulting valid_at to created.
+  const fm = {
+    invalid_at: "2025-07-01T00:00:00.000Z",
+    created: "2025-08-15T00:00:00.000Z",
+    eventTimeSource: "extracted" as const,
+  };
+  // Well before ingestion/created — still authoritative (open start).
+  assert.equal(isValidAsOf(fm, Date.parse("2024-01-01T00:00:00.000Z")), true);
+  // Mid-window — authoritative.
+  assert.equal(isValidAsOf(fm, Date.parse("2025-06-15T00:00:00.000Z")), true);
+  // Exactly at invalid_at — NOT authoritative (exclusive upper bound).
+  assert.equal(isValidAsOf(fm, Date.parse("2025-07-01T00:00:00.000Z")), false);
+  // After invalid_at — not authoritative.
+  assert.equal(isValidAsOf(fm, Date.parse("2026-01-01T00:00:00.000Z")), false);
+});
+
+test("isValidAsOf: legacy memory without eventTimeSource keeps created fallback (#1578 r3)", () => {
+  // A legacy memory with invalid_at but no eventTimeSource must NOT become
+  // open-start — it keeps the pre-#1578 [created, invalid_at) behaviour so
+  // supersession/backfill semantics are unchanged.
+  const fm = {
+    invalid_at: "2025-12-31T00:00:00.000Z",
+    created: "2025-06-01T00:00:00.000Z",
+  };
+  // Before created — not authoritative (legacy behaviour preserved).
+  assert.equal(isValidAsOf(fm, Date.parse("2025-05-01T00:00:00.000Z")), false);
+  assert.equal(isValidAsOf(fm, Date.parse("2025-09-01T00:00:00.000Z")), true);
+});
+
 test("isValidAsOf: timezone-suffixed ISO strings compare via Date.parse, not lexicographic", () => {
   // Two strings that order differently lexicographically vs as Dates.
   // 2025-01-01T00:00:00+02:00 == 2024-12-31T22:00:00Z

--- a/packages/remnic-core/src/temporal-validity.ts
+++ b/packages/remnic-core/src/temporal-validity.ts
@@ -82,11 +82,34 @@ export function effectiveInvalidAt(
 export function isValidAsOf(
   fm: Pick<
     MemoryFrontmatter,
-    "valid_at" | "invalid_at" | "created" | "supersededAt" | "status"
+    | "valid_at"
+    | "invalid_at"
+    | "created"
+    | "supersededAt"
+    | "status"
+    | "eventTimeSource"
   >,
   asOfMs: number,
 ): boolean {
   if (!Number.isFinite(asOfMs)) return true;
+  // Open-start bi-temporal interval (#1578 r3): an extracted end-only bound
+  // (eventTimeSource "extracted", no valid_at, has invalid_at) is true from
+  // the indefinite past. Without this, effectiveValidAt falls back to
+  // `created` and a historical as_of before ingestion hides a fact that was
+  // actually true up until invalid_at (chatgpt-codex thread on
+  // orchestrator.ts:15533). Gated on eventTimeSource so legacy memories
+  // (no bi-temporal provenance) keep the created-anchor fallback.
+  const explicitValidAt = fm.valid_at?.trim();
+  if (
+    (!explicitValidAt || explicitValidAt.length === 0) &&
+    fm.eventTimeSource === "extracted"
+  ) {
+    const invalidAt = effectiveInvalidAt(fm);
+    if (invalidAt !== undefined) {
+      const invalidAtMs = Date.parse(invalidAt);
+      if (Number.isFinite(invalidAtMs)) return invalidAtMs > asOfMs;
+    }
+  }
   const validAtMs = Date.parse(effectiveValidAt(fm));
   if (!Number.isFinite(validAtMs)) return false;
   if (validAtMs > asOfMs) return false;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -810,8 +810,9 @@ export interface PluginConfig {
    * Turn on to exclude validity-expired facts from default injection
    * candidates (they remain findable by explicit search and `as_of`
    * queries). Storage round-trips `observedAt`/`eventTimeSource`; the
-   * extraction prompt → `resolveEventTime` write-time wiring lands in a
-   * follow-on PR, so new extractions are not yet event-time-resolved.
+   * extraction prompt emits an optional per-fact `eventTime` expression
+   * and `resolveFactEventTime` resolves it against the source turn
+   * timestamp at write time (#1578 PR2).
    */
   temporalBiTemporal: boolean;
   /**
@@ -2893,6 +2894,15 @@ export interface ExtractedFact {
    * walked through. Persisted under reasoning-traces/.
    */
   reasoningTrace?: ExtractedReasoningTrace;
+  /**
+   * Optional event-time expression for bi-temporal validity (#1578 PR2).
+   * Verbatim temporal anchor extracted from the conversation ("2025-03-01",
+   * "last March", "since 2024", "until 2025-06-01"). Resolved against the
+   * source turn timestamp at write time by `resolveFactEventTime` — never
+   * re-resolved at read. Absent when the fact carries no temporal anchor or
+   * when `temporal.biTemporal` is off.
+   */
+  eventTime?: string;
 }
 
 export interface ExtractedReasoningTraceStep {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19966,
+      "packages/remnic-core/src/orchestrator.ts": 19965,
       "packages/remnic-core/src/cli.ts": 9363,
       "packages/remnic-core/src/access-service.ts": 8781,
       "packages/remnic-core/src/storage.ts": 7720,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,10 +4,10 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19911,
+      "packages/remnic-core/src/orchestrator.ts": 19966,
       "packages/remnic-core/src/cli.ts": 9363,
       "packages/remnic-core/src/access-service.ts": 8781,
-      "packages/remnic-core/src/storage.ts": 7709,
+      "packages/remnic-core/src/storage.ts": 7720,
       "packages/remnic-core/src/config.ts": 4558
     },
     "oversizedFileCount": 10,


### PR DESCRIPTION
Part of #1578 (bi-temporal validity). Standards: #1520.

## What

Completes the extraction → persist wiring so extracted facts carry an anchored `validAt` derived from the transcript's temporal expressions. PR1 already landed the storage layer (`valid_at`/`invalid_at`/`observedAt`/`eventTimeSource` frontmatter, `resolveEventTime`, `temporal-validity` helpers, config gate `temporal.biTemporal`). This PR2 connects the persist path.

## Changes

| File | Change |
|---|---|
| `extraction.ts` | Prompt emits optional per-fact `eventTime` (empty string when gate off → byte-identical); parse consumer captures `eventTime`/`event_time` from LLM output |
| `event-time.ts` | `resolveFactEventTime` — pure write-time wrapper: `(expression, anchor) → {validFrom?, validUntil?, observedAt, eventTimeSource}` |
| `orchestrator.ts` | `persistExtraction`: when `temporal.biTemporal` on, resolve each fact's `eventTime` against `sourceContext.validAt` (source turn timestamp) and pass `validFrom→validAt` + `observedAt` + `eventTimeSource` through `writeMemory`. **Never touches `Date.now()`** — replay/import of old transcripts anchors to the transcript era |
| `schemas.ts` / `types.ts` | `eventTime` field on `ExtractedFact` + schema |
| `extraction-eventtime-wiring.test.ts` | New test (rewritten after prior file-leak revert) |

## Bi-temporal invariant

Replay of a 2025 transcript: `"last March"` with anchor `2025-04-10` → `validFrom = 2025-03-…`, **not** today. The same expression with a 2026 anchor yields a 2026 date — resolution is anchor-driven, never wall-clock.

## Gates

- `npm run preflight:quick` → `[preflight] OK (quick)`
- `npm run test:entity-hardening` → 246/246 pass
- `node scripts/check-ratchets.mjs` → OK (orchestrator.ts net-zero: thin delegation only; 3 redundant `//` separators removed to compensate the 3 added wiring lines)

## Chokepoints used / not applicable

- `writeMemory` storage chokepoint (storage.ts) — already accepts `validAt`/`observedAt`/`eventTimeSource` from PR1; no storage changes in this PR.
- Config gate: `temporal.biTemporal` (`this.config.temporalBiTemporal`), not a new `config.*Enabled` read — ratchet-clean.
- Not applicable: ScopePlan (#1521), serialize-mutations (#1524), validation boundary (#1525) — this is write-path temporal wiring, not namespace/validation/lock work.

## Notes

- Byte-identical when `temporal.biTemporal` is off (rule 39): `biTemporal` is `undefined`, validAt stays `sourceContext?.validAt`, no `observedAt`/`eventTimeSource` emitted.
- `validUntil` from extraction (e.g. `"until 2025-06"`) is resolved by `resolveFactEventTime` and tested at the resolver level; persisting `invalid_at` at extraction write-time and the supersession integration are PR3 scope (per the issue: `validUntil` writes go through `updateMemoryFrontmatter`).
- GPU LongMemEval temporal-category artifact deferred to PR4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persist, recall validity (`isValidAsOf`), and temporal supersession in `orchestrator.ts`; behavior is gated on `temporal.biTemporal` but end-only intervals and promotion forwarding change how facts expire and supersede when enabled.
> 
> **Overview**
> Wires **#1578 PR2**: optional per-fact `eventTime` from extraction is resolved at persist time against the **source turn** timestamp (not wall-clock), then written as `valid_at` / `invalid_at`, `observedAt`, and `eventTimeSource`.
> 
> **Resolver & formats:** Adds `resolveFactEventTime` and **YYYY-MM** handling (e.g. `until 2025-06` → exclusive end at next month; bare `2025-03` → month start). Extraction prompts gain gated bi-temporal instructions; normalization and Zod accept `eventTime` / `event_time` (including gateway path).
> 
> **Persist path:** `persistExtraction` applies resolved bounds on normal writes, chunks, and shared/profile promotion. `writeMemory` / `writeChunk` accept `invalidAt`. End-only extracted facts get **open-start** `as_of` semantics in `isValidAsOf` when `eventTimeSource === "extracted"`; temporal supersession is skipped for end-only extracted bounds so historical “until …” facts do not retire active state.
> 
> **Live capture:** Buffer turns set `sourceValidAt` when `temporal.biTemporal` is on. New `extraction-eventtime-wiring.test.ts` covers anchoring, schema passthrough, and storage round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393f727a89eb7a06335d1aa8fb95e46a1c0ba45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->