### PR TITLE
feat(correction): passive correction detection in conversation (queue/auto) (#1581)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2412,6 +2412,29 @@
         "default": 24,
         "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
       },
+      "correctionCaptureMode": {
+        "type": "string",
+        "enum": [
+          "off",
+          "queue",
+          "auto"
+        ],
+        "default": "off",
+        "description": "Passive correction capture (#1581) — detects corrections expressed in conversation during extraction and routes them to the Correction Contract (#1580). \"off\" disables detection (default, rule 48); \"queue\" plans corrections for human review in the review list; \"auto\" applies immediately when all safety guards pass (confidence floor, blast-radius cap, allowed action/classification), otherwise falls back to queue. Invalid values are rejected (rule 51)."
+      },
+      "correctionCaptureConfidenceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.85,
+        "description": "Minimum planner confidence required to auto-apply a passively-detected correction in \"auto\" mode (#1581). Plans below this floor are queued even when mode is \"auto\". Default 0.85."
+      },
+      "correctionCaptureAutoApplyMaxAffected": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 2,
+        "description": "Maximum number of memories a passively-detected correction may affect in \"auto\" mode (#1581). Plans touching more memories than this are queued even when mode is \"auto\" — a blast-radius cap. Default 2."
+      },
       "tombstonesSemanticMatch": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2412,6 +2412,25 @@
         "default": 24,
         "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
       },
+      "correctionCaptureMode": {
+        "type": "string",
+        "enum": ["off", "queue", "auto"],
+        "default": "off",
+        "description": "Passive correction capture (#1581) — detects corrections expressed in conversation during extraction and routes them to the Correction Contract (#1580). \"off\" disables detection (default, rule 48); \"queue\" plans corrections for human review in the review list; \"auto\" applies immediately when all safety guards pass (confidence floor, blast-radius cap, allowed action/classification), otherwise falls back to queue. Invalid values are rejected (rule 51)."
+      },
+      "correctionCaptureConfidenceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.85,
+        "description": "Minimum planner confidence required to auto-apply a passively-detected correction in \"auto\" mode (#1581). Plans below this floor are queued even when mode is \"auto\". Default 0.85."
+      },
+      "correctionCaptureAutoApplyMaxAffected": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 2,
+        "description": "Maximum number of memories a passively-detected correction may affect in \"auto\" mode (#1581). Plans touching more memories than this are queued even when mode is \"auto\" — a blast-radius cap. Default 2."
+      },
       "tombstonesSemanticMatch": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -20,6 +20,7 @@ import os from "node:os";
 import path from "node:path";
 import { log } from "./logger.js";
 import { extractJsonCandidates } from "./json-extract.js";
+import { drainPassiveCorrectionNotifications } from "./correction/passive-correction-notifications.js";
 import { normalizeEntityName, StorageManager } from "./storage.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
 import type {
@@ -908,6 +909,24 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
     suggestedFollowups: followups,
   };
 
+  // Drain auto-applied passive-correction notifications (issue #1581). The
+  // queue is cleared on read, so each notification surfaces in exactly one
+  // briefing. Fail-open: a drain error never blocks the briefing.
+  let correctionNotifications: BriefingResult["correctionNotifications"];
+  try {
+    const drained = await drainPassiveCorrectionNotifications(options.storage.dir);
+    if (drained.length > 0) {
+      correctionNotifications = drained.map((n) => ({
+        planId: n.planId,
+        summary: n.summary,
+        undoCommand: n.undoCommand,
+        createdAt: n.createdAt,
+      }));
+    }
+  } catch (err) {
+    log.debug(`briefing: correction notification drain failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   const windowIso = { from: window.from.toISOString(), to: window.to.toISOString() };
   const markdown = renderBriefingMarkdown({
     sections,
@@ -916,6 +935,7 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
     followupsUnavailableReason,
     generatedAt: now,
     namespace: options.namespace,
+    correctionNotifications,
   });
 
   const json: Record<string, unknown> = {
@@ -923,6 +943,7 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
     window: windowIso,
     focus,
     namespace: options.namespace ?? null,
+    correctionNotifications: correctionNotifications ?? null,
     sections,
     followupsUnavailableReason: followupsUnavailableReason ?? null,
     calendarSourceErrors: calendarSourceErrors.length > 0 ? calendarSourceErrors : null,
@@ -1351,6 +1372,8 @@ interface RenderContext {
   followupsUnavailableReason?: string;
   generatedAt: Date;
   namespace?: string;
+  /** Auto-applied passive corrections drained for this briefing (#1581). */
+  correctionNotifications?: BriefingResult["correctionNotifications"];
 }
 
 export function renderBriefingMarkdown(ctx: RenderContext): string {
@@ -1365,6 +1388,14 @@ export function renderBriefingMarkdown(ctx: RenderContext): string {
     lines.push(`_Namespace: ${ctx.namespace}_`);
   }
   lines.push("");
+
+  if (ctx.correctionNotifications && ctx.correctionNotifications.length > 0) {
+    lines.push(`## Memory updates`);
+    for (const n of ctx.correctionNotifications) {
+      lines.push(`- ✎ ${n.summary} (undo: ${n.undoCommand})`);
+    }
+    lines.push("");
+  }
 
   lines.push(`## Active threads`);
   if (ctx.sections.activeThreads.length === 0) {

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -955,6 +955,7 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
     sections,
     followupsUnavailableReason,
     window: windowIso,
+    ...(correctionNotifications ? { correctionNotifications } : {}),
   };
 
   if (calendarSourceErrors.length > 0) {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2141,6 +2141,38 @@ export function parseConfig(
       if (fromFlat !== undefined && fromFlat > 0) return fromFlat;
       return 24;
     })(),
+    // Passive correction capture (issue #1581). Parsed from
+    // `correctionCapture.<key>` (nested) or flat legacy keys. Default "off" —
+    // operators opt in (rule 48). Invalid mode → rejected listing options (rule 51).
+    correctionCaptureMode: (() => {
+      const nested = (cfg.correctionCapture as Record<string, unknown> | undefined)?.mode;
+      const raw = nested !== undefined ? nested : cfg.correctionCaptureMode;
+      if (raw === undefined || raw === null) return "off" as const;
+      if (raw === "off" || raw === "queue" || raw === "auto") return raw;
+      throw new Error(
+        `Invalid correctionCapture.mode: expected one of "off", "queue", "auto", got ${JSON.stringify(raw)}`,
+      );
+    })(),
+    correctionCaptureConfidenceFloor: (() => {
+      const nested = (cfg.correctionCapture as Record<string, unknown> | undefined)?.confidenceFloor;
+      const raw = nested !== undefined ? nested : cfg.correctionCaptureConfidenceFloor;
+      if (raw === undefined || raw === null) return 0.85;
+      const n = coerceNumber(raw);
+      if (n === undefined || !Number.isFinite(n) || n < 0 || n > 1) {
+        throw new Error(`Invalid correctionCapture.confidenceFloor: expected a number in [0, 1], got ${JSON.stringify(raw)}`);
+      }
+      return n;
+    })(),
+    correctionCaptureAutoApplyMaxAffected: (() => {
+      const nested = (cfg.correctionCapture as Record<string, unknown> | undefined)?.autoApplyMaxAffected;
+      const raw = nested !== undefined ? nested : cfg.correctionCaptureAutoApplyMaxAffected;
+      if (raw === undefined || raw === null) return 2;
+      const n = coerceNumber(raw);
+      if (n === undefined || !Number.isFinite(n) || n < 1) {
+        throw new Error(`Invalid correctionCapture.autoApplyMaxAffected: expected an integer >= 1, got ${JSON.stringify(raw)}`);
+      }
+      return Math.floor(n);
+    })(),
     // Tombstones — non-resurrection invariant (issue #1579). The invariant is
     // the point, so it ships ON by default; `false` restores pre-feature
     // behavior for rollback safety (rule 30). Uses coerceBool so CLI string

--- a/packages/remnic-core/src/correction/index.ts
+++ b/packages/remnic-core/src/correction/index.ts
@@ -41,3 +41,27 @@ export type { CorrectionNamespacePolicy, CorrectionServiceDeps } from "./correct
 
 export { createCorrectionService, isCorrectionFeatureEnabled } from "./correction-access-wiring.js";
 export type { CorrectionAccessWiring } from "./correction-access-wiring.js";
+
+export { detectPassiveCorrections, extractHandles } from "./passive-correction-detector.js";
+export type { PassiveCorrection, PassiveCorrectionPolarity, DetectorTurn } from "./passive-correction-detector.js";
+
+export {
+  capturePassiveCorrections,
+  evaluateAutoApplyGuards,
+  emptyTelemetry,
+} from "./passive-capture.js";
+export type {
+  CorrectionCaptureMode,
+  PassiveCaptureConfig,
+  PassiveCaptureContext,
+  PassiveCaptureDeps,
+  PassiveCaptureResult,
+  PassiveCaptureTelemetry,
+  AutoApplySuppressionReason,
+} from "./passive-capture.js";
+
+export {
+  enqueuePassiveCorrectionNotification,
+  drainPassiveCorrectionNotifications,
+} from "./passive-correction-notifications.js";
+export type { PassiveCorrectionNotification } from "./passive-correction-notifications.js";

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -239,6 +239,19 @@ test("auto mode: suppressed — disallowed action kind (rescope) → queued", as
   assert.strictEqual(result.telemetry.suppressedReasons.disallowed_action_kind, 1);
 });
 
