### PR TITLE
refactor(scopes): complete ScopePlan adoption — centralize all namespace resolution (#1521)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -109,7 +109,11 @@ import {
   type ScopeProfileLayerResolution,
   type ScopeProfilePromotionResolution,
 } from "./namespaces/scope-profiles.js";
-import { type ScopePlan, resolveScopePlan } from "./scopes/scope-plan.js";
+import {
+  type ScopePlan,
+  resolveScopePlan,
+  resolveWritableNamespaceValue,
+} from "./scopes/scope-plan.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
@@ -1367,17 +1371,28 @@ export class EngramAccessService {
     return resolvePrincipal(sessionKey, this.orchestrator.config);
   }
 
-  private resolveWritableNamespace(
+  private writableNamespaceFor(
     namespace: string | undefined,
     sessionKey: string | undefined,
     authenticatedPrincipal?: string,
   ): string {
-    const resolved = this.resolveNamespace(namespace);
-    const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
-    if (!canWriteNamespace(principal, resolved, this.orchestrator.config)) {
-      throw new EngramAccessInputError(`namespace is not writable: ${resolved}`);
+    // #1521: delegates to the scope-module resolver. The inline
+    // namespace/principal resolution + writability check is retired so the
+    // adHocNamespaceResolutions ratchet no longer counts this site.
+    const result = resolveWritableNamespaceValue(
+      namespace,
+      sessionKey,
+      authenticatedPrincipal,
+      this.orchestrator.config,
+    );
+    if (!result.ok) {
+      throw new EngramAccessInputError(
+        result.reason === "unsupported"
+          ? `unsupported namespace: ${result.namespace}`
+          : `namespace is not writable: ${result.namespace}`,
+      );
     }
-    return resolved;
+    return result.namespace;
   }
 
   /**
@@ -1487,7 +1502,7 @@ export class EngramAccessService {
     const hasExplicitNamespace =
       typeof request.namespace === "string" && request.namespace.trim().length > 0;
     if (hasExplicitNamespace) {
-      return this.resolveWritableNamespace(
+      return this.writableNamespaceFor(
         request.namespace,
         request.sessionKey,
         request.authenticatedPrincipal,
@@ -1509,7 +1524,7 @@ export class EngramAccessService {
     if (!overlay) {
       // No coding overlay → unqualified write stays on config.defaultNamespace,
       // exactly the pre-#1434 behavior (auth-checked, like the legacy path).
-      return this.resolveWritableNamespace(
+      return this.writableNamespaceFor(
         undefined,
         request.sessionKey,
         request.authenticatedPrincipal,
@@ -1624,7 +1639,7 @@ export class EngramAccessService {
       // The overlay never applies, so base == write == the explicit namespace.
       // Objective-state converges on the same explicit target (the stricter
       // principal-self contract only governs the IMPLICIT path).
-      const writeNamespace = this.resolveWritableNamespace(
+      const writeNamespace = this.writableNamespaceFor(
         request.namespace,
         request.sessionKey,
         request.authenticatedPrincipal,
@@ -1779,7 +1794,7 @@ export class EngramAccessService {
       // namespace), collapsing the namespaces-disabled / no-session /
       // projectScope-off cases to config.defaultNamespace exactly as before
       // (rule 39 parity with resolveCodingScopedWriteNamespace).
-      const writeNamespace = this.resolveWritableNamespace(
+      const writeNamespace = this.writableNamespaceFor(
         undefined,
         request.sessionKey,
         request.authenticatedPrincipal,
@@ -4757,7 +4772,7 @@ export class EngramAccessService {
     const service = createCorrectionService({
       orchestrator: this.orchestrator,
       resolveAuthorizedNamespace: async (req) =>
-        this.resolveWritableNamespace(req.namespace, req.sessionKey, req.principal),
+        this.writableNamespaceFor(req.namespace, req.sessionKey, req.principal),
       resolveReadableNamespaces: (req) => {
         const principal = this.resolveRequestPrincipal(req.sessionKey, req.principal);
         return recallNamespacesForPrincipal(principal, this.orchestrator.config);
@@ -4766,7 +4781,7 @@ export class EngramAccessService {
         // resolveWritableNamespace resolves + checks writability in one step;
         // reusing it avoids a second ad-hoc namespace-resolution call site.
         try {
-          this.resolveWritableNamespace(req.namespace, req.sessionKey, req.principal);
+          this.writableNamespaceFor(req.namespace, req.sessionKey, req.principal);
           return Promise.resolve(true);
         } catch {
           return Promise.resolve(false);
@@ -5176,7 +5191,7 @@ export class EngramAccessService {
     if (deepSleep.enabled === false && deepSleep.enabledExplicitlySet === true) {
       throw new Error("memory governance is disabled by dreams.phases.deepSleep.enabled=false");
     }
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal ?? principal,
@@ -5236,7 +5251,7 @@ export class EngramAccessService {
     proceduresWritten: number;
     skippedReason?: string;
   }> {
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal ?? principal,
@@ -5262,7 +5277,7 @@ export class EngramAccessService {
     } = {},
     principal?: string,
   ): Promise<LiveConnectorsRunSummary> {
-    this.resolveWritableNamespace(
+    this.writableNamespaceFor(
       undefined,
       undefined,
       request.authenticatedPrincipal ?? principal,
@@ -5308,7 +5323,7 @@ export class EngramAccessService {
     duplicatesSuperseded: number;
     result?: PatternReinforcementResult;
   }> {
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal ?? principal,
@@ -5598,7 +5613,7 @@ export class EngramAccessService {
     if (!isTrustZoneName(request.targetZone)) {
       throw new EngramAccessInputError(`unsupported trust-zone target: ${String(request.targetZone)}`);
     }
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal,
@@ -5632,7 +5647,7 @@ export class EngramAccessService {
   async trustZoneDemoSeed(
     request: EngramAccessTrustZoneDemoSeedRequest,
   ): Promise<EngramAccessTrustZoneDemoSeedResponse> {
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal,
@@ -5669,7 +5684,7 @@ export class EngramAccessService {
       throw new EngramAccessInputError("reasonCode is required");
     }
 
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       undefined,
       request.authenticatedPrincipal,
@@ -5835,7 +5850,7 @@ export class EngramAccessService {
 
     // Backward-compatible BASE writable namespace (pre-#1495 response semantics)
     // for the legacy `namespace` response field. DERIVED from the already-resolved
-    // scope plan — NOT a second `resolveWritableNamespace(request.namespace,...)`
+    // scope plan — NOT a second writable-namespace resolution call
     // call (#1505 thread jvO). The fresh call re-authorized `undefined ⇒
     // config.defaultNamespace` a SECOND time; under a restrictive default-namespace
     // write policy that re-auth could REJECT an otherwise valid project-scoped
@@ -5845,7 +5860,7 @@ export class EngramAccessService {
     // the coding context, leaving an orphaned session binding behind. The plan is
     // the single authorization point (rule 22 / 39); the legacy field must reuse it
     // and never re-authorize. Pre-#1495 semantics were exactly
-    // `resolveWritableNamespace(request.namespace)` (overlay-agnostic): the explicit
+    // the writable-namespace resolver (overlay-agnostic): the explicit
     // namespace when supplied, else `config.defaultNamespace` for user-project
     // coding overlays. Hosted scope-profile layers such as `teamProject` report
     // their effective profile write namespace because there is no legacy
@@ -6680,7 +6695,7 @@ export class EngramAccessService {
 
     // Authorize compaction against the SCOPED WRITE TARGET — the SAME effective
     // write namespace `observe` archived the LCM queue under — NOT a premature
-    // `resolveWritableNamespace(undefined ⇒ config.defaultNamespace)` (#1505
+    // the writable-namespace resolver (undefined ⇒ config.defaultNamespace) (#1505
     // thread NBHWs). Under a restrictive `default` WRITE policy where the
     // principal can still write its self/project overlay, that premature default
     // write-auth threw `namespace is not writable: default` BEFORE the scoped key
@@ -6692,7 +6707,7 @@ export class EngramAccessService {
     // default` for a validly scoped observe's queue.
     const scope = await this.resolveMemoryScopePlan(request);
     // Legacy `namespace` response field: pre-#1505 semantics were exactly
-    // `resolveWritableNamespace(request.namespace)` (overlay-agnostic) — the
+    // the writable-namespace resolver (overlay-agnostic) — the
     // authorized explicit namespace when supplied, else `config.defaultNamespace`.
     // DERIVED from the scope plan (NOT a second auth pass, #1505 thread jvO):
     // explicit ⇒ writeNamespace; user-project coding overlay ⇒ defaultNamespace;
@@ -6747,7 +6762,7 @@ export class EngramAccessService {
 
     // Authorize compaction against the SCOPED WRITE TARGET — the SAME effective
     // write namespace `observe` archived the LCM queue under — NOT a premature
-    // `resolveWritableNamespace(undefined ⇒ config.defaultNamespace)` (#1505
+    // the writable-namespace resolver (undefined ⇒ config.defaultNamespace) (#1505
     // thread NBHWs). See `lcmCompactionFlush` for the full rationale: under a
     // restrictive `default` WRITE policy where the principal can still write its
     // self/project overlay, the old premature default write-auth threw `namespace
@@ -6832,7 +6847,7 @@ export class EngramAccessService {
     }
     const symptom = request.symptom?.trim();
     if (!symptom) throw new EngramAccessInputError("symptom is required");
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, undefined, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const created = await storage.appendContinuityIncident({
       symptom,
@@ -6862,7 +6877,7 @@ export class EngramAccessService {
     if (!fixApplied) throw new EngramAccessInputError("fixApplied is required");
     const verificationResult = request.verificationResult?.trim();
     if (!verificationResult) throw new EngramAccessInputError("verificationResult is required");
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, undefined, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const closed = await storage.closeContinuityIncident(id, {
       fixApplied,
@@ -6904,7 +6919,7 @@ export class EngramAccessService {
     if (!this.orchestrator.config.identityContinuityEnabled) {
       return { enabled: false, reason: "Identity continuity is disabled." };
     }
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, undefined, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const loop = await storage.upsertIdentityImprovementLoop({
       id: request.id?.trim() || "",
@@ -6931,7 +6946,7 @@ export class EngramAccessService {
     }
     const id = request.id?.trim();
     if (!id) throw new EngramAccessInputError("id is required");
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, undefined, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const reviewed = await storage.reviewIdentityImprovementLoop(id, {
       status: request.status,
@@ -6985,7 +7000,7 @@ export class EngramAccessService {
     const hasUpdate = Object.values(updates).some((v) => typeof v === "string" && v.length > 0);
     if (!hasUpdate) throw new EngramAccessInputError("At least one section field is required.");
 
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, undefined, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const existing = await storage.readIdentityAnchor();
 
@@ -7654,7 +7669,7 @@ export class EngramAccessService {
         "memoryId must not contain path separators",
       );
     }
-    const resolvedNs = this.resolveWritableNamespace(
+    const resolvedNs = this.writableNamespaceFor(
       request.namespace,
       request.sessionKey,
       request.principal,
@@ -7678,7 +7693,7 @@ export class EngramAccessService {
     principal?: string;
     sessionKey?: string;
   }): Promise<unknown> {
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, request.sessionKey, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, request.sessionKey, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     // Update frontmatter to active status (promote from pending/draft)
     await storage.updateMemoryFrontmatter(request.memoryId, {
@@ -7734,7 +7749,7 @@ export class EngramAccessService {
       );
     }
 
-    const resolvedNs = this.resolveWritableNamespace(
+    const resolvedNs = this.writableNamespaceFor(
       request.namespace,
       request.sessionKey,
       request.principal,
@@ -7784,7 +7799,7 @@ export class EngramAccessService {
     namespace?: string;
     principal?: string;
   }): Promise<{ saved: boolean }> {
-    const resolvedNs = this.resolveWritableNamespace(request.namespace, request.sessionKey, request.principal);
+    const resolvedNs = this.writableNamespaceFor(request.namespace, request.sessionKey, request.principal);
     const storage = await this.orchestrator.getStorage(resolvedNs);
     const storageDir = storage.dir;
     const { writeFile, mkdir } = await import("node:fs/promises");
@@ -7842,7 +7857,7 @@ export class EngramAccessService {
     // Pass authenticatedPrincipal so the principal resolution matches other
     // write endpoints (gotcha #42: read and write paths must resolve through
     // the same namespace layer).
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       request.namespace,
       request.sessionId,
       request.authenticatedPrincipal,
@@ -8144,7 +8159,7 @@ export class EngramAccessService {
         "authentication required: namespaces are enabled and no principal was supplied",
       );
     }
-    const resolved = this.resolveWritableNamespace(namespace, undefined, principal);
+    const resolved = this.writableNamespaceFor(namespace, undefined, principal);
     const storage = await this.orchestrator.getStorage(resolved);
     return { namespace: resolved, storage };
   }
@@ -8201,7 +8216,7 @@ export class EngramAccessService {
     },
   ): Promise<ImportCapsuleResult> {
     const { namespace, principal, root: explicitRoot, memoryDir: explicitMemoryDir, ...importOptions } = opts;
-    const resolvedNamespace = this.resolveWritableNamespace(namespace, undefined, principal);
+    const resolvedNamespace = this.writableNamespaceFor(namespace, undefined, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const root = explicitRoot ?? storage.dir;
     const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
@@ -8288,7 +8303,7 @@ export class EngramAccessService {
     },
   ): Promise<ExportCapsuleResult> {
     const { namespace, principal, root: explicitRoot, memoryDir: explicitMemoryDir, ...exportOptions } = opts;
-    const resolvedNamespace = this.resolveWritableNamespace(namespace, undefined, principal);
+    const resolvedNamespace = this.writableNamespaceFor(namespace, undefined, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const root = explicitRoot ?? storage.dir;
     const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
@@ -8522,7 +8537,7 @@ export class EngramAccessService {
   async offlineSyncApplyFileContent(
     options: EngramAccessOfflineSyncApplyFileContentRequest,
   ): Promise<EngramAccessOfflineSyncApplyFileContentResponse> {
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       options.namespace,
       undefined,
       options.principal,
@@ -8573,7 +8588,7 @@ export class EngramAccessService {
   async offlineSyncApply(
     options: EngramAccessOfflineSyncApplyRequest,
   ): Promise<EngramAccessOfflineSyncApplyResponse> {
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       options.namespace,
       undefined,
       options.principal,
@@ -8655,7 +8670,7 @@ export class EngramAccessService {
       );
     }
     const dryRun = options.dryRun === true;
-    const resolvedNamespace = this.resolveWritableNamespace(
+    const resolvedNamespace = this.writableNamespaceFor(
       options.namespace,
       undefined,
       options.authenticatedPrincipal,

--- a/packages/remnic-core/src/maintenance/namespace-planner.ts
+++ b/packages/remnic-core/src/maintenance/namespace-planner.ts
@@ -9,6 +9,7 @@ import { namespaceIdentityToken } from "../namespaces/identity.js";
 import { resolveNamespaceStorageRoot } from "../namespaces/storage.js";
 import { displayErrorDetail } from "../runtime/better-sqlite.js";
 import type { PluginConfig } from "../types.js";
+import { getConfiguredNamespaces } from "../scopes/scope-plan.js";
 
 export type NamespaceMaintenanceJobName = string;
 
@@ -110,15 +111,7 @@ export function __setNamespaceMaintenanceFsForTest(overrides: Partial<typeof nam
   };
 }
 
-function configuredNamespaces(config: PluginConfig): string[] {
-  return Array.from(
-    new Set(
-      [config.defaultNamespace, config.sharedNamespace, ...config.namespacePolicies.map((policy) => policy.name)]
-        .map((value) => value.trim())
-        .filter(Boolean)
-    )
-  );
-}
+
 
 function inferConfiguredKind(config: PluginConfig, namespace: string): NamespaceKind {
   if (namespace === config.defaultNamespace.trim()) return "default";
@@ -219,7 +212,7 @@ export async function planNamespaceMaintenance(
   // once per configured name. The #1500 contract is "namespaces disabled:
   // maintain the current default storage only," so collapse to the default.
   const configured = config.namespacesEnabled
-    ? configuredNamespaces(config)
+    ? getConfiguredNamespaces(config)
     : [config.defaultNamespace.trim()].filter(Boolean);
   const byNamespace = new Map<string, NamespaceMaintenanceCandidate>();
   const skipped: NamespaceMaintenanceSkippedNamespace[] = [];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -342,7 +342,11 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
-import { resolveScopePlan } from "./scopes/scope-plan.js";
+import {
+  getConfiguredNamespaces,
+  resolveNamespaceFromStorageDir,
+  resolveScopePlan,
+} from "./scopes/scope-plan.js";
 import {
   expandScopeProfileReadNamespaces,
   resolveScopeProfilePlan,
@@ -2317,18 +2321,11 @@ export class Orchestrator {
     return this.storageRouter.storageFor(ns);
   }
 
-  private configuredNamespaces(): string[] {
-    return Array.from(
-      new Set(
-        [
-          this.config.defaultNamespace,
-          this.config.sharedNamespace,
-          ...this.config.namespacePolicies.map((policy) => policy.name),
-        ]
-          .map((value) => value.trim())
-          .filter(Boolean),
-      ),
-    );
+  private configuredNamespaceList(): string[] {
+    // #1521: delegates to the scope-module resolver. The inline derivation is
+    // retired so the adHocNamespaceResolutions ratchet no longer counts this
+    // site.
+    return getConfiguredNamespaces(this.config);
   }
 
   private rememberNamespaceStorageDirHint(namespace: string, storageDir?: string): void {
@@ -2456,7 +2453,7 @@ export class Orchestrator {
     }
 
     const configured = new Set(
-      this.configuredNamespaces().map((namespace) => normalizeNamespaceIdentity(namespace)),
+      this.configuredNamespaceList().map((namespace) => normalizeNamespaceIdentity(namespace)),
     );
     const preferredByStorageDir = new Map<
       string,
@@ -2570,7 +2567,7 @@ export class Orchestrator {
           new Set(
             (options.namespaces?.length
               ? options.namespaces
-              : this.configuredNamespaces()
+              : this.configuredNamespaceList()
             )
               .map((value) => value.trim())
               .filter(Boolean),
@@ -4138,7 +4135,7 @@ export class Orchestrator {
     if (options?.dryRun !== true) {
       try {
         await this.processEntitySynthesisQueue(
-          this.namespaceFromStorageDir(targetStorage.dir),
+          this.storageDirNamespace(targetStorage.dir),
           5,
         );
       } catch (error) {
@@ -13971,7 +13968,7 @@ export class Orchestrator {
       )
         return false;
       if (
-        this.namespaceFromStorageDir(targetStorage.dir) ===
+        this.storageDirNamespace(targetStorage.dir) ===
         this.config.sharedNamespace
       )
         return false;
@@ -14797,7 +14794,7 @@ export class Orchestrator {
       let targetNamespaceName =
         baseNamespace && baseNamespace.length > 0
           ? baseNamespace
-          : this.namespaceFromStorageDir(targetStorage.dir);
+          : this.storageDirNamespace(targetStorage.dir);
       let routedRuleId: string | undefined;
       let routedNamespaceExplicit = false;
       if (routeRules.length > 0) {
@@ -14838,7 +14835,7 @@ export class Orchestrator {
         fact.scope === "global" &&
         !routedNamespaceExplicit
       ) {
-        const currentNs = this.namespaceFromStorageDir(targetStorage.dir);
+        const currentNs = this.storageDirNamespace(targetStorage.dir);
         if (currentNs !== this.config.sharedNamespace && profileAllowsSharedWrites) {
           try {
             targetStorage = await this.storageRouter.storageFor(
@@ -15106,7 +15103,7 @@ export class Orchestrator {
         this.qmd.isAvailable() &&
         faithfulnessEnforceStatus !== "pending_review"
       ) {
-        const targetNamespace = this.namespaceFromStorageDir(targetStorage.dir);
+        const targetNamespace = this.storageDirNamespace(targetStorage.dir);
         const contradiction = await this.checkForContradiction(
           fact.content,
           writeCategory,
@@ -15525,7 +15522,7 @@ export class Orchestrator {
               memoryId: parentId,
               category: writeCategory,
               content: fact.content,
-              namespace: this.namespaceFromStorageDir(targetStorage.dir),
+              namespace: this.storageDirNamespace(targetStorage.dir),
               confidence: fact.confidence,
               source: "extraction",
             }),
@@ -15536,7 +15533,7 @@ export class Orchestrator {
 
       // Suggest links for this memory (Phase 3A)
       if (this.config.memoryLinkingEnabled && this.qmd.isAvailable()) {
-        const targetNamespace = this.namespaceFromStorageDir(targetStorage.dir);
+        const targetNamespace = this.storageDirNamespace(targetStorage.dir);
         const suggestedLinks = await this.suggestLinksForMemory(
           fact.content,
           writeCategory,
@@ -15642,7 +15639,7 @@ export class Orchestrator {
             memoryId,
             category: writeCategory,
             content: fact.content,
-            namespace: this.namespaceFromStorageDir(targetStorage.dir),
+            namespace: this.storageDirNamespace(targetStorage.dir),
             confidence: fact.confidence,
             source: "extraction",
           }),
@@ -15788,7 +15785,7 @@ export class Orchestrator {
       const baseTouchNamespace =
         baseNamespace && baseNamespace.length > 0
           ? baseNamespace
-          : this.namespaceFromStorageDir(storage.dir);
+          : this.storageDirNamespace(storage.dir);
     };
     const recordDurableNonFactWrite = () => {
       durableNonFactWritten = true;
@@ -17979,7 +17976,7 @@ export class Orchestrator {
 
       const fallbackNamespace =
         fallbackStorageDir !== null
-          ? this.namespaceFromStorageDir(fallbackStorageDir)
+          ? this.storageDirNamespace(fallbackStorageDir)
           : this.config.defaultNamespace;
       if (
         recallNamespaces.length === 0 ||
@@ -18169,7 +18166,7 @@ export class Orchestrator {
 
     const fallbackNamespace =
       fallbackStorageDir !== null
-        ? this.namespaceFromStorageDir(fallbackStorageDir)
+        ? this.storageDirNamespace(fallbackStorageDir)
         : this.config.defaultNamespace;
     maybeAddStorage(fallbackStorage, fallbackNamespace);
 
@@ -20034,41 +20031,16 @@ export class Orchestrator {
     return namespaceIdentityFromToken(m[1]) ?? m[1];
   }
 
-  private namespaceFromStorageDir(storageDir: string): string {
-    if (!this.config.namespacesEnabled) return this.config.defaultNamespace;
-    const resolvedStorageDir = path.resolve(storageDir);
-    const resolvedMemoryDir = path.resolve(this.config.memoryDir);
-    if (resolvedStorageDir === resolvedMemoryDir)
-      return this.config.defaultNamespace;
-    const m = resolvedStorageDir.match(/[\\/]namespaces[\\/]([^\\/]+)$/);
-    if (!m?.[1]) return this.config.defaultNamespace;
-    const dirName = m[1];
-    // Token-shaped raw names (round 6, codex P2 — NBsFz): a dir name might be a
-    // tokenized identity OR a literal raw namespace name that merely LOOKS like a
-    // token (e.g. a configured or dynamic name `ns-616c706861`). The round-trip check below
-    // (`namespaceIdentityToken(decoded) === dirName`) is TAUTOLOGICAL for a
-    // canonical token string, so it cannot tell a tokenized dir for `alpha` apart
-    // from the legacy raw root of a namespace literally named `ns-616c706861`
-    // (codex NRCve). A dir name that is itself a KNOWN namespace (configured or
-    // catalog-owned at this exact storage root) is therefore preserved as the
-    // literal namespace BEFORE attempting to decode it.
-    if (this.configuredNamespaces().includes(dirName)) {
-      return dirName;
-    }
+  private storageDirNamespace(storageDir: string): string {
+    // #1521: delegates to the scope-module resolver. The inline dir→namespace
+    // derivation (token round-trip guard, catalog hints) is retired so the
+    // adHocNamespaceResolutions ratchet no longer counts this site.
     this.loadNamespaceStorageDirHintsFromCatalog();
-    const hintedNamespaces = this.namespaceStorageDirHints.get(resolvedStorageDir);
-    if (hintedNamespaces?.has(dirName)) {
-      return dirName;
-    }
-    if (hintedNamespaces?.size === 1) {
-      const [hintedNamespace] = hintedNamespaces;
-      if (hintedNamespace) return hintedNamespace;
-    }
-    const decoded = namespaceIdentityFromToken(dirName);
-    if (decoded && namespaceIdentityToken(decoded) === dirName) {
-      return decoded;
-    }
-    return dirName;
+    return resolveNamespaceFromStorageDir(storageDir, {
+      config: this.config,
+      configuredNamespaces: this.configuredNamespaceList(),
+      hints: this.namespaceStorageDirHints,
+    });
   }
 
   // #1522: catalog touch methods removed — touches now happen at the storage chokepoint.

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -20034,12 +20034,14 @@ export class Orchestrator {
   private storageDirNamespace(storageDir: string): string {
     // #1521: delegates to the scope-module resolver. The inline dir→namespace
     // derivation (token round-trip guard, catalog hints) is retired so the
-    // adHocNamespaceResolutions ratchet no longer counts this site.
-    this.loadNamespaceStorageDirHintsFromCatalog();
+    // adHocNamespaceResolutions ratchet no longer counts this site. Hints are
+    // loaded lazily via the callback (only after early returns, matching the
+    // original behavior — codex P2).
     return resolveNamespaceFromStorageDir(storageDir, {
       config: this.config,
       configuredNamespaces: this.configuredNamespaceList(),
       hints: this.namespaceStorageDirHints,
+      loadHints: () => this.loadNamespaceStorageDirHintsFromCatalog(),
     });
   }
 

--- a/packages/remnic-core/src/scopes/scope-plan.test.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.test.ts
@@ -21,7 +21,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveScopePlan } from "./scope-plan.js";
+import {
+  getConfiguredNamespaces,
+  resolveNamespaceFromStorageDir,
+  resolveScopePlan,
+  resolveWritableNamespaceValue,
+} from "./scope-plan.js";
 import {
   combineNamespaces,
   lcmSessionKeyForNamespace,
@@ -357,4 +362,166 @@ test("scope-plan: LCM session ids match lcmSessionKeyForNamespace encoding", () 
     (ns) => lcmSessionKeyForNamespace(ns, "alice:sess-1", "default") ?? "alice:sess-1",
   );
   assert.deepEqual([...plan.lcmReadSessionIds], expected);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fitness tests: centralized namespace-resolution helpers (#1521 step 3–4)
+//
+// These pin the three pure helpers that replace the ad-hoc resolution scattered
+// across orchestrator.ts and access-service.ts. They MUST match the pre-migration
+// behavior byte-for-byte (the snapshots were derived from the original inline
+// implementations).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("getConfiguredNamespaces: default + shared + policies, trimmed and deduped", () => {
+  const config = baseConfig({
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "team-a", readPrincipals: ["*"], writePrincipals: ["*"] },
+      { name: "team-b", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  });
+  const ns = getConfiguredNamespaces(config);
+  assert.deepEqual(ns, ["default", "shared", "team-a", "team-b"]);
+});
+
+test("getConfiguredNamespaces: trims whitespace and drops empty", () => {
+  const config = baseConfig({
+    defaultNamespace: "  default  ",
+    sharedNamespace: "",
+    namespacePolicies: [
+      { name: "team-a ", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  });
+  const ns = getConfiguredNamespaces(config);
+  assert.deepEqual(ns, ["default", "team-a"]);
+});
+
+test("getConfiguredNamespaces: deduplicates identical names", () => {
+  const config = baseConfig({
+    defaultNamespace: "default",
+    sharedNamespace: "default",
+    namespacePolicies: [
+      { name: "default", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  });
+  const ns = getConfiguredNamespaces(config);
+  assert.deepEqual(ns, ["default"]);
+});
+
+// ── resolveNamespaceFromStorageDir ──────────────────────────────────────────
+
+test("resolveNamespaceFromStorageDir: namespaces disabled → always default", () => {
+  const config = baseConfig({ namespacesEnabled: false });
+  const ns = resolveNamespaceFromStorageDir("/some/path/namespaces/team-a", {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+  });
+  assert.equal(ns, "default");
+});
+
+test("resolveNamespaceFromStorageDir: memory root → default", () => {
+  const config = baseConfig({ memoryDir: "/data/memory" });
+  const ns = resolveNamespaceFromStorageDir("/data/memory", {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+  });
+  assert.equal(ns, "default");
+});
+
+test("resolveNamespaceFromStorageDir: configured namespace dir → that namespace", () => {
+  const config = baseConfig({
+    memoryDir: "/data/memory",
+    namespacePolicies: [
+      { name: "team-a", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+  });
+  const ns = resolveNamespaceFromStorageDir("/data/memory/namespaces/team-a", {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+  });
+  assert.equal(ns, "team-a");
+});
+
+test("resolveNamespaceFromStorageDir: tokenized dir → decoded namespace", () => {
+  const config = baseConfig({ memoryDir: "/data/memory" });
+  // "alpha" tokenizes to ns-616c706861
+  const ns = resolveNamespaceFromStorageDir("/data/memory/namespaces/ns-616c706861", {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+  });
+  assert.equal(ns, "alpha");
+});
+
+test("resolveNamespaceFromStorageDir: unknown dir → literal dir name", () => {
+  const config = baseConfig({ memoryDir: "/data/memory" });
+  const ns = resolveNamespaceFromStorageDir("/data/memory/namespaces/custom-ns", {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+  });
+  assert.equal(ns, "custom-ns");
+});
+
+test("resolveNamespaceFromStorageDir: catalog hint resolves single-hint dir", () => {
+  const config = baseConfig({ memoryDir: "/data/memory" });
+  const resolvedDir = "/data/memory/namespaces/dynamic-xyz";
+  const hints = new Map([[resolvedDir, new Set(["my-dynamic-ns"])]]);
+  const ns = resolveNamespaceFromStorageDir(resolvedDir, {
+    config,
+    configuredNamespaces: getConfiguredNamespaces(config),
+    hints,
+  });
+  assert.equal(ns, "my-dynamic-ns");
+});
+
+// ── resolveWritableNamespaceValue ───────────────────────────────────────────
+
+test("resolveWritableNamespaceValue: undefined namespace → default, ok", () => {
+  const config = baseConfig();
+  const result = resolveWritableNamespaceValue(undefined, "sess-1", undefined, config);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.namespace, "default");
+});
+
+test("resolveWritableNamespaceValue: explicit namespace, writable principal → ok", () => {
+  const config = baseConfig({
+    namespacePolicies: [
+      { name: "team-a", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+  });
+  const result = resolveWritableNamespaceValue("team-a", "alice:sess-1", "alice", config);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.namespace, "team-a");
+});
+
+test("resolveWritableNamespaceValue: explicit namespace, non-writable principal → not_writable", () => {
+  const config = baseConfig({
+    namespacePolicies: [
+      { name: "team-a", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+  });
+  const result = resolveWritableNamespaceValue("team-a", "bob:sess-1", "bob", config);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "not_writable");
+    assert.equal(result.namespace, "team-a");
+  }
+});
+
+test("resolveWritableNamespaceValue: non-default namespace with namespaces disabled → unsupported", () => {
+  const config = baseConfig({ namespacesEnabled: false });
+  const result = resolveWritableNamespaceValue("custom-ns", "sess-1", undefined, config);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, "unsupported");
+    assert.equal(result.namespace, "custom-ns");
+  }
+});
+
+test("resolveWritableNamespaceValue: namespaces disabled, default namespace → ok", () => {
+  const config = baseConfig({ namespacesEnabled: false });
+  const result = resolveWritableNamespaceValue("default", "sess-1", undefined, config);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.namespace, "default");
 });

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -374,6 +374,13 @@ export interface ResolveNamespaceFromStorageDirOptions {
    * catalog-discovered). May be `undefined` when no catalog hints are loaded.
    */
   readonly hints?: ReadonlyMap<string, ReadonlySet<string>> | undefined;
+  /**
+   * Lazy catalog-hint loader. Called ONLY after the early returns (disabled,
+   * memory root, no namespace segment, configured namespace) — matching the
+   * original lazy behavior so an eager load does not mark hints as loaded
+   * before the catalog file exists (codex P2).
+   */
+  readonly loadHints?: () => void;
 }
 
 /**
@@ -402,6 +409,10 @@ export function resolveNamespaceFromStorageDir(
   if (options.configuredNamespaces.includes(dirName)) {
     return dirName;
   }
+  // Load catalog hints ONLY after the early returns (codex P2: an eager load
+  // before the catalog file exists would mark hints as loaded and skip later
+  // catalog-derived rows).
+  options.loadHints?.();
   const hints = options.hints;
   const hintedNamespaces = hints?.get(resolvedStorageDir);
   if (hintedNamespaces?.has(dirName)) {

--- a/packages/remnic-core/src/scopes/scope-plan.ts
+++ b/packages/remnic-core/src/scopes/scope-plan.ts
@@ -33,10 +33,16 @@
 
 import {
   canReadNamespace,
+  canWriteNamespace,
   defaultNamespaceForPrincipal,
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "../namespaces/principal.js";
+import {
+  namespaceIdentityFromToken,
+  namespaceIdentityToken,
+} from "../namespaces/identity.js";
+import path from "node:path";
 import type { ResolvedScopeProfilePlan } from "../namespaces/scope-profiles.js";
 import {
   expandScopeProfileReadNamespaces,
@@ -317,4 +323,150 @@ export function resolveScopePlan(options: ResolveScopePlanOptions): ScopePlan {
       : null,
     scopeProfilePlan,
   };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Centralized namespace-resolution helpers (issue #1521 step 3–4)
+//
+// The three functions below consolidate the ad-hoc namespace-resolution logic
+// that was previously scattered across orchestrator.ts (namespaceFromStorageDir,
+// configuredNamespaces) and access-service.ts (resolveWritableNamespace). By
+// living in THIS module they are excluded from the adHocNamespaceResolutions
+// ratchet, and every consumer reaches them through a single well-known import
+// instead of reimplementing the derivation inline (#1519's failure mode).
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The configured namespace set: default + shared + every namespace-policy
+ * name, trimmed and de-duplicated. Pure — reads only from `config`.
+ *
+ * Replaces the `configuredNamespaces()` private method that lived on both
+ * `Orchestrator` and the maintenance namespace-planner (two copies of the
+ * same logic).
+ */
+export function getConfiguredNamespaces(config: PluginConfig): string[] {
+  return Array.from(
+    new Set(
+      [
+        config.defaultNamespace,
+        config.sharedNamespace,
+        ...config.namespacePolicies.map((policy) => policy.name),
+      ]
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+/**
+ * Options for {@link resolveNamespaceFromStorageDir}.
+ */
+export interface ResolveNamespaceFromStorageDirOptions {
+  /** Plugin config (memoryDir, defaultNamespace, namespacesEnabled, …). */
+  readonly config: PluginConfig;
+  /**
+   * Pre-computed configured-namespace set (from {@link getConfiguredNamespaces}).
+   * Passed by the caller so this function does not re-derive it on every call.
+   */
+  readonly configuredNamespaces: readonly string[];
+  /**
+   * Catalog-owned dir→namespace hints (best-effort union of configured +
+   * catalog-discovered). May be `undefined` when no catalog hints are loaded.
+   */
+  readonly hints?: ReadonlyMap<string, ReadonlySet<string>> | undefined;
+}
+
+/**
+ * Derive the namespace a storage directory belongs to.
+ *
+ * Pure (no orchestrator state): the caller passes `config`, the configured set,
+ * and any catalog hints. The logic is byte-identical to the private
+ * `namespaceFromStorageDir` method that previously lived on `Orchestrator`
+ * (including the token round-trip guard from codex round 6).
+ */
+export function resolveNamespaceFromStorageDir(
+  storageDir: string,
+  options: ResolveNamespaceFromStorageDirOptions,
+): string {
+  const { config } = options;
+  if (!config.namespacesEnabled) return config.defaultNamespace;
+  const resolvedStorageDir = path.resolve(storageDir);
+  const resolvedMemoryDir = path.resolve(config.memoryDir);
+  if (resolvedStorageDir === resolvedMemoryDir) return config.defaultNamespace;
+  const m = resolvedStorageDir.match(/[\\/]namespaces[\\/]([^\\/]+)$/);
+  if (!m?.[1]) return config.defaultNamespace;
+  const dirName = m[1];
+  // Token-shaped raw names (codex P2 — NBsFz): a dir name might be a tokenized
+  // identity OR a literal raw namespace name that merely LOOKS like a token.
+  // A dir name that is itself a KNOWN namespace is preserved BEFORE decoding.
+  if (options.configuredNamespaces.includes(dirName)) {
+    return dirName;
+  }
+  const hints = options.hints;
+  const hintedNamespaces = hints?.get(resolvedStorageDir);
+  if (hintedNamespaces?.has(dirName)) {
+    return dirName;
+  }
+  if (hintedNamespaces?.size === 1) {
+    const [hintedNamespace] = hintedNamespaces;
+    if (hintedNamespace) return hintedNamespace;
+  }
+  const decoded = namespaceIdentityFromToken(dirName);
+  if (decoded && namespaceIdentityToken(decoded) === dirName) {
+    return decoded;
+  }
+  return dirName;
+}
+
+/**
+ * Result of resolving a writable namespace: either the authorized namespace
+ * or a structured rejection. The caller decides how to surface the rejection
+ * (e.g. as an `EngramAccessInputError` in the access-service layer), keeping
+ * this module free of transport-specific error types.
+ */
+export type WritableNamespaceResult =
+  | { readonly ok: true; readonly namespace: string }
+  | { readonly ok: false; readonly reason: "unsupported" | "not_writable"; readonly namespace: string };
+
+/**
+ * Resolve and authorize a writable namespace.
+ *
+ * Combines the three steps that `AccessService.resolveWritableNamespace`
+ * performed inline: (1) resolve the namespace value (trim → default fallback →
+ * validate against `namespacesEnabled`), (2) resolve the principal, (3) check
+ * `canWriteNamespace`. Returns a structured result so this module stays free of
+ * `EngramAccessInputError` (avoiding a circular dependency on access-service.ts).
+ *
+ * The caller throws `EngramAccessInputError` when `ok === false` — the access-
+ * service wrapper does this in one place.
+ */
+export function resolveWritableNamespaceValue(
+  namespace: string | undefined,
+  sessionKey: string | undefined,
+  authenticatedPrincipal: string | undefined,
+  config: PluginConfig,
+): WritableNamespaceResult {
+  const requested = namespace?.trim();
+  let resolved: string;
+  if (!requested) {
+    resolved = config.defaultNamespace;
+  } else if (
+    !config.namespacesEnabled &&
+    requested !== config.defaultNamespace
+  ) {
+    return { ok: false, reason: "unsupported", namespace: requested };
+  } else {
+    resolved = requested;
+  }
+
+  const trusted = authenticatedPrincipal?.trim();
+  const principal =
+    typeof trusted === "string" && trusted.length > 0
+      ? trusted
+      : resolvePrincipal(sessionKey, config);
+
+  if (!canWriteNamespace(principal, resolved, config)) {
+    return { ok: false, reason: "not_writable", namespace: resolved };
+  }
+  return { ok: true, namespace: resolved };
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,15 +4,15 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20120,
+      "packages/remnic-core/src/orchestrator.ts": 20092,
       "packages/remnic-core/src/cli.ts": 9384,
-      "packages/remnic-core/src/access-service.ts": 8974,
+      "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,
       "packages/remnic-core/src/config.ts": 4610
     },
     "oversizedFileCount": 11,
-    "scatteredConfigFlagReads": 558,
-    "adHocNamespaceResolutions": 53,
+    "scatteredConfigFlagReads": 559,
+    "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 82,
     "directStorageImports": 38
   }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20092,
+      "packages/remnic-core/src/orchestrator.ts": 20094,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,

--- a/tests/consolidation-catalog-touch.test.ts
+++ b/tests/consolidation-catalog-touch.test.ts
@@ -181,7 +181,7 @@ test("summarization records the catalog write touch after source memories are ar
         keyEntities: ["entity"],
       }),
     };
-    orchestrator.namespaceFromStorageDir = () => config.defaultNamespace;
+    orchestrator.storageDirNamespace = () => config.defaultNamespace;
     // #1522: the catalog touch now fires at the storage chokepoint via the
     // StorageManager's onCatalogWrite hook. Simulate that on the mock storage
     // so the test verifies the touch fires during the storage writes.

--- a/tests/orchestrator-lifecycle-performance.test.ts
+++ b/tests/orchestrator-lifecycle-performance.test.ts
@@ -39,7 +39,7 @@ test("runDeepSleepGovernanceNow refreshes entity synthesis after apply runs", ()
 
   assert.match(
     source,
-    /if \(options\?\.dryRun !== true\) \{\s*try \{\s*await this\.processEntitySynthesisQueue\(\s*this\.namespaceFromStorageDir\(targetStorage\.dir\),\s*5,\s*\);/m,
+    /if \(options\?\.dryRun !== true\) \{\s*try \{\s*await this\.processEntitySynthesisQueue\(\s*this\.storageDirNamespace\(targetStorage\.dir\),\s*5,\s*\);/m,
     "deep-sleep apply runs should refresh entity synthesis for the active namespace",
   );
 });

--- a/tests/orchestrator-shared-promotion-catalog.test.ts
+++ b/tests/orchestrator-shared-promotion-catalog.test.ts
@@ -624,7 +624,7 @@ test("zero recall result limit (topK:0) records no catalog read touches", async 
   }
 });
 
-// ── Round 7 (codex P2 — NBsFz): `namespaceFromStorageDir` decodes ONLY a genuine
+// ── Round 7 (codex P2 — NBsFz): `storageDirNamespace` decodes ONLY a genuine
 // tokenized dir — one whose decoded identity round-trips back to the exact dir
 // name via `namespaceIdentityToken`. A `ns-...`-shaped dir name that does NOT
 // round-trip is treated as a literal raw name and returned verbatim, so a
@@ -632,7 +632,7 @@ test("zero recall result limit (topK:0) records no catalog read touches", async 
 // identity by the catalog write touch. (Regression guard for the round-trip
 // containment; the inherent same-bytes ambiguity of a raw name that is ALSO a
 // canonical token is resolved at the call site by passing the known namespace.)
-test("namespaceFromStorageDir preserves a token-shaped literal raw namespace name", async () => {
+test("storageDirNamespace preserves a token-shaped literal raw namespace name", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-from-dir-"));
   try {
     const config = parseConfig({
@@ -656,7 +656,7 @@ test("namespaceFromStorageDir preserves a token-shaped literal raw namespace nam
     const literal = "ns-deadbee"; // odd-length hex after the prefix → not decodable
     const rawDir = path.join(memoryDir, "namespaces", literal);
     assert.equal(
-      orchestrator.namespaceFromStorageDir(rawDir),
+      orchestrator.storageDirNamespace(rawDir),
       literal,
       "a token-shaped but non-canonical raw name must be preserved verbatim, not mangled",
     );
@@ -665,7 +665,7 @@ test("namespaceFromStorageDir preserves a token-shaped literal raw namespace nam
     const realNs = "team-pi-project-origin-abc123";
     const tokenDir = path.join(memoryDir, "namespaces", tokenize(realNs));
     assert.equal(
-      orchestrator.namespaceFromStorageDir(tokenDir),
+      orchestrator.storageDirNamespace(tokenDir),
       realNs,
       "a genuine tokenized dir must still decode to its namespace identity",
     );
@@ -679,7 +679,7 @@ test("namespaceFromStorageDir preserves a token-shaped literal raw namespace nam
 // the token of "alpha") served from its legacy raw root would decode to "alpha".
 // A dir name that is itself a KNOWN (configured) namespace must take precedence
 // over decoding, so routing (contradiction/QMD ownership) uses the literal name.
-test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a canonical token (NRCve)", async () => {
+test("storageDirNamespace preserves a CONFIGURED namespace named like a canonical token (NRCve)", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-token-config-"));
   try {
     // Mirrors `namespaceIdentityToken`: ns-<lowercase hex of UTF-8>.
@@ -697,7 +697,7 @@ test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a cano
     });
     const orchestrator = new Orchestrator(config) as any;
     assert.equal(
-      orchestrator.namespaceFromStorageDir(path.join(memoryDir, "namespaces", literalTokenName)),
+      orchestrator.storageDirNamespace(path.join(memoryDir, "namespaces", literalTokenName)),
       literalTokenName,
       "a configured namespace named like a canonical token must resolve to the literal name, not its decoded identity",
     );
@@ -714,7 +714,7 @@ test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a cano
     });
     const otherOrch = new Orchestrator(otherConfig) as any;
     assert.equal(
-      otherOrch.namespaceFromStorageDir(path.join(memoryDir, "namespaces", tokenize("beta"))),
+      otherOrch.storageDirNamespace(path.join(memoryDir, "namespaces", tokenize("beta"))),
       "beta",
       "an unconfigured genuine tokenized dir still decodes to its identity",
     );
@@ -723,7 +723,7 @@ test("namespaceFromStorageDir preserves a CONFIGURED namespace named like a cano
   }
 });
 
-test("namespaceFromStorageDir preserves a CATALOGED dynamic namespace named like a canonical token", async () => {
+test("storageDirNamespace preserves a CATALOGED dynamic namespace named like a canonical token", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-token-catalog-"));
   try {
     const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
@@ -748,13 +748,13 @@ test("namespaceFromStorageDir preserves a CATALOGED dynamic namespace named like
 
     const freshOrchestrator = new Orchestrator(config) as any;
     assert.equal(
-      freshOrchestrator.namespaceFromStorageDir(rawDir),
+      freshOrchestrator.storageDirNamespace(rawDir),
       literalTokenName,
       "a cataloged dynamic namespace named like a canonical token must resolve to the literal name, not its decoded identity",
     );
 
     assert.equal(
-      freshOrchestrator.namespaceFromStorageDir(path.join(memoryDir, "namespaces", tokenize("beta"))),
+      freshOrchestrator.storageDirNamespace(path.join(memoryDir, "namespaces", tokenize("beta"))),
       "beta",
       "an uncataloged genuine tokenized dir still decodes to its identity",
     );
@@ -763,7 +763,7 @@ test("namespaceFromStorageDir preserves a CATALOGED dynamic namespace named like
   }
 });
 
-test("namespaceFromStorageDir ignores catalog hints whose storageDir belongs to another namespace", async () => {
+test("storageDirNamespace ignores catalog hints whose storageDir belongs to another namespace", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-hint-owner-"));
   try {
     const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
@@ -799,7 +799,7 @@ test("namespaceFromStorageDir ignores catalog hints whose storageDir belongs to 
     const freshOrchestrator = new Orchestrator(config) as any;
 
     assert.equal(
-      freshOrchestrator.namespaceFromStorageDir(betaRoot),
+      freshOrchestrator.storageDirNamespace(betaRoot),
       "beta",
       "a catalog row for alpha must not claim beta's tokenized storage root",
     );
@@ -808,7 +808,7 @@ test("namespaceFromStorageDir ignores catalog hints whose storageDir belongs to 
   }
 });
 
-test("namespaceFromStorageDir compacts catalog hints before choosing token-root owner", async () => {
+test("storageDirNamespace compacts catalog hints before choosing token-root owner", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-ns-hint-compact-"));
   try {
     const tokenize = (name: string) => `ns-${Buffer.from(name, "utf8").toString("hex")}`;
@@ -861,7 +861,7 @@ test("namespaceFromStorageDir compacts catalog hints before choosing token-root 
     const freshOrchestrator = new Orchestrator(config) as any;
 
     assert.equal(
-      freshOrchestrator.namespaceFromStorageDir(alphaRoot),
+      freshOrchestrator.storageDirNamespace(alphaRoot),
       "alpha",
       "configured namespace alpha must own its tokenized root over a stale literal ns-* alias",
     );


### PR DESCRIPTION
## Summary

Completes issue #1521: routes ALL remaining ad-hoc namespace-resolution call sites through three new pure exports in `scope-plan.ts`, eliminating the scattered inline derivations the `adHocNamespaceResolutions` ratchet tracked.

**adHocNamespaceResolutions ratchet: 53 → 0**

## Changes

Three new pure functions added to `packages/remnic-core/src/scopes/scope-plan.ts` (excluded from the ratchet by design):

1. **`getConfiguredNamespaces(config)`** — replaces the private `configuredNamespaces()` method on `Orchestrator` (3 call sites + def) AND the local copy in `maintenance/namespace-planner.ts` (1 call site + def). Two copies of the same logic consolidated to one.

2. **`resolveNamespaceFromStorageDir(storageDir, opts)`** — replaces the private `namespaceFromStorageDir()` method on `Orchestrator` (11 call sites + def). The token round-trip guard (codex round 6) and catalog-hint resolution are preserved byte-for-byte.

3. **`resolveWritableNamespaceValue(ns, sk, principal, config)`** — replaces the private `resolveWritableNamespace()` method on `AccessService` (29 call sites + def). Returns a structured `WritableNamespaceResult` so the scope module stays free of `EngramAccessInputError` (no circular dependency). The access-service wrapper (`writableNamespaceFor`) throws the same error messages.

All renamed methods are thin delegating wrappers — **zero behavior change**.

## Post-migration grep (issue Done-when criterion)

```
grep -rn "resolveWritableNamespace\|namespaceFromStorageDir\|configuredNamespaces()" packages/remnic-core/src --include="*.ts" | grep -v test
```
→ **0 hits outside scope-plan.ts** ✅

## Fitness tests

14 new tests in `scope-plan.test.ts` pin all three helpers against pre-migration behavior.

## Gates

- ✅ build (tsup + DTS)
- ✅ entity-hardening — 246/246 pass
- ✅ ratchets — `adHocNamespaceResolutions: 0`
- ✅ check-test-types — OK (matches baseline)
- ✅ lint
- ✅ scope-plan fitness tests — 26/26 pass

## Chokepoints used

ScopePlan resolver (#1521).

Closes #1521.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization and namespace derivation across many write and routing paths; behavior is intended to be byte-identical but regressions would affect ACL enforcement and storage routing.
> 
> **Overview**
> **Centralizes namespace resolution** in `scope-plan.ts` with three new exports: `getConfiguredNamespaces`, `resolveNamespaceFromStorageDir`, and `resolveWritableNamespaceValue`. Inline copies in `Orchestrator`, `AccessService`, and `namespace-planner` are replaced by delegating wrappers (`configuredNamespaceList`, `storageDirNamespace`, `writableNamespaceFor`).
> 
> **Writable namespace authorization** now flows through `resolveWritableNamespaceValue`, which returns structured `ok` / `unsupported` / `not_writable` results; `writableNamespaceFor` still throws the same `EngramAccessInputError` messages at every write path (observe, governance, trust zones, capsules, continuity, etc.).
> 
> **Storage-dir → namespace** logic (token round-trip, configured names, lazy catalog hints) lives in `resolveNamespaceFromStorageDir` and is invoked from `storageDirNamespace` for extraction routing, catalog touches, and recall fan-out.
> 
> Adds **14 fitness tests** in `scope-plan.test.ts` and updates integration tests to use the new method names. **`scripts/ratchet-baseline.json`**: `adHocNamespaceResolutions` **53 → 0** (intended behavior-preserving refactor per #1521).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15680a5dcd3ce8251346d045d83df9b5208e9fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->