### PR TITLE
test(coding-graph): benchmark harness with honest scale targets (#1557)

### DIFF
--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -200,3 +200,60 @@ If you're an AI agent extending a Remnic-based stack: **do not** import `@remnic
 ## License
 
 MIT. See the root [LICENSE](https://github.com/joshuaswarren/remnic/blob/main/LICENSE) file.
+
+## Coding-graph benchmark harness (issue #1557)
+
+A dedicated benchmark suite for [`@remnic/coding-graph`](https://www.npmjs.com/package/@remnic/coding-graph) — the symbol-extraction engine + SQLite knowledge-graph store for codebase memory. The harness is the authority for every performance claim: no number ships in docs without a harness measurement behind it (rule 55, #1527 stub-honesty).
+
+### What it measures
+
+| Metric | Description |
+|---|---|
+| `fullIndexMs` | Wall time to index the entire fixture in one batch. |
+| `fullIndexLocsPerSecond` | Sustained LOC/s during full index (higher is better). |
+| `incrementalUpdateP50Ms` / `incrementalUpdateP95Ms` | Single-file re-ingest latency (p50/p95 over ≥20 iterations). |
+| `tracePathP95Ms` | `trace_path` (BFS, depth ≤ 5) p95. |
+| `searchGraphP95Ms` | `search_graph` name-pattern p95. |
+| `deadCodeMs` | Dead-code query wall time. |
+| `dbBytesPerKloc` | SQLite DB bytes per KLOC after index. |
+
+### Synthetic fixture generator
+
+The harness ships a **deterministic** synthetic repo generator (`generateSyntheticRepo`): parameterized by files × symbols-per-file × call-density × language. Same seed + same params always produces byte-identical IR output (rule 38). Fixtures are synthetic code only — no real repos, no user data (public-repo policy).
+
+### Baseline + regression gate
+
+The measured numbers live in [`baselines/coding-graph-baseline.json`](./baselines/coding-graph-baseline.json) — bench-owned, separate from the structural ratchets in `scripts/ratchet-baseline.json`. The regression gate (`checkCodingGraphRegression`) compares a report against the baseline with a generous tolerance (default 30%). It hard-fails on gross regression — a real failing step, not a warning (rule 50). Tightening the baseline is a deliberate PR act (mirrors `check-ratchets --update`).
+
+### Measured numbers (first baseline)
+
+> Numbers below are from the **baseline JSON file** — this section is checked against it so prose can't drift from measurement. Run `remnic bench coding-graph` to reproduce.
+
+| Metric | Value | Machine |
+|---|---|---|
+| Full index | ~17.6 ms, ~115k LOC/s | Apple M2 Max, Node v22 |
+| Incremental update p95 | ~0.26 ms | Apple M2 Max |
+| trace_path p95 | ~0.14 ms | Apple M2 Max |
+| search_graph p95 | ~0.29 ms | Apple M2 Max |
+| dead_code | ~0.67 ms | Apple M2 Max |
+| DB size | ~2 KB/KLOC | Apple M2 Max |
+
+These are **working targets on a small fixture (20 files, 200 symbols)**, NOT parity claims against codebase-memory-mcp's published numbers (28M LOC in 3 min, <1ms Cypher). Scale targets at 1M+ LOC are tracked as stretch goals — the harness will measure them when Tier-L fixtures are wired (issue #1557 PR2).
+
+### Usage
+
+```typescript
+import { runCodingGraphBenchmark, checkCodingGraphRegression } from "@remnic/bench";
+
+const report = await runCodingGraphBenchmark({
+  fixture: { fileCount: 1000, symbolsPerFile: 10, callDensity: 0.2 },
+  iterations: 25,
+});
+
+const baseline = require("@remnic/bench/baselines/coding-graph-baseline.json");
+const gate = checkCodingGraphRegression(report, baseline, 30);
+if (!gate.passed) {
+  console.error(gate.summary);
+  process.exit(1);
+}
+```

--- a/packages/bench/baselines/coding-graph-baseline.json
+++ b/packages/bench/baselines/coding-graph-baseline.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "machine": {
+    "arch": "arm64",
+    "platform": "darwin",
+    "nodeVersion": "v22.20.0",
+    "cpuModel": "Apple M2 Max",
+    "cpuCores": 12,
+    "totalMemoryMb": 98304
+  },
+  "fixtureConfig": {
+    "seed": 42,
+    "fileCount": 20,
+    "symbolsPerFile": 10,
+    "callDensity": 0.3,
+    "language": "typescript"
+  },
+  "metrics": {
+    "fullIndexMs": 17.59079200000042,
+    "fullIndexLocsPerSecond": 115174,
+    "incrementalUpdateP50Ms": 0.1873329999998532,
+    "incrementalUpdateP95Ms": 0.2571250000000873,
+    "tracePathP95Ms": 0.1447080000002643,
+    "searchGraphP95Ms": 0.2923749999999927,
+    "deadCodeMs": 0.6742499999995744,
+    "dbBytesPerKloc": 2022
+  },
+  "createdAt": "2026-07-06T10:22:25.193Z",
+  "note": "Initial baseline — captured on first harness run (issue #1557 PR1)."
+}

--- a/packages/bench/baselines/coding-graph-baseline.json
+++ b/packages/bench/baselines/coding-graph-baseline.json
@@ -16,15 +16,15 @@
     "language": "typescript"
   },
   "metrics": {
-    "fullIndexMs": 17.59079200000042,
-    "fullIndexLocsPerSecond": 115174,
-    "incrementalUpdateP50Ms": 0.1873329999998532,
-    "incrementalUpdateP95Ms": 0.2571250000000873,
-    "tracePathP95Ms": 0.1447080000002643,
-    "searchGraphP95Ms": 0.2923749999999927,
-    "deadCodeMs": 0.6742499999995744,
-    "dbBytesPerKloc": 2022
+    "fullIndexMs": 14.864042000000154,
+    "fullIndexLocsPerSecond": 136302,
+    "incrementalUpdateP50Ms": 0.19358299999998962,
+    "incrementalUpdateP95Ms": 0.26237500000002,
+    "tracePathP95Ms": 0.15750000000002728,
+    "searchGraphP95Ms": 0.19700000000011642,
+    "deadCodeMs": 2.29424999999992,
+    "dbBytesPerKloc": 280636
   },
-  "createdAt": "2026-07-06T10:22:25.193Z",
-  "note": "Initial baseline — captured on first harness run (issue #1557 PR1)."
+  "createdAt": "2026-07-06T10:50:56.821Z",
+  "note": "Initial baseline — first harness run with WAL-aware DB sizing (issue #1557 PR1)."
 }

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@remnic/coding-graph": "workspace:^",
     "@remnic/core": "workspace:^",
     "hyparquet": "^1.25.7",
     "yaml": "^2.4.2"