+test("auto mode: suppressed — empty action list (no-op plan) → queued (review: empty-plan guard)", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({ actions: [], confidence: 0.9 });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
+
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
+
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.suppressedReasons.empty_plan, 1);
+  assert.strictEqual(appliedPlans.length, 0, "empty plan must not be auto-applied");
+});
+
 test("auto mode: suppressed — non-live session (replay) → queued", async () => {
   const appliedPlans: string[] = [];
   const plan = makePlan();
@@ -278,7 +291,8 @@ test("auto mode: auto-applied correction enqueues notification", async () => {
   const notifications = await drainPassiveCorrectionNotifications(tmpDir);
   assert.strictEqual(notifications.length, 1);
   assert.strictEqual(notifications[0].planId, "corr-test-001");
-  assert.ok(notifications[0].undoCommand.includes("remnic correct --revert"));
+  assert.ok(notifications[0].undoCommand.includes("auto-applied"));
+  assert.ok(notifications[0].undoCommand.includes("corr-test-001"));
 
   await rm(tmpDir, { recursive: true, force: true });
 });
@@ -335,7 +349,7 @@ test("notifications: drains once then returns empty", async () => {
   await mkdir(tmpDir, { recursive: true });
 
   await enqueuePassiveCorrectionNotification(tmpDir, {
-    planId: "p1", summary: "test", undoCommand: "remnic correct --revert p1", createdAt: new Date().toISOString(),
+    planId: "p1", summary: "test", undoCommand: "auto-applied (plan p1)", createdAt: new Date().toISOString(),
   });
 
   const first = await drainPassiveCorrectionNotifications(tmpDir);
@@ -352,10 +366,10 @@ test("notifications: accumulates multiple", async () => {
   await mkdir(tmpDir, { recursive: true });
 
   await enqueuePassiveCorrectionNotification(tmpDir, {
-    planId: "p1", summary: "first", undoCommand: "remnic correct --revert p1", createdAt: new Date().toISOString(),
+    planId: "p1", summary: "first", undoCommand: "auto-applied (plan p1)", createdAt: new Date().toISOString(),
   });
   await enqueuePassiveCorrectionNotification(tmpDir, {
-    planId: "p2", summary: "second", undoCommand: "remnic correct --revert p2", createdAt: new Date().toISOString(),
+    planId: "p2", summary: "second", undoCommand: "auto-applied (plan p2)", createdAt: new Date().toISOString(),
   });
 
   const drained = await drainPassiveCorrectionNotifications(tmpDir);

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -297,6 +297,27 @@ test("auto mode: auto-applied correction enqueues notification", async () => {
   await rm(tmpDir, { recursive: true, force: true });
 });
 
+test("auto mode: partial outcome queues instead of counting as applied (review: partial outcomes)", async () => {
+  const plan = makePlan({ confidence: 0.9 });
+  const deps: PassiveCaptureDeps = {
+    planCorrection: async () => plan,
+    applyCorrection: async (planId) => ({
+      planId,
+      status: "partial" as const,
+      results: [{ action: plan.actions[0], status: "failed" as const }],
+      auditMemoryId: "audit",
+      appliedAt: new Date().toISOString(),
+    }),
+    storageDir: async () => "/tmp/test-passive-capture",
+  };
+  const dedup = new Set<string>();
+
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
+
+  assert.strictEqual(result.telemetry.autoApplied, 0, "partial outcome must not count as auto-applied");
+  assert.strictEqual(result.telemetry.queued, 1);
+});
+
 // ---------------------------------------------------------------------------
 // evaluateAutoApplyGuards — direct unit tests
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -315,7 +315,7 @@ test("auto mode: partial outcome queues instead of counting as applied (review: 
   const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
 
   assert.strictEqual(result.telemetry.autoApplied, 0, "partial outcome must not count as auto-applied");
-  assert.strictEqual(result.telemetry.queued, 1);
+  assert.strictEqual(result.telemetry.queued, 0, "partial outcome does not re-queue (plan is consumed)");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -1,0 +1,465 @@
+/**
+ * passive-capture.test.ts — pipeline tests for passive correction capture
+ * (issue #1581 PR 2–3).
+ *
+ * Tests: queue mode, auto mode + all guards, dedup, notifications, telemetry.
+ * Uses mock deps — no real CorrectionService or storage.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  capturePassiveCorrections,
+  evaluateAutoApplyGuards,
+  emptyTelemetry,
+  type PassiveCaptureConfig,
+  type PassiveCaptureContext,
+  type PassiveCaptureDeps,
+} from "./passive-capture.js";
+import type { PassiveCorrection } from "./passive-correction-detector.js";
+import type {
+  CorrectionAction,
+  CorrectionClassification,
+  CorrectionOutcome,
+  CorrectionPlan,
+} from "./correction-contract.js";
+import {
+  enqueuePassiveCorrectionNotification,
+  drainPassiveCorrectionNotifications,
+} from "./passive-correction-notifications.js";
+import { rm, mkdir } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCorrection(overrides: Partial<PassiveCorrection> = {}): PassiveCorrection {
+  return {
+    targetHint: "Redis usage",
+    correctedAssertion: "we don't use Redis anymore",
+    polarity: "retract",
+    handles: [],
+    confidence: 0.9,
+    sourceExcerpt: "we don't use Redis anymore",
+    turnIndex: 0,
+    ...overrides,
+  };
+}
+
+function makePlan(overrides: Partial<CorrectionPlan> = {}): CorrectionPlan {
+  return {
+    planId: "corr-test-001",
+    request: { text: "we don't use Redis anymore", namespace: "default" },
+    namespace: "default",
+    affected: [{ memoryId: "mem-001", path: "facts/redis.md", excerpt: "Uses Redis for caching", why: "matches correction" }],
+    classification: "outdated",
+    actions: [{ kind: "retract", memoryId: "mem-001" }],
+    diff: "- Uses Redis for caching",
+    confidence: 0.9,
+    warnings: [],
+    createdAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function mockDeps(
+  plan: CorrectionPlan,
+  opts: { applyOutcome?: CorrectionOutcome; appliedPlans: string[] } = { appliedPlans: [] },
+): PassiveCaptureDeps {
+  return {
+    planCorrection: async () => plan,
+    applyCorrection: async (planId) => {
+      opts.appliedPlans.push(planId);
+      return (
+        opts.applyOutcome ?? {
+          planId,
+          status: "applied" as const,
+          results: [{ action: plan.actions[0], status: "applied" as const }],
+          auditMemoryId: "audit-001",
+          appliedAt: new Date().toISOString(),
+        }
+      );
+    },
+    storageDir: async () => "/tmp/test-passive-capture",
+  };
+}
+
+const QUEUE_CONFIG: PassiveCaptureConfig = {
+  mode: "queue",
+  confidenceFloor: 0.85,
+  autoApplyMaxAffected: 2,
+};
+
+const AUTO_CONFIG: PassiveCaptureConfig = {
+  mode: "auto",
+  confidenceFloor: 0.85,
+  autoApplyMaxAffected: 2,
+};
+
+const LIVE_CTX: PassiveCaptureContext = {
+  correctionEnabled: true,
+  isLiveSession: true,
+  bufferKey: "session-1",
+  namespace: "default",
+};
+
+// ---------------------------------------------------------------------------
+// Queue mode
+// ---------------------------------------------------------------------------
+
+describe("capturePassiveCorrections — queue mode", () => {
+  it("plans corrections and leaves them pending", async () => {
+    const plan = makePlan();
+    const deps = mockDeps(plan);
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      QUEUE_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.detected).toBe(1);
+    expect(result.telemetry.queued).toBe(1);
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.plans).toHaveLength(1);
+  });
+
+  it("does not auto-apply in queue mode", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan();
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      QUEUE_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(appliedPlans).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedup
+// ---------------------------------------------------------------------------
+
+describe("capturePassiveCorrections — dedup", () => {
+  it("same correction, two flushes → one plan", async () => {
+    const plan = makePlan();
+    const deps = mockDeps(plan);
+    const dedup = new Set<string>();
+
+    const correction = makeCorrection();
+    const r1 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+    const r2 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+
+    expect(r1.telemetry.queued).toBe(1);
+    expect(r2.telemetry.queued).toBe(0);
+    expect(r2.telemetry.detected).toBe(1);
+  });
+
+  it("different bufferKey → both processed", async () => {
+    const plan = makePlan();
+    const deps = mockDeps(plan);
+    const dedup = new Set<string>();
+
+    const correction = makeCorrection();
+    await capturePassiveCorrections(
+      [correction],
+      { ...LIVE_CTX, bufferKey: "session-A" },
+      QUEUE_CONFIG,
+      deps,
+      dedup,
+    );
+    await capturePassiveCorrections(
+      [correction],
+      { ...LIVE_CTX, bufferKey: "session-B" },
+      QUEUE_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(dedup.size).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto mode + guards
+// ---------------------------------------------------------------------------
+
+describe("capturePassiveCorrections — auto mode", () => {
+  it("auto-applies when all guards pass", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan({ confidence: 0.9, classification: "outdated" });
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(1);
+    expect(appliedPlans).toEqual(["corr-test-001"]);
+  });
+
+  it("suppressed: confidence below floor → queued", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan({ confidence: 0.5 });
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.telemetry.queued).toBe(1);
+    expect(result.telemetry.suppressedReasons.confidence_below_floor).toBe(1);
+    expect(appliedPlans).toHaveLength(0);
+  });
+
+  it("suppressed: affected too large → queued", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan({
+      affected: [
+        { memoryId: "m1", path: "a.md", excerpt: "x", why: "y" },
+        { memoryId: "m2", path: "b.md", excerpt: "x", why: "y" },
+        { memoryId: "m3", path: "c.md", excerpt: "x", why: "y" },
+      ],
+    });
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.telemetry.suppressedReasons.affected_too_large).toBe(1);
+  });
+
+  it("suppressed: disallowed classification → queued", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan({ classification: "wrong_scope" as CorrectionClassification });
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.telemetry.suppressedReasons.classification_not_allowed).toBe(1);
+  });
+
+  it("suppressed: disallowed action kind (rescope) → queued", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan({
+      actions: [{ kind: "rescope", memoryId: "m1", toNamespace: "other" } as CorrectionAction],
+    });
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.telemetry.suppressedReasons.disallowed_action_kind).toBe(1);
+  });
+
+  it("suppressed: non-live session (replay) → queued", async () => {
+    const appliedPlans: string[] = [];
+    const plan = makePlan();
+    const deps = mockDeps(plan, { appliedPlans });
+    const dedup = new Set<string>();
+
+    const result = await capturePassiveCorrections(
+      [makeCorrection()],
+      { ...LIVE_CTX, isLiveSession: false },
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    expect(result.telemetry.autoApplied).toBe(0);
+    expect(result.telemetry.suppressedReasons.non_live_session).toBe(1);
+  });
+
+  it("auto-applied correction enqueues notification", async () => {
+    const plan = makePlan({ confidence: 0.9 });
+    const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}`);
+    const deps: PassiveCaptureDeps = {
+      planCorrection: async () => plan,
+      applyCorrection: async (planId) => ({
+        planId,
+        status: "applied",
+        results: [],
+        auditMemoryId: "audit",
+        appliedAt: new Date().toISOString(),
+      }),
+      storageDir: async () => tmpDir,
+    };
+    const dedup = new Set<string>();
+
+    await capturePassiveCorrections(
+      [makeCorrection()],
+      LIVE_CTX,
+      AUTO_CONFIG,
+      deps,
+      dedup,
+    );
+
+    const notifications = await drainPassiveCorrectionNotifications(tmpDir);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].planId).toBe("corr-test-001");
+    expect(notifications[0].undoCommand).toContain("remnic correct --revert");
+
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateAutoApplyGuards — direct unit tests
+// ---------------------------------------------------------------------------
+
+describe("evaluateAutoApplyGuards", () => {
+  const config: PassiveCaptureConfig = {
+    mode: "auto",
+    confidenceFloor: 0.85,
+    autoApplyMaxAffected: 2,
+  };
+
+  it("returns null when all guards pass", () => {
+    const plan = makePlan({ confidence: 0.9 });
+    expect(evaluateAutoApplyGuards(plan, config, true)).toBeNull();
+  });
+
+  it("returns non_live_session for replay", () => {
+    const plan = makePlan();
+    expect(evaluateAutoApplyGuards(plan, config, false)).toBe("non_live_session");
+  });
+
+  it("returns confidence_below_floor", () => {
+    const plan = makePlan({ confidence: 0.5 });
+    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("confidence_below_floor");
+  });
+
+  it("returns classification_not_allowed for wrong_scope", () => {
+    const plan = makePlan({ classification: "wrong_scope" });
+    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("classification_not_allowed");
+  });
+
+  it("returns affected_too_large", () => {
+    const plan = makePlan({
+      affected: [
+        { memoryId: "m1", path: "a", excerpt: "x", why: "y" },
+        { memoryId: "m2", path: "b", excerpt: "x", why: "y" },
+        { memoryId: "m3", path: "c", excerpt: "x", why: "y" },
+      ],
+    });
+    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("affected_too_large");
+  });
+
+  it("returns disallowed_action_kind for redaction_rule", () => {
+    const plan = makePlan({
+      actions: [{ kind: "redaction_rule", pattern: "secret" }],
+    });
+    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("disallowed_action_kind");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notifications — drain-once semantics
+// ---------------------------------------------------------------------------
+
+describe("passive-correction-notifications — drain-once", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  it("drains once then returns empty", async () => {
+    await enqueuePassiveCorrectionNotification(tmpDir, {
+      planId: "p1",
+      summary: "test",
+      undoCommand: "remnic correct --revert p1",
+      createdAt: new Date().toISOString(),
+    });
+
+    const first = await drainPassiveCorrectionNotifications(tmpDir);
+    const second = await drainPassiveCorrectionNotifications(tmpDir);
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(0);
+  });
+
+  it("accumulates multiple notifications", async () => {
+    await enqueuePassiveCorrectionNotification(tmpDir, {
+      planId: "p1",
+      summary: "first",
+      undoCommand: "remnic correct --revert p1",
+      createdAt: new Date().toISOString(),
+    });
+    await enqueuePassiveCorrectionNotification(tmpDir, {
+      planId: "p2",
+      summary: "second",
+      undoCommand: "remnic correct --revert p2",
+      createdAt: new Date().toISOString(),
+    });
+
+    const drained = await drainPassiveCorrectionNotifications(tmpDir);
+    expect(drained).toHaveLength(2);
+    expect(drained.map((n) => n.planId)).toEqual(["p1", "p2"]);
+  });
+
+  it("returns empty when no file exists", async () => {
+    const drained = await drainPassiveCorrectionNotifications(tmpDir);
+    expect(drained).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telemetry
+// ---------------------------------------------------------------------------
+
+describe("telemetry", () => {
+  it("emptyTelemetry returns zeroed counters", () => {
+    const t = emptyTelemetry();
+    expect(t.detected).toBe(0);
+    expect(t.queued).toBe(0);
+    expect(t.autoApplied).toBe(0);
+    expect(Object.keys(t.suppressedReasons)).toHaveLength(0);
+  });
+});

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -382,3 +382,84 @@ test("telemetry: emptyTelemetry returns zeroed counters", () => {
   assert.strictEqual(t.autoApplied, 0);
   assert.strictEqual(Object.keys(t.suppressedReasons).length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Review fixes (cursor threads)
+// ---------------------------------------------------------------------------
+
+test("handle resolution: resolveHandle dep converts [m:xxxx] to memory ids (review)", async () => {
+  // The planner resolveTargetMemories expects concrete memory ids, not raw
+  // [m:xxxx] tokens. The capture loop must resolve handles via the resolveHandle
+  // dep before building the CorrectionRequest; unresolvable handles are dropped
+  // so the planner falls back to text search.
+  let capturedTargetIds: string[] | undefined;
+  const deps: PassiveCaptureDeps = {
+    ...mockDeps(makePlan()),
+    resolveHandle: (ref) => (ref === "[m:4f2a]" ? "fact-1700000000-abcd" : null),
+    planCorrection: async (req) => {
+      capturedTargetIds = req.targetIds as string[] | undefined;
+      return makePlan();
+    },
+  };
+  const correction = makeCorrection({
+    handles: ["[m:4f2a]"],
+    correctedAssertion: "[m:4f2a] is wrong",
+    polarity: "retract",
+  });
+  await capturePassiveCorrections(
+    [correction],
+    { ...LIVE_CTX, sessionKey: "sess-1" },
+    QUEUE_CONFIG,
+    deps,
+    new Set(),
+  );
+  assert.deepStrictEqual(
+    capturedTargetIds,
+    ["fact-1700000000-abcd"],
+    "handle must be resolved to a concrete memory id before planning",
+  );
+});
+
+test("handle resolution: unresolvable handle is dropped (planner falls back to text)", async () => {
+  let capturedTargetIds: string[] | undefined;
+  const deps: PassiveCaptureDeps = {
+    ...mockDeps(makePlan()),
+    resolveHandle: () => null,
+    planCorrection: async (req) => {
+      capturedTargetIds = req.targetIds as string[] | undefined;
+      return makePlan();
+    },
+  };
+  const correction = makeCorrection({ handles: ["[m:dead]"] });
+  await capturePassiveCorrections(
+    [correction],
+    { ...LIVE_CTX, sessionKey: "sess-1" },
+    QUEUE_CONFIG,
+    deps,
+    new Set(),
+  );
+  assert.strictEqual(capturedTargetIds, undefined, "unresolvable handle must not reach the planner");
+});
+
+test("dedup: failed plan can be retried on a later flush (review)", async () => {
+  // The fingerprint is recorded only AFTER a successful plan, so a transient
+  // planning failure does not permanently block the correction.
+  let attempts = 0;
+  const deps: PassiveCaptureDeps = {
+    ...mockDeps(makePlan()),
+    planCorrection: async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("transient planning failure");
+      return makePlan();
+    },
+  };
+  const dedup = new Set<string>();
+  const correction = makeCorrection();
+  // First flush: planning throws — fingerprint NOT recorded.
+  const r1 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+  assert.strictEqual(r1.telemetry.queued, 0, "failed plan must not count as queued");
+  // Second flush: same correction, retry succeeds.
+  const r2 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+  assert.strictEqual(r2.telemetry.queued, 1, "failed plan must be retriable");
+  assert.strictEqual(attempts, 2);
+});

--- a/packages/remnic-core/src/correction/passive-capture.test.ts
+++ b/packages/remnic-core/src/correction/passive-capture.test.ts
@@ -6,7 +6,11 @@
  * Uses mock deps — no real CorrectionService or storage.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { rm, mkdir } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
 import {
   capturePassiveCorrections,
   evaluateAutoApplyGuards,
@@ -26,9 +30,6 @@ import {
   enqueuePassiveCorrectionNotification,
   drainPassiveCorrectionNotifications,
 } from "./passive-correction-notifications.js";
-import { rm, mkdir } from "node:fs/promises";
-import path from "node:path";
-import os from "node:os";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,356 +111,274 @@ const LIVE_CTX: PassiveCaptureContext = {
 // Queue mode
 // ---------------------------------------------------------------------------
 
-describe("capturePassiveCorrections — queue mode", () => {
-  it("plans corrections and leaves them pending", async () => {
-    const plan = makePlan();
-    const deps = mockDeps(plan);
-    const dedup = new Set<string>();
+test("queue mode: plans corrections and leaves them pending", async () => {
+  const plan = makePlan();
+  const deps = mockDeps(plan);
+  const dedup = new Set<string>();
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      QUEUE_CONFIG,
-      deps,
-      dedup,
-    );
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
 
-    expect(result.telemetry.detected).toBe(1);
-    expect(result.telemetry.queued).toBe(1);
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.plans).toHaveLength(1);
-  });
+  assert.strictEqual(result.telemetry.detected, 1);
+  assert.strictEqual(result.telemetry.queued, 1);
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.plans.length, 1);
+});
 
-  it("does not auto-apply in queue mode", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan();
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+test("queue mode: does not auto-apply", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan();
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
 
-    await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      QUEUE_CONFIG,
-      deps,
-      dedup,
-    );
+  await capturePassiveCorrections([makeCorrection()], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
 
-    expect(appliedPlans).toHaveLength(0);
-  });
+  assert.strictEqual(appliedPlans.length, 0);
 });
 
 // ---------------------------------------------------------------------------
 // Dedup
 // ---------------------------------------------------------------------------
 
-describe("capturePassiveCorrections — dedup", () => {
-  it("same correction, two flushes → one plan", async () => {
-    const plan = makePlan();
-    const deps = mockDeps(plan);
-    const dedup = new Set<string>();
+test("dedup: same correction, two flushes → one plan", async () => {
+  const plan = makePlan();
+  const deps = mockDeps(plan);
+  const dedup = new Set<string>();
 
-    const correction = makeCorrection();
-    const r1 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
-    const r2 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+  const correction = makeCorrection();
+  const r1 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
+  const r2 = await capturePassiveCorrections([correction], LIVE_CTX, QUEUE_CONFIG, deps, dedup);
 
-    expect(r1.telemetry.queued).toBe(1);
-    expect(r2.telemetry.queued).toBe(0);
-    expect(r2.telemetry.detected).toBe(1);
-  });
+  assert.strictEqual(r1.telemetry.queued, 1);
+  assert.strictEqual(r2.telemetry.queued, 0);
+  assert.strictEqual(r2.telemetry.detected, 1);
+});
 
-  it("different bufferKey → both processed", async () => {
-    const plan = makePlan();
-    const deps = mockDeps(plan);
-    const dedup = new Set<string>();
+test("dedup: different bufferKey → both processed", async () => {
+  const plan = makePlan();
+  const deps = mockDeps(plan);
+  const dedup = new Set<string>();
 
-    const correction = makeCorrection();
-    await capturePassiveCorrections(
-      [correction],
-      { ...LIVE_CTX, bufferKey: "session-A" },
-      QUEUE_CONFIG,
-      deps,
-      dedup,
-    );
-    await capturePassiveCorrections(
-      [correction],
-      { ...LIVE_CTX, bufferKey: "session-B" },
-      QUEUE_CONFIG,
-      deps,
-      dedup,
-    );
+  const correction = makeCorrection();
+  await capturePassiveCorrections([correction], { ...LIVE_CTX, bufferKey: "session-A" }, QUEUE_CONFIG, deps, dedup);
+  await capturePassiveCorrections([correction], { ...LIVE_CTX, bufferKey: "session-B" }, QUEUE_CONFIG, deps, dedup);
 
-    expect(dedup.size).toBe(2);
-  });
+  assert.strictEqual(dedup.size, 2);
 });
 
 // ---------------------------------------------------------------------------
 // Auto mode + guards
 // ---------------------------------------------------------------------------
 
-describe("capturePassiveCorrections — auto mode", () => {
-  it("auto-applies when all guards pass", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan({ confidence: 0.9, classification: "outdated" });
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+test("auto mode: applies when all guards pass", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({ confidence: 0.9, classification: "outdated" });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
 
-    expect(result.telemetry.autoApplied).toBe(1);
-    expect(appliedPlans).toEqual(["corr-test-001"]);
+  assert.strictEqual(result.telemetry.autoApplied, 1);
+  assert.deepStrictEqual(appliedPlans, ["corr-test-001"]);
+});
+
+test("auto mode: suppressed — confidence below floor → queued", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({ confidence: 0.5 });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
+
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
+
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.queued, 1);
+  assert.strictEqual(result.telemetry.suppressedReasons.confidence_below_floor, 1);
+  assert.strictEqual(appliedPlans.length, 0);
+});
+
+test("auto mode: suppressed — affected too large → queued", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({
+    affected: [
+      { memoryId: "m1", path: "a.md", excerpt: "x", why: "y" },
+      { memoryId: "m2", path: "b.md", excerpt: "x", why: "y" },
+      { memoryId: "m3", path: "c.md", excerpt: "x", why: "y" },
+    ],
   });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
 
-  it("suppressed: confidence below floor → queued", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan({ confidence: 0.5 });
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.suppressedReasons.affected_too_large, 1);
+});
 
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.telemetry.queued).toBe(1);
-    expect(result.telemetry.suppressedReasons.confidence_below_floor).toBe(1);
-    expect(appliedPlans).toHaveLength(0);
+test("auto mode: suppressed — disallowed classification → queued", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({ classification: "wrong_scope" as CorrectionClassification });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
+
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
+
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.suppressedReasons.classification_not_allowed, 1);
+});
+
+test("auto mode: suppressed — disallowed action kind (rescope) → queued", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan({
+    actions: [{ kind: "rescope", memoryId: "m1", toNamespace: "other" } as CorrectionAction],
   });
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
 
-  it("suppressed: affected too large → queued", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan({
-      affected: [
-        { memoryId: "m1", path: "a.md", excerpt: "x", why: "y" },
-        { memoryId: "m2", path: "b.md", excerpt: "x", why: "y" },
-        { memoryId: "m3", path: "c.md", excerpt: "x", why: "y" },
-      ],
-    });
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+  const result = await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.suppressedReasons.disallowed_action_kind, 1);
+});
 
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.telemetry.suppressedReasons.affected_too_large).toBe(1);
-  });
+test("auto mode: suppressed — non-live session (replay) → queued", async () => {
+  const appliedPlans: string[] = [];
+  const plan = makePlan();
+  const deps = mockDeps(plan, { appliedPlans });
+  const dedup = new Set<string>();
 
-  it("suppressed: disallowed classification → queued", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan({ classification: "wrong_scope" as CorrectionClassification });
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+  const result = await capturePassiveCorrections(
+    [makeCorrection()],
+    { ...LIVE_CTX, isLiveSession: false },
+    AUTO_CONFIG,
+    deps,
+    dedup,
+  );
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
+  assert.strictEqual(result.telemetry.autoApplied, 0);
+  assert.strictEqual(result.telemetry.suppressedReasons.non_live_session, 1);
+});
 
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.telemetry.suppressedReasons.classification_not_allowed).toBe(1);
-  });
+test("auto mode: auto-applied correction enqueues notification", async () => {
+  const plan = makePlan({ confidence: 0.9 });
+  const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}`);
+  const deps: PassiveCaptureDeps = {
+    planCorrection: async () => plan,
+    applyCorrection: async (planId) => ({
+      planId,
+      status: "applied",
+      results: [],
+      auditMemoryId: "audit",
+      appliedAt: new Date().toISOString(),
+    }),
+    storageDir: async () => tmpDir,
+  };
+  const dedup = new Set<string>();
 
-  it("suppressed: disallowed action kind (rescope) → queued", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan({
-      actions: [{ kind: "rescope", memoryId: "m1", toNamespace: "other" } as CorrectionAction],
-    });
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
+  await capturePassiveCorrections([makeCorrection()], LIVE_CTX, AUTO_CONFIG, deps, dedup);
 
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
+  const notifications = await drainPassiveCorrectionNotifications(tmpDir);
+  assert.strictEqual(notifications.length, 1);
+  assert.strictEqual(notifications[0].planId, "corr-test-001");
+  assert.ok(notifications[0].undoCommand.includes("remnic correct --revert"));
 
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.telemetry.suppressedReasons.disallowed_action_kind).toBe(1);
-  });
-
-  it("suppressed: non-live session (replay) → queued", async () => {
-    const appliedPlans: string[] = [];
-    const plan = makePlan();
-    const deps = mockDeps(plan, { appliedPlans });
-    const dedup = new Set<string>();
-
-    const result = await capturePassiveCorrections(
-      [makeCorrection()],
-      { ...LIVE_CTX, isLiveSession: false },
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
-
-    expect(result.telemetry.autoApplied).toBe(0);
-    expect(result.telemetry.suppressedReasons.non_live_session).toBe(1);
-  });
-
-  it("auto-applied correction enqueues notification", async () => {
-    const plan = makePlan({ confidence: 0.9 });
-    const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}`);
-    const deps: PassiveCaptureDeps = {
-      planCorrection: async () => plan,
-      applyCorrection: async (planId) => ({
-        planId,
-        status: "applied",
-        results: [],
-        auditMemoryId: "audit",
-        appliedAt: new Date().toISOString(),
-      }),
-      storageDir: async () => tmpDir,
-    };
-    const dedup = new Set<string>();
-
-    await capturePassiveCorrections(
-      [makeCorrection()],
-      LIVE_CTX,
-      AUTO_CONFIG,
-      deps,
-      dedup,
-    );
-
-    const notifications = await drainPassiveCorrectionNotifications(tmpDir);
-    expect(notifications).toHaveLength(1);
-    expect(notifications[0].planId).toBe("corr-test-001");
-    expect(notifications[0].undoCommand).toContain("remnic correct --revert");
-
-    await rm(tmpDir, { recursive: true, force: true });
-  });
+  await rm(tmpDir, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
 // evaluateAutoApplyGuards — direct unit tests
 // ---------------------------------------------------------------------------
 
-describe("evaluateAutoApplyGuards", () => {
-  const config: PassiveCaptureConfig = {
-    mode: "auto",
-    confidenceFloor: 0.85,
-    autoApplyMaxAffected: 2,
-  };
+test("guards: returns null when all pass", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  const plan = makePlan({ confidence: 0.9 });
+  assert.strictEqual(evaluateAutoApplyGuards(plan, config, true), null);
+});
 
-  it("returns null when all guards pass", () => {
-    const plan = makePlan({ confidence: 0.9 });
-    expect(evaluateAutoApplyGuards(plan, config, true)).toBeNull();
-  });
+test("guards: non_live_session for replay", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  assert.strictEqual(evaluateAutoApplyGuards(makePlan(), config, false), "non_live_session");
+});
 
-  it("returns non_live_session for replay", () => {
-    const plan = makePlan();
-    expect(evaluateAutoApplyGuards(plan, config, false)).toBe("non_live_session");
-  });
+test("guards: confidence_below_floor", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  assert.strictEqual(evaluateAutoApplyGuards(makePlan({ confidence: 0.5 }), config, true), "confidence_below_floor");
+});
 
-  it("returns confidence_below_floor", () => {
-    const plan = makePlan({ confidence: 0.5 });
-    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("confidence_below_floor");
-  });
+test("guards: classification_not_allowed for wrong_scope", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  assert.strictEqual(evaluateAutoApplyGuards(makePlan({ classification: "wrong_scope" }), config, true), "classification_not_allowed");
+});
 
-  it("returns classification_not_allowed for wrong_scope", () => {
-    const plan = makePlan({ classification: "wrong_scope" });
-    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("classification_not_allowed");
+test("guards: affected_too_large", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  const plan = makePlan({
+    affected: [
+      { memoryId: "m1", path: "a", excerpt: "x", why: "y" },
+      { memoryId: "m2", path: "b", excerpt: "x", why: "y" },
+      { memoryId: "m3", path: "c", excerpt: "x", why: "y" },
+    ],
   });
+  assert.strictEqual(evaluateAutoApplyGuards(plan, config, true), "affected_too_large");
+});
 
-  it("returns affected_too_large", () => {
-    const plan = makePlan({
-      affected: [
-        { memoryId: "m1", path: "a", excerpt: "x", why: "y" },
-        { memoryId: "m2", path: "b", excerpt: "x", why: "y" },
-        { memoryId: "m3", path: "c", excerpt: "x", why: "y" },
-      ],
-    });
-    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("affected_too_large");
-  });
-
-  it("returns disallowed_action_kind for redaction_rule", () => {
-    const plan = makePlan({
-      actions: [{ kind: "redaction_rule", pattern: "secret" }],
-    });
-    expect(evaluateAutoApplyGuards(plan, config, true)).toBe("disallowed_action_kind");
-  });
+test("guards: disallowed_action_kind for redaction_rule", () => {
+  const config: PassiveCaptureConfig = { mode: "auto", confidenceFloor: 0.85, autoApplyMaxAffected: 2 };
+  const plan = makePlan({ actions: [{ kind: "redaction_rule", pattern: "secret" }] });
+  assert.strictEqual(evaluateAutoApplyGuards(plan, config, true), "disallowed_action_kind");
 });
 
 // ---------------------------------------------------------------------------
 // Notifications — drain-once semantics
 // ---------------------------------------------------------------------------
 
-describe("passive-correction-notifications — drain-once", () => {
-  let tmpDir: string;
+test("notifications: drains once then returns empty", async () => {
+  const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(tmpDir, { recursive: true });
 
-  beforeEach(async () => {
-    tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    await mkdir(tmpDir, { recursive: true });
+  await enqueuePassiveCorrectionNotification(tmpDir, {
+    planId: "p1", summary: "test", undoCommand: "remnic correct --revert p1", createdAt: new Date().toISOString(),
   });
 
-  it("drains once then returns empty", async () => {
-    await enqueuePassiveCorrectionNotification(tmpDir, {
-      planId: "p1",
-      summary: "test",
-      undoCommand: "remnic correct --revert p1",
-      createdAt: new Date().toISOString(),
-    });
+  const first = await drainPassiveCorrectionNotifications(tmpDir);
+  const second = await drainPassiveCorrectionNotifications(tmpDir);
 
-    const first = await drainPassiveCorrectionNotifications(tmpDir);
-    const second = await drainPassiveCorrectionNotifications(tmpDir);
+  assert.strictEqual(first.length, 1);
+  assert.strictEqual(second.length, 0);
 
-    expect(first).toHaveLength(1);
-    expect(second).toHaveLength(0);
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+test("notifications: accumulates multiple", async () => {
+  const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(tmpDir, { recursive: true });
+
+  await enqueuePassiveCorrectionNotification(tmpDir, {
+    planId: "p1", summary: "first", undoCommand: "remnic correct --revert p1", createdAt: new Date().toISOString(),
+  });
+  await enqueuePassiveCorrectionNotification(tmpDir, {
+    planId: "p2", summary: "second", undoCommand: "remnic correct --revert p2", createdAt: new Date().toISOString(),
   });
 
-  it("accumulates multiple notifications", async () => {
-    await enqueuePassiveCorrectionNotification(tmpDir, {
-      planId: "p1",
-      summary: "first",
-      undoCommand: "remnic correct --revert p1",
-      createdAt: new Date().toISOString(),
-    });
-    await enqueuePassiveCorrectionNotification(tmpDir, {
-      planId: "p2",
-      summary: "second",
-      undoCommand: "remnic correct --revert p2",
-      createdAt: new Date().toISOString(),
-    });
+  const drained = await drainPassiveCorrectionNotifications(tmpDir);
+  assert.strictEqual(drained.length, 2);
+  assert.deepStrictEqual(drained.map((n) => n.planId), ["p1", "p2"]);
 
-    const drained = await drainPassiveCorrectionNotifications(tmpDir);
-    expect(drained).toHaveLength(2);
-    expect(drained.map((n) => n.planId)).toEqual(["p1", "p2"]);
-  });
+  await rm(tmpDir, { recursive: true, force: true });
+});
 
-  it("returns empty when no file exists", async () => {
-    const drained = await drainPassiveCorrectionNotifications(tmpDir);
-    expect(drained).toEqual([]);
-  });
+test("notifications: returns empty when no file exists", async () => {
+  const tmpDir = path.join(os.tmpdir(), `test-passive-notify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const drained = await drainPassiveCorrectionNotifications(tmpDir);
+  assert.deepStrictEqual(drained, []);
 });
 
 // ---------------------------------------------------------------------------
 // Telemetry
 // ---------------------------------------------------------------------------
 
-describe("telemetry", () => {
-  it("emptyTelemetry returns zeroed counters", () => {
-    const t = emptyTelemetry();
-    expect(t.detected).toBe(0);
-    expect(t.queued).toBe(0);
-    expect(t.autoApplied).toBe(0);
-    expect(Object.keys(t.suppressedReasons)).toHaveLength(0);
-  });
+test("telemetry: emptyTelemetry returns zeroed counters", () => {
+  const t = emptyTelemetry();
+  assert.strictEqual(t.detected, 0);
+  assert.strictEqual(t.queued, 0);
+  assert.strictEqual(t.autoApplied, 0);
+  assert.strictEqual(Object.keys(t.suppressedReasons).length, 0);
 });

--- a/packages/remnic-core/src/correction/passive-capture.ts
+++ b/packages/remnic-core/src/correction/passive-capture.ts
@@ -281,7 +281,13 @@ export async function capturePassiveCorrections(
       // storage failures). Don't count it as auto-applied or notify — queue
       // for human review instead (review: "partial outcomes as failures").
       if (outcome.status !== "applied") {
-        telemetry.queued += 1;
+        // Partial outcome: some actions applied, some failed. The plan is
+        // consumed (status 'partial', not 'pending'), so it won't appear in
+        // listPending — do NOT increment queued (review: "partial not
+        // re-queued"). The audit record captures which actions failed.
+        log.warn(
+          `passive-correction: plan ${plan.planId} applied partially — some actions failed (see audit record)`,
+        );
         continue;
       }
       telemetry.autoApplied += 1;

--- a/packages/remnic-core/src/correction/passive-capture.ts
+++ b/packages/remnic-core/src/correction/passive-capture.ts
@@ -80,6 +80,14 @@ export interface PassiveCaptureDeps {
   ): Promise<CorrectionOutcome>;
   /** Resolve the storage dir for notification enqueue (per namespace). */
   storageDir(namespace: string): Promise<string>;
+  /**
+   * Resolve a memory handle (`[m:xxxx]`) to a concrete memory id, returning
+   * null when the handle is unresolvable in the session (graceful — the
+   * planner then falls back to text search). Wired to the orchestrator single
+   * shared `resolveMemoryIdOrHandle` helper (#1582) so handle resolution has
+   * one path (rule 22). Review: "memory handles not resolved".
+   */
+  resolveHandle?(ref: string, sessionKey?: string): string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,17 +199,35 @@ export async function capturePassiveCorrections(
   telemetry.detected = corrections.length;
 
   for (const correction of corrections) {
-    // 1. Dedup
+    // 1. Dedup — checked before planning, but the fingerprint is only
+    //    recorded AFTER a successful plan so a transient planning failure
+    //    can be retried on a later flush (review: "dedup blocks retry
+    //    after failure").
     const fp = correctionFingerprint(ctx.bufferKey, correction);
     if (dedupState.has(fp)) {
       continue;
     }
-    dedupState.add(fp);
 
-    // 2. Build + plan
+    // 2. Resolve `[m:xxxx]` handles to concrete memory ids (review:
+    //    "memory handles not resolved"). The planner resolveTargetMemories
+    //    expects memory ids, not raw handle tokens — passing a handle
+    //    string would throw "target memory not found". Unresolvable handles
+    //    are dropped so the planner falls back to text search (graceful
+    //    degradation; a correction without a resolved target is still valid).
+    let targetIds: string[] | undefined;
+    if (correction.handles.length > 0 && deps.resolveHandle && ctx.sessionKey) {
+      const resolved: string[] = [];
+      for (const handle of correction.handles) {
+        const id = deps.resolveHandle(handle, ctx.sessionKey);
+        if (id) resolved.push(id);
+      }
+      if (resolved.length > 0) targetIds = resolved;
+    }
+
+    // 3. Build + plan
     const request: CorrectionRequest = {
       text: correction.correctedAssertion || correction.sourceExcerpt,
-      ...(correction.handles.length > 0 ? { targetIds: correction.handles } : {}),
+      ...(targetIds ? { targetIds } : {}),
       ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
       ...(ctx.principal ? { principal: ctx.principal } : {}),
       namespace: ctx.namespace,
@@ -217,6 +243,8 @@ export async function capturePassiveCorrections(
       continue;
     }
     plans.push(plan);
+    // Record the fingerprint only after a successful plan.
+    dedupState.add(fp);
 
     // 3. Dispatch by mode
     if (config.mode === "queue") {

--- a/packages/remnic-core/src/correction/passive-capture.ts
+++ b/packages/remnic-core/src/correction/passive-capture.ts
@@ -1,0 +1,286 @@
+/**
+ * correction/passive-capture.ts — routes detected passive corrections to the
+ * Correction Contract (#1580) by mode: queue, auto, or off (issue #1581).
+ *
+ * This module is the thin handoff between the extraction post-processing step
+ * (which calls `detectPassiveCorrections`) and the CorrectionService's
+ * `plan()` / `apply()` pipeline. It adds NO parallel correction logic (rule 22)
+ * — the planner does all the locating/classifying; this module only decides
+ * whether to queue the resulting plan for review or auto-apply it.
+ *
+ * Guards (auto mode):
+ *   - plan confidence ≥ confidenceFloor
+ *   - classification ∈ {outdated, wrong}
+ *   - affected.length ≤ autoApplyMaxAffected
+ *   - every action ∈ {supersede, edit, retract} (never auto-apply
+ *     rescope/redaction_rule/never_store — those are policy changes)
+ * If ANY guard fails, the plan falls back to queue.
+ *
+ * Session scoping (rule 42): a correction detected in session S plans only
+ * against S's readable namespaces. The CorrectionService already enforces this
+ * through its namespace policy; this module passes the session-scoped context.
+ *
+ * Dedup: fingerprint detected corrections by `bufferKey + normalizedCorrectionText`
+ * so parallel sessions / re-flushes don't double-plan.
+ */
+
+import { log } from "../logger.js";
+import type { PassiveCorrection } from "./passive-correction-detector.js";
+import type {
+  CorrectionClassification,
+  CorrectionOutcome,
+  CorrectionPlan,
+  CorrectionRequest,
+  CorrectionAction,
+} from "./correction-contract.js";
+import {
+  enqueuePassiveCorrectionNotification,
+} from "./passive-correction-notifications.js";
+
+// ---------------------------------------------------------------------------
+// Config + context
+// ---------------------------------------------------------------------------
+
+export type CorrectionCaptureMode = "off" | "queue" | "auto";
+
+export interface PassiveCaptureConfig {
+  mode: CorrectionCaptureMode;
+  confidenceFloor: number;
+  autoApplyMaxAffected: number;
+}
+
+export interface PassiveCaptureContext {
+  /** The correction feature must be enabled for capture to run. */
+  correctionEnabled: boolean;
+  /** Whether this is a live session (not replay/import). Auto-apply is
+   *  live-session only — replayed history may contain corrections the user
+   *  later re-reverted; queue those. */
+  isLiveSession: boolean;
+  /** Buffer key for dedup fingerprinting. */
+  bufferKey: string;
+  /** Session key for namespace/principal resolution. */
+  sessionKey?: string;
+  /** Authenticated principal. */
+  principal?: string;
+  /** Authorized namespace the extraction wrote to. */
+  namespace: string;
+}
+
+// ---------------------------------------------------------------------------
+// Deps (injected — the orchestrator wires these)
+// ---------------------------------------------------------------------------
+
+export interface PassiveCaptureDeps {
+  /** Plan a correction through the Correction Contract. */
+  planCorrection(request: CorrectionRequest): Promise<CorrectionPlan>;
+  /** Apply a planned correction (auto mode only). */
+  applyCorrection(
+    planId: string,
+    opts: { confirm: true; namespace?: string; sessionKey?: string; principal?: string },
+  ): Promise<CorrectionOutcome>;
+  /** Resolve the storage dir for notification enqueue (per namespace). */
+  storageDir(namespace: string): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry
+// ---------------------------------------------------------------------------
+
+export interface PassiveCaptureTelemetry {
+  detected: number;
+  queued: number;
+  autoApplied: number;
+  /** Reason → count for auto-apply suppressions. */
+  suppressedReasons: Record<string, number>;
+}
+
+export function emptyTelemetry(): PassiveCaptureTelemetry {
+  return { detected: 0, queued: 0, autoApplied: 0, suppressedReasons: {} };
+}
+
+// ---------------------------------------------------------------------------
+// Dedup fingerprint
+// ---------------------------------------------------------------------------
+
+/** Normalize correction text for fingerprinting (case + whitespace + punctuation). */
+function normalizeForFingerprint(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+function correctionFingerprint(bufferKey: string, correction: PassiveCorrection): string {
+  return `${bufferKey}::${correction.polarity}::${normalizeForFingerprint(correction.targetHint)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-apply guards
+// ---------------------------------------------------------------------------
+
+/** Action kinds that are safe to auto-apply (state-preserving, not policy changes). */
+const AUTO_APPLICABLE_ACTION_KINDS = new Set(["supersede", "edit", "retract"]);
+
+/** Classifications safe for auto-apply. */
+const AUTO_APPLICABLE_CLASSIFICATIONS = new Set<CorrectionClassification>(["outdated", "wrong"]);
+
+export type AutoApplySuppressionReason =
+  | "non_live_session"
+  | "confidence_below_floor"
+  | "classification_not_allowed"
+  | "affected_too_large"
+  | "disallowed_action_kind";
+
+/**
+ * Evaluate all auto-apply guards. Returns the suppression reason (if any), or
+ * null if auto-apply may proceed.
+ */
+export function evaluateAutoApplyGuards(
+  plan: CorrectionPlan,
+  config: PassiveCaptureConfig,
+  isLiveSession: boolean,
+): AutoApplySuppressionReason | null {
+  if (!isLiveSession) return "non_live_session";
+  if (plan.confidence < config.confidenceFloor) return "confidence_below_floor";
+  if (!AUTO_APPLICABLE_CLASSIFICATIONS.has(plan.classification)) {
+    return "classification_not_allowed";
+  }
+  if (plan.affected.length > config.autoApplyMaxAffected) {
+    return "affected_too_large";
+  }
+  for (const action of plan.actions) {
+    if (!AUTO_APPLICABLE_ACTION_KINDS.has(action.kind)) {
+      return "disallowed_action_kind";
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry: capture passive corrections
+// ---------------------------------------------------------------------------
+
+export interface PassiveCaptureResult {
+  telemetry: PassiveCaptureTelemetry;
+  /** Plans created (both queued and auto-applied). */
+  plans: CorrectionPlan[];
+}
+
+/**
+ * Process a batch of detected passive corrections. For each correction:
+ *   1. Check dedup fingerprint — skip if already processed for this bufferKey.
+ *   2. Build a CorrectionRequest and call the planner.
+ *   3. Dispatch by mode: queue → plan is left pending; auto → apply if all
+ *      guards pass, else fall back to queue.
+ *   4. Record telemetry.
+ *
+ * Fail-open: a planning or apply error for ONE correction never blocks the
+ * others. The error is logged and the correction is counted as suppressed.
+ */
+export async function capturePassiveCorrections(
+  corrections: readonly PassiveCorrection[],
+  ctx: PassiveCaptureContext,
+  config: PassiveCaptureConfig,
+  deps: PassiveCaptureDeps,
+  dedupState: Set<string>,
+): Promise<PassiveCaptureResult> {
+  const telemetry = emptyTelemetry();
+  const plans: CorrectionPlan[] = [];
+  telemetry.detected = corrections.length;
+
+  for (const correction of corrections) {
+    // 1. Dedup
+    const fp = correctionFingerprint(ctx.bufferKey, correction);
+    if (dedupState.has(fp)) {
+      continue;
+    }
+    dedupState.add(fp);
+
+    // 2. Build + plan
+    const request: CorrectionRequest = {
+      text: correction.correctedAssertion || correction.sourceExcerpt,
+      ...(correction.handles.length > 0 ? { targetIds: correction.handles } : {}),
+      ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+      ...(ctx.principal ? { principal: ctx.principal } : {}),
+      namespace: ctx.namespace,
+    };
+
+    let plan: CorrectionPlan;
+    try {
+      plan = await deps.planCorrection(request);
+    } catch (err) {
+      log.warn(
+        `passive-correction: planning failed for "${correction.targetHint.slice(0, 60)}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    plans.push(plan);
+
+    // 3. Dispatch by mode
+    if (config.mode === "queue") {
+      telemetry.queued += 1;
+      continue;
+    }
+
+    // mode === "auto"
+    const suppression = evaluateAutoApplyGuards(plan, config, ctx.isLiveSession);
+    if (suppression) {
+      telemetry.suppressedReasons[suppression] =
+        (telemetry.suppressedReasons[suppression] ?? 0) + 1;
+      telemetry.queued += 1;
+      continue;
+    }
+
+    // Guards passed — auto-apply
+    try {
+      const outcome = await deps.applyCorrection(plan.planId, {
+        confirm: true,
+        namespace: ctx.namespace,
+        ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+        ...(ctx.principal ? { principal: ctx.principal } : {}),
+      });
+      telemetry.autoApplied += 1;
+
+      // Enqueue notification for the next briefing
+      try {
+        const dir = await deps.storageDir(ctx.namespace);
+        await enqueuePassiveCorrectionNotification(dir, {
+          planId: plan.planId,
+          summary: buildNotificationSummary(plan),
+          undoCommand: `remnic correct --revert ${plan.planId}`,
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        // Notification is best-effort — never block on it.
+        log.debug(`passive-correction: notification enqueue failed (non-fatal): ${err}`);
+      }
+    } catch (err) {
+      log.warn(
+        `passive-correction: auto-apply failed for plan ${plan.planId}: ${err instanceof Error ? err.message : String(err)} — plan left in queue`,
+      );
+      telemetry.queued += 1;
+    }
+  }
+
+  return { telemetry, plans };
+}
+
+// ---------------------------------------------------------------------------
+// Notification summary builder
+// ---------------------------------------------------------------------------
+
+function buildNotificationSummary(plan: CorrectionPlan): string {
+  const action = plan.actions[0];
+  if (!action) {
+    return plan.request.text.slice(0, 80);
+  }
+  const target =
+    action.kind === "supersede"
+      ? action.loserId
+      : action.kind === "edit" || action.kind === "retract" || action.kind === "rescope"
+        ? action.memoryId
+        : "pattern";
+  return `${plan.classification}: ${plan.request.text.slice(0, 60)}${plan.request.text.length > 60 ? "..." : ""} (${target})`;
+}

--- a/packages/remnic-core/src/correction/passive-capture.ts
+++ b/packages/remnic-core/src/correction/passive-capture.ts
@@ -277,6 +277,13 @@ export async function capturePassiveCorrections(
         ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
         ...(ctx.principal ? { principal: ctx.principal } : {}),
       });
+      // A partial outcome means some actions failed (per-action races or
+      // storage failures). Don't count it as auto-applied or notify — queue
+      // for human review instead (review: "partial outcomes as failures").
+      if (outcome.status !== "applied") {
+        telemetry.queued += 1;
+        continue;
+      }
       telemetry.autoApplied += 1;
 
       // Enqueue notification for the next briefing

--- a/packages/remnic-core/src/correction/passive-capture.ts
+++ b/packages/remnic-core/src/correction/passive-capture.ts
@@ -139,7 +139,8 @@ export type AutoApplySuppressionReason =
   | "confidence_below_floor"
   | "classification_not_allowed"
   | "affected_too_large"
-  | "disallowed_action_kind";
+  | "disallowed_action_kind"
+  | "empty_plan";
 
 /**
  * Evaluate all auto-apply guards. Returns the suppression reason (if any), or
@@ -157,6 +158,13 @@ export function evaluateAutoApplyGuards(
   }
   if (plan.affected.length > config.autoApplyMaxAffected) {
     return "affected_too_large";
+  }
+  // An empty action list is a no-op plan (review: "queue plans that contain no
+  // actions"). Auto-applying it would mark a correction as applied, write an
+  // audit record + notification, and record the dedup fingerprint — yet nothing
+  // changed. Suppress so it queues for human review instead.
+  if (plan.actions.length === 0) {
+    return "empty_plan";
   }
   for (const action of plan.actions) {
     if (!AUTO_APPLICABLE_ACTION_KINDS.has(action.kind)) {
@@ -277,7 +285,7 @@ export async function capturePassiveCorrections(
         await enqueuePassiveCorrectionNotification(dir, {
           planId: plan.planId,
           summary: buildNotificationSummary(plan),
-          undoCommand: `remnic correct --revert ${plan.planId}`,
+          undoCommand: `auto-applied (plan ${plan.planId})`,
           createdAt: new Date().toISOString(),
         });
       } catch (err) {

--- a/packages/remnic-core/src/correction/passive-correction-detector.test.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.test.ts
@@ -246,3 +246,18 @@ test("double-quoted correction is still suppressed (isWithinQuotes uses double q
   const retracts = results.filter((r) => r.polarity === "retract");
   assert.strictEqual(retracts.length, 0, "double-quoted speech must still be suppressed");
 });
+
+test("overlapping cues dedup: 'actually, we don't use Redis anymore' emits one correction (review)", () => {
+  // Both the "actually" (update) and "don't use X anymore" (retract) patterns
+  // match the same targetHint. Polarity-agnostic dedup keeps one correction.
+  const results = detectPassiveCorrections(
+    user("actually, we don't use Redis anymore for caching"),
+  );
+  const redisCorrections = results.filter((r) =>
+    r.targetHint.toLowerCase().includes("redis"),
+  );
+  assert.ok(
+    redisCorrections.length <= 1,
+    `overlapping cues for same target must emit at most one correction, got ${redisCorrections.length}`,
+  );
+});

--- a/packages/remnic-core/src/correction/passive-correction-detector.test.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.test.ts
@@ -1,0 +1,242 @@
+/**
+ * passive-correction-detector.test.ts — fixture matrix for passive correction
+ * detection (issue #1581 PR 1).
+ *
+ * Positive fixtures (≥12): direct update, retraction, stop-storing, tense/
+ * morphology variants, correction embedded mid-paragraph, handle-referenced.
+ * Anti-fixtures (≥8): quoting someone else's correction; correcting a third
+ * party; hypothetical; self-correction within the same turn that resolves
+ * itself; the agent being corrected about a tool output, not stored memory.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectPassiveCorrections,
+  extractHandles,
+  type DetectorTurn,
+} from "./passive-correction-detector.js";
+
+function user(content: string): DetectorTurn[] {
+  return [{ role: "user", content }];
+}
+
+describe("detectPassiveCorrections — positive fixtures", () => {
+  it("direct update: 'actually we use PostgreSQL now'", () => {
+    const results = detectPassiveCorrections(user("actually we use PostgreSQL now, not MySQL"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("direct update: 'no, we renamed that service'", () => {
+    const results = detectPassiveCorrections(user("no, we renamed that service to auth-svc"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("retraction: 'we don't use Redis anymore'", () => {
+    const results = detectPassiveCorrections(user("we don't use Redis anymore"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "retract")).toBe(true);
+  });
+
+  it("retraction: 'that's wrong'", () => {
+    const results = detectPassiveCorrections(user("that's wrong, I never said that"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "retract")).toBe(true);
+  });
+
+  it("stop-storing: 'stop suggesting Vim'", () => {
+    const results = detectPassiveCorrections(user("stop suggesting Vim, I switched to Helix months ago"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "stop_storing")).toBe(true);
+  });
+
+  it("stop-storing: 'don't bring up that project'", () => {
+    const results = detectPassiveCorrections(user("don't bring up that project anymore"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "stop_storing")).toBe(true);
+  });
+
+  it("tense variant: 'we switched to' (past)", () => {
+    const results = detectPassiveCorrections(user("we switched to GitHub Actions for CI"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("tense variant: 'we're switching to' (progressive)", () => {
+    const results = detectPassiveCorrections(user("we're switching to pnpm from npm"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("tense variant: 'we've migrated to' (present perfect)", () => {
+    const results = detectPassiveCorrections(user("we've migrated to PostgreSQL"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("'no longer' phrasing", () => {
+    const results = detectPassiveCorrections(user("I no longer work on that project"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("'that's outdated' phrasing", () => {
+    const results = detectPassiveCorrections(user("that's outdated, the API changed last week"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("correction embedded mid-paragraph", () => {
+    const results = detectPassiveCorrections(
+      user("I was reviewing the architecture and noticed the docs say we use AWS. Actually, we moved to GCP last quarter, so those docs need updating."),
+    );
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("deadline moved to Friday", () => {
+    const results = detectPassiveCorrections(user("the deadline moved to Friday"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.polarity === "update")).toBe(true);
+  });
+
+  it("handle-referenced: '[m:4f2a] is wrong'", () => {
+    const results = detectPassiveCorrections(user("that's wrong, [m:4f2a] is incorrect — the real value is 42"));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const correction = results[0];
+    expect(correction.handles).toContain("[m:4f2a]");
+  });
+
+  it("multiple handles extracted", () => {
+    const results = detectPassiveCorrections(
+      user("actually, [m:4f2a] and [m:8b1c] are both outdated"),
+    );
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].handles).toContain("[m:4f2a]");
+    expect(results[0].handles).toContain("[m:8b1c]");
+  });
+});
+
+describe("detectPassiveCorrections — anti-fixtures (zero false plans)", () => {
+  it("quoting someone else's correction", () => {
+    const results = detectPassiveCorrections(
+      user('Bob told me "that\'s wrong" about the deployment process'),
+    );
+    // The turn mentions "that's wrong" but in a quote about someone else
+    expect(results.filter((r) => r.polarity === "retract")).toHaveLength(0);
+  });
+
+  it("correcting a third party: 'tell Bob he's wrong about X'", () => {
+    const results = detectPassiveCorrections(
+      user("tell Bob he's wrong about the API design"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("hypothetical: 'if we ever moved to MySQL'", () => {
+    const results = detectPassiveCorrections(
+      user("if we ever moved to MySQL, we'd need to rewrite the migrations"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("hypothetical: 'what if we switch to'", () => {
+    const results = detectPassiveCorrections(
+      user("what if we switch to a different framework?"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("self-resolving correction: 'actually wait, the original was right'", () => {
+    const results = detectPassiveCorrections(
+      user("actually, wait, never mind, the original was right"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("self-resolving: 'scratch that'", () => {
+    const results = detectPassiveCorrections(
+      user("actually we moved to... no, scratch that, we're still on the old system"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("tool output correction: 'the output is wrong'", () => {
+    const results = detectPassiveCorrections(
+      user("the output is wrong, the test results don't match"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("agent being corrected about code, not stored memory", () => {
+    const results = detectPassiveCorrections(
+      user("your code has a bug in the error handler"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("suppose / hypothetical scenario", () => {
+    const results = detectPassiveCorrections(
+      user("suppose we changed the database — what would break?"),
+    );
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("detectPassiveCorrections — characterization", () => {
+  it("assistant turns are not scanned", () => {
+    const results = detectPassiveCorrections([
+      { role: "assistant", content: "actually, we moved to PostgreSQL" },
+    ]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("empty content produces no corrections", () => {
+    const results = detectPassiveCorrections([
+      { role: "user", content: "" },
+    ]);
+    expect(results).toHaveLength(0);
+  });
+
+  it("non-corrective user text produces no corrections", () => {
+    const results = detectPassiveCorrections(
+      user("Can you help me write a function to parse JSON?"),
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("multiple corrections in one turn are deduped by polarity+target", () => {
+    const results = detectPassiveCorrections(
+      user("we don't use Redis anymore. Also we don't use Redis anymore."),
+    );
+    // Same polarity + same target hint → one correction after dedup
+    const retracts = results.filter((r) => r.polarity === "retract");
+    expect(retracts.length).toBeLessThanOrEqual(2); // dedup may or may not collapse depending on window
+  });
+
+  it("confidence is in [0, 1]", () => {
+    const results = detectPassiveCorrections(user("we switched to Go"));
+    for (const r of results) {
+      expect(r.confidence).toBeGreaterThanOrEqual(0);
+      expect(r.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("sourceExcerpt is populated", () => {
+    const results = detectPassiveCorrections(user("we switched to Go"));
+    for (const r of results) {
+      expect(r.sourceExcerpt.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("extractHandles", () => {
+  it("extracts [m:xxxx] handles", () => {
+    expect(extractHandles("see [m:4f2a] and [m:8b1c]")).toEqual(["[m:4f2a]", "[m:8b1c]"]);
+  });
+
+  it("returns empty for no handles", () => {
+    expect(extractHandles("no handles here")).toEqual([]);
+  });
+});

--- a/packages/remnic-core/src/correction/passive-correction-detector.test.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.test.ts
@@ -9,7 +9,8 @@
  * itself; the agent being corrected about a tool output, not stored memory.
  */
 
-import { describe, it, expect } from "vitest";
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
 import {
   detectPassiveCorrections,
   extractHandles,
@@ -20,223 +21,208 @@ function user(content: string): DetectorTurn[] {
   return [{ role: "user", content }];
 }
 
-describe("detectPassiveCorrections — positive fixtures", () => {
-  it("direct update: 'actually we use PostgreSQL now'", () => {
-    const results = detectPassiveCorrections(user("actually we use PostgreSQL now, not MySQL"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("direct update: 'no, we renamed that service'", () => {
-    const results = detectPassiveCorrections(user("no, we renamed that service to auth-svc"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("retraction: 'we don't use Redis anymore'", () => {
-    const results = detectPassiveCorrections(user("we don't use Redis anymore"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "retract")).toBe(true);
-  });
-
-  it("retraction: 'that's wrong'", () => {
-    const results = detectPassiveCorrections(user("that's wrong, I never said that"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "retract")).toBe(true);
-  });
-
-  it("stop-storing: 'stop suggesting Vim'", () => {
-    const results = detectPassiveCorrections(user("stop suggesting Vim, I switched to Helix months ago"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "stop_storing")).toBe(true);
-  });
-
-  it("stop-storing: 'don't bring up that project'", () => {
-    const results = detectPassiveCorrections(user("don't bring up that project anymore"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "stop_storing")).toBe(true);
-  });
-
-  it("tense variant: 'we switched to' (past)", () => {
-    const results = detectPassiveCorrections(user("we switched to GitHub Actions for CI"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("tense variant: 'we're switching to' (progressive)", () => {
-    const results = detectPassiveCorrections(user("we're switching to pnpm from npm"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("tense variant: 'we've migrated to' (present perfect)", () => {
-    const results = detectPassiveCorrections(user("we've migrated to PostgreSQL"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("'no longer' phrasing", () => {
-    const results = detectPassiveCorrections(user("I no longer work on that project"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("'that's outdated' phrasing", () => {
-    const results = detectPassiveCorrections(user("that's outdated, the API changed last week"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("correction embedded mid-paragraph", () => {
-    const results = detectPassiveCorrections(
-      user("I was reviewing the architecture and noticed the docs say we use AWS. Actually, we moved to GCP last quarter, so those docs need updating."),
-    );
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("deadline moved to Friday", () => {
-    const results = detectPassiveCorrections(user("the deadline moved to Friday"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results.some((r) => r.polarity === "update")).toBe(true);
-  });
-
-  it("handle-referenced: '[m:4f2a] is wrong'", () => {
-    const results = detectPassiveCorrections(user("that's wrong, [m:4f2a] is incorrect — the real value is 42"));
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    const correction = results[0];
-    expect(correction.handles).toContain("[m:4f2a]");
-  });
-
-  it("multiple handles extracted", () => {
-    const results = detectPassiveCorrections(
-      user("actually, [m:4f2a] and [m:8b1c] are both outdated"),
-    );
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results[0].handles).toContain("[m:4f2a]");
-    expect(results[0].handles).toContain("[m:8b1c]");
-  });
+test("positive: direct update — actually we use PostgreSQL now", () => {
+  const results = detectPassiveCorrections(user("actually we use PostgreSQL now, not MySQL"));
+  assert.ok(results.length >= 1, `expected >=1 correction, got ${results.length}`);
+  assert.ok(results.some((r) => r.polarity === "update"));
 });
 
-describe("detectPassiveCorrections — anti-fixtures (zero false plans)", () => {
-  it("quoting someone else's correction", () => {
-    const results = detectPassiveCorrections(
-      user('Bob told me "that\'s wrong" about the deployment process'),
-    );
-    // The turn mentions "that's wrong" but in a quote about someone else
-    expect(results.filter((r) => r.polarity === "retract")).toHaveLength(0);
-  });
-
-  it("correcting a third party: 'tell Bob he's wrong about X'", () => {
-    const results = detectPassiveCorrections(
-      user("tell Bob he's wrong about the API design"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("hypothetical: 'if we ever moved to MySQL'", () => {
-    const results = detectPassiveCorrections(
-      user("if we ever moved to MySQL, we'd need to rewrite the migrations"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("hypothetical: 'what if we switch to'", () => {
-    const results = detectPassiveCorrections(
-      user("what if we switch to a different framework?"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("self-resolving correction: 'actually wait, the original was right'", () => {
-    const results = detectPassiveCorrections(
-      user("actually, wait, never mind, the original was right"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("self-resolving: 'scratch that'", () => {
-    const results = detectPassiveCorrections(
-      user("actually we moved to... no, scratch that, we're still on the old system"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("tool output correction: 'the output is wrong'", () => {
-    const results = detectPassiveCorrections(
-      user("the output is wrong, the test results don't match"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("agent being corrected about code, not stored memory", () => {
-    const results = detectPassiveCorrections(
-      user("your code has a bug in the error handler"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("suppose / hypothetical scenario", () => {
-    const results = detectPassiveCorrections(
-      user("suppose we changed the database — what would break?"),
-    );
-    expect(results).toHaveLength(0);
-  });
+test("positive: direct update — no, we renamed that service", () => {
+  const results = detectPassiveCorrections(user("no, we renamed that service to auth-svc"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
 });
 
-describe("detectPassiveCorrections — characterization", () => {
-  it("assistant turns are not scanned", () => {
-    const results = detectPassiveCorrections([
-      { role: "assistant", content: "actually, we moved to PostgreSQL" },
-    ]);
-    expect(results).toHaveLength(0);
-  });
-
-  it("empty content produces no corrections", () => {
-    const results = detectPassiveCorrections([
-      { role: "user", content: "" },
-    ]);
-    expect(results).toHaveLength(0);
-  });
-
-  it("non-corrective user text produces no corrections", () => {
-    const results = detectPassiveCorrections(
-      user("Can you help me write a function to parse JSON?"),
-    );
-    expect(results).toHaveLength(0);
-  });
-
-  it("multiple corrections in one turn are deduped by polarity+target", () => {
-    const results = detectPassiveCorrections(
-      user("we don't use Redis anymore. Also we don't use Redis anymore."),
-    );
-    // Same polarity + same target hint → one correction after dedup
-    const retracts = results.filter((r) => r.polarity === "retract");
-    expect(retracts.length).toBeLessThanOrEqual(2); // dedup may or may not collapse depending on window
-  });
-
-  it("confidence is in [0, 1]", () => {
-    const results = detectPassiveCorrections(user("we switched to Go"));
-    for (const r of results) {
-      expect(r.confidence).toBeGreaterThanOrEqual(0);
-      expect(r.confidence).toBeLessThanOrEqual(1);
-    }
-  });
-
-  it("sourceExcerpt is populated", () => {
-    const results = detectPassiveCorrections(user("we switched to Go"));
-    for (const r of results) {
-      expect(r.sourceExcerpt.length).toBeGreaterThan(0);
-    }
-  });
+test("positive: retraction — we don't use Redis anymore", () => {
+  const results = detectPassiveCorrections(user("we don't use Redis anymore"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "retract"));
 });
 
-describe("extractHandles", () => {
-  it("extracts [m:xxxx] handles", () => {
-    expect(extractHandles("see [m:4f2a] and [m:8b1c]")).toEqual(["[m:4f2a]", "[m:8b1c]"]);
-  });
+test("positive: retraction — that's wrong", () => {
+  const results = detectPassiveCorrections(user("that's wrong, I never said that"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "retract"));
+});
 
-  it("returns empty for no handles", () => {
-    expect(extractHandles("no handles here")).toEqual([]);
-  });
+test("positive: stop-storing — stop suggesting Vim", () => {
+  const results = detectPassiveCorrections(user("stop suggesting Vim, I switched to Helix months ago"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "stop_storing"));
+});
+
+test("positive: stop-storing — don't bring up that project", () => {
+  const results = detectPassiveCorrections(user("don't bring up that project anymore"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "stop_storing"));
+});
+
+test("positive: tense variant — we switched to (past)", () => {
+  const results = detectPassiveCorrections(user("we switched to GitHub Actions for CI"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: tense variant — we're switching to (progressive)", () => {
+  const results = detectPassiveCorrections(user("we're switching to pnpm from npm"));
+  assert.ok(results.length >= 1, `expected >=1, got ${results.length}`);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: tense variant — we've migrated to (present perfect)", () => {
+  const results = detectPassiveCorrections(user("we've migrated to PostgreSQL"));
+  assert.ok(results.length >= 1, `expected >=1, got ${results.length}`);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: no longer phrasing", () => {
+  const results = detectPassiveCorrections(user("I no longer work on that project"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: that's outdated phrasing", () => {
+  const results = detectPassiveCorrections(user("that's outdated, the API changed last week"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: correction embedded mid-paragraph", () => {
+  const results = detectPassiveCorrections(
+    user("I was reviewing the architecture and noticed the docs say we use AWS. Actually, we moved to GCP last quarter, so those docs need updating."),
+  );
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: deadline moved to Friday", () => {
+  const results = detectPassiveCorrections(user("the deadline moved to Friday"));
+  assert.ok(results.length >= 1);
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("positive: handle-referenced [m:4f2a] is wrong", () => {
+  const results = detectPassiveCorrections(user("that's wrong, [m:4f2a] is incorrect — the real value is 42"));
+  assert.ok(results.length >= 1);
+  assert.ok(results[0].handles.includes("[m:4f2a]"));
+});
+
+test("positive: multiple handles extracted", () => {
+  const results = detectPassiveCorrections(
+    user("actually, [m:4f2a] and [m:8b1c] are both outdated"),
+  );
+  assert.ok(results.length >= 1, `expected >=1, got ${results.length}`);
+  assert.ok(results[0].handles.includes("[m:4f2a]"));
+  assert.ok(results[0].handles.includes("[m:8b1c]"));
+});
+
+// ── Anti-fixtures ──────────────────────────────────────────────────────────
+
+test("anti-fixture: quoting someone else's correction", () => {
+  const results = detectPassiveCorrections(
+    user('Bob told me "that\'s wrong" about the deployment process'),
+  );
+  const retracts = results.filter((r) => r.polarity === "retract");
+  assert.strictEqual(retracts.length, 0, `expected 0 retract corrections, got ${retracts.length}`);
+});
+
+test("anti-fixture: correcting a third party", () => {
+  const results = detectPassiveCorrections(
+    user("tell Bob he's wrong about the API design"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: hypothetical — if we ever moved to MySQL", () => {
+  const results = detectPassiveCorrections(
+    user("if we ever moved to MySQL, we'd need to rewrite the migrations"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: hypothetical — what if we switch", () => {
+  const results = detectPassiveCorrections(
+    user("what if we switch to a different framework?"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: self-resolving — actually wait, the original was right", () => {
+  const results = detectPassiveCorrections(
+    user("actually, wait, never mind, the original was right"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: self-resolving — scratch that", () => {
+  const results = detectPassiveCorrections(
+    user("actually we moved to... no, scratch that, we're still on the old system"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: tool output correction", () => {
+  const results = detectPassiveCorrections(
+    user("the output is wrong, the test results don't match"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: agent corrected about code, not stored memory", () => {
+  const results = detectPassiveCorrections(
+    user("your code has a bug in the error handler"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("anti-fixture: suppose / hypothetical scenario", () => {
+  const results = detectPassiveCorrections(
+    user("suppose we changed the database — what would break?"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+// ── Characterization ───────────────────────────────────────────────────────
+
+test("characterization: assistant turns are not scanned", () => {
+  const results = detectPassiveCorrections([
+    { role: "assistant", content: "actually, we moved to PostgreSQL" },
+  ]);
+  assert.strictEqual(results.length, 0);
+});
+
+test("characterization: empty content produces no corrections", () => {
+  const results = detectPassiveCorrections([{ role: "user", content: "" }]);
+  assert.strictEqual(results.length, 0);
+});
+
+test("characterization: non-corrective user text produces no corrections", () => {
+  const results = detectPassiveCorrections(
+    user("Can you help me write a function to parse JSON?"),
+  );
+  assert.strictEqual(results.length, 0);
+});
+
+test("characterization: confidence is in [0, 1]", () => {
+  const results = detectPassiveCorrections(user("we switched to Go"));
+  for (const r of results) {
+    assert.ok(r.confidence >= 0 && r.confidence <= 1);
+  }
+});
+
+test("characterization: sourceExcerpt is populated", () => {
+  const results = detectPassiveCorrections(user("we switched to Go"));
+  for (const r of results) {
+    assert.ok(r.sourceExcerpt.length > 0);
+  }
+});
+
+// ── extractHandles ─────────────────────────────────────────────────────────
+
+test("extractHandles: extracts [m:xxxx] handles", () => {
+  assert.deepStrictEqual(extractHandles("see [m:4f2a] and [m:8b1c]"), ["[m:4f2a]", "[m:8b1c]"]);
+});
+
+test("extractHandles: returns empty for no handles", () => {
+  assert.deepStrictEqual(extractHandles("no handles here"), []);
 });

--- a/packages/remnic-core/src/correction/passive-correction-detector.test.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.test.ts
@@ -226,3 +226,23 @@ test("extractHandles: extracts [m:xxxx] handles", () => {
 test("extractHandles: returns empty for no handles", () => {
   assert.deepStrictEqual(extractHandles("no handles here"), []);
 });
+
+test("contraction does not suppress a correction phrase (review: apostrophe quote detection)", () => {
+  // OLD isWithinQuotes treated the ASCII apostrophe as a quote opener. A single
+  // contraction with no closing apostrophe ("We've switched to Postgres") left
+  // the scanner in quoted mode and suppressed the correction — a false negative.
+  // Only double quotes delimit quoted speech; apostrophes are contractions.
+  const results = detectPassiveCorrections(user("We've switched to Postgres"));
+  assert.ok(results.length > 0, "contraction-led correction must be detected");
+  assert.ok(results.some((r) => r.polarity === "update"));
+});
+
+test("double-quoted correction is still suppressed (isWithinQuotes uses double quotes only)", () => {
+  // After dropping single-quote handling, real double-quoted speech must STILL
+  // be suppressed — only the delimiter set changed, not the suppression itself.
+  const results = detectPassiveCorrections(
+    user('Bob told me "that\'s wrong" about the deployment process'),
+  );
+  const retracts = results.filter((r) => r.polarity === "retract");
+  assert.strictEqual(retracts.length, 0, "double-quoted speech must still be suppressed");
+});

--- a/packages/remnic-core/src/correction/passive-correction-detector.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.ts
@@ -223,21 +223,21 @@ function extractCorrectedAssertion(
  * words the user is relaying, not the user correcting their own memory).
  */
 function isWithinQuotes(text: string, matchIndex: number): boolean {
-  let inQuote: string | null = null;
+  // Only DOUBLE quotes delimit quoted speech. Single quotes (ASCII apostrophe
+  // and smart single quotes) are deliberately NOT treated as delimiters: in
+  // English they are overwhelmingly contractions/possessives
+  // ("I don't think we switched"), which would falsely mark a
+  // correction as quoted speech and suppress a valid detection (false
+  // negative). A contraction before the correction phrase must not flip the
+  // detector into quoted mode.
+  let inQuote = false;
   for (let i = 0; i < matchIndex && i < text.length; i++) {
     const c = text[i];
-    if (inQuote === null) {
-      if (c === '"' || c === '\u201c' || c === '\u201d' || c === '\u2018' || c === '\u2019') {
-        inQuote = c;
-      } else if (c === '\'') {
-        // Smart-quote-style single quote — treat as quote open.
-        inQuote = c;
-      }
-    } else if (c === inQuote || (inQuote === '\u201c' && c === '\u201d') || (inQuote === '\u201d' && c === '\u201c')) {
-      inQuote = null;
+    if (c === '"' || c === '\u201c' || c === '\u201d') {
+      inQuote = !inQuote;
     }
   }
-  return inQuote !== null;
+  return inQuote;
 }
 
 /**

--- a/packages/remnic-core/src/correction/passive-correction-detector.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.ts
@@ -266,8 +266,9 @@ function detectAntiFixture(text: string): string | null {
  * corrections.
  *
  * A single turn may produce multiple corrections if different patterns match
- * different parts of the text. Dedup by (turnIndex, polarity, targetHint) so
- * overlapping patterns on the same phrase produce one correction.
+ * different parts of the text. Dedup by (turnIndex, targetHint) so overlapping
+ * patterns on the same phrase (e.g. "actually, we don't use Redis anymore"
+ * matching both update + retract) produce one correction.
  */
 export function detectPassiveCorrections(
   turns: readonly DetectorTurn[],
@@ -300,7 +301,11 @@ export function detectPassiveCorrections(
 
       const targetHint = extractTargetHint(content, match);
       const correctedAssertion = extractCorrectedAssertion(content, pattern.polarity);
-      const dedupKey = `${i}:${pattern.polarity}:${targetHint}`;
+      // Polarity-agnostic: "actually, we don't use Redis anymore" matches
+      // both the update ("actually") and retract ("don't use ... anymore")
+      // patterns with the same targetHint — emit one correction, not two
+      // (review: "deduplicate overlapping passive-correction cues").
+      const dedupKey = `${i}:${targetHint}`;
       if (seen.has(dedupKey)) continue;
       seen.add(dedupKey);
 

--- a/packages/remnic-core/src/correction/passive-correction-detector.ts
+++ b/packages/remnic-core/src/correction/passive-correction-detector.ts
@@ -1,0 +1,320 @@
+/**
+ * correction/passive-correction-detector.ts — morphology-aware heuristic detector
+ * for corrections expressed passively in conversation turns (issue #1581).
+ *
+ * Users correct their agents constantly in conversation: "no, we renamed that
+ * service", "I don't use Vim anymore", "the deadline moved to Friday". This
+ * module detects those corrections from turn text — NO extra LLM call — so the
+ * passive-capture module can route them to the Correction Contract (#1580).
+ *
+ * Design:
+ *   - Pure function: `detectPassiveCorrections(turns)` → `PassiveCorrection[]`.
+ *   - Only USER turns are scanned (assistants don't correct their own memory).
+ *   - Morphology-aware: matches conjugations/variants per AGENTS.md intent
+ *     guardrail ("heuristics must be morphology-aware and precedence-tested").
+ *   - Anti-fixture guards reject: hypotheticals, third-party corrections,
+ *     quoted-speech corrections, and self-resolving corrections.
+ *
+ * The detector is deliberately CONSERVATIVE — it prefers false negatives
+ * (missing a correction) over false positives (flooding the review queue).
+ * The nightly contradiction scan and the interactive correction chat (#1583)
+ * catch what passive detection misses.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PassiveCorrectionPolarity = "update" | "retract" | "stop_storing";
+
+export interface PassiveCorrection {
+  /** What the user says is wrong ("Redis", "the deadline", "my editor preference"). */
+  targetHint: string;
+  /** The new truth, or "" for pure retractions. */
+  correctedAssertion: string;
+  polarity: PassiveCorrectionPolarity;
+  /** `[m:xxxx]` handle references found verbatim in the turn (#1582). */
+  handles: string[];
+  /** Heuristic confidence in [0, 1] — influences auto-apply gating. */
+  confidence: number;
+  /** The verbatim source text that triggered the detection. */
+  sourceExcerpt: string;
+  /** Index of the turn in the input array that produced this correction. */
+  turnIndex: number;
+}
+
+export interface DetectorTurn {
+  role: "user" | "assistant" | "other";
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern definitions
+// ---------------------------------------------------------------------------
+
+interface CorrectionPattern {
+  polarity: PassiveCorrectionPolarity;
+  /** Regex MUST be case-insensitive and use word boundaries where appropriate. */
+  regex: RegExp;
+  /** Confidence assigned when this pattern is the sole signal. */
+  confidence: number;
+}
+
+/**
+ * Strong correction signals — these phrases reliably indicate the user is
+ * correcting a stored memory about their own world. Each is morphology-aware
+ * (covers present/progressive/past tenses and common variants).
+ */
+const PATTERNS: readonly CorrectionPattern[] = [
+  // ── update: new fact replaces / corrects an old one ──────────────────────
+  {
+    polarity: "update",
+    // "actually, it's X not Y" / "actually we use X now"
+    regex: /\bactually[,\s]+(?:it'?s|we|the|i|our|my|\[m:)/i,
+    confidence: 0.85,
+  },
+  {
+    polarity: "update",
+    // "we switched/switching/switched to X"
+    regex: /\bwe\b\s*(?:(?:'re|'ve|are|have)\s+)?(?:switch(?:ed|ing)?|migrat(?:ed|ing)?|mov(?:ed|ing)?|chang(?:ed|ing)?)\s+(?:to|over to|from)\b/i,
+    confidence: 0.9,
+  },
+  {
+    polarity: "update",
+    // "we renamed X to Y" / "i renamed"
+    regex: /\b(?:we|i)\s+renam(?:ed|ing)\b/i,
+    confidence: 0.9,
+  },
+  {
+    polarity: "update",
+    // "it's now X" / "the deadline moved to X" / "the date changed to X"
+    regex: /\b(?:it'?s now|the\s+(?:deadline|date|meeting|standup|review)\s+(?:moved|chang(?:ed|ing))?\s*to)\b/i,
+    confidence: 0.85,
+  },
+  {
+    polarity: "update",
+    // "no, " at the start of a turn or clause — strong correction signal
+    regex: /(?:^|\.\s+|\n)\s*no[,\s]+(?:we|i|it|the|our|my|that)\b/i,
+    confidence: 0.8,
+  },
+  {
+    polarity: "update",
+    // "no longer" / "not anymore" + an activity
+    regex: /\b(?:no longer|not anymore)\b/i,
+    confidence: 0.8,
+  },
+  {
+    polarity: "update",
+    // Standalone "outdated" — catches "are both outdated", "is outdated", etc.
+    regex: /\boutdated\b/i,
+    confidence: 0.75,
+  },
+  {
+    polarity: "update",
+    // "that's outdated" / "that's old"
+    regex: /\bthat'?s\s+(?:outdated|old|no longer (?:true|correct|accurate))\b/i,
+    confidence: 0.85,
+  },
+  // ── retract: user says a fact is simply wrong ────────────────────────────
+  {
+    polarity: "retract",
+    regex: /\bthat'?s\s+(?:wrong|not right|incorrect|not true|false)\b/i,
+    confidence: 0.85,
+  },
+  {
+    polarity: "retract",
+    // "we don't use X anymore" / "I don't use X anymore"
+    regex: /\b(?:we|i)\s+don'?t\s+use\s+\S+\s+anymore\b/i,
+    confidence: 0.9,
+  },
+  {
+    polarity: "retract",
+    regex: /\bforget about\b/i,
+    confidence: 0.8,
+  },
+  // ── stop_storing: user wants the agent to stop a behavior ────────────────
+  {
+    polarity: "stop_storing",
+    regex: /\bstop\s+(?:suggesting|bringing\s+up|recommending|reminding\s+me\s+(?:about)?)\b/i,
+    confidence: 0.9,
+  },
+  {
+    polarity: "stop_storing",
+    regex: /\b(?:don'?t|never)\s+(?:mention|suggest|recommend|store|bring\s+up)\b/i,
+    confidence: 0.85,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Anti-fixture guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Hypothetical markers — if present near the correction signal, the turn is
+ * discussing a hypothetical scenario, not correcting a stored fact.
+ */
+const HYPOTHETICAL_REGEX =
+  /\b(?:if\s+(?:we|you|i|they)\s+(?:ever|were|could|might|should|decide)|what\s+if|suppose|hypothetically|in\s+(?:theory|principle)|let'?s\s+say|imagine\s+if)\b/i;
+
+/**
+ * Third-party correction markers — the user is correcting someone else, not
+ * their agent's memory of their own world.
+ */
+const THIRD_PARTY_REGEX =
+  /\b(?:tell\s+\w+\s+(?:he|she|they|you)'?re?\s+wrong|he'?s\s+wrong\s+about|she'?s\s+wrong\s+about|they'?re\s+wrong\s+about|correct\s+\w+\s+on)\b/i;
+
+/**
+ * Tool-output correction — the user is saying a tool's output is wrong, not
+ * that their stored memory is wrong.
+ */
+const TOOL_OUTPUT_REGEX =
+  /\b(?:the\s+(?:output|result|response|error|log)|your\s+(?:output|result|response|code|answer))\s+(?:is\s+)?(?:wrong|incorrect|bad|off)\b/i;
+
+/**
+ * Self-resolving correction — the user corrects themselves within the same
+ * turn ("actually wait, no, the original was right"). These turn back and
+ * cancel out.
+ */
+const SELF_RESOLVE_REGEX =
+  /(?:actually|wait|no)[,\s]+(?:never\s*mind|forget\s*(?:that|it)|the\s+(?:original|first)\s+(?:was|is)\s+(?:right|correct)|scratch\s+that|disregard)/i;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract `[m:xxxx]` handle references from text (#1582). */
+export function extractHandles(text: string): string[] {
+  const matches = text.match(/\[m:[0-9a-fA-F]{4,}\]/g);
+  return matches ?? [];
+}
+
+/**
+ * Extract a target hint from the matched correction text. Returns a short
+ * phrase (≤80 chars) the planner can use to locate the affected memory.
+ */
+function extractTargetHint(text: string, match: RegExpMatchArray): string {
+  const matchStart = match.index ?? 0;
+  // Take a window around the match: 20 chars before to 60 chars after.
+  const start = Math.max(0, matchStart - 20);
+  const end = Math.min(text.length, matchStart + match[0].length + 60);
+  const window = text.slice(start, end).replace(/\s+/g, " ").trim();
+  return window.length > 80 ? window.slice(0, 77) + "..." : window;
+}
+
+/**
+ * Extract the corrected assertion — the new truth the user is expressing.
+ * For "update" polarity, this is the full turn text (the planner searches for
+ * the old fact and drafts a replacement). For "retract", it's "" (no
+ * replacement). For "stop_storing", it's the behavior to suppress.
+ */
+function extractCorrectedAssertion(
+  text: string,
+  polarity: PassiveCorrectionPolarity,
+): string {
+  if (polarity === "retract") return "";
+  // For update/stop_storing, the full turn IS the assertion (truncated).
+  const trimmed = text.replace(/\s+/g, " ").trim();
+  return trimmed.length > 200 ? trimmed.slice(0, 197) + "..." : trimmed;
+}
+
+/**
+ * Check whether a regex match at the given index is within quotation marks.
+ * Used to reject corrections that are actually quoted speech (someone else's
+ * words the user is relaying, not the user correcting their own memory).
+ */
+function isWithinQuotes(text: string, matchIndex: number): boolean {
+  let inQuote: string | null = null;
+  for (let i = 0; i < matchIndex && i < text.length; i++) {
+    const c = text[i];
+    if (inQuote === null) {
+      if (c === '"' || c === '\u201c' || c === '\u201d' || c === '\u2018' || c === '\u2019') {
+        inQuote = c;
+      } else if (c === '\'') {
+        // Smart-quote-style single quote — treat as quote open.
+        inQuote = c;
+      }
+    } else if (c === inQuote || (inQuote === '\u201c' && c === '\u201d') || (inQuote === '\u201d' && c === '\u201c')) {
+      inQuote = null;
+    }
+  }
+  return inQuote !== null;
+}
+
+/**
+ * Check whether any anti-fixture guard fires on the turn text.
+ * Returns the guard name that blocked detection, or null if clean.
+ */
+function detectAntiFixture(text: string): string | null {
+  if (SELF_RESOLVE_REGEX.test(text)) return "self_resolving";
+  if (HYPOTHETICAL_REGEX.test(text)) return "hypothetical";
+  if (THIRD_PARTY_REGEX.test(text)) return "third_party";
+  if (TOOL_OUTPUT_REGEX.test(text)) return "tool_output";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect passive corrections in a sequence of conversation turns.
+ *
+ * Only USER turns are scanned — assistant turns don't express corrections to
+ * the agent's stored memory. Each user turn is checked against the correction
+ * patterns; anti-fixture guards reject turns that look like hypotheticals,
+ * third-party corrections, tool-output complaints, or self-resolving double-
+ * corrections.
+ *
+ * A single turn may produce multiple corrections if different patterns match
+ * different parts of the text. Dedup by (turnIndex, polarity, targetHint) so
+ * overlapping patterns on the same phrase produce one correction.
+ */
+export function detectPassiveCorrections(
+  turns: readonly DetectorTurn[],
+): PassiveCorrection[] {
+  const results: PassiveCorrection[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < turns.length; i++) {
+    const turn = turns[i];
+    if (turn.role !== "user") continue;
+    const content = turn.content?.trim();
+    if (!content) continue;
+
+    // Anti-fixture guards take precedence — one guard kills ALL corrections
+    // from this turn (a hypothetical turn can't contain a real correction).
+    const guard = detectAntiFixture(content);
+    if (guard) continue;
+
+    const handles = extractHandles(content);
+
+    for (const pattern of PATTERNS) {
+      const match = pattern.regex.exec(content);
+      if (!match) continue;
+
+      // Reject corrections that appear within quotation marks — the user is
+      // relaying someone else's words, not correcting their own stored memory.
+      if (match.index !== undefined && isWithinQuotes(content, match.index)) {
+        continue;
+      }
+
+      const targetHint = extractTargetHint(content, match);
+      const correctedAssertion = extractCorrectedAssertion(content, pattern.polarity);
+      const dedupKey = `${i}:${pattern.polarity}:${targetHint}`;
+      if (seen.has(dedupKey)) continue;
+      seen.add(dedupKey);
+
+      results.push({
+        targetHint,
+        correctedAssertion,
+        polarity: pattern.polarity,
+        handles,
+        confidence: pattern.confidence,
+        sourceExcerpt: content.slice(0, 200),
+        turnIndex: i,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/remnic-core/src/correction/passive-correction-notifications.ts
+++ b/packages/remnic-core/src/correction/passive-correction-notifications.ts
@@ -1,0 +1,121 @@
+/**
+ * correction/passive-correction-notifications.ts — JSONL notification queue
+ * for auto-applied passive corrections (issue #1581).
+ *
+ * When passive capture auto-applies a correction, it enqueues a one-line
+ * notification here: `✎ Memory updated: <summary> (undo: remnic correct --revert <planId>)`.
+ * The next session-start briefing drains the queue ONCE (temp-file-then-rename,
+ * rule 54) and clears it, so a notification is shown exactly once.
+ *
+ * File location: `<storageDir>/state/corrections/notifications.jsonl`
+ */
+
+import { mkdir, readFile, rename, writeFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import { serializeMutations } from "../utils/serialize-mutations.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PassiveCorrectionNotification {
+  planId: string;
+  /** One-line human-readable summary of what changed. */
+  summary: string;
+  /** Undo command the user can run. */
+  undoCommand: string;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path
+// ---------------------------------------------------------------------------
+
+function notificationsPath(storageDir: string): string {
+  return path.join(storageDir, "state", "corrections", "notifications.jsonl");
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a notification line to the JSONL queue. Atomic (rule 54): the line
+ * is written to a temp file then renamed over the real file. Multiple
+ * notifications accumulate across calls — the queue is drained, not replaced.
+ */
+export async function enqueuePassiveCorrectionNotification(
+  storageDir: string,
+  notification: PassiveCorrectionNotification,
+): Promise<void> {
+  const filePath = notificationsPath(storageDir);
+  await serializeMutations(`passive-notification:${filePath}`, async () => {
+    // Read existing content (if any) so we accumulate rather than overwrite.
+    let existing = "";
+    try {
+      existing = await readFile(filePath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") throw err;
+    }
+
+    await mkdir(path.dirname(filePath), { recursive: true });
+    const line = `${JSON.stringify(notification)}\n`;
+    const content = existing + line;
+
+    const tmp = `${filePath}.${process.pid}.${Date.now().toString(36)}.tmp`;
+    await writeFile(tmp, content, "utf-8");
+    await rename(tmp, filePath);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Drain (read + clear — exactly once)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read all pending notifications and atomically clear the file. Returns the
+ * notifications in insertion order. If the file does not exist, returns [].
+ *
+ * Drain-once semantics: the file is deleted after reading, so calling this
+ * twice in a row returns notifications only the first time.
+ */
+export async function drainPassiveCorrectionNotifications(
+  storageDir: string,
+): Promise<PassiveCorrectionNotification[]> {
+  const filePath = notificationsPath(storageDir);
+  return serializeMutations(`passive-notification:${filePath}`, async () => {
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") return [];
+      throw err;
+    }
+
+    const notifications: PassiveCorrectionNotification[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        notifications.push(JSON.parse(trimmed) as PassiveCorrectionNotification);
+      } catch {
+        // Skip malformed lines (rule 34 — best-effort, never crash a briefing).
+        continue;
+      }
+    }
+
+    // Clear the file atomically (delete is atomic enough for this use case —
+    // the worst case is a duplicate notification, never a lost one, because
+    // the read already captured the content).
+    try {
+      await unlink(filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT") throw err;
+    }
+
+    return notifications;
+  });
+}

--- a/packages/remnic-core/src/correction/passive-correction-notifications.ts
+++ b/packages/remnic-core/src/correction/passive-correction-notifications.ts
@@ -3,7 +3,9 @@
  * for auto-applied passive corrections (issue #1581).
  *
  * When passive capture auto-applies a correction, it enqueues a one-line
- * notification here: `✎ Memory updated: <summary> (undo: remnic correct --revert <planId>)`.
+ * notification here: `✎ Memory updated: <summary> (auto-applied (plan <planId>))`.
+ * The plan id is referenced (not a revert command) because `remnic correct`
+ * has no `--revert` flag — corrections are page-versioned for manual revert.
  * The next session-start briefing drains the queue ONCE (temp-file-then-rename,
  * rule 54) and clears it, so a notification is shown exactly once.
  *

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -24,6 +24,10 @@ import { SmartBuffer } from "./buffer.js";
 import { chunkContent, type ChunkingConfig } from "./chunking.js";
 import { semanticChunkContent, type SemanticChunkResult } from "./semantic-chunking.js";
 import { ExtractionEngine } from "./extraction.js";
+import { detectPassiveCorrections } from "./correction/passive-correction-detector.js";
+import { capturePassiveCorrections, type PassiveCaptureConfig } from "./correction/passive-capture.js";
+import { createCorrectionService } from "./correction/correction-access-wiring.js";
+import type { CorrectionService } from "./correction/correction-service.js";
 import { isAboveImportanceThreshold, scoreImportance } from "./importance.js";
 import {
   judgeFactDurability,
@@ -1979,6 +1983,16 @@ export class Orchestrator {
     string,
     { count: number; lastAccessed: string }
   > = new Map();
+
+  // Passive correction capture (issue #1581) — dedup state + lazy service.
+  private passiveCorrectionDedup: Set<string> = new Set();
+  private _passiveCorrectionService: CorrectionService | null = null;
+  private passiveCorrectionTelemetry: {
+    detected: number;
+    queued: number;
+    autoApplied: number;
+    suppressedReasonCounts: Record<string, number>;
+  } = { detected: 0, queued: 0, autoApplied: 0, suppressedReasonCounts: {} };
 
   // Background serial queue for extractions (agent_end optimization)
   // Queue stores promises that resolve when extraction should run
@@ -13012,6 +13026,111 @@ export class Orchestrator {
     }
   }
 
+  /**
+   * Passive correction capture (issue #1581) — detects corrections expressed
+   * passively in conversation turns and routes them to the Correction Contract
+   * (#1580). Called from `runExtraction` after persistence completes.
+   *
+   * Thin wiring: delegates ALL correction logic to the detector + capture
+   * modules + the CorrectionService. This method only checks gates, calls the
+   * detector, and routes results. Fail-open: capture errors never block the
+   * extraction return path.
+   */
+  private async maybeCapturePassiveCorrections(
+    turns: readonly BufferTurn[],
+    opts: {
+      sessionKey: string;
+      principal?: string;
+      namespace: string;
+      bufferKey: string;
+      isLiveSession: boolean;
+    },
+  ): Promise<void> {
+    const mode = this.config.correctionCaptureMode;
+    if (mode === "off") return;
+    if (!this.config.correctionEnabled) return;
+
+    try {
+      const corrections = detectPassiveCorrections(
+        turns.map((t) => ({ role: t.role, content: t.content })),
+      );
+      if (corrections.length === 0) return;
+
+      // Replay/import: force queue-only mode even if config says auto.
+      const effectiveMode = opts.isLiveSession ? mode : "queue";
+      const captureConfig: PassiveCaptureConfig = {
+        mode: effectiveMode,
+        confidenceFloor: this.config.correctionCaptureConfidenceFloor,
+        autoApplyMaxAffected: this.config.correctionCaptureAutoApplyMaxAffected,
+      };
+
+      const service = this.passiveCorrectionService();
+      const result = await capturePassiveCorrections(
+        corrections,
+        {
+          correctionEnabled: this.config.correctionEnabled,
+          isLiveSession: opts.isLiveSession,
+          bufferKey: opts.bufferKey,
+          sessionKey: opts.sessionKey,
+          principal: opts.principal,
+          namespace: opts.namespace,
+        },
+        captureConfig,
+        {
+          planCorrection: (req) => service.plan(req),
+          applyCorrection: (planId, applyOpts) => service.apply(planId, applyOpts),
+          storageDir: async (ns) => (await this.getStorage(ns)).dir,
+        },
+        this.passiveCorrectionDedup,
+      );
+
+      // Accumulate telemetry
+      this.passiveCorrectionTelemetry.detected += result.telemetry.detected;
+      this.passiveCorrectionTelemetry.queued += result.telemetry.queued;
+      this.passiveCorrectionTelemetry.autoApplied += result.telemetry.autoApplied;
+      for (const [reason, count] of Object.entries(result.telemetry.suppressedReasons)) {
+        this.passiveCorrectionTelemetry.suppressedReasonCounts[reason] =
+          (this.passiveCorrectionTelemetry.suppressedReasonCounts[reason] ?? 0) + count;
+      }
+    } catch (err) {
+      // Fail-open: passive capture never blocks extraction.
+      log.debug(
+        `passive-correction: capture failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /** Lazily construct the CorrectionService for passive capture. Stateless
+   *  across requests (per #1580 design); cached for the orchestrator's life. */
+  private passiveCorrectionService(): CorrectionService {
+    if (this._passiveCorrectionService) return this._passiveCorrectionService;
+    this._passiveCorrectionService = createCorrectionService({
+      orchestrator: this,
+      resolveAuthorizedNamespace: async (req) =>
+        req.namespace ?? this.config.defaultNamespace,
+      resolveReadableNamespaces: (req) => [
+        req.namespace ?? this.config.defaultNamespace,
+      ],
+      canWriteNamespace: async () => true,
+      llmComplete: async ({ system, user }) => {
+        const llmResult = await this.localLlm.chatCompletion(
+          [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          { operation: "correction-classify", priority: "background" },
+        );
+        if (!llmResult) {
+          throw new Error(
+            "passive correction classify+draft: local LLM unavailable (disabled or in cooldown)",
+          );
+        }
+        return llmResult.content;
+      },
+    });
+    return this._passiveCorrectionService;
+  }
+
   private async runExtraction(
     turns: BufferTurn[],
     options: {
@@ -13444,6 +13563,19 @@ export class Orchestrator {
     }
 
     await clearBuffer({ ignoreAbort: true });
+
+    // Passive correction capture (issue #1581) — detect corrections expressed
+    // passively in the extracted turns and route to the Correction Contract.
+    // Runs AFTER persistence + buffer clear so a capture failure never blocks
+    // the extraction return. `clearBufferAfterExtraction` gates live-session
+    // auto-apply (replay/import → queue-only).
+    await this.maybeCapturePassiveCorrections(normalizedTurns as BufferTurn[], {
+      sessionKey,
+      principal,
+      namespace: selfNamespace,
+      bufferKey,
+      isLiveSession: clearBufferAfterExtraction,
+    });
 
     // Build memory box from this extraction (v8.0 Phase 2A)
     // Topics are derived from the current extraction's facts and entities only —

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -342,6 +342,7 @@ import {
 } from "./namespaces/identity.js";
 import {
   canReadNamespace,
+  canWriteNamespace,
   defaultNamespaceForPrincipal,
   recallNamespacesForPrincipal,
   resolvePrincipal,
@@ -13080,6 +13081,17 @@ export class Orchestrator {
           planCorrection: (req) => service.plan(req),
           applyCorrection: (planId, applyOpts) => service.apply(planId, applyOpts),
           storageDir: async (ns) => (await this.getStorage(ns)).dir,
+          // Resolve `[m:xxxx]` handles to concrete memory ids via the single
+          // shared helper (#1582). Returns null on miss/ambiguity so the
+          // capture loop drops the handle and the planner falls back to text
+          // search (review: "memory handles not resolved").
+          resolveHandle: (ref, sessionKey) => {
+            try {
+              return this.resolveMemoryIdOrHandle(ref, sessionKey);
+            } catch {
+              return null;
+            }
+          },
         },
         this.passiveCorrectionDedup,
       );
@@ -13106,12 +13118,29 @@ export class Orchestrator {
     if (this._passiveCorrectionService) return this._passiveCorrectionService;
     this._passiveCorrectionService = createCorrectionService({
       orchestrator: this,
-      resolveAuthorizedNamespace: async (req) =>
-        req.namespace ?? this.config.defaultNamespace,
-      resolveReadableNamespaces: (req) => [
-        req.namespace ?? this.config.defaultNamespace,
-      ],
-      canWriteNamespace: async () => true,
+      // Session-scoped write ACL (review: "passive capture bypasses write
+      // ACL"). A correction detected in session S plans only against S readable
+      // namespaces and applies only to writable ones (rule 42) — passive
+      // capture never becomes a cross-tenant mutation vector. Mirrors the
+      // access-service createCorrectionService wiring rather than bypassing it.
+      resolveAuthorizedNamespace: async (req) => {
+        const principal = req.principal || resolvePrincipal(req.sessionKey, this.config);
+        const ns = req.namespace ?? defaultNamespaceForPrincipal(principal, this.config);
+        if (!canWriteNamespace(principal, ns, this.config)) {
+          throw new Error(
+            `passive correction: namespace "${ns}" is not writable for principal ${principal ?? "(none)"}`,
+          );
+        }
+        return ns;
+      },
+      resolveReadableNamespaces: (req) => {
+        const principal = req.principal || resolvePrincipal(req.sessionKey, this.config);
+        return recallNamespacesForPrincipal(principal, this.config);
+      },
+      canWriteNamespace: async (req) => {
+        const principal = req.principal || resolvePrincipal(req.sessionKey, this.config);
+        return canWriteNamespace(principal, req.namespace, this.config);
+      },
       llmComplete: async ({ system, user }) => {
         const llmResult = await this.localLlm.chatCompletion(
           [
@@ -13242,6 +13271,33 @@ export class Orchestrator {
         `skipping extraction: below threshold (totalChars=${totalChars}, userTurns=${userTurns.length})`,
       );
       await clearBuffer();
+      // Passive correction capture runs even when extraction is skipped for
+      // being below the char/user-turn threshold (review: "skipped extraction
+      // skips capture"). A short correction like "stop using Vim" is under
+      // extractionMinChars but is exactly the high-value case this feature
+      // exists for. Best-effort namespace: writeNamespaceOverride wins, else
+      // the session self namespace (coding overlay included). The ACL in
+      // passiveCorrectionService authorizes the actual plan/apply.
+      {
+        const capturePrincipal =
+          typeof options.principalOverride === "string" && options.principalOverride.length > 0
+            ? options.principalOverride
+            : resolvePrincipal(sessionKey, this.config);
+        const captureNamespace =
+          typeof options.writeNamespaceOverride === "string" && options.writeNamespaceOverride.length > 0
+            ? options.writeNamespaceOverride
+            : this.resolveSelfNamespace(sessionKey);
+        await this.maybeCapturePassiveCorrections(
+          normalizedTurns as BufferTurn[],
+          {
+            sessionKey,
+            principal: capturePrincipal,
+            namespace: captureNamespace,
+            bufferKey,
+            isLiveSession: clearBufferAfterExtraction,
+          },
+        );
+      }
       return {
         status: "skipped",
         reason: "below_threshold",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13275,28 +13275,25 @@ export class Orchestrator {
       // being below the char/user-turn threshold (review: "skipped extraction
       // skips capture"). A short correction like "stop using Vim" is under
       // extractionMinChars but is exactly the high-value case this feature
-      // exists for. Best-effort namespace: writeNamespaceOverride wins, else
-      // the session self namespace (coding overlay included). The ACL in
-      // passiveCorrectionService authorizes the actual plan/apply.
+      // exists for. The write namespace resolves through the SAME scope-profile
+      // plan as the full extraction path so corrections target the active
+      // profile's write layer, not just resolveSelfNamespace (review:
+      // "below-threshold wrong namespace"). The ACL in passiveCorrectionService
+      // authorizes the actual plan/apply.
       {
         const capturePrincipal =
           typeof options.principalOverride === "string" && options.principalOverride.length > 0
             ? options.principalOverride
             : resolvePrincipal(sessionKey, this.config);
-        const captureNamespace =
-          typeof options.writeNamespaceOverride === "string" && options.writeNamespaceOverride.length > 0
-            ? options.writeNamespaceOverride
-            : this.resolveSelfNamespace(sessionKey);
-        await this.maybeCapturePassiveCorrections(
-          normalizedTurns as BufferTurn[],
-          {
-            sessionKey,
-            principal: capturePrincipal,
-            namespace: captureNamespace,
-            bufferKey,
-            isLiveSession: clearBufferAfterExtraction,
-          },
-        );
+        const captureWO = typeof options.writeNamespaceOverride === "string" && options.writeNamespaceOverride.length > 0
+          ? options.writeNamespaceOverride : undefined;
+        const captureCodingCtx = sessionKey ? this.getCodingContextForSession(sessionKey) : null;
+        const captureCodingOv = resolveCodingNamespaceOverlay(captureCodingCtx, this.config.codingMode, this.config.defaultNamespace);
+        const captureScopePlan = resolveScopeProfilePlan({ config: this.config, principal: capturePrincipal, codingContext: captureCodingCtx, codingOverlay: captureCodingOv });
+        const captureNamespace = captureWO ?? captureScopePlan?.writeNamespace ?? this.resolveSelfNamespace(sessionKey);
+        await this.maybeCapturePassiveCorrections(normalizedTurns as BufferTurn[], {
+          sessionKey, principal: capturePrincipal, namespace: captureNamespace, bufferKey, isLiveSession: clearBufferAfterExtraction,
+        });
       }
       return {
         status: "skipped",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13245,13 +13245,13 @@ export class Orchestrator {
     );
     if (targetTurns.length === 0) {
       log.debug("skipping extraction: no non-context turns after normalization");
+      // Context-only turns may still contain corrections (review: "context-only
+      // turns skip capture"). Scan normalizedTurns before clearing the buffer.
+      if (normalizedTurns.length > 0) {
+        await this.maybeCapturePassiveCorrections(normalizedTurns as BufferTurn[], { sessionKey, principal: resolvePrincipal(sessionKey, this.config), namespace: this.resolveSelfNamespace(sessionKey), bufferKey, isLiveSession: clearBufferAfterExtraction });
+      }
       await clearBuffer();
-      return {
-        status: "skipped",
-        reason: "empty_normalized_turns",
-        persistedCount: 0,
-        durableOutputCount: 0,
-      };
+      return { status: "skipped", reason: "empty_normalized_turns", persistedCount: 0, durableOutputCount: 0 };
     }
     const sourceValidAt = latestSourceValidAtFromTurns(targetTurns);
     throwIfDeadlineExceeded("before_extract");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13494,13 +13494,12 @@ export class Orchestrator {
         meta.lastExtractionAt = new Date().toISOString();
         await storage.saveMeta(meta);
       }
+      // Correction-only turns that meet char/user-turn thresholds but yield
+      // zero facts still need passive capture (review: "empty extraction skips
+      // capture"). selfNamespace/principal already resolved above.
+      await this.maybeCapturePassiveCorrections(normalizedTurns as BufferTurn[], { sessionKey, principal, namespace: selfNamespace, bufferKey, isLiveSession: clearBufferAfterExtraction });
       await clearBuffer();
-      return {
-        status: "skipped",
-        reason: "empty_extraction_result",
-        persistedCount: 0,
-        durableOutputCount: 0,
-      };
+      return { status: "skipped", reason: "empty_extraction_result", persistedCount: 0, durableOutputCount: 0 };
     }
 
     let threadIdForExtraction: string | null = null;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -862,6 +862,29 @@ export interface PluginConfig {
    * `24`. Parsed from `correction.planTtlHours` / `correctionPlanTtlHours`.
    */
   correctionPlanTtlHours: number;
+  /**
+   * Passive correction capture (issue #1581) — detects corrections expressed
+   * passively in conversation turns during extraction and routes them to the
+   * Correction Contract (#1580). `"off"` disables detection entirely; `"queue"`
+   * plans corrections for human review (conservative); `"auto"` applies
+   * immediately when all safety guards pass, otherwise falls back to queue.
+   * Default `"off"` — operators opt in (rule 48). Parsed from
+   * `correctionCapture.mode` / `correctionCaptureMode`.
+   */
+  correctionCaptureMode: "off" | "queue" | "auto";
+  /**
+   * Minimum planner confidence for auto-apply (issue #1581). Plans below this
+   * floor are queued even in `"auto"` mode. Default `0.85`. Parsed from
+   * `correctionCapture.confidenceFloor` / `correctionCaptureConfidenceFloor`.
+   */
+  correctionCaptureConfidenceFloor: number;
+  /**
+   * Maximum affected memories for auto-apply (issue #1581). Plans touching more
+   * memories than this are queued even in `"auto"` mode — a blast-radius cap.
+   * Default `2`. Parsed from `correctionCapture.autoApplyMaxAffected` /
+   * `correctionCaptureAutoApplyMaxAffected`.
+   */
+  correctionCaptureAutoApplyMaxAffected: number;
   // Tombstones — non-resurrection invariant (issue #1579).
   /**
    * Master gate for the tombstone non-resurrection invariant. When `true`

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -2201,6 +2201,19 @@ export interface BriefingResult {
    * Allows callers to distinguish "no events today" from "source unavailable".
    */
   calendarSourceErrors?: BriefingCalendarSourceError[];
+  /**
+   * Auto-applied passive corrections drained from the notification queue at
+   * briefing time (issue #1581). Each carries a one-line summary and the undo
+   * command. Drained exactly once — the queue file is cleared on read, so a
+   * notification appears in at most one briefing. Absent when the correction
+   * capture feature is off or no corrections were auto-applied.
+   */
+  correctionNotifications?: ReadonlyArray<{
+    planId: string;
+    summary: string;
+    undoCommand: string;
+    createdAt: string;
+  }>;
 }
 
 /**

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20282,
+      "packages/remnic-core/src/orchestrator.ts": 20279,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20226,
+      "packages/remnic-core/src/orchestrator.ts": 20282,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20279,
+      "packages/remnic-core/src/orchestrator.ts": 20278,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20094,
+      "packages/remnic-core/src/orchestrator.ts": 20226,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,
-      "packages/remnic-core/src/config.ts": 4610
+      "packages/remnic-core/src/config.ts": 4642
     },
     "oversizedFileCount": 11,
-    "scatteredConfigFlagReads": 559,
+    "scatteredConfigFlagReads": 561,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 82,
     "directStorageImports": 38


### PR DESCRIPTION
Closes #1581. Part of #1572.

## What

Users correct their agents constantly *in conversation* — "no, we renamed that service", "I don't use Vim anymore", "the deadline moved to Friday". Remnic's observe pipeline sees every one of these turns and previously treated them as ordinary content. This PR adds **passive correction detection** that captures these corrections where users already are — on any connected host, zero new UI — and routes them to the merged Correction Contract plan/apply pipeline (#1580).

## Modules

- **`correction/passive-correction-detector.ts`** — morphology-aware heuristic detector. Pure function `detectPassiveCorrections(turns)` → `PassiveCorrection[]`. Scans only USER turns (no extra LLM call). Matches tense/conjugation variants ("we switched/we're switching/we've switched", "no longer", "not anymore"). Anti-fixture guards reject hypotheticals, third-party corrections, quoted speech, self-resolving corrections, and corrections about tool output vs stored memory.
- **`correction/passive-capture.ts`** — thin handoff to `correctionService.plan()` (#1580 planner does all locating/classifying; this module adds no parallel logic). Dispatch by mode:
  - `queue` — persist plan, surface in the review list as a `correction` item type.
  - `auto` — apply immediately iff **all** guards hold: plan confidence ≥ floor; classification ∈ {outdated, wrong}; affected ≤ max; every action ∈ {supersede, edit, retract}. Otherwise falls back to queue. Dedup via `bufferKey + normalizedCorrectionText`.
  - **Session scoping** — a correction in session S plans only against S's readable namespaces, applies only to writable ones (rule 42). Never a cross-tenant vector.
- **`correction/passive-correction-notifications.ts`** — JSONL notification queue for auto-applied corrections. Drains once into the next session-start briefing (`✎ Memory updated: …`, with undo path) via temp-file-then-rename (rule 54), then clears. Uses `serializeMutations`.
- **Wiring** — orchestrator extraction post-processing step invokes the detector (off by default; gated on `correctionCaptureMode`). Extraction entry-path parity (rule 39): buffered/forced/compaction flush run detection identically; replay runs queue-only.

## Config (default off — operators opt in, rule 48)

| Key | Default | |
|---|---|---|
| `correctionCaptureMode` | `"off"` | `"off" \| "queue" \| "auto"`; invalid → rejected listing options (rule 51) |
| `correctionCaptureConfidenceFloor` | `0.85` | auto-apply gate |
| `correctionCaptureAutoApplyMaxAffected` | `2` | auto-apply blast-radius cap |

## Tests (52, node:test)

- Detector fixture matrix: ≥12 positive (direct update, retraction, stop-storing, tense/morphology variants, mid-paragraph, `[m:xxxx]`-referenced) + ≥8 anti-fixtures (quoting someone else, correcting a third party, hypothetical, self-resolving, tool-output-not-memory). Assert: zero false plans.
- Capture: queue mode leaves plans pending; dedup (same correction, two flushes → one plan); namespace scoping (two principals, same daemon → separate plans).
- Auto mode: every guard gets a one-guard-off suppression test (confidence below floor / affected too large / disallowed classification / disallowed action kind).
- Characterization: extraction output on a correction-free transcript is byte-identical to pre-feature.

## Done-when mapping

- ✅ Live-session fixture: "we don't use Redis anymore" → queued plan in review list; auto mode (thresholds met) → recall no longer surfaces the fact, briefing carries the ✎ line, revert works.
- ✅ Anti-fixture suite green (zero false plans).
- ✅ Telemetry counters observable via console_state (detected / queued / auto-applied / auto-apply-suppressed(reason) / reverted); false-apply rate measurable for #1584.

## Chokepoints used

- `serializeMutations` / `withHeldFileLock` (#1524) for the notification queue + keyed mutation.
- Correction Contract plan/apply (#1580) — passive capture delegates planning; adds no parallel planning logic (rule 22).
- PluginConfig / parseConfig / manifest configSchema kept in sync (check-config-contract + sync:openclaw-plugin green).
- Config gate reads `correctionCaptureMode` (flat key), not a new `config.*Enabled` flag.

## Verification

- `npm run preflight:quick` → `[preflight] OK (quick)`
- `npm run test:entity-hardening` → 246/246 pass
- `node scripts/check-ratchets.mjs` → OK (orchestrator +132 / config +32 baseline updated)
- `npm run check-config-contract` → OK
- `npm run check:openclaw-plugin-sync` + `npm run sync:openclaw-plugin` → OK
- passive-correction suites → 52/52 pass

Replay/import ingestion is queue-only (never auto-apply from replayed history — re-reverted corrections would re-apply).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Can mutate stored memories automatically when `correctionCaptureMode` is `auto`, though multiple guards and default-off config limit blast radius; orchestrator extraction path changes are broad but fail-open.
> 
> **Overview**
> Adds **passive correction capture** so user corrections in chat (e.g. “we don’t use Redis anymore”) can be detected during extraction and routed into the existing Correction Contract **plan/apply** pipeline—default **off** via new `correctionCaptureMode` (`off` | `queue` | `auto`) plus confidence and blast-radius settings in plugin config and `parseConfig`.
> 
> A new **heuristic detector** scans user turns (no extra LLM), with anti-fixture guards; **capture** deduplicates, resolves `[m:xxxx]` handles, and in `auto` mode applies only when guards pass (live session, confidence floor, limited affected count, allowed classifications/actions)—otherwise queues. **Auto-applies** enqueue one-shot JSONL notifications drained into the daily briefing as a **Memory updates** section.
> 
> The **orchestrator** wires capture after extraction (and on skipped paths: below threshold, empty extraction, context-only turns) with session/namespace write ACLs and replay forced to queue-only. Extensive node:test coverage for detector, capture, and notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c34ca34f2ce5817b309f9dfd64b85e5bed6b4160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->