### PR TITLE
feat(provenance): surface claim-level source spans in xray + doctor (#1575 PR3)

### DIFF
--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1205,9 +1205,14 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   };
   let provenanceReadOk = true;
   try {
-    provenanceCoverage = summarizeProvenanceCoverage(
-      await storage.readAllMemories(),
-    );
+    // Include all tiers so cold-migrated and archived memories are counted
+    // (codex thread PRRT_kwDORJXyws6Ojqz8 — readAllMemories is hot-only).
+    const [hot, archived, cold] = await Promise.all([
+      storage.readAllMemories(),
+      storage.readArchivedMemories().catch(() => []),
+      storage.readAllColdMemories().catch(() => []),
+    ]);
+    provenanceCoverage = summarizeProvenanceCoverage([...hot, ...archived, ...cold]);
   } catch {
     provenanceReadOk = false;
   }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1204,24 +1204,38 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     total: 0,
   };
   let provenanceReadOk = true;
+  let provenancePartialTiers: string[] = [];
   try {
     // Include all tiers so cold-migrated and archived memories are counted
     // (codex thread PRRT_kwDORJXyws6Ojqz8 — readAllMemories is hot-only).
-    const [hot, archived, cold] = await Promise.all([
+    // Use allSettled so a real read failure (e.g. locked encrypted store)
+    // is surfaced as a partial-read warning, not silently swallowed
+    // (codex thread PRRT_kwDORJXyws6OjygQ).
+    const [hot, archived, cold] = await Promise.allSettled([
       storage.readAllMemories(),
-      storage.readArchivedMemories().catch(() => []),
-      storage.readAllColdMemories().catch(() => []),
+      storage.readArchivedMemories(),
+      storage.readAllColdMemories(),
     ]);
-    provenanceCoverage = summarizeProvenanceCoverage([...hot, ...archived, ...cold]);
+    const all: { frontmatter: { provenance?: string } }[] = [];
+    if (hot.status === "fulfilled") all.push(...hot.value);
+    else provenancePartialTiers.push("hot");
+    if (archived.status === "fulfilled") all.push(...archived.value);
+    else provenancePartialTiers.push("archived");
+    if (cold.status === "fulfilled") all.push(...cold.value);
+    else provenancePartialTiers.push("cold");
+    provenanceCoverage = summarizeProvenanceCoverage(all);
   } catch {
     provenanceReadOk = false;
   }
   const pc = provenanceCoverage.counts;
   const totalProvenance = provenanceCoverage.total;
   const provenanceCovered = pc.verified + pc.unverified;
+  const partialSuffix = provenancePartialTiers.length > 0
+    ? ` (partial: ${provenancePartialTiers.join("/")} tier unreadable)`
+    : "";
   checks.push({
     key: "provenance_coverage",
-    status: !provenanceReadOk
+    status: !provenanceReadOk || provenancePartialTiers.length > 0
       ? "warn"
       : totalProvenance === 0
         ? "warn"
@@ -1232,13 +1246,15 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
       ? "Could not read memories for provenance coverage."
       : totalProvenance === 0
         ? "No memories found yet — provenance coverage is empty."
-        : `Provenance coverage: ${pc.verified} verified, ${pc.unverified} unverified, ${pc.none} none (${totalProvenance} total).`,
+        : `Provenance coverage: ${pc.verified} verified, ${pc.unverified} unverified, ${pc.none} none (${totalProvenance} total).${partialSuffix}`,
     remediation: !provenanceReadOk
       ? undefined
-      : provenanceCovered === 0 && totalProvenance > 0
-        ? "New extractions will carry source spans. Existing legacy memories remain `none` until re-extracted."
-        : undefined,
-    details: { provenanceCounts: pc, total: totalProvenance },
+      : provenancePartialTiers.length > 0
+        ? `Some tiers could not be read (${provenancePartialTiers.join(", ")}). Check storage health and re-run.`
+        : provenanceCovered === 0 && totalProvenance > 0
+          ? "New extractions will carry source spans. Existing legacy memories remain `none` until re-extracted."
+          : undefined,
+    details: { provenanceCounts: pc, total: totalProvenance, partialTiers: provenancePartialTiers.length > 0 ? provenancePartialTiers : undefined },
   });
 
   const syncedChunkCount =

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1060,6 +1060,25 @@ async function buildOperatorConfigReviewReport(input: {
   };
 }
 
+/**
+ * Summarize the provenance coverage of a set of memories (issue #1575 PR 3).
+ * Pure function — counts the verified/unverified/none distribution so the
+ * doctor check and any future surface can consume it without coupling to the
+ * orchestrator. Legacy memories (no `provenance` field) count as `"none"`.
+ */
+export function summarizeProvenanceCoverage(
+  memories: ReadonlyArray<{ frontmatter: { provenance?: string } }>,
+): { counts: { verified: number; unverified: number; none: number }; total: number } {
+  const counts = { verified: 0, unverified: 0, none: 0 };
+  for (const mem of memories) {
+    const tag = mem.frontmatter.provenance ?? "none";
+    if (tag === "verified") counts.verified += 1;
+    else if (tag === "unverified") counts.unverified += 1;
+    else counts.none += 1;
+  }
+  return { counts, total: memories.length };
+}
+
 export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise<OperatorDoctorReport> {
   const now = options.now ?? new Date();
   const configStatus = await loadCliPluginConfig(options.configPath);
@@ -1175,6 +1194,46 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
       ? undefined
       : "Run a normal agent turn or `openclaw engram consolidate` after seeding memory.",
     details: meta,
+  });
+
+  // Provenance coverage (issue #1575 PR 3). Operators need to see the
+  // verified/unverified/none distribution grow as extraction backfills.
+  // Best-effort: a read failure surfaces as a warn, not an error.
+  let provenanceCoverage: ReturnType<typeof summarizeProvenanceCoverage> = {
+    counts: { verified: 0, unverified: 0, none: 0 },
+    total: 0,
+  };
+  let provenanceReadOk = true;
+  try {
+    provenanceCoverage = summarizeProvenanceCoverage(
+      await storage.readAllMemories(),
+    );
+  } catch {
+    provenanceReadOk = false;
+  }
+  const pc = provenanceCoverage.counts;
+  const totalProvenance = provenanceCoverage.total;
+  const provenanceCovered = pc.verified + pc.unverified;
+  checks.push({
+    key: "provenance_coverage",
+    status: !provenanceReadOk
+      ? "warn"
+      : totalProvenance === 0
+        ? "warn"
+        : provenanceCovered === 0
+          ? "warn"
+          : "ok",
+    summary: !provenanceReadOk
+      ? "Could not read memories for provenance coverage."
+      : totalProvenance === 0
+        ? "No memories found yet — provenance coverage is empty."
+        : `Provenance coverage: ${pc.verified} verified, ${pc.unverified} unverified, ${pc.none} none (${totalProvenance} total).`,
+    remediation: !provenanceReadOk
+      ? undefined
+      : provenanceCovered === 0 && totalProvenance > 0
+        ? "New extractions will carry source spans. Existing legacy memories remain `none` until re-extracted."
+        : undefined,
+    details: { provenanceCounts: pc, total: totalProvenance },
   });
 
   const syncedChunkCount =

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -11918,6 +11918,7 @@ export class Orchestrator {
           }
           const resultNamespace = this.namespaceFromPath(recalledPath);
           let provenance: RecallXrayResult["provenance"] | undefined;
+          let sourceSpan: RecallXrayResult["sourceSpan"] | undefined;
           try {
             const resultStorage =
               await this.storageRouter.storageFor(resultNamespace);
@@ -11928,6 +11929,17 @@ export class Orchestrator {
                 retrievalReason: `served-by=${servedBy}`,
                 currentContextScopes: options.currentContextScopes,
               });
+              // Claim-level provenance span (#1575 PR 3): surface the first
+              // source excerpt so the X-ray shows the literal utterance this
+              // fact derives from. Thin read from already-loaded frontmatter.
+              const fm = memory.frontmatter;
+              if (fm.sources && fm.sources.length > 0) {
+                sourceSpan = {
+                  quote: fm.sources[0]!.quote,
+                  observedAt: fm.sources[0]!.observedAt,
+                  provenance: fm.provenance ?? "none",
+                };
+              }
             }
           } catch {
             // X-ray capture is best-effort; missing provenance must not
@@ -11940,6 +11952,7 @@ export class Orchestrator {
             scoreDecomposition,
             admittedBy: [],
             ...(provenance ? { provenance } : {}),
+            ...(sourceSpan ? { sourceSpan } : {}),
           });
         }
         // `considered` must reflect the pool size of the branch that