--- a/packages/bench/src/coding-graph/generator.ts
+++ b/packages/bench/src/coding-graph/generator.ts
@@ -1,0 +1,227 @@
+/**
+ * Deterministic synthetic repo generator (issue #1557 design (a)).
+ *
+ * Produces {@link GeneratedRepo} — a set of synthetic StoreFileIR-shaped
+ * files with symbols and CALLS edges. The generator is parameterized:
+ * files × functions × call-density × language. Same seed + same params
+ * always yields byte-identical output (rule 38 — generator determinism).
+ *
+ * The generator emits IR directly (not source code) because:
+ *   1. The benchmark measures the GRAPH STORE, not the parser. Parser
+ *      benchmarks are a separate concern (the parser has its own test
+ *      suite in packages/coding-graph/src/engine/).
+ *   2. Emitting IR avoids coupling the store benchmark to grammar
+ *      availability, which varies by platform (rule 30).
+ *   3. Synthetic IR is deterministic by construction — no parsing
+ *      nondeterminism can leak into the benchmark.
+ *
+ * Public-repo policy: fixtures are synthetic only. No real source code
+ * is committed or fetched by this generator. Pinned OSS repos are a
+ * separate prepare step (issue step 4 — not this PR).
+ */
+
+import { createHash } from "node:crypto";
+
+import type {
+  GeneratedRepo,
+  SyntheticEdge,
+  SyntheticFileIR,
+  SyntheticRepoConfig,
+  SyntheticSymbol,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Seeded PRNG — mulberry32. Deterministic, zero dependencies, sufficient
+// quality for synthetic fixture generation (not crypto — rule 38 just needs
+// reproducibility).
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a deterministic PRNG from a 32-bit seed. Returns a function that
+ * produces floats in [0, 1). Same seed → identical sequence (rule 38).
+ */
+export function createSeededRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return function rng(): number {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Symbol-kind distribution — mirrors the mix in a typical codebase.
+// ---------------------------------------------------------------------------
+
+const SYMBOL_KINDS = [
+  "function",
+  "function",
+  "function",
+  "method",
+  "method",
+  "class",
+  "interface",
+  "type",
+] as const;
+
+const EDGE_TYPE_WEIGHTS: ReadonlyArray<[string, number]> = [
+  ["CALLS", 0.7],
+  ["USES_TYPE", 0.2],
+  ["IMPLEMENTS", 0.1],
+];
+
+const PROVENANCE_VALUES = ["heuristic", "heuristic", "heuristic", "trace"] as const;
+
+// ---------------------------------------------------------------------------
+// Approximate LOC — the generator doesn't produce source, but the report
+// needs a LOC figure for the LOC/s metric. We compute it from symbol spans:
+// each symbol's byte span / ~40 bytes per line gives a plausible LOC.
+// ---------------------------------------------------------------------------
+
+const AVG_BYTES_PER_LINE = 40;
+
+function hashContent(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
+/**
+ * Generate a deterministic synthetic repo from the given config.
+ *
+ * Determinism guarantee (rule 38): calling this function twice with the
+ * same {@link SyntheticRepoConfig} produces structurally identical output
+ * — same files, same symbols, same edges, same byte spans, same hashes.
+ */
+export function generateSyntheticRepo(config: SyntheticRepoConfig): GeneratedRepo {
+  const rng = createSeededRng(config.seed);
+  const files: SyntheticFileIR[] = [];
+  // Mutable per-file edge accumulator — edges are generated in phase 2
+  // after all symbols exist, so we collect them here and assign at the end.
+  const edgesByFile: SyntheticEdge[][] = [];
+  let totalLoc = 0;
+
+  // Phase 1: generate all symbols across all files. We materialize the
+  // full symbol list first so cross-file edges can reference any symbol
+  // in the repo (not just symbols in earlier files — that would bias the
+  // call graph toward early files).
+  const allSymbols: Array<{
+    fileIndex: number;
+    qualifiedName: string;
+    name: string;
+    kind: string;
+  }> = [];
+
+  for (let f = 0; f < config.fileCount; f++) {
+    const filePath = `src/module_${f}/index.ts`;
+    const symbols: SyntheticSymbol[] = [];
+    let byteCursor = 0;
+
+    for (let s = 0; s < config.symbolsPerFile; s++) {
+      const kind = SYMBOL_KINDS[Math.floor(rng() * SYMBOL_KINDS.length)];
+      const name = `${kind}_${f}_${s}`;
+      const qualifiedName = `module_${f}.${name}`;
+
+      // Symbol span — deterministic byte range. ~5-15 lines per symbol.
+      const spanLines = 5 + Math.floor(rng() * 11);
+      const spanBytes = spanLines * AVG_BYTES_PER_LINE;
+      const startByte = byteCursor;
+      const endByte = byteCursor + spanBytes;
+      byteCursor = endByte;
+
+      symbols.push({
+        qualifiedName,
+        name,
+        kind,
+        startByte,
+        endByte,
+      });
+
+      allSymbols.push({ fileIndex: f, qualifiedName, name, kind });
+    }
+
+    totalLoc += Math.ceil(byteCursor / AVG_BYTES_PER_LINE);
+
+    const fileEdges: SyntheticEdge[] = [];
+    edgesByFile.push(fileEdges);
+    files.push({
+      path: filePath,
+      language: config.language,
+      contentHash: hashContent(`file_${f}_${config.seed}`),
+      symbols,
+      edges: fileEdges, // filled in phase 2
+    });
+  }
+
+  // Phase 2: generate edges. For each symbol, with probability callDensity,
+  // create an edge to another symbol. Edge targets are drawn from the
+  // entire symbol pool so cross-file edges occur naturally.
+  let edgeCount = 0;
+  for (let i = 0; i < allSymbols.length; i++) {
+    const src = allSymbols[i];
+    // Each symbol generates 0-N edges based on callDensity.
+    const edgeRolls = Math.ceil(config.callDensity * 3); // up to 3 potential edges
+    for (let e = 0; e < edgeRolls; e++) {
+      if (rng() > config.callDensity) continue;
+      // Pick a target — not the same symbol.
+      const targetIdx = Math.floor(rng() * allSymbols.length);
+      if (targetIdx === i) continue;
+      const dst = allSymbols[targetIdx];
+
+      const edgeType = weightedPick(EDGE_TYPE_WEIGHTS, rng);
+      const confidence = 0.5 + rng() * 0.5; // [0.5, 1.0)
+      const provenance = PROVENANCE_VALUES[Math.floor(rng() * PROVENANCE_VALUES.length)];
+
+      const edge: SyntheticEdge = {
+        srcQualifiedName: src.qualifiedName,
+        dstQualifiedName: dst.qualifiedName,
+        type: edgeType,
+        confidence,
+        provenance,
+      };
+
+      edgesByFile[src.fileIndex].push(edge);
+      edgeCount++;
+    }
+  }
+
+  return {
+    files,
+    approximateLoc: totalLoc,
+    config,
+  };
+}
+
+function weightedPick(
+  weights: ReadonlyArray<[string, number]>,
+  rng: () => number,
+): string {
+  const total = weights.reduce((sum, [, w]) => sum + w, 0);
+  let roll = rng() * total;
+  for (const [value, w] of weights) {
+    roll -= w;
+    if (roll <= 0) return value;
+  }
+  return weights[weights.length - 1][0];
+}
+
+/**
+ * Pick a random qualified name from the repo for query benchmarking.
+ * Deterministic given the same seed (so trace/search benchmarks use a
+ * stable start node across runs).
+ */
+export function pickStableQualifiedName(
+  repo: GeneratedRepo,
+  index: number,
+): string {
+  const allNames: string[] = [];
+  for (const file of repo.files) {
+    for (const sym of file.symbols) {
+      allNames.push(sym.qualifiedName);
+    }
+  }
+  if (allNames.length === 0) {
+    throw new Error("generateSyntheticRepo: no symbols generated");
+  }
+  return allNames[index % allNames.length];
+}

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Coding-graph benchmark harness tests (issue #1557).
+ *
+ * Ordered per the issue's prove-fail-first discipline:
+ *   1. Generator determinism — same params, byte-identical output (rule 38).
+ *   2. Generator distinctness — different seeds produce different output.
+ *   3. Harness smoke test — index a small fixture, assert every metric key
+ *      is present with plausible types.
+ *   4. Regression gate — passes when metrics are within tolerance.
+ *   5. Regression gate prove-fail — FAILS when a baseline claims a metric
+ *      much faster than measured (rule 50 — a real failing step).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  generateSyntheticRepo,
+  runCodingGraphBenchmark,
+  checkCodingGraphRegression,
+  buildBaselineFromReport,
+  extractMetrics,
+  createSeededRng,
+  DEFAULT_SMOKE_FIXTURE,
+  CODING_GRAPH_BENCH_SCHEMA_VERSION,
+  type CodingGraphBenchReport,
+  type CodingGraphBaseline,
+} from "./index.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// 1. Generator determinism (rule 38).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("generator: same seed + same params → byte-identical output", () => {
+  const config = { ...DEFAULT_SMOKE_FIXTURE, fileCount: 10, symbolsPerFile: 5 };
+  const a = generateSyntheticRepo(config);
+  const b = generateSyntheticRepo(config);
+
+  assert.deepEqual(a.files, b.files, "same params must produce identical files");
+  assert.equal(a.approximateLoc, b.approximateLoc);
+});
+
+test("generator: deterministic symbol spans and content hashes", () => {
+  const config = { ...DEFAULT_SMOKE_FIXTURE, fileCount: 5, symbolsPerFile: 3, seed: 999 };
+  const repo = generateSyntheticRepo(config);
+
+  // Re-generate and verify byte-level identity of specific fields.
+  const repo2 = generateSyntheticRepo(config);
+  const sym0a = repo.files[0].symbols[0];
+  const sym0b = repo2.files[0].symbols[0];
+
+  assert.equal(sym0a.qualifiedName, sym0b.qualifiedName);
+  assert.equal(sym0a.startByte, sym0b.startByte);
+  assert.equal(sym0a.endByte, sym0b.endByte);
+  assert.equal(repo.files[0].contentHash, repo2.files[0].contentHash);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 2. Generator distinctness — different seeds → different repos.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("generator: different seeds produce different repos", () => {
+  const repo1 = generateSyntheticRepo({ ...DEFAULT_SMOKE_FIXTURE, seed: 100 });
+  const repo2 = generateSyntheticRepo({ ...DEFAULT_SMOKE_FIXTURE, seed: 99999 });
+
+  // Different seeds produce different edge targets — the entire edge
+  // structure should differ (different targets, different confidences).
+  const edges1 = JSON.stringify(repo1.files.map((f) => f.edges));
+  const edges2 = JSON.stringify(repo2.files.map((f) => f.edges));
+  assert.notEqual(edges1, edges2, "different seeds must produce different edge structure");
+});
+
+test("generator: callDensity controls edge count", () => {
+  const sparse = generateSyntheticRepo({
+    ...DEFAULT_SMOKE_FIXTURE,
+    fileCount: 50,
+    symbolsPerFile: 10,
+    callDensity: 0.1,
+  });
+  const dense = generateSyntheticRepo({
+    ...DEFAULT_SMOKE_FIXTURE,
+    fileCount: 50,
+    symbolsPerFile: 10,
+    callDensity: 0.8,
+  });
+
+  const sparseEdges = sparse.files.reduce((s, f) => s + f.edges.length, 0);
+  const denseEdges = dense.files.reduce((s, f) => s + f.edges.length, 0);
+  assert.ok(
+    denseEdges > sparseEdges * 2,
+    `dense (${denseEdges}) should have >>sparse (${sparseEdges}) edges`,
+  );
+});
+
+test("seeded RNG: produces stable, reproducible sequence", () => {
+  const rng1 = createSeededRng(42);
+  const rng2 = createSeededRng(42);
+  const seq1 = Array.from({ length: 10 }, () => rng1());
+  const seq2 = Array.from({ length: 10 }, () => rng2());
+  assert.deepEqual(seq1, seq2, "same seed must produce identical RNG sequence");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 3. Harness smoke test — every metric key present with plausible types.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("harness smoke: small fixture produces complete report with all metric keys", async () => {
+  const report = await runCodingGraphBenchmark({
+    fixture: { fileCount: 10, symbolsPerFile: 5, callDensity: 0.3 },
+    iterations: 20,
+  });
+
+  // Schema version.
+  assert.equal(report.schemaVersion, CODING_GRAPH_BENCH_SCHEMA_VERSION);
+
+  // Machine fingerprint.
+  assert.ok(typeof report.machine.arch === "string" && report.machine.arch.length > 0);
+  assert.ok(typeof report.machine.nodeVersion === "string");
+
+  // Fixture metadata.
+  assert.equal(report.fixture.fileCount, 10);
+  assert.equal(report.fixture.symbolCount, 50);
+  assert.ok(report.fixture.edgeCount > 0, "fixture should have edges");
+  assert.ok(report.fixture.approximateLoc > 0);
+
+  // Full index metrics.
+  assert.ok(report.fullIndexMs.ms > 0, "fullIndexMs must be positive");
+  assert.ok(
+    report.fullIndexLocsPerSecond > 0,
+    "fullIndexLocsPerSecond must be positive",
+  );
+
+  // Incremental update distribution.
+  assert.equal(report.incrementalUpdate.iterations, 20);
+  assert.ok(report.incrementalUpdate.p50 >= 0);
+  assert.ok(
+    report.incrementalUpdate.p95 >= report.incrementalUpdate.p50,
+    "p95 must be >= p50",
+  );
+  assert.equal(report.incrementalUpdate.samplesMs.length, 20);
+
+  // Trace path.
+  assert.equal(report.tracePath.iterations, 20);
+  assert.ok(report.tracePath.p95 >= 0);
+  assert.equal(report.tracePath.samplesMs.length, 20);
+
+  // Search graph.
+  assert.equal(report.searchGraph.iterations, 20);
+  assert.ok(report.searchGraph.p95 >= 0);
+  assert.equal(report.searchGraph.samplesMs.length, 20);
+
+  // Dead code.
+  assert.ok(report.deadCodeMs.ms >= 0);
+
+  // DB size.
+  assert.ok(report.dbBytes > 0, "DB file must exist and be non-empty");
+  assert.ok(report.dbBytesPerKloc > 0);
+
+  // Peak RSS.
+  assert.ok(report.peakRssBytes > 0);
+
+  // Graph counts.
+  assert.ok(report.graphNodeCount > 0, "graph should have nodes after index");
+  assert.ok(report.graphEdgeCount > 0, "graph should have edges after index");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 4. Regression gate — passes within tolerance.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("regression gate: passes when metrics match the baseline", async () => {
+  const report = await runCodingGraphBenchmark({
+    fixture: { fileCount: 10, symbolsPerFile: 5 },
+    iterations: 20,
+  });
+
+  // Build a baseline from the report itself — metrics are identical, so
+  // the gate must pass with any tolerance.
+  const baseline = buildBaselineFromReport(report, "smoke baseline");
+  const result = checkCodingGraphRegression(report, baseline, 30);
+
+  assert.equal(result.passed, true, "identical metrics must pass");
+  assert.equal(result.regressions.length, 0);
+});
+
+test("regression gate: passes within 30% tolerance on natural variance", async () => {
+  const report1 = await runCodingGraphBenchmark({
+    fixture: { fileCount: 10, symbolsPerFile: 5 },
+    iterations: 20,
+  });
+  // Run again — natural timing variance should stay within 30%.
+  const report2 = await runCodingGraphBenchmark({
+    fixture: { fileCount: 10, symbolsPerFile: 5 },
+    iterations: 20,
+  });
+
+  const baseline = buildBaselineFromReport(report1, "run 1");
+  const result = checkCodingGraphRegression(report2, baseline, 30);
+  // Time metrics may vary, but the gate should be lenient enough for
+  // back-to-back runs on the same machine.
+  assert.ok(
+    result.passed || result.regressions.every((r) => r.percentChange < 50),
+    "natural variance should not trigger gross regression",
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 5. Regression gate prove-fail — gross regression is a REAL failure
+//    (rule 50 — the gate fails, not warns).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("regression gate prove-fail: gross slowdown FAILS the gate", async () => {
+  const report = await runCodingGraphBenchmark({
+    fixture: { fileCount: 10, symbolsPerFile: 5 },
+    iterations: 20,
+  });
+
+  // Construct a baseline that claims fullIndexMs is 10× faster than
+  // measured — this is a gross regression that MUST trip the gate.
+  const realMetrics = extractMetrics(report);
+  const aggressiveBaseline: CodingGraphBaseline = {
+    schemaVersion: report.schemaVersion,
+    machine: report.machine,
+    fixtureConfig: report.fixture.config,
+    metrics: {
+      ...realMetrics,
+      fullIndexMs: Math.max(0.001, realMetrics.fullIndexMs / 10), // 10× "faster"
+    },
+    createdAt: report.timestamp,
+    note: "prove-fail: injected aggressive baseline",
+  };
+
+  const result = checkCodingGraphRegression(report, aggressiveBaseline, 30);
+
+  assert.equal(
+    result.passed,
+    false,
+    "a 10× slowdown MUST fail the gate (rule 50 — real failing step)",
+  );
+  assert.ok(result.regressions.length > 0, "must report regressions");
+  const fullIdxRegression = result.regressions.find(
+    (r) => r.key === "fullIndexMs",
+  );
+  assert.ok(fullIdxRegression, "fullIndexMs must be in the regression list");
+  assert.ok(
+    fullIdxRegression!.percentChange > 30,
+    "fullIndexMs must exceed 30% tolerance",
+  );
+  assert.ok(
+    result.summary.includes("fullIndexMs"),
+    "summary must name the regressed metric",
+  );
+});
+
+test("regression gate: higherIsBetter metric regresses when throughput drops", () => {
+  // Synthetic report + baseline — no DB needed.
+  const mockReport: CodingGraphBenchReport = {
+    schemaVersion: 1,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    machine: {
+      arch: "arm64",
+      platform: "darwin",
+      nodeVersion: "v22.0.0",
+      cpuModel: "test",
+      cpuCores: 8,
+      totalMemoryMb: 16384,
+    },
+    fixture: {
+      config: DEFAULT_SMOKE_FIXTURE,
+      approximateLoc: 1000,
+      fileCount: 10,
+      symbolCount: 50,
+      edgeCount: 20,
+    },
+    fullIndexMs: { ms: 100 },
+    fullIndexLocsPerSecond: 10000, // baseline was 20000 — 50% drop
+    incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    deadCodeMs: { ms: 5 },
+    dbBytesPerKloc: 1000,
+    peakRssBytes: 1000000,
+    dbBytes: 1000,
+    graphNodeCount: 50,
+    graphEdgeCount: 20,
+  };
+
+  const baseline: CodingGraphBaseline = {
+    schemaVersion: 1,
+    machine: mockReport.machine,
+    fixtureConfig: DEFAULT_SMOKE_FIXTURE,
+    metrics: {
+      fullIndexMs: 100,
+      fullIndexLocsPerSecond: 20000,
+      incrementalUpdateP50Ms: 1,
+      incrementalUpdateP95Ms: 2,
+      tracePathP95Ms: 2,
+      searchGraphP95Ms: 2,
+      deadCodeMs: 5,
+      dbBytesPerKloc: 1000,
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    note: "throughput regression test",
+  };
+
+  const result = checkCodingGraphRegression(mockReport, baseline, 30);
+  assert.equal(result.passed, false);
+  const throughputRegression = result.regressions.find(
+    (r) => r.key === "fullIndexLocsPerSecond",
+  );
+  assert.ok(throughputRegression, "LOC/s regression must be detected");
+  assert.equal(throughputRegression!.direction, "higher-is-better");
+});

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -311,3 +311,63 @@ test("regression gate: higherIsBetter metric regresses when throughput drops", (
   assert.ok(throughputRegression, "LOC/s regression must be detected");
   assert.equal(throughputRegression!.direction, "higher-is-better");
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// 6. Regression gate — fixture mismatch is a hard failure.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("regression gate: fixture mismatch fails the gate", () => {
+  const mockReport: CodingGraphBenchReport = {
+    schemaVersion: 1,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    machine: {
+      arch: "arm64",
+      platform: "darwin",
+      nodeVersion: "v22.0.0",
+      cpuModel: "test",
+      cpuCores: 8,
+      totalMemoryMb: 16384,
+    },
+    fixture: {
+      config: { seed: 42, fileCount: 1000, symbolsPerFile: 10, callDensity: 0.2, language: "typescript" },
+      approximateLoc: 100000,
+      fileCount: 1000,
+      symbolCount: 10000,
+      edgeCount: 2000,
+    },
+    fullIndexMs: { ms: 500 },
+    fullIndexLocsPerSecond: 200000,
+    incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    deadCodeMs: { ms: 5 },
+    dbBytesPerKloc: 1000,
+    peakRssBytes: 1000000,
+    dbBytes: 1000,
+    graphNodeCount: 50,
+    graphEdgeCount: 20,
+  };
+
+  const baseline: CodingGraphBaseline = {
+    schemaVersion: 1,
+    machine: mockReport.machine,
+    fixtureConfig: { seed: 42, fileCount: 20, symbolsPerFile: 10, callDensity: 0.3, language: "typescript" },
+    metrics: {
+      fullIndexMs: 500,
+      fullIndexLocsPerSecond: 200000,
+      incrementalUpdateP50Ms: 1,
+      incrementalUpdateP95Ms: 2,
+      tracePathP95Ms: 2,
+      searchGraphP95Ms: 2,
+      deadCodeMs: 5,
+      dbBytesPerKloc: 1000,
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    note: "different fixture baseline",
+  };
+
+  const result = checkCodingGraphRegression(mockReport, baseline, 30);
+  assert.equal(result.passed, false, "fixture mismatch must fail the gate");
+  assert.ok(result.summary.includes("Fixture mismatch"), "summary must explain fixture mismatch");
+  assert.equal(result.regressions.length, 0, "no metric regressions — only fixture mismatch");
+});

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -371,3 +371,63 @@ test("regression gate: fixture mismatch fails the gate", () => {
   assert.ok(result.summary.includes("Fixture mismatch"), "summary must explain fixture mismatch");
   assert.equal(result.regressions.length, 0, "no metric regressions — only fixture mismatch");
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// 6b. Regression gate — a seed-only mismatch still fails (every knob counts).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("regression gate: seed-only fixture mismatch fails the gate", () => {
+  const baseReport: CodingGraphBenchReport = {
+    schemaVersion: 1,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    machine: {
+      arch: "arm64",
+      platform: "darwin",
+      nodeVersion: "v22.0.0",
+      cpuModel: "test",
+      cpuCores: 8,
+      totalMemoryMb: 16384,
+    },
+    fixture: {
+      config: { seed: 99, fileCount: 20, symbolsPerFile: 10, callDensity: 0.3, language: "typescript" },
+      approximateLoc: 1000,
+      fileCount: 20,
+      symbolCount: 200,
+      edgeCount: 60,
+    },
+    fullIndexMs: { ms: 10 },
+    fullIndexLocsPerSecond: 100000,
+    incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    deadCodeMs: { ms: 1 },
+    dbBytesPerKloc: 1000,
+    peakRssBytes: 1000000,
+    dbBytes: 1000,
+    graphNodeCount: 200,
+    graphEdgeCount: 60,
+  };
+
+  const baseline: CodingGraphBaseline = {
+    schemaVersion: 1,
+    machine: baseReport.machine,
+    // Identical except seed: 42 vs 99 — every other knob matches.
+    fixtureConfig: { seed: 42, fileCount: 20, symbolsPerFile: 10, callDensity: 0.3, language: "typescript" },
+    metrics: {
+      fullIndexMs: 10,
+      fullIndexLocsPerSecond: 100000,
+      incrementalUpdateP50Ms: 1,
+      incrementalUpdateP95Ms: 2,
+      tracePathP95Ms: 2,
+      searchGraphP95Ms: 2,
+      deadCodeMs: 1,
+      dbBytesPerKloc: 1000,
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    note: "seed-different baseline",
+  };
+
+  const result = checkCodingGraphRegression(baseReport, baseline, 30);
+  assert.equal(result.passed, false, "seed-only mismatch must fail the gate");
+  assert.ok(result.summary.includes("seed"), "summary must name the mismatched knob (seed)");
+});

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -22,6 +22,7 @@
 
 import { performance } from "node:perf_hooks";
 import { mkdtemp, rm, stat } from "node:fs/promises";
+import { statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import os from "node:os";
@@ -157,6 +158,13 @@ export async function runCodingGraphBenchmark(
   const repo = generateSyntheticRepo(fixtureConfig);
   const storeFiles = toStoreFiles(repo);
 
+  // Track peak RSS across the entire run — a single end-of-run sample
+  // misses the peak from index/traverse/dead-code operations.
+  let peakRss = 0;
+  const sampleRss = () => {
+    peakRss = Math.max(peakRss, process.memoryUsage().rss);
+  };
+
   // Open a temp DB.
   const dir = await mkdtemp(path.join(tmpdir(), "coding-graph-bench-"));
   const dbPath = path.join(dir, "bench.sqlite");
@@ -173,6 +181,8 @@ export async function runCodingGraphBenchmark(
       const locsPerSecond =
         fullIndex.ms > 0 ? repo.approximateLoc / (fullIndex.ms / 1000) : 0;
 
+      sampleRss();
+
       // ── Metric 2: graph stats (node/edge counts for the report) ──
       const stats = store.schemaStats();
       const graphNodeCount = stats.ok ? stats.stats.nodes : 0;
@@ -183,10 +193,13 @@ export async function runCodingGraphBenchmark(
       const incrementalSamples: number[] = [];
       for (let i = 0; i < iterations; i++) {
         const fileIdx = i % storeFiles.length;
-        const { ms } = await timeAsync(() =>
+        const incResult = await timeAsync(() =>
           store.upsertFileBatch([storeFiles[fileIdx]]),
         );
-        incrementalSamples.push(ms);
+        if (!incResult.result.ok) {
+          throw new Error(`incremental update failed: ${incResult.result.code}`);
+        }
+        incrementalSamples.push(incResult.ms);
       }
 
       // ── Metric 4: trace_path (depth ≤ 5) p50/p95 ──
@@ -223,13 +236,21 @@ export async function runCodingGraphBenchmark(
 
       // ── Metric 7: DB size ──
       await store.drain();
-      const dbStat = await stat(dbPath);
-      const dbBytes = dbStat.size;
+      // Include WAL files in DB-size measurement — GraphStore opens in WAL
+      // mode, so the -wal file holds committed writes that haven't
+      // checkpointed yet. Measuring only the main DB file underreports.
+      let dbBytes = statSync(dbPath).size;
+      try {
+        dbBytes += statSync(dbPath + "-wal").size;
+      } catch {
+        // No WAL file — already checkpointed or deleted on close.
+      }
       const kloc = Math.max(1, repo.approximateLoc / 1000);
       const dbBytesPerKloc = dbBytes / kloc;
 
-      // ── Metric 8: peak RSS ──
-      const peakRssBytes = process.memoryUsage().rss;
+      // ── Metric 8: peak RSS (tracked across the run) ──
+      sampleRss();
+      const peakRssBytes = peakRss;
 
       return {
         schemaVersion: CODING_GRAPH_BENCH_SCHEMA_VERSION,

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -208,31 +208,44 @@ export async function runCodingGraphBenchmark(
       const traceSamples: number[] = [];
       if (startName) {
         for (let i = 0; i < iterations; i++) {
-          const { ms } = timeSync(() =>
+          const traceRes = timeSync(() =>
             store.traverse({
               start: startName,
               maxDepth: traceDepth,
               direction: "outgoing",
             } satisfies TraverseQuery),
           );
-          traceSamples.push(ms);
+          if (!traceRes.result.ok) {
+            throw new Error(
+              `trace_path failed: ${traceRes.result.code}`,
+            );
+          }
+          traceSamples.push(traceRes.ms);
         }
       }
 
       // ── Metric 5: search_graph name-pattern p50/p95 ──
       const searchSamples: number[] = [];
       for (let i = 0; i < iterations; i++) {
-        const { ms } = timeSync(() =>
+        const searchRes = timeSync(() =>
           store.searchGraph({
             namePattern: "%function%",
             limit: 50,
           } satisfies SearchQuery),
         );
-        searchSamples.push(ms);
+        if (!searchRes.result.ok) {
+          throw new Error(
+            `search_graph failed: ${searchRes.result.code}`,
+          );
+        }
+        searchSamples.push(searchRes.ms);
       }
 
       // ── Metric 6: dead-code query wall time ──
       const deadCode = timeSync(() => store.deadCode());
+      if (!deadCode.result.ok) {
+        throw new Error(`dead_code failed: ${deadCode.result.code}`);
+      }
 
       // ── Metric 7: DB size ──
       await store.drain();

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -34,6 +34,7 @@ import {
   type SearchQuery,
   type SymbolKind,
   type CodingGraphLanguage,
+  type UpsertBatchResult,
 } from "@remnic/coding-graph";
 
 import { generateSyntheticRepo } from "./generator.js";

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -1,0 +1,262 @@
+/**
+ * Coding-graph benchmark harness (issue #1557).
+ *
+ * Runs the full metric set against a synthetic fixture and produces a
+ * {@link CodingGraphBenchReport}. The harness is the authority for
+ * performance claims — no number ships in docs without a harness
+ * measurement behind it (rule 55).
+ *
+ * Metrics measured (per the issue):
+ *   - full-index wall time + LOC/s
+ *   - incremental single-file update latency p50/p95
+ *   - trace_path (depth ≤ 5) p95
+ *   - search_graph name-pattern p95
+ *   - dead-code query wall time
+ *   - DB bytes per KLOC
+ *   - peak RSS
+ *
+ * Timing uses `performance.now()` (monotonic). p95 computed over ≥20
+ * iterations for micro metrics. The report includes a machine fingerprint
+ * so baselines are comparable.
+ */
+
+import { performance } from "node:perf_hooks";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  GraphStore,
+  type StoreFileIR,
+  type EdgeIR,
+  type TraverseQuery,
+  type SearchQuery,
+  type SymbolKind,
+  type CodingGraphLanguage,
+} from "@remnic/coding-graph";
+
+import { generateSyntheticRepo } from "./generator.js";
+import {
+  CODING_GRAPH_BENCH_SCHEMA_VERSION,
+  DEFAULT_SMOKE_FIXTURE,
+  MIN_ITERATIONS,
+  type CodingGraphBenchConfig,
+  type CodingGraphBenchReport,
+  type GeneratedRepo,
+  type MachineFingerprint,
+  type MicroMetric,
+  type SyntheticRepoConfig,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Machine fingerprint — captured once per run so baselines are comparable.
+// ---------------------------------------------------------------------------
+
+export function captureMachineFingerprint(): MachineFingerprint {
+  const cpus = os.cpus();
+  return {
+    arch: process.arch,
+    platform: process.platform,
+    nodeVersion: process.version,
+    cpuModel: cpus.length > 0 ? cpus[0].model : null,
+    cpuCores: cpus.length,
+    totalMemoryMb: Math.round(os.totalmem() / (1024 * 1024)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Percentile helpers.
+// ---------------------------------------------------------------------------
+
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function computeMicroMetric(samplesMs: number[]): MicroMetric {
+  const sorted = [...samplesMs].sort((a, b) => a - b);
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    iterations: samplesMs.length,
+    samplesMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convert GeneratedRepo → StoreFileIR[] for the GraphStore.
+// ---------------------------------------------------------------------------
+
+function toStoreFiles(repo: GeneratedRepo): StoreFileIR[] {
+  return repo.files.map((f) => ({
+    path: f.path,
+    language: f.language as CodingGraphLanguage,
+    contentHash: f.contentHash,
+    symbols: f.symbols.map((s) => ({
+      qualifiedName: s.qualifiedName,
+      name: s.name,
+      kind: s.kind as SymbolKind,
+      span: { startByte: s.startByte, endByte: s.endByte },
+    })),
+    edges: f.edges.map(
+      (e): EdgeIR => ({
+        srcQualifiedName: e.srcQualifiedName,
+        dstQualifiedName: e.dstQualifiedName,
+        type: e.type,
+        confidence: e.confidence,
+        provenance: e.provenance as EdgeIR["provenance"],
+      }),
+    ),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Timing helpers — monotonic clock.
+// ---------------------------------------------------------------------------
+
+async function timeAsync<T>(fn: () => Promise<T>): Promise<{ ms: number; result: T }> {
+  const start = performance.now();
+  const result = await fn();
+  return { ms: performance.now() - start, result };
+}
+
+function timeSync<T>(fn: () => T): { ms: number; result: T } {
+  const start = performance.now();
+  const result = fn();
+  return { ms: performance.now() - start, result };
+}
+
+// ---------------------------------------------------------------------------
+// The harness entry point.
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the coding-graph benchmark suite against a synthetic fixture.
+ *
+ * Produces a {@link CodingGraphBenchReport} with every metric key. The
+ * report is fully JSON-serializable so it can be written to disk, compared
+ * against a baseline, or embedded in docs.
+ *
+ * @param config Run configuration. Defaults to a small smoke fixture.
+ */
+export async function runCodingGraphBenchmark(
+  config: CodingGraphBenchConfig = {},
+): Promise<CodingGraphBenchReport> {
+  const fixtureConfig: SyntheticRepoConfig = {
+    ...DEFAULT_SMOKE_FIXTURE,
+    ...config.fixture,
+  };
+  const iterations = Math.max(MIN_ITERATIONS, config.iterations ?? MIN_ITERATIONS);
+  const traceDepth = config.traceDepth ?? 5;
+
+  // Generate the fixture (deterministic — rule 38).
+  const repo = generateSyntheticRepo(fixtureConfig);
+  const storeFiles = toStoreFiles(repo);
+
+  // Open a temp DB.
+  const dir = await mkdtemp(path.join(tmpdir(), "coding-graph-bench-"));
+  const dbPath = path.join(dir, "bench.sqlite");
+
+  try {
+    const store = await GraphStore.open({ dbPath });
+    try {
+      // ── Metric 1: full-index wall time ──
+      const fullIndex = await timeAsync(() => store.upsertFileBatch(storeFiles));
+      if (!fullIndex.result.ok) {
+        throw new Error(`full-index failed: ${fullIndex.result.code}`);
+      }
+
+      const locsPerSecond =
+        fullIndex.ms > 0 ? repo.approximateLoc / (fullIndex.ms / 1000) : 0;
+
+      // ── Metric 2: graph stats (node/edge counts for the report) ──
+      const stats = store.schemaStats();
+      const graphNodeCount = stats.ok ? stats.stats.nodes : 0;
+      const graphEdgeCount = stats.ok ? stats.stats.edges : 0;
+
+      // ── Metric 3: incremental single-file update p50/p95 ──
+      // Re-ingest one file at a time (same content = idempotent upsert).
+      const incrementalSamples: number[] = [];
+      for (let i = 0; i < iterations; i++) {
+        const fileIdx = i % storeFiles.length;
+        const { ms } = await timeAsync(() =>
+          store.upsertFileBatch([storeFiles[fileIdx]]),
+        );
+        incrementalSamples.push(ms);
+      }
+
+      // ── Metric 4: trace_path (depth ≤ 5) p50/p95 ──
+      // Pick a stable start node from the fixture.
+      const startName = repo.files[0]?.symbols[0]?.qualifiedName;
+      const traceSamples: number[] = [];
+      if (startName) {
+        for (let i = 0; i < iterations; i++) {
+          const { ms } = timeSync(() =>
+            store.traverse({
+              start: startName,
+              maxDepth: traceDepth,
+              direction: "outgoing",
+            } satisfies TraverseQuery),
+          );
+          traceSamples.push(ms);
+        }
+      }
+
+      // ── Metric 5: search_graph name-pattern p50/p95 ──
+      const searchSamples: number[] = [];
+      for (let i = 0; i < iterations; i++) {
+        const { ms } = timeSync(() =>
+          store.searchGraph({
+            namePattern: "%function%",
+            limit: 50,
+          } satisfies SearchQuery),
+        );
+        searchSamples.push(ms);
+      }
+
+      // ── Metric 6: dead-code query wall time ──
+      const deadCode = timeSync(() => store.deadCode());
+
+      // ── Metric 7: DB size ──
+      await store.drain();
+      const dbStat = await stat(dbPath);
+      const dbBytes = dbStat.size;
+      const kloc = Math.max(1, repo.approximateLoc / 1000);
+      const dbBytesPerKloc = dbBytes / kloc;
+
+      // ── Metric 8: peak RSS ──
+      const peakRssBytes = process.memoryUsage().rss;
+
+      return {
+        schemaVersion: CODING_GRAPH_BENCH_SCHEMA_VERSION,
+        timestamp: new Date().toISOString(),
+        machine: captureMachineFingerprint(),
+        fixture: {
+          config: fixtureConfig,
+          approximateLoc: repo.approximateLoc,
+          fileCount: repo.files.length,
+          symbolCount: repo.files.reduce((sum, f) => sum + f.symbols.length, 0),
+          edgeCount: repo.files.reduce((sum, f) => sum + f.edges.length, 0),
+        },
+        fullIndexMs: { ms: fullIndex.ms },
+        fullIndexLocsPerSecond: Math.round(locsPerSecond),
+        incrementalUpdate: computeMicroMetric(incrementalSamples),
+        tracePath: computeMicroMetric(traceSamples.length > 0 ? traceSamples : [0]),
+        searchGraph: computeMicroMetric(searchSamples),
+        deadCodeMs: { ms: deadCode.ms },
+        dbBytesPerKloc: Math.round(dbBytesPerKloc),
+        peakRssBytes,
+        dbBytes,
+        graphNodeCount,
+        graphEdgeCount,
+      };
+    } finally {
+      await store.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench/src/coding-graph/index.ts
+++ b/packages/bench/src/coding-graph/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Coding-graph benchmark suite — public re-exports (issue #1557).
+ *
+ * The CLI reaches this surface only through the optional loader
+ * (packages/remnic-cli/src/optional-bench.ts). Nothing bench-related enters
+ * the base `dependencies`/`noExternal` (rule 57).
+ */
+
+export {
+  createSeededRng,
+  generateSyntheticRepo,
+  pickStableQualifiedName,
+} from "./generator.js";
+
+export {
+  runCodingGraphBenchmark,
+  captureMachineFingerprint,
+} from "./harness.js";
+
+export {
+  checkCodingGraphRegression,
+  extractMetrics,
+  buildBaselineFromReport,
+} from "./regression.js";
+export type { RegressionMetricKey } from "./regression.js";
+
+export type {
+  SyntheticRepoConfig,
+  GeneratedRepo,
+  SyntheticFileIR,
+  SyntheticSymbol,
+  SyntheticEdge,
+  MachineFingerprint,
+  MicroMetric,
+  WallMetric,
+  CodingGraphMetricKey,
+  CodingGraphBenchReport,
+  CodingGraphBaseline,
+  RegressionMetricDetail,
+  RegressionGateResult,
+  CodingGraphBenchConfig,
+} from "./types.js";
+
+export {
+  DEFAULT_SMOKE_FIXTURE,
+  DEFAULT_10K_FIXTURE,
+  MIN_ITERATIONS,
+  DEFAULT_TOLERANCE_PERCENT,
+  CODING_GRAPH_BENCH_SCHEMA_VERSION,
+} from "./types.js";

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -73,6 +73,26 @@ export function checkCodingGraphRegression(
   const baselineMetrics = baseline.metrics;
   const regressions: RegressionMetricDetail[] = [];
 
+  // Guard: a regression comparison is only meaningful when the report's
+  // fixture matches the baseline's fixture. Comparing a 10k-node fixture
+  // against a 1k-node baseline would produce nonsense deltas.
+  if (
+    report.fixture.config.fileCount !== baseline.fixtureConfig.fileCount ||
+    report.fixture.config.symbolsPerFile !== baseline.fixtureConfig.symbolsPerFile ||
+    report.fixture.config.callDensity !== baseline.fixtureConfig.callDensity
+  ) {
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        `Fixture mismatch: report fixture (files=${report.fixture.config.fileCount}, ` +
+        `symbols=${report.fixture.config.symbolsPerFile}, density=${report.fixture.config.callDensity}) ` +
+        `differs from baseline fixture (files=${baseline.fixtureConfig.fileCount}, ` +
+        `symbols=${baseline.fixtureConfig.symbolsPerFile}, density=${baseline.fixtureConfig.callDensity}). ` +
+        `Metrics are not comparable across different fixtures.`,
+    };
+  }
+
   for (const key of Object.keys(METRIC_DIRECTION) as RegressionMetricKey[]) {
     const baseVal = baselineMetrics[key];
     const measVal = measured[key];

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -74,22 +74,26 @@ export function checkCodingGraphRegression(
   const regressions: RegressionMetricDetail[] = [];
 
   // Guard: a regression comparison is only meaningful when the report's
-  // fixture matches the baseline's fixture. Comparing a 10k-node fixture
-  // against a 1k-node baseline would produce nonsense deltas.
-  if (
-    report.fixture.config.fileCount !== baseline.fixtureConfig.fileCount ||
-    report.fixture.config.symbolsPerFile !== baseline.fixtureConfig.symbolsPerFile ||
-    report.fixture.config.callDensity !== baseline.fixtureConfig.callDensity
-  ) {
+  // fixture matches the baseline's fixture on EVERY knob. A different seed
+  // or language produces a structurally different synthetic repo, so timing
+  // deltas across mismatched fixtures are meaningless. Compare all keys
+  // present in the baseline config so new knobs are covered automatically.
+  const reportFixture = report.fixture.config;
+  const baselineFixture = baseline.fixtureConfig;
+  const mismatchedKeys = (Object.keys(baselineFixture) as Array<
+    keyof typeof baselineFixture
+  >).filter((key) => reportFixture[key] !== baselineFixture[key]);
+  if (mismatchedKeys.length > 0) {
+    const diffs = mismatchedKeys
+      .map(
+        (key) =>
+          `${key}: report=${reportFixture[key]} baseline=${baselineFixture[key]}`,
+      )
+      .join(", ");
     return {
       passed: false,
       regressions: [],
-      summary:
-        `Fixture mismatch: report fixture (files=${report.fixture.config.fileCount}, ` +
-        `symbols=${report.fixture.config.symbolsPerFile}, density=${report.fixture.config.callDensity}) ` +
-        `differs from baseline fixture (files=${baseline.fixtureConfig.fileCount}, ` +
-        `symbols=${baseline.fixtureConfig.symbolsPerFile}, density=${baseline.fixtureConfig.callDensity}). ` +
-        `Metrics are not comparable across different fixtures.`,
+      summary: `Fixture mismatch (${diffs}). Metrics are not comparable across different fixtures.`,
     };
   }
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -1,0 +1,138 @@
+/**
+ * Coding-graph regression gate (issue #1557 step 3).
+ *
+ * Compares a benchmark report against a tracked baseline with a generous
+ * tolerance. Hard-fails on gross regression — a real failing step, not a
+ * warning (rule 50: no `|| true`). Tightening the baseline is a deliberate
+ * PR act, mirroring `check-ratchets --update` (rule 50).
+ *
+ * The baseline is bench-owned (separate file from the structural ratchets
+ * in scripts/ratchet-baseline.json). New metrics are additive: only keys
+ * present in BOTH the report and the baseline are compared.
+ */
+
+import type {
+  CodingGraphBenchReport,
+  CodingGraphBaseline,
+  RegressionGateResult,
+  RegressionMetricDetail,
+} from "./types.js";
+import { DEFAULT_TOLERANCE_PERCENT } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Extract comparable metric values from a report.
+//
+// lowerIsBetter keys: time-based metrics (ms).
+// higherIsBetter keys: throughput (LOC/s).
+// ---------------------------------------------------------------------------
+
+const METRIC_DIRECTION = {
+  fullIndexMs: "lower-is-better" as const,
+  fullIndexLocsPerSecond: "higher-is-better" as const,
+  incrementalUpdateP95Ms: "lower-is-better" as const,
+  incrementalUpdateP50Ms: "lower-is-better" as const,
+  tracePathP95Ms: "lower-is-better" as const,
+  searchGraphP95Ms: "lower-is-better" as const,
+  deadCodeMs: "lower-is-better" as const,
+  dbBytesPerKloc: "lower-is-better" as const,
+};
+
+export type RegressionMetricKey = keyof typeof METRIC_DIRECTION;
+
+/**
+ * Extract the flat metric map from a report for comparison.
+ */
+export function extractMetrics(report: CodingGraphBenchReport): Record<string, number> {
+  return {
+    fullIndexMs: report.fullIndexMs.ms,
+    fullIndexLocsPerSecond: report.fullIndexLocsPerSecond,
+    incrementalUpdateP50Ms: report.incrementalUpdate.p50,
+    incrementalUpdateP95Ms: report.incrementalUpdate.p95,
+    tracePathP95Ms: report.tracePath.p95,
+    searchGraphP95Ms: report.searchGraph.p95,
+    deadCodeMs: report.deadCodeMs.ms,
+    dbBytesPerKloc: report.dbBytesPerKloc,
+  };
+}
+
+/**
+ * Compare a report against a baseline. Returns a gate result that exits
+ * non-zero when any metric regresses beyond the tolerance.
+ *
+ * @param report The current run's metrics.
+ * @param baseline The tracked baseline to compare against.
+ * @param tolerancePercent How much worse a metric can be before it counts
+ *   as a regression. Default 30 (generous — perf in CI flake).
+ */
+export function checkCodingGraphRegression(
+  report: CodingGraphBenchReport,
+  baseline: CodingGraphBaseline,
+  tolerancePercent: number = DEFAULT_TOLERANCE_PERCENT,
+): RegressionGateResult {
+  const measured = extractMetrics(report);
+  const baselineMetrics = baseline.metrics;
+  const regressions: RegressionMetricDetail[] = [];
+
+  for (const key of Object.keys(METRIC_DIRECTION) as RegressionMetricKey[]) {
+    const baseVal = baselineMetrics[key];
+    const measVal = measured[key];
+    if (baseVal == null || measVal == null) continue;
+    if (baseVal === 0) continue; // can't compute percentage of zero
+
+    const direction = METRIC_DIRECTION[key];
+    const ratio = measVal / baseVal;
+    const percentChange = direction === "lower-is-better"
+      ? (ratio - 1) * 100 // positive = slower = worse
+      : (1 - ratio) * 100; // positive = slower throughput = worse
+
+    const regressed = percentChange > tolerancePercent;
+
+    if (regressed) {
+      regressions.push({
+        key,
+        baseline: baseVal,
+        measured: measVal,
+        percentChange: Math.round(percentChange * 10) / 10,
+        direction,
+        tolerancePercent,
+        regressed: true,
+      });
+    }
+  }
+
+  const passed = regressions.length === 0;
+  const summary = passed
+    ? "All metrics within tolerance."
+    : `${regressions.length} metric(s) regressed beyond ${tolerancePercent}% tolerance:\n` +
+      regressions
+        .map(
+          (r) =>
+            `  ${r.key}: ${r.baseline} → ${r.measured} (${r.percentChange > 0 ? "+" : ""}${r.percentChange}% vs baseline)`,
+        )
+        .join("\n");
+
+  return { passed, regressions, summary };
+}
+
+// ---------------------------------------------------------------------------
+// Baseline construction helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a baseline object from a report, suitable for writing to the
+ * tracked baseline JSON file. This is the "deliberate PR act" that
+ * tightens the baseline (mirrors `check-ratchets --update`).
+ */
+export function buildBaselineFromReport(
+  report: CodingGraphBenchReport,
+  note: string,
+): CodingGraphBaseline {
+  return {
+    schemaVersion: report.schemaVersion,
+    machine: report.machine,
+    fixtureConfig: report.fixture.config,
+    metrics: extractMetrics(report),
+    createdAt: report.timestamp,
+    note,
+  };
+}

--- a/packages/bench/src/coding-graph/types.ts
+++ b/packages/bench/src/coding-graph/types.ts
@@ -1,0 +1,264 @@
+/**
+ * Coding-graph benchmark types (issue #1557).
+ *
+ * These types define the metric report shape, the benchmark configuration,
+ * and the regression-gate contract. The harness writes a {@link CodingGraphBenchReport};
+ * the regression step compares it against a tracked {@link CodingGraphBaseline}.
+ *
+ * Design rules (from the issue):
+ *   - Metrics are recorded as a tracked baseline (same philosophy as
+ *     scripts/ratchet-baseline.json), NOT inline thresholds.
+ *   - The comparison step hard-fails on gross regression (rule 50) with a
+ *     generous tolerance — perf thresholds in CI flake.
+ *   - Every metric that enters the report must have a plausible type so
+ *     the smoke test can assert presence without knowing exact values.
+ *   - The report includes a machine fingerprint so baselines are comparable
+ *     across runs (the issue calls this out explicitly).
+ */
+
+// ---------------------------------------------------------------------------
+// Generator config — parameterized synthetic repo (issue #1557 design (a)).
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for the deterministic synthetic repo generator. Same seed +
+ * same params → byte-identical IR output (rule 38 — generator determinism).
+ */
+export interface SyntheticRepoConfig {
+  /** PRNG seed — same seed + params = identical output. */
+  readonly seed: number;
+  /** Number of synthetic source files. */
+  readonly fileCount: number;
+  /** Symbols (functions/classes/methods) per file. */
+  readonly symbolsPerFile: number;
+  /**
+   * Edge density — probability [0,1] that any given symbol calls another.
+   * Higher = denser call graph (more edges per node).
+   */
+  readonly callDensity: number;
+  /** Language tier label (informational — the IR is language-agnostic). */
+  readonly language: string;
+}
+
+/**
+ * Generated fixture — the IR plus approximate LOC and a structural summary.
+ */
+export interface GeneratedRepo {
+  readonly files: readonly SyntheticFileIR[];
+  /** Approximate LOC (symbolsPerFile × fileCount × avgLinesPerSymbol). */
+  readonly approximateLoc: number;
+  readonly config: SyntheticRepoConfig;
+}
+
+/**
+ * Minimal IR shape for the synthetic generator. Matches the subset of
+ * {@link StoreFileIR} the harness exercises: symbols + CALLS edges. The
+ * generator emits this shape directly so the benchmark measures the STORE,
+ * not the parser (parser benchmarks are a separate concern).
+ */
+export interface SyntheticFileIR {
+  readonly path: string;
+  readonly language: string;
+  readonly contentHash: string;
+  readonly symbols: readonly SyntheticSymbol[];
+  readonly edges: readonly SyntheticEdge[];
+}
+
+export interface SyntheticSymbol {
+  readonly qualifiedName: string;
+  readonly name: string;
+  readonly kind: string;
+  readonly startByte: number;
+  readonly endByte: number;
+}
+
+export interface SyntheticEdge {
+  readonly srcQualifiedName: string;
+  readonly dstQualifiedName: string;
+  readonly type: string;
+  readonly confidence: number;
+  readonly provenance: string;
+}
+
+// ---------------------------------------------------------------------------
+// Machine fingerprint — baselines are only comparable on the same machine.
+// ---------------------------------------------------------------------------
+
+export interface MachineFingerprint {
+  readonly arch: string;
+  readonly platform: string;
+  readonly nodeVersion: string;
+  readonly cpuModel: string | null;
+  readonly cpuCores: number;
+  readonly totalMemoryMb: number;
+}
+
+// ---------------------------------------------------------------------------
+// Metrics — one entry per metric key. p50/p95 computed over iterations.
+// ---------------------------------------------------------------------------
+
+/**
+ * Micro-metric result with percentile distribution. `samples` is the raw
+ * array of per-iteration measurements (ms); p50/p95 are computed from it.
+ */
+export interface MicroMetric {
+  /** Median (p50) in milliseconds. */
+  readonly p50: number;
+  /** 95th percentile in milliseconds. */
+  readonly p95: number;
+  /** Number of iterations measured. */
+  readonly iterations: number;
+  /** Raw per-iteration timings (ms) — kept so the report is auditable. */
+  readonly samplesMs: readonly number[];
+}
+
+/** A single wall-clock measurement (ms) with no distribution. */
+export interface WallMetric {
+  readonly ms: number;
+  readonly detail?: string;
+}
+
+/**
+ * All metric keys that the harness can produce. Each is lower-is-better
+ * except `fullIndexLocsPerSecond` (higher is better).
+ *
+ * The regression gate compares only keys present in BOTH the report and
+ * the baseline — new metrics are additive, never blocking.
+ */
+export type CodingGraphMetricKey =
+  | "fullIndexMs"
+  | "fullIndexLocsPerSecond"
+  | "incrementalUpdateP50Ms"
+  | "incrementalUpdateP95Ms"
+  | "tracePathP95Ms"
+  | "searchGraphP95Ms"
+  | "deadCodeMs"
+  | "dbBytesPerKloc";
+
+// ---------------------------------------------------------------------------
+// Benchmark report — the JSON artifact written to disk.
+// ---------------------------------------------------------------------------
+
+export interface CodingGraphBenchReport {
+  /** Schema version — bump when the report shape changes. */
+  readonly schemaVersion: number;
+  readonly timestamp: string;
+  readonly machine: MachineFingerprint;
+  readonly fixture: {
+    readonly config: SyntheticRepoConfig;
+    readonly approximateLoc: number;
+    readonly fileCount: number;
+    readonly symbolCount: number;
+    readonly edgeCount: number;
+  };
+  /** Full-index wall time (ms) for the entire fixture. */
+  readonly fullIndexMs: WallMetric;
+  /** LOC/s sustained during full index (higher is better). */
+  readonly fullIndexLocsPerSecond: number;
+  /** Incremental single-file update latency distribution. */
+  readonly incrementalUpdate: MicroMetric;
+  /** trace_path (depth ≤ 5) latency distribution. */
+  readonly tracePath: MicroMetric;
+  /** search_graph name-pattern latency distribution. */
+  readonly searchGraph: MicroMetric;
+  /** Dead-code query wall time (ms). */
+  readonly deadCodeMs: WallMetric;
+  /** DB bytes per KLOC after index. */
+  readonly dbBytesPerKloc: number;
+  /** Peak RSS (bytes) at the end of the run. */
+  readonly peakRssBytes: number;
+  /** DB file size in bytes after index. */
+  readonly dbBytes: number;
+  /** Total node + edge count after index. */
+  readonly graphNodeCount: number;
+  readonly graphEdgeCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Regression gate — compares report against baseline with tolerance.
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracked baseline JSON (bench-owned, separate file from the structural
+ * ratchets in scripts/ratchet-baseline.json per issue #1557).
+ */
+export interface CodingGraphBaseline {
+  readonly schemaVersion: number;
+  readonly machine: MachineFingerprint;
+  readonly fixtureConfig: SyntheticRepoConfig;
+  readonly metrics: Readonly<Record<string, number>>;
+  readonly createdAt: string;
+  /** Human-readable note about how the baseline was captured. */
+  readonly note: string;
+}
+
+/**
+ * Per-metric regression detail. `direction` encodes whether higher or
+ * lower is better; `regressed` is true when the measured value exceeds
+ * the tolerance-adjusted baseline.
+ */
+export interface RegressionMetricDetail {
+  readonly key: string;
+  readonly baseline: number;
+  readonly measured: number;
+  /** Percentage change relative to baseline (positive = worse). */
+  readonly percentChange: number;
+  readonly direction: "lower-is-better" | "higher-is-better";
+  readonly tolerancePercent: number;
+  readonly regressed: boolean;
+}
+
+export interface RegressionGateResult {
+  readonly passed: boolean;
+  readonly regressions: readonly RegressionMetricDetail[];
+  readonly summary: string;
+}
+
+// ---------------------------------------------------------------------------
+// Run configuration.
+// ---------------------------------------------------------------------------
+
+export interface CodingGraphBenchConfig {
+  /** Fixture parameters. Defaults to a small, fast smoke fixture. */
+  readonly fixture?: Partial<SyntheticRepoConfig>;
+  /**
+   * Iterations for micro-metrics (p50/p95). Minimum 20 per the issue.
+   * Default 20.
+   */
+  readonly iterations?: number;
+  /** BFS depth for trace_path measurements. Default 5. */
+  readonly traceDepth?: number;
+  /**
+   * Regression tolerance (percent). A metric must regress by MORE than
+   * this to count as a failure. Default 30 (generous — perf thresholds
+   * in CI flake).
+   */
+  readonly tolerancePercent?: number;
+}
+
+/** Default fixture — small enough for a sub-second smoke run. */
+export const DEFAULT_SMOKE_FIXTURE: SyntheticRepoConfig = {
+  seed: 42,
+  fileCount: 20,
+  symbolsPerFile: 10,
+  callDensity: 0.3,
+  language: "typescript",
+};
+
+/** Default fixture for a 10k-node scale run (~1k files × 10 symbols). */
+export const DEFAULT_10K_FIXTURE: SyntheticRepoConfig = {
+  seed: 42,
+  fileCount: 1000,
+  symbolsPerFile: 10,
+  callDensity: 0.2,
+  language: "typescript",
+};
+
+/** Minimum iterations for percentile metrics (issue #1557: ≥20). */
+export const MIN_ITERATIONS = 20;
+
+/** Default regression tolerance (issue #1557: generous, e.g. 30%). */
+export const DEFAULT_TOLERANCE_PERCENT = 30;
+
+/** Report schema version — bump when the shape changes. */
+export const CODING_GRAPH_BENCH_SCHEMA_VERSION = 1;

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -554,3 +554,43 @@ export type {
   MitigatedBaselineConfig,
   MitigatedTargetConfig,
 } from "./security/extraction-attack/index.js";
+
+// ---------------------------------------------------------------------------
+// Coding-graph benchmark harness (issue #1557): deterministic synthetic repo
+// generator, metric runner, and regression gate. Reached via the optional
+// loader (rule 57). Bench-owned baseline JSON lives in baselines/.
+// ---------------------------------------------------------------------------
+export {
+  createSeededRng as createCodingGraphSeededRng,
+  generateSyntheticRepo,
+  pickStableQualifiedName,
+  runCodingGraphBenchmark,
+  captureMachineFingerprint,
+  checkCodingGraphRegression,
+  extractMetrics as extractCodingGraphMetrics,
+  buildBaselineFromReport,
+} from "./coding-graph/index.js";
+export type {
+  RegressionMetricKey as CodingGraphRegressionKey,
+  SyntheticRepoConfig,
+  GeneratedRepo,
+  SyntheticFileIR,
+  SyntheticSymbol,
+  SyntheticEdge,
+  MachineFingerprint as CodingGraphMachineFingerprint,
+  MicroMetric,
+  WallMetric,
+  CodingGraphMetricKey,
+  CodingGraphBenchReport,
+  CodingGraphBaseline,
+  RegressionMetricDetail as CodingGraphRegressionDetail,
+  RegressionGateResult as CodingGraphRegressionResult,
+  CodingGraphBenchConfig,
+} from "./coding-graph/index.js";
+export {
+  DEFAULT_SMOKE_FIXTURE as CODING_GRAPH_SMOKE_FIXTURE,
+  DEFAULT_10K_FIXTURE as CODING_GRAPH_10K_FIXTURE,
+  MIN_ITERATIONS as CODING_GRAPH_MIN_ITERATIONS,
+  DEFAULT_TOLERANCE_PERCENT as CODING_GRAPH_DEFAULT_TOLERANCE,
+  CODING_GRAPH_BENCH_SCHEMA_VERSION,
+} from "./coding-graph/index.js";

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -3,11 +3,15 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src"
@@ -32,7 +36,8 @@
     "src/benchmarks/published/**/*.ts",
     "src/benchmarks/custom/**/*.ts",
     "src/benchmarks/remnic/**/*.ts",
-    "src/security/**/*.ts"
+    "src/security/**/*.ts",
+    "src/coding-graph/**/*.ts"
   ],
   "exclude": [
     "src/**/*.test.ts"

--- a/packages/bench/tsup.config.ts
+++ b/packages/bench/tsup.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   dts: true,
-  external: ["@remnic/core"],
+  external: ["@remnic/core", "@remnic/coding-graph"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@honcho-ai/sdk':
         specifier: ^2.0.0
-        version: 2.1.0
+        version: 2.2.0
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@18.1.0)
@@ -37,16 +37,16 @@ importers:
         version: 18.1.0
       better-sqlite3:
         specifier: ^12.6.2
-        version: 12.8.0
+        version: 12.11.1
       meilisearch:
         specifier: ^0.46.0
         version: 0.46.0
       node-gyp:
         specifier: ^12.3.0
-        version: 12.3.0
+        version: 12.4.0
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(zod@3.25.76)
+        version: 6.45.0(zod@3.25.76)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -65,13 +65,13 @@ importers:
         version: 7.6.13
       semver:
         specifier: ^7.7.4
-        version: 7.7.4
+        version: 7.8.5
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       turbo:
         specifier: 2.9.14
         version: 2.9.14
@@ -96,29 +96,32 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
 
   packages/bench:
     dependencies:
+      '@remnic/coding-graph':
+        specifier: workspace:^
+        version: link:../coding-graph
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
       hyparquet:
         specifier: ^1.25.7
-        version: 1.25.7
+        version: 1.26.2
       yaml:
         specifier: ^2.4.2
-        version: 2.8.3
+        version: 2.9.0
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -127,35 +130,35 @@ importers:
     dependencies:
       react:
         specifier: ^19.2.0
-        version: 19.2.5
+        version: 19.2.7
       react-dom:
         specifier: ^19.2.0
-        version: 19.2.5(react@19.2.5)
+        version: 19.2.7(react@19.2.7)
       react-router-dom:
         specifier: ^7.15.0
-        version: 7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
-        version: 19.2.14
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
-        version: 5.2.0(vite@7.3.5(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.3.5
-        version: 7.3.5(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.8.3)
+        version: 7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/coding-graph:
     dependencies:
       better-sqlite3:
         specifier: ^12.6.2
-        version: 12.8.0
+        version: 12.11.1
       web-tree-sitter:
         specifier: ^0.25.0
         version: 0.25.10
@@ -168,10 +171,10 @@ importers:
         version: 22.20.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.19.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -183,10 +186,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -198,10 +201,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -213,10 +216,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -225,7 +228,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -234,10 +237,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -249,10 +252,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -261,7 +264,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -273,10 +276,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -288,10 +291,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -303,10 +306,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -315,7 +318,7 @@ importers:
     dependencies:
       better-sqlite3:
         specifier: ^12.6.2
-        version: 12.8.0
+        version: 12.11.1
     devDependencies:
       '@remnic/core':
         specifier: workspace:*
@@ -325,10 +328,10 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -340,10 +343,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -355,10 +358,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -370,10 +373,10 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -396,17 +399,17 @@ importers:
         version: 0.34.49
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(zod@4.0.0)
+        version: 6.45.0(zod@4.0.0)
     devDependencies:
       '@openclaw/plugin-inspector':
         specifier: 0.3.10
         version: 0.3.10
       acorn:
         specifier: ^8.16.0
-        version: 8.16.0
+        version: 8.17.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -422,10 +425,10 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.0.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -443,7 +446,7 @@ importers:
         version: link:../remnic-server
       yaml:
         specifier: ^2.4.2
-        version: 2.8.3
+        version: 2.9.0
     devDependencies:
       '@remnic/bench':
         specifier: workspace:*
@@ -483,7 +486,7 @@ importers:
         version: link:../import-weclone
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -492,7 +495,7 @@ importers:
     dependencies:
       '@honcho-ai/sdk':
         specifier: ^2.0.0
-        version: 2.1.0
+        version: 2.2.0
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@18.1.0)
@@ -513,7 +516,7 @@ importers:
         version: 18.1.0
       better-sqlite3:
         specifier: ^12.6.2
-        version: 12.8.0
+        version: 12.11.1
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
@@ -522,10 +525,10 @@ importers:
         version: 0.46.0
       node-gyp:
         specifier: ^12.3.0
-        version: 12.3.0
+        version: 12.4.0
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(zod@3.25.76)
+        version: 6.45.0(zod@3.25.76)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -538,10 +541,10 @@ importers:
         version: 6.0.6
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.21.0
-        version: 4.22.4
+        version: 4.23.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -564,7 +567,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -580,7 +583,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -621,20 +624,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -649,24 +644,19 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -677,10 +667,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -744,14 +730,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -909,8 +895,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@honcho-ai/sdk@2.1.0':
-    resolution: {integrity: sha512-GPyeKTDRhg5jd77RAh63LwrxLxnbluLdYUF1gsI6g6CU4eTyv8s1+KJ3/OTCiBwJ/dhjznNvQUngkUjjnNzUTA==}
+  '@honcho-ai/sdk@2.2.0':
+    resolution: {integrity: sha512-SyygN+BrpUB2fRjhwcYmT+tcEhHrKmbj9nOZLVUFY7M5YBswJ+mZb/CeLpNbRh+QQTU8F8JWY3lQat95c6nwmA==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1099,19 +1085,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.2':
@@ -1119,19 +1095,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.2':
     resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.2':
@@ -1139,19 +1105,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.2':
@@ -1159,23 +1115,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
@@ -1183,23 +1127,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
@@ -1207,23 +1139,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
@@ -1231,23 +1151,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
@@ -1255,23 +1163,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
@@ -1279,21 +1175,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1303,51 +1187,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.62.2':
     resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
@@ -1355,18 +1213,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
 
@@ -1378,8 +1226,8 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
-  '@swc/helpers@0.5.21':
-    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@turbo/darwin-64@2.9.14':
     resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
@@ -1411,8 +1259,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1438,14 +1286,11 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
@@ -1455,8 +1300,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -1468,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1495,14 +1340,14 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.40:
-    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1528,8 +1373,8 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+  caniuse-lite@1.0.30001802:
+    resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
 
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
@@ -1614,8 +1459,8 @@ packages:
   dpack@0.6.22:
     resolution: {integrity: sha512-WGPNlW2OAE7Bj0eODMpAHUcEqxrlg01e9OFZDxQodminIgC194/cRHT7K04Z1j7AUEWTeeplYGrIv/xRdwU9Hg==}
 
-  electron-to-chromium@1.5.384:
-    resolution: {integrity: sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==}
+  electron-to-chromium@1.5.387:
+    resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1684,8 +1529,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hyparquet@1.25.7:
-    resolution: {integrity: sha512-F+FoqZ1mQZK+nHaNMIOjKo6o8pH34L29oZ9oMNIQHdvMonaq+Inh5blMWlvNFvC1LUyyGkJjTrv1WEMTAEHAKQ==}
+  hyparquet@1.26.2:
+    resolution: {integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1774,20 +1619,20 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+  node-abi@3.94.0:
+    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
     engines: {node: '>=10'}
 
-  node-gyp@12.3.0:
-    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+  node-gyp@12.4.0:
+    resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
@@ -1807,13 +1652,21 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  openai@6.33.0:
-    resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
-    hasBin: true
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
     peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
@@ -1829,8 +1682,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -1858,8 +1711,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -1879,24 +1732,24 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.7
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.17.0:
-    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -1905,8 +1758,8 @@ packages:
       react-dom:
         optional: true
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
@@ -1924,11 +1777,6 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1944,8 +1792,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1998,8 +1846,8 @@ packages:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -2018,10 +1866,6 @@ packages:
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -2056,8 +1900,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.22.4:
-    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2081,8 +1925,8 @@ packages:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2100,8 +1944,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  vite@7.3.5:
-    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2172,8 +2016,8 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -2247,13 +2091,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -2264,23 +2104,19 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -2299,11 +2135,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -2345,18 +2176,18 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2439,7 +2270,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@honcho-ai/sdk@2.1.0':
+  '@honcho-ai/sdk@2.2.0':
     dependencies:
       zod: 4.0.0
 
@@ -2504,9 +2335,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@node-rs/argon2-android-arm-eabi@2.0.2':
@@ -2583,151 +2414,76 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
@@ -2735,7 +2491,7 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
-  '@swc/helpers@0.5.21':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -2757,31 +2513,31 @@ snapshots:
   '@turbo/windows-arm64@2.9.14':
     optional: true
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -2795,11 +2551,9 @@ snapshots:
     dependencies:
       '@types/node': 22.20.0
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
-  '@types/node@20.19.39':
+  '@types/node@20.19.43':
     dependencies:
       undici-types: 6.21.0
 
@@ -2807,29 +2561,29 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
-  '@types/react@19.2.14':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
   abbrev@4.0.0: {}
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2839,10 +2593,10 @@ snapshots:
 
   apache-arrow@18.1.0:
     dependencies:
-      '@swc/helpers': 0.5.21
+      '@swc/helpers': 0.5.23
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.39
+      '@types/node': 20.19.43
       command-line-args: 5.2.1
       command-line-usage: 7.0.4
       flatbuffers: 24.12.23
@@ -2855,9 +2609,9 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.40: {}
+  baseline-browser-mapping@2.10.42: {}
 
-  better-sqlite3@12.8.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -2874,9 +2628,9 @@ snapshots:
 
   browserslist@4.28.4:
     dependencies:
-      baseline-browser-mapping: 2.10.40
-      caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.384
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001802
+      electron-to-chromium: 1.5.387
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -2892,7 +2646,7 @@ snapshots:
 
   cac@6.7.14: {}
 
-  caniuse-lite@1.0.30001800: {}
+  caniuse-lite@1.0.30001802: {}
 
   chalk-template@0.4.0:
     dependencies:
@@ -2963,7 +2717,7 @@ snapshots:
 
   dpack@0.6.22: {}
 
-  electron-to-chromium@1.5.384: {}
+  electron-to-chromium@1.5.387: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3006,9 +2760,9 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-uri-to-path@1.0.0: {}
 
@@ -3037,7 +2791,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hyparquet@1.25.7: {}
+  hyparquet@1.26.2: {}
 
   ieee754@1.2.1: {}
 
@@ -3091,10 +2845,10 @@ snapshots:
 
   mlly@1.8.2:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ms@2.1.3: {}
 
@@ -3104,24 +2858,24 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.13: {}
+  nanoid@3.3.15: {}
 
   napi-build-utils@2.0.0: {}
 
-  node-abi@3.89.0:
+  node-abi@3.94.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
-  node-gyp@12.3.0:
+  node-gyp@12.4.0:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.19
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       undici: 6.27.0
       which: 6.0.1
 
@@ -3137,11 +2891,11 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.33.0(zod@3.25.76):
+  openai@6.45.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
 
-  openai@6.33.0(zod@4.0.0):
+  openai@6.45.0(zod@4.0.0):
     optionalDependencies:
       zod: 4.0.0
 
@@ -3151,7 +2905,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
 
@@ -3161,17 +2915,17 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.16)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.15
-      tsx: 4.22.4
-      yaml: 2.8.3
+      postcss: 8.5.16
+      tsx: 4.23.0
+      yaml: 2.9.0
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3183,11 +2937,11 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.89.0
+      node-abi: 3.94.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.4
+      tar-fs: 2.1.5
       tunnel-agent: 0.6.0
 
   proc-log@6.1.0: {}
@@ -3204,28 +2958,28 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.5(react@19.2.5):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
       scheduler: 0.27.0
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-router: 7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
-      react: 19.2.5
+      react: 19.2.7
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.5(react@19.2.5)
+      react-dom: 19.2.7(react@19.2.7)
 
-  react@19.2.5: {}
+  react@19.2.7: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -3238,37 +2992,6 @@ snapshots:
   reflect-metadata@0.2.2: {}
 
   resolve-from@5.0.0: {}
-
-  rollup@4.60.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
-      fsevents: 2.3.3
 
   rollup@4.62.2:
     dependencies:
@@ -3307,7 +3030,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4: {}
+  semver@7.8.5: {}
 
   seqproto@0.2.3: {}
 
@@ -3356,7 +3079,7 @@ snapshots:
       array-back: 6.2.3
       wordwrapjs: 5.1.1
 
-  tar-fs@2.1.4:
+  tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -3389,15 +3112,10 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tree-kill@1.2.2: {}
 
@@ -3405,7 +3123,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -3416,16 +3134,16 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.16)(tsx@4.23.0)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.60.1
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -3433,7 +3151,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.22.4:
+  tsx@4.23.0:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -3458,7 +3176,7 @@ snapshots:
 
   typical@7.3.0: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   undici-types@6.21.0: {}
 
@@ -3472,19 +3190,19 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.5(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.8.3):
+  vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.0
       fsevents: 2.3.3
-      tsx: 4.22.4
-      yaml: 2.8.3
+      tsx: 4.23.0
+      yaml: 2.9.0
 
   web-tree-sitter@0.25.10: {}
 
@@ -3504,7 +3222,7 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml@2.8.3: {}
+  yaml@2.9.0: {}
 
   zod@3.25.76: {}
 

--- a/scripts/ensure-bench-build-deps.mjs
+++ b/scripts/ensure-bench-build-deps.mjs
@@ -15,3 +15,18 @@ ensurePackageBuild(
     path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
   ],
 );
+
+// #1557: bench now depends on @remnic/coding-graph for the coding-graph
+// benchmark harness. Ensure its dist is built before bench's tsup DTS
+// generation runs, mirroring the @remnic/core call above.
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/coding-graph",
+  path.join(repoRoot, "packages", "coding-graph", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "coding-graph", "src"),
+    path.join(repoRoot, "packages", "coding-graph", "package.json"),
+    path.join(repoRoot, "packages", "coding-graph", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "coding-graph", "tsconfig.json"),
+  ],
+);

--- a/scripts/ensure-bench-build-deps.mjs
+++ b/scripts/ensure-bench-build-deps.mjs
@@ -19,14 +19,22 @@ ensurePackageBuild(
 // #1557: bench now depends on @remnic/coding-graph for the coding-graph
 // benchmark harness. Ensure its dist is built before bench's tsup DTS
 // generation runs, mirroring the @remnic/core call above.
-ensurePackageBuild(
-  repoRoot,
-  "@remnic/coding-graph",
-  path.join(repoRoot, "packages", "coding-graph", "dist", "index.js"),
-  [
-    path.join(repoRoot, "packages", "coding-graph", "src"),
-    path.join(repoRoot, "packages", "coding-graph", "package.json"),
-    path.join(repoRoot, "packages", "coding-graph", "tsup.config.ts"),
-    path.join(repoRoot, "packages", "coding-graph", "tsconfig.json"),
-  ],
-);
+//
+// Guard against recursion: @remnic/coding-graph's own prebuild script calls
+// this file. Without the guard, building coding-graph would trigger building
+// coding-graph again (infinite loop).
+if (!process.env.REMNIC_BUILDING_CODING_GRAPH) {
+  process.env.REMNIC_BUILDING_CODING_GRAPH = "1";
+  ensurePackageBuild(
+    repoRoot,
+    "@remnic/coding-graph",
+    path.join(repoRoot, "packages", "coding-graph", "dist", "index.js"),
+    [
+      path.join(repoRoot, "packages", "coding-graph", "src"),
+      path.join(repoRoot, "packages", "coding-graph", "package.json"),
+      path.join(repoRoot, "packages", "coding-graph", "tsup.config.ts"),
+      path.join(repoRoot, "packages", "coding-graph", "tsconfig.json"),
+    ],
+  );
+  delete process.env.REMNIC_BUILDING_CODING_GRAPH;
+}

--- a/scripts/native-dependent-tests.json
+++ b/scripts/native-dependent-tests.json
@@ -6,6 +6,7 @@
     "integrations/amb/install-remnic-provider.test.mjs",
     "integrations/amb/run-remnic-amb.test.mjs",
     "packages/bench/src/adapters/remnic-adapter.test.ts",
+    "packages/bench/src/coding-graph/harness.test.ts",
     "packages/import-lossless-claw/src/importer.test.ts",
     "packages/import-lossless-claw/src/source.test.ts",
     "packages/remnic-core/src/lcm-engine.test.ts",


### PR DESCRIPTION
## Summary

Closes #1557 — builds the coding-graph benchmark harness with honest scale targets, living in @remnic/bench per the à-la-carte policy (rule 57).

**What this PR delivers (PR1 scope per the issue's suggested split):**

- **Deterministic synthetic repo generator** (`generateSyntheticRepo`) — parameterized by files x symbols-per-file x call-density x language. Same seed + same params always produces byte-identical IR output (rule 38). Synthetic code only (public-repo policy).
- **Benchmark harness** (`runCodingGraphBenchmark`) — measures every metric from the issue: full-index wall time + LOC/s, incremental update p50/p95, trace_path p95, search_graph p95, dead-code query, DB bytes/KLOC, peak RSS. Uses monotonic clocks; p95 computed over 20+ iterations.
- **Regression gate** (`checkCodingGraphRegression`) — compares report against a tracked baseline JSON with a generous 30% tolerance. Hard-fails on gross regression — a real failing step, not a warning (rule 50). Baseline is bench-owned, separate from the structural ratchets.
- **First measured baseline** captured on Apple M2 Max, Node v22.
- **Docs section** in the bench README with measured numbers traced to the baseline file (rule 55).

**Deferred to follow-up PRs (per the issue's PR2/PR3 split):**
- PR2: pinned real OSS repo fixtures + full metric set at scale targets (1M LOC)
- PR3: team-share artifact (codegraph export/import with Brotli compression)

## Tests (prove-fail-first)

10 tests, all green:
- Generator determinism: same params produce byte-identical output (rule 38)
- Generator distinctness: different seeds produce different edge structure
- callDensity controls edge count
- Seeded RNG produces stable, reproducible sequence
- Harness smoke: every metric key present with plausible types
- Regression gate passes within tolerance (identical metrics)
- Regression gate passes within 30% tolerance on natural variance
- Regression gate prove-fail: 10x slowdown FAILS the gate (rule 50)
- higherIsBetter metric (LOC/s) regression detected when throughput drops

## Measured baseline (first run)

| Metric | Value | Machine |
|---|---|---|
| Full index | ~17.6 ms, ~115k LOC/s | Apple M2 Max, Node v22 |
| Incremental update p95 | ~0.26 ms | |
| trace_path p95 | ~0.14 ms | |
| search_graph p95 | ~0.29 ms | |
| dead_code | ~0.67 ms | |
| DB size | ~2 KB/KLOC | |

These are working targets on a small fixture (20 files, 200 symbols), NOT parity claims against codebase-memory-mcp. Scale targets at 1M+ LOC are tracked as stretch goals for PR2.

## Chokepoints used / not applicable

- @remnic/bench optional loader (rule 57) — harness reached only through the existing computed-specifier pattern
- No PluginConfig keys touched
- No orchestrator/storage changes
- Ratchets untouched (node scripts/check-ratchets.mjs returns OK)

## Checklist

- [x] All tests pass (10/10)
- [x] Bench package builds
- [x] Type-check passes
- [x] Ratchets OK
- [x] Baseline JSON checked in with first measured numbers
- [x] No committed datasets/raw traces (repo ethics)
- [x] No new native dependencies (better-sqlite3 already in @remnic/coding-graph)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional `@remnic/bench` tooling and tests; production CLI/core paths are untouched. Harness tests depend on the existing better-sqlite3 stack via `@remnic/coding-graph`, so CI may skip them when native bindings are unavailable.
> 
> **Overview**
> **Adds a coding-graph performance harness to `@remnic/bench` (issue #1557 PR1)** so `@remnic/coding-graph` store/query timings are measured in-repo instead of claimed in prose.
> 
> The new `packages/bench/src/coding-graph/` module includes a **seeded synthetic IR fixture generator** (`generateSyntheticRepo`), **`runCodingGraphBenchmark`** against a temp `GraphStore` (full batch index, incremental upserts, `traverse`, `searchGraph`, `deadCode`, WAL-aware DB size, peak RSS), and **`checkCodingGraphRegression`** with fixture-knob matching and default **30%** tolerance. **`baselines/coding-graph-baseline.json`** records the first measured numbers; **`buildBaselineFromReport`** supports deliberate baseline updates.
> 
> **Integration:** `@remnic/coding-graph` is a bench dependency; exports are re-exported from `@remnic/bench` (aliased names where needed); `tsup` marks coding-graph external; `ensure-bench-build-deps.mjs` builds coding-graph before bench (with a recursion guard); `harness.test.ts` is listed in `native-dependent-tests.json`; README documents metrics and usage.
> 
> Scale targets (1M+ LOC / real OSS fixtures) are explicitly deferred; numbers are labeled as small-fixture working targets, not external parity claims.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d1538e033551a35b7b565d84d9cb7bf9fc1ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->