### PR TITLE
refactor(config): CapabilitySet — recall-planner-llm + direct-answer gate migration (#1523)

### DIFF
--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -96,6 +96,34 @@ test("resolveCapabilities returns a frozen object", () => {
   assert.equal(Object.isFrozen(caps), true, "CapabilitySet must be frozen");
 });
 
+test("resolveCapabilities is deterministic — same config always yields identical gate values (one-resolution-per-op #1523)", () => {
+  // The one-resolution-per-op contract (issue #1523): resolve ONCE at the
+  // operation entry, thread the frozen result down. This test proves the
+  // resolution is deterministic — calling it twice with the same config
+  // produces identical values for every gate, so there is never a reason to
+  // re-resolve mid-operation.
+  const config = parseConfig({
+    rerankCacheEnabled: true,
+    recallDirectAnswerEnabled: false,
+    recallMmrEnabled: true,
+    recallPlannerLlmEnabled: true,
+    graphRecallEnabled: true,
+  });
+  const first = resolveCapabilities(config);
+  const second = resolveCapabilities(config);
+  for (const field of FIELDS) {
+    assert.equal(
+      first[field],
+      second[field],
+      `field ${field} must be deterministic across resolutions`,
+    );
+  }
+  // Both must be frozen — a mid-operation mutation would break the contract.
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(second), true);
+});
+
+
 // ---------------------------------------------------------------------------
 // GraphConstructionCapabilitySet — gate-parity tests (issue #1566 Cluster A).
 //

--- a/packages/remnic-core/src/direct-answer-wiring.test.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.test.ts
@@ -13,7 +13,6 @@ import type { TrustZoneName } from "./trust-zones.js";
 type WiringConfig = DirectAnswerWiringInput["config"];
 
 const BASE_CONFIG: WiringConfig = {
-  recallDirectAnswerEnabled: true,
   recallDirectAnswerTokenOverlapFloor: 0.5,
   recallDirectAnswerImportanceFloor: 0.7,
   recallDirectAnswerAmbiguityMargin: 0.15,
@@ -105,27 +104,14 @@ test("tryDirectAnswer disabled-path does not call any source accessor", async ()
   assert.deepEqual(sources.calls.importance, []);
 });
 
-// ── Backward-compat (#1523): omit top-level `enabled`, fall back to config ──
+// ── One-resolution-per-op (#1523): `enabled` is the sole gate ──────────────
 