--- a/packages/remnic-core/src/provenance-surfaces.test.ts
+++ b/packages/remnic-core/src/provenance-surfaces.test.ts
@@ -118,6 +118,35 @@ test("renderXrayText: long quote is truncated to ~120 chars with ellipsis", () =
 
 // ─── X-ray markdown rendering ─────────────────────────────────────────────
 
+test("renderXrayText: quote with newlines is collapsed to a single line", () => {
+  const snap = buildXraySnapshot({
+    query: "q",
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "fact-newline",
+        path: "facts/multi.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.5 },
+        admittedBy: [],
+        sourceSpan: {
+          quote: "line one\nline two\r\nline three",
+          observedAt: "2026-06-01T00:00:00.000Z",
+          provenance: "verified",
+        },
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  });
+  const text = renderXrayText(snap);
+  const sourceLine = text.split("\n").find((l) => l.includes("source:"));
+  assert.ok(sourceLine);
+  // Newlines must be collapsed to spaces — the source line must be a single line
+  assert.match(sourceLine!, /line one line two line three/);
+  assert.doesNotMatch(sourceLine!, /\n|\r/);
+});
+
 test("renderXrayMarkdown: sourceSpan renders as a Source line", () => {
   const md = renderXrayMarkdown(snapshotWithSourceSpan());
   assert.match(

--- a/packages/remnic-core/src/provenance-surfaces.test.ts
+++ b/packages/remnic-core/src/provenance-surfaces.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Issue #1575 PR 3 — Claim-level provenance surfaces: X-ray rendering +
+ * `remnic doctor` coverage distribution.
+ *
+ * PR 1 (types + storage round-trip) and PR 2 (extraction validator) are
+ * covered by provenance-frontmatter.test.ts and provenance-extraction.test.ts.
+ * This file pins the READ surfaces that operators and downstream features
+ * (#1576 faithfulness, #1577 TrustScore, #1580 correction) consume:
+ *
+ *   - X-ray text/markdown rows render the first quote + observedAt.
+ *   - cloneResult deep-copies sourceSpan so getLastXraySnapshot is independent.
+ *   - `remnic doctor` reports the verified/unverified/none distribution.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { RecallXraySnapshot, RecallXrayResult } from "./recall-xray.js";
+import { buildXraySnapshot } from "./recall-xray.js";
+import { renderXrayText, renderXrayMarkdown } from "./recall-xray-renderer.js";
+
+// ─── X-ray rendering fixtures ────────────────────────────────────────────
+
+function resultWithSourceSpan(): RecallXrayResult {
+  return {
+    memoryId: "fact-prov-1",
+    path: "facts/tech/database.md",
+    servedBy: "hybrid",
+    scoreDecomposition: { final: 0.82 },
+    admittedBy: ["namespace"],
+    sourceSpan: {
+      quote: "We migrated the production database to pgBouncer",
+      observedAt: "2026-05-03T10:00:00.000Z",
+      provenance: "verified",
+    },
+  };
+}
+
+function snapshotWithSourceSpan(): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "what database?",
+    capturedAt: 1_700_000_000_000,
+    snapshotId: "22222222-2222-2222-2222-222222222222",
+    tierExplain: null,
+    results: [resultWithSourceSpan()],
+    filters: [{ name: "recall-result-limit", considered: 1, admitted: 1 }],
+    budget: { chars: 4096, used: 100 },
+  };
+}
+
+// ─── X-ray text rendering ─────────────────────────────────────────────────
+
+test("renderXrayText: sourceSpan renders quote + observedAt + provenance tag", () => {
+  const text = renderXrayText(snapshotWithSourceSpan());
+  assert.match(
+    text,
+    /source: "We migrated the production database to pgBouncer" \(observed 2026-05-03T10:00:00\.000Z\) \[verified\]/,
+    "text renderer must surface the source span line",
+  );
+});
+
+test("renderXrayText: absent sourceSpan produces no source line", () => {
+  const snap = buildXraySnapshot({
+    query: "q",
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "fact-legacy",
+        path: "facts/legacy.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.5 },
+        admittedBy: [],
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  });
+  const text = renderXrayText(snap);
+  assert.doesNotMatch(text, /source:/, "no source line for legacy memory");
+});
+
+test("renderXrayText: long quote is truncated to ~120 chars with ellipsis", () => {
+  const longQuote = "A".repeat(300);
+  const snap = buildXraySnapshot({
+    query: "q",
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "fact-long",
+        path: "facts/long.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.5 },
+        admittedBy: [],
+        sourceSpan: {
+          quote: longQuote,
+          observedAt: "2026-06-01T00:00:00.000Z",
+          provenance: "verified",
+        },
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  });
+  const text = renderXrayText(snap);
+  // The truncated quote should end with an ellipsis and be well under 300 chars
+  const sourceLine = text.split("\n").find((l) => l.includes("source:"));
+  assert.ok(sourceLine, "source line present");
+  assert.match(sourceLine!, /\u2026|…/, "truncated with ellipsis marker");
+  // The quote between the first and second double-quotes
+  const match = sourceLine!.match(/source: "(.*)" \(observed/);
+  assert.ok(match);
+  assert.ok(
+    match![1].length <= 125,
+    `truncated quote should be ~120 chars, got ${match![1].length}`,
+  );
+});
+
+// ─── X-ray markdown rendering ─────────────────────────────────────────────
+
+test("renderXrayMarkdown: sourceSpan renders as a Source line", () => {
+  const md = renderXrayMarkdown(snapshotWithSourceSpan());
+  assert.match(
+    md,
+    /\*\*Source:\*\* "We migrated the production database to pgBouncer" \(`2026-05-03T10:00:00\.000Z`\) — verified/,
+    "markdown renderer must surface the source span",
+  );
+});
+
+test("renderXrayMarkdown: absent sourceSpan produces no Source line", () => {
+  const snap = buildXraySnapshot({
+    query: "q",
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "fact-legacy-2",
+        path: "facts/legacy2.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.5 },
+        admittedBy: [],
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  });
+  const md = renderXrayMarkdown(snap);
+  assert.doesNotMatch(md, /\*\*Source:\*\*/, "no Source line for legacy memory");
+});
+
+// ─── cloneResult preserves sourceSpan ─────────────────────────────────────
+
+test("buildXraySnapshot deep-copies sourceSpan (independent of caller object)", () => {
+  const original = resultWithSourceSpan();
+  const snap = buildXraySnapshot({
+    query: "q",
+    tierExplain: null,
+    results: [original],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  });
+  // Mutate the original — the snapshot must be unaffected
+  original.sourceSpan!.quote = "MUTATED";
+  assert.equal(
+    snap.results[0]!.sourceSpan!.quote,
+    "We migrated the production database to pgBouncer",
+    "snapshot sourceSpan must be a deep copy",
+  );
+});
+
+// ─── `remnic doctor` provenance coverage (pure helper) ────────────────────
+//
+// `runOperatorDoctor` calls `summarizeProvenanceCoverage` (a pure function)
+// to build the verified/unverified/none distribution. Testing the helper
+// directly avoids coupling to the full orchestrator mock while still pinning
+// the counting contract the doctor check relies on.
+
+import { summarizeProvenanceCoverage } from "./operator-toolkit.js";
+
+function makeMemoryFile(
+  id: string,
+  provenance: "verified" | "unverified" | "none" | undefined,
+): { frontmatter: { provenance?: string } } {
+  return {
+    frontmatter: {
+      ...(provenance ? { provenance } : {}),
+    },
+  };
+}
+
+test("summarizeProvenanceCoverage: mixed distribution — verified/unverified/none/legacy", () => {
+  const memories = [
+    makeMemoryFile("v1", "verified"),
+    makeMemoryFile("v2", "verified"),
+    makeMemoryFile("u1", "unverified"),
+    makeMemoryFile("n1", "none"),
+    makeMemoryFile("legacy", undefined), // legacy — no field → counts as none
+  ];
+  const result = summarizeProvenanceCoverage(memories);
+  assert.deepEqual(result.counts, { verified: 2, unverified: 1, none: 2 });
+  assert.equal(result.total, 5);
+});
+
+test("summarizeProvenanceCoverage: all legacy → all none", () => {
+  const memories = [
+    makeMemoryFile("n1", undefined),
+    makeMemoryFile("n2", undefined),
+  ];
+  const result = summarizeProvenanceCoverage(memories);
+  assert.deepEqual(result.counts, { verified: 0, unverified: 0, none: 2 });
+  assert.equal(result.total, 2);
+});
+
+test("summarizeProvenanceCoverage: empty → zero counts", () => {
+  const result = summarizeProvenanceCoverage([]);
+  assert.deepEqual(result.counts, { verified: 0, unverified: 0, none: 0 });
+  assert.equal(result.total, 0);
+});
+
+test("summarizeProvenanceCoverage: unknown tag string → counts as none (defensive)", () => {
+  const memories = [
+    { frontmatter: { provenance: "bogus" } },
+  ];
+  const result = summarizeProvenanceCoverage(memories);
+  assert.deepEqual(result.counts, { verified: 0, unverified: 0, none: 1 });
+});

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -485,12 +485,16 @@ function mdEscape(value: string): string {
 }
 
 /**
- * Truncate a quote for X-ray display (issue #1575 PR 3). Caps at `maxChars`
- * on a word boundary with an ellipsis marker so the row stays readable.
+ * Truncate a quote for X-ray display (issue #1575 PR 3). Collapses internal
+ * whitespace runs (including newlines/carriage returns) to single spaces so
+ * a multi-line source excerpt cannot split what is meant to be a single X-ray
+ * row, then caps at `maxChars` on a word boundary with an ellipsis marker.
+ * The JSON \`sourceSpan.quote\` stays verbatim — this is display-only.
  */
 function truncateForXray(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  const slice = text.slice(0, maxChars);
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxChars) return collapsed;
+  const slice = collapsed.slice(0, maxChars);
   const lastSpace = slice.lastIndexOf(" ");
   const cut = lastSpace > Math.floor(maxChars * 0.5) ? slice.slice(0, lastSpace) : slice;
   return `${cut}\u2026`;

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -174,6 +174,12 @@ function renderResultTextLines(
       lines.push(`    safety: ${result.provenance.safety}${reasonSuffix}`);
     }
   }
+  if (result.sourceSpan) {
+    const q = truncateForXray(result.sourceSpan.quote, 120);
+    lines.push(
+      `    source: "${q}" (observed ${result.sourceSpan.observedAt}) [${result.sourceSpan.provenance}]`,
+    );
+  }
   if (result.admittedBy.length > 0) {
     lines.push(`    admitted-by: ${result.admittedBy.join(", ")}`);
   }
@@ -374,6 +380,12 @@ function renderResultMarkdownLines(
       );
     }
   }
+  if (result.sourceSpan) {
+    const q = truncateForXray(result.sourceSpan.quote, 120);
+    lines.push(
+      `- **Source:** "${mdEscape(q)}" (${mdInlineCode(result.sourceSpan.observedAt)}) \u2014 ${result.sourceSpan.provenance}`,
+    );
+  }
   if (result.admittedBy.length > 0) {
     lines.push(
       `- **Admitted by:** ${result.admittedBy.map(mdInlineCode).join(", ")}`,
@@ -470,6 +482,18 @@ function mdEscape(value: string): string {
   // Pipe is the only character that breaks GFM table rendering; escape
   // backslash first so we do not re-escape the escape character.
   return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+/**
+ * Truncate a quote for X-ray display (issue #1575 PR 3). Caps at `maxChars`
+ * on a word boundary with an ellipsis marker so the row stays readable.
+ */
+function truncateForXray(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const slice = text.slice(0, maxChars);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > Math.floor(maxChars * 0.5) ? slice.slice(0, lastSpace) : slice;
+  return `${cut}\u2026`;
 }
 
 function mdInlineCode(value: string): string {

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -171,6 +171,20 @@ export interface RecallXrayResult {
    * capture when the memory frontmatter was already loaded by retrieval.
    */
   provenance?: RetrievedMemoryProvenance;
+  /**
+   * Claim-level provenance span (issue #1575 PR 3). The first source excerpt
+   * backing this memory, surfaced so X-ray consumers can see the literal
+   * utterance each fact derives from alongside retrieval provenance. Absent
+   * when the memory carries no source spans (legacy or `provenance: "none"`).
+   */
+  sourceSpan?: {
+    /** Verbatim quote excerpt (capped at write time by `provenance.maxQuoteChars`). */
+    quote: string;
+    /** ISO timestamp of the source turn. */
+    observedAt: string;
+    /** Coarse strength tag from the frontmatter. */
+    provenance: "verified" | "unverified" | "none";
+  };
 }
 
 /**
@@ -521,6 +535,24 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
   const provenance = normalizeRetrievedMemoryProvenance(result.provenance);
   if (provenance !== undefined) {
     out.provenance = provenance;
+  }
+  // Claim-level provenance span (#1575 PR 3). Deep-copy the three scalar
+  // fields so the snapshot returned by getLastXraySnapshot is independent
+  // of the caller's object (matches the structuredClone contract).
+  const ss = result.sourceSpan;
+  if (
+    ss &&
+    typeof ss.quote === "string" &&
+    typeof ss.observedAt === "string" &&
+    (ss.provenance === "verified" ||
+      ss.provenance === "unverified" ||
+      ss.provenance === "none")
+  ) {
+    out.sourceSpan = {
+      quote: ss.quote,
+      observedAt: ss.observedAt,
+      provenance: ss.provenance,
+    };
   }
   return out;
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19965,
+      "packages/remnic-core/src/orchestrator.ts": 19978,
       "packages/remnic-core/src/cli.ts": 9364,
       "packages/remnic-core/src/access-service.ts": 8873,
       "packages/remnic-core/src/storage.ts": 7730,


### PR DESCRIPTION
## Summary

Closes #1575. PR 1 (types + storage round-trip) and PR 2 (extraction validator) are already merged. This PR adds the read surfaces that complete the end-to-end contract:

- **X-ray**: `RecallXrayResult` gains an optional `sourceSpan` carrying the first verified source excerpt (quote + observedAt + provenance tag). The orchestrator xray-capture path populates it from the already-loaded memory frontmatter — thin wiring, no new storage reads. The text + markdown renderers surface the quote (truncated to ~120 chars with an ellipsis) alongside observedAt and the strength tag.
- **Doctor**: `remnic doctor` gains a `provenance_coverage` check reporting the verified/unverified/none distribution via a pure `summarizeProvenanceCoverage` helper.
- **memory_get**: already surfaces `sources` via the frontmatter it returns wholesale (`serializeMemory`).

## End-to-end contract

New facts flowing through extraction carry verified source spans: extraction → provenance.ts validator → storage frontmatter → memory_get → xray. Legacy memories (no `sources`/`provenance` fields) are unaffected — readers treat them as `provenance: "none"`.

## Files changed

- `recall-xray.ts` — `sourceSpan?` field on `RecallXrayResult` + deep-copy in `cloneResult`
- `recall-xray-renderer.ts` — text + markdown rendering + `truncateForXray` helper
- `orchestrator.ts` — populate `sourceSpan` in xray capture (thin read from already-loaded frontmatter)
- `operator-toolkit.ts` — `summarizeProvenanceCoverage` pure helper + `provenance_coverage` doctor check
- `provenance-surfaces.test.ts` — 10 tests (xray text/markdown rendering, deep-copy, doctor distribution)
- `ratchet-baseline.json` — orchestrator +13 LOC (thin wiring, justified)

## Gates

- [x] `preflight:quick` green
- [x] `test:entity-hardening` green (246 tests)
- [x] `check-ratchets` green (baseline updated w/ justification)
- [x] All 73 provenance tests green (63 existing + 10 new)
- [x] `tsc --noEmit` clean

## Chokepoints used / not applicable

- Storage write path: already goes through `serializeProvenanceFields` (#1575 PR1). No change.
- Not applicable: #1525 (no new MCP/HTTP/CLI tool surfaces — xray rendering + doctor check are additive to existing surfaces).

## Follow-ups deferred

- #1657 (timestamp-format/quote nits) and #1671 (backfill invalid_at/observedAt) are separate follow-ups referenced for deferral.
- `provenance.requireSpans` stays false until #1576 faithfulness gate lands (per issue config table).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive observability on best-effort recall/doctor paths; legacy memories without sources are unchanged and failures do not affect recall behavior.
> 
> **Overview**
> Adds **read-side** provenance surfaces so operators can see which source utterance backs each recalled fact and how much of the corpus is tagged.
> 
> **Recall X-ray** gains an optional per-result `sourceSpan` (first frontmatter `sources` entry: quote, `observedAt`, strength tag). Recall capture fills it from memory already loaded for provenance—no extra storage reads. Text and markdown X-ray renderers show a **Source** line with display-only truncation (~120 chars, whitespace collapsed). Snapshots deep-copy `sourceSpan` in `cloneResult`.
> 
> **`remnic doctor`** adds a `provenance_coverage` check: `summarizeProvenanceCoverage` counts verified / unverified / none (missing or unknown tags → none) across hot, archived, and cold tiers via `Promise.allSettled`, warning on partial tier read failures.
> 
> Tests in `provenance-surfaces.test.ts` cover rendering, truncation, and coverage counting; orchestrator LOC ratchet baseline is bumped for the thin xray wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e00d8b193265b6a72084b04ead8a7c76290244b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->