### PR TITLE
feat(coding-graph): semantic layer — symbol embeddings, SIMILAR_TO, semantic_query (#1556)

### DIFF
--- a/packages/coding-graph/README.md
+++ b/packages/coding-graph/README.md
@@ -60,3 +60,60 @@ Install it alongside @remnic/core to enable codebase-graph features:
 - CLAUDE.md rule 57 (à-la-carte) and AGENTS.md rule 44 (computed-specifier dynamic import)
 - `web-tree-sitter` chosen to avoid the native-binding pain called out in
   #1518 / #1538 — see #1548 for the full design rationale
+
+## Semantic layer (#1556)
+
+The optional semantic layer adds symbol embeddings, `SIMILAR_TO` near-clone
+edges, and `semantic_query` (natural-language retrieval over the symbol graph).
+
+### Privacy posture
+
+**Default configuration sends nothing anywhere.** The semantic layer is OFF by
+default (`SemanticConfig.enabled = false`). When off, zero embedding provider
+calls are made and zero rows are written to the `symbol_vectors` table — the
+gate-off test (`semantic.test.ts: gate-off`) asserts this end to end.
+
+When `enabled = true`:
+- With **no embedding provider** configured: the feature degrades gracefully.
+  `SIMILAR_TO` edges are still produced via local, deterministic MinHash/LSH
+  (pure TypeScript, no network). `semantic_query` returns a tagged
+  `{ ok: false, code: "provider_unavailable" }` — never an empty result
+  masquerading as "no matches".
+- With a **remote embedding provider** configured (e.g. OpenAI or an
+  OpenAI-compatible endpoint via the host embedding provider registry):
+  symbol text (canonical form: kind + qualified name + signature + body
+  excerpt) leaves the machine to be embedded. This is the same path
+  @remnic/core's `EmbeddingFallback` uses for conversation embeddings —
+  no new network stack is introduced.
+
+The canonical text that is embedded is the canonical text that is hashed for
+the cache (rule 23): `signature + doc comment + first N tokens of body`,
+whitespace- and punctuation-normalized so formatting variants hash
+identically. Cached vectors are reused on re-index when the content hash is
+unchanged (rule 37).
+
+### API surface
+
+```typescript
+import {
+  resolveSemanticConfig,
+  indexSymbolVectors,
+  computeSimilarTo,
+  similarEdgesToEdgeIR,
+  semanticQuery,
+} from "@remnic/coding-graph";
+
+const config = resolveSemanticConfig({ enabled: true });
+
+// Index: embed symbols, cache by canonical-text hash
+const indexResult = await indexSymbolVectors({ store, provider, repoRoot, config });
+
+// SIMILAR_TO: MinHash/LSH candidates → cosine confirmation
+const similar = computeSimilarTo({ store, provider, config });
+if (similar.ok) {
+  await store.upsertEdges(similarEdgesToEdgeIR(similar.edges));
+}
+
+// semantic_query: embed query → top-k → hydrate with graph context
+const query = await semanticQuery({ store, provider, repoRoot, config, query: "payment processing" });
+```

--- a/packages/coding-graph/README.md
+++ b/packages/coding-graph/README.md
@@ -108,8 +108,10 @@ const config = resolveSemanticConfig({ enabled: true });
 // Index: embed symbols, cache by canonical-text hash
 const indexResult = await indexSymbolVectors({ store, provider, repoRoot, config });
 
-// SIMILAR_TO: MinHash/LSH candidates → cosine confirmation
-const similar = computeSimilarTo({ store, provider, config });
+// SIMILAR_TO: MinHash/LSH candidates → cosine confirmation.
+// repoRoot (or prebuilt bodies) is required so the pipeline hashes real
+// symbol bodies, not qualified names.
+const similar = computeSimilarTo({ store, provider, repoRoot, config });
 if (similar.ok) {
   await store.upsertEdges(similarEdgesToEdgeIR(similar.edges));
 }

--- a/packages/coding-graph/src/graph-schema.ts
+++ b/packages/coding-graph/src/graph-schema.ts
@@ -243,6 +243,26 @@ function createTables(db: BetterSqlite3Database): void {
     CREATE INDEX IF NOT EXISTS idx_co_changes_a ON co_changes(file_a);
     CREATE INDEX IF NOT EXISTS idx_co_changes_b ON co_changes(file_b);
   `);
+  // Semantic layer (issue #1556): symbol embedding vectors. Additive to v1
+  // (CREATE TABLE IF NOT EXISTS — same rule-23 pattern as node_attributes).
+  // One row per (node_id, model_id): a node re-embedded under a different
+  // provider/model gets a distinct row so a provider swap does not
+  // overwrite the prior vectors (the cache invalidation test covers this).
+  // content_hash is the canonical-text hash (rule 37) — a re-index compares
+  // it to decide whether to re-embed. CASCADE on nodes(id) keeps the table
+  // in lockstep with node lifetimes (foreign_keys=ON is set in GraphStore.open).
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS symbol_vectors (
+      node_id      TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE,
+      model_id     TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      dims         INTEGER NOT NULL CHECK (dims > 0),
+      vector       BLOB NOT NULL,
+      PRIMARY KEY (node_id, model_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_symbol_vectors_model
+      ON symbol_vectors(model_id);
+  `);
   // repopulate both tables in lockstep without ordering concerns.
   db.exec(`
     CREATE TABLE IF NOT EXISTS fts_index (

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -354,6 +354,14 @@ export interface SnippetQuery {
    */
   qualifiedName?: string;
   /**
+   * Optional repo root override. When set, the snippet is read from this
+   * root instead of the root captured at GraphStore.open() time, so a
+   * caller that supplies its own repoRoot (e.g. semanticQuery) hydrates
+   * snippets even when the store was opened without one (chatgpt-codex-
+   * connector + cursor: 'Snippet hydration ignores query repoRoot').
+   */
+  repoRoot?: string;
+  /**
    * Optional deterministic node id. When set, the lookup resolves by
    * `nodes.id` (unique) instead of `qualified_name`, so a hit whose
    * qualified name is duplicated across files still hydrates the exact
@@ -2373,7 +2381,10 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
-    if (this.repoRoot === undefined) {
+    const root = typeof query.repoRoot === "string" && query.repoRoot.length > 0
+      ? query.repoRoot
+      : this.repoRoot;
+    if (root === undefined) {
       return { ok: false, code: "repo_root_unset" };
     }
     // Wrap the DB lookup in try/catch (cursor Bugbot: 'SQLite errors
@@ -2412,7 +2423,7 @@ export class GraphStore {
     if (rows.length === 0) return { ok: false, code: "not_found" };
     if (rows.length > 1) return { ok: false, code: "ambiguous_name" };
     const node = rows[0]!;
-    const absolutePath = path.resolve(this.repoRoot, node.file_path);
+    const absolutePath = path.resolve(root, node.file_path);
     // Read the file from disk and slice the span. readFile is the
     // single fs call — no streaming, no mmap, just one allocation per
     // request. The store caches nothing; the caller may.
@@ -2531,13 +2542,13 @@ export class GraphStore {
     readonly contentHash: string;
     readonly dims: number;
     readonly vector: Float32Array;
-  }): Promise<void> {
+  }): Promise<boolean> {
     // Honor the closing flag (not just closed) and serialize via the write
     // queue, matching upsertFileBatch / upsertEdges / clearSemanticSimilarToEdges
     // — otherwise concurrent graph ingestion can interleave a vector upsert
     // with a transactional node delete (cursor Bugbot: 'Vector writes ignore
     // closing flag' + 'Vector writes bypass write queue').
-    if (this.closed || this.closing) return;
+    if (this.closed || this.closing) return false;
     const buf = Buffer.from(input.vector.buffer, input.vector.byteOffset, input.vector.byteLength);
     await this.queue.schedule(async () => {
       this.db
@@ -2551,6 +2562,7 @@ export class GraphStore {
         )
         .run(input.nodeId, input.modelId, input.contentHash, input.dims, buf);
     });
+    return true;
   }
 
   /**

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2525,25 +2525,32 @@ export class GraphStore {
    * caller (the semantic indexer) has ALREADY decided to re-embed (the
    * content_hash differs from the cached row); this method just persists.
    */
-  writeSymbolVector(input: {
+  async writeSymbolVector(input: {
     readonly nodeId: string;
     readonly modelId: string;
     readonly contentHash: string;
     readonly dims: number;
     readonly vector: Float32Array;
-  }): void {
-    if (this.closed) return;
+  }): Promise<void> {
+    // Honor the closing flag (not just closed) and serialize via the write
+    // queue, matching upsertFileBatch / upsertEdges / clearSemanticSimilarToEdges
+    // — otherwise concurrent graph ingestion can interleave a vector upsert
+    // with a transactional node delete (cursor Bugbot: 'Vector writes ignore
+    // closing flag' + 'Vector writes bypass write queue').
+    if (this.closed || this.closing) return;
     const buf = Buffer.from(input.vector.buffer, input.vector.byteOffset, input.vector.byteLength);
-    this.db
-      .prepare(
-        `INSERT INTO symbol_vectors (node_id, model_id, content_hash, dims, vector)
-           VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(node_id, model_id) DO UPDATE SET
-           content_hash = excluded.content_hash,
-           dims = excluded.dims,
-           vector = excluded.vector`,
-      )
-      .run(input.nodeId, input.modelId, input.contentHash, input.dims, buf);
+    await this.queue.schedule(async () => {
+      this.db
+        .prepare(
+          `INSERT INTO symbol_vectors (node_id, model_id, content_hash, dims, vector)
+             VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(node_id, model_id) DO UPDATE SET
+             content_hash = excluded.content_hash,
+             dims = excluded.dims,
+             vector = excluded.vector`,
+        )
+        .run(input.nodeId, input.modelId, input.contentHash, input.dims, buf);
+    });
   }
 
   /**
@@ -2629,12 +2636,17 @@ export class GraphStore {
    * ON DELETE CASCADE on nodes(id) when a node is pruned, so this method
    * is only for the targeted-invalidation path.
    */
-  deleteSymbolVectors(nodeIds: readonly string[]): void {
-    if (this.closed || nodeIds.length === 0) return;
-    this.runChunkedDelete(
-      "DELETE FROM symbol_vectors WHERE node_id IN (%PH%)",
-      nodeIds,
-    );
+  async deleteSymbolVectors(nodeIds: readonly string[]): Promise<void> {
+    // Same closing-flag + write-queue discipline as writeSymbolVector
+    // (cursor Bugbot: 'Vector writes ignore closing flag' + 'Vector writes
+    // bypass write queue').
+    if (this.closed || this.closing || nodeIds.length === 0) return;
+    await this.queue.schedule(async () => {
+      this.runChunkedDelete(
+        "DELETE FROM symbol_vectors WHERE node_id IN (%PH%)",
+        nodeIds,
+      );
+    });
   }
 
   /**

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -621,6 +621,18 @@ export class GraphStore {
   private readonly repoRoot: string | undefined;
   private closed = false;
   private closing = false;
+  /**
+   * True once close() has begun (closing) or completed (closed). Public so
+   * callers that hold a GraphStore reference can return the documented
+   * 'store_closed' degradation code instead of treating a closed store as
+   * an empty graph (cursor Bugbot: 'Closed store reports success'). The
+   * read primitives already short-circuit on this internally; this getter
+   * lets the semantic entry points do the same BEFORE calling a read that
+   * would return [].
+   */
+  get isClosed(): boolean {
+    return this.closed || this.closing;
+  }
   // Shared drain-and-close promise so a second close() called while the
   // first is still draining awaits the same completion instead of
   // resolving early (chatgpt-codex-connector P2: 'Wait for an

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2484,6 +2484,220 @@ export class GraphStore {
       lang: node.lang,
     };
   }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Semantic layer (issue #1556): symbol_vectors table read/write.
+  // The db is private; these methods are the ONLY surface the semantic
+  // indexer/query path uses. Vectors are float32 BLOBs; content_hash is
+  // the canonical-text hash (rule 37 — the cache invalidation key).
+  // ──────────────────────────────────────────────────────────────────────
+
+  /**
+   * Upsert one symbol vector. Idempotent on (node_id, model_id). The
+   * caller (the semantic indexer) has ALREADY decided to re-embed (the
+   * content_hash differs from the cached row); this method just persists.
+   */
+  writeSymbolVector(input: {
+    readonly nodeId: string;
+    readonly modelId: string;
+    readonly contentHash: string;
+    readonly dims: number;
+    readonly vector: Float32Array;
+  }): void {
+    if (this.closed) return;
+    const buf = Buffer.from(input.vector.buffer, input.vector.byteOffset, input.vector.byteLength);
+    this.db
+      .prepare(
+        `INSERT INTO symbol_vectors (node_id, model_id, content_hash, dims, vector)
+           VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(node_id, model_id) DO UPDATE SET
+           content_hash = excluded.content_hash,
+           dims = excluded.dims,
+           vector = excluded.vector`,
+      )
+      .run(input.nodeId, input.modelId, input.contentHash, input.dims, buf);
+  }
+
+  /**
+   * Read one vector row by (node_id, model_id). Returns null when absent.
+   * Used by the indexer's cache-check path (skip re-embed when content_hash
+   * matches) and by the cache-hit test.
+   */
+  readSymbolVector(
+    nodeId: string,
+    modelId: string,
+  ): { readonly contentHash: string; readonly dims: number; readonly vector: Float32Array } | null {
+    if (this.closed) return null;
+    const row = expectRow<{ content_hash: string; dims: number; vector: Uint8Array }>(
+      this.db
+        .prepare(
+          `SELECT content_hash, dims, vector FROM symbol_vectors
+            WHERE node_id = ? AND model_id = ?`,
+        )
+        .get(nodeId, modelId),
+      ["content_hash", "dims", "vector"],
+    );
+    if (!row) return null;
+    return {
+      contentHash: row.content_hash,
+      dims: row.dims,
+      vector: new Float32Array(row.vector.buffer, row.vector.byteOffset, row.vector.byteLength / 4),
+    };
+  }
+
+  /**
+   * Read every vector row for a given model. Used by brute-force cosine
+   * retrieval (SIMILAR_TO confirmation + semantic_query). Returns node
+   * metadata alongside the vector so callers can hydrate hits without a
+   * second round-trip.
+   */
+  readAllSymbolVectors(modelId: string): readonly {
+    readonly nodeId: string;
+    readonly qualifiedName: string;
+    readonly filePath: string;
+    readonly dims: number;
+    readonly vector: Float32Array;
+    readonly contentHash: string;
+  }[] {
+    if (this.closed) return [];
+    const rows = expectRows<{
+      node_id: string;
+      qualified_name: string;
+      file_path: string;
+      dims: number;
+      vector: Uint8Array;
+      content_hash: string;
+    }>(
+      this.db
+        .prepare(
+          `SELECT sv.node_id, sv.dims, sv.vector, sv.content_hash,
+                  n.qualified_name, f.path AS file_path
+             FROM symbol_vectors sv
+             JOIN nodes n ON sv.node_id = n.id
+             JOIN files f ON n.file_id = f.id
+            WHERE sv.model_id = ?`,
+        )
+        .all(modelId),
+      ["node_id", "qualified_name", "file_path", "dims", "vector", "content_hash"],
+    );
+    return rows.map((r) => ({
+      nodeId: r.node_id,
+      qualifiedName: r.qualified_name,
+      filePath: r.file_path,
+      dims: r.dims,
+      contentHash: r.content_hash,
+      vector: new Float32Array(r.vector.buffer, r.vector.byteOffset, r.vector.byteLength / 4),
+    }));
+  }
+
+  /**
+   * Delete vector rows for a set of node ids (all models). Used by the
+   * cache-invalidation path when a symbol's canonical text changed AND
+   * it could not be re-embedded (provider gone) — the stale vector must
+   * not survive to pollute cosine retrieval. Cascades via the schema's
+   * ON DELETE CASCADE on nodes(id) when a node is pruned, so this method
+   * is only for the targeted-invalidation path.
+   */
+  deleteSymbolVectors(nodeIds: readonly string[]): void {
+    if (this.closed || nodeIds.length === 0) return;
+    this.runChunkedDelete(
+      "DELETE FROM symbol_vectors WHERE node_id IN (%PH%)",
+      nodeIds,
+    );
+  }
+
+  /**
+   * Read every node with its file path + span, for the semantic indexer.
+   * The indexer reads source text from disk (via repoRoot) and builds
+   * canonical text per node. Returns kind + qualified_name + span so the
+   * indexer can reconstruct the SymbolIR-equivalent without a second
+   * join. Ordered by qualified_name for deterministic processing order.
+   */
+  readNodesForSemantic(): readonly {
+    readonly nodeId: string;
+    readonly qualifiedName: string;
+    readonly kind: string;
+    readonly filePath: string;
+    readonly startByte: number;
+    readonly endByte: number;
+    readonly lang: string;
+  }[] {
+    if (this.closed) return [];
+    const rows = expectRows<{
+      id: string;
+      qualified_name: string;
+      label: string;
+      file_path: string;
+      span_start: number;
+      span_end: number;
+      lang: string;
+    }>(
+      this.db
+        .prepare(
+          `SELECT n.id, n.qualified_name, n.label, n.span_start, n.span_end, n.lang,
+                  f.path AS file_path
+             FROM nodes n JOIN files f ON n.file_id = f.id
+            ORDER BY n.qualified_name ASC`,
+        )
+        .all(),
+      ["id", "qualified_name", "label", "file_path", "span_start", "span_end", "lang"],
+    );
+    return rows.map((r) => ({
+      nodeId: r.id,
+      qualifiedName: r.qualified_name,
+      kind: r.label,
+      filePath: r.file_path,
+      startByte: r.span_start,
+      endByte: r.span_end,
+      lang: r.lang,
+    }));
+  }
+
+  /**
+   * Read the callers and callees of a node by qualified name, for
+   * semantic_query hydration (the issue: hydrate each hit with graph
+   * context — defining file, direct callers/callees).
+   */
+  readNeighbors(
+    qualifiedName: string,
+  ): { readonly callers: readonly string[]; readonly callees: readonly string[] } {
+    if (this.closed) return { callers: [], callees: [] };
+    // Resolve the node id first.
+    const nodeRow = expectRow<{ id: string }>(
+      this.db
+        .prepare("SELECT id FROM nodes WHERE qualified_name = ?")
+        .get(qualifiedName),
+      ["id"],
+    );
+    if (!nodeRow) return { callers: [], callees: [] };
+    const id = nodeRow.id;
+    // Callers: nodes that CALL this node (edges where dst = id, type CALLS).
+    const callerRows = expectRows<{ qualified_name: string }>(
+      this.db
+        .prepare(
+          `SELECT n.qualified_name FROM edges e
+             JOIN nodes n ON e.src = n.id
+            WHERE e.dst = ? AND e.type = 'CALLS'`,
+        )
+        .all(id),
+      ["qualified_name"],
+    );
+    // Callees: nodes this node CALLS (edges where src = id, type CALLS).
+    const calleeRows = expectRows<{ qualified_name: string }>(
+      this.db
+        .prepare(
+          `SELECT n.qualified_name FROM edges e
+             JOIN nodes n ON e.dst = n.id
+            WHERE e.src = ? AND e.type = 'CALLS'`,
+        )
+        .all(id),
+      ["qualified_name"],
+    );
+    return {
+      callers: callerRows.map((r) => r.qualified_name),
+      callees: calleeRows.map((r) => r.qualified_name),
+    };
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -348,7 +348,19 @@ export type DeadCodeResult =
  * and slices `[span_start, span_end)` from the on-disk bytes.
  */
 export interface SnippetQuery {
-  qualifiedName: string;
+  /**
+   * Qualified name to resolve. Optional when `nodeId` is supplied — the
+   * guard requires at least one of the two.
+   */
+  qualifiedName?: string;
+  /**
+   * Optional deterministic node id. When set, the lookup resolves by
+   * `nodes.id` (unique) instead of `qualified_name`, so a hit whose
+   * qualified name is duplicated across files still hydrates the exact
+   * node's snippet instead of failing with `ambiguous_name`
+   * (chatgpt-codex-connector P2: 'Hydrate snippets by node id as well').
+   */
+  nodeId?: string;
   /**
    * Optional lines of context to include before and after the span
    * (default 0 — exact span only). Context is line-aligned: the slice
@@ -2325,9 +2337,13 @@ export class GraphStore {
     if (query == null || typeof query !== "object") {
       return { ok: false, code: "invalid_query" };
     }
+    // Prefer a deterministic node id when supplied — it is unique, so it
+    // never hits the qualified-name ambiguity path.
+    const hasNodeId = typeof query.nodeId === "string" && query.nodeId.length > 0;
     if (
-      typeof query.qualifiedName !== "string" ||
-      query.qualifiedName.length === 0
+      !hasNodeId &&
+      (typeof query.qualifiedName !== "string" ||
+        query.qualifiedName.length === 0)
     ) {
       return { ok: false, code: "invalid_query" };
     }
@@ -2372,9 +2388,9 @@ export class GraphStore {
             `SELECT n.id, n.qualified_name, n.span_start, n.span_end, n.lang,
                     f.path AS file_path
                FROM nodes n JOIN files f ON n.file_id = f.id
-              WHERE n.qualified_name = ?`,
+              WHERE ${hasNodeId ? "n.id = ?" : "n.qualified_name = ?"}`,
           )
-          .all(query.qualifiedName),
+          .all(hasNodeId ? query.nodeId : query.qualifiedName),
         ["id", "qualified_name", "file_path", "span_start", "span_end", "lang"],
       );
     } catch (error) {
@@ -2555,6 +2571,7 @@ export class GraphStore {
     readonly nodeId: string;
     readonly qualifiedName: string;
     readonly filePath: string;
+    readonly kind: string;
     readonly dims: number;
     readonly vector: Float32Array;
     readonly contentHash: string;
@@ -2563,6 +2580,7 @@ export class GraphStore {
     const rows = expectRows<{
       node_id: string;
       qualified_name: string;
+      label: string;
       file_path: string;
       dims: number;
       vector: Uint8Array;
@@ -2571,19 +2589,20 @@ export class GraphStore {
       this.db
         .prepare(
           `SELECT sv.node_id, sv.dims, sv.vector, sv.content_hash,
-                  n.qualified_name, f.path AS file_path
+                  n.qualified_name, n.label, f.path AS file_path
              FROM symbol_vectors sv
              JOIN nodes n ON sv.node_id = n.id
              JOIN files f ON n.file_id = f.id
             WHERE sv.model_id = ?`,
         )
         .all(modelId),
-      ["node_id", "qualified_name", "file_path", "dims", "vector", "content_hash"],
+      ["node_id", "qualified_name", "label", "file_path", "dims", "vector", "content_hash"],
     );
     return rows.map((r) => ({
       nodeId: r.node_id,
       qualifiedName: r.qualified_name,
       filePath: r.file_path,
+      kind: r.label,
       dims: r.dims,
       contentHash: r.content_hash,
       vector: new Float32Array(r.vector.buffer, r.vector.byteOffset, r.vector.byteLength / 4),
@@ -2604,6 +2623,27 @@ export class GraphStore {
       "DELETE FROM symbol_vectors WHERE node_id IN (%PH%)",
       nodeIds,
     );
+  }
+
+  /**
+   * Remove every SIMILAR_TO edge written by the semantic similarity
+   * pipeline (type 'SIMILAR_TO', provenance 'semantic'). The pipeline
+   * recomputes the FULL near-clone edge set on each run, so callers MUST
+   * clear the prior set before upserting the new one — otherwise an edge
+   * between two symbols that stopped being similar survives indefinitely
+   * and graph traversal keeps reporting a stale clone relationship
+   * (chatgpt-codex-connector P2: 'Replace old SIMILAR_TO edges on
+   * recompute'). Scoped to provenance 'semantic' so non-semantic edges
+   * are untouched. Serialized via the write queue so it cannot interleave
+   * a concurrent file-batch edge upsert.
+   */
+  async clearSemanticSimilarToEdges(): Promise<void> {
+    if (this.closed || this.closing) return;
+    await this.queue.schedule(async () => {
+      this.db
+        .prepare("DELETE FROM edges WHERE type = ? AND provenance = ?")
+        .run("SIMILAR_TO", "semantic");
+    });
   }
 
   /**

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2698,6 +2698,42 @@ export class GraphStore {
       callees: calleeRows.map((r) => r.qualified_name),
     };
   }
+
+  /**
+   * Read callers/callees by node id directly (avoids the qualified-name
+   * ambiguity when duplicate names exist across files). Used by
+   * semantic_query hydration (chatgpt-codex-connector: 'Use the hit node
+   * id when hydrating neighbors').
+   */
+  readNeighborsByNodeId(
+    nodeId: string,
+  ): { readonly callers: readonly string[]; readonly callees: readonly string[] } {
+    if (this.closed) return { callers: [], callees: [] };
+    const callerRows = expectRows<{ qualified_name: string }>(
+      this.db
+        .prepare(
+          `SELECT n.qualified_name FROM edges e
+             JOIN nodes n ON e.src = n.id
+            WHERE e.dst = ? AND e.type = 'CALLS'`,
+        )
+        .all(nodeId),
+      ["qualified_name"],
+    );
+    const calleeRows = expectRows<{ qualified_name: string }>(
+      this.db
+        .prepare(
+          `SELECT n.qualified_name FROM edges e
+             JOIN nodes n ON e.dst = n.id
+            WHERE e.src = ? AND e.type = 'CALLS'`,
+        )
+        .all(nodeId),
+      ["qualified_name"],
+    );
+    return {
+      callers: callerRows.map((r) => r.qualified_name),
+      callees: calleeRows.map((r) => r.qualified_name),
+    };
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/coding-graph/src/index.ts
+++ b/packages/coding-graph/src/index.ts
@@ -367,3 +367,13 @@ export type {
   LspTextDocumentItem,
   LspTextDocumentPositionParams,
 } from "./lsp/types.js";
+
+
+// ---------------------------------------------------------------------------
+// Semantic layer (issue #1556): symbol embeddings, SIMILAR_TO near-clone
+// edges, and semantic_query. OFF by default (SemanticConfig.enabled = false).
+// The layer builds on @remnic/core's host embedding provider + fallback —
+// no new embedding stack. See ./semantic/index.ts for the full surface.
+// ---------------------------------------------------------------------------
+
+export * from "./semantic/index.js";

--- a/packages/coding-graph/src/semantic/canonical-text.test.ts
+++ b/packages/coding-graph/src/semantic/canonical-text.test.ts
@@ -113,3 +113,38 @@ test("canonical text: body truncated to maxBodyLines (token budget)", () => {
   assert.ok(body4.split(/\s+/).length <= 4, `truncated body should have <=4 tokens, got ${body4.split(/\s+/).length}`);
   assert.ok(bodyAll.split(/\s+/).length > 4, "full body should have more than 4 tokens");
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// Braceless arrow functions keep their body (cursor Bugbot: 'Arrow bodies
+// lost in canonical text'). collapseWhitespace splits `=>` into `= >`, so
+// the signature/body split must search the NORMALIZED arrow form.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("canonical text: braceless arrow body is captured, not empty", () => {
+  const raw = "const double = (x) => x * 2";
+  const sym = fn("mod.double", raw);
+  const text = buildCanonicalText({ symbol: sym, rawText: raw });
+  const body = text.split("BODY:")[1]!.trim();
+  assert.ok(body.length > 0, `braceless arrow should keep a non-empty body, got "${body}"`);
+  assert.ok(body.includes("x"), `body should include the expression text, got "${body}"`);
+});
+
+test("canonical text: braceless arrow variants canonicalize identically", () => {
+  const spaced = "const f = (x) => x + 1";
+  const tight = "const f=(x)=>x+1";
+  const sym = fn("mod.f", spaced);
+  assert.equal(
+    buildCanonicalText({ symbol: sym, rawText: spaced }),
+    buildCanonicalText({ symbol: sym, rawText: tight }),
+  );
+});
+
+test("canonical text: braced arrow still splits at the brace", () => {
+  const raw = "const f = (x) => { return x + 1; }";
+  const sym = fn("mod.f", raw);
+  const text = buildCanonicalText({ symbol: sym, rawText: raw });
+  const body = text.split("BODY:")[1]!.trim();
+  assert.ok(body.length > 0, "braced arrow should keep a body");
+  assert.ok(body.includes("return"), `braced arrow body should include the block, got "${body}"`);
+});
+

--- a/packages/coding-graph/src/semantic/canonical-text.test.ts
+++ b/packages/coding-graph/src/semantic/canonical-text.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Canonical-text builder tests (issue #1556 step 1 — prove-fail-before).
+ *
+ * Rule 23/38: ONE canonical form. Two formatting-variant fixtures of the
+ * same function MUST produce the same canonical text; the embedded string
+ * equals the hashed string (one assertion).
+ *
+ * Rule 37: cache invalidation. When canonical text changes (rename / body
+ * edit), the hash changes.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCanonicalText,
+  buildCanonicalTextAndHash,
+  canonicalTextHash,
+  collapseWhitespace,
+} from "./canonical-text.js";
+import type { SymbolIR } from "@remnic/core";
+
+function fn(qname: string, rawText: string): SymbolIR {
+  return {
+    kind: "function",
+    name: qname.split(".").pop() ?? qname,
+    qualifiedName: qname,
+    span: { startByte: 0, endByte: rawText.length },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Rule 23/38: ONE canonical form — formatting variants hash identically.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("canonical text: whitespace-only variants produce identical text", () => {
+  const variantA = `function add(a, b) {\n    return a + b;\n}`;
+  const variantB = `function  add(a,b){\n\treturn a+b;\n}`;
+  const sym = fn("mod.add", variantA);
+  const textA = buildCanonicalText({ symbol: sym, rawText: variantA });
+  const textB = buildCanonicalText({ symbol: sym, rawText: variantB });
+  assert.equal(textA, textB, "indentation/spacing variants must canonicalize identically");
+});
+
+test("canonical text: brace-style variants produce identical text", () => {
+  const sameLine = `function foo(x) { return x * 2; }`;
+  const newLine = `function foo(x)\n{\n  return x * 2;\n}`;
+  const sym = fn("mod.foo", sameLine);
+  assert.equal(
+    buildCanonicalText({ symbol: sym, rawText: sameLine }),
+    buildCanonicalText({ symbol: sym, rawText: newLine }),
+  );
+});
+
+test("canonical text: the embedded string equals the hashed string (rule 23)", () => {
+  const raw = `function bar(n) { return n + 1; }`;
+  const sym = fn("mod.bar", raw);
+  const { text, hash } = buildCanonicalTextAndHash({ symbol: sym, rawText: raw });
+  // The hash is over the EXACT text returned — no transformation gap.
+  assert.equal(hash, canonicalTextHash(text));
+  // And a different text produces a different hash.
+  const other = buildCanonicalTextAndHash({ symbol: fn("mod.baz", raw), rawText: raw });
+  assert.notEqual(hash, other.hash);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Rule 37: cache invalidation — rename / body change changes the hash.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("canonical hash: rename changes the hash (cache invalidation)", () => {
+  const raw = `function f() { return 42; }`;
+  const before = buildCanonicalTextAndHash({ symbol: fn("mod.oldName", raw), rawText: raw });
+  const after = buildCanonicalTextAndHash({ symbol: fn("mod.newName", raw), rawText: raw });
+  assert.notEqual(before.hash, after.hash, "a rename must invalidate the cache");
+});
+
+test("canonical hash: body change changes the hash", () => {
+  const rawA = `function f() { return 1; }`;
+  const rawB = `function f() { return 2; }`;
+  const before = buildCanonicalTextAndHash({ symbol: fn("mod.f", rawA), rawText: rawA });
+  const after = buildCanonicalTextAndHash({ symbol: fn("mod.f", rawB), rawText: rawB });
+  assert.notEqual(before.hash, after.hash);
+});
+
+test("canonical hash: unchanged symbol is stable (idempotent)", () => {
+  const raw = `function stable() { console.log("hi"); }`;
+  const a = buildCanonicalTextAndHash({ symbol: fn("mod.stable", raw), rawText: raw });
+  const b = buildCanonicalTextAndHash({ symbol: fn("mod.stable", raw), rawText: raw });
+  assert.equal(a.hash, b.hash);
+  assert.equal(a.text, b.text);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// collapseWhitespace unit
+// ──────────────────────────────────────────────────────────────────────────
+
+test("collapseWhitespace: tabs/newlines/multiple-spaces → single space", () => {
+  assert.equal(collapseWhitespace("\t\thello   world\t"), "hello world");
+  assert.equal(collapseWhitespace("a\n\n\n\nb"), "a b");
+  assert.equal(collapseWhitespace("  line one \n line two  "), "line one line two");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Body truncation respects maxBodyLines
+// ──────────────────────────────────────────────────────────────────────────
+
+test("canonical text: body truncated to maxBodyLines (token budget)", () => {
+  const raw = `function big() { ${Array.from({ length: 50 }, (_, i) => `const x${i} = ${i};`).join(" ")} }`;
+  const sym = fn("mod.big", raw);
+  const text4 = buildCanonicalText({ symbol: sym, rawText: raw, maxBodyLines: 4 });
+  const textAll = buildCanonicalText({ symbol: sym, rawText: raw, maxBodyLines: 0 });
+  const body4 = text4.split("BODY:")[1]!.trim();
+  const bodyAll = textAll.split("BODY:")[1]!.trim();
+  assert.ok(body4.split(/\s+/).length <= 4, `truncated body should have <=4 tokens, got ${body4.split(/\s+/).length}`);
+  assert.ok(bodyAll.split(/\s+/).length > 4, "full body should have more than 4 tokens");
+});

--- a/packages/coding-graph/src/semantic/canonical-text.ts
+++ b/packages/coding-graph/src/semantic/canonical-text.ts
@@ -1,0 +1,203 @@
+/**
+ * Canonical-text builder for symbol embeddings (issue #1556).
+ *
+ * Rule 23/38 — ONE canonical form. The exact string that is embedded is
+ * the exact string that is hashed for the embedding cache. Two formatting-
+ * variant fixtures of the same function MUST produce the same canonical
+ * text; the cache-hash test asserts this end to end.
+ *
+ * The canonical form (per the issue design):
+ *   `signature + doc comment + first N lines of body`,
+ * normalized (sorted-key serialization where structured, stable truncation).
+ *
+ * Normalization strategy: ALL whitespace (including newlines) is collapsed
+ * to single spaces BEFORE signature/body split. This absorbs every
+ * formatting variant (indentation, brace placement, trailing whitespace,
+ * tabs vs spaces) so two semantically-identical functions produce IDENTICAL
+ * canonical text. The "first N lines" budget is then applied as a stable
+ * TOKEN budget over the collapsed text — stable because token count is
+ * formatting-independent.
+ *
+ * IMPORTANT: this module takes pre-extracted text spans, not raw source.
+ * The caller (the indexer) slices `[startByte, endByte)` from disk and
+ * passes the raw symbol text. Canonicalization here is about producing a
+ * stable embedding input from that raw text, not about re-parsing.
+ */
+import { createHash } from "node:crypto";
+
+import type { SymbolIR } from "@remnic/core";
+
+import { DEFAULT_CANONICAL_BODY_LINES } from "./config.js";
+
+/**
+ * Input to the canonical-text builder. `rawText` is the symbol's on-disk
+ * source slice `[startByte, endByte)`. `docComment` is the leading
+ * comment block immediately above the symbol, if the caller extracted one
+ * (the parser does not currently emit doc comments on SymbolIR, so this
+ * is optional and may be empty/undefined — the canonical form degrades
+ * gracefully to `signature + body`).
+ */
+export interface CanonicalTextInput {
+  readonly symbol: SymbolIR;
+  /** Raw source text of the symbol span. */
+  readonly rawText: string;
+  /** Optional leading doc comment (/** … *\/ or // … lines). */
+  readonly docComment?: string;
+  /** Body token budget (default {@link DEFAULT_CANONICAL_BODY_LINES}). */
+  readonly maxBodyLines?: number;
+}
+
+/**
+ * Collapse ALL whitespace runs (including newlines) to single spaces and
+ * trim. This is the universal normalization pass: it absorbs indentation,
+ * brace placement, trailing whitespace, tabs vs spaces, and line-ending
+ * differences. After this pass, two formatting variants of the same
+ * function are byte-identical.
+ */
+export function collapseWhitespace(text: string): string {
+  return text
+    // Insert spaces around punctuation so a,b and a, b canonicalize identically.
+    .replace(/([{}()<>\[\],;:?!=+\-*/%&|^~])/g, " $1 ")
+    // Collapse all whitespace runs (including those introduced above) to single spaces.
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Line-oriented whitespace collapse (preserves line structure). Used when
+ * line boundaries matter (e.g. the "first N lines" budget needs real
+ * lines). Collapses intra-line whitespace runs but keeps newlines.
+ */
+export function collapseWhitespaceKeepLines(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.replace(/[ \t]+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Split normalized symbol text into signature + body at the first body-
+ * open marker (`{`, `=>`, `:` preceded by a non-type context). The split
+ * is CHARACTER-level on the fully-whitespace-normalized text, so a
+ * same-line function `function f() { return 1; }` and a brace-newline
+ * variant `function f()\n{ return 1; }` both split at the same `{`.
+ *
+ * Returns `{ signature, body }` — both whitespace-normalized. The
+ * signature includes the marker char so the canonical form is stable.
+ */
+function splitSignatureBody(normalized: string): { readonly signature: string; readonly body: string } {
+  // Find the first body-open marker. `{` is the universal one; `=>` covers
+  // arrow functions; `:` covers type/enum members where the "body" is the
+  // type expression. Order matters: check multi-char markers first.
+  const markers = ["{", "=>"];
+  let cutIdx = Infinity;
+  for (const m of markers) {
+    const idx = normalized.indexOf(m);
+    if (idx >= 0 && idx < cutIdx) cutIdx = idx;
+  }
+  if (cutIdx === Infinity) {
+    // No body marker — treat the whole text as signature (e.g. `type Foo = string`).
+    return { signature: normalized, body: "" };
+  }
+  // Signature is everything up to and INCLUDING the marker.
+  const signature = normalized.slice(0, cutIdx + 1).trim();
+  const body = normalized.slice(cutIdx + 1).trim();
+  return { signature, body };
+}
+
+/**
+ * Extract a coarse signature string from raw symbol text. The text is
+ * fully whitespace-normalized first, then split at the first body-open
+ * marker. The returned signature is stable across all formatting variants
+ * of the same function.
+ */
+export function extractSignatureLine(
+  rawText: string,
+  _kind: SymbolIR["kind"],
+): string {
+  const normalized = collapseWhitespace(rawText);
+  return splitSignatureBody(normalized).signature;
+}
+
+/**
+ * Extract the body (everything after the signature/header marker) from
+ * raw symbol text, truncated to the first `maxBodyLines` tokens. Tokens
+ * are whitespace-delimited words/operators in the normalized body text —
+ * this is a STABLE budget (formatting-independent) unlike line-based
+ * truncation. `maxBodyLines` is the config field name; it functions as a
+ * token budget here (each "line" ≈ one significant token).
+ *
+ * `maxBodyLines <= 0` means unlimited (return the full normalized body).
+ */
+export function extractBodyText(rawText: string, maxBodyLines: number): string {
+  const normalized = collapseWhitespace(rawText);
+  const body = splitSignatureBody(normalized).body;
+  if (maxBodyLines <= 0 || body.length === 0) return body;
+  const tokens = body.split(/\s+/);
+  return tokens.slice(0, maxBodyLines).join(" ");
+}
+
+/**
+ * Build the canonical embedding text for a symbol.
+ *
+ * The form (rule 23/38 — ONE form, every consumer):
+ *   KIND:<kind>\nQNAME:<qualifiedName>\nSIG:<signature>\n[DOC:<doc>]\nBODY:<body>
+ *
+ * `kind` and `qualifiedName` are included as stable prefix lines so two
+ * functions with identical bodies but different names (the "renamed
+ * variable" clone fixture) embed close but not identically — the qualified
+ * name differentiates them at the embedding level while the body dominates
+ * the similarity. The cache hash, by contrast, is over the FULL canonical
+ * text including the name, so a rename invalidates the cache (rule 37).
+ *
+ * Normalization:
+ *   - ALL whitespace collapsed (indentation/brace-style/newlines absorbed)
+ *   - body truncated to maxBodyLines tokens (stable budget)
+ */
+export function buildCanonicalText(input: CanonicalTextInput): string {
+  const { symbol, rawText, docComment, maxBodyLines } = input;
+  const budget = maxBodyLines ?? DEFAULT_CANONICAL_BODY_LINES;
+  const signature = extractSignatureLine(rawText, symbol.kind);
+  const body = extractBodyText(rawText, budget);
+  const doc = docComment ? collapseWhitespace(docComment) : "";
+  const parts = [
+    `KIND:${symbol.kind}`,
+    `QNAME:${symbol.qualifiedName}`,
+    `SIG:${signature}`,
+  ];
+  if (doc.length > 0) parts.push(`DOC:${doc}`);
+  parts.push(`BODY:${body}`);
+  return parts.join("\n");
+}
+
+/**
+ * The cache key for a canonical text. This is sha256 over the EXACT
+ * canonical text string (rule 23 — the embedded string equals the hashed
+ * string). When the canonical text changes (e.g. a rename edits the
+ * qualified name, or the body changes), the hash changes, and:
+ *   1. the cached vector is invalidated (re-embedded), and
+ *   2. any SIMILAR_TO edge derived from it is recomputed.
+ *
+ * This is the single chokepoint for cache invalidation (rule 37). Every
+ * layer that persists a vector persists THIS hash alongside it; every
+ * re-index compares THIS hash to decide whether to re-embed.
+ */
+export function canonicalTextHash(canonicalText: string): string {
+  return createHash("sha256").update(canonicalText, "utf8").digest("hex");
+}
+
+/**
+ * Convenience: build canonical text AND its hash in one call. The hash is
+ * over the returned text — callers that store both MUST store the exact
+ * `text` alongside the `hash` (never re-derive the text from disk and hash
+ * separately, or a formatter run between the two would silently
+ * re-embed — rule 37).
+ */
+export function buildCanonicalTextAndHash(
+  input: CanonicalTextInput,
+): { readonly text: string; readonly hash: string } {
+  const text = buildCanonicalText(input);
+  return { text, hash: canonicalTextHash(text) };
+}

--- a/packages/coding-graph/src/semantic/canonical-text.ts
+++ b/packages/coding-graph/src/semantic/canonical-text.ts
@@ -88,23 +88,39 @@ export function collapseWhitespaceKeepLines(text: string): string {
  * signature includes the marker char so the canonical form is stable.
  */
 function splitSignatureBody(normalized: string): { readonly signature: string; readonly body: string } {
-  // Find the first body-open marker. `{` is the universal one; `=>` covers
-  // arrow functions; `:` covers type/enum members where the "body" is the
-  // type expression. Order matters: check multi-char markers first.
-  const markers = ["{", "=>"];
-  let cutIdx = Infinity;
-  for (const m of markers) {
-    const idx = normalized.indexOf(m);
-    if (idx >= 0 && idx < cutIdx) cutIdx = idx;
+  // Find the body-open marker. `{` is the universal one (functions,
+  // classes, blocks). When there is no `{` we fall back to the arrow
+  // form so braceless arrow functions (`const f = (x) => x + 1`) split
+  // at the arrow instead of collapsing to an empty body.
+  //
+  // collapseWhitespace's punctuation-spacer turns `=>` into `= >`, so
+  // the raw `=>` marker NEVER appears in the normalized text — search
+  // the normalized form (`= >`) or this whole branch is dead and
+  // braceless arrows lose their body (cursor Bugbot: 'Arrow bodies lost
+  // in canonical text'). Embeddings, cache hashes, and MinHash inputs
+  // then omitted arrow-function logic.
+  const braceIdx = normalized.indexOf("{");
+  if (braceIdx >= 0) {
+    const signature = normalized.slice(0, braceIdx + 1).trim();
+    const body = normalized.slice(braceIdx + 1).trim();
+    return { signature, body };
   }
-  if (cutIdx === Infinity) {
-    // No body marker — treat the whole text as signature (e.g. `type Foo = string`).
-    return { signature: normalized, body: "" };
+  const arrowIdx = normalized.indexOf("=>");
+  const arrowNormIdx = normalized.indexOf("= >");
+  if (arrowIdx >= 0) {
+    const signature = normalized.slice(0, arrowIdx + 2).trim();
+    const body = normalized.slice(arrowIdx + 2).trim();
+    return { signature, body };
   }
-  // Signature is everything up to and INCLUDING the marker.
-  const signature = normalized.slice(0, cutIdx + 1).trim();
-  const body = normalized.slice(cutIdx + 1).trim();
-  return { signature, body };
+  if (arrowNormIdx >= 0) {
+    // `= >` spans 3 chars (`= `, ` `, `>`); cut after the `>`.
+    const bodyStart = arrowNormIdx + 3;
+    const signature = normalized.slice(0, bodyStart).trim();
+    const body = normalized.slice(bodyStart).trim();
+    return { signature, body };
+  }
+  // No body marker — treat the whole text as signature (e.g. `type Foo = string`).
+  return { signature: normalized, body: "" };
 }
 
 /**

--- a/packages/coding-graph/src/semantic/config.ts
+++ b/packages/coding-graph/src/semantic/config.ts
@@ -1,0 +1,187 @@
+/**
+ * Semantic-layer configuration for @remnic/coding-graph (issue #1556).
+ *
+ * Rule 30/48: the semantic layer is OFF by default. Embedding costs compute
+ * and possibly tokens, so nothing in this module touches a provider, writes
+ * a vector, or sends symbol text off-machine unless `enabled` is explicitly
+ * true. The gate-off characterization test (`gate-off.test.ts`) asserts
+ * this end to end.
+ *
+ * The config object is intentionally self-contained in this package rather
+ * than wired into @remnic/core/config.ts — the coding-graph package is an
+ * optional peer dep and must compile standalone. Host integrations
+ * (core/config.ts + openclaw.plugin.json schema) resolve to this same
+ * shape via `resolveSemanticConfig()`, which reads the documented env vars
+ * with the `ENGRAM_` fallback (gotcha 9).
+ */
+import type { EdgeProvenance } from "../graph-schema.js";
+
+/**
+ * Default SIMILAR_TO cosine confirmation threshold (issue #1556 design).
+ * 0.92 is the codebase-memory-mcp precedent — high enough to avoid
+ * false near-clone pairs across structurally-similar but logically-distinct
+ * functions, low enough to catch genuine copy-paste with a renamed
+ * variable.
+ */
+export const DEFAULT_SIMILAR_TO_THRESHOLD = 0.92;
+
+/**
+ * Default maximum symbols embedded per indexing run. Bounds per-run
+ * provider cost. 0 means unlimited (the host budget is the only cap).
+ */
+export const DEFAULT_MAX_SYMBOLS_PER_RUN = 0;
+
+/**
+ * Confidence band assigned to MinHash-only SIMILAR_TO edges when no
+ * embedding provider is available (deterministic, local). Kept below the
+ * embedding-confirmed band so consumers can distinguish provenance quality.
+ * The issue designates this a distinct, documented lower band.
+ */
+export const MINHASH_ONLY_CONFIDENCE = 0.5;
+
+/**
+ * Confidence band assigned to embedding-confirmed SIMILAR_TO edges. Uses
+ * the actual cosine similarity score (≥ similarToThreshold), so this is
+ * the FLOOR for that band — the real confidence is the cosine value.
+ */
+export const EMBEDDING_CONFIRMED_MIN_CONFIDENCE = 0.92;
+
+/**
+ * Edge type emitted by the SIMILAR_TO pipeline. Lives in the `edges`
+ * table with `provenance: "semantic"` (already in EDGE_PROVENANCE_VALUES).
+ */
+export const SIMILAR_TO_EDGE_TYPE = "SIMILAR_TO";
+
+/**
+ * The single provenance tag for every edge this module writes.
+ */
+export const SEMANTIC_PROVENANCE: EdgeProvenance = "semantic";
+
+/**
+ * Canonical-text body line budget. `signature + doc comment + first N lines
+ * of body` per the issue design. N is bounded so a 5k-line function does
+ * not dominate the embedded string (and the provider token budget).
+ */
+export const DEFAULT_CANONICAL_BODY_LINES = 16;
+
+/**
+ * Token shingle width for MinHash. 3 tokens per shingle is the standard
+ * near-duplicate-detection width — small enough to catch renamed-variable
+ * clones (most shingles survive a single rename), large enough that
+ * boilerplate coincidence does not flood the candidate set.
+ */
+export const MINHASH_SHINGLE_WIDTH = 3;
+
+/**
+ * Number of MinHash permutations (hash functions). More = tighter Jaccard
+ * estimate = more compute. 128 gives ~±5% Jaccard error at p=0.95 which
+ * is well inside the 0.92 cosine confirmation gate's margin.
+ */
+export const MINHASH_NUM_PERMUTATIONS = 128;
+
+/**
+ * Number of LSH bands. More bands = more candidate pairs (higher recall,
+ * lower precision before the cosine gate). 32 bands of 4 rows each is the
+ * banding that pairs a Jaccard ≥ 0.4 with high probability while keeping
+ * the candidate set small for typical repos.
+ */
+export const LSH_NUM_BANDS = 32;
+
+/**
+ * The LSH banding — derived: rows per band = permutations / bands.
+ */
+export const LSH_ROWS_PER_BAND = MINHASH_NUM_PERMUTATIONS / LSH_NUM_BANDS;
+
+/**
+ * LSH candidate-pair Jaccard floor implied by the banding (s ≈ (1/b)^(1/r)).
+ * Below this Jaccard similarity a pair is almost never a candidate. Kept as
+ * a named constant so the determinism test can assert the candidate set is
+ * a pure function of (seeds, inputs) without a hidden threshold drift.
+ */
+export const LSH_CANDIDATE_JACCARD_FLOOR = Math.pow(1 / LSH_NUM_BANDS, 1 / LSH_ROWS_PER_BAND);
+
+/**
+ * Self-contained semantic config. Resolved from host config + env.
+ *
+ * `enabled` is the single gate for the whole layer. When false, every
+ * semantic entry point (index-time vector writes, SIMILAR_TO edges,
+ * semantic_query) returns a tagged `{ ok: false, code: "semantic_disabled" }`
+ * WITHOUT touching the provider or the vectors table (gate-off parity).
+ */
+export interface SemanticConfig {
+  /** Master gate. Default false (rule 30/48). */
+  readonly enabled: boolean;
+  /** Cosine threshold for SIMILAR_TO confirmation. Default 0.92. */
+  readonly similarToThreshold: number;
+  /** Per-run embedding budget (0 = unlimited). Default 0. */
+  readonly maxSymbolsPerRun: number;
+  /** Canonical-text body line budget. Default 16. */
+  readonly canonicalBodyLines: number;
+}
+
+/**
+ * Environment variable names. `REMNIC_*` is primary; `ENGRAM_*` is the
+ * fallback (gotcha 9 — legacy env names still bind).
+ */
+const ENV_ENABLED = ["REMNIC_CODING_GRAPH_SEMANTIC_ENABLED", "ENGRAM_CODING_GRAPH_SEMANTIC_ENABLED"];
+const ENV_THRESHOLD = ["REMNIC_CODING_GRAPH_SEMANTIC_SIMILAR_TO_THRESHOLD", "ENGRAM_CODING_GRAPH_SEMANTIC_SIMILAR_TO_THRESHOLD"];
+const ENV_MAX_SYMBOLS = ["REMNIC_CODING_GRAPH_SEMANTIC_MAX_SYMBOLS_PER_RUN", "ENGRAM_CODING_GRAPH_SEMANTIC_MAX_SYMBOLS_PER_RUN"];
+
+/**
+ * Resolve a boolean env var. Accepts true/false/1/0 (case-insensitive).
+ */
+function resolveBoolEnv(names: readonly string[], fallback: boolean, env: NodeJS.ProcessEnv): boolean {
+  for (const name of names) {
+    const raw = env[name];
+    if (raw === undefined) continue;
+    const v = raw.trim().toLowerCase();
+    if (v === "true" || v === "1") return true;
+    if (v === "false" || v === "0") return false;
+    // Malformed value: ignore (do not throw — a typo must not crash indexing).
+  }
+  return fallback;
+}
+
+/**
+ * Resolve a positive-number env var. Ignores malformed/NaN/negative values
+ * rather than throwing (a config typo must not crash the indexer).
+ */
+function resolveNumberEnv(names: readonly string[], fallback: number, env: NodeJS.ProcessEnv): number {
+  for (const name of names) {
+    const raw = env[name];
+    if (raw === undefined) continue;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return fallback;
+}
+
+/**
+ * Resolve the semantic config from an optional host-provided partial plus
+ * the environment. Explicit host values win; env vars fill the gaps;
+ * documented defaults apply last.
+ *
+ * `env` defaults to `process.env` but is a parameter so tests can pin the
+ * environment deterministically (rule 38 — no implicit process state).
+ */
+export function resolveSemanticConfig(
+  host?: Partial<SemanticConfig>,
+  env: NodeJS.ProcessEnv = process.env,
+): SemanticConfig {
+  const enabled =
+    host?.enabled ?? resolveBoolEnv(ENV_ENABLED, false, env);
+  const similarToThreshold =
+    host?.similarToThreshold ?? resolveNumberEnv(ENV_THRESHOLD, DEFAULT_SIMILAR_TO_THRESHOLD, env);
+  const maxSymbolsPerRun =
+    host?.maxSymbolsPerRun ?? resolveNumberEnv(ENV_MAX_SYMBOLS, DEFAULT_MAX_SYMBOLS_PER_RUN, env);
+  const canonicalBodyLines =
+    host?.canonicalBodyLines ?? DEFAULT_CANONICAL_BODY_LINES;
+  return {
+    enabled,
+    // Clamp threshold into [0,1] — a malformed env must not produce an
+    // out-of-range confidence gate.
+    similarToThreshold: Math.min(1, Math.max(0, similarToThreshold)),
+    maxSymbolsPerRun: Math.max(0, Math.floor(maxSymbolsPerRun)),
+    canonicalBodyLines: Math.max(0, Math.floor(canonicalBodyLines)),
+  };
+}

--- a/packages/coding-graph/src/semantic/config.ts
+++ b/packages/coding-graph/src/semantic/config.ts
@@ -142,12 +142,36 @@ function coerceHostBool(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value === "string") {
     const v = value.trim().toLowerCase();
-    if (v === "false" || v === "0" || v === "no" || v === "") return false;
-    if (v === "true" || v === "1" || v === "yes") return true;
-    return true;
+    // Fail CLOSED: only explicit affirmatives enable the layer. Any other
+    // value ("false"/"0"/"no"/"off"/"disabled"/""/unknown) is an opt-out,
+    // so a malformed or unrecognized host string can never silently enable
+    // remote embedding against operator intent (cursor Bugbot: 'Unknown
+    // enabled strings enable semantic').
+    if (v === "true" || v === "1" || v === "yes" || v === "on") return true;
+    return false;
   }
   if (typeof value === "number") return value !== 0;
   return Boolean(value);
+}
+
+/**
+ * Coerce a host-provided number (which may arrive as a numeric string from
+ * JSON/CLI config) to a finite number, so a malformed value like
+ * maxSymbolsPerRun:"abc" cannot become NaN and silently disable the vector
+ * budget (NaN > 0 is false → unlimited) or break cosine confirmation
+ * (comparisons against NaN are false). undefined/null/non-finite → undefined
+ * (fall through to env/default). Negative finite numbers pass through so the
+ * downstream clamp still controls range (chatgpt-codex-connector: 'Validate
+ * host numeric config before clamping').
+ */
+function coerceHostNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string") {
+    const n = Number(value.trim());
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
 }
 
 function resolveBoolEnv(names: readonly string[], fallback: boolean, env: NodeJS.ProcessEnv): boolean {
@@ -191,11 +215,11 @@ export function resolveSemanticConfig(
   const enabled =
     coerceHostBool(host?.enabled) ?? resolveBoolEnv(ENV_ENABLED, false, env);
   const similarToThreshold =
-    host?.similarToThreshold ?? resolveNumberEnv(ENV_THRESHOLD, DEFAULT_SIMILAR_TO_THRESHOLD, env);
+    coerceHostNumber(host?.similarToThreshold) ?? resolveNumberEnv(ENV_THRESHOLD, DEFAULT_SIMILAR_TO_THRESHOLD, env);
   const maxSymbolsPerRun =
-    host?.maxSymbolsPerRun ?? resolveNumberEnv(ENV_MAX_SYMBOLS, DEFAULT_MAX_SYMBOLS_PER_RUN, env);
+    coerceHostNumber(host?.maxSymbolsPerRun) ?? resolveNumberEnv(ENV_MAX_SYMBOLS, DEFAULT_MAX_SYMBOLS_PER_RUN, env);
   const canonicalBodyLines =
-    host?.canonicalBodyLines ?? DEFAULT_CANONICAL_BODY_LINES;
+    coerceHostNumber(host?.canonicalBodyLines) ?? DEFAULT_CANONICAL_BODY_LINES;
   return {
     enabled,
     // Clamp threshold into [0,1] — a malformed env must not produce an

--- a/packages/coding-graph/src/semantic/config.ts
+++ b/packages/coding-graph/src/semantic/config.ts
@@ -130,6 +130,26 @@ const ENV_MAX_SYMBOLS = ["REMNIC_CODING_GRAPH_SEMANTIC_MAX_SYMBOLS_PER_RUN", "EN
 /**
  * Resolve a boolean env var. Accepts true/false/1/0 (case-insensitive).
  */
+/**
+ * Coerce a host-provided boolean (which may arrive as a string/number from
+ * JSON or CLI config) to a real boolean, so "false"/"0"/"no" do not become
+ * truthy and silently enable vector indexing despite an explicit opt-out
+ * (chatgpt-codex-connector: 'Coerce host enabled before trusting it').
+ * undefined/null → undefined (fall through to env/default).
+ */
+function coerceHostBool(value: unknown): boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (v === "false" || v === "0" || v === "no" || v === "") return false;
+    if (v === "true" || v === "1" || v === "yes") return true;
+    return true;
+  }
+  if (typeof value === "number") return value !== 0;
+  return Boolean(value);
+}
+
 function resolveBoolEnv(names: readonly string[], fallback: boolean, env: NodeJS.ProcessEnv): boolean {
   for (const name of names) {
     const raw = env[name];
@@ -169,7 +189,7 @@ export function resolveSemanticConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): SemanticConfig {
   const enabled =
-    host?.enabled ?? resolveBoolEnv(ENV_ENABLED, false, env);
+    coerceHostBool(host?.enabled) ?? resolveBoolEnv(ENV_ENABLED, false, env);
   const similarToThreshold =
     host?.similarToThreshold ?? resolveNumberEnv(ENV_THRESHOLD, DEFAULT_SIMILAR_TO_THRESHOLD, env);
   const maxSymbolsPerRun =

--- a/packages/coding-graph/src/semantic/config.ts
+++ b/packages/coding-graph/src/semantic/config.ts
@@ -70,7 +70,7 @@ export const DEFAULT_CANONICAL_BODY_LINES = 16;
  * clones (most shingles survive a single rename), large enough that
  * boilerplate coincidence does not flood the candidate set.
  */
-export const MINHASH_SHINGLE_WIDTH = 3;
+export const MINHASH_SHINGLE_WIDTH = 2;
 
 /**
  * Number of MinHash permutations (hash functions). More = tighter Jaccard

--- a/packages/coding-graph/src/semantic/index.ts
+++ b/packages/coding-graph/src/semantic/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Semantic layer barrel (issue #1556).
+ *
+ * One import surface for the optional semantic layer:
+ *   - config (SemanticConfig + resolveSemanticConfig)
+ *   - canonical-text (buildCanonicalText + hash)
+ *   - minhash (MinHasher + cosineSimilarity)
+ *   - vectors (indexSymbolVectors)
+ *   - similarity (computeSimilarTo + similarEdgesToEdgeIR)
+ *   - semantic-query (semanticQuery)
+ *   - types (tagged results)
+ */
+export {
+  DEFAULT_SIMILAR_TO_THRESHOLD,
+  DEFAULT_MAX_SYMBOLS_PER_RUN,
+  MINHASH_ONLY_CONFIDENCE,
+  SIMILAR_TO_EDGE_TYPE,
+  SEMANTIC_PROVENANCE,
+  DEFAULT_CANONICAL_BODY_LINES,
+  resolveSemanticConfig,
+  type SemanticConfig,
+} from "./config.js";
+
+export {
+  buildCanonicalText,
+  buildCanonicalTextAndHash,
+  canonicalTextHash,
+  collapseWhitespace,
+  extractSignatureLine,
+  extractBodyText,
+  type CanonicalTextInput,
+} from "./canonical-text.js";
+
+export {
+  MinHasher,
+  createMinHasher,
+  minHashSignature,
+  lshBandKeys,
+  shingleSet,
+  tokenizeForShingling,
+  cosineSimilarity,
+  MINHASH_SEEDS,
+  type LshIndexEntry,
+} from "./minhash.js";
+
+export {
+  indexSymbolVectors,
+  modelIdFor,
+  type IndexVectorsInput,
+} from "./vectors.js";
+
+export {
+  computeSimilarTo,
+  similarEdgesToEdgeIR,
+  estimateJaccard,
+  CONFIRM_OPERATOR,
+  type SimilarToInput,
+} from "./similarity.js";
+
+export {
+  semanticQuery,
+  DEFAULT_SEMANTIC_QUERY_LIMIT,
+  type SemanticQueryInput,
+} from "./semantic-query.js";
+
+export type {
+  SymbolVector,
+  SymbolVectorRow,
+  SemanticFailure,
+  SemanticFailureCode,
+  IndexVectorsResult,
+  SimilarCandidate,
+  SimilarEdge,
+  SimilarToResult,
+  SemanticQueryHit,
+  SemanticQuerySuccess,
+  SemanticQueryOutcome,
+} from "./types.js";

--- a/packages/coding-graph/src/semantic/minhash.test.ts
+++ b/packages/coding-graph/src/semantic/minhash.test.ts
@@ -1,0 +1,197 @@
+/**
+ * MinHash/LSH determinism + clone/hard-negative tests (issue #1556 steps 3–4).
+ *
+ * Rule 38: candidate set is a pure function of (seeds, inputs). Two runs
+ * over the same fixture produce an identical candidate set.
+ *
+ * Fixtures:
+ *   - TRUE CLONE: copy-pasted function with a renamed variable MUST pair.
+ *   - HARD NEGATIVE: similar length, different logic — must NOT pair.
+ *
+ * Rule 35 spirit: cosine confirmation boundary at exactly similarToThreshold.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MinHasher,
+  createMinHasher,
+  cosineSimilarity,
+} from "./minhash.js";
+import {
+  estimateJaccard,
+} from "./similarity.js";
+import {
+  tokenizeForShingling,
+  shingleSet,
+  MINHASH_SEEDS,
+} from "./minhash.js";
+import {
+  MINHASH_NUM_PERMUTATIONS,
+  LSH_NUM_BANDS,
+  LSH_ROWS_PER_BAND,
+} from "./config.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Rule 38: determinism — same fixture, two runs, identical candidate set
+// ──────────────────────────────────────────────────────────────────────────
+
+const CLONE_A = `function processPayment(amount, currency) {
+  const fee = amount * 0.029;
+  const total = amount + fee;
+  return { total, currency };
+}`;
+
+const CLONE_B = `function processPayment(amount, currency) {
+  const fee = amount * 0.029;
+  const totalAmount = amount + fee;
+  return { total: totalAmount, currency };
+}`;
+
+const HARD_NEG = `function validateSchema(data, schema) {
+  for (const key of Object.keys(schema)) {
+    if (!(key in data)) return false;
+  }
+  return true;
+}`;
+
+test("MinHash: determinism — two runs produce identical candidate sets", () => {
+  const run1 = createMinHasher();
+  const run2 = createMinHasher();
+  const entries = [
+    { nodeId: "n1", qualifiedName: "mod.cloneA", body: CLONE_A },
+    { nodeId: "n2", qualifiedName: "mod.cloneB", body: CLONE_B },
+    { nodeId: "n3", qualifiedName: "mod.hardNeg", body: HARD_NEG },
+  ];
+  for (const e of entries) {
+    run1.add(e);
+    run2.add(e);
+  }
+  const c1 = run1.findCandidates();
+  const c2 = run2.findCandidates();
+  assert.equal(c1.length, c2.length);
+  for (let i = 0; i < c1.length; i++) {
+    assert.equal(c1[i]!.aNodeId, c2[i]!.aNodeId);
+    assert.equal(c1[i]!.bNodeId, c2[i]!.bNodeId);
+    assert.equal(c1[i]!.jaccard, c2[i]!.jaccard);
+  }
+});
+
+test("MinHash: true-clone fixtures MUST pair as candidates", () => {
+  const hasher = createMinHasher();
+  hasher.add({ nodeId: "n1", qualifiedName: "mod.cloneA", body: CLONE_A });
+  hasher.add({ nodeId: "n2", qualifiedName: "mod.cloneB", body: CLONE_B });
+  hasher.add({ nodeId: "n3", qualifiedName: "mod.hardNeg", body: HARD_NEG });
+  const candidates = hasher.findCandidates();
+  // The clone pair must appear in the candidate set.
+  const clonePair = candidates.find(
+    (c) =>
+      (c.aNodeId === "n1" && c.bNodeId === "n2") ||
+      (c.aNodeId === "n2" && c.bNodeId === "n1"),
+  );
+  assert.ok(clonePair, "true-clone fixtures must be LSH candidates");
+  assert.ok(clonePair!.jaccard > 0.3, `clone Jaccard should be high, got ${clonePair!.jaccard}`);
+});
+
+test("MinHash: hard-negative fixtures must NOT pair as candidates", () => {
+  const hasher = createMinHasher();
+  hasher.add({ nodeId: "n1", qualifiedName: "mod.cloneA", body: CLONE_A });
+  hasher.add({ nodeId: "n3", qualifiedName: "mod.hardNeg", body: HARD_NEG });
+  const candidates = hasher.findCandidates();
+  const hardPair = candidates.find(
+    (c) =>
+      (c.aNodeId === "n1" && c.bNodeId === "n3") ||
+      (c.aNodeId === "n3" && c.bNodeId === "n1"),
+  );
+  // The hard negative must NOT be a candidate (or if it is, Jaccard must
+  // be low enough that the cosine/SIMILAR_TO gate rejects it).
+  if (hardPair) {
+    assert.ok(
+      hardPair.jaccard < 0.5,
+      `hard-negative Jaccard must be low, got ${hardPair.jaccard}`,
+    );
+  }
+  // Direct Jaccard estimate for clarity.
+  const direct = estimateJaccard(CLONE_A, HARD_NEG);
+  assert.ok(direct < 0.4, `clone vs hard-negative Jaccard should be < 0.4, got ${direct}`);
+});
+
+test("MinHash: estimateJaccard is symmetric and bounded [0,1]", () => {
+  const j1 = estimateJaccard(CLONE_A, CLONE_B);
+  const j2 = estimateJaccard(CLONE_B, CLONE_A);
+  assert.equal(j1, j2, "Jaccard must be symmetric");
+  assert.ok(j1 >= 0 && j1 <= 1);
+  assert.ok(j1 > 0.3, `clone Jaccard > 0.3 expected, got ${j1}`);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Rule 35 spirit: cosine boundary
+// ──────────────────────────────────────────────────────────────────────────
+
+test("cosineSimilarity: identical vectors → 1.0, orthogonal → 0.0", () => {
+  const v = new Float32Array([1, 0, 0]);
+  assert.equal(cosineSimilarity(v, v), 1.0);
+  const w = new Float32Array([0, 1, 0]);
+  assert.equal(cosineSimilarity(v, w), 0.0);
+});
+
+test("cosineSimilarity: boundary ≥ threshold confirms (decided once)", () => {
+  // Two vectors at exactly cosine 0.92 should confirm (≥, not >).
+  // Construct a pair at exactly the default threshold.
+  const a = new Float32Array([1, 0]);
+  // cos(a, b) = b[0] / |b|. For cos = 0.92: b = [0.92, sqrt(1-0.92^2)].
+  const cos = 0.92;
+  const b = new Float32Array([cos, Math.sqrt(1 - cos * cos)]);
+  const actual = cosineSimilarity(a, b);
+  assert.ok(Math.abs(actual - cos) < 1e-6, `cosine should be ~0.92, got ${actual}`);
+  // The similarity pipeline uses >= threshold (CONFIRM_OPERATOR), so at
+  // exactly threshold it confirms. The similarity.test.ts covers the
+  // full pipeline; here we verify the primitive.
+  assert.ok(actual >= 0.92, "at exactly 0.92, >= confirms");
+});
+
+test("cosineSimilarity: zero-norm vector → 0 (no NaN)", () => {
+  const zero = new Float32Array([0, 0, 0]);
+  const v = new Float32Array([1, 2, 3]);
+  assert.equal(cosineSimilarity(zero, v), 0);
+  assert.equal(cosineSimilarity(v, zero), 0);
+  assert.ok(Number.isFinite(cosineSimilarity(zero, zero)));
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Seeds are frozen named constants (rule 38)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("MINHASH_SEEDS: frozen, named, deterministic", () => {
+  assert.equal(MINHASH_SEEDS.length, MINHASH_NUM_PERMUTATIONS);
+  assert.ok(Object.isFrozen(MINHASH_SEEDS));
+  // Same seed values every run (determinism).
+  const first = MINHASH_SEEDS[0]!;
+  const tenth = MINHASH_SEEDS[10]!;
+  assert.ok(typeof first === "bigint");
+  assert.ok(first > 0n);
+  assert.ok(tenth > 0n);
+  assert.notEqual(first, tenth);
+});
+
+test("LSH banding: bands * rows = permutations", () => {
+  assert.equal(LSH_NUM_BANDS * LSH_ROWS_PER_BAND, MINHASH_NUM_PERMUTATIONS);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tokenizer/shingle unit tests
+// ──────────────────────────────────────────────────────────────────────────
+
+test("tokenizeForShingling: lowercase + split on non-alphanumeric", () => {
+  assert.deepEqual(tokenizeForShingling("Hello, World! 42"), ["hello", "world", "42"]);
+  assert.deepEqual(tokenizeForShingling("foo_bar baz"), ["foo_bar", "baz"]);
+});
+
+test("shingleSet: width-2 shingles, deduped", () => {
+  const tokens = ["a", "b", "c", "d", "a", "b", "c"];
+  const shingles = shingleSet(tokens);
+  // width-2 shingles: "a b", "b c", "c d", "d a", "a b" (dup), "b c" (dup) → 4 unique
+  assert.ok(shingles.size >= 3);
+  assert.ok(shingles.has("a b"));
+  assert.ok(shingles.has("b c"));
+});

--- a/packages/coding-graph/src/semantic/minhash.ts
+++ b/packages/coding-graph/src/semantic/minhash.ts
@@ -171,6 +171,11 @@ export class MinHasher {
     if (this.signatures.has(entry.nodeId)) return;
     const tokens = tokenizeForShingling(entry.body);
     const shingles = shingleSet(tokens);
+    // Skip empty bodies — they would all get the same all-max signature
+    // and flood the candidate set with false pairs
+    // (chatgpt-codex-connector: 'Keep empty bodies out of shared MinHash
+    // buckets').
+    if (shingles.size === 0) return;
     const sig = minHashSignature(shingles);
     this.signatures.set(entry.nodeId, sig);
     this.qnames.set(entry.nodeId, entry.qualifiedName);

--- a/packages/coding-graph/src/semantic/minhash.ts
+++ b/packages/coding-graph/src/semantic/minhash.ts
@@ -1,0 +1,256 @@
+/**
+ * MinHash / LSH candidate generation for SIMILAR_TO near-clone detection
+ * (issue #1556).
+ *
+ * Design (per the issue): token-shingle MinHash/LSH over normalized symbol
+ * bodies (pure TS, deterministic given fixed seeds). This produces a
+ * candidate-pair set cheaply; the cosine-confirmation layer (similarity.ts)
+ * then filters candidates by embedding cosine ≥ threshold.
+ *
+ * Rule 38 — determinism. The seeds are NAMED CONSTANTS (not module-private
+ * state, not `Date.now()`/`Math.random()`). Two runs over the same fixture
+ * repo produce an identical candidate set. The determinism test asserts
+ * this byte-for-byte.
+ *
+ * Rule 11 — no module-level mutable state. The hash tables live on the
+ * MinHasher instance returned by `createMinHasher()`, never at module
+ * scope. Two indexers in one process are fully isolated.
+ */
+import { createHash } from "node:crypto";
+
+import { LSH_NUM_BANDS, LSH_ROWS_PER_BAND, MINHASH_NUM_PERMUTATIONS, MINHASH_SHINGLE_WIDTH } from "./config.js";
+
+/**
+ * Fixed, named 64-bit seeds for the MinHash permutations. These are the
+ * ONLY source of randomness in the candidate pipeline. Changing them
+ * changes every candidate set, so they are frozen constants — the
+ * determinism test pins their exact values.
+ *
+ * Generated as `sha256("remnic:minhash:seed:N").slice(0,16)` interpreted
+ * as a big-endian u64. Using a hash-of-a-string keeps them reproducible
+ * (no magic-looking literals) while still being arbitrary fixed values.
+ */
+function seedFor(index: number): bigint {
+  const hex = createHash("sha256")
+    .update(`remnic:minhash:seed:${index}`, "utf8")
+    .digest("hex")
+    .slice(0, 16);
+  return BigInt(`0x${hex}`);
+}
+
+export const MINHASH_SEEDS: readonly bigint[] = Object.freeze(
+  Array.from({ length: MINHASH_NUM_PERMUTATIONS }, (_, i) => seedFor(i)),
+);
+
+/**
+ * A 64-bit MurmurHash3 x64 finalizer — fast, well-distributed, and
+ * deterministic. Used as the base hash; MinHash permutations are
+ * (a*x + b) mod Mersenne over this base.
+ */
+function hash64(data: string): bigint {
+  const buf = createHash("sha256").update(data, "utf8").digest();
+  // Read the first 8 bytes as big-endian u64 — sha256 is already a strong
+  // mixing function, so we skip the MurmurHash3 body and use sha256 as
+  // the universal hash. Determinism is the only hard requirement; speed
+  // is secondary (the candidate set is small after LSH banding).
+  let h = 0n;
+  for (let i = 0; i < 8; i++) {
+    h = (h << 8n) | BigInt(buf[i]!);
+  }
+  return h;
+}
+
+// 2^61 - 1, a Mersenne prime — the MinHash modulus.
+const MINHASH_MODULUS = (1n << 61n) - 1n;
+
+/**
+ * Normalize symbol body text into a token stream for shingling.
+ *
+ * Normalization:
+ *   - lowercase (case-insensitive clone detection — `MyFunc` vs `myfunc`)
+ *   - split on non-alphanumeric (identifiers, numbers, operators become tokens)
+ *   - drop empty tokens
+ *
+ * This is deliberately coarse: the goal is Jaccard over token sets, not
+ * semantic parsing. A renamed variable changes exactly one token per
+ * occurrence, so Jaccard stays high for genuine clones.
+ */
+export function tokenizeForShingling(body: string): string[] {
+  return body
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Build the set of shingles (n-grams of width MINHASH_SHINGLE_WIDTH) from
+ * a token stream. Returns a Set so duplicate shingles collapse (Jaccard
+ * is over the SET of shingles, not a multiset).
+ */
+export function shingleSet(tokens: readonly string[]): Set<string> {
+  if (tokens.length < MINHASH_SHINGLE_WIDTH) {
+    // Too few tokens for a full shingle — use the whole token sequence as
+    // a single shingle so short symbols still participate.
+    return new Set(tokens.length > 0 ? [tokens.join(" ")] : []);
+  }
+  const out = new Set<string>();
+  for (let i = 0; i <= tokens.length - MINHASH_SHINGLE_WIDTH; i++) {
+    out.add(tokens.slice(i, i + MINHASH_SHINGLE_WIDTH).join(" "));
+  }
+  return out;
+}
+
+/**
+ * Compute the MinHash signature (array of permutation minima) for a set
+ * of shingles. Signature length = MINHASH_NUM_PERMUTATIONS. The estimated
+ * Jaccard similarity between two signatures is the fraction of matching
+ * positions.
+ */
+export function minHashSignature(shingles: Set<string>): bigint[] {
+  const sig: bigint[] = [];
+  if (shingles.size === 0) {
+    // Empty body → max-value signature so it never collides with anything.
+    for (let i = 0; i < MINHASH_NUM_PERMUTATIONS; i++) sig.push(MINHASH_MODULUS);
+    return sig;
+  }
+  const shingleArr = Array.from(shingles);
+  for (let p = 0; p < MINHASH_NUM_PERMUTATIONS; p++) {
+    const a = MINHASH_SEEDS[p]!;
+    const b = MINHASH_SEEDS[(p * 2 + 1) % MINHASH_SEEDS.length]!;
+    let min = MINHASH_MODULUS;
+    for (const s of shingleArr) {
+      const h = (a * hash64(s) + b) % MINHASH_MODULUS;
+      if (h < min) min = h;
+    }
+    sig.push(min);
+  }
+  return sig;
+}
+
+/**
+ * LSH band key — the concatenation of one band's rows from the signature.
+ * Two signatures that share at least one band key are a candidate pair.
+ */
+export function lshBandKeys(signature: readonly bigint[]): string[] {
+  const keys: string[] = [];
+  for (let b = 0; b < LSH_NUM_BANDS; b++) {
+    const start = b * LSH_ROWS_PER_BAND;
+    const end = start + LSH_ROWS_PER_BAND;
+    keys.push(signature.slice(start, end).map((v) => v.toString(16)).join("|"));
+  }
+  return keys;
+}
+
+/**
+ * An indexed symbol body ready for LSH bucketing.
+ */
+export interface LshIndexEntry {
+  readonly nodeId: string;
+  readonly qualifiedName: string;
+  readonly body: string;
+}
+
+/**
+ * A MinHash/LSH indexer instance. Owns the band→node-id bucket map on the
+ * instance (rule 11). `findCandidates` returns the deduplicated candidate
+ * pair set with estimated Jaccard for each pair.
+ */
+export class MinHasher {
+  /** band key → set of node ids in that band. */
+  private readonly buckets: Map<string, Set<string>> = new Map();
+  /** node id → signature (for Jaccard estimation on candidate pairs). */
+  private readonly signatures: Map<string, bigint[]> = new Map();
+  /** node id → qualified name (for readable candidate output). */
+  private readonly qnames: Map<string, string> = new Map();
+
+  /**
+   * Add a symbol body to the LSH index. Idempotent — re-adding the same
+   * (nodeId, body) is a no-op.
+   */
+  add(entry: LshIndexEntry): void {
+    if (this.signatures.has(entry.nodeId)) return;
+    const tokens = tokenizeForShingling(entry.body);
+    const shingles = shingleSet(tokens);
+    const sig = minHashSignature(shingles);
+    this.signatures.set(entry.nodeId, sig);
+    this.qnames.set(entry.nodeId, entry.qualifiedName);
+    for (const key of lshBandKeys(sig)) {
+      let bucket = this.buckets.get(key);
+      if (!bucket) {
+        bucket = new Set();
+        this.buckets.set(key, bucket);
+      }
+      bucket.add(entry.nodeId);
+    }
+  }
+
+  /**
+   * Find all candidate pairs (pairs sharing at least one LSH band) with
+   * their estimated Jaccard similarity. Returns a stable-sorted array
+   * (by aNodeId then bNodeId) so the determinism test can compare runs
+   * byte-for-byte.
+   */
+  findCandidates(): { readonly aNodeId: string; readonly bNodeId: string; readonly aQualifiedName: string; readonly bQualifiedName: string; readonly jaccard: number }[] {
+    const pairSet = new Set<string>();
+    const pairs: { aNodeId: string; bNodeId: string; aQualifiedName: string; bQualifiedName: string; jaccard: number }[] = [];
+    for (const bucket of this.buckets.values()) {
+      if (bucket.size < 2) continue;
+      const ids = Array.from(bucket).sort();
+      for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+          const a = ids[i]!;
+          const b = ids[j]!;
+          const key = `${a}\0${b}`;
+          if (pairSet.has(key)) continue;
+          pairSet.add(key);
+          const sigA = this.signatures.get(a)!;
+          const sigB = this.signatures.get(b)!;
+          let matches = 0;
+          for (let k = 0; k < sigA.length; k++) {
+            if (sigA[k] === sigB[k]) matches++;
+          }
+          pairs.push({
+            aNodeId: a,
+            bNodeId: b,
+            aQualifiedName: this.qnames.get(a) ?? a,
+            bQualifiedName: this.qnames.get(b) ?? b,
+            jaccard: matches / sigA.length,
+          });
+        }
+      }
+    }
+    pairs.sort((x, y) => {
+      if (x.aNodeId !== y.aNodeId) return x.aNodeId < y.aNodeId ? -1 : 1;
+      return x.bNodeId < y.bNodeId ? -1 : x.bNodeId > y.bNodeId ? 1 : 0;
+    });
+    return pairs;
+  }
+}
+
+/**
+ * Construct a fresh MinHasher (rule 11 — state on the instance).
+ */
+export function createMinHasher(): MinHasher {
+  return new MinHasher();
+}
+
+/**
+ * Cosine similarity between two equal-length float vectors. Returns 0 for
+ * zero-norm vectors (no division-by-zero). This is the brute-force
+ * retrieval primitive shared by SIMILAR_TO confirmation and semantic_query.
+ */
+export function cosineSimilarity(a: Float32Array | number[], b: Float32Array | number[]): number {
+  const len = Math.min(a.length, b.length);
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < len; i++) {
+    const av = a[i]!;
+    const bv = b[i]!;
+    dot += av * bv;
+    normA += av * av;
+    normB += bv * bv;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -102,6 +102,7 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
       nodeId: r.nodeId,
       qualifiedName: r.qualifiedName,
       filePath: r.filePath,
+      kind: r.kind,
       dims: r.dims,
       score: cosineSimilarity(queryF32, r.vector),
     }))
@@ -115,7 +116,12 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
     const neighbors = store.readNeighborsByNodeId(h.nodeId);
     let snippet = "";
     try {
-      const snippetResult = await store.snippetFor({ qualifiedName: h.qualifiedName });
+      // Hydrate by the exact node id from the vector row, not the
+      // qualified name — a name duplicated across files would otherwise
+      // hit 'ambiguous_name' and leave the snippet empty even though the
+      // vector row identified the precise node (chatgpt-codex-connector
+      // P2: 'Hydrate snippets by node id as well').
+      const snippetResult = await store.snippetFor({ nodeId: h.nodeId });
       if (snippetResult.ok) snippet = snippetResult.text;
     } catch {
       // snippetFor returns tagged failures, not throws — this is defensive.
@@ -123,7 +129,7 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
     hits.push({
       qualifiedName: h.qualifiedName,
       filePath: h.filePath,
-      kind: "",
+      kind: h.kind,
       score: h.score,
       snippet,
       callers: neighbors.callers,

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -134,7 +134,7 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
       // hit 'ambiguous_name' and leave the snippet empty even though the
       // vector row identified the precise node (chatgpt-codex-connector
       // P2: 'Hydrate snippets by node id as well').
-      const snippetResult = await store.snippetFor({ nodeId: h.nodeId });
+      const snippetResult = await store.snippetFor({ nodeId: h.nodeId, repoRoot });
       if (snippetResult.ok) snippet = snippetResult.text;
     } catch {
       // snippetFor returns tagged failures, not throws — this is defensive.

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -58,6 +58,12 @@ export const DEFAULT_SEMANTIC_QUERY_LIMIT = 10;
  */
 export async function semanticQuery(input: SemanticQueryInput): Promise<SemanticQueryOutcome> {
   const { store, provider, repoRoot, config, query, signal } = input;
+  // Closed store is a distinct degradation (rule 34) — do not treat it as
+  // an empty vectors table that returns 'no_vectors' (cursor Bugbot:
+  // 'Closed store reports success').
+  if (store.isClosed) {
+    return { ok: false, code: "store_closed" };
+  }
   if (!config.enabled) {
     return { ok: false, code: "semantic_disabled" };
   }
@@ -97,7 +103,14 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
   }
 
   const limit = Math.max(1, input.limit ?? DEFAULT_SEMANTIC_QUERY_LIMIT);
+  // Only score vectors whose dimensionality matches the query embedding.
+  // cosineSimilarity compares over the SHORTER length, so a row from a
+  // different model size would otherwise get a misleading partial-overlap
+  // score and rank incorrectly instead of being excluded (cursor Bugbot:
+  // 'Mismatched embedding lengths scored').
+  const queryDims = queryF32.length;
   const scored = rows
+    .filter((r) => r.dims === queryDims)
     .map((r) => ({
       nodeId: r.nodeId,
       qualifiedName: r.qualifiedName,

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -12,8 +12,7 @@
  * When the provider is available but returns zero hits, `ok:true` with
  * empty hits is the honest answer.
  */
-import { readFile } from "node:fs/promises";
-import path from "node:path";
+
 
 import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
 import {
@@ -75,13 +74,14 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
     raw = await provider.embed(query, { signal, inputType: "query" });
   } catch (error) {
     if (error instanceof EmbeddingTimeoutError) {
-      return { ok: false, code: "provider_timeout", message: String(error) };
+      return { ok: false, code: "provider_timeout" };
     }
     if (error instanceof EmbeddingProviderUnavailableError) {
-      return { ok: false, code: "provider_unavailable", message: String(error) };
+      return { ok: false, code: "provider_unavailable" };
     }
     // Unknown provider error → treat as unavailable (the provider is broken).
-    return { ok: false, code: "provider_unavailable", message: error instanceof Error ? error.message : String(error) };
+    // Do NOT include the raw error message (may leak paths/stacks to clients).
+    return { ok: false, code: "provider_unavailable" };
   }
   const queryVec = normalizeHostEmbeddingVector(raw);
   if (!queryVec || queryVec.length === 0) {
@@ -112,13 +112,13 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
   // Hydrate each hit with graph context (callers/callees + snippet).
   const hits: SemanticQueryHit[] = [];
   for (const h of scored) {
-    const neighbors = store.readNeighbors(h.qualifiedName);
+    const neighbors = store.readNeighborsByNodeId(h.nodeId);
     let snippet = "";
     try {
-      const abs = path.resolve(repoRoot, h.filePath);
-      snippet = await readSnippet(abs, 0, 0);
+      const snippetResult = await store.snippetFor({ qualifiedName: h.qualifiedName });
+      if (snippetResult.ok) snippet = snippetResult.text;
     } catch {
-      snippet = "";
+      // snippetFor returns tagged failures, not throws — this is defensive.
     }
     hits.push({
       qualifiedName: h.qualifiedName,
@@ -139,9 +139,3 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
  * full source span is available via store.snippetFor; here we just want
  * enough context for the agent to orient.
  */
-async function readSnippet(absolutePath: string, startByte: number, endByte: number): Promise<string> {
-  const bytes = await readFile(absolutePath);
-  const text = bytes.toString("utf8");
-  const lines = text.split(/\r?\n/).slice(0, 20);
-  return lines.join("\n");
-}

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -1,0 +1,147 @@
+/**
+ * semantic_query — natural-language retrieval over the symbol graph
+ * (issue #1556 PR3 component).
+ *
+ * Embed the query via the host provider / EmbeddingFallback
+ * (`mode: "lookup"`), top-k symbols by cosine, hydrate each hit with
+ * graph context (defining file, direct callers/callees).
+ *
+ * Rule 34 — degradation matrix. Provider missing / timeout / malformed
+ * vector (`normalizeHostEmbeddingVector` returns null) → three distinct
+ * `{ok:false}` codes, never an empty result masquerading as "no matches".
+ * When the provider is available but returns zero hits, `ok:true` with
+ * empty hits is the honest answer.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
+import {
+  EmbeddingProviderUnavailableError,
+  EmbeddingTimeoutError,
+} from "@remnic/core/embedding-fallback";
+import { normalizeHostEmbeddingVector } from "@remnic/core/host-embedding-provider";
+
+import type { GraphStore } from "../graph-store.js";
+import type { SemanticConfig } from "./config.js";
+import { cosineSimilarity } from "./minhash.js";
+import { modelIdFor } from "./vectors.js";
+import type { SemanticQueryHit, SemanticQueryOutcome } from "./types.js";
+
+/**
+ * Input to {@link semanticQuery}.
+ */
+export interface SemanticQueryInput {
+  readonly store: GraphStore;
+  readonly provider: HostEmbeddingProvider | undefined;
+  readonly repoRoot: string;
+  readonly config: SemanticConfig;
+  readonly query: string;
+  readonly limit?: number;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Default top-k for semantic_query.
+ */
+export const DEFAULT_SEMANTIC_QUERY_LIMIT = 10;
+
+/**
+ * Run a semantic query: embed → top-k → hydrate.
+ *
+ * Degradation matrix (rule 34):
+ *   - !config.enabled              → { ok:false, code:"semantic_disabled" }
+ *   - no provider                  → { ok:false, code:"provider_unavailable" }
+ *   - provider throws timeout      → { ok:false, code:"provider_timeout" }
+ *   - provider returns null/malformed → { ok:false, code:"malformed_vector" }
+ *   - no vectors in table          → { ok:false, code:"no_vectors" }
+ *   - ok but zero hits             → { ok:true, hits:[] }
+ */
+export async function semanticQuery(input: SemanticQueryInput): Promise<SemanticQueryOutcome> {
+  const { store, provider, repoRoot, config, query, signal } = input;
+  if (!config.enabled) {
+    return { ok: false, code: "semantic_disabled" };
+  }
+  if (query.length === 0) {
+    return { ok: false, code: "invalid_query", message: "query must be non-empty" };
+  }
+  if (!provider) {
+    return { ok: false, code: "provider_unavailable" };
+  }
+
+  // Embed the query (lookup mode — short timeout budget).
+  let raw: ArrayLike<number> | null;
+  try {
+    raw = await provider.embed(query, { signal, inputType: "query" });
+  } catch (error) {
+    if (error instanceof EmbeddingTimeoutError) {
+      return { ok: false, code: "provider_timeout", message: String(error) };
+    }
+    if (error instanceof EmbeddingProviderUnavailableError) {
+      return { ok: false, code: "provider_unavailable", message: String(error) };
+    }
+    // Unknown provider error → treat as unavailable (the provider is broken).
+    return { ok: false, code: "provider_unavailable", message: error instanceof Error ? error.message : String(error) };
+  }
+  const queryVec = normalizeHostEmbeddingVector(raw);
+  if (!queryVec || queryVec.length === 0) {
+    return { ok: false, code: "malformed_vector" };
+  }
+  const queryF32 = new Float32Array(queryVec);
+
+  // Brute-force cosine over all vectors for this model.
+  const modelId = modelIdFor(provider);
+  const rows = store.readAllSymbolVectors(modelId);
+  if (rows.length === 0) {
+    return { ok: false, code: "no_vectors" };
+  }
+
+  const limit = Math.max(1, input.limit ?? DEFAULT_SEMANTIC_QUERY_LIMIT);
+  const scored = rows
+    .map((r) => ({
+      nodeId: r.nodeId,
+      qualifiedName: r.qualifiedName,
+      filePath: r.filePath,
+      dims: r.dims,
+      score: cosineSimilarity(queryF32, r.vector),
+    }))
+    .filter((r) => Number.isFinite(r.score))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  // Hydrate each hit with graph context (callers/callees + snippet).
+  const hits: SemanticQueryHit[] = [];
+  for (const h of scored) {
+    const neighbors = store.readNeighbors(h.qualifiedName);
+    let snippet = "";
+    try {
+      const abs = path.resolve(repoRoot, h.filePath);
+      snippet = await readSnippet(abs, 0, 0);
+    } catch {
+      snippet = "";
+    }
+    hits.push({
+      qualifiedName: h.qualifiedName,
+      filePath: h.filePath,
+      kind: "",
+      score: h.score,
+      snippet,
+      callers: neighbors.callers,
+      callees: neighbors.callees,
+    });
+  }
+
+  return { ok: true, hits };
+}
+
+/**
+ * Read a short snippet (first ~20 lines) from a file for hydration. The
+ * full source span is available via store.snippetFor; here we just want
+ * enough context for the agent to orient.
+ */
+async function readSnippet(absolutePath: string, startByte: number, endByte: number): Promise<string> {
+  const bytes = await readFile(absolutePath);
+  const text = bytes.toString("utf8");
+  const lines = text.split(/\r?\n/).slice(0, 20);
+  return lines.join("\n");
+}

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Semantic-layer integration tests (issue #1556 steps 1–6 done-when).
+ *
+ * Covers:
+ *   - Cache-hit: unchanged symbol on reindex → zero embed calls (counting
+ *     stub provider, rule 33).
+ *   - Gate-off parity: semantic.enabled=false → zero vectors-table writes,
+ *     zero provider calls.
+ *   - Degradation matrix: provider missing / timeout / malformed vector →
+ *     three distinct {ok:false} codes (rule 34).
+ *   - SIMILAR_TO pipeline end-to-end with a stub provider.
+ *   - Budgets: maxSymbolsPerRun respected.
+ *
+ * Uses a real GraphStore backed by a temp SQLite DB + a counting stub
+ * HostEmbeddingProvider (rule 33 — signature matches the interface).
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
+
+import { GraphStore } from "../graph-store.js";
+import type { StoreFileIR } from "../graph-store.js";
+import {
+  indexSymbolVectors,
+  computeSimilarTo,
+  similarEdgesToEdgeIR,
+  semanticQuery,
+  resolveSemanticConfig,
+  type SemanticConfig,
+} from "./index.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Counting stub provider — signature matches HostEmbeddingProvider (rule 33).
+// ──────────────────────────────────────────────────────────────────────────
+
+function createCountingProvider(
+  opts: { failMode?: "timeout" | "null" | "throw" | "malformed" } = {},
+): HostEmbeddingProvider & { embedCount: number; reset(): void } {
+  let embedCount = 0;
+  const dims = 8;
+  return {
+    id: "stub-embedder",
+    model: "stub-model-v1",
+    dimensions: dims,
+    embed(text: string) {
+      embedCount += 1;
+      if (opts.failMode === "timeout") {
+        throw new (class extends Error {
+          readonly code = "ETIMEDOUT";
+        })("stub timeout");
+      }
+      if (opts.failMode === "throw") {
+        throw new Error("stub throw");
+      }
+      if (opts.failMode === "null") {
+        return null;
+      }
+      if (opts.failMode === "malformed") {
+        return [NaN, Infinity, "bad" as unknown as number] as unknown as ArrayLike<number>;
+      }
+      // Deterministic pseudo-embedding: hash the text to a fixed-size vector.
+      // Two similar texts produce similar vectors (cosine close to 1.0) so
+      // the SIMILAR_TO pipeline can confirm clones.
+      const vec = new Array<number>(dims).fill(0);
+      for (let i = 0; i < text.length; i++) {
+        vec[i % dims]! += text.charCodeAt(i)!;
+      }
+      // Normalize to unit length so cosine is meaningful.
+      const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+      return vec.map((v) => v / norm);
+    },
+    reset() {
+      embedCount = 0;
+    },
+    get embedCount2() {
+      return embedCount;
+    },
+  } as unknown as HostEmbeddingProvider & { embedCount: number; reset(): void };
+}
+
+// Fix the counting provider properly.
+function countingProvider(
+  opts: { failMode?: "timeout" | "null" | "throw" | "malformed" } = {},
+): HostEmbeddingProvider & { embedCount: number; reset(): void } {
+  let embedCount = 0;
+  const dims = 8;
+  const provider: HostEmbeddingProvider & { embedCount: number; reset(): void } = {
+    id: "stub-embedder",
+    model: "stub-model-v1",
+    dimensions: dims,
+    embedCount: 0,
+    reset() {
+      embedCount = 0;
+      provider.embedCount = 0;
+    },
+    embed(text: string) {
+      embedCount += 1;
+      provider.embedCount = embedCount;
+      if (opts.failMode === "timeout") throw new Error("stub timeout");
+      if (opts.failMode === "throw") throw new Error("stub throw");
+      if (opts.failMode === "null") return null;
+      if (opts.failMode === "malformed") {
+        return [NaN, Infinity] as unknown as ArrayLike<number>;
+      }
+      const vec = new Array<number>(dims).fill(0);
+      for (let i = 0; i < text.length; i++) {
+        vec[i % dims]! += text.charCodeAt(i)!;
+      }
+      const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+      return vec.map((v) => v / norm);
+    },
+  };
+  return provider;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+const ENABLED_CONFIG: SemanticConfig = resolveSemanticConfig({ enabled: true });
+const DISABLED_CONFIG: SemanticConfig = resolveSemanticConfig({ enabled: false });
+
+function makeFileIR(filePath: string, symbols: { name: string; qname: string; kind: string; start: number; end: number }[], content: string): StoreFileIR {
+  return {
+    path: filePath,
+    language: "typescript" as never,
+    contentHash: "0".repeat(64),
+    symbols: symbols.map((s) => ({
+      kind: s.kind as never,
+      name: s.name,
+      qualifiedName: s.qname,
+      span: { startByte: s.start, endByte: s.end },
+    })),
+    imports: [],
+    exports: [],
+    callSites: [],
+    routes: [],
+  } as unknown as StoreFileIR;
+}
+
+async function tempStore(): Promise<{ store: GraphStore; dir: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "semtest-"));
+  const dbPath = path.join(dir, "graph.db");
+  const store = await GraphStore.open({ dbPath, repoRoot: dir });
+  const cleanup = async () => {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  };
+  return { store, dir, cleanup };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cache-hit: unchanged symbol → zero embed calls on reindex (rule 37)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("cache-hit: unchanged symbol on reindex → zero embed calls", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function hello() { return 42; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "hello", qname: "mod.hello", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    // First index: embeds once.
+    const r1 = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r1.ok, true);
+    if (r1.ok) {
+      assert.equal(r1.embedded, 1);
+      assert.equal(r1.cached, 0);
+    }
+    assert.equal(provider.embedCount, 1, "first index should embed once");
+
+    // Re-index: cache hit → zero embeds.
+    provider.reset();
+    const r2 = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r2.ok, true);
+    if (r2.ok) {
+      assert.equal(r2.embedded, 0);
+      assert.equal(r2.cached, 1);
+    }
+    assert.equal(provider.embedCount, 0, "reindex should use cache — zero embeds");
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Gate-off parity: semantic disabled → zero writes, zero calls
+// ──────────────────────────────────────────────────────────────────────────
+
+test("gate-off: semantic.enabled=false → zero vectors writes, zero provider calls", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function foo() { return 1; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "foo", qname: "mod.foo", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config: DISABLED_CONFIG });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "semantic_disabled");
+    assert.equal(provider.embedCount, 0, "disabled → zero provider calls");
+    // No vectors in the table.
+    const vecs = store.readAllSymbolVectors("stub-model-v1");
+    assert.equal(vecs.length, 0, "disabled → zero vectors written");
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Degradation matrix: provider missing / timeout / malformed → distinct codes
+// ──────────────────────────────────────────────────────────────────────────
+
+test("degradation: no provider → provider_unavailable", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const r = await indexSymbolVectors({ store, provider: undefined, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "provider_unavailable");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("degradation: provider returns null → skipped, not crash", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function foo() { return 1; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "foo", qname: "mod.foo", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider({ failMode: "null" });
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.embedded, 0);
+      assert.equal(r.skipped, 1);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test("degradation: provider throws → skipped, not crash", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function foo() { return 1; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "foo", qname: "mod.foo", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider({ failMode: "throw" });
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.skipped, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("degradation: malformed vector (NaN/Infinity) → skipped", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function foo() { return 1; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "foo", qname: "mod.foo", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider({ failMode: "malformed" });
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      // normalizeHostEmbeddingVector rejects NaN/Infinity → skipped.
+      assert.equal(r.skipped, 1);
+      assert.equal(r.embedded, 0);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Budgets: maxSymbolsPerRun respected
+// ──────────────────────────────────────────────────────────────────────────
+
+test("budget: maxSymbolsPerRun=2 limits embedding to 2 symbols", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function a() { return 1; }\nfunction b() { return 2; }\nfunction c() { return 3; }\nfunction d() { return 4; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "a", qname: "mod.a", kind: "function", start: 0, end: 24 },
+      { name: "b", qname: "mod.b", kind: "function", start: 25, end: 50 },
+      { name: "c", qname: "mod.c", kind: "function", start: 51, end: 76 },
+      { name: "d", qname: "mod.d", kind: "function", start: 77, end: 102 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    const config = resolveSemanticConfig({ enabled: true, maxSymbolsPerRun: 2 });
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.ok(r.embedded <= 2, `should embed at most 2, got ${r.embedded}`);
+    }
+    assert.ok(provider.embedCount <= 2, `provider called at most 2 times, got ${provider.embedCount}`);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("budget: maxSymbolsPerRun=0 means unlimited", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function a() { return 1; }\nfunction b() { return 2; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "a", qname: "mod.a", kind: "function", start: 0, end: 24 },
+      { name: "b", qname: "mod.b", kind: "function", start: 25, end: 50 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.embedded, 2, "unlimited budget embeds all");
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// SIMILAR_TO pipeline end-to-end
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: computeSimilarTo with gate-off returns semantic_disabled", () => {
+  const r = computeSimilarTo({ store: null as never, provider: undefined, config: DISABLED_CONFIG });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.code, "semantic_disabled");
+});
+
+test("SIMILAR_TO: similarEdgesToEdgeIR maps to EdgeIR with semantic provenance", () => {
+  const edges = similarEdgesToEdgeIR([
+    { srcQualifiedName: "mod.a", dstQualifiedName: "mod.b", confidence: 0.95, confirmed: true },
+  ]);
+  assert.equal(edges.length, 1);
+  assert.equal(edges[0]!.type, "SIMILAR_TO");
+  assert.equal(edges[0]!.provenance, "semantic");
+  assert.equal(edges[0]!.confidence, 0.95);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// semantic_query degradation matrix
+// ──────────────────────────────────────────────────────────────────────────
+
+test("semanticQuery: disabled → semantic_disabled", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const r = await semanticQuery({ store, provider: undefined, repoRoot: dir, config: DISABLED_CONFIG, query: "test" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "semantic_disabled");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("semanticQuery: no provider → provider_unavailable", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const r = await semanticQuery({ store, provider: undefined, repoRoot: dir, config: ENABLED_CONFIG, query: "test" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "provider_unavailable");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("semanticQuery: empty query → invalid_query", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const provider = countingProvider();
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "invalid_query");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("semanticQuery: no vectors in table → no_vectors", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const provider = countingProvider();
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "test" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "no_vectors");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("semanticQuery: with vectors → returns ranked hits", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function greet(name) { return "hello " + name; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "greet", qname: "mod.greet", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "greet function" });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.ok(r.hits.length >= 1);
+      assert.equal(r.hits[0]!.qualifiedName, "mod.greet");
+      assert.ok(r.hits[0]!.score > 0);
+    }
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -31,6 +31,8 @@ import {
   similarEdgesToEdgeIR,
   semanticQuery,
   resolveSemanticConfig,
+  DEFAULT_SIMILAR_TO_THRESHOLD,
+  DEFAULT_MAX_SYMBOLS_PER_RUN,
   type SemanticConfig,
 } from "./index.js";
 
@@ -917,3 +919,92 @@ test("writeSymbolVector: returns false on a closed store (write dropped)", async
   await cleanup();
 });
 
+
+// ──────────────────────────────────────────────────────────────────────────
+// coerceHostBool fails CLOSED: unrecognized enabled strings are an opt-out,
+// not an opt-in, so a malformed host value can never silently enable remote
+// embedding (cursor Bugbot: 'Unknown enabled strings enable semantic').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("config: unknown enabled strings fail closed to false", () => {
+  // Explicit affirmatives still enable.
+  assert.equal(resolveSemanticConfig({ enabled: "on" as never }).enabled, true);
+  assert.equal(resolveSemanticConfig({ enabled: "yes" as never }).enabled, true);
+  assert.equal(resolveSemanticConfig({ enabled: "true" as never }).enabled, true);
+  // Unrecognized / opt-out wording must NOT enable (fail closed).
+  assert.equal(resolveSemanticConfig({ enabled: "disabled" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "off" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "maybe" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "enabled" as never }).enabled, false);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Host numeric config is coerced: a malformed string ("abc") must not become
+// NaN and silently disable the vector budget (NaN > 0 is false → unlimited)
+// or the cosine gate. It falls through to the documented default instead
+// (chatgpt-codex-connector: 'Validate host numeric config before clamping').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("config: malformed host numbers fall back to default (no NaN)", () => {
+  const cfg = resolveSemanticConfig({
+    enabled: true,
+    maxSymbolsPerRun: "abc" as never,
+    similarToThreshold: "xyz" as never,
+  });
+  assert.equal(Number.isNaN(cfg.maxSymbolsPerRun), false, "maxSymbolsPerRun must not be NaN");
+  assert.equal(Number.isNaN(cfg.similarToThreshold), false, "similarToThreshold must not be NaN");
+  // Falls through to the documented defaults.
+  assert.equal(cfg.maxSymbolsPerRun, DEFAULT_MAX_SYMBOLS_PER_RUN);
+  assert.equal(cfg.similarToThreshold, DEFAULT_SIMILAR_TO_THRESHOLD);
+  // A valid numeric string is still honored.
+  const cfg2 = resolveSemanticConfig({ enabled: true, maxSymbolsPerRun: "5" as never });
+  assert.equal(cfg2.maxSymbolsPerRun, 5);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cache hits still work when the provider does not declare dimensions
+// (optional). The dims gate is skipped, so re-indexing an unchanged symbol
+// uses the cache instead of re-embedding every run (cursor Bugbot: 'Cache
+// misses without provider dimensions').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("cache-hit: provider without dimensions still caches on reindex", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = `function cached() { return 1; }`;
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "cached", qname: "mod.cached", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    // Provider that does NOT declare `dimensions` (the field is optional).
+    let calls = 0;
+    const provider = {
+      id: "nodims-embedder",
+      model: "nodims-model",
+      async embed() {
+        calls += 1;
+        return [1, 0, 0, 0, 0, 0, 0, 0];
+      },
+    } as unknown as HostEmbeddingProvider;
+
+    const r1 = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r1.ok, true);
+    if (r1.ok) {
+      assert.equal(r1.embedded, 1);
+      assert.equal(r1.cached, 0);
+    }
+    assert.equal(calls, 1, "first index embeds once");
+
+    const r2 = await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r2.ok, true);
+    if (r2.ok) {
+      assert.equal(r2.embedded, 0);
+      assert.equal(r2.cached, 1);
+    }
+    assert.equal(calls, 1, "reindex must hit cache — no second embed");
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -441,3 +441,177 @@ test("semanticQuery: with vectors → returns ranked hits", async () => {
     await cleanup();
   }
 });
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// Budget applies to embed WORK, not the candidate list — a bounded run
+// must make progress across runs (cursor Bugbot + chatgpt-codex-connector
+// P2: bounded index could remain permanently incomplete).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("budget: bounded run makes progress across runs (not stuck on cached prefix)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "function a() { return 1; }\nfunction b() { return 2; }\nfunction c() { return 3; }\nfunction d() { return 4; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "a", qname: "mod.a", kind: "function", start: 0, end: 24 },
+      { name: "b", qname: "mod.b", kind: "function", start: 25, end: 50 },
+      { name: "c", qname: "mod.c", kind: "function", start: 51, end: 76 },
+      { name: "d", qname: "mod.d", kind: "function", start: 77, end: 102 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    const config = resolveSemanticConfig({ enabled: true, maxSymbolsPerRun: 2 });
+
+    // Run 1: embeds the first 2 (a, b).
+    const r1 = await indexSymbolVectors({ store, provider, repoRoot: dir, config });
+    assert.equal(r1.ok, true);
+    if (r1.ok) assert.equal(r1.embedded, 2, "run 1 embeds 2");
+    assert.equal(provider.embedCount, 2);
+
+    // Run 2: a, b are cached (no embed); c, d are now embedded. Before the
+    // fix this re-sliced the same alphabetical prefix and embedded 0 new
+    // symbols every run.
+    const r2 = await indexSymbolVectors({ store, provider, repoRoot: dir, config });
+    assert.equal(r2.ok, true);
+    if (r2.ok) {
+      assert.equal(r2.embedded, 2, "run 2 embeds the NEXT 2 (progress)");
+      assert.equal(r2.cached, 2, "run 2 skips the 2 already-cached symbols");
+    }
+    assert.equal(provider.embedCount, 4, "4 total embeds across the two runs");
+
+    // Run 3: everything cached — zero new embeds.
+    provider.reset();
+    const r3 = await indexSymbolVectors({ store, provider, repoRoot: dir, config });
+    if (r3.ok) assert.equal(r3.embedded, 0, "run 3: all cached, no new embeds");
+    assert.equal(provider.embedCount, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// computeSimilarTo refuses to guess when it has neither bodies nor a
+// repoRoot — silent qname-MinHashing would miss real clones (chatgpt-
+// codex-connector P2: 'Require source bodies before MinHashing').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: no bodies and no repoRoot → repo_root_unset (not silent qname MinHash)", () => {
+  const r = computeSimilarTo({ store: null as never, provider: undefined, config: ENABLED_CONFIG });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.code, "repo_root_unset");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// clearSemanticSimilarToEdges: recompute replace semantics — stale
+// SIMILAR_TO edges are removed while non-semantic edges survive
+// (chatgpt-codex-connector P2: 'Replace old SIMILAR_TO edges on recompute').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: clearSemanticSimilarToEdges removes only semantic SIMILAR_TO edges", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "function f() { return 1; }\nfunction g() { return 2; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "f", qname: "mod.f", kind: "function", start: 0, end: 23 },
+      { name: "g", qname: "mod.g", kind: "function", start: 24, end: 47 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    // Seed a semantic SIMILAR_TO edge AND a structural CALLS edge f→g.
+    await store.upsertEdges([
+      { srcQualifiedName: "mod.f", dstQualifiedName: "mod.g", type: "SIMILAR_TO", confidence: 0.93, provenance: "semantic" },
+      { srcQualifiedName: "mod.f", dstQualifiedName: "mod.g", type: "CALLS", confidence: 1, provenance: "heuristic" },
+    ]);
+
+    const beforeSimilar = store.traverse({ start: "mod.f", edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.equal(beforeSimilar.ok, true);
+    if (beforeSimilar.ok) {
+      assert.ok(beforeSimilar.hits.some((h) => h.qualifiedName === "mod.g"), "SIMILAR_TO edge present before clear");
+    }
+
+    await store.clearSemanticSimilarToEdges();
+
+    const afterSimilar = store.traverse({ start: "mod.f", edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.equal(afterSimilar.ok, true);
+    if (afterSimilar.ok) {
+      assert.ok(!afterSimilar.hits.some((h) => h.qualifiedName === "mod.g"), "SIMILAR_TO edge gone after clear");
+    }
+    // The structural CALLS edge survives.
+    const afterCalls = store.traverse({ start: "mod.f", edgeTypes: ["CALLS"], maxDepth: 1 });
+    assert.equal(afterCalls.ok, true);
+    if (afterCalls.ok) {
+      assert.ok(afterCalls.hits.some((h) => h.qualifiedName === "mod.g"), "CALLS edge preserved");
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// semantic_query: hit.kind is the node label, not empty (cursor Bugbot:
+// 'Query hits omit symbol kind').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("semanticQuery: hits carry the symbol kind", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "function greet(name) { return 'hi ' + name; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "greet", qname: "mod.greet", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "greet" });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.ok(r.hits.length >= 1);
+      assert.equal(r.hits[0]!.kind, "function", "hit.kind should be the node label, not empty");
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// semantic_query: snippet hydrates by node id, so a qualified name
+// duplicated across files still resolves the exact node's snippet
+// (chatgpt-codex-connector P2: 'Hydrate snippets by node id as well').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("semanticQuery: duplicate qualified name still hydrates a snippet (by node id)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const srcA = "function dup() { return 1; }";
+    const srcB = "function dup() { return 2; }";
+    await writeFile(path.join(dir, "a.ts"), srcA);
+    await writeFile(path.join(dir, "b.ts"), srcB);
+    await store.upsertFileBatch([
+      makeFileIR("a.ts", [{ name: "dup", qname: "mod.dup", kind: "function", start: 0, end: srcA.length }], srcA),
+      makeFileIR("b.ts", [{ name: "dup", qname: "mod.dup", kind: "function", start: 0, end: srcB.length }], srcB),
+    ]);
+
+    const provider = countingProvider();
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "dup" });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      // Both nodes share qname "mod.dup" but distinct node ids; hydrating
+      // by node id must yield a real snippet for at least one hit (the old
+      // qname path returned 'ambiguous_name' and left every snippet empty).
+      const withSnippet = r.hits.filter((h) => h.snippet.length > 0);
+      assert.ok(withSnippet.length >= 1, "at least one hit should carry a snippet despite the duplicate name");
+    }
+  } finally {
+    await cleanup();
+  }
+});
+

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -844,3 +844,76 @@ test("SIMILAR_TO: bodyless declarations yield no MinHash candidates", async () =
   }
 });
 
+// ──────────────────────────────────────────────────────────────────────────
+// Host-provided enabled is coerced — "false"/"0" must not become truthy
+// and silently enable vector indexing (chatgpt-codex-connector: 'Coerce
+// host enabled before trusting it').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("config: host enabled string 'false'/'0' coerce to false (not truthy)", () => {
+  assert.equal(resolveSemanticConfig({ enabled: "false" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "0" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "no" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "" as never }).enabled, false);
+  assert.equal(resolveSemanticConfig({ enabled: "true" as never }).enabled, true);
+  assert.equal(resolveSemanticConfig({ enabled: true }).enabled, true);
+  assert.equal(resolveSemanticConfig({ enabled: false }).enabled, false);
+  // Absent host value still falls through to env/default (false).
+  assert.equal(resolveSemanticConfig({}).enabled, false);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// snippetFor honors a query-level repoRoot override, so a store opened
+// without repoRoot can still hydrate snippets when the caller supplies one
+// (chatgpt-codex-connector + cursor: 'Snippet hydration ignores query
+// repoRoot').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("snippetFor: query repoRoot overrides a store opened without repoRoot", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "semroot-"));
+  const dbPath = path.join(dir, "graph.db");
+  const store = await GraphStore.open({ dbPath }); // NO repoRoot
+  try {
+    const src = "function greet(name) { return 'hi ' + name; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "greet", qname: "mod.greet", kind: "function", start: 0, end: src.length },
+    ], src);
+    await store.upsertFileBatch([ir]);
+    const nodeId = nodeIdFor({ qualifiedName: "mod.greet", filePath: "a.ts", label: "function" });
+
+    // No override → store has no repoRoot → repo_root_unset.
+    const noRoot = await store.snippetFor({ nodeId });
+    assert.equal(noRoot.ok, false);
+    if (!noRoot.ok) assert.equal(noRoot.code, "repo_root_unset");
+
+    // Override supplied → snippet resolves from the caller's repoRoot.
+    const withRoot = await store.snippetFor({ nodeId, repoRoot: dir });
+    assert.equal(withRoot.ok, true);
+    if (withRoot.ok) assert.ok(withRoot.text.includes("greet"), "snippet hydrates from the query repoRoot");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// writeSymbolVector reports whether it persisted (returns false on a
+// closed store) so the indexer does not count dropped writes as embedded
+// (cursor Bugbot: 'Embedded count after dropped writes').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("writeSymbolVector: returns false on a closed store (write dropped)", async () => {
+  const { store, cleanup } = await tempStore();
+  await store.close();
+  const persisted = await store.writeSymbolVector({
+    nodeId: "deadbeef",
+    modelId: "m",
+    contentHash: "h".repeat(64),
+    dims: 8,
+    vector: new Float32Array(8),
+  });
+  assert.equal(persisted, false, "closed store must report the write as not persisted");
+  await cleanup();
+});
+

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -46,7 +46,7 @@ function createCountingProvider(
     id: "stub-embedder",
     model: "stub-model-v1",
     dimensions: dims,
-    embed(text: string) {
+    async embed(text: string) {
       embedCount += 1;
       if (opts.failMode === "timeout") {
         throw new (class extends Error {
@@ -97,7 +97,7 @@ function countingProvider(
       embedCount = 0;
       provider.embedCount = 0;
     },
-    embed(text: string) {
+    async embed(text: string) {
       embedCount += 1;
       provider.embedCount = embedCount;
       if (opts.failMode === "timeout") throw new Error("stub timeout");

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -22,10 +22,11 @@ import test from "node:test";
 
 import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
 
-import { GraphStore } from "../graph-store.js";
+import { GraphStore, nodeIdFor } from "../graph-store.js";
 import type { StoreFileIR } from "../graph-store.js";
 import {
   indexSymbolVectors,
+  modelIdFor,
   computeSimilarTo,
   similarEdgesToEdgeIR,
   semanticQuery,
@@ -613,5 +614,109 @@ test("semanticQuery: duplicate qualified name still hydrates a snippet (by node 
   } finally {
     await cleanup();
   }
+});
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// MinHash-only edges are the documented NO-PROVIDER fallback. When a
+// provider IS configured, a pair missing a vector is skipped (await
+// cosine confirmation) instead of bypassing it with a MinHash-only edge
+// (cursor Bugbot: 'MinHash edges with provider set').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: provider set + missing vectors → no MinHash-only bypass", () => {
+  const body = "function compute(x, y) { const z = x + y; return z * 2 + x - y; }";
+  const bodies = new Map<string, { readonly qualifiedName: string; readonly body: string }>([
+    ["n1", { qualifiedName: "mod.a", body }],
+    ["n2", { qualifiedName: "mod.b", body }],
+  ]);
+
+  // Provider configured, no vectors → must NOT emit MinHash-only edges.
+  const withProvider = computeSimilarTo({
+    store: null as never,
+    provider: countingProvider(),
+    config: ENABLED_CONFIG,
+    bodies,
+    vectors: new Map<string, Float32Array>(),
+  });
+  assert.equal(withProvider.ok, true);
+  if (withProvider.ok) {
+    assert.equal(withProvider.minhashOnly, 0, "provider active → no MinHash-only bypass");
+    assert.equal(withProvider.edges.length, 0, "no edges when vectors missing and provider active");
+  }
+
+  // No provider → MinHash-only edges are the documented local fallback.
+  const noProvider = computeSimilarTo({
+    store: null as never,
+    provider: undefined,
+    config: ENABLED_CONFIG,
+    bodies,
+  });
+  assert.equal(noProvider.ok, true);
+  if (noProvider.ok) {
+    assert.ok(noProvider.minhashOnly >= 1, "no provider → MinHash-only edges emitted");
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Mismatched-dimensionality vectors are excluded from ranking. cosine over
+// the shorter length would otherwise give a misleading partial score to a
+// row from a different model size (cursor Bugbot: 'Mismatched embedding
+// lengths scored').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("semanticQuery: mismatched-dims vectors are excluded from ranking", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "function a() { return 1; }\nfunction b() { return 2; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "a", qname: "mod.a", kind: "function", start: 0, end: 23 },
+      { name: "b", qname: "mod.b", kind: "function", start: 24, end: 47 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider();
+    const modelId = modelIdFor(provider);
+    const idA = nodeIdFor({ qualifiedName: "mod.a", filePath: "a.ts", label: "function" });
+    const idB = nodeIdFor({ qualifiedName: "mod.b", filePath: "a.ts", label: "function" });
+    // a: dims=8 (matches the query provider); b: dims=4 (mismatched → excluded).
+    store.writeSymbolVector({ nodeId: idA, modelId, contentHash: "h".repeat(64), dims: 8, vector: new Float32Array(8) });
+    store.writeSymbolVector({ nodeId: idB, modelId, contentHash: "h".repeat(64), dims: 4, vector: new Float32Array(4) });
+
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "a" });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      const names = r.hits.map((h) => h.qualifiedName);
+      assert.ok(names.includes("mod.a"), "matching-dims hit included");
+      assert.ok(!names.includes("mod.b"), "mismatched-dims hit excluded");
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Closed store is a distinct degradation code (rule 34), not an empty
+// graph that returns ok:true / no_vectors (cursor Bugbot: 'Closed store
+// reports success').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("closed store: indexSymbolVectors returns store_closed (not ok with zeros)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  await store.close();
+  const r = await indexSymbolVectors({ store, provider: countingProvider(), repoRoot: dir, config: ENABLED_CONFIG });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.code, "store_closed");
+  await cleanup();
+});
+
+test("closed store: semanticQuery returns store_closed (not no_vectors)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  await store.close();
+  const r = await semanticQuery({ store, provider: countingProvider(), repoRoot: dir, config: ENABLED_CONFIG, query: "x" });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.code, "store_closed");
+  await cleanup();
 });
 

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -624,37 +624,42 @@ test("semanticQuery: duplicate qualified name still hydrates a snippet (by node 
 // (cursor Bugbot: 'MinHash edges with provider set').
 // ──────────────────────────────────────────────────────────────────────────
 
-test("SIMILAR_TO: provider set + missing vectors → no MinHash-only bypass", () => {
-  const body = "function compute(x, y) { const z = x + y; return z * 2 + x - y; }";
-  const bodies = new Map<string, { readonly qualifiedName: string; readonly body: string }>([
-    ["n1", { qualifiedName: "mod.a", body }],
-    ["n2", { qualifiedName: "mod.b", body }],
-  ]);
+test("SIMILAR_TO: provider set + missing vectors → no MinHash-only bypass", async () => {
+  const { store, cleanup } = await tempStore();
+  try {
+    const body = "function compute(x, y) { const z = x + y; return z * 2 + x - y; }";
+    const bodies = new Map<string, { readonly qualifiedName: string; readonly body: string }>([
+      ["n1", { qualifiedName: "mod.a", body }],
+      ["n2", { qualifiedName: "mod.b", body }],
+    ]);
 
-  // Provider configured, no vectors → must NOT emit MinHash-only edges.
-  const withProvider = computeSimilarTo({
-    store: null as never,
-    provider: countingProvider(),
-    config: ENABLED_CONFIG,
-    bodies,
-    vectors: new Map<string, Float32Array>(),
-  });
-  assert.equal(withProvider.ok, true);
-  if (withProvider.ok) {
-    assert.equal(withProvider.minhashOnly, 0, "provider active → no MinHash-only bypass");
-    assert.equal(withProvider.edges.length, 0, "no edges when vectors missing and provider active");
-  }
+    // Provider configured, no vectors → must NOT emit MinHash-only edges.
+    const withProvider = computeSimilarTo({
+      store,
+      provider: countingProvider(),
+      config: ENABLED_CONFIG,
+      bodies,
+      vectors: new Map<string, Float32Array>(),
+    });
+    assert.equal(withProvider.ok, true);
+    if (withProvider.ok) {
+      assert.equal(withProvider.minhashOnly, 0, "provider active → no MinHash-only bypass");
+      assert.equal(withProvider.edges.length, 0, "no edges when vectors missing and provider active");
+    }
 
-  // No provider → MinHash-only edges are the documented local fallback.
-  const noProvider = computeSimilarTo({
-    store: null as never,
-    provider: undefined,
-    config: ENABLED_CONFIG,
-    bodies,
-  });
-  assert.equal(noProvider.ok, true);
-  if (noProvider.ok) {
-    assert.ok(noProvider.minhashOnly >= 1, "no provider → MinHash-only edges emitted");
+    // No provider → MinHash-only edges are the documented local fallback.
+    const noProvider = computeSimilarTo({
+      store,
+      provider: undefined,
+      config: ENABLED_CONFIG,
+      bodies,
+    });
+    assert.equal(noProvider.ok, true);
+    if (noProvider.ok) {
+      assert.ok(noProvider.minhashOnly >= 1, "no provider → MinHash-only edges emitted");
+    }
+  } finally {
+    await cleanup();
   }
 });
 
@@ -681,8 +686,8 @@ test("semanticQuery: mismatched-dims vectors are excluded from ranking", async (
     const idA = nodeIdFor({ qualifiedName: "mod.a", filePath: "a.ts", label: "function" });
     const idB = nodeIdFor({ qualifiedName: "mod.b", filePath: "a.ts", label: "function" });
     // a: dims=8 (matches the query provider); b: dims=4 (mismatched → excluded).
-    store.writeSymbolVector({ nodeId: idA, modelId, contentHash: "h".repeat(64), dims: 8, vector: new Float32Array(8) });
-    store.writeSymbolVector({ nodeId: idB, modelId, contentHash: "h".repeat(64), dims: 4, vector: new Float32Array(4) });
+    await store.writeSymbolVector({ nodeId: idA, modelId, contentHash: "h".repeat(64), dims: 8, vector: new Float32Array(8) });
+    await store.writeSymbolVector({ nodeId: idB, modelId, contentHash: "h".repeat(64), dims: 4, vector: new Float32Array(4) });
 
     const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "a" });
     assert.equal(r.ok, true);
@@ -718,5 +723,124 @@ test("closed store: semanticQuery returns store_closed (not no_vectors)", async 
   assert.equal(r.ok, false);
   if (!r.ok) assert.equal(r.code, "store_closed");
   await cleanup();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// computeSimilarTo honors the closed store (cursor Bugbot: 'SimilarTo
+// ignores closed store').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("closed store: computeSimilarTo returns store_closed", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  await store.close();
+  const r = computeSimilarTo({
+    store,
+    provider: undefined,
+    config: ENABLED_CONFIG,
+    repoRoot: dir,
+    bodies: new Map(),
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.code, "store_closed");
+  await cleanup();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cosine confirmation requires matching dims (cursor Bugbot: 'SimilarTo
+// skips embedding length check').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: cosine confirmation skips mismatched-dims pairs", async () => {
+  const { store, cleanup } = await tempStore();
+  try {
+    const body = "function compute(x, y) { const z = x + y; return z * 2; }";
+    const bodies = new Map<string, { readonly qualifiedName: string; readonly body: string }>([
+      ["n1", { qualifiedName: "mod.a", body }],
+      ["n2", { qualifiedName: "mod.b", body }],
+    ]);
+    const vectors = new Map<string, Float32Array>([
+      ["n1", new Float32Array(8)],
+      ["n2", new Float32Array(4)], // mismatched dims
+    ]);
+    // Pair has vectors but mismatched dims → not cosine-confirmed; provider
+    // active → not MinHash-only either → no edges.
+    const r = computeSimilarTo({
+      store,
+      provider: countingProvider(),
+      config: ENABLED_CONFIG,
+      bodies,
+      vectors,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.edges.length, 0, "mismatched-dims pair must not be cosine-confirmed");
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Budget bounds provider CALLS, not successful writes — a degraded provider
+// must not bypass the cost cap (chatgpt-codex-connector: 'Count failed embed
+// attempts against the vector budget').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("budget: degraded provider cost is bounded by maxSymbolsPerRun (attempts, not successes)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "function a() { return 1; }\nfunction b() { return 2; }\nfunction c() { return 3; }\nfunction d() { return 4; }";
+    await writeFile(path.join(dir, "a.ts"), src);
+    const ir = makeFileIR("a.ts", [
+      { name: "a", qname: "mod.a", kind: "function", start: 0, end: 24 },
+      { name: "b", qname: "mod.b", kind: "function", start: 25, end: 50 },
+      { name: "c", qname: "mod.c", kind: "function", start: 51, end: 76 },
+      { name: "d", qname: "mod.d", kind: "function", start: 77, end: 102 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const provider = countingProvider({ failMode: "throw" });
+    const config = resolveSemanticConfig({ enabled: true, maxSymbolsPerRun: 2 });
+    const r = await indexSymbolVectors({ store, provider, repoRoot: dir, config });
+    assert.equal(r.ok, true);
+    // Every embed throws → zero successes, but the provider must NOT be
+    // called for all four nodes. Before the fix, `embedded` never reached
+    // the limit (all throws) so the loop called the provider for every
+    // remaining node, bypassing the per-run cost cap.
+    assert.ok(
+      provider.embedCount <= 2,
+      `degraded provider calls must be bounded by maxSymbolsPerRun, got ${provider.embedCount}`,
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// MinHash runs over the extracted BODY only — bodyless declarations
+// (stubs/types with no body) yield no candidates instead of name-driven
+// spurious pairs (chatgpt-codex-connector: 'MinHash only the extracted
+// body text').
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: bodyless declarations yield no MinHash candidates", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = "type A = string;\ntype B = number;\ntype C = boolean;";
+    await writeFile(path.join(dir, "t.ts"), src);
+    const ir = makeFileIR("t.ts", [
+      { name: "A", qname: "mod.A", kind: "type", start: 0, end: 16 },
+      { name: "B", qname: "mod.B", kind: "type", start: 17, end: 33 },
+      { name: "C", qname: "mod.C", kind: "type", start: 34, end: 51 },
+    ], src);
+    await store.upsertFileBatch([ir]);
+
+    const r = computeSimilarTo({ store, provider: undefined, config: ENABLED_CONFIG, repoRoot: dir });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.candidates, 0, "bodyless declarations produce no MinHash candidates");
+      assert.equal(r.edges.length, 0, "no SIMILAR_TO edges from bodyless declarations");
+    }
+  } finally {
+    await cleanup();
+  }
 });
 

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -1,0 +1,200 @@
+/**
+ * SIMILAR_TO near-clone pipeline (issue #1556 PR2 component).
+ *
+ * Cheap-first, deterministic:
+ *   1. MinHash/LSH candidate generation over normalized symbol bodies.
+ *   2. Cosine confirmation by embedding ≥ threshold when vectors exist.
+ *
+ * Edges carry `provenance: "semantic"` + the similarity score as
+ * confidence. No provider → MinHash-only edges carry a distinct lower
+ * confidence band (documented), and the pipeline still runs (MinHash is
+ * local and deterministic).
+ *
+ * Rule 35 spirit: the threshold boundary (≥ vs >) is decided ONCE here
+ * (≥ threshold confirms) and documented. The boundary test pins it.
+ *
+ * Rule 38: the candidate set is a pure function of (seeds, inputs). Two
+ * runs over the same fixture produce an identical edge set.
+ */
+import type { GraphStore } from "../graph-store.js";
+import type { EdgeIR } from "../graph-store.js";
+import { buildCanonicalTextAndHash } from "./canonical-text.js";
+import {
+  MINHASH_ONLY_CONFIDENCE,
+  SEMANTIC_PROVENANCE,
+  SIMILAR_TO_EDGE_TYPE,
+} from "./config.js";
+import type { SemanticConfig } from "./config.js";
+import { cosineSimilarity, createMinHasher, tokenizeForShingling, shingleSet } from "./minhash.js";
+import type { SimilarEdge, SimilarToResult } from "./types.js";
+import type { SemanticFailure } from "./types.js";
+import { modelIdFor } from "./vectors.js";
+import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
+
+/**
+ * Input to {@link computeSimilarTo}.
+ */
+export interface SimilarToInput {
+  readonly store: GraphStore;
+  readonly provider: HostEmbeddingProvider | undefined;
+  readonly config: SemanticConfig;
+  /**
+   * Symbol bodies keyed by nodeId. The caller (the indexer or a
+   * standalone pass) reads source text and builds canonical bodies. When
+   * absent, the pipeline reads nodes from the store + disk itself.
+   */
+  readonly bodies?: ReadonlyMap<string, { readonly qualifiedName: string; readonly body: string }>;
+  /**
+   * Vectors keyed by nodeId (the persisted embedding). When absent, the
+   * pipeline reads them from the store via readAllSymbolVectors.
+   */
+  readonly vectors?: ReadonlyMap<string, Float32Array>;
+}
+
+/**
+ * The comparison operator for cosine confirmation. Decided ONCE (rule 35
+ * spirit): `>= threshold`. A pair at EXACTLY the threshold confirms. The
+ * boundary test asserts this.
+ */
+export const CONFIRM_OPERATOR = ">=" as const;
+
+/**
+ * Compute SIMILAR_TO edges.
+ *
+ * Returns the edges (for the caller to persist via store.upsertEdges) plus
+ * counts. The caller persists; this function is pure over its inputs
+ * (rule 38 — deterministic given seeds + bodies + vectors).
+ *
+ * When `config.enabled` is false → tagged semantic_disabled (no work, no
+ * candidate generation — gate-off parity).
+ */
+export function computeSimilarTo(input: SimilarToInput): SimilarToResult | SemanticFailure {
+  const { store, provider, config } = input;
+  if (!config.enabled) {
+    return { ok: false, code: "semantic_disabled" };
+  }
+
+  const bodies = input.bodies ?? readBodiesFromStore(store);
+  const modelId = provider ? modelIdFor(provider) : undefined;
+  const vectors = input.vectors ?? (modelId ? readVectorsMap(store, modelId) : new Map<string, Float32Array>());
+
+  // Pass 1: MinHash/LSH candidates.
+  const hasher = createMinHasher();
+  for (const [nodeId, entry] of bodies) {
+    hasher.add({ nodeId, qualifiedName: entry.qualifiedName, body: entry.body });
+  }
+  const candidates = hasher.findCandidates();
+
+  // Pass 2: cosine confirmation.
+  const edges: SimilarEdge[] = [];
+  let confirmed = 0;
+  let minhashOnly = 0;
+  for (const c of candidates) {
+    const va = vectors.get(c.aNodeId);
+    const vb = vectors.get(c.bNodeId);
+    if (va && vb) {
+      const cos = cosineSimilarity(va, vb);
+      // rule 35: >= threshold confirms (decided once, here).
+      if (cos >= config.similarToThreshold) {
+        edges.push({
+          srcQualifiedName: c.aQualifiedName,
+          dstQualifiedName: c.bQualifiedName,
+          confidence: cos,
+          confirmed: true,
+        });
+        confirmed += 1;
+      }
+    } else {
+      // MinHash-only: no vectors for one or both nodes. Distinct lower
+      // confidence band (documented). The Jaccard estimate gates this so
+      // structurally-similar-but-unrelated pairs do not flood.
+      if (c.jaccard >= config.similarToThreshold) {
+        edges.push({
+          srcQualifiedName: c.aQualifiedName,
+          dstQualifiedName: c.bQualifiedName,
+          confidence: MINHASH_ONLY_CONFIDENCE,
+          confirmed: false,
+        });
+        minhashOnly += 1;
+      }
+    }
+  }
+
+  // Stable sort: by confidence desc, then src qname, then dst qname.
+  edges.sort((a, b) => {
+    if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+    if (a.srcQualifiedName !== b.srcQualifiedName) return a.srcQualifiedName < b.srcQualifiedName ? -1 : 1;
+    return a.dstQualifiedName < b.dstQualifiedName ? -1 : a.dstQualifiedName > b.dstQualifiedName ? 1 : 0;
+  });
+
+  return { ok: true, edges, candidates: candidates.length, confirmed, minhashOnly };
+}
+
+/**
+ * Convert SimilarEdge[] to the store's EdgeIR[] for persistence via
+ * upsertEdges. Provenance is always "semantic"; type is SIMILAR_TO.
+ */
+export function similarEdgesToEdgeIR(edges: readonly SimilarEdge[]): EdgeIR[] {
+  return edges.map((e) => ({
+    srcQualifiedName: e.srcQualifiedName,
+    dstQualifiedName: e.dstQualifiedName,
+    type: SIMILAR_TO_EDGE_TYPE,
+    confidence: e.confidence,
+    provenance: SEMANTIC_PROVENANCE,
+  }));
+}
+
+/**
+ * Read canonical bodies for every persisted node from the store + disk.
+ * Used when the caller does not supply pre-built bodies. Returns a map
+ * keyed by nodeId with the canonical body text (the MinHash input).
+ *
+ * Note: this reads from disk synchronously per node, so callers that
+ * already have bodies in memory should pass them via `input.bodies`.
+ */
+function readBodiesFromStore(store: GraphStore): Map<string, { readonly qualifiedName: string; readonly body: string }> {
+  const out = new Map<string, { readonly qualifiedName: string; readonly body: string }>();
+  for (const node of store.readNodesForSemantic()) {
+    // Build a body from the qualified name + kind tokens when disk is not
+    // reachable (the canonical-body text for MinHash only needs the token
+    // stream, not the full source — the indexer path supplies real bodies).
+    const { text } = buildCanonicalTextAndHash({
+      symbol: {
+        kind: node.kind as never,
+        name: node.qualifiedName.split(/[.#:]/).pop() ?? node.qualifiedName,
+        qualifiedName: node.qualifiedName,
+        span: { startByte: node.startByte, endByte: node.endByte },
+      },
+      rawText: node.qualifiedName,
+      maxBodyLines: 0,
+    });
+    out.set(node.nodeId, { qualifiedName: node.qualifiedName, body: text });
+  }
+  return out;
+}
+
+/**
+ * Read the vectors table into a nodeId → Float32Array map for cosine
+ * confirmation. Uses the model id derived from the provider.
+ */
+function readVectorsMap(store: GraphStore, modelId: string): Map<string, Float32Array> {
+  const out = new Map<string, Float32Array>();
+  for (const row of store.readAllSymbolVectors(modelId)) {
+    out.set(row.nodeId, row.vector);
+  }
+  return out;
+}
+
+/**
+ * Estimate Jaccard similarity between two bodies directly (no LSH). Used
+ * by the hard-negative test to assert two bodies are NOT similar.
+ */
+export function estimateJaccard(bodyA: string, bodyB: string): number {
+  const sa = shingleSet(tokenizeForShingling(bodyA));
+  const sb = shingleSet(tokenizeForShingling(bodyB));
+  if (sa.size === 0 && sb.size === 0) return 1;
+  let inter = 0;
+  for (const s of sa) if (sb.has(s)) inter += 1;
+  const union = sa.size + sb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -21,7 +21,7 @@ import path from "node:path";
 const fs = { readFileSync: fsReadFileSync };
 import type { GraphStore } from "../graph-store.js";
 import type { EdgeIR } from "../graph-store.js";
-import { buildCanonicalTextAndHash } from "./canonical-text.js";
+import { extractBodyText } from "./canonical-text.js";
 import {
   MINHASH_ONLY_CONFIDENCE,
   SEMANTIC_PROVENANCE,
@@ -104,6 +104,13 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
       message: "computeSimilarTo needs either 'bodies' or 'repoRoot' to read source text",
     };
   }
+  // Closed store is a distinct degradation (rule 34) — readNodesForSemantic
+  // would return [] and we would report { ok: true, edges: [] } instead of
+  // the documented store_closed code used by the other entry points (cursor
+  // Bugbot: 'SimilarTo ignores closed store').
+  if (store.isClosed) {
+    return { ok: false, code: "store_closed" };
+  }
   const bodies = input.bodies ?? readBodiesFromStore(store, input.repoRoot);
   const modelId = provider ? modelIdFor(provider) : undefined;
   const vectors = input.vectors ?? (modelId ? readVectorsMap(store, modelId) : new Map<string, Float32Array>());
@@ -122,7 +129,12 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
   for (const c of candidates) {
     const va = vectors.get(c.aNodeId);
     const vb = vectors.get(c.bNodeId);
-    if (va && vb) {
+    if (va && vb && va.length === vb.length) {
+      // Require matching dimensionality — cosineSimilarity compares over the
+      // shorter length, so mismatched-dims rows would get a misleading
+      // partial-overlap score (cursor Bugbot: 'SimilarTo skips embedding
+      // length check'). Pairs that fail this fall through to the no-provider
+      // MinHash-only branch or are skipped.
       const cos = cosineSimilarity(va, vb);
       // rule 35: >= threshold confirms (decided once, here).
       if (cos >= config.similarToThreshold) {
@@ -204,22 +216,15 @@ function readBodiesFromStore(store: GraphStore, repoRoot?: string): Map<string, 
       } catch {
         // File not readable — body stays empty, symbol is skipped by MinHasher.
       }
-    } else {
-      // No repoRoot — fall back to qualified name tokens so the pipeline
-      // still runs (useful for tests that supply bodies explicitly).
-      rawText = node.qualifiedName;
     }
-    const { text } = buildCanonicalTextAndHash({
-      symbol: {
-        kind: node.kind as never,
-        name: node.qualifiedName.split(/[.#:]/).pop() ?? node.qualifiedName,
-        qualifiedName: node.qualifiedName,
-        span: { startByte: node.startByte, endByte: node.endByte },
-      },
-      rawText,
-      maxBodyLines: 0,
-    });
-    out.set(node.nodeId, { qualifiedName: node.qualifiedName, body: text });
+    // MinHash the extracted BODY only, not the full canonical text. The
+    // canonical form includes KIND/QNAME/SIG metadata; tokenizing it would
+    // let empty-body stubs/declarations emit name-driven candidates among
+    // unrelated symbols. extractBodyText returns "" for a bodyless symbol,
+    // and the hasher skips empty bodies entirely (chatgpt-codex-connector:
+    // 'MinHash only the extracted body text').
+    const body = extractBodyText(rawText, 0);
+    out.set(node.nodeId, { qualifiedName: node.qualifiedName, body });
   }
   return out;
 }

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -91,6 +91,19 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
     return { ok: false, code: "semantic_disabled" };
   }
 
+  // Without pre-built bodies AND without a repoRoot, the only available
+  // text is the qualified name, which MinHashes name similarity rather
+  // than body similarity — real copy-paste clones with different names
+  // are silently missed. Refuse to guess: require one of the two so the
+  // pipeline always MinHashes actual symbol bodies (chatgpt-codex-
+  // connector P2: 'Require source bodies before MinHashing').
+  if (!input.bodies && !input.repoRoot) {
+    return {
+      ok: false,
+      code: "repo_root_unset",
+      message: "computeSimilarTo needs either 'bodies' or 'repoRoot' to read source text",
+    };
+  }
   const bodies = input.bodies ?? readBodiesFromStore(store, input.repoRoot);
   const modelId = provider ? modelIdFor(provider) : undefined;
   const vectors = input.vectors ?? (modelId ? readVectorsMap(store, modelId) : new Map<string, Float32Array>());

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -16,6 +16,9 @@
  * Rule 38: the candidate set is a pure function of (seeds, inputs). Two
  * runs over the same fixture produce an identical edge set.
  */
+import { readFileSync as fsReadFileSync } from "node:fs";
+import path from "node:path";
+const fs = { readFileSync: fsReadFileSync };
 import type { GraphStore } from "../graph-store.js";
 import type { EdgeIR } from "../graph-store.js";
 import { buildCanonicalTextAndHash } from "./canonical-text.js";
@@ -39,6 +42,11 @@ export interface SimilarToInput {
   readonly provider: HostEmbeddingProvider | undefined;
   readonly config: SemanticConfig;
   /**
+   * Repo root for reading source text from disk when bodies are not
+   * supplied. Required when bodies is absent.
+   */
+  readonly repoRoot?: string;
+  /**
    * Symbol bodies keyed by nodeId. The caller (the indexer or a
    * standalone pass) reads source text and builds canonical bodies. When
    * absent, the pipeline reads nodes from the store + disk itself.
@@ -59,6 +67,15 @@ export interface SimilarToInput {
 export const CONFIRM_OPERATOR = ">=" as const;
 
 /**
+ * Jaccard gate for MinHash-only SIMILAR_TO edges (no embedding provider).
+ * Well below the cosine similarToThreshold (0.92) because token-Jaccard
+ * for near-clone code is typically 0.3-0.8. 0.5 catches genuine
+ * copy-paste with minor renames while rejecting structurally-similar
+ * but logically-unrelated pairs.
+ */
+export const MINHASH_JACCARD_GATE = 0.5;
+
+/**
  * Compute SIMILAR_TO edges.
  *
  * Returns the edges (for the caller to persist via store.upsertEdges) plus
@@ -74,7 +91,7 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
     return { ok: false, code: "semantic_disabled" };
   }
 
-  const bodies = input.bodies ?? readBodiesFromStore(store);
+  const bodies = input.bodies ?? readBodiesFromStore(store, input.repoRoot);
   const modelId = provider ? modelIdFor(provider) : undefined;
   const vectors = input.vectors ?? (modelId ? readVectorsMap(store, modelId) : new Map<string, Float32Array>());
 
@@ -106,9 +123,12 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
       }
     } else {
       // MinHash-only: no vectors for one or both nodes. Distinct lower
-      // confidence band (documented). The Jaccard estimate gates this so
-      // structurally-similar-but-unrelated pairs do not flood.
-      if (c.jaccard >= config.similarToThreshold) {
+      // confidence band (documented). Use a Jaccard gate well below the
+      // cosine threshold — MinHash Jaccard for near-clones is typically
+      // 0.3-0.8; the cosine 0.92 gate would suppress almost all MinHash
+      // edges. The MINHASH_JACCARD_GATE is the documented floor for
+      // local (no-provider) SIMILAR_TO edges.
+      if (c.jaccard >= MINHASH_JACCARD_GATE) {
         edges.push({
           srcQualifiedName: c.aQualifiedName,
           dstQualifiedName: c.bQualifiedName,
@@ -152,12 +172,25 @@ export function similarEdgesToEdgeIR(edges: readonly SimilarEdge[]): EdgeIR[] {
  * Note: this reads from disk synchronously per node, so callers that
  * already have bodies in memory should pass them via `input.bodies`.
  */
-function readBodiesFromStore(store: GraphStore): Map<string, { readonly qualifiedName: string; readonly body: string }> {
+function readBodiesFromStore(store: GraphStore, repoRoot?: string): Map<string, { readonly qualifiedName: string; readonly body: string }> {
   const out = new Map<string, { readonly qualifiedName: string; readonly body: string }>();
   for (const node of store.readNodesForSemantic()) {
-    // Build a body from the qualified name + kind tokens when disk is not
-    // reachable (the canonical-body text for MinHash only needs the token
-    // stream, not the full source — the indexer path supplies real bodies).
+    let rawText = "";
+    if (repoRoot) {
+      try {
+        const abs = path.resolve(repoRoot, node.filePath);
+        const bytes = fs.readFileSync(abs);
+        const start = Math.max(0, node.startByte);
+        const end = Math.min(bytes.length, node.endByte);
+        if (start <= end) rawText = bytes.subarray(start, end).toString("utf8");
+      } catch {
+        // File not readable — body stays empty, symbol is skipped by MinHasher.
+      }
+    } else {
+      // No repoRoot — fall back to qualified name tokens so the pipeline
+      // still runs (useful for tests that supply bodies explicitly).
+      rawText = node.qualifiedName;
+    }
     const { text } = buildCanonicalTextAndHash({
       symbol: {
         kind: node.kind as never,
@@ -165,7 +198,7 @@ function readBodiesFromStore(store: GraphStore): Map<string, { readonly qualifie
         qualifiedName: node.qualifiedName,
         span: { startByte: node.startByte, endByte: node.endByte },
       },
-      rawText: node.qualifiedName,
+      rawText,
       maxBodyLines: 0,
     });
     out.set(node.nodeId, { qualifiedName: node.qualifiedName, body: text });

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -134,13 +134,16 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
         });
         confirmed += 1;
       }
-    } else {
-      // MinHash-only: no vectors for one or both nodes. Distinct lower
-      // confidence band (documented). Use a Jaccard gate well below the
+    } else if (!provider) {
+      // MinHash-only is the documented fallback for the NO-PROVIDER
+      // (local, deterministic) mode. When a provider IS configured we do
+      // NOT emit MinHash-only edges for pairs missing a vector — that
+      // would bypass the cosine confirmation path during partial / not-
+      // yet-indexed state. Such pairs are simply skipped; they will be
+      // cosine-confirmed once indexing completes (cursor Bugbot: 'MinHash
+      // edges with provider set'). Use a Jaccard gate well below the
       // cosine threshold — MinHash Jaccard for near-clones is typically
-      // 0.3-0.8; the cosine 0.92 gate would suppress almost all MinHash
-      // edges. The MINHASH_JACCARD_GATE is the documented floor for
-      // local (no-provider) SIMILAR_TO edges.
+      // 0.3-0.8; the MINHASH_JACCARD_GATE is the documented floor.
       if (c.jaccard >= MINHASH_JACCARD_GATE) {
         edges.push({
           srcQualifiedName: c.aQualifiedName,
@@ -151,6 +154,8 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
         minhashOnly += 1;
       }
     }
+    // else: provider configured but a vector is missing → skip (await
+    // indexing + cosine confirmation; do not bypass with MinHash-only).
   }
 
   // Stable sort: by confidence desc, then src qname, then dst qname.

--- a/packages/coding-graph/src/semantic/types.ts
+++ b/packages/coding-graph/src/semantic/types.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared types for the semantic layer (issue #1556).
+ *
+ * Tagged failures follow rule 34 — every entry point returns a
+ * discriminated union so a caller that switches on `result.code` never
+ * observes a thrown error from the semantic layer.
+ */
+
+/**
+ * A persisted symbol vector. `vector` is the float32 embedding; `dims`
+ * is its dimensionality; `modelId` identifies the provider+model that
+ * produced it (so a provider swap invalidates the cache); `contentHash`
+ * is the canonical-text hash (so a canonical-text change invalidates the
+ * cache — rule 37).
+ */
+export interface SymbolVector {
+  readonly nodeId: string;
+  readonly qualifiedName: string;
+  readonly vector: Float32Array;
+  readonly dims: number;
+  readonly modelId: string;
+  readonly contentHash: string;
+}
+
+/**
+ * A row read back from the vectors table for brute-force cosine.
+ */
+export interface SymbolVectorRow {
+  readonly nodeId: string;
+  readonly qualifiedName: string;
+  readonly vector: Float32Array;
+  readonly dims: number;
+  readonly modelId: string;
+  readonly contentHash: string;
+  readonly filePath: string;
+}
+
+/**
+ * Tagged-failure codes shared across the semantic layer.
+ *
+ * - `semantic_disabled`: the master gate is off (rule 30/48). No provider
+ *   call, no vectors-table write, no edge emitted.
+ * - `provider_unavailable`: no host embedding provider registered for the
+ *   given scope.
+ * - `provider_timeout`: the provider exceeded the lookup budget.
+ * - `malformed_vector`: `normalizeHostEmbeddingVector` returned null.
+ * - `repo_root_unset`: the store was opened without a repoRoot, so source
+ *   text cannot be read.
+ * - `store_closed`: the store is closed.
+ * - `db_error`: an underlying SQLite error.
+ * - `no_vectors`: semantic_query ran but the vectors table is empty.
+ * - `invalid_query`: malformed query input.
+ */
+export type SemanticFailureCode =
+  | "semantic_disabled"
+  | "provider_unavailable"
+  | "provider_timeout"
+  | "malformed_vector"
+  | "repo_root_unset"
+  | "store_closed"
+  | "db_error"
+  | "no_vectors"
+  | "invalid_query";
+
+export interface SemanticFailure {
+  readonly ok: false;
+  readonly code: SemanticFailureCode;
+  readonly message?: string;
+}
+
+/**
+ * Result of indexing vectors for a batch of symbols.
+ */
+export interface IndexVectorsResult {
+  readonly ok: true;
+  readonly embedded: number;
+  readonly cached: number;
+  readonly skipped: number;
+}
+
+/**
+ * A SIMILAR_TO candidate pair from the MinHash/LSH pass.
+ */
+export interface SimilarCandidate {
+  readonly aNodeId: string;
+  readonly bNodeId: string;
+  readonly aQualifiedName: string;
+  readonly bQualifiedName: string;
+  readonly jaccard: number;
+}
+
+/**
+ * A confirmed SIMILAR_TO edge (after cosine confirmation when available).
+ */
+export interface SimilarEdge {
+  readonly srcQualifiedName: string;
+  readonly dstQualifiedName: string;
+  readonly confidence: number;
+  readonly confirmed: boolean;
+}
+
+/**
+ * Result of the SIMILAR_TO pipeline.
+ */
+export interface SimilarToResult {
+  readonly ok: true;
+  readonly edges: readonly SimilarEdge[];
+  readonly candidates: number;
+  readonly confirmed: number;
+  readonly minhashOnly: number;
+}
+
+/**
+ * A hydrated semantic_query hit — graph context attached so the agent
+ * gets structure, not just a snippet.
+ */
+export interface SemanticQueryHit {
+  readonly qualifiedName: string;
+  readonly filePath: string;
+  readonly kind: string;
+  readonly score: number;
+  readonly snippet: string;
+  readonly callers: readonly string[];
+  readonly callees: readonly string[];
+}
+
+/**
+ * Result of semantic_query. When degraded, `ok: true` still carries the
+ * (possibly empty) hits plus a `degraded` tag so the caller never
+ * mistakes "no matches" for "backend broken" (rule 34).
+ */
+export interface SemanticQuerySuccess {
+  readonly ok: true;
+  readonly hits: readonly SemanticQueryHit[];
+  readonly degraded?: "provider_unavailable" | "provider_timeout" | "malformed_vector";
+}
+
+export type SemanticQueryOutcome = SemanticQuerySuccess | SemanticFailure;

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -1,0 +1,172 @@
+/**
+ * Symbol-vector indexing (issue #1556 PR1 component).
+ *
+ * Reads source text from disk, builds canonical text, checks the cache
+ * (skip re-embed when content_hash matches), embeds via the host provider,
+ * and persists vectors to the `symbol_vectors` table.
+ *
+ * Rule 30/48: when `config.enabled` is false, this module returns a tagged
+ * `{ ok: false, code: "semantic_disabled" }` WITHOUT reading source,
+ * calling the provider, or writing a vector (gate-off parity test covers
+ * this). The gate is checked at this single chokepoint — callers never
+ * need to re-check.
+ *
+ * Rule 44: vectors are written only for symbols that persisted
+ * successfully. The indexer reads nodes from the store (which only
+ * contains persisted nodes), so a `parse_failed` file contributes zero
+ * nodes and thus zero vectors.
+ *
+ * Rule 37: cache invalidation. When a symbol's canonical text changes,
+ * its content_hash changes, the cached row no longer matches, and the
+ * vector is re-embedded. The old vector is overwritten (ON CONFLICT
+ * UPDATE). Any SIMILAR_TO edge derived from the old vector is recomputed
+ * by the similarity pipeline on its next run.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { HostEmbeddingProvider } from "@remnic/core/host-embedding-provider";
+import { normalizeHostEmbeddingVector } from "@remnic/core/host-embedding-provider";
+
+import type { GraphStore } from "../graph-store.js";
+import { buildCanonicalTextAndHash } from "./canonical-text.js";
+import type { SemanticConfig } from "./config.js";
+import type { IndexVectorsResult, SemanticFailure } from "./types.js";
+
+/**
+ * Input to {@link indexSymbolVectors}. The store provides node metadata +
+ * the vectors table; the provider embeds; repoRoot resolves file paths.
+ */
+export interface IndexVectorsInput {
+  readonly store: GraphStore;
+  readonly provider: HostEmbeddingProvider | undefined;
+  readonly repoRoot: string;
+  readonly config: SemanticConfig;
+  /**
+   * Optional abort signal forwarded to the provider. The indexer does not
+   * impose its own timeout (the provider's embed() contract handles that).
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * The model id used for cache keying. Derives from the provider's `model`
+ * (falling back to `id`) so a provider/model swap produces a distinct
+ * cache namespace and does not overwrite the prior vectors.
+ */
+export function modelIdFor(provider: HostEmbeddingProvider): string {
+  return provider.model ?? provider.id;
+}
+
+/**
+ * Index symbol vectors for every persisted node in the store.
+ *
+ * Flow:
+ *   1. Gate: if !config.enabled → tagged semantic_disabled (no work).
+ *   2. Provider check: if no provider → tagged provider_unavailable.
+ *   3. Read all nodes from the store (persisted only — rule 44).
+ *   4. For each node (within maxSymbolsPerRun budget):
+ *      a. Read source text from disk.
+ *      b. Build canonical text + hash.
+ *      c. Cache check: skip if cached row's content_hash matches.
+ *      d. Embed via provider.
+ *      e. Normalize (reject malformed → counted as skipped).
+ *      f. Persist vector.
+ *   5. Return counts.
+ *
+ * Budget order (rule 27): recently-changed symbols first. The store's
+ * readNodesForSemantic returns nodes ordered by qualified_name; the
+ * indexer applies the caller-supplied priority before slicing. When no
+ * priority is given, all nodes are eligible (budget 0 = unlimited).
+ */
+export async function indexSymbolVectors(
+  input: IndexVectorsInput,
+): Promise<IndexVectorsResult | SemanticFailure> {
+  const { store, provider, repoRoot, config, signal } = input;
+
+  // Rule 30/48 + rule 39: single gate chokepoint.
+  if (!config.enabled) {
+    return { ok: false, code: "semantic_disabled" };
+  }
+  if (!provider) {
+    return { ok: false, code: "provider_unavailable" };
+  }
+
+  const modelId = modelIdFor(provider);
+  const nodes = store.readNodesForSemantic();
+  const budget = config.maxSymbolsPerRun > 0 ? config.maxSymbolsPerRun : nodes.length;
+  // rule 27: guard slice(-n) for n=0. budget is already ≥ 0 here, but
+  // maxSymbolsPerRun=0 means unlimited (all nodes), not "zero nodes".
+  const eligible = nodes.slice(0, budget);
+
+  let embedded = 0;
+  let cached = 0;
+  let skipped = 0;
+
+  for (const node of eligible) {
+    if (signal?.aborted) break;
+    // Read source text from disk.
+    const absolutePath = path.resolve(repoRoot, node.filePath);
+    let bytes: Buffer;
+    try {
+      bytes = await readFile(absolutePath);
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    const start = Math.max(0, node.startByte);
+    const end = Math.min(bytes.length, node.endByte);
+    if (start > end) {
+      skipped += 1;
+      continue;
+    }
+    const rawText = bytes.subarray(start, end).toString("utf8");
+
+    // Canonical text + hash (rule 23/37).
+    const { hash } = buildCanonicalTextAndHash({
+      symbol: {
+        kind: node.kind as never,
+        name: node.qualifiedName.split(/[.#:]/).pop() ?? node.qualifiedName,
+        qualifiedName: node.qualifiedName,
+        span: { startByte: node.startByte, endByte: node.endByte },
+      },
+      rawText,
+      maxBodyLines: config.canonicalBodyLines,
+    });
+
+    // Cache check: skip re-embed when content_hash matches.
+    const cachedRow = store.readSymbolVector(node.nodeId, modelId);
+    if (cachedRow && cachedRow.contentHash === hash) {
+      cached += 1;
+      continue;
+    }
+
+    // Embed via provider.
+    let raw: ArrayLike<number> | null;
+    try {
+      raw = await provider.embed(rawText, {
+        signal,
+        inputType: "document",
+      });
+    } catch {
+      skipped += 1;
+      continue;
+    }
+    const vec = normalizeHostEmbeddingVector(raw);
+    if (!vec || vec.length === 0) {
+      skipped += 1;
+      continue;
+    }
+    const float32 = new Float32Array(vec);
+    store.writeSymbolVector({
+      nodeId: node.nodeId,
+      modelId,
+      contentHash: hash,
+      dims: float32.length,
+      vector: float32,
+    });
+    embedded += 1;
+  }
+
+  return { ok: true, embedded, cached, skipped };
+}

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -157,9 +157,17 @@ export async function indexSymbolVectors(
       maxBodyLines: config.canonicalBodyLines,
     });
 
-    // Cache check: skip re-embed when content_hash matches.
+    // Cache check: skip re-embed when content_hash matches AND the stored
+    // dims still equal the active provider's declared dimensions. A model
+    // that keeps the same model_id but changes vector size would otherwise
+    // leave stale-dimensionality rows cached (cursor Bugbot: 'Cache ignores
+    // embedding dimension changes').
     const cachedRow = store.readSymbolVector(node.nodeId, modelId);
-    if (cachedRow && cachedRow.contentHash === hash) {
+    if (
+      cachedRow &&
+      cachedRow.contentHash === hash &&
+      cachedRow.dims === provider.dimensions
+    ) {
       cached += 1;
       continue;
     }
@@ -195,14 +203,22 @@ export async function indexSymbolVectors(
       continue;
     }
     const float32 = new Float32Array(vec);
-    await store.writeSymbolVector({
+    // Only count a persisted embed — writeSymbolVector returns false (and
+    // is a no-op) when the store is closing/closed, so progress reporting
+    // must not claim an embedding that was dropped (cursor Bugbot: 'Embedded
+    // count after dropped writes').
+    const persisted = await store.writeSymbolVector({
       nodeId: node.nodeId,
       modelId,
       contentHash: hash,
       dims: float32.length,
       vector: float32,
     });
-    embedded += 1;
+    if (persisted) {
+      embedded += 1;
+    } else {
+      skipped += 1;
+    }
   }
 
   return { ok: true, embedded, cached, skipped };

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -161,12 +161,15 @@ export async function indexSymbolVectors(
     // dims still equal the active provider's declared dimensions. A model
     // that keeps the same model_id but changes vector size would otherwise
     // leave stale-dimensionality rows cached (cursor Bugbot: 'Cache ignores
-    // embedding dimension changes').
+    // embedding dimension changes'). When the provider does not declare
+    // dimensions (optional), the dims gate is skipped so caching still
+    // works instead of re-embedding every run (cursor Bugbot: 'Cache misses
+    // without provider dimensions').
     const cachedRow = store.readSymbolVector(node.nodeId, modelId);
     if (
       cachedRow &&
       cachedRow.contentHash === hash &&
-      cachedRow.dims === provider.dimensions
+      (provider.dimensions === undefined || cachedRow.dims === provider.dimensions)
     ) {
       cached += 1;
       continue;

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -116,13 +116,17 @@ export async function indexSymbolVectors(
   let embedded = 0;
   let cached = 0;
   let skipped = 0;
+  // Budget bounds provider CALLS (cost), not successful writes. A degraded
+  // provider that throws / returns null / returns a malformed vector for
+  // many uncached symbols must not bypass the per-run cost cap by never
+  // incrementing `embedded` (chatgpt-codex-connector: 'Count failed embed
+  // attempts against the vector budget'). Cached rows do not consume
+  // budget (no provider call); source-read failures do not either.
+  let embedAttempts = 0;
 
   for (const node of nodes) {
     if (signal?.aborted) break;
-    // Stop once this run has embedded `limit` symbols (0 = unlimited).
-    // Cached rows do NOT consume budget — they `continue` below before
-    // any embed call, so a bounded run still makes forward progress.
-    if (limit > 0 && embedded >= limit) break;
+    if (limit > 0 && embedAttempts >= limit) break;
     // Read source text from disk.
     const absolutePath = path.resolve(repoRoot, node.filePath);
     let bytes: Buffer;
@@ -160,6 +164,9 @@ export async function indexSymbolVectors(
       continue;
     }
 
+    // Count the embed attempt (cost) BEFORE the call, regardless of
+    // outcome, so a failed/null/malformed result still consumes budget.
+    embedAttempts += 1;
     // Embed the CANONICAL text (not the raw span) so the vector
     // corresponds to the content_hash that gates cache hits (rule 23).
     // This also respects canonicalBodyLines as a cost/privacy bound.
@@ -174,7 +181,7 @@ export async function indexSymbolVectors(
       // different content_hash and we cannot re-embed, delete the stale
       // row so semantic_query/cosine confirmation do not serve it.
       if (cachedRow && cachedRow.contentHash !== hash) {
-        store.deleteSymbolVectors([node.nodeId]);
+        await store.deleteSymbolVectors([node.nodeId]);
       }
       skipped += 1;
       continue;
@@ -182,13 +189,13 @@ export async function indexSymbolVectors(
     const vec = normalizeHostEmbeddingVector(raw);
     if (!vec || vec.length === 0) {
       if (cachedRow && cachedRow.contentHash !== hash) {
-        store.deleteSymbolVectors([node.nodeId]);
+        await store.deleteSymbolVectors([node.nodeId]);
       }
       skipped += 1;
       continue;
     }
     const float32 = new Float32Array(vec);
-    store.writeSymbolVector({
+    await store.writeSymbolVector({
       nodeId: node.nodeId,
       modelId,
       contentHash: hash,

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -84,6 +84,13 @@ export async function indexSymbolVectors(
 ): Promise<IndexVectorsResult | SemanticFailure> {
   const { store, provider, repoRoot, config, signal } = input;
 
+  // Closed store is a distinct degradation (rule 34) — do not treat it as
+  // an empty graph that returns { ok: true } with zero counts (cursor
+  // Bugbot: 'Closed store reports success').
+  if (store.isClosed) {
+    return { ok: false, code: "store_closed" };
+  }
+
   // Rule 30/48 + rule 39: single gate chokepoint.
   if (!config.enabled) {
     return { ok: false, code: "semantic_disabled" };

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -94,17 +94,28 @@ export async function indexSymbolVectors(
 
   const modelId = modelIdFor(provider);
   const nodes = store.readNodesForSemantic();
-  const budget = config.maxSymbolsPerRun > 0 ? config.maxSymbolsPerRun : nodes.length;
-  // rule 27: guard slice(-n) for n=0. budget is already ≥ 0 here, but
-  // maxSymbolsPerRun=0 means unlimited (all nodes), not "zero nodes".
-  const eligible = nodes.slice(0, budget);
+  // Budget applies to EMBED WORK, not the candidate list. Slicing the
+  // full node list (ordered by qualified_name) BEFORE the cache check
+  // meant a bounded run kept re-visiting the cached alphabetical prefix
+  // and never reached uncached or changed symbols later in the list, so
+  // a bounded semantic index could remain permanently incomplete. Now
+  // every node gets a cache check and only a successful embed consumes
+  // budget, so progress accumulates across runs until every symbol is
+  // embedded (cursor Bugbot: 'Embedding budget uses alphabetical order';
+  // chatgpt-codex-connector P2: 'Apply vector budget after skipping
+  // cached rows'). maxSymbolsPerRun=0 means unlimited.
+  const limit = config.maxSymbolsPerRun;
 
   let embedded = 0;
   let cached = 0;
   let skipped = 0;
 
-  for (const node of eligible) {
+  for (const node of nodes) {
     if (signal?.aborted) break;
+    // Stop once this run has embedded `limit` symbols (0 = unlimited).
+    // Cached rows do NOT consume budget — they `continue` below before
+    // any embed call, so a bounded run still makes forward progress.
+    if (limit > 0 && embedded >= limit) break;
     // Read source text from disk.
     const absolutePath = path.resolve(repoRoot, node.filePath);
     let bytes: Buffer;

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -122,8 +122,9 @@ export async function indexSymbolVectors(
     }
     const rawText = bytes.subarray(start, end).toString("utf8");
 
-    // Canonical text + hash (rule 23/37).
-    const { hash } = buildCanonicalTextAndHash({
+    // Canonical text + hash (rule 23/37). The embedded string MUST equal
+    // the hashed string (rule 23 — one form everywhere).
+    const { text: canonicalText, hash } = buildCanonicalTextAndHash({
       symbol: {
         kind: node.kind as never,
         name: node.qualifiedName.split(/[.#:]/).pop() ?? node.qualifiedName,
@@ -141,19 +142,30 @@ export async function indexSymbolVectors(
       continue;
     }
 
-    // Embed via provider.
+    // Embed the CANONICAL text (not the raw span) so the vector
+    // corresponds to the content_hash that gates cache hits (rule 23).
+    // This also respects canonicalBodyLines as a cost/privacy bound.
     let raw: ArrayLike<number> | null;
     try {
-      raw = await provider.embed(rawText, {
+      raw = await provider.embed(canonicalText, {
         signal,
         inputType: "document",
       });
     } catch {
+      // Stale vector cleanup (rule 37): if a prior vector exists with a
+      // different content_hash and we cannot re-embed, delete the stale
+      // row so semantic_query/cosine confirmation do not serve it.
+      if (cachedRow && cachedRow.contentHash !== hash) {
+        store.deleteSymbolVectors([node.nodeId]);
+      }
       skipped += 1;
       continue;
     }
     const vec = normalizeHostEmbeddingVector(raw);
     if (!vec || vec.length === 0) {
+      if (cachedRow && cachedRow.contentHash !== hash) {
+        store.deleteSymbolVectors([node.nodeId]);
+      }
       skipped += 1;
       continue;
     }


### PR DESCRIPTION
## Summary

Implements the optional semantic layer for `@remnic/coding-graph` (issue #1556, Track B Phase 3).

**Components:**
- **Canonical-text builder** (`canonical-text.ts`): ONE form (rule 23/38) — punctuation + whitespace normalization so formatting variants hash identically. The embedded string equals the hashed string. Body token-budget truncation.
- **`symbol_vectors` table** (additive to graph-schema v1): float32 BLOB vectors keyed by `(node_id, model_id)` with `content_hash` (the cache invalidation key, rule 37). CASCADE on `nodes(id)`.
- **MinHash/LSH** (`minhash.ts`): deterministic candidate generation over token-shingled symbol bodies (fixed named seeds, rule 38). Width-2 token shingles for clone-detection recall.
- **SIMILAR_TO pipeline** (`similarity.ts`): MinHash candidates → cosine confirmation `≥ similarToThreshold` (default 0.92). MinHash-only edges carry a distinct lower confidence band when no provider is available.
- **`indexSymbolVectors`** (`vectors.ts`): embed → cache-check → persist. Cache-hit skips re-embed when content_hash matches (rule 37).
- **`semantic_query`** (`semantic-query.ts`): embed query → brute-force cosine top-k → hydrate each hit with defining file + direct callers/callees.
- **Config** (`config.ts`): `SemanticConfig` — OFF by default (rule 30/48). Env resolver with `ENGRAM_` fallback.

**Gate-off parity** (rule 39): when `enabled = false`, zero provider calls, zero vectors-table writes. Tested end to end.

## Privacy posture (rule 55)

Default configuration sends nothing anywhere. With a remote provider configured, canonical symbol text (kind + qualified name + signature + body excerpt) leaves the machine — same path as `EmbeddingFallback`. With no provider, `SIMILAR_TO` still works via local deterministic MinHash; `semantic_query` returns tagged `{ ok: false, code: "provider_unavailable" }` — never an empty result masquerading as "no matches".

## Tests (34 total, all green)

- `canonical-text.test.ts` (8): determinism across formatting variants, hash stability, cache invalidation on rename/body-change, token-budget truncation.
- `minhash.test.ts` (11): determinism (two runs → identical candidate set), true-clone fixture MUST pair, hard-negative fixture must NOT pair, cosine boundary (≥ threshold), frozen seeds.
- `semantic.test.ts` (15): cache-hit (zero embed calls on reindex), gate-off parity, degradation matrix (null/throw/malformed/no-provider → distinct tagged codes), budget limits, `SIMILAR_TO` gate-off, `semantic_query` full pipeline with ranked hits.

## Files

- `packages/coding-graph/src/semantic/` — 8 new modules + 3 test files
- `packages/coding-graph/src/graph-schema.ts` — `symbol_vectors` table (additive)
- `packages/coding-graph/src/graph-store.ts` — vector read/write methods + `readNodesForSemantic` + `readNeighbors`
- `packages/coding-graph/src/index.ts` — semantic barrel re-export
- `packages/coding-graph/README.md` — privacy posture + API docs

## Chokepoints used / not applicable

- Builds on `@remnic/core/host-embedding-provider` (`registerHostEmbeddingProvider`/`normalizeHostEmbeddingVector`) and `embedding-fallback` error types — no new embedding stack.
- Gate at one chokepoint (`SemanticConfig.enabled`) for both index-time and query-time (rule 39).
- `#1525` validation registry: not applicable (no new MCP tools/HTTP routes in this PR; the MCP-surface issue #1554 wires `semantic_query` via the registry when it lands).

## Done-when checklist

- [x] Determinism + clone/hard-negative fixtures green
- [x] Cache-hit and invalidation tests green
- [x] Degradation matrix green
- [x] Gate-off parity green
- [x] Docs state privacy posture with implementation-backed claims
- [x] Ratchets untouched (additive only — new table, new module, no god-file changes beyond thin vector methods)
- [ ] Preflight + pre-merge-check (running now)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Optional feature is off by default, but when enabled it can send canonical symbol text to remote embedders and adds substantial graph-store write paths; integration tests mitigate regressions in caching, budgets, and degradation behavior.
> 
> **Overview**
> Introduces an **optional semantic layer** for `@remnic/coding-graph` (#1556), exported from the package and documented in the README with a clear **privacy posture** (off by default; remote embedding only when enabled and a provider is configured).
> 
> **Persistence and store API:** Adds a `symbol_vectors` table (per `node_id` + `model_id`, `content_hash`, float32 BLOB) and extends `GraphStore` with vector CRUD, semantic node/neighbor reads, scoped `SIMILAR_TO` edge clearing, and a public `isClosed` getter. **`snippetFor`** now accepts optional `nodeId` and per-query `repoRoot` so hydration works when names collide or the store was opened without a repo root.
> 
> **New `semantic/` pipeline:** `resolveSemanticConfig` (fail-closed boolean coercion, env/`ENGRAM_` fallbacks), **canonical text** (normalized signature + body excerpt, single hash for embed cache), **`indexSymbolVectors`** (content-hash cache, per-run embed budgets on attempts not successes), **`computeSimilarTo`** (body-only MinHash/LSH → cosine ≥ threshold when vectors exist; local MinHash-only when no provider), and **`semanticQuery`** (embed query, dimension-matched cosine top-k, snippets + callers/callees). Tagged outcomes include `semantic_disabled`, `provider_unavailable`, `store_closed`, and related codes instead of silent empty results.
> 
> **Tests** cover gate-off parity, cache hits/invalidation, budgets, closed-store behavior, and clone vs hard-negative fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc91bbcd68be146bb1c4cd1c433b7620f445b735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->