-test("tryDirectAnswer falls back to config.recallDirectAnswerEnabled when `enabled` is omitted (disabled)", async () => {
-  // Old input shape: config carries recallDirectAnswerEnabled: false and no
-  // top-level `enabled`. Must short-circuit as "disabled" (identical to the
-  // pre-#1523 behavior) rather than treating undefined as enabled.
-  const sources = makeMockSources({ memories: [makeMemory()] });
-  const result = await tryDirectAnswer({
-    query: "does not matter",
-    namespace: "default",
-    config: { ...BASE_CONFIG, recallDirectAnswerEnabled: false },
-    sources,
-  });
-  assert.equal(result.eligible, false);
-  assert.equal(result.reason, "disabled");
-  assert.equal(sources.calls.listCandidates, 0);
-});
-
-test("tryDirectAnswer falls back to config.recallDirectAnswerEnabled when `enabled` is omitted (enabled)", async () => {
-  // Old input shape with recallDirectAnswerEnabled: true and no `enabled` must
-  // NOT short-circuit — it proceeds to materialize candidates.
+test("tryDirectAnswer disabled when `enabled: false` even with matching candidates (caps wins over any config-derived value)", async () => {
+  // Issue #1523 contract: the resolved capability is the sole gate.
+  // `enabled` comes from `resolveCapabilities(config).recallDirectAnswer`,
+  // resolved ONCE at the recall entry. This test proves the gate value is
+  // authoritative — when it says disabled, the function short-circuits
+  // regardless of candidate quality.
   const sources = makeMockSources({
     memories: [makeMemory({ tags: ["pnpm"], content: "remnic uses pnpm" })],
     trustZones: { m1: "trusted" },
@@ -134,7 +120,28 @@ test("tryDirectAnswer falls back to config.recallDirectAnswerEnabled when `enabl
   const result = await tryDirectAnswer({
     query: "package manager remnic",
     namespace: "default",
-    config: BASE_CONFIG, // recallDirectAnswerEnabled: true
+    config: BASE_CONFIG,
+    enabled: false,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "disabled");
+  assert.equal(sources.calls.listCandidates, 0);
+});
+
+test("tryDirectAnswer proceeds when `enabled: true` and candidates match", async () => {
+  // Same contract, positive case: when the resolved capability says enabled,
+  // the function proceeds to materialize candidates.
+  const sources = makeMockSources({
+    memories: [makeMemory({ tags: ["pnpm"], content: "remnic uses pnpm" })],
+    trustZones: { m1: "trusted" },
+    importance: { m1: 0.9 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    enabled: true,
     sources,
   });
   assert.notEqual(result.reason, "disabled");

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -14,8 +14,9 @@
  *
  * Short-circuit contract:
  *
- * - When the resolved gate (`input.enabled` if supplied, else
- *   `config.recallDirectAnswerEnabled`) is `false`, the function returns the
+ * - When the resolved gate (`input.enabled`, projected from
+ *   `caps.recallDirectAnswer` at the recall-operation entry) is `false`, the
+ *   function returns the
  *   eligibility verdict with reason `"disabled"` without touching any source
  *   accessor.  This is the documented default.
  * - When enabled, the wiring cheaply drops non-trusted-zone memories
@@ -74,7 +75,6 @@ export interface DirectAnswerWiringInput {
   namespace: string;
   config: Pick<
     PluginConfig,
-    | "recallDirectAnswerEnabled"
     | "recallDirectAnswerTokenOverlapFloor"
     | "recallDirectAnswerImportanceFloor"
     | "recallDirectAnswerAmbiguityMargin"
@@ -82,13 +82,12 @@ export interface DirectAnswerWiringInput {
   >;
   /**
    * Direct-answer capability gate, resolved once at the recall-operation entry
-   * (issue #1523: `caps.recallDirectAnswer`). OPTIONAL and additive: when the
-   * caller supplies it, this module and the orchestrator agree on a single
-   * resolved gate value for the whole operation. When omitted, we fall back to
-   * `config.recallDirectAnswerEnabled` so existing callers on the old input
-   * shape keep identical behavior.
+   * via `resolveCapabilities(config).recallDirectAnswer` (issue #1523). This
+   * is the sole gate — the function no longer reads the config flag directly.
+   * Callers MUST pass the resolved capability so the whole operation agrees on
+   * a single gate value.
    */
-  enabled?: boolean;
+  enabled: boolean;
   sources: DirectAnswerSources;
   queryEntityRefs?: string[];
   abortSignal?: AbortSignal;
@@ -105,10 +104,7 @@ export async function tryDirectAnswer(
   const { query, namespace, config, enabled, sources, queryEntityRefs, abortSignal } = input;
 
   const eligibilityConfig: DirectAnswerConfig = {
-    // Prefer the resolved capability when supplied; fall back to the config
-    // flag so callers on the old input shape (config-only, no `enabled`) get
-    // identical gating (issue #1523 backward-compat).
-    enabled: enabled ?? config.recallDirectAnswerEnabled,
+    enabled,
     tokenOverlapFloor: config.recallDirectAnswerTokenOverlapFloor,
     importanceFloor: config.recallDirectAnswerImportanceFloor,
     ambiguityMargin: config.recallDirectAnswerAmbiguityMargin,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1396,12 +1396,11 @@ export async function resolveRecallModeDecisionAsync(
   options: RecallModeGraphOptions & {
     config: PluginConfig;
     /**
-     * Recall-operation capability gates (issue #1523). OPTIONAL and additive:
-     * the recall orchestrator passes a resolved set, but existing callers that
-     * only pass `config` + planner flags stay backward-compatible — the LLM
-     * planner gate falls back to `config.recallPlannerLlmEnabled` when omitted.
+     * Recall-operation capability gates (issue #1523). REQUIRED: the recall
+     * orchestrator always passes a resolved set — the LLM planner gate reads
+     * `caps.recallPlannerLlm`, never re-derives from config.
      */
-    caps?: CapabilitySet;
+    caps: CapabilitySet;
     hints?: string[];
     llm?: FallbackLlmClient;
     signal?: AbortSignal;
@@ -1410,10 +1409,8 @@ export async function resolveRecallModeDecisionAsync(
   const heuristicDecision = resolveRecallModeDecision(options);
 
   // Planner globally off, or LLM planning not opted into → heuristic only.
-  // Prefer the resolved capability when supplied; otherwise fall back to the
-  // config flag so callers on the old option shape get identical gating.
-  const plannerLlmEnabled =
-    options.caps?.recallPlannerLlm ?? options.config.recallPlannerLlmEnabled;
+  // Read the resolved capability (issue #1523) — never re-derive from config.
+  const plannerLlmEnabled = options.caps.recallPlannerLlm;
   if (!options.plannerEnabled || !plannerLlmEnabled) {
     return heuristicDecision;
   }
@@ -1423,9 +1420,9 @@ export async function resolveRecallModeDecisionAsync(
     options.prompt,
     options.hints,
     options.config,
+    options.caps,
     options.llm,
     options.signal,
-    options.caps,
   );
 
   // Shadow mode: record what the LLM would have chosen but keep the heuristic

--- a/packages/remnic-core/src/recall-planner-llm.test.ts
+++ b/packages/remnic-core/src/recall-planner-llm.test.ts
@@ -41,7 +41,7 @@ test("returns heuristic without calling the LLM when recallPlannerLlmEnabled is 
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ capturedOptions: captured, result: { mode: "no_recall" } });
 
-  const result = await planRecallModeLLM("what did we decide about auth?", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("what did we decide about auth?", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 0, "LLM must not be contacted when disabled");
   assert.equal(result.source, "heuristic");
@@ -55,7 +55,7 @@ test("uses the LLM classification when enabled", async () => {
   const config = parseConfig({ recallPlannerLlmEnabled: true });
   const llm = stubLlm({ result: { mode: "graph_mode", reason: "asks for root cause" }, modelUsed: "anthropic/claude" });
 
-  const result = await planRecallModeLLM("restart the gateway", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("restart the gateway", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(result.source, "llm");
   assert.equal(result.mode, "graph_mode");
@@ -75,7 +75,7 @@ test("forwards taskModelChain AND recallPlannerModel in gateway mode (provider-a
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ capturedOptions: captured, result: { mode: "minimal" } });
 
-  await planRecallModeLLM("check status", undefined, config, llm, undefined, resolveCapabilities(config));
+  await planRecallModeLLM("check status", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 1);
   // recallPlannerModel is tried first (prepended), taskModelChain is the fallback chain.
@@ -98,7 +98,7 @@ test("plugin mode passes only the explicit model, no gateway chain", async () =>
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
 
-  await planRecallModeLLM("summarize the project", undefined, config, llm, undefined, resolveCapabilities(config));
+  await planRecallModeLLM("summarize the project", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 1);
   assert.equal(captured[0]?.model, "openai/gpt-5.5");
@@ -110,7 +110,7 @@ test("falls back to heuristic when the LLM throws", async () => {
   const config = parseConfig({ recallPlannerLlmEnabled: true });
   const llm = stubLlm({ throwError: "boom" });
 
-  const result = await planRecallModeLLM("what happened during the outage?", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("what happened during the outage?", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(result.source, "heuristic-fallback");
   assert.equal(result.fallbackUsed, true);
@@ -124,7 +124,7 @@ test("falls back to heuristic when the LLM returns no parseable result", async (
   const config = parseConfig({ recallPlannerLlmEnabled: true });
   const llm = stubLlm({ result: null });
 
-  const result = await planRecallModeLLM("how did we get here?", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("how did we get here?", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(result.source, "heuristic-fallback");
   assert.equal(result.fallbackUsed, true);
@@ -140,7 +140,7 @@ test("falls back without a network attempt when the chain is empty and the model
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ available: false, capturedOptions: captured, result: { mode: "full" } });
 
-  const result = await planRecallModeLLM("anything", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("anything", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 0, "no network attempt when nothing is routable");
   assert.equal(result.source, "heuristic-fallback");
@@ -156,7 +156,7 @@ test("attempts the call (and falls back) when a provider-qualified model overrid
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ available: false, capturedOptions: captured, result: null });
 
-  const result = await planRecallModeLLM("anything", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("anything", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 1, "qualified model override → still attempt the call");
   assert.equal(captured[0]?.model, "openai/gpt-5.5");
@@ -171,7 +171,7 @@ test("an already-aborted recall short-circuits to the heuristic without an LLM c
   const ac = new AbortController();
   ac.abort();
 
-  const result = await planRecallModeLLM("what did we decide?", undefined, config, llm, ac.signal, resolveCapabilities(config));
+  const result = await planRecallModeLLM("what did we decide?", undefined, config, resolveCapabilities(config), llm, ac.signal);
 
   assert.equal(captured.length, 0, "no LLM call when the recall is already aborted");
   assert.equal(result.source, "heuristic-fallback");
@@ -185,7 +185,7 @@ test("forwards the abort signal into the LLM call (cancellation contract)", asyn
   const llm = stubLlm({ capturedOptions: captured, result: { mode: "minimal" } });
   const ac = new AbortController();
 
-  await planRecallModeLLM("check status", undefined, config, llm, ac.signal, resolveCapabilities(config));
+  await planRecallModeLLM("check status", undefined, config, resolveCapabilities(config), llm, ac.signal);
 
   assert.equal(captured.length, 1);
   assert.equal(captured[0]?.signal, ac.signal, "recall abort signal must reach FallbackLlmClient");
@@ -196,7 +196,7 @@ test("empty prompts skip the LLM entirely", async () => {
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
 
-  const result = await planRecallModeLLM("   ", undefined, config, llm, undefined, resolveCapabilities(config));
+  const result = await planRecallModeLLM("   ", undefined, config, resolveCapabilities(config), llm, undefined);
 
   assert.equal(captured.length, 0);
   assert.equal(result.mode, "no_recall"); // heuristic returns no_recall for empty
@@ -222,4 +222,23 @@ test("resolveRecallPlannerLlmOptions drops bare model names but keeps provider-q
     parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "anthropic/claude-haiku-4-5" }),
   );
   assert.equal(qualified.model, "anthropic/claude-haiku-4-5");
+});
+
+test("caps.recallPlannerLlm is authoritative — disabled caps wins over enabled config flag (one-resolution-per-op #1523)", async () => {
+  // Issue #1523 contract: the capability resolved at the operation entry is
+  // THE gate. Construct a deliberate mismatch: config says enabled, but the
+  // resolved CapabilitySet says disabled. The function must NOT call the LLM.
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
+
+  // Manually construct caps with recallPlannerLlm: false (simulating a
+  // resolution that disagrees with the raw config — e.g. session toggle off).
+  const caps = { ...resolveCapabilities(config), recallPlannerLlm: false } as any;
+
+  const result = await planRecallModeLLM("what did we decide?", undefined, config, caps, llm, undefined);
+
+  assert.equal(captured.length, 0, "LLM must not be contacted when caps says disabled, even if config says enabled");
+  assert.equal(result.source, "heuristic");
+  assert.equal(result.reason, "llm-disabled");
 });

--- a/packages/remnic-core/src/recall-planner-llm.ts
+++ b/packages/remnic-core/src/recall-planner-llm.ts
@@ -188,16 +188,15 @@ export async function planRecallModeLLM(
   prompt: string,
   hints: string[] | undefined,
   config: PluginConfig,
+  caps: CapabilitySet,
   llm?: FallbackLlmClient,
   signal?: AbortSignal,
-  caps?: CapabilitySet,
 ): Promise<RecallPlannerLlmResult> {
   const heuristicMode = planRecallMode(prompt);
 
-  // `caps` is OPTIONAL and additive (issue #1523). Prefer the resolved
-  // capability when supplied; fall back to the config flag so existing callers
-  // that pass only `config` keep identical gating.
-  const plannerLlmEnabled = caps?.recallPlannerLlm ?? config.recallPlannerLlmEnabled;
+  // The recall-operation entry resolved this gate once (issue #1523); read the
+  // capability, never re-derive it from raw config here.
+  const plannerLlmEnabled = caps.recallPlannerLlm;
   if (!plannerLlmEnabled) {
     return heuristicResult(heuristicMode, "heuristic", "llm-disabled", 0, false);
   }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20123,
+      "packages/remnic-core/src/orchestrator.ts": 20120,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8974,
       "packages/remnic-core/src/storage.ts": 7730,
       "packages/remnic-core/src/config.ts": 4610
     },
     "oversizedFileCount": 11,
-    "scatteredConfigFlagReads": 564,
+    "scatteredConfigFlagReads": 558,
     "adHocNamespaceResolutions": 53,
     "unmigratedHandlerCount": 82,
     "directStorageImports": 38

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -531,11 +531,6 @@ tests/recall-hardening.test.ts(674,3): TS2349
 tests/recall-hardening.test.ts(749,3): TS2349
 tests/recall-hardening.test.ts(807,3): TS2349
 tests/recall-hardening.test.ts(809,3): TS2349
-tests/recall-mode-gating.test.ts(78,57): TS2345
-tests/recall-mode-gating.test.ts(93,57): TS2345
-tests/recall-mode-gating.test.ts(114,57): TS2345
-tests/recall-mode-gating.test.ts(130,57): TS2345
-tests/recall-mode-gating.test.ts(157,57): TS2345
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
 tests/release-workflow-public-packages.test.ts(152,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -531,6 +531,11 @@ tests/recall-hardening.test.ts(674,3): TS2349
 tests/recall-hardening.test.ts(749,3): TS2349
 tests/recall-hardening.test.ts(807,3): TS2349
 tests/recall-hardening.test.ts(809,3): TS2349
+tests/recall-mode-gating.test.ts(78,57): TS2345
+tests/recall-mode-gating.test.ts(93,57): TS2345
+tests/recall-mode-gating.test.ts(114,57): TS2345
+tests/recall-mode-gating.test.ts(130,57): TS2345
+tests/recall-mode-gating.test.ts(157,57): TS2345
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
 tests/release-workflow-public-packages.test.ts(152,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,1 @@
+export * from "@remnic/core/capabilities";

--- a/tests/recall-mode-gating.test.ts
+++ b/tests/recall-mode-gating.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRecallModeDecisionAsync,
 } from "../src/orchestrator.js";
 import { parseConfig } from "../src/config.js";
+import { resolveCapabilities } from "../src/capabilities.js";
 import type { FallbackLlmClient } from "../src/fallback-llm.js";
 import type { RecallPlanMode } from "../src/types.js";
 
@@ -81,6 +82,7 @@ test("resolveRecallModeDecisionAsync uses heuristic when LLM planning is not opt
     multiGraphMemoryEnabled: true,
     prompt: "restart the gateway",
     config,
+    caps: resolveCapabilities(config),
     llm: stubPlannerLlm("graph_mode"),
   });
   // LLM stub says graph_mode, but it must not be consulted.
@@ -96,6 +98,7 @@ test("resolveRecallModeDecisionAsync applies the LLM classification when opted i
     multiGraphMemoryEnabled: true,
     prompt: "restart the gateway",
     config,
+    caps: resolveCapabilities(config),
     llm: stubPlannerLlm("graph_mode", "wants history"),
   });
   assert.equal(decision.effectiveMode, "graph_mode");
@@ -117,6 +120,7 @@ test("resolveRecallModeDecisionAsync gates an LLM graph_mode to full when graph 
     multiGraphMemoryEnabled: true,
     prompt: "restart the gateway",
     config,
+    caps: resolveCapabilities(config),
     llm: stubPlannerLlm("graph_mode"),
   });
   // Same graph gating as the heuristic path.
@@ -133,6 +137,7 @@ test("resolveRecallModeDecisionAsync shadow mode keeps the heuristic effective d
     multiGraphMemoryEnabled: true,
     prompt: "restart the gateway", // heuristic → minimal
     config,
+    caps: resolveCapabilities(config),
     llm: stubPlannerLlm("graph_mode"),
   });
   // Effective stays on the heuristic; the LLM's choice is recorded for comparison.
@@ -160,6 +165,7 @@ test("resolveRecallModeDecisionAsync skips the LLM entirely when the planner is 
     multiGraphMemoryEnabled: true,
     prompt: "what happened in the timeline",
     config,
+    caps: resolveCapabilities(config),
     llm,
   });
   assert.equal(decision.effectiveMode, "full");


### PR DESCRIPTION
## Summary

Part of #1520 Phase 1. Migrates the recall-planner-llm and direct-answer gate chain to read from the frozen `CapabilitySet` (resolved once at the recall-operation entry) instead of scattered `config.*Enabled` reads. This is the chokepoint the `scatteredConfigFlagReads` ratchet targets.

## What changed

**Gate resolution is now one-place, one-resolution-per-op:**

| Flag | Before | After |
|---|---|---|
| `recallPlannerLlmEnabled` | `caps?.recallPlannerLlm ?? config.recallPlannerLlmEnabled` (3 sites) | `caps.recallPlannerLlm` (1 resolution in `capabilities.ts`) |
| `recallDirectAnswerEnabled` | `enabled ?? config.recallDirectAnswerEnabled` (1 site + 2 comments) | `enabled` param, required (1 resolution in `capabilities.ts`) |

**Files changed:**
- `recall-planner-llm.ts` — `caps: CapabilitySet` is now required (moved before optional params); reads `caps.recallPlannerLlm`, never `config.recallPlannerLlmEnabled`
- `direct-answer-wiring.ts` — `enabled: boolean` is now required; removed `recallDirectAnswerEnabled` from the `Pick<PluginConfig>` type and the `??` fallback
- `orchestrator.ts` — `resolveRecallModeDecisionAsync` `caps` is required; reads `options.caps.recallPlannerLlm` directly (thin wiring only)

**Tests:**
- `capabilities.test.ts` — added one-resolution-per-op determinism test (same config → identical frozen gate values)
- `recall-planner-llm.test.ts` — added caps-wins-over-config mismatch test (caps says disabled, config says enabled → LLM NOT called)
- `direct-answer-wiring.test.ts` — replaced backward-compat fallback tests with one-resolution-per-op tests proving `enabled` is the sole gate

## Ratchet

`scatteredConfigFlagReads`: **564 → 558** (–6 reads, all from the recall gate chain). Baseline updated via `--update`.

## Chokepoints used / not applicable

- **CapabilitySet** (`caps.*`) — used for `recallPlannerLlm` and `recallDirectAnswer` gates
- Not applicable: serialize-mutations, ScopePlan, operation registry (no new mutation/namespace/handler paths)

## Gates passed

- ✅ `pnpm --filter @remnic/core build` (ESM + DTS)
- ✅ `node scripts/check-ratchets.mjs` (all metrics ≤ baseline)
- ✅ `npm run test:entity-hardening` (246/246 pass)
- ✅ `tsc --noEmit` (0 errors)
- ✅ Specific tests: capabilities + direct-answer-wiring + recall-planner-llm (41/41 pass)

## Test-typecheck baseline

Refreshed `scripts/test-typecheck-baseline.txt` — the baseline drifted from origin/main due to the latest merges (#1686/#1679/#1689). No new errors introduced by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall-mode and direct-answer gating on the hot path with a breaking API for callers that omitted `caps`/`enabled`; behavior is intended to match when entry resolves capabilities once, with new tests for authoritative caps.
> 
> **Overview**
> Completes another **#1523** slice: recall gates are resolved **once** via `resolveCapabilities` at the operation entry and passed down—no mid-path `config.*Enabled` or `enabled ?? config` fallbacks.
> 
> **Recall LLM planner:** `planRecallModeLLM` and `resolveRecallModeDecisionAsync` now take **required** `caps` and gate only on `caps.recallPlannerLlm` (signature reorders `caps` before optional `llm`/`signal`). **Direct answer:** `tryDirectAnswer` requires **`enabled: boolean`** from `caps.recallDirectAnswer`; `recallDirectAnswerEnabled` is dropped from the wiring config `Pick`.
> 
> Tests add **determinism** for frozen caps, **caps-over-config** mismatch cases (disabled caps must skip the LLM / direct-answer I/O), and integration tests pass `resolveCapabilities(config)`. **`src/capabilities.ts`** re-exports `@remnic/core/capabilities`. Ratchet **`scatteredConfigFlagReads`**: 564 → **558**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a358a8024603796cd39a2cbc27c1d94860dfb640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->