### PR TITLE
feat(recall): unified TrustScore stage + epistemic rendering (#1577)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -105,61 +105,491 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "openaiApiKey": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "const": false
-          }
+      "abstractionAnchorsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
+      },
+      "abstractionNodeStoreDir": {
+        "type": "string",
+        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
+      },
+      "accessTrackingBufferMaxSize": {
+        "type": "number",
+        "default": 100,
+        "description": "Max entries in access tracking buffer before flush"
+      },
+      "accessTrackingEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Track memory access counts and recency"
+      },
+      "actionGraphRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
+      },
+      "activeRecallAgents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
+      },
+      "activeRecallAllowChainedActiveMemory": {
+        "type": "boolean",
+        "default": false,
+        "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
+      },
+      "activeRecallAllowedChatTypes": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "direct",
+            "group",
+            "channel"
+          ]
+        },
+        "default": [
+          "direct",
+          "group",
+          "channel"
         ],
-        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+        "description": "OpenClaw chat types eligible for active recall."
       },
-      "openaiBaseUrl": {
+      "activeRecallAttachRecallExplain": {
+        "type": "boolean",
+        "default": false,
+        "description": "Attach recall explain output to active-recall diagnostics."
+      },
+      "activeRecallCacheTtlMs": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 120000,
+        "default": 15000,
+        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
+      },
+      "activeRecallCustomInstruction": {
         "type": "string",
-        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+        "description": "Optional custom guidance for the active-recall builder."
       },
-      "model": {
+      "activeRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection — when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
+      },
+      "activeRecallEntityGraphDepth": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "Entity-graph traversal depth used by active recall."
+      },
+      "activeRecallIncludeCausalTrajectories": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include causal trajectory recall evidence in active-recall summaries."
+      },
+      "activeRecallIncludeDaySummary": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include the latest day summary in active-recall context."
+      },
+      "activeRecallMaxSummaryChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 220,
+        "description": "Maximum summary size produced by the active-recall surface."
+      },
+      "activeRecallModel": {
         "type": "string",
-        "default": "gpt-5.5",
-        "description": "OpenAI model for extraction/consolidation"
+        "description": "Optional model selection for active recall."
       },
-      "reasoningEffort": {
+      "activeRecallModelFallbackPolicy": {
+        "type": "string",
+        "enum": [
+          "default-remote",
+          "resolved-only"
+        ],
+        "default": "default-remote",
+        "description": "How active recall falls back when an explicit model cannot be resolved."
+      },
+      "activeRecallPersistTranscripts": {
+        "type": "boolean",
+        "default": false,
+        "description": "Persist full active-recall request and response transcripts."
+      },
+      "activeRecallPromptAppend": {
+        "type": "string",
+        "description": "Optional additional guidance for the active-recall builder."
+      },
+      "activeRecallPromptStyle": {
+        "type": "string",
+        "enum": [
+          "balanced",
+          "strict",
+          "contextual",
+          "recall-heavy",
+          "precision-heavy",
+          "preference-only"
+        ],
+        "default": "balanced",
+        "description": "Context assembly style for the active-recall surface."
+      },
+      "activeRecallQueryMode": {
+        "type": "string",
+        "enum": [
+          "recent",
+          "message",
+          "full"
+        ],
+        "default": "recent",
+        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
+      },
+      "activeRecallRecentAssistantChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 400,
+        "description": "Per-assistant-turn character cap for active-recall context assembly."
+      },
+      "activeRecallRecentAssistantTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "How many recent assistant turns to include in the active-recall query context."
+      },
+      "activeRecallRecentUserChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 600,
+        "description": "Per-user-turn character cap for active-recall context assembly."
+      },
+      "activeRecallRecentUserTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4,
+        "default": 2,
+        "description": "How many recent user turns to include in the active-recall query context."
+      },
+      "activeRecallThinking": {
+        "type": "string",
+        "enum": [
+          "off",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "adaptive"
+        ],
+        "default": "low",
+        "description": "Reasoning effort used by the active-recall engine."
+      },
+      "activeRecallTimeoutMs": {
+        "type": "integer",
+        "minimum": 250,
+        "default": 15000,
+        "description": "Timeout for an active-recall run."
+      },
+      "activeRecallTranscriptDir": {
+        "type": "string",
+        "default": "active-recall",
+        "description": "Memory-relative directory for active-recall transcripts."
+      },
+      "agentAccessHttp": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Start the local Engram HTTP access server during plugin startup."
+          },
+          "host": {
+            "type": "string",
+            "default": "127.0.0.1",
+            "description": "Loopback host to bind for the Engram HTTP access server."
+          },
+          "port": {
+            "type": "number",
+            "default": 4318,
+            "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
+          },
+          "authToken": {
+            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "source"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "command": {}
+                }
+              }
+            ]
+          },
+          "principal": {
+            "type": "string",
+            "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
+          },
+          "maxBodyBytes": {
+            "type": "number",
+            "default": 131072,
+            "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "autoPromoteMinConfidenceTier": {
+        "type": "string",
+        "enum": [
+          "explicit",
+          "implied"
+        ],
+        "default": "explicit",
+        "description": "Minimum confidence tier for auto-promotion."
+      },
+      "autoPromoteToSharedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "fact",
+            "correction",
+            "decision",
+            "preference"
+          ]
+        },
+        "default": [
+          "fact",
+          "correction",
+          "decision",
+          "preference"
+        ],
+        "description": "Categories eligible for auto-promotion to shared."
+      },
+      "autoPromoteToSharedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
+      },
+      "beforeResetTimeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 30000,
+        "default": 2000,
+        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
+      },
+      "behaviorLoopAutoTuneEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
+      },
+      "behaviorLoopLearningWindowDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
+      },
+      "behaviorLoopMaxDeltaPerCycle": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
+      },
+      "behaviorLoopMinSignalCount": {
+        "type": "number",
+        "default": 10,
+        "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
+      },
+      "behaviorLoopProtectedParams": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "maxMemoryTokens",
+          "qmdMaxResults",
+          "qmdColdMaxResults",
+          "recallPlannerMaxQmdResultsMinimal",
+          "verbatimArtifactsMaxRecall"
+        ],
+        "description": "Runtime parameters that auto-tuning must never modify."
+      },
+      "benchmarkBaselineSnapshotsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
+      },
+      "benchmarkDeltaReporterEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
+      },
+      "benchmarkStoredBaselineEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable stored baseline comparisons for benchmark delta reporting."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
+      },
+      "binaryLifecycleBackendType": {
         "type": "string",
         "enum": [
           "none",
-          "low",
-          "medium",
-          "high"
+          "filesystem",
+          "s3"
         ],
-        "default": "low",
-        "description": "Reasoning effort for extraction"
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
       },
-      "triggerMode": {
-        "type": "string",
-        "enum": [
-          "smart",
-          "every_n",
-          "time_based"
-        ],
-        "default": "smart",
-        "description": "Buffer trigger mode"
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
       },
-      "bufferMaxTurns": {
+      "binaryLifecycleGracePeriodDays": {
         "type": "number",
-        "default": 5,
-        "description": "Max turns before forced extraction"
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "boostAccessCount": {
+        "type": "boolean",
+        "default": true,
+        "description": "Boost frequently accessed memories in search results"
+      },
+      "boxMaxMemories": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum memories per box before forced seal."
+      },
+      "boxRecallDays": {
+        "type": "number",
+        "default": 3,
+        "description": "Number of recent days of boxes to add during recall."
+      },
+      "boxTimeGapMs": {
+        "type": "number",
+        "default": 1800000,
+        "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
+      },
+      "boxTopicShiftThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
+      },
+      "briefing": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {
+          "enabled": true,
+          "defaultWindow": "yesterday",
+          "defaultFormat": "markdown",
+          "maxFollowups": 5,
+          "calendarSource": null,
+          "saveByDefault": false,
+          "saveDir": null,
+          "llmFollowups": true
+        },
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "defaultWindow": {
+            "type": "string",
+            "default": "yesterday"
+          },
+          "defaultFormat": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "json"
+            ],
+            "default": "markdown"
+          },
+          "maxFollowups": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          },
+          "calendarSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "saveByDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "saveDir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "llmFollowups": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
       },
       "bufferMaxMinutes": {
         "type": "number",
         "default": 15,
         "description": "Max minutes before forced extraction"
       },
-      "bufferSurpriseTriggerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
+      "bufferMaxTurns": {
+        "type": "number",
+        "default": 5,
+        "description": "Max turns before forced extraction"
+      },
+      "bufferSurpriseK": {
+        "type": "number",
+        "default": 5,
+        "minimum": 1,
+        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      },
+      "bufferSurpriseProbeTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "minimum": 1,
+        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+      },
+      "bufferSurpriseRecentMemoryCount": {
+        "type": "number",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
       },
       "bufferSurpriseThreshold": {
         "type": "number",
@@ -168,308 +598,940 @@
         "maximum": 1,
         "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
       },
-      "bufferSurpriseK": {
-        "type": "number",
-        "default": 5,
-        "minimum": 1,
-        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      "bufferSurpriseTriggerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
       },
-      "bufferSurpriseRecentMemoryCount": {
+      "calibrationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable recall calibration rules (v9.0, default off)."
+      },
+      "calibrationMaxChars": {
         "type": "number",
-        "default": 20,
+        "default": 1200,
+        "description": "Maximum characters of calibration content to include per recall pass."
+      },
+      "calibrationMaxRulesPerRecall": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of calibration rules to include per recall pass."
+      },
+      "captureMode": {
+        "type": "string",
+        "enum": [
+          "implicit",
+          "explicit",
+          "hybrid"
+        ],
+        "default": "implicit",
+        "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
+      },
+      "causalGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
+      },
+      "causalRuleExtractionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
+      },
+      "causalTrajectoryMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
+      },
+      "causalTrajectoryRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant causal trajectories to recall context."
+      },
+      "causalTrajectoryStoreDir": {
+        "type": "string",
+        "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
+      },
+      "chat": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default — spawns LLM calls so explicit opt-in (rule 48).",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
+          },
+          "model": {
+            "type": "string",
+            "default": "",
+            "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
+          },
+          "maxToolCallsPerTurn": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 64,
+            "default": 8,
+            "description": "Max tool calls per user turn before partial-reply fallback (rule 34 — never a silent stall)."
+          },
+          "sessionTtlHours": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 72,
+            "description": "Hours after which idle chat session state is cleaned up."
+          }
+        }
+      },
+      "checkpointEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable conversation checkpoints"
+      },
+      "checkpointTurns": {
+        "type": "number",
+        "default": 15,
+        "description": "Number of turns per checkpoint"
+      },
+      "chunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic chunking of long memories"
+      },
+      "chunkingMinTokens": {
+        "type": "number",
+        "default": 150,
+        "description": "Minimum tokens to trigger chunking"
+      },
+      "chunkingOverlapSentences": {
+        "type": "number",
+        "default": 2,
+        "description": "Number of sentences to overlap between chunks"
+      },
+      "chunkingTargetTokens": {
+        "type": "number",
+        "default": 200,
+        "description": "Target tokens per chunk"
+      },
+      "citationsAutoDetect": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-enable citations when the Codex adapter is detected."
+      },
+      "citationsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+      },
+      "cmcBehaviorConfidenceThreshold": {
+        "type": "number",
+        "default": 0.6,
+        "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
+      },
+      "cmcBehaviorLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC behavior pattern learning (default off)."
+      },
+      "cmcBehaviorMinFrequency": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum frequency for a behavior pattern to be learned by CMC."
+      },
+      "cmcBehaviorMinSessions": {
+        "type": "number",
+        "default": 2,
+        "description": "Minimum sessions a behavior must appear in before CMC learns it."
+      },
+      "cmcConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC consolidation pass (default off)."
+      },
+      "cmcConsolidationMinRecurrence": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum recurrence count before a CMC pattern is consolidated."
+      },
+      "cmcConsolidationMinSessions": {
+        "type": "number",
+        "default": 2,
+        "description": "Minimum sessions a CMC pattern must appear in before consolidation."
+      },
+      "cmcConsolidationSuccessThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
+      },
+      "cmcEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
+      },
+      "cmcLifecycleCausalImpactWeight": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Weight of causal impact score in CMC lifecycle scoring."
+      },
+      "cmcRetrievalCounterfactualBoost": {
+        "type": "number",
+        "default": 0.4,
+        "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
+      },
+      "cmcRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC retrieval at recall time (default off)."
+      },
+      "cmcRetrievalMaxChars": {
+        "type": "number",
+        "default": 800,
+        "description": "Maximum characters of CMC content included per recall pass."
+      },
+      "cmcRetrievalMaxDepth": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum graph depth traversed during CMC retrieval."
+      },
+      "cmcStitchLookbackDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Number of days to look back when stitching causal trajectories."
+      },
+      "cmcStitchMaxEdgesPerTrajectory": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum edges per trajectory during CMC stitching."
+      },
+      "cmcStitchMinScore": {
+        "type": "number",
+        "default": 2.5,
+        "description": "Minimum score for a causal edge to be stitched into a trajectory."
+      },
+      "codex": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "installExtension": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install the Remnic Codex memory extension during Codex connector setup."
+          },
+          "codexHome": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null,
+            "description": "Optional Codex home directory override used for connector install and materialization."
+          }
+        }
+      },
+      "codexCompat": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "threadIdBufferKeying": {
+            "type": "boolean",
+            "default": true
+          },
+          "compactionFlushMode": {
+            "type": "string",
+            "enum": [
+              "signal",
+              "heuristic",
+              "auto"
+            ],
+            "default": "auto"
+          },
+          "fingerprintDedup": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "codexMarketplaceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex marketplace integration for plugin discovery and installation."
+      },
+      "codexMaterializeMaxSummaryTokens": {
+        "type": "number",
         "minimum": 0,
-        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+        "default": 4500,
+        "description": "Whitespace-token cap for Codex memory summary materialization."
       },
-      "bufferSurpriseProbeTimeoutMs": {
+      "codexMaterializeMemories": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex native memory materialization into the Codex memories directory."
+      },
+      "codexMaterializeNamespace": {
+        "type": "string",
+        "default": "auto",
+        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
+      },
+      "codexMaterializeOnConsolidation": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
+      },
+      "codexMaterializeOnSessionEnd": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization from the Codex session-end hook."
+      },
+      "codexMaterializeRolloutRetentionDays": {
         "type": "number",
-        "default": 2000,
+        "minimum": 0,
+        "default": 30,
+        "description": "Retention window in days for Codex rollout materialization artifacts."
+      },
+      "codingKnowledge": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Durable coding-knowledge surface — Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
+          },
+          "decisionRecords": {
+            "type": "boolean",
+            "default": true,
+            "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
+          },
+          "architectureCard": {
+            "type": "boolean",
+            "default": true,
+            "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
+          },
+          "sessionDelta": {
+            "type": "boolean",
+            "default": true,
+            "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
+          },
+          "architectureCardLlmSummary": {
+            "type": "boolean",
+            "default": false,
+            "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
+          },
+          "structuralProvider": {
+            "type": "string",
+            "enum": [
+              "none",
+              "subprocess",
+              "native"
+            ],
+            "default": "none",
+            "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
+          },
+          "structuralProviderCommand": {
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
+          },
+          "codegraphTools": {
+            "type": "boolean",
+            "default": false,
+            "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default — tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
+          },
+          "codegraphDbDir": {
+            "type": "string",
+            "default": "",
+            "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+          }
+        }
+      },
+      "codingMode": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Coding-agent project/branch scoping (issue #569).",
+        "properties": {
+          "projectScope": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
+          },
+          "branchScope": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
+          },
+          "globalFallback": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
+          }
+        }
+      },
+      "collectJudgeTrainingPairs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+      },
+      "commandsListEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
+      },
+      "commitmentDecayDays": {
+        "type": "integer",
         "minimum": 1,
-        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+        "default": 90,
+        "description": "Days before fulfilled/expired commitments are removed"
+      },
+      "commitmentLedgerDir": {
+        "type": "string",
+        "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
+      },
+      "commitmentLedgerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
+      },
+      "commitmentLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
+      },
+      "commitmentStaleDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
+      },
+      "compactionResetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
+      },
+      "compoundingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable compounding engine (v5.0). Default off."
+      },
+      "compoundingInjectEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
+      },
+      "compoundingSemanticEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic compounding synthesis (reserved/experimental)."
+      },
+      "compoundingSynthesisTimeoutMs": {
+        "type": "number",
+        "default": 15000,
+        "description": "Timeout for compounding synthesis (ms)."
+      },
+      "compoundingWeeklyCronEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
+      },
+      "compressionGuidelineLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
+      },
+      "compressionGuidelineSemanticRefinementEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
+      },
+      "compressionGuidelineSemanticTimeoutMs": {
+        "type": "number",
+        "default": 2500,
+        "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
+      },
+      "connectors": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
+        "properties": {
+          "googleDrive": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+              },
+              "clientId": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
+              },
+              "clientSecret": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
+              },
+              "refreshToken": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "folderIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
+              }
+            }
+          },
+          "notion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
+              },
+              "databaseIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
+          },
+          "gmail": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+              },
+              "clientId": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
+              },
+              "clientSecret": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
+              },
+              "refreshToken": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
+              },
+              "userId": {
+                "type": "string",
+                "default": "me",
+                "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
+              },
+              "query": {
+                "type": "string",
+                "default": "in:inbox",
+                "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
+          },
+          "github": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
+              },
+              "userLogin": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
+              },
+              "repos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "includeDiscussions": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
+              }
+            }
+          }
+        }
       },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,
         "description": "Run consolidation every N extractions"
       },
-      "highSignalPatterns": {
+      "consolidationMinIntervalMs": {
+        "type": "number",
+        "default": 600000,
+        "description": "Minimum interval between consolidation runs (ms)."
+      },
+      "consolidationRequireNonZeroExtraction": {
+        "type": "boolean",
+        "default": true,
+        "description": "Only schedule consolidation when the last extraction produced durable outputs."
+      },
+      "contextCompressionActionsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
+      },
+      "continuityAuditEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable continuity audit artifact generation workflows"
+      },
+      "continuityIncidentLoggingEnabled": {
+        "type": "boolean",
+        "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
+      },
+      "contradictionAutoResolve": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically supersede contradicted memories"
+      },
+      "contradictionDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic contradiction detection with LLM verification"
+      },
+      "contradictionMinConfidence": {
+        "type": "number",
+        "default": 0.9,
+        "description": "Minimum LLM confidence to auto-resolve contradictions"
+      },
+      "contradictionScan": {
+        "type": "object",
+        "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
+          },
+          "similarityFloor": {
+            "type": "number",
+            "default": 0.82,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Embedding cosine similarity floor for candidate pair generation"
+          },
+          "topicOverlapFloor": {
+            "type": "number",
+            "default": 0.4,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
+          },
+          "maxPairsPerRun": {
+            "type": "integer",
+            "default": 500,
+            "minimum": 1,
+            "description": "Cap on candidate pairs evaluated per cron run"
+          },
+          "cooldownDays": {
+            "type": "integer",
+            "default": 14,
+            "minimum": 0,
+            "description": "Cooldown in days. 0 = always re-evaluate."
+          },
+          "autoMergeDuplicates": {
+            "type": "boolean",
+            "default": false,
+            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
+          }
+        }
+      },
+      "contradictionSimilarityThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "QMD similarity threshold to trigger contradiction check"
+      },
+      "conversationIndexBackend": {
+        "type": "string",
+        "enum": [
+          "qmd",
+          "faiss"
+        ],
+        "default": "qmd",
+        "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
+      },
+      "conversationIndexEmbedOnUpdate": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
+      },
+      "conversationIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
+      },
+      "conversationIndexFaissHealthTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
+      },
+      "conversationIndexFaissIndexDir": {
+        "type": "string",
+        "default": "state/conversation-index/faiss",
+        "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
+      },
+      "conversationIndexFaissMaxBatchSize": {
+        "type": "number",
+        "default": 512,
+        "description": "Maximum transcript chunk batch size per FAISS upsert call."
+      },
+      "conversationIndexFaissMaxSearchK": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum top-K allowed for FAISS search requests."
+      },
+      "conversationIndexFaissModelId": {
+        "type": "string",
+        "default": "text-embedding-3-small",
+        "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
+      },
+      "conversationIndexFaissPythonBin": {
+        "type": "string",
+        "default": "",
+        "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
+      },
+      "conversationIndexFaissScriptPath": {
+        "type": "string",
+        "default": "",
+        "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
+      },
+      "conversationIndexFaissSearchTimeoutMs": {
+        "type": "number",
+        "default": 5000,
+        "description": "Timeout (ms) for FAISS search operations."
+      },
+      "conversationIndexFaissUpsertTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout (ms) for FAISS upsert operations."
+      },
+      "conversationIndexMinUpdateIntervalMs": {
+        "type": "number",
+        "default": 900000,
+        "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
+      },
+      "conversationIndexQmdCollection": {
+        "type": "string",
+        "default": "openclaw-engram-conversations",
+        "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
+      },
+      "conversationIndexRetentionDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Days to retain conversation chunk docs."
+      },
+      "conversationRecallMaxChars": {
+        "type": "number",
+        "default": 2500,
+        "description": "Max characters of semantic conversation recall to include."
+      },
+      "conversationRecallTimeoutMs": {
+        "type": "number",
+        "default": 800,
+        "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
+      },
+      "conversationRecallTopK": {
+        "type": "number",
+        "default": 3,
+        "description": "Top-K conversation chunks to include."
+      },
+      "correctionApplyRequiresConfirm": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
+      },
+      "correctionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for the Correction Contract (#1580) — the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
+      },
+      "correctionMaxAffected": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 10,
+        "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
+      },
+      "correctionPlanTtlHours": {
+        "type": "number",
+        "default": 24,
+        "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
+      },
+      "creationMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
+      },
+      "cronConversationRecallMode": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "always",
+          "never"
+        ],
+        "default": "auto",
+        "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
+      },
+      "cronRecallAllowlist": {
         "type": "array",
         "items": {
           "type": "string"
         },
-        "description": "Custom regex patterns for immediate extraction"
+        "default": [],
+        "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
       },
-      "maxMemoryTokens": {
+      "cronRecallInstructionHeavyTokenCap": {
         "type": "number",
-        "default": 2000,
-        "description": "Max memory-context tokens per turn"
+        "default": 36,
+        "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
       },
-      "memoryOsPreset": {
+      "cronRecallMode": {
         "type": "string",
         "enum": [
-          "conservative",
-          "balanced",
-          "research",
-          "research-max",
-          "local-llm-heavy"
+          "all",
+          "none",
+          "allowlist"
         ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+        "default": "all",
+        "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
       },
-      "qmdEnabled": {
+      "cronRecallNormalizedQueryMaxChars": {
+        "type": "number",
+        "default": 480,
+        "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
+      },
+      "cronRecallPolicyEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Use QMD for search"
+        "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
       },
-      "qmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram",
-        "description": "QMD collection name"
-      },
-      "qmdMaxResults": {
-        "type": "number",
-        "default": 8,
-        "description": "Max QMD results per search"
-      },
-      "qmdColdTierEnabled": {
+      "crossSignalsSemanticEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
+        "description": "Enable semantic cross-signal grouping (reserved/experimental)."
       },
-      "qmdColdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-cold",
-        "description": "Secondary QMD collection name used for cold-tier fallback recall"
-      },
-      "qmdColdMaxResults": {
+      "crossSignalsSemanticTimeoutMs": {
         "type": "number",
-        "default": 8,
-        "description": "Max cold-tier QMD results considered before final recall cap"
+        "default": 4000,
+        "description": "Timeout for semantic cross-signal grouping (ms)."
       },
-      "qmdTierMigrationEnabled": {
+      "daySummaryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
+      },
+      "daySummaryTimezone": {
+        "type": "string",
+        "default": "",
+        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+      },
+      "debug": {
         "type": "boolean",
         "default": false,
-        "description": "Enable value-aware migration between hot and cold QMD tiers"
+        "description": "Enable debug logging"
       },
-      "qmdTierDemotionMinAgeDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Minimum hot-memory age in days before tier demotion is eligible"
-      },
-      "qmdTierDemotionValueThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
-      },
-      "qmdTierPromotionValueThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
-      },
-      "qmdTierParityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierParityHiMemEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierAutoBackfillEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
-      },
-      "qmdSupportedVersion": {
+      "defaultNamespace": {
         "type": "string",
-        "default": "2.5.3",
-        "description": "Highest QMD version this Remnic build will auto-install"
+        "default": "default",
+        "description": "Default namespace name."
       },
-      "qmdAutoUpgradeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
-      },
-      "qmdAutoUpgradeCheckIntervalMs": {
-        "type": "number",
-        "minimum": 60000,
-        "default": 86400000,
-        "description": "Minimum interval between QMD auto-upgrade checks"
-      },
-      "qmdChunkStrategy": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "regex"
-        ],
-        "default": "auto",
-        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
-      },
-      "qmdCandidateLimit": {
-        "type": "number",
-        "minimum": 1,
-        "description": "Optional candidate limit forwarded to supported QMD query paths"
-      },
-      "qmdQueryRerankEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
-      },
-      "qmdSearchStrategy": {
-        "type": "string",
-        "enum": [
-          "hybrid",
-          "lex-vec",
-          "lex"
-        ],
-        "default": "hybrid",
-        "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdSubprocessStrategy": {
-        "type": "string",
-        "enum": [
-          "query",
-          "search"
-        ],
-        "default": "query",
-        "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdDaemonTimeoutMs": {
-        "type": "number",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 8000,
-        "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
-      },
-      "qmdIndexName": {
-        "type": "string",
-        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
-      },
-      "qmdForceCpu": {
-        "type": "boolean",
-        "default": false,
-        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
-      },
-      "qmdGpuBackend": {
-        "type": [
-          "string",
-          "boolean"
-        ],
-        "enum": [
-          "auto",
-          "metal",
-          "cuda",
-          "vulkan",
-          "false",
-          false
-        ],
-        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
-      },
-      "qmdEmbedParallelism": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 8,
-        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
-      },
-      "qmdEmbedModel": {
-        "type": "string",
-        "description": "Optional QMD_EMBED_MODEL override"
-      },
-      "qmdRerankModel": {
-        "type": "string",
-        "description": "Optional QMD_RERANK_MODEL override"
-      },
-      "qmdGenerateModel": {
-        "type": "string",
-        "description": "Optional QMD_GENERATE_MODEL override"
-      },
-      "embeddingFallbackEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
-      },
-      "embeddingFallbackProvider": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "openai",
-          "local"
-        ],
-        "default": "auto",
-        "description": "Embedding provider selection for semantic fallback"
-      },
-      "hostEmbeddingProviderEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
-      },
-      "hostEmbeddingProviderId": {
-        "type": "string",
-        "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
-      },
-      "hostEmbeddingProviderModel": {
-        "type": "string",
-        "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
-      },
-      "embeddingFallbackModel": {
-        "type": "string",
-        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
-      },
-      "qmdPath": {
-        "type": "string",
-        "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
-      },
-      "memoryDir": {
-        "type": "string",
-        "description": "Override memory storage directory"
-      },
-      "entitySchemas": {
-        "type": "object",
-        "description": "Optional per-entity-type structured section schema customizations.",
-        "additionalProperties": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "sections": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "aliases": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "anyOf": [
-                  {
-                    "required": [
-                      "key"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "title"
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "required": [
-            "sections"
+      "defaultRecallNamespaces": {
+        "type": "array",
+        "description": "Which namespaces to include by default in recall.",
+        "items": {
+          "type": "string",
+          "enum": [
+            "self",
+            "shared"
           ]
-        }
+        },
+        "default": [
+          "self",
+          "shared"
+        ]
+      },
+      "defaultScopeProfile": {
+        "type": "string",
+        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+      },
+      "delinearizeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
       },
       "dreaming": {
         "type": "object",
@@ -657,6 +1719,821 @@
           }
         }
       },
+      "embeddingFallbackEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
+      },
+      "embeddingFallbackModel": {
+        "type": "string",
+        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
+      },
+      "embeddingFallbackProvider": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "openai",
+          "local"
+        ],
+        "default": "auto",
+        "description": "Embedding provider selection for semantic fallback"
+      },
+      "emitLegacyTools": {
+        "type": "boolean",
+        "default": false,
+        "description": "Advertise legacy engram_* / engram.* MCP tool aliases alongside the canonical remnic_* names. Issue #1550: defaults to false on fresh installs (halving the advertised tools/list surface); when existing legacy connector entries are present on disk the default stays true so upgrades never silently break a configured legacy client. An explicit value always wins."
+      },
+      "enrichmentAutoOnCreate": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+      },
+      "enrichmentEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+      },
+      "enrichmentMaxCandidatesPerEntity": {
+        "type": "integer",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
+      },
+      "entityActivityLogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Log timestamped activity per entity"
+      },
+      "entityActivityLogMaxEntries": {
+        "type": "number",
+        "default": 20,
+        "description": "Max activity entries per entity before oldest are pruned"
+      },
+      "entityAliasesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Store aliases per entity file"
+      },
+      "entityGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
+      },
+      "entityRelationshipsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Track entity-to-entity relationships during extraction"
+      },
+      "entityRetrievalEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
+      },
+      "entityRetrievalMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "description": "Hard character cap for the entity retrieval section."
+      },
+      "entityRetrievalMaxHints": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum entity targets summarized in one recall pass."
+      },
+      "entityRetrievalMaxRelatedEntities": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum related entities listed per target when confidence is high."
+      },
+      "entityRetrievalMaxSupportingFacts": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum supporting fact/timeline snippets considered per entity target."
+      },
+      "entityRetrievalRecentTurns": {
+        "type": "number",
+        "default": 6,
+        "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
+      },
+      "entitySchemas": {
+        "type": "object",
+        "description": "Optional per-entity-type structured section schema customizations.",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sections": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "aliases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": [
+                      "key"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "title"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "sections"
+          ]
+        }
+      },
+      "entitySummaryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Generate LLM summaries for entities during consolidation"
+      },
+      "entitySynthesisMaxTokens": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "const": 0
+          },
+          {
+            "type": "integer",
+            "minimum": 10
+          }
+        ],
+        "default": 500,
+        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
+      },
+      "episodeNoteModeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
+      },
+      "evalHarnessEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
+      },
+      "evalShadowModeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
+      },
+      "evalStoreDir": {
+        "type": "string",
+        "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
+      },
+      "eventOrderRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable event-order evidence recall for chronology questions."
+      },
+      "eventOrderRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the event-order evidence recall section."
+      },
+      "eventOrderRecallMaxResults": {
+        "type": "integer",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum recalled items for event-order evidence."
+      },
+      "eventOrderRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 24000,
+        "minimum": 1,
+        "description": "Recent-token scan window for event-order evidence."
+      },
+      "eventOrderRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 12,
+        "minimum": 1,
+        "description": "Recent-turn scan window for event-order evidence."
+      },
+      "explicitCueRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      },
+      "explicitCueRecallMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the explicit cue evidence recall section."
+      },
+      "explicitCueRecallMaxReferences": {
+        "type": "number",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      },
+      "extractionDedupeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable deduplication of near-identical extraction batches within a time window."
+      },
+      "extractionDedupeWindowMs": {
+        "type": "number",
+        "default": 300000,
+        "description": "Window for extraction dedupe fingerprints (ms)."
+      },
+      "extractionFaithfulnessContextChars": {
+        "type": "number",
+        "default": 400,
+        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+      },
+      "extractionFaithfulnessGate": {
+        "type": "string",
+        "enum": [
+          "off",
+          "shadow",
+          "enforce"
+        ],
+        "default": "off",
+        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+      },
+      "extractionFaithfulnessModel": {
+        "type": "string",
+        "default": "",
+        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+      },
+      "extractionFaithfulnessTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+      },
+      "extractionJudgeBatchSize": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
+      },
+      "extractionJudgeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
+      },
+      "extractionJudgeMaxDeferrals": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+      },
+      "extractionJudgeModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
+      },
+      "extractionJudgeShadow": {
+        "type": "boolean",
+        "default": false,
+        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
+      },
+      "extractionJudgeTelemetryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+      },
+      "extractionMaxEntitiesPerRun": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum entities persisted from a single extraction run."
+      },
+      "extractionMaxFactsPerRun": {
+        "type": "number",
+        "default": 12,
+        "description": "Maximum facts persisted from a single extraction run."
+      },
+      "extractionMaxOutputTokens": {
+        "type": "number",
+        "default": 16384,
+        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
+      },
+      "extractionMaxProfileUpdatesPerRun": {
+        "type": "number",
+        "default": 4,
+        "description": "Maximum profile updates persisted from a single extraction run."
+      },
+      "extractionMaxQuestionsPerRun": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum questions persisted from a single extraction run."
+      },
+      "extractionMaxTurnChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
+      },
+      "extractionMinChars": {
+        "type": "number",
+        "default": 40,
+        "description": "Minimum combined user/assistant characters required before extraction runs."
+      },
+      "extractionMinImportanceLevel": {
+        "type": "string",
+        "enum": [
+          "trivial",
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ],
+        "default": "low",
+        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
+      "extractionMinUserTurns": {
+        "type": "number",
+        "default": 1,
+        "description": "Minimum number of user turns required before extraction runs."
+      },
+      "extractionScopeClassificationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
+      },
+      "extractionTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
+      },
+      "factArchivalAgeDays": {
+        "type": "number",
+        "default": 90,
+        "description": "Minimum age in days before a fact is eligible for archival."
+      },
+      "factArchivalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
+      },
+      "factArchivalMaxAccessCount": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
+      },
+      "factArchivalMaxImportance": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
+      },
+      "factArchivalProtectedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "commitment",
+          "preference",
+          "decision",
+          "principle",
+          "procedure"
+        ],
+        "description": "Categories that protect a fact from archival regardless of other criteria."
+      },
+      "factDeduplicationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
+      },
+      "fastGatewayAgentId": {
+        "type": "string",
+        "default": "",
+        "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
+      },
+      "feedbackEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
+      },
+      "fileHygiene": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional: keep OpenClaw bootstrap workspace files small and warn before silent truncation risk.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master switch for file hygiene (default off)."
+          },
+          "lintEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "If true, warn when bootstrap files approach budget."
+          },
+          "lintBudgetBytes": {
+            "type": "number",
+            "default": 20000,
+            "description": "Budget in bytes used for lint warnings (approx)."
+          },
+          "lintWarnRatio": {
+            "type": "number",
+            "default": 0.8,
+            "description": "Warn when file size >= budget * warnRatio."
+          },
+          "lintPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "IDENTITY.md",
+              "MEMORY.md"
+            ],
+            "description": "Workspace-relative paths to lint (or absolute paths)."
+          },
+          "rotateEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, rotate oversized markdown files into an archive and replace with a lean index."
+          },
+          "rotateMaxBytes": {
+            "type": "number",
+            "default": 18000,
+            "description": "Rotate when a target file exceeds this size (bytes)."
+          },
+          "rotateKeepTailChars": {
+            "type": "number",
+            "default": 2000,
+            "description": "How many characters of the old file to keep inline (tail) for continuity."
+          },
+          "rotatePaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "IDENTITY.md"
+            ],
+            "description": "Workspace-relative paths to rotate (or absolute paths)."
+          },
+          "archiveDir": {
+            "type": "string",
+            "default": ".engram-archive",
+            "description": "Workspace-relative archive directory where rotated files are stored."
+          },
+          "runMinIntervalMs": {
+            "type": "number",
+            "default": 300000,
+            "description": "Minimum interval between hygiene runs (ms)."
+          },
+          "warningsLogEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, append warnings to a log file under memoryDir."
+          },
+          "warningsLogPath": {
+            "type": "string",
+            "default": "hygiene/warnings.md",
+            "description": "memoryDir-relative path to write warnings to."
+          },
+          "indexEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Reserved: write an Engram index file in workspace (not required for rotation)."
+          },
+          "indexPath": {
+            "type": "string",
+            "default": "ENGRAM_INDEX.md",
+            "description": "Workspace-relative index path (if indexEnabled)."
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "flushOnResetEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
+      },
+      "focusedListRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
+      },
+      "focusedListRecallMaxChars": {
+        "type": "integer",
+        "default": 2600,
+        "minimum": 0,
+        "description": "Character budget for the focused list evidence recall section."
+      },
+      "focusedListRecallMaxResults": {
+        "type": "integer",
+        "default": 40,
+        "minimum": 0,
+        "description": "Maximum recalled items for focused list evidence."
+      },
+      "focusedListRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 14000,
+        "minimum": 1,
+        "description": "Recent-token scan window for focused list evidence."
+      },
+      "focusedListRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 64,
+        "minimum": 1,
+        "description": "Recent-turn scan window for focused list evidence."
+      },
+      "gatewayAgentId": {
+        "type": "string",
+        "default": "",
+        "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
+      },
+      "graphActivationDecay": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Per-hop activation decay factor (0-1). Default 0.7."
+      },
+      "graphAssistInFullModeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run bounded graph expansion during full recall mode when seed results exist."
+      },
+      "graphAssistMinSeedResults": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum seed recall results required before full-mode graph assist runs."
+      },
+      "graphAssistShadowEvalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
+      },
+      "graphEdgeDecayCadenceMs": {
+        "type": "number",
+        "default": 604800000,
+        "minimum": 60000,
+        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
+      },
+      "graphEdgeDecayEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
+      },
+      "graphEdgeDecayFloor": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Floor confidence will not decay below. Default 0.1."
+      },
+      "graphEdgeDecayPerWindow": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Per-window confidence drop applied during decay. Default 0.1."
+      },
+      "graphEdgeDecayVisibilityThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
+      },
+      "graphEdgeDecayWindowMs": {
+        "type": "number",
+        "default": 7776000000,
+        "minimum": 60000,
+        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
+      },
+      "graphExpandedIntentEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
+      },
+      "graphExpansionActivationWeight": {
+        "type": "number",
+        "default": 0.65,
+        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
+      },
+      "graphExpansionBlendMax": {
+        "type": "number",
+        "default": 0.95,
+        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
+      },
+      "graphExpansionBlendMin": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
+      },
+      "graphLateralInhibitionBeta": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
+      },
+      "graphLateralInhibitionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
+      },
+      "graphLateralInhibitionTopM": {
+        "type": "number",
+        "default": 7,
+        "description": "Number of top competing nodes considered for lateral inhibition"
+      },
+      "graphRecallColdMirrorCollection": {
+        "type": "string",
+        "description": "QMD collection name for cold-mirror graph recall results."
+      },
+      "graphRecallColdMirrorMinAgeDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
+      },
+      "graphRecallDampingFactor": {
+        "type": "number",
+        "default": 0.85,
+        "description": "PageRank-style damping factor for graph activation propagation."
+      },
+      "graphRecallEnableDebug": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable verbose debug output for graph recall operations."
+      },
+      "graphRecallEnableTrace": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable detailed graph recall trace logging for debugging."
+      },
+      "graphRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
+      },
+      "graphRecallEntityHintMax": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of entity hints added per graph recall result."
+      },
+      "graphRecallEntityHintMaxChars": {
+        "type": "number",
+        "default": 200,
+        "description": "Maximum characters per entity hint added during graph recall."
+      },
+      "graphRecallEntityHintsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Inject entity hint summaries alongside graph-recalled memories."
+      },
+      "graphRecallEntityPriorBoost": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Score boost applied to nodes with strong entity priors."
+      },
+      "graphRecallExpansionScoreThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Minimum blended score required to include a graph-expanded node in results."
+      },
+      "graphRecallExplainEdgeLimit": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum edges described per node in a graph recall explanation."
+      },
+      "graphRecallExplainEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Append natural-language graph reasoning explanations to recall output."
+      },
+      "graphRecallExplainMaxChars": {
+        "type": "number",
+        "default": 500,
+        "description": "Maximum characters per graph recall explanation."
+      },
+      "graphRecallExplainMaxPaths": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum reasoning paths included in a graph recall explanation."
+      },
+      "graphRecallExplainToolEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Expose a graph explain tool to agents during graph recall."
+      },
+      "graphRecallHubBias": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Bias weight toward hub-seed selection (0-1)."
+      },
+      "graphRecallMaxExpandedNodes": {
+        "type": "number",
+        "default": 30,
+        "description": "Maximum total nodes visited during graph recall expansion."
+      },
+      "graphRecallMaxExpansions": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of expansion hops per graph recall query."
+      },
+      "graphRecallMaxPerSeed": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum graph-expanded results per seed node."
+      },
+      "graphRecallMaxSeedNodes": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of seed nodes selected for graph recall expansion."
+      },
+      "graphRecallMaxTrailPerNode": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum trail length followed per node during graph traversal."
+      },
+      "graphRecallMinEdgeWeight": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Minimum edge weight to follow during graph recall traversal."
+      },
+      "graphRecallMinSeedScore": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
+      },
+      "graphRecallPreferHubSeeds": {
+        "type": "boolean",
+        "default": false,
+        "description": "Prefer high-degree hub nodes as graph recall seeds."
+      },
+      "graphRecallRecencyHalfLifeDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Half-life in days for recency decay applied to graph-expanded nodes."
+      },
+      "graphRecallShadowEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run graph recall in shadow mode - evaluate but do not add results."
+      },
+      "graphRecallShadowSampleRate": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Fraction of turns evaluated in shadow mode (0-1)."
+      },
+      "graphRecallSnapshotDir": {
+        "type": "string",
+        "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
+      },
+      "graphRecallSnapshotEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write graph recall snapshots for offline analysis."
+      },
+      "graphRecallStoreColdMirror": {
+        "type": "boolean",
+        "default": false,
+        "description": "Store cold-path graph recall results in a secondary QMD collection."
+      },
+      "graphRecallUseEntityPriors": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost seed nodes using entity prior scores during graph recall."
+      },
+      "graphTraversalConfidenceFloor": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
+      },
+      "graphTraversalPageRankIterations": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
+      },
+      "graphWriteSessionAdjacencyEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
+      },
+      "harmonicRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
+      },
       "heartbeat": {
         "type": "object",
         "additionalProperties": false,
@@ -695,86 +2572,1057 @@
           }
         }
       },
-      "codingMode": {
+      "highSignalPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Custom regex patterns for immediate extraction"
+      },
+      "hostEmbeddingProviderEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
+      },
+      "hostEmbeddingProviderId": {
+        "type": "string",
+        "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
+      },
+      "hostEmbeddingProviderModel": {
+        "type": "string",
+        "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
+      },
+      "hourlySummariesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable hourly conversation summaries"
+      },
+      "hourlySummariesExtendedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
+      },
+      "hourlySummariesIncludeSystemMessages": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include system messages in extended hourly summaries (use with care)."
+      },
+      "hourlySummariesIncludeToolStats": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
+      },
+      "hourlySummariesMaxTurnsPerRun": {
+        "type": "number",
+        "default": 200,
+        "description": "Maximum transcript turns to consider per session per hourly summarizer run."
+      },
+      "hourlySummaryCronAutoRegister": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
+      },
+      "identityContinuityEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable identity continuity workflows (anchor, incidents, audits)"
+      },
+      "identityEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
+      },
+      "identityInjectionMode": {
+        "type": "string",
+        "enum": [
+          "recovery_only",
+          "minimal",
+          "full"
+        ],
+        "default": "recovery_only",
+        "description": "Controls when identity continuity context is added to recall assembly"
+      },
+      "identityMaxInjectChars": {
+        "type": "number",
+        "default": 1200,
+        "description": "Maximum characters allowed for identity continuity context"
+      },
+      "initGateTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 30000,
+        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+      },
+      "injectQuestions": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include the most relevant open question in generated memory context"
+      },
+      "inlineSourceAttributionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
+      },
+      "inlineSourceAttributionFormat": {
+        "type": "string",
+        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
+        "description": "Template used when inline source attribution is enabled."
+      },
+      "intentRoutingBoost": {
+        "type": "number",
+        "default": 0.12,
+        "description": "Maximum score boost applied for intent-compatible memory matches."
+      },
+      "intentRoutingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Attach intent metadata to memories and boost compatible memories at recall."
+      },
+      "ircEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
+      },
+      "ircIncludeCorrections": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include corrections when building IRC rules (default on)."
+      },
+      "ircMaxPreferences": {
+        "type": "number",
+        "default": 20,
+        "description": "Maximum number of preferences to include in IRC rules."
+      },
+      "ircMinConfidence": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
+      },
+      "judgeTrainingDir": {
+        "type": "string",
+        "default": "",
+        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+      },
+      "knowledgeIndexEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Inject a compact Knowledge Index of top entities into every recall"
+      },
+      "knowledgeIndexMaxChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Hard character cap for the Knowledge Index section"
+      },
+      "knowledgeIndexMaxEntities": {
+        "type": "number",
+        "default": 40,
+        "description": "Max entities included in the Knowledge Index"
+      },
+      "lanceDbPath": {
+        "type": "string",
+        "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
+      },
+      "lanceEmbeddingDimension": {
+        "type": "number",
+        "default": 1536,
+        "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
+      },
+      "lancedbEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable LanceDB as a supplemental search backend."
+      },
+      "lcmArchiveRetentionDays": {
+        "type": "number",
+        "default": 90,
+        "description": "Days to retain archived LCM summaries"
+      },
+      "lcmDeterministicMaxTokens": {
+        "type": "number",
+        "default": 512,
+        "description": "Max tokens for deterministic (non-LLM) summaries"
+      },
+      "lcmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Lossless Context Management (LCM) subsystem"
+      },
+      "lcmFreshTailTurns": {
+        "type": "number",
+        "default": 16,
+        "description": "Number of recent turns kept verbatim (not summarized)"
+      },
+      "lcmLeafBatchSize": {
+        "type": "number",
+        "default": 8,
+        "description": "Number of turns per leaf node in the LCM DAG"
+      },
+      "lcmMaxDepth": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum depth of the LCM summary DAG"
+      },
+      "lcmObserveConcurrency": {
+        "type": "number",
+        "default": 1,
+        "description": "Maximum independent LCM observe jobs to process concurrently."
+      },
+      "lcmRecallBudgetShare": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
+      },
+      "lcmRollupFanIn": {
+        "type": "number",
+        "default": 4,
+        "description": "Number of children per rollup node in the LCM DAG"
+      },
+      "lcmTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
+      },
+      "lifecycleArchiveDecayThreshold": {
+        "type": "number",
+        "default": 0.85,
+        "description": "Decay threshold for lifecycle demotion to archived state semantics."
+      },
+      "lifecycleFilterStaleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
+      },
+      "lifecycleMetricsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
+      },
+      "lifecyclePolicyEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
+      },
+      "lifecyclePromoteHeatThreshold": {
+        "type": "number",
+        "default": 0.55,
+        "description": "Heat threshold for lifecycle promotion to validated/active states."
+      },
+      "lifecycleProtectedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decision",
+          "principle",
+          "commitment",
+          "preference",
+          "procedure"
+        ],
+        "description": "Categories that lifecycle policy will not auto-archive."
+      },
+      "lifecycleStaleDecayThreshold": {
+        "type": "number",
+        "default": 0.65,
+        "description": "Decay threshold for lifecycle demotion to stale."
+      },
+      "localLlm400CooldownMs": {
+        "type": "number",
+        "default": 120000,
+        "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
+      },
+      "localLlm400TripThreshold": {
+        "type": "number",
+        "default": 5,
+        "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
+      },
+      "localLlmApiKey": {
+        "type": "string",
+        "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
+      },
+      "localLlmAuthHeader": {
+        "type": "boolean",
+        "default": true,
+        "description": "If false, do not send Authorization header even when localLlmApiKey is set"
+      },
+      "localLlmDisableThinking": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+      },
+      "localLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
+      },
+      "localLlmFallback": {
+        "type": "boolean",
+        "default": true,
+        "description": "Fall back to cloud OpenAI if local LLM is unavailable"
+      },
+      "localLlmFastEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
+      },
+      "localLlmFastModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
+      },
+      "localLlmFastTimeoutMs": {
+        "type": "number",
+        "default": 15000,
+        "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
+      },
+      "localLlmFastUrl": {
+        "type": "string",
+        "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
+      },
+      "localLlmHeaders": {
         "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Coding-agent project/branch scoping (issue #569).",
-        "properties": {
-          "projectScope": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
-          },
-          "branchScope": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
-          },
-          "globalFallback": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
-          }
+        "description": "Optional additional headers for local/compatible endpoint requests",
+        "additionalProperties": {
+          "type": "string"
         }
       },
-      "codingKnowledge": {
+      "localLlmHomeDir": {
+        "type": "string",
+        "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
+      },
+      "localLlmMaxContext": {
+        "type": "number",
+        "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
+      },
+      "localLlmModel": {
+        "type": "string",
+        "default": "local-model",
+        "description": "Model name for local LLM requests"
+      },
+      "localLlmRetry5xxCount": {
+        "type": "number",
+        "default": 1,
+        "description": "Number of retry attempts for local LLM 5xx responses."
+      },
+      "localLlmRetryBackoffMs": {
+        "type": "number",
+        "default": 400,
+        "description": "Base backoff delay between local LLM retries (ms)."
+      },
+      "localLlmTimeoutMs": {
+        "type": "number",
+        "default": 180000,
+        "description": "Hard timeout for local LLM requests (ms)"
+      },
+      "localLlmUrl": {
+        "type": "string",
+        "default": "http://localhost:1234/v1",
+        "description": "URL for local LLM OpenAI-compatible endpoint"
+      },
+      "localLmsBinDir": {
+        "type": "string",
+        "description": "Optional bin directory prepended to PATH for LMS CLI execution."
+      },
+      "localLmsCliPath": {
+        "type": "string",
+        "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
+      },
+      "maintenanceIncludeBranchNamespaces": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+      },
+      "maintenanceIncludeProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceIncludeTeamProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceMaxNamespacesPerCycle": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+      },
+      "maintenanceNamespaceFanoutEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+      },
+      "maintenanceNamespaceLockStaleMs": {
+        "type": "number",
+        "default": 600000,
+        "minimum": 1,
+        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
+      },
+      "maxCompressionTokensPerHour": {
+        "type": "number",
+        "default": 1500,
+        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
+      },
+      "maxEntityGraphEdgesPerMemory": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum entity graph edges written per memory write. Default 10."
+      },
+      "maxGraphTraversalSteps": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum BFS hops during spreading activation. Default 3."
+      },
+      "maxMemoryTokens": {
+        "type": "number",
+        "default": 2000,
+        "description": "Max memory-context tokens per turn"
+      },
+      "maxProactiveQuestionsPerExtraction": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
+      },
+      "maxSummaryCount": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum number of summaries to include"
+      },
+      "maxTranscriptTokens": {
+        "type": "number",
+        "default": 1000,
+        "description": "Maximum tokens for transcript context"
+      },
+      "maxTranscriptTurns": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum transcript turns to include"
+      },
+      "meilisearchApiKey": {
+        "type": "string",
+        "description": "API key for Meilisearch (when searchBackend=meilisearch)"
+      },
+      "meilisearchAutoIndex": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
+      },
+      "meilisearchEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Meilisearch as a supplemental search backend."
+      },
+      "meilisearchHost": {
+        "type": "string",
+        "default": "http://localhost:7700",
+        "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
+      },
+      "meilisearchTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
+      },
+      "memoryBoxesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
+      },
+      "memoryDir": {
+        "type": "string",
+        "description": "Override memory storage directory"
+      },
+      "memoryExtensionsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
+      },
+      "memoryExtensionsRoot": {
+        "type": "string",
+        "default": "",
+        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
+      "memoryLinkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic memory linking to build knowledge graph"
+      },
+      "memoryOsPreset": {
+        "type": "string",
+        "enum": [
+          "conservative",
+          "balanced",
+          "research",
+          "research-max",
+          "local-llm-heavy"
+        ],
+        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+      },
+      "memoryPoisoningDefenseEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
+      },
+      "memoryReconstructionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
+      },
+      "memoryReconstructionMaxExpansions": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of entity expansions per recall cycle"
+      },
+      "memoryRedTeamBenchEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
+      },
+      "memoryUtilityLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
+      },
+      "messagePartsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
+      },
+      "messagePartsRecallMaxResults": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
+      },
+      "model": {
+        "type": "string",
+        "default": "gpt-5.5",
+        "description": "OpenAI model for extraction/consolidation"
+      },
+      "modelSource": {
+        "type": "string",
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+      },
+      "multiGraphMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
+      },
+      "namespaceCatalogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+      },
+      "namespacePolicies": {
+        "type": "array",
+        "description": "Namespace access policies.",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "readPrincipals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "writePrincipals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "includeInRecallByDefault": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "readPrincipals",
+            "writePrincipals"
+          ]
+        }
+      },
+      "namespacesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable multi-agent namespaces (v3.0). Default off."
+      },
+      "nativeKnowledge": {
         "type": "object",
         "additionalProperties": false,
-        "default": {},
-        "description": "Durable coding-knowledge surface — Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
+        "description": "Optional: search curated workspace markdown files directly during recall without converting them into durable memory files.",
         "properties": {
           "enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
+            "description": "Master switch for curated workspace file recall."
           },
-          "decisionRecords": {
-            "type": "boolean",
-            "default": true,
-            "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
-          },
-          "architectureCard": {
-            "type": "boolean",
-            "default": true,
-            "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
-          },
-          "sessionDelta": {
-            "type": "boolean",
-            "default": true,
-            "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
-          },
-          "architectureCardLlmSummary": {
-            "type": "boolean",
-            "default": false,
-            "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
-          },
-          "structuralProvider": {
-            "type": "string",
-            "enum": [
-              "none",
-              "subprocess",
-              "native"
+          "includeFiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "IDENTITY.md",
+              "MEMORY.md"
             ],
-            "default": "none",
-            "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
+            "description": "Workspace-relative curated markdown files to scan for native knowledge recall."
           },
-          "structuralProviderCommand": {
+          "maxChunkChars": {
+            "type": "number",
+            "default": 900,
+            "description": "Maximum chunk size per native knowledge section before it is split."
+          },
+          "maxResults": {
+            "type": "number",
+            "default": 4,
+            "description": "Maximum native knowledge chunks to add to recall."
+          },
+          "maxChars": {
+            "type": "number",
+            "default": 2400,
+            "description": "Maximum total characters to add from native knowledge recall."
+          },
+          "stateDir": {
             "type": "string",
-            "default": "",
-            "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
+            "default": "state/native-knowledge",
+            "description": "Memory-relative directory used for backend-agnostic native knowledge sync state."
           },
-          "codegraphTools": {
-            "type": "boolean",
-            "default": false,
-            "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default — tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
+          "openclawWorkspace": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional adapter for OpenClaw workspace artifacts such as bootstrap docs, handoffs, daily summaries, and automation notes.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable the OpenClaw workspace native-knowledge adapter."
+              },
+              "bootstrapFiles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [
+                  "IDENTITY.md",
+                  "MEMORY.md",
+                  "USER.md"
+                ],
+                "description": "Workspace-relative bootstrap docs treated as high-confidence native knowledge."
+              },
+              "handoffGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [
+                  "**/*handoff*.md",
+                  "handoffs/**/*.md"
+                ],
+                "description": "Glob patterns (relative to workspaceDir) used to discover handoff notes."
+              },
+              "dailySummaryGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [
+                  "**/*daily*summary*.md",
+                  "summaries/**/*.md"
+                ],
+                "description": "Glob patterns (relative to workspaceDir) used to discover daily summary notes."
+              },
+              "automationNoteGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Optional glob patterns for automation-written status or operating notes."
+              },
+              "workspaceDocGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Optional glob patterns for other explicitly allowlisted workspace docs."
+              },
+              "excludeGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Additional glob patterns appended to the built-in workspace safety excludes."
+              },
+              "sharedSafeGlobs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Optional glob patterns that should be tagged as shared-safe when no explicit privacy class is present."
+              }
+            },
+            "required": [
+              "enabled"
+            ]
           },
-          "codegraphDbDir": {
-            "type": "string",
-            "default": "",
-            "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+          "obsidianVaults": {
+            "type": "array",
+            "default": [],
+            "description": "Optional Obsidian vault adapters to sync into backend-agnostic native knowledge records.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable vault identifier used in synced note metadata."
+                },
+                "rootDir": {
+                  "type": "string",
+                  "description": "Absolute path to the Obsidian vault root."
+                },
+                "includeGlobs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "**/*.md"
+                  ],
+                  "description": "Glob patterns (relative to the vault root) that are eligible for sync."
+                },
+                "excludeGlobs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    ".obsidian/**",
+                    "**/*.canvas",
+                    "**/*.png",
+                    "**/*.jpg",
+                    "**/*.jpeg",
+                    "**/*.gif",
+                    "**/*.pdf"
+                  ],
+                  "description": "Glob patterns excluded from sync."
+                },
+                "namespace": {
+                  "type": "string",
+                  "description": "Default namespace assigned to records from this vault."
+                },
+                "privacyClass": {
+                  "type": "string",
+                  "description": "Operator-defined privacy class preserved on synced records."
+                },
+                "folderRules": {
+                  "type": "array",
+                  "default": [],
+                  "description": "Optional per-folder overrides for namespace or privacy classification.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "pathPrefix": {
+                        "type": "string",
+                        "description": "Vault-relative folder prefix that activates the override."
+                      },
+                      "namespace": {
+                        "type": "string",
+                        "description": "Namespace override for matching notes."
+                      },
+                      "privacyClass": {
+                        "type": "string",
+                        "description": "Privacy-class override for matching notes."
+                      }
+                    },
+                    "required": [
+                      "pathPrefix"
+                    ]
+                  }
+                },
+                "dailyNotePatterns": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "YYYY-MM-DD"
+                  ],
+                  "description": "Filename patterns used to derive daily-note dates (for example `YYYY-MM-DD` or `YYYY/MM/DD`)."
+                },
+                "materializeBacklinks": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "If true, compute backlinks from wikilink targets for recall hints and explainability."
+                }
+              },
+              "required": [
+                "rootDir"
+              ]
+            }
           }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "negativeExamplesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable negative examples (track retrieved-but-not-useful memories) and apply a small ranking penalty."
+      },
+      "negativeExamplesPenaltyCap": {
+        "type": "number",
+        "default": 0.25,
+        "description": "Maximum ranking penalty applied from negative examples."
+      },
+      "negativeExamplesPenaltyPerHit": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
+      },
+      "nightlyGovernanceCronAutoRegister": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
+      },
+      "objectiveStateMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
+      },
+      "objectiveStateRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant objective-state snapshots to recall context."
+      },
+      "objectiveStateSnapshotWritesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow writing typed objective-state snapshots to the objective-state store."
+      },
+      "objectiveStateStoreDir": {
+        "type": "string",
+        "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
+      },
+      "openaiApiKey": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "const": false
+          }
+        ],
+        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+      },
+      "openaiBaseUrl": {
+        "type": "string",
+        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+      },
+      "openclawChannelEnvelopeCleaningEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
+      },
+      "openclawFlushPlanProcessingEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
+      },
+      "openclawMessageReceivedCaptureEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
+      },
+      "openclawReplyMetadataCaptureEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
+      },
+      "openclawReplyMetadataExtractionHintsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
+      },
+      "openclawToolSnippetMaxChars": {
+        "type": "integer",
+        "minimum": 80,
+        "maximum": 4000,
+        "default": 600,
+        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
+      },
+      "openclawToolsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
+      },
+      "operatorAwareConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+      },
+      "oramaDbPath": {
+        "type": "string",
+        "description": "Directory path for Orama persistence files (when searchBackend=orama)"
+      },
+      "oramaEmbeddingDimension": {
+        "type": "number",
+        "default": 1536,
+        "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
+      },
+      "oramaEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Orama as a supplemental search backend."
+      },
+      "parallelAgentWeights": {
+        "type": "object",
+        "default": {
+          "direct": 1,
+          "contextual": 0.7,
+          "temporal": 0.85
+        },
+        "description": "Score weights per retrieval agent source applied during result merge."
+      },
+      "parallelMaxResultsPerAgent": {
+        "type": "number",
+        "default": 20,
+        "description": "Maximum results fetched per agent before merge."
+      },
+      "parallelRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
+      },
+      "patternReinforcementCadenceMs": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 604800000,
+        "description": "Minimum interval (ms) between pattern-reinforcement runs. Default 7 days. Set to 0 to disable cadence gating (manual / test invocation)."
+      },
+      "patternReinforcementCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "preference",
+          "fact",
+          "decision"
+        ],
+        "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
+      },
+      "patternReinforcementEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
+      },
+      "patternReinforcementMinCount": {
+        "type": "integer",
+        "minimum": 2,
+        "maximum": 1000,
+        "default": 3,
+        "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
+      },
+      "peerProfileReasonerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
+      },
+      "peerProfileReasonerMaxFieldsPerRun": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+      },
+      "peerProfileReasonerMinInteractions": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+      },
+      "peerProfileReasonerModel": {
+        "type": "string",
+        "default": "auto",
+        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+      },
+      "peerProfileRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
+      },
+      "peerProfileRecallMaxFields": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
+      },
+      "principalFromSessionKeyMode": {
+        "type": "string",
+        "enum": [
+          "map",
+          "prefix",
+          "regex"
+        ],
+        "default": "map",
+        "description": "How to derive principal identity from sessionKey."
+      },
+      "principalFromSessionKeyRules": {
+        "type": "array",
+        "description": "Rules for resolving principal from sessionKey (ordered).",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "match": {
+              "type": "string"
+            },
+            "principal": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "match",
+            "principal"
+          ]
         }
+      },
+      "proactiveExtractionCategoryAllowlist": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
+      },
+      "proactiveExtractionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
+      },
+      "proactiveExtractionMaxTokens": {
+        "type": "number",
+        "default": 900,
+        "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
+      },
+      "proactiveExtractionTimeoutMs": {
+        "type": "number",
+        "default": 2500,
+        "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
       },
       "procedural": {
         "type": "object",
@@ -832,6 +3680,1611 @@
             "description": "When true, installer may register the nightly procedural mining cron job."
           }
         }
+      },
+      "profilingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
+      },
+      "profilingMaxTraces": {
+        "type": "number",
+        "default": 100,
+        "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
+      },
+      "profilingStorageDir": {
+        "type": "string",
+        "default": "",
+        "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
+      },
+      "promotionByOutcomeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
+      },
+      "provenance": {
+        "type": "object",
+        "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
+          },
+          "maxQuoteChars": {
+            "type": "integer",
+            "default": 300,
+            "minimum": 1,
+            "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
+          },
+          "requireSpans": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
+          }
+        }
+      },
+      "qmdAutoEmbedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
+      },
+      "qmdAutoUpgradeCheckIntervalMs": {
+        "type": "number",
+        "minimum": 60000,
+        "default": 86400000,
+        "description": "Minimum interval between QMD auto-upgrade checks"
+      },
+      "qmdAutoUpgradeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+      },
+      "qmdCandidateLimit": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Optional candidate limit forwarded to supported QMD query paths"
+      },
+      "qmdChunkStrategy": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "regex"
+        ],
+        "default": "auto",
+        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+      },
+      "qmdColdCollection": {
+        "type": "string",
+        "default": "openclaw-engram-cold",
+        "description": "Secondary QMD collection name used for cold-tier fallback recall"
+      },
+      "qmdColdMaxResults": {
+        "type": "number",
+        "default": 8,
+        "description": "Max cold-tier QMD results considered before final recall cap"
+      },
+      "qmdColdTierEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
+      },
+      "qmdCollection": {
+        "type": "string",
+        "default": "openclaw-engram",
+        "description": "QMD collection name"
+      },
+      "qmdDaemonEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Prefer the shared QMD MCP session for faster searches when available."
+      },
+      "qmdDaemonRecheckIntervalMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Re-probe interval when daemon is down (ms)"
+      },
+      "qmdDaemonTimeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 8000,
+        "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
+      },
+      "qmdDaemonUrl": {
+        "type": "string",
+        "default": "http://localhost:8181/mcp",
+        "description": "Legacy compatibility setting retained for QMD daemon configuration."
+      },
+      "qmdEmbedMinIntervalMs": {
+        "type": "number",
+        "default": 3600000,
+        "description": "Minimum interval between background QMD embed runs (ms)."
+      },
+      "qmdEmbedModel": {
+        "type": "string",
+        "description": "Optional QMD_EMBED_MODEL override"
+      },
+      "qmdEmbedParallelism": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 8,
+        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+      },
+      "qmdEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use QMD for search"
+      },
+      "qmdExplainEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Request QMD explain traces for recall debugging when supported."
+      },
+      "qmdForceCpu": {
+        "type": "boolean",
+        "default": false,
+        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+      },
+      "qmdGenerateModel": {
+        "type": "string",
+        "description": "Optional QMD_GENERATE_MODEL override"
+      },
+      "qmdGpuBackend": {
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "enum": [
+          "auto",
+          "metal",
+          "cuda",
+          "vulkan",
+          "false",
+          false
+        ],
+        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+      },
+      "qmdIndexName": {
+        "type": "string",
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
+      },
+      "qmdIntentHintsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
+      },
+      "qmdMaintenanceDebounceMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Debounce window for background QMD maintenance updates (ms)."
+      },
+      "qmdMaintenanceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
+      },
+      "qmdMaxResults": {
+        "type": "number",
+        "default": 8,
+        "description": "Max QMD results per search"
+      },
+      "qmdPath": {
+        "type": "string",
+        "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
+      },
+      "qmdQueryRerankEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+      },
+      "qmdRecallCacheMaxEntries": {
+        "type": "number",
+        "default": 128,
+        "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
+      },
+      "qmdRecallCacheStaleTtlMs": {
+        "type": "number",
+        "default": 600000,
+        "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
+      },
+      "qmdRecallCacheTtlMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
+      },
+      "qmdRerankModel": {
+        "type": "string",
+        "description": "Optional QMD_RERANK_MODEL override"
+      },
+      "qmdSearchStrategy": {
+        "type": "string",
+        "enum": [
+          "hybrid",
+          "lex-vec",
+          "lex"
+        ],
+        "default": "hybrid",
+        "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
+      },
+      "qmdSubprocessStrategy": {
+        "type": "string",
+        "enum": [
+          "query",
+          "search"
+        ],
+        "default": "query",
+        "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
+      },
+      "qmdSupportedVersion": {
+        "type": "string",
+        "default": "2.5.3",
+        "description": "Highest QMD version this Remnic build will auto-install"
+      },
+      "qmdTierAutoBackfillEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
+      },
+      "qmdTierDemotionMinAgeDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Minimum hot-memory age in days before tier demotion is eligible"
+      },
+      "qmdTierDemotionValueThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
+      },
+      "qmdTierMigrationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable value-aware migration between hot and cold QMD tiers"
+      },
+      "qmdTierParityGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierParityHiMemEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierPromotionValueThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
+      },
+      "qmdUpdateMinIntervalMs": {
+        "type": "number",
+        "default": 900000,
+        "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
+      },
+      "qmdUpdateTimeoutMs": {
+        "type": "number",
+        "default": 90000,
+        "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
+      },
+      "quarantinePromotionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Reserve future promotion flows from quarantine into higher-trust zones."
+      },
+      "queryAwareIndexingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
+      },
+      "queryAwareIndexingMaxCandidates": {
+        "type": "number",
+        "default": 200,
+        "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
+      },
+      "queryExpansionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
+      },
+      "queryExpansionMaxQueries": {
+        "type": "number",
+        "default": 4,
+        "description": "Max expanded queries to run (including the original prompt)."
+      },
+      "queryExpansionMinTokenLen": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum token length to include in heuristic query expansion."
+      },
+      "reasoningEffort": {
+        "type": "string",
+        "enum": [
+          "none",
+          "low",
+          "medium",
+          "high"
+        ],
+        "default": "low",
+        "description": "Reasoning effort for extraction"
+      },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+      },
+      "recallBudgetChars": {
+        "type": "number",
+        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
+      },
+      "recallConfidenceGateEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
+      },
+      "recallConfidenceGateThreshold": {
+        "type": "number",
+        "default": 0.12,
+        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
+      },
+      "recallCoreDeadlineMs": {
+        "type": "number",
+        "default": 75000,
+        "description": "Default deadline in ms recorded for core recall sections."
+      },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallDirectAnswerAmbiguityMargin": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.15,
+        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+      },
+      "recallDirectAnswerEligibleTaxonomyBuckets": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decisions",
+          "principles",
+          "conventions",
+          "runbooks",
+          "entities"
+        ],
+        "description": "Taxonomy category IDs eligible for direct-answer routing."
+      },
+      "recallDirectAnswerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
+      },
+      "recallDirectAnswerImportanceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerTokenOverlapFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.55,
+        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDisclosureEscalation": {
+        "type": "string",
+        "enum": [
+          "manual",
+          "auto"
+        ],
+        "default": "manual",
+        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+      },
+      "recallDisclosureEscalationThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.5,
+        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+      },
+      "recallEnrichmentDeadlineMs": {
+        "type": "number",
+        "default": 25000,
+        "description": "Default deadline in ms recorded for enrichment recall sections."
+      },
+      "recallGraphDamping": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.999999999,
+        "default": 0.85,
+        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+      },
+      "recallGraphEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
+      },
+      "recallGraphIterations": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 500,
+        "default": 20,
+        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+      },
+      "recallGraphTopK": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 10000,
+        "default": 50,
+        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
+      },
+      "recallHandleSnapshotDepth": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 5,
+        "description": "Issue #1582 — number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
+      },
+      "recallMemoryHandles": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #1582 — append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
+      },
+      "recallMemoryWorthFilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
+      },
+      "recallMemoryWorthHalfLifeMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
+      },
+      "recallMmrEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
+      },
+      "recallMmrLambda": {
+        "type": "number",
+        "default": 0.7,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
+      },
+      "recallMmrTopN": {
+        "type": "number",
+        "default": 40,
+        "minimum": 0,
+        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
+      },
+      "recallOuterTimeoutMs": {
+        "type": "number",
+        "default": 75000,
+        "description": "Outer timeout in ms for the full recall pipeline."
+      },
+      "recallPipeline": {
+        "type": "array",
+        "description": "Ordered recall sections with per-section budgets and feature knobs.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "maxChars": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "consolidateTriggerLines": {
+              "type": "number"
+            },
+            "consolidateTargetLines": {
+              "type": "number"
+            },
+            "maxEntities": {
+              "type": "number"
+            },
+            "maxResults": {
+              "type": "number"
+            },
+            "maxTurns": {
+              "type": "number"
+            },
+            "maxTokens": {
+              "type": "number"
+            },
+            "lookbackHours": {
+              "type": "number"
+            },
+            "maxCount": {
+              "type": "number"
+            },
+            "topK": {
+              "type": "number"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "maxPatterns": {
+              "type": "number"
+            },
+            "forceGeneric": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "id"
+          ]
+        }
+      },
+      "recallPlannerEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
+      },
+      "recallPlannerLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+      },
+      "recallPlannerMaxMemoryHints": {
+        "type": "number",
+        "default": 24,
+        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
+      },
+      "recallPlannerMaxPromptChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Maximum characters of prompt context to send to the recall planner."
+      },
+      "recallPlannerMaxQmdResultsFull": {
+        "type": "number",
+        "default": 8,
+        "description": "QMD cap used when recall planner selects full mode."
+      },
+      "recallPlannerMaxQmdResultsMinimal": {
+        "type": "number",
+        "default": 4,
+        "description": "QMD cap used when recall planner selects minimal mode."
+      },
+      "recallPlannerModel": {
+        "type": "string",
+        "default": "gpt-5.5",
+        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
+      },
+      "recallPlannerShadowMode": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
+      },
+      "recallPlannerTelemetryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Emit telemetry events for recall planner decisions."
+      },
+      "recallPlannerTimeoutMs": {
+        "type": "number",
+        "default": 1500,
+        "description": "Timeout in ms for recall planner inference."
+      },
+      "recallPlannerUseResponsesApi": {
+        "type": "boolean",
+        "default": true,
+        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
+      },
+      "recallReasoningTraceBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+      },
+      "recallTranscriptRetentionDays": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 365,
+        "default": 30,
+        "description": "Days of runtime recall audit transcripts to retain before pruning."
+      },
+      "recallTranscriptsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
+      },
+      "recencyWeight": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Weight for recency boosting in search (0-1)"
+      },
+      "recordEmptyRecallImpressions": {
+        "type": "boolean",
+        "default": false,
+        "description": "Record recall impressions with empty memoryIds when no memory context is added."
+      },
+      "reinforcementRecallBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
+      },
+      "reinforcementRecallBoostMax": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.3,
+        "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
+      },
+      "reinforcementRecallBoostWeight": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.05,
+        "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
+      },
+      "remoteSearchApiKey": {
+        "type": "string",
+        "description": "API key for remote search backend (when searchBackend=remote)"
+      },
+      "remoteSearchBaseUrl": {
+        "type": "string",
+        "description": "Base URL for remote search backend (when searchBackend=remote)"
+      },
+      "remoteSearchTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout in ms for remote search backend requests"
+      },
+      "rerankCacheEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Cache re-ranking results in-memory for repeated queries."
+      },
+      "rerankCacheTtlMs": {
+        "type": "number",
+        "default": 3600000,
+        "description": "TTL for in-memory re-ranking cache (ms)."
+      },
+      "rerankEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable LLM re-ranking of retrieved memories. Default off."
+      },
+      "rerankMaxCandidates": {
+        "type": "number",
+        "default": 20,
+        "description": "Max candidates to send to the re-ranker."
+      },
+      "rerankProvider": {
+        "type": "string",
+        "default": "local",
+        "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
+        "enum": [
+          "local",
+          "cloud"
+        ]
+      },
+      "rerankTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
+      },
+      "respectBundledActiveMemoryToggle": {
+        "type": "boolean",
+        "default": true,
+        "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
+      },
+      "responseGuidanceRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable response guidance recall for user answer-shape preferences."
+      },
+      "responseGuidanceRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the response guidance recall section."
+      },
+      "responseGuidanceRecallMaxResults": {
+        "type": "integer",
+        "default": 48,
+        "minimum": 0,
+        "description": "Maximum recalled items for response guidance."
+      },
+      "responseGuidanceRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 16000,
+        "minimum": 1,
+        "description": "Recent-token scan window for response guidance."
+      },
+      "responseGuidanceRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 64,
+        "minimum": 1,
+        "description": "Recent-turn scan window for response guidance."
+      },
+      "resumeBundleDir": {
+        "type": "string",
+        "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
+      },
+      "resumeBundlesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
+      },
+      "routingRulesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable custom memory routing rules (v8.7). Default off."
+      },
+      "routingRulesStateFile": {
+        "type": "string",
+        "default": "state/routing-rules.json",
+        "description": "Relative path under memoryDir for persisted routing rules."
+      },
+      "scopeProfiles": {
+        "type": "object",
+        "default": {},
+        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "readOrder": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "writeDefault": {
+              "type": "string",
+              "enum": [
+                "userProject",
+                "teamProject",
+                "userGlobal",
+                "serverShared"
+              ]
+            },
+            "promotionTargets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "userProject",
+                  "teamProject",
+                  "userGlobal",
+                  "serverShared"
+                ]
+              }
+            },
+            "teamProject": {
+              "type": "object",
+              "properties": {
+                "namespaceTemplate": {
+                  "type": "string"
+                },
+                "teamId": {
+                  "type": "string"
+                }
+              }
+            },
+            "autoPromote": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "targets": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "teamProject",
+                      "serverShared",
+                      "userGlobal",
+                      "userProject"
+                    ]
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "minConfidenceTier": {
+                  "type": "string",
+                  "enum": [
+                    "explicit",
+                    "implied",
+                    "inferred",
+                    "speculative"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "searchBackend": {
+        "type": "string",
+        "enum": [
+          "qmd",
+          "remote",
+          "noop",
+          "lancedb",
+          "meilisearch",
+          "orama"
+        ],
+        "default": "qmd",
+        "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
+      },
+      "secureStoreEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
+      },
+      "secureStoreEncryptOnWrite": {
+        "type": "boolean",
+        "default": true,
+        "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
+      },
+      "semanticChunkingConfig": {
+        "type": "object",
+        "default": {},
+        "description": "Optional overrides for the semantic chunking algorithm",
+        "properties": {
+          "targetTokens": {
+            "type": "number",
+            "default": 200,
+            "description": "Target tokens per chunk"
+          },
+          "minTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Minimum tokens for a segment before merging with neighbor"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 400,
+            "description": "Maximum tokens for a segment before recursive splitting"
+          },
+          "smoothingWindowSize": {
+            "type": "number",
+            "default": 3,
+            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+          },
+          "boundaryThresholdStdDevs": {
+            "type": "number",
+            "default": 1,
+            "description": "Standard deviations below mean for boundary detection"
+          },
+          "embeddingBatchSize": {
+            "type": "number",
+            "default": 32,
+            "description": "Batch size for embedding requests"
+          },
+          "fallbackToRecursive": {
+            "type": "boolean",
+            "default": true,
+            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          }
+        }
+      },
+      "semanticChunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+      },
+      "semanticConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable periodic semantic consolidation of similar memories."
+      },
+      "semanticConsolidationExcludeCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "correction",
+          "commitment",
+          "procedure"
+        ],
+        "description": "Memory categories excluded from semantic consolidation."
+      },
+      "semanticConsolidationIntervalHours": {
+        "type": "number",
+        "default": 168,
+        "description": "Hours between automatic consolidation runs (168 = weekly)."
+      },
+      "semanticConsolidationMaxPerRun": {
+        "type": "number",
+        "default": 100,
+        "description": "Max memories to consolidate per run to limit LLM cost."
+      },
+      "semanticConsolidationMinClusterSize": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum cluster size before consolidation triggers."
+      },
+      "semanticConsolidationModel": {
+        "type": "string",
+        "default": "auto",
+        "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
+      },
+      "semanticConsolidationThreshold": {
+        "type": "number",
+        "default": 0.8,
+        "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
+      },
+      "semanticDedupCandidates": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
+      },
+      "semanticDedupEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Issue #373 — enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
+      },
+      "semanticDedupThreshold": {
+        "type": "number",
+        "default": 0.92,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
+      },
+      "semanticRulePromotionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
+      },
+      "semanticRuleVerificationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
+      },
+      "sessionObserverBands": {
+        "type": "array",
+        "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maxBytes": {
+              "type": "number"
+            },
+            "triggerDeltaBytes": {
+              "type": "number"
+            },
+            "triggerDeltaTokens": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "maxBytes",
+            "triggerDeltaBytes",
+            "triggerDeltaTokens"
+          ]
+        },
+        "default": [
+          {
+            "maxBytes": 50000,
+            "triggerDeltaBytes": 4800,
+            "triggerDeltaTokens": 1200
+          },
+          {
+            "maxBytes": 200000,
+            "triggerDeltaBytes": 9600,
+            "triggerDeltaTokens": 2400
+          },
+          {
+            "maxBytes": 1000000000,
+            "triggerDeltaBytes": 19200,
+            "triggerDeltaTokens": 4800
+          }
+        ]
+      },
+      "sessionObserverDebounceMs": {
+        "type": "number",
+        "default": 120000,
+        "description": "Minimum interval between heartbeat observer triggers per session (ms)."
+      },
+      "sessionObserverEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
+      },
+      "sessionTogglesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
+      },
+      "sharedContextDir": {
+        "type": "string",
+        "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
+      },
+      "sharedContextEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable shared-context assembly and tools (v4.0). Default off."
+      },
+      "sharedContextMaxInjectChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Max characters of shared-context to include in each recall context."
+      },
+      "sharedCrossSignalSemanticEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
+      },
+      "sharedCrossSignalSemanticMaxCandidates": {
+        "type": "number",
+        "default": 120,
+        "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
+      },
+      "sharedCrossSignalSemanticTimeoutMs": {
+        "type": "number",
+        "default": 4000,
+        "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
+      },
+      "sharedNamespace": {
+        "type": "string",
+        "default": "shared",
+        "description": "Shared namespace name."
+      },
+      "slotBehavior": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "requireExclusiveMemorySlot": {
+            "type": "boolean",
+            "default": true
+          },
+          "onSlotMismatch": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warn",
+              "silent"
+            ],
+            "default": "error"
+          }
+        }
+      },
+      "slowLogEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, log slow operations (durations + metadata; never logs content)"
+      },
+      "slowLogThresholdMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Threshold for slow operation logging (ms)"
+      },
+      "summarizationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic memory summarization/compression"
+      },
+      "summarizationImportanceThreshold": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Only compress memories with importance below this threshold"
+      },
+      "summarizationProtectedTags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "commitment",
+          "preference",
+          "decision",
+          "principle"
+        ],
+        "description": "Tags that protect memories from compression"
+      },
+      "summarizationRecentToKeep": {
+        "type": "number",
+        "default": 300,
+        "description": "Number of recent memories to keep uncompressed"
+      },
+      "summarizationTriggerCount": {
+        "type": "number",
+        "default": 1000,
+        "description": "Memory count threshold to trigger summarization"
+      },
+      "summaryModel": {
+        "type": "string",
+        "description": "Model for hourly summaries (defaults to main model)"
+      },
+      "summaryRecallHours": {
+        "type": "number",
+        "default": 24,
+        "description": "Hours of summary history to recall"
+      },
+      "tagIndexMaxEntries": {
+        "type": "number",
+        "default": 10000,
+        "description": "Maximum number of entries in the tag index."
+      },
+      "tagMaxPerMemory": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum number of tags assigned per memory."
+      },
+      "tagMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable tag-based memory indexing and recall boosting."
+      },
+      "tagRecallBoost": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Score boost applied to memories whose tags match the query."
+      },
+      "tagRecallMaxMatches": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of tag-matched memories added per recall."
+      },
+      "targetedFactRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable targeted fact evidence recall for direct answer questions."
+      },
+      "targetedFactRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the targeted fact evidence recall section."
+      },
+      "targetedFactRecallMaxResults": {
+        "type": "integer",
+        "default": 48,
+        "minimum": 0,
+        "description": "Maximum recalled items for targeted fact evidence."
+      },
+      "targetedFactRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 12000,
+        "minimum": 1,
+        "description": "Recent-token scan window for targeted fact evidence."
+      },
+      "targetedFactRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 8,
+        "minimum": 1,
+        "description": "Recent-turn scan window for targeted fact evidence."
+      },
+      "taskModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+        "required": [
+          "primary"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "primary": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
+      "taxonomyAutoGenResolver": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
+      },
+      "taxonomyEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
+      },
+      "teams": {
+        "type": "object",
+        "default": {},
+        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "principals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "projectNamespaceTemplate": {
+              "type": "string"
+            },
+            "read": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "write": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "promote": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "temporalBiTemporal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
+      },
+      "temporalBoostRecentDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Memories from the last N days receive a recency boost during recall."
+      },
+      "temporalBoostScore": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Score boost applied to recent memories during recall."
+      },
+      "temporalDecayEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply temporal decay to older memories during recall scoring."
+      },
+      "temporalExpiredInInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
+      },
+      "temporalIndexMaxEntries": {
+        "type": "number",
+        "default": 5000,
+        "description": "Maximum number of entries in the temporal index."
+      },
+      "temporalIndexWindowDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Number of days to include in the temporal index window."
+      },
+      "temporalMemoryTreeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
+      },
+      "temporalSupersessionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
+      },
+      "temporalSupersessionIncludeInRecall": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
+      },
+      "threadingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable conversation threading"
+      },
+      "threadingGapMinutes": {
+        "type": "number",
+        "default": 30,
+        "description": "Minutes of gap to start a new thread"
+      },
+      "timeGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
+      },
+      "tmtHourlyMinMemories": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
+      },
+      "tmtSummaryMaxTokens": {
+        "type": "number",
+        "default": 300,
+        "description": "Max tokens for each TMT summary node. Default: 300."
+      },
+      "tombstonesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active — visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
+      },
+      "tombstonesSemanticMatch": {
+        "type": "boolean",
+        "default": false,
+        "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
+      },
+      "tombstonesSemanticThreshold": {
+        "type": "number",
+        "default": 0.9,
+        "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
+      },
+      "topicExtractionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable topic extraction during consolidation"
+      },
+      "topicExtractionTopN": {
+        "type": "number",
+        "default": 50,
+        "description": "Number of top topics to extract"
+      },
+      "traceRecallContent": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
+      },
+      "traceWeaverEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
+      },
+      "traceWeaverLookbackDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Days back to search for trace links."
+      },
+      "traceWeaverOverlapThreshold": {
+        "type": "number",
+        "default": 0.4,
+        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
+      },
+      "transcriptEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable transcript archiving"
+      },
+      "transcriptRecallHours": {
+        "type": "number",
+        "default": 12,
+        "description": "Hours of transcript history to recall"
+      },
+      "transcriptRetentionDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Days to retain transcript entries"
+      },
+      "transcriptSkipChannelTypes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "cron"
+        ],
+        "description": "Channel types to skip from transcript logging (e.g., cron)"
+      },
+      "triggerMode": {
+        "type": "string",
+        "enum": [
+          "smart",
+          "every_n",
+          "time_based"
+        ],
+        "default": "smart",
+        "description": "Buffer trigger mode"
+      },
+      "trustScoreEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Master gate for the unified TrustScore recall stage (#1577). When off the stage is absent and ranking is byte-identical to the pre-feature pipeline. Flip via #1574 ablation evidence only."
+      },
+      "trustScoreEpistemicRendering": {
+        "type": "boolean",
+        "default": false,
+        "description": "Append deterministic trust hedges to injected memory lines so the downstream model knows each memory's epistemic status (#1577). Separate gate from scoring."
+      },
+      "trustScoreMaxMultiplier": {
+        "type": "number",
+        "default": 1.25,
+        "description": "Upper bound of the trust multiplier mapping [0,1] → [minMultiplier, maxMultiplier] (#1577)."
+      },
+      "trustScoreMinMultiplier": {
+        "type": "number",
+        "default": 0.5,
+        "description": "Lower bound of the trust multiplier mapping [0,1] → [minMultiplier, maxMultiplier] (#1577)."
+      },
+      "trustScoreQuarantine": {
+        "type": "boolean",
+        "default": true,
+        "description": "Exclude hard-negative (quarantine-band) memories from injection while keeping them visible in X-ray with the reason (#1577). Only effective under trustScoreEnabled."
+      },
+      "trustScoreWeights": {
+        "type": "object",
+        "description": "Per-component trust weights (#1577). Keys: memoryWorth, provenance, faithfulness, corroboration, contradiction, domainCalibration, feedback, recency. Values are numbers in [0,1]; sum-normalized at parse. Invalid entries are dropped (rule 51).",
+        "default": {},
+        "properties": {
+          "memoryWorth": {
+            "type": "number"
+          },
+          "provenance": {
+            "type": "number"
+          },
+          "faithfulness": {
+            "type": "number"
+          },
+          "corroboration": {
+            "type": "number"
+          },
+          "contradiction": {
+            "type": "number"
+          },
+          "domainCalibration": {
+            "type": "number"
+          },
+          "feedback": {
+            "type": "number"
+          },
+          "recency": {
+            "type": "number"
+          }
+        }
+      },
+      "trustZoneRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
+      },
+      "trustZoneStoreDir": {
+        "type": "string",
+        "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
+      },
+      "trustZonesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
+      },
+      "verbatimArtifactCategories": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "fact",
+            "preference",
+            "correction",
+            "entity",
+            "decision",
+            "relationship",
+            "principle",
+            "commitment",
+            "moment",
+            "skill",
+            "procedure"
+          ]
+        },
+        "default": [
+          "decision",
+          "correction",
+          "principle",
+          "commitment"
+        ],
+        "description": "Memory categories eligible for artifact extraction."
+      },
+      "verbatimArtifactsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write quote-first artifact anchors during extraction and include them in recall."
+      },
+      "verbatimArtifactsMaxRecall": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum artifact anchors added per recall."
+      },
+      "verbatimArtifactsMinConfidence": {
+        "type": "number",
+        "default": 0.8,
+        "description": "Minimum extraction confidence required before writing an artifact."
+      },
+      "verboseRecallVisibility": {
+        "type": "boolean",
+        "default": true,
+        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
+      },
+      "verifiedRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+      },
+      "versioningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable page-level versioning with sidecar snapshots."
+      },
+      "versioningMaxPerPage": {
+        "type": "integer",
+        "default": 50,
+        "minimum": 0,
+        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
+      },
+      "versioningSidecarDir": {
+        "type": "string",
+        "default": ".versions",
+        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
       },
       "wearables": {
         "type": "object",
@@ -1065,4462 +5518,65 @@
           }
         }
       },
-      "secureStoreEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
-      },
-      "secureStoreEncryptOnWrite": {
-        "type": "boolean",
-        "default": true,
-        "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
-      },
-      "slotBehavior": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "requireExclusiveMemorySlot": {
-            "type": "boolean",
-            "default": true
-          },
-          "onSlotMismatch": {
-            "type": "string",
-            "enum": [
-              "error",
-              "warn",
-              "silent"
-            ],
-            "default": "error"
-          }
-        }
-      },
-      "beforeResetTimeoutMs": {
-        "type": "integer",
-        "minimum": 100,
-        "maximum": 30000,
-        "default": 2000,
-        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
-      },
-      "initGateTimeoutMs": {
-        "type": "integer",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 30000,
-        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
-      },
-      "flushOnResetEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
-      },
-      "commandsListEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
-      },
-      "openclawToolsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
-      },
-      "openclawToolSnippetMaxChars": {
-        "type": "integer",
-        "minimum": 80,
-        "maximum": 4000,
-        "default": 600,
-        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
-      },
-      "openclawMessageReceivedCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
-      },
-      "openclawReplyMetadataCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
-      },
-      "openclawReplyMetadataExtractionHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
-      },
-      "openclawChannelEnvelopeCleaningEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
-      },
-      "openclawFlushPlanProcessingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
-      },
-      "sessionTogglesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
-      },
-      "verboseRecallVisibility": {
-        "type": "boolean",
-        "default": true,
-        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
-      },
-      "recallTranscriptsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
-      },
-      "recallTranscriptRetentionDays": {
-        "type": "integer",
-        "minimum": 1,
-        "maximum": 365,
-        "default": 30,
-        "description": "Days of runtime recall audit transcripts to retain before pruning."
-      },
-      "respectBundledActiveMemoryToggle": {
-        "type": "boolean",
-        "default": true,
-        "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
-      },
-      "activeRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection — when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
-      },
-      "activeRecallAgents": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
-      },
-      "activeRecallAllowedChatTypes": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "direct",
-            "group",
-            "channel"
-          ]
-        },
-        "default": [
-          "direct",
-          "group",
-          "channel"
-        ],
-        "description": "OpenClaw chat types eligible for active recall."
-      },
-      "activeRecallQueryMode": {
-        "type": "string",
-        "enum": [
-          "recent",
-          "message",
-          "full"
-        ],
-        "default": "recent",
-        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
-      },
-      "activeRecallPromptStyle": {
-        "type": "string",
-        "enum": [
-          "balanced",
-          "strict",
-          "contextual",
-          "recall-heavy",
-          "precision-heavy",
-          "preference-only"
-        ],
-        "default": "balanced",
-        "description": "Context assembly style for the active-recall surface."
-      },
-      "activeRecallCustomInstruction": {
-        "type": "string",
-        "description": "Optional custom guidance for the active-recall builder."
-      },
-      "activeRecallPromptAppend": {
-        "type": "string",
-        "description": "Optional additional guidance for the active-recall builder."
-      },
-      "activeRecallMaxSummaryChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 220,
-        "description": "Maximum summary size produced by the active-recall surface."
-      },
-      "activeRecallRecentUserTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 4,
-        "default": 2,
-        "description": "How many recent user turns to include in the active-recall query context."
-      },
-      "activeRecallRecentAssistantTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "How many recent assistant turns to include in the active-recall query context."
-      },
-      "activeRecallRecentUserChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 600,
-        "description": "Per-user-turn character cap for active-recall context assembly."
-      },
-      "activeRecallRecentAssistantChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 400,
-        "description": "Per-assistant-turn character cap for active-recall context assembly."
-      },
-      "activeRecallThinking": {
-        "type": "string",
-        "enum": [
-          "off",
-          "minimal",
-          "low",
-          "medium",
-          "high",
-          "xhigh",
-          "adaptive"
-        ],
-        "default": "low",
-        "description": "Reasoning effort used by the active-recall engine."
-      },
-      "activeRecallTimeoutMs": {
-        "type": "integer",
-        "minimum": 250,
-        "default": 15000,
-        "description": "Timeout for an active-recall run."
-      },
-      "activeRecallCacheTtlMs": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 120000,
-        "default": 15000,
-        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
-      },
-      "activeRecallModel": {
-        "type": "string",
-        "description": "Optional model selection for active recall."
-      },
-      "activeRecallModelFallbackPolicy": {
-        "type": "string",
-        "enum": [
-          "default-remote",
-          "resolved-only"
-        ],
-        "default": "default-remote",
-        "description": "How active recall falls back when an explicit model cannot be resolved."
-      },
-      "activeRecallPersistTranscripts": {
-        "type": "boolean",
-        "default": false,
-        "description": "Persist full active-recall request and response transcripts."
-      },
-      "activeRecallTranscriptDir": {
-        "type": "string",
-        "default": "active-recall",
-        "description": "Memory-relative directory for active-recall transcripts."
-      },
-      "activeRecallEntityGraphDepth": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "Entity-graph traversal depth used by active recall."
-      },
-      "activeRecallIncludeCausalTrajectories": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include causal trajectory recall evidence in active-recall summaries."
-      },
-      "activeRecallIncludeDaySummary": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include the latest day summary in active-recall context."
-      },
-      "activeRecallAttachRecallExplain": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach recall explain output to active-recall diagnostics."
-      },
-      "activeRecallAllowChainedActiveMemory": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
-      },
-      "codex": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "installExtension": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install the Remnic Codex memory extension during Codex connector setup."
-          },
-          "codexHome": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null,
-            "description": "Optional Codex home directory override used for connector install and materialization."
-          }
-        }
-      },
-      "connectors": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
-        "properties": {
-          "googleDrive": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "folderIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
-              }
-            }
-          },
-          "notion": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
-              },
-              "databaseIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "gmail": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "userId": {
-                "type": "string",
-                "default": "me",
-                "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
-              },
-              "query": {
-                "type": "string",
-                "default": "in:inbox",
-                "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "github": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
-              },
-              "userLogin": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
-              },
-              "repos": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "includeDiscussions": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
-              }
-            }
-          }
-        }
-      },
-      "codexMaterializeMemories": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex native memory materialization into the Codex memories directory."
-      },
-      "codexMaterializeNamespace": {
-        "type": "string",
-        "default": "auto",
-        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
-      },
-      "codexMaterializeMaxSummaryTokens": {
-        "type": "number",
-        "minimum": 0,
-        "default": 4500,
-        "description": "Whitespace-token cap for Codex memory summary materialization."
-      },
-      "codexMaterializeRolloutRetentionDays": {
-        "type": "number",
-        "minimum": 0,
-        "default": 30,
-        "description": "Retention window in days for Codex rollout materialization artifacts."
-      },
-      "codexMaterializeOnConsolidation": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
-      },
-      "codexMaterializeOnSessionEnd": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization from the Codex session-end hook."
-      },
-      "codexMarketplaceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex marketplace integration for plugin discovery and installation."
-      },
-      "versioningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable page-level versioning with sidecar snapshots."
-      },
-      "versioningMaxPerPage": {
-        "type": "integer",
-        "default": 50,
-        "minimum": 0,
-        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
-      },
-      "versioningSidecarDir": {
-        "type": "string",
-        "default": ".versions",
-        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
-      },
-      "taxonomyEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
-      },
-      "taxonomyAutoGenResolver": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
-      },
-      "emitLegacyTools": {
-        "type": "boolean",
-        "default": false,
-        "description": "Advertise legacy engram_* / engram.* MCP tool aliases alongside the canonical remnic_* names. Issue #1550: defaults to false on fresh installs (halving the advertised tools/list surface); when existing legacy connector entries are present on disk the default stays true so upgrades never silently break a configured legacy client. An explicit value always wins."
-      },
-      "citationsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
-      },
-      "citationsAutoDetect": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-enable citations when the Codex adapter is detected."
-      },
-      "memoryExtensionsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
-      },
-      "memoryExtensionsRoot": {
-        "type": "string",
-        "default": "",
-        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
-      },
-      "binaryLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
-      },
-      "binaryLifecycleGracePeriodDays": {
-        "type": "number",
-        "default": 7,
-        "minimum": 0,
-        "description": "Days to wait before cleaning local copies of mirrored binary files."
-      },
-      "binaryLifecycleBackendType": {
-        "type": "string",
-        "enum": [
-          "none",
-          "filesystem",
-          "s3"
-        ],
-        "default": "none",
-        "description": "Storage backend for binary lifecycle mirror stage."
-      },
-      "binaryLifecycleBackendPath": {
-        "type": "string",
-        "default": "",
-        "description": "Base path for the filesystem storage backend."
-      },
-      "codexCompat": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "threadIdBufferKeying": {
-            "type": "boolean",
-            "default": true
-          },
-          "compactionFlushMode": {
-            "type": "string",
-            "enum": [
-              "signal",
-              "heuristic",
-              "auto"
-            ],
-            "default": "auto"
-          },
-          "fingerprintDedup": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      },
-      "debug": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable debug logging"
-      },
-      "identityEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
-      },
-      "identityContinuityEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable identity continuity workflows (anchor, incidents, audits)"
-      },
-      "identityInjectionMode": {
-        "type": "string",
-        "enum": [
-          "recovery_only",
-          "minimal",
-          "full"
-        ],
-        "default": "recovery_only",
-        "description": "Controls when identity continuity context is added to recall assembly"
-      },
-      "identityMaxInjectChars": {
-        "type": "number",
-        "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context"
-      },
-      "continuityIncidentLoggingEnabled": {
-        "type": "boolean",
-        "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
-      },
-      "continuityAuditEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable continuity audit artifact generation workflows"
-      },
-      "sessionObserverEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
-      },
-      "sessionObserverDebounceMs": {
-        "type": "number",
-        "default": 120000,
-        "description": "Minimum interval between heartbeat observer triggers per session (ms)."
-      },
-      "sessionObserverBands": {
-        "type": "array",
-        "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "maxBytes": {
-              "type": "number"
-            },
-            "triggerDeltaBytes": {
-              "type": "number"
-            },
-            "triggerDeltaTokens": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "maxBytes",
-            "triggerDeltaBytes",
-            "triggerDeltaTokens"
-          ]
-        },
-        "default": [
-          {
-            "maxBytes": 50000,
-            "triggerDeltaBytes": 4800,
-            "triggerDeltaTokens": 1200
-          },
-          {
-            "maxBytes": 200000,
-            "triggerDeltaBytes": 9600,
-            "triggerDeltaTokens": 2400
-          },
-          {
-            "maxBytes": 1000000000,
-            "triggerDeltaBytes": 19200,
-            "triggerDeltaTokens": 4800
-          }
-        ]
-      },
-      "injectQuestions": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include the most relevant open question in generated memory context"
-      },
-      "commitmentDecayDays": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 90,
-        "description": "Days before fulfilled/expired commitments are removed"
-      },
-      "workspaceDir": {
-        "type": "string",
-        "description": "Override workspace directory path"
-      },
-      "fileHygiene": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: keep OpenClaw bootstrap workspace files small and warn before silent truncation risk.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master switch for file hygiene (default off)."
-          },
-          "lintEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "If true, warn when bootstrap files approach budget."
-          },
-          "lintBudgetBytes": {
-            "type": "number",
-            "default": 20000,
-            "description": "Budget in bytes used for lint warnings (approx)."
-          },
-          "lintWarnRatio": {
-            "type": "number",
-            "default": 0.8,
-            "description": "Warn when file size >= budget * warnRatio."
-          },
-          "lintPaths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md",
-              "MEMORY.md"
-            ],
-            "description": "Workspace-relative paths to lint (or absolute paths)."
-          },
-          "rotateEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, rotate oversized markdown files into an archive and replace with a lean index."
-          },
-          "rotateMaxBytes": {
-            "type": "number",
-            "default": 18000,
-            "description": "Rotate when a target file exceeds this size (bytes)."
-          },
-          "rotateKeepTailChars": {
-            "type": "number",
-            "default": 2000,
-            "description": "How many characters of the old file to keep inline (tail) for continuity."
-          },
-          "rotatePaths": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md"
-            ],
-            "description": "Workspace-relative paths to rotate (or absolute paths)."
-          },
-          "archiveDir": {
-            "type": "string",
-            "default": ".engram-archive",
-            "description": "Workspace-relative archive directory where rotated files are stored."
-          },
-          "runMinIntervalMs": {
-            "type": "number",
-            "default": 300000,
-            "description": "Minimum interval between hygiene runs (ms)."
-          },
-          "warningsLogEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, append warnings to a log file under memoryDir."
-          },
-          "warningsLogPath": {
-            "type": "string",
-            "default": "hygiene/warnings.md",
-            "description": "memoryDir-relative path to write warnings to."
-          },
-          "indexEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Reserved: write an Engram index file in workspace (not required for rotation)."
-          },
-          "indexPath": {
-            "type": "string",
-            "default": "ENGRAM_INDEX.md",
-            "description": "Workspace-relative index path (if indexEnabled)."
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "nativeKnowledge": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: search curated workspace markdown files directly during recall without converting them into durable memory files.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master switch for curated workspace file recall."
-          },
-          "includeFiles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              "IDENTITY.md",
-              "MEMORY.md"
-            ],
-            "description": "Workspace-relative curated markdown files to scan for native knowledge recall."
-          },
-          "maxChunkChars": {
-            "type": "number",
-            "default": 900,
-            "description": "Maximum chunk size per native knowledge section before it is split."
-          },
-          "maxResults": {
-            "type": "number",
-            "default": 4,
-            "description": "Maximum native knowledge chunks to add to recall."
-          },
-          "maxChars": {
-            "type": "number",
-            "default": 2400,
-            "description": "Maximum total characters to add from native knowledge recall."
-          },
-          "stateDir": {
-            "type": "string",
-            "default": "state/native-knowledge",
-            "description": "Memory-relative directory used for backend-agnostic native knowledge sync state."
-          },
-          "openclawWorkspace": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Optional adapter for OpenClaw workspace artifacts such as bootstrap docs, handoffs, daily summaries, and automation notes.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Enable the OpenClaw workspace native-knowledge adapter."
-              },
-              "bootstrapFiles": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "IDENTITY.md",
-                  "MEMORY.md",
-                  "USER.md"
-                ],
-                "description": "Workspace-relative bootstrap docs treated as high-confidence native knowledge."
-              },
-              "handoffGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "**/*handoff*.md",
-                  "handoffs/**/*.md"
-                ],
-                "description": "Glob patterns (relative to workspaceDir) used to discover handoff notes."
-              },
-              "dailySummaryGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [
-                  "**/*daily*summary*.md",
-                  "summaries/**/*.md"
-                ],
-                "description": "Glob patterns (relative to workspaceDir) used to discover daily summary notes."
-              },
-              "automationNoteGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns for automation-written status or operating notes."
-              },
-              "workspaceDocGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns for other explicitly allowlisted workspace docs."
-              },
-              "excludeGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Additional glob patterns appended to the built-in workspace safety excludes."
-              },
-              "sharedSafeGlobs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional glob patterns that should be tagged as shared-safe when no explicit privacy class is present."
-              }
-            },
-            "required": [
-              "enabled"
-            ]
-          },
-          "obsidianVaults": {
-            "type": "array",
-            "default": [],
-            "description": "Optional Obsidian vault adapters to sync into backend-agnostic native knowledge records.",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Stable vault identifier used in synced note metadata."
-                },
-                "rootDir": {
-                  "type": "string",
-                  "description": "Absolute path to the Obsidian vault root."
-                },
-                "includeGlobs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    "**/*.md"
-                  ],
-                  "description": "Glob patterns (relative to the vault root) that are eligible for sync."
-                },
-                "excludeGlobs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    ".obsidian/**",
-                    "**/*.canvas",
-                    "**/*.png",
-                    "**/*.jpg",
-                    "**/*.jpeg",
-                    "**/*.gif",
-                    "**/*.pdf"
-                  ],
-                  "description": "Glob patterns excluded from sync."
-                },
-                "namespace": {
-                  "type": "string",
-                  "description": "Default namespace assigned to records from this vault."
-                },
-                "privacyClass": {
-                  "type": "string",
-                  "description": "Operator-defined privacy class preserved on synced records."
-                },
-                "folderRules": {
-                  "type": "array",
-                  "default": [],
-                  "description": "Optional per-folder overrides for namespace or privacy classification.",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "pathPrefix": {
-                        "type": "string",
-                        "description": "Vault-relative folder prefix that activates the override."
-                      },
-                      "namespace": {
-                        "type": "string",
-                        "description": "Namespace override for matching notes."
-                      },
-                      "privacyClass": {
-                        "type": "string",
-                        "description": "Privacy-class override for matching notes."
-                      }
-                    },
-                    "required": [
-                      "pathPrefix"
-                    ]
-                  }
-                },
-                "dailyNotePatterns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "default": [
-                    "YYYY-MM-DD"
-                  ],
-                  "description": "Filename patterns used to derive daily-note dates (for example `YYYY-MM-DD` or `YYYY/MM/DD`)."
-                },
-                "materializeBacklinks": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "If true, compute backlinks from wikilink targets for recall hints and explainability."
-                }
-              },
-              "required": [
-                "rootDir"
-              ]
-            }
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "agentAccessHttp": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Start the local Engram HTTP access server during plugin startup."
-          },
-          "host": {
-            "type": "string",
-            "default": "127.0.0.1",
-            "description": "Loopback host to bind for the Engram HTTP access server."
-          },
-          "port": {
-            "type": "number",
-            "default": 4318,
-            "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
-          },
-          "authToken": {
-            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "source"
-                ],
-                "properties": {
-                  "source": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "provider": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "string"
-                  },
-                  "command": {}
-                }
-              }
-            ]
-          },
-          "principal": {
-            "type": "string",
-            "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
-          },
-          "maxBodyBytes": {
-            "type": "number",
-            "default": 131072,
-            "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "accessTrackingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track memory access counts and recency"
-      },
-      "accessTrackingBufferMaxSize": {
-        "type": "number",
-        "default": 100,
-        "description": "Max entries in access tracking buffer before flush"
-      },
-      "recencyWeight": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Weight for recency boosting in search (0-1)"
-      },
-      "boostAccessCount": {
-        "type": "boolean",
-        "default": true,
-        "description": "Boost frequently accessed memories in search results"
-      },
-      "recordEmptyRecallImpressions": {
-        "type": "boolean",
-        "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is added."
-      },
-      "recallPlannerEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
-      },
-      "recallPlannerLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
-      },
-      "recallPlannerModel": {
-        "type": "string",
-        "default": "gpt-5.5",
-        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
-      },
-      "recallPlannerTimeoutMs": {
-        "type": "number",
-        "default": 1500,
-        "description": "Timeout in ms for recall planner inference."
-      },
-      "recallPlannerUseResponsesApi": {
-        "type": "boolean",
-        "default": true,
-        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
-      },
-      "recallPlannerMaxPromptChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters of prompt context to send to the recall planner."
-      },
-      "recallPlannerMaxMemoryHints": {
-        "type": "number",
-        "default": 24,
-        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
-      },
-      "recallPlannerShadowMode": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
-      },
-      "recallPlannerTelemetryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit telemetry events for recall planner decisions."
-      },
-      "recallPlannerMaxQmdResultsMinimal": {
-        "type": "number",
-        "default": 4,
-        "description": "QMD cap used when recall planner selects minimal mode."
-      },
-      "recallPlannerMaxQmdResultsFull": {
-        "type": "number",
-        "default": 8,
-        "description": "QMD cap used when recall planner selects full mode."
-      },
-      "intentRoutingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach intent metadata to memories and boost compatible memories at recall."
-      },
-      "intentRoutingBoost": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Maximum score boost applied for intent-compatible memory matches."
-      },
-      "verbatimArtifactsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write quote-first artifact anchors during extraction and include them in recall."
-      },
-      "verbatimArtifactsMinConfidence": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Minimum extraction confidence required before writing an artifact."
-      },
-      "verbatimArtifactsMaxRecall": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum artifact anchors added per recall."
-      },
-      "verbatimArtifactCategories": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "fact",
-            "preference",
-            "correction",
-            "entity",
-            "decision",
-            "relationship",
-            "principle",
-            "commitment",
-            "moment",
-            "skill",
-            "procedure"
-          ]
-        },
-        "default": [
-          "decision",
-          "correction",
-          "principle",
-          "commitment"
-        ],
-        "description": "Memory categories eligible for artifact extraction."
-      },
-      "memoryBoxesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
-      },
-      "boxTopicShiftThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
-      },
-      "boxTimeGapMs": {
-        "type": "number",
-        "default": 1800000,
-        "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
-      },
-      "boxMaxMemories": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum memories per box before forced seal."
-      },
-      "traceWeaverEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
-      },
-      "traceWeaverLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days back to search for trace links."
-      },
-      "traceWeaverOverlapThreshold": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
-      },
-      "boxRecallDays": {
-        "type": "number",
-        "default": 3,
-        "description": "Number of recent days of boxes to add during recall."
-      },
-      "episodeNoteModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
-      },
-      "queryAwareIndexingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
-      },
-      "queryAwareIndexingMaxCandidates": {
-        "type": "number",
-        "default": 200,
-        "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
-      },
-      "temporalIndexWindowDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Number of days to include in the temporal index window."
-      },
-      "temporalIndexMaxEntries": {
-        "type": "number",
-        "default": 5000,
-        "description": "Maximum number of entries in the temporal index."
-      },
-      "temporalBoostRecentDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Memories from the last N days receive a recency boost during recall."
-      },
-      "temporalBoostScore": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to recent memories during recall."
-      },
-      "temporalDecayEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply temporal decay to older memories during recall scoring."
-      },
-      "tombstonesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active — visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
-      },
-      "correctionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the Correction Contract (#1580) — the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
-      },
-      "correctionApplyRequiresConfirm": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
-      },
-      "correctionMaxAffected": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 10,
-        "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
-      },
-      "correctionPlanTtlHours": {
-        "type": "number",
-        "default": 24,
-        "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
-      },
-      "tombstonesSemanticMatch": {
-        "type": "boolean",
-        "default": false,
-        "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
-      },
-      "tombstonesSemanticThreshold": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
-      },
-      "tagMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable tag-based memory indexing and recall boosting."
-      },
-      "tagMaxPerMemory": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum number of tags assigned per memory."
-      },
-      "tagIndexMaxEntries": {
-        "type": "number",
-        "default": 10000,
-        "description": "Maximum number of entries in the tag index."
-      },
-      "tagRecallBoost": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to memories whose tags match the query."
-      },
-      "tagRecallMaxMatches": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of tag-matched memories added per recall."
-      },
-      "multiGraphMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
-      },
-      "graphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
-      },
-      "graphRecallMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of expansion hops per graph recall query."
-      },
-      "graphRecallMaxPerSeed": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum graph-expanded results per seed node."
-      },
-      "graphRecallMinEdgeWeight": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Minimum edge weight to follow during graph recall traversal."
-      },
-      "graphRecallShadowEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run graph recall in shadow mode - evaluate but do not add results."
-      },
-      "graphRecallSnapshotEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write graph recall snapshots for offline analysis."
-      },
-      "graphRecallShadowSampleRate": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Fraction of turns evaluated in shadow mode (0-1)."
-      },
-      "graphRecallExplainToolEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Expose a graph explain tool to agents during graph recall."
-      },
-      "graphRecallStoreColdMirror": {
-        "type": "boolean",
-        "default": false,
-        "description": "Store cold-path graph recall results in a secondary QMD collection."
-      },
-      "graphRecallColdMirrorCollection": {
-        "type": "string",
-        "description": "QMD collection name for cold-mirror graph recall results."
-      },
-      "graphRecallColdMirrorMinAgeDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
-      },
-      "graphRecallUseEntityPriors": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost seed nodes using entity prior scores during graph recall."
-      },
-      "graphRecallEntityPriorBoost": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Score boost applied to nodes with strong entity priors."
-      },
-      "graphRecallPreferHubSeeds": {
-        "type": "boolean",
-        "default": false,
-        "description": "Prefer high-degree hub nodes as graph recall seeds."
-      },
-      "graphRecallHubBias": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Bias weight toward hub-seed selection (0-1)."
-      },
-      "graphRecallRecencyHalfLifeDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Half-life in days for recency decay applied to graph-expanded nodes."
-      },
-      "graphRecallDampingFactor": {
-        "type": "number",
-        "default": 0.85,
-        "description": "PageRank-style damping factor for graph activation propagation."
-      },
-      "graphRecallMaxSeedNodes": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of seed nodes selected for graph recall expansion."
-      },
-      "graphRecallMaxExpandedNodes": {
-        "type": "number",
-        "default": 30,
-        "description": "Maximum total nodes visited during graph recall expansion."
-      },
-      "graphRecallMaxTrailPerNode": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum trail length followed per node during graph traversal."
-      },
-      "graphRecallMinSeedScore": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
-      },
-      "graphRecallExpansionScoreThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Minimum blended score required to include a graph-expanded node in results."
-      },
-      "graphRecallExplainMaxPaths": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum reasoning paths included in a graph recall explanation."
-      },
-      "graphRecallExplainMaxChars": {
-        "type": "number",
-        "default": 500,
-        "description": "Maximum characters per graph recall explanation."
-      },
-      "graphRecallExplainEdgeLimit": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum edges described per node in a graph recall explanation."
-      },
-      "graphRecallExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Append natural-language graph reasoning explanations to recall output."
-      },
-      "graphRecallEntityHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Inject entity hint summaries alongside graph-recalled memories."
-      },
-      "graphRecallEntityHintMax": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity hints added per graph recall result."
-      },
-      "graphRecallEntityHintMaxChars": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum characters per entity hint added during graph recall."
-      },
-      "graphRecallSnapshotDir": {
-        "type": "string",
-        "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
-      },
-      "graphRecallEnableTrace": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable detailed graph recall trace logging for debugging."
-      },
-      "graphRecallEnableDebug": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable verbose debug output for graph recall operations."
-      },
-      "graphExpandedIntentEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
-      },
-      "graphAssistInFullModeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run bounded graph expansion during full recall mode when seed results exist."
-      },
-      "graphAssistShadowEvalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
-      },
-      "graphAssistMinSeedResults": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum seed recall results required before full-mode graph assist runs."
-      },
-      "entityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
-      },
-      "timeGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
-      },
-      "graphWriteSessionAdjacencyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
-      },
-      "causalGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
-      },
-      "maxGraphTraversalSteps": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum BFS hops during spreading activation. Default 3."
-      },
-      "graphActivationDecay": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Per-hop activation decay factor (0-1). Default 0.7."
-      },
-      "graphTraversalConfidenceFloor": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
-      },
-      "graphTraversalPageRankIterations": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
-      },
-      "graphExpansionActivationWeight": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
-      },
-      "graphExpansionBlendMin": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "graphExpansionBlendMax": {
-        "type": "number",
-        "default": 0.95,
-        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "maxEntityGraphEdgesPerMemory": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum entity graph edges written per memory write. Default 10."
-      },
-      "delinearizeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
-      },
-      "recallConfidenceGateEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
-      },
-      "recallConfidenceGateThreshold": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
-      },
-      "causalRuleExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
-      },
-      "memoryReconstructionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
-      },
-      "memoryReconstructionMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity expansions per recall cycle"
-      },
-      "graphLateralInhibitionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
-      },
-      "graphLateralInhibitionBeta": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
-      },
-      "graphLateralInhibitionTopM": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of top competing nodes considered for lateral inhibition"
-      },
-      "graphEdgeDecayEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
-      },
-      "graphEdgeDecayCadenceMs": {
-        "type": "number",
-        "default": 604800000,
-        "minimum": 60000,
-        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
-      },
-      "graphEdgeDecayWindowMs": {
-        "type": "number",
-        "default": 7776000000,
-        "minimum": 60000,
-        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
-      },
-      "graphEdgeDecayPerWindow": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Per-window confidence drop applied during decay. Default 0.1."
-      },
-      "graphEdgeDecayFloor": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Floor confidence will not decay below. Default 0.1."
-      },
-      "graphEdgeDecayVisibilityThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
-      },
-      "temporalMemoryTreeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
-      },
-      "tmtHourlyMinMemories": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
-      },
-      "tmtSummaryMaxTokens": {
-        "type": "number",
-        "default": 300,
-        "description": "Max tokens for each TMT summary node. Default: 300."
-      },
-      "explicitCueRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
-      },
-      "explicitCueRecallMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the explicit cue evidence recall section."
-      },
-      "explicitCueRecallMaxReferences": {
-        "type": "number",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum query-visible cues expanded by explicit cue recall."
-      },
-      "targetedFactRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable targeted fact evidence recall for direct answer questions."
-      },
-      "targetedFactRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the targeted fact evidence recall section."
-      },
-      "targetedFactRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 8,
-        "minimum": 1,
-        "description": "Recent-turn scan window for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 12000,
-        "minimum": 1,
-        "description": "Recent-token scan window for targeted fact evidence."
-      },
-      "focusedListRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
-      },
-      "focusedListRecallMaxChars": {
-        "type": "integer",
-        "default": 2600,
-        "minimum": 0,
-        "description": "Character budget for the focused list evidence recall section."
-      },
-      "focusedListRecallMaxResults": {
-        "type": "integer",
-        "default": 40,
-        "minimum": 0,
-        "description": "Maximum recalled items for focused list evidence."
-      },
-      "focusedListRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for focused list evidence."
-      },
-      "focusedListRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 14000,
-        "minimum": 1,
-        "description": "Recent-token scan window for focused list evidence."
-      },
-      "responseGuidanceRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable response guidance recall for user answer-shape preferences."
-      },
-      "responseGuidanceRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the response guidance recall section."
-      },
-      "responseGuidanceRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 16000,
-        "minimum": 1,
-        "description": "Recent-token scan window for response guidance."
-      },
-      "eventOrderRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable event-order evidence recall for chronology questions."
-      },
-      "eventOrderRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the event-order evidence recall section."
-      },
-      "eventOrderRecallMaxResults": {
-        "type": "integer",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum recalled items for event-order evidence."
-      },
-      "eventOrderRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 12,
-        "minimum": 1,
-        "description": "Recent-turn scan window for event-order evidence."
-      },
-      "eventOrderRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 24000,
-        "minimum": 1,
-        "description": "Recent-token scan window for event-order evidence."
-      },
-      "queryExpansionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
-      },
-      "queryExpansionMaxQueries": {
-        "type": "number",
-        "default": 4,
-        "description": "Max expanded queries to run (including the original prompt)."
-      },
-      "queryExpansionMinTokenLen": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum token length to include in heuristic query expansion."
-      },
-      "rerankEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LLM re-ranking of retrieved memories. Default off."
-      },
-      "rerankProvider": {
-        "type": "string",
-        "default": "local",
-        "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
-        "enum": [
-          "local",
-          "cloud"
-        ]
-      },
-      "rerankMaxCandidates": {
-        "type": "number",
-        "default": 20,
-        "description": "Max candidates to send to the re-ranker."
-      },
-      "rerankTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
-      },
-      "rerankCacheEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Cache re-ranking results in-memory for repeated queries."
-      },
-      "rerankCacheTtlMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "TTL for in-memory re-ranking cache (ms)."
-      },
-      "feedbackEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
-      },
-      "negativeExamplesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable negative examples (track retrieved-but-not-useful memories) and apply a small ranking penalty."
-      },
-      "negativeExamplesPenaltyPerHit": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
-      },
-      "negativeExamplesPenaltyCap": {
-        "type": "number",
-        "default": 0.25,
-        "description": "Maximum ranking penalty applied from negative examples."
-      },
-      "chunkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic chunking of long memories"
-      },
-      "chunkingTargetTokens": {
-        "type": "number",
-        "default": 200,
-        "description": "Target tokens per chunk"
-      },
-      "chunkingMinTokens": {
-        "type": "number",
-        "default": 150,
-        "description": "Minimum tokens to trigger chunking"
-      },
-      "chunkingOverlapSentences": {
-        "type": "number",
-        "default": 2,
-        "description": "Number of sentences to overlap between chunks"
-      },
-      "semanticChunkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
-      },
-      "semanticChunkingConfig": {
-        "type": "object",
-        "default": {},
-        "description": "Optional overrides for the semantic chunking algorithm",
-        "properties": {
-          "targetTokens": {
-            "type": "number",
-            "default": 200,
-            "description": "Target tokens per chunk"
-          },
-          "minTokens": {
-            "type": "number",
-            "default": 100,
-            "description": "Minimum tokens for a segment before merging with neighbor"
-          },
-          "maxTokens": {
-            "type": "number",
-            "default": 400,
-            "description": "Maximum tokens for a segment before recursive splitting"
-          },
-          "smoothingWindowSize": {
-            "type": "number",
-            "default": 3,
-            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
-          },
-          "boundaryThresholdStdDevs": {
-            "type": "number",
-            "default": 1,
-            "description": "Standard deviations below mean for boundary detection"
-          },
-          "embeddingBatchSize": {
-            "type": "number",
-            "default": 32,
-            "description": "Batch size for embedding requests"
-          },
-          "fallbackToRecursive": {
-            "type": "boolean",
-            "default": true,
-            "description": "Fall back to recursive chunking when embeddings are unavailable"
-          }
-        }
-      },
-      "contradictionDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic contradiction detection with LLM verification"
-      },
-      "contradictionSimilarityThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "QMD similarity threshold to trigger contradiction check"
-      },
-      "contradictionMinConfidence": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Minimum LLM confidence to auto-resolve contradictions"
-      },
-      "contradictionAutoResolve": {
-        "type": "boolean",
-        "default": true,
-        "description": "Automatically supersede contradicted memories"
-      },
-      "contradictionScan": {
-        "type": "object",
-        "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
-          },
-          "similarityFloor": {
-            "type": "number",
-            "default": 0.82,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Embedding cosine similarity floor for candidate pair generation"
-          },
-          "topicOverlapFloor": {
-            "type": "number",
-            "default": 0.4,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
-          },
-          "maxPairsPerRun": {
-            "type": "integer",
-            "default": 500,
-            "minimum": 1,
-            "description": "Cap on candidate pairs evaluated per cron run"
-          },
-          "cooldownDays": {
-            "type": "integer",
-            "default": 14,
-            "minimum": 0,
-            "description": "Cooldown in days. 0 = always re-evaluate."
-          },
-          "autoMergeDuplicates": {
-            "type": "boolean",
-            "default": false,
-            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
-          }
-        }
-      },
-      "patternReinforcementEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
-      },
-      "patternReinforcementCadenceMs": {
-        "type": "integer",
-        "minimum": 0,
-        "default": 604800000,
-        "description": "Minimum interval (ms) between pattern-reinforcement runs. Default 7 days. Set to 0 to disable cadence gating (manual / test invocation)."
-      },
-      "patternReinforcementMinCount": {
-        "type": "integer",
-        "minimum": 2,
-        "maximum": 1000,
-        "default": 3,
-        "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
-      },
-      "patternReinforcementCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "preference",
-          "fact",
-          "decision"
-        ],
-        "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
-      },
-      "reinforcementRecallBoostEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
-      },
-      "reinforcementRecallBoostWeight": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.05,
-        "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
-      },
-      "reinforcementRecallBoostMax": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.3,
-        "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
-      },
-      "temporalSupersessionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
-      },
-      "temporalSupersessionIncludeInRecall": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
-      },
-      "temporalBiTemporal": {
-        "type": "boolean",
-        "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
-      },
-      "temporalExpiredInInjection": {
-        "type": "boolean",
-        "default": false,
-        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
-      },
-      "recallDirectAnswerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
-      },
-      "recallDisclosureEscalation": {
-        "type": "string",
-        "enum": [
-          "manual",
-          "auto"
-        ],
-        "default": "manual",
-        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
-      },
-      "recallDisclosureEscalationThreshold": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.5,
-        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
-      },
-      "recallGraphEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
-      },
-      "recallGraphDamping": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 0.999999999,
-        "default": 0.85,
-        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
-      },
-      "recallGraphIterations": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 500,
-        "default": 20,
-        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
-      },
-      "recallGraphTopK": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 10000,
-        "default": 50,
-        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
-      },
-      "recallDirectAnswerTokenOverlapFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.55,
-        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDirectAnswerImportanceFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.7,
-        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDirectAnswerAmbiguityMargin": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.15,
-        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
-      },
-      "recallDirectAnswerEligibleTaxonomyBuckets": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decisions",
-          "principles",
-          "conventions",
-          "runbooks",
-          "entities"
-        ],
-        "description": "Taxonomy category IDs eligible for direct-answer routing."
-      },
-      "recallCrossNamespaceBudgetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
-      },
-      "recallCrossNamespaceBudgetWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 60000,
-        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
-      },
-      "recallCrossNamespaceBudgetSoftLimit": {
-        "type": "number",
-        "minimum": 0,
-        "default": 10,
-        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
-      },
-      "recallCrossNamespaceBudgetHardLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
-      },
-      "recallAuditAnomalyDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
-      },
-      "recallAuditAnomalyWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 300000,
-        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
-      },
-      "recallAuditAnomalyRepeatQueryLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 5,
-        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
-      },
-      "recallAuditAnomalyNamespaceWalkLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 3,
-        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
-      },
-      "recallAuditAnomalyHighCardinalityLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 50,
-        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
-      },
-      "recallAuditAnomalyRapidFireLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
-      },
-      "recallMemoryWorthFilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
-      },
-      "recallMemoryWorthHalfLifeMs": {
-        "type": "number",
-        "minimum": 0,
-        "default": 0,
-        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
-      },
-      "recallMemoryHandles": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #1582 — append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
-      },
-      "recallHandleSnapshotDepth": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 50,
-        "default": 5,
-        "description": "Issue #1582 — number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
-      },
-      "memoryLinkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory linking to build knowledge graph"
-      },
-      "threadingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation threading"
-      },
-      "threadingGapMinutes": {
-        "type": "number",
-        "default": 30,
-        "description": "Minutes of gap to start a new thread"
-      },
-      "summarizationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory summarization/compression"
-      },
-      "summarizationTriggerCount": {
+      "workIndexAutoRebuildDebounceMs": {
         "type": "number",
         "default": 1000,
-        "description": "Memory count threshold to trigger summarization"
-      },
-      "summarizationRecentToKeep": {
-        "type": "number",
-        "default": 300,
-        "description": "Number of recent memories to keep uncompressed"
-      },
-      "summarizationImportanceThreshold": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Only compress memories with importance below this threshold"
-      },
-      "summarizationProtectedTags": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle"
-        ],
-        "description": "Tags that protect memories from compression"
-      },
-      "topicExtractionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable topic extraction during consolidation"
-      },
-      "topicExtractionTopN": {
-        "type": "number",
-        "default": 50,
-        "description": "Number of top topics to extract"
-      },
-      "transcriptEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable transcript archiving"
-      },
-      "chat": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default — spawns LLM calls so explicit opt-in (rule 48).",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
-          },
-          "model": {
-            "type": "string",
-            "default": "",
-            "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
-          },
-          "maxToolCallsPerTurn": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 64,
-            "default": 8,
-            "description": "Max tool calls per user turn before partial-reply fallback (rule 34 — never a silent stall)."
-          },
-          "sessionTtlHours": {
-            "type": "integer",
-            "minimum": 1,
-            "default": 72,
-            "description": "Hours after which idle chat session state is cleaned up."
-          }
-        }
-      },
-      "captureMode": {
-        "type": "string",
-        "enum": [
-          "implicit",
-          "explicit",
-          "hybrid"
-        ],
-        "default": "implicit",
-        "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
-      },
-      "transcriptRetentionDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days to retain transcript entries"
-      },
-      "transcriptSkipChannelTypes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "cron"
-        ],
-        "description": "Channel types to skip from transcript logging (e.g., cron)"
-      },
-      "transcriptRecallHours": {
-        "type": "number",
-        "default": 12,
-        "description": "Hours of transcript history to recall"
-      },
-      "maxTranscriptTurns": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum transcript turns to include"
-      },
-      "maxTranscriptTokens": {
-        "type": "number",
-        "default": 1000,
-        "description": "Maximum tokens for transcript context"
-      },
-      "checkpointEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable conversation checkpoints"
-      },
-      "checkpointTurns": {
-        "type": "number",
-        "default": 15,
-        "description": "Number of turns per checkpoint"
-      },
-      "compactionResetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
-      },
-      "hourlySummariesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable hourly conversation summaries"
-      },
-      "daySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
-      },
-      "daySummaryTimezone": {
-        "type": "string",
-        "default": "",
-        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
-      },
-      "summaryRecallHours": {
-        "type": "number",
-        "default": 24,
-        "description": "Hours of summary history to recall"
-      },
-      "maxSummaryCount": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum number of summaries to include"
-      },
-      "summaryModel": {
-        "type": "string",
-        "description": "Model for hourly summaries (defaults to main model)"
-      },
-      "modelSource": {
-        "type": "string",
-        "enum": [
-          "plugin",
-          "gateway"
-        ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
-      },
-      "gatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
-      },
-      "fastGatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
-      },
-      "taskModelChain": {
-        "type": "object",
-        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
-        "required": [
-          "primary"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "primary": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
-          },
-          "fallbacks": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            },
-            "default": [],
-            "description": "Fallback gateway models tried after primary"
-          }
-        }
-      },
-      "localLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
-      },
-      "localLlmUrl": {
-        "type": "string",
-        "default": "http://localhost:1234/v1",
-        "description": "URL for local LLM OpenAI-compatible endpoint"
-      },
-      "localLlmModel": {
-        "type": "string",
-        "default": "local-model",
-        "description": "Model name for local LLM requests"
-      },
-      "localLlmApiKey": {
-        "type": "string",
-        "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
-      },
-      "localLlmHeaders": {
-        "type": "object",
-        "description": "Optional additional headers for local/compatible endpoint requests",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "localLlmAuthHeader": {
-        "type": "boolean",
-        "default": true,
-        "description": "If false, do not send Authorization header even when localLlmApiKey is set"
-      },
-      "localLlmFallback": {
-        "type": "boolean",
-        "default": true,
-        "description": "Fall back to cloud OpenAI if local LLM is unavailable"
-      },
-      "localLlmHomeDir": {
-        "type": "string",
-        "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
-      },
-      "localLmsCliPath": {
-        "type": "string",
-        "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
-      },
-      "localLmsBinDir": {
-        "type": "string",
-        "description": "Optional bin directory prepended to PATH for LMS CLI execution."
-      },
-      "localLlmTimeoutMs": {
-        "type": "number",
-        "default": 180000,
-        "description": "Hard timeout for local LLM requests (ms)"
-      },
-      "slowLogEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, log slow operations (durations + metadata; never logs content)"
-      },
-      "slowLogThresholdMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Threshold for slow operation logging (ms)"
-      },
-      "traceRecallContent": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
-      },
-      "profilingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
-      },
-      "profilingStorageDir": {
-        "type": "string",
-        "default": "",
-        "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
-      },
-      "profilingMaxTraces": {
-        "type": "number",
-        "default": 100,
-        "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
-      },
-      "extractionDedupeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable deduplication of near-identical extraction batches within a time window."
-      },
-      "extractionDedupeWindowMs": {
-        "type": "number",
-        "default": 300000,
-        "description": "Window for extraction dedupe fingerprints (ms)."
-      },
-      "extractionMinChars": {
-        "type": "number",
-        "default": 40,
-        "description": "Minimum combined user/assistant characters required before extraction runs."
-      },
-      "extractionMinImportanceLevel": {
-        "type": "string",
-        "enum": [
-          "trivial",
-          "low",
-          "normal",
-          "high",
-          "critical"
-        ],
-        "default": "low",
-        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
-      },
-      "extractionTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
-      },
-      "extractionScopeClassificationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
-      },
-      "extractionJudgeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
-      },
-      "extractionJudgeModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
-      },
-      "extractionJudgeBatchSize": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
-      },
-      "extractionJudgeShadow": {
-        "type": "boolean",
-        "default": false,
-        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
-      },
-      "extractionJudgeMaxDeferrals": {
-        "type": "number",
-        "default": 2,
-        "minimum": 1,
-        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
-      },
-      "extractionJudgeTelemetryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
-      },
-      "collectJudgeTrainingPairs": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
-      },
-      "judgeTrainingDir": {
-        "type": "string",
-        "default": "",
-        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
-      },
-      "extractionFaithfulnessGate": {
-        "type": "string",
-        "enum": [
-          "off",
-          "shadow",
-          "enforce"
-        ],
-        "default": "off",
-        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
-      },
-      "extractionFaithfulnessModel": {
-        "type": "string",
-        "default": "",
-        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
-      },
-      "extractionFaithfulnessContextChars": {
-        "type": "number",
-        "default": 400,
-        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
-      },
-      "extractionFaithfulnessTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
-      },
-      "inlineSourceAttributionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
-      },
-      "inlineSourceAttributionFormat": {
-        "type": "string",
-        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
-        "description": "Template used when inline source attribution is enabled."
-      },
-      "provenance": {
-        "type": "object",
-        "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
-        "additionalProperties": false,
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
-          },
-          "maxQuoteChars": {
-            "type": "integer",
-            "default": 300,
-            "minimum": 1,
-            "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
-          },
-          "requireSpans": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
-          }
-        }
-      },
-      "extractionMinUserTurns": {
-        "type": "number",
-        "default": 1,
-        "description": "Minimum number of user turns required before extraction runs."
-      },
-      "extractionMaxTurnChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
-      },
-      "extractionMaxFactsPerRun": {
-        "type": "number",
-        "default": 12,
-        "description": "Maximum facts persisted from a single extraction run."
-      },
-      "extractionMaxEntitiesPerRun": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum entities persisted from a single extraction run."
-      },
-      "extractionMaxQuestionsPerRun": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum questions persisted from a single extraction run."
-      },
-      "extractionMaxProfileUpdatesPerRun": {
-        "type": "number",
-        "default": 4,
-        "description": "Maximum profile updates persisted from a single extraction run."
-      },
-      "consolidationRequireNonZeroExtraction": {
-        "type": "boolean",
-        "default": true,
-        "description": "Only schedule consolidation when the last extraction produced durable outputs."
-      },
-      "consolidationMinIntervalMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Minimum interval between consolidation runs (ms)."
-      },
-      "qmdMaintenanceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
-      },
-      "qmdMaintenanceDebounceMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Debounce window for background QMD maintenance updates (ms)."
-      },
-      "qmdAutoEmbedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
-      },
-      "qmdEmbedMinIntervalMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "Minimum interval between background QMD embed runs (ms)."
-      },
-      "qmdUpdateTimeoutMs": {
-        "type": "number",
-        "default": 90000,
-        "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
-      },
-      "qmdUpdateMinIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
-      },
-      "maintenanceNamespaceFanoutEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
-      },
-      "maintenanceMaxNamespacesPerCycle": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
-      },
-      "maintenanceIncludeProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceIncludeBranchNamespaces": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
-      },
-      "maintenanceIncludeTeamProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceNamespaceLockStaleMs": {
-        "type": "number",
-        "default": 600000,
-        "minimum": 1,
-        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
-      },
-      "localLlmRetry5xxCount": {
-        "type": "number",
-        "default": 1,
-        "description": "Number of retry attempts for local LLM 5xx responses."
-      },
-      "localLlmRetryBackoffMs": {
-        "type": "number",
-        "default": 400,
-        "description": "Base backoff delay between local LLM retries (ms)."
-      },
-      "localLlm400TripThreshold": {
-        "type": "number",
-        "default": 5,
-        "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
-      },
-      "localLlm400CooldownMs": {
-        "type": "number",
-        "default": 120000,
-        "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
-      },
-      "localLlmMaxContext": {
-        "type": "number",
-        "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
-      },
-      "localLlmFastEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
-      },
-      "localLlmFastModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
-      },
-      "localLlmFastUrl": {
-        "type": "string",
-        "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
-      },
-      "localLlmFastTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
-      },
-      "localLlmDisableThinking": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
-      },
-      "hourlySummaryCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
-      },
-      "nightlyGovernanceCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
-      },
-      "hourlySummariesExtendedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
-      },
-      "hourlySummariesIncludeToolStats": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
-      },
-      "hourlySummariesIncludeSystemMessages": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include system messages in extended hourly summaries (use with care)."
-      },
-      "hourlySummariesMaxTurnsPerRun": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum transcript turns to consider per session per hourly summarizer run."
-      },
-      "conversationIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
-      },
-      "conversationIndexBackend": {
-        "type": "string",
-        "enum": [
-          "qmd",
-          "faiss"
-        ],
-        "default": "qmd",
-        "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
-      },
-      "conversationIndexQmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-conversations",
-        "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
-      },
-      "conversationIndexRetentionDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Days to retain conversation chunk docs."
-      },
-      "conversationIndexMinUpdateIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
-      },
-      "conversationIndexEmbedOnUpdate": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
-      },
-      "conversationIndexFaissScriptPath": {
-        "type": "string",
-        "default": "",
-        "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
-      },
-      "conversationIndexFaissPythonBin": {
-        "type": "string",
-        "default": "",
-        "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
-      },
-      "conversationIndexFaissModelId": {
-        "type": "string",
-        "default": "text-embedding-3-small",
-        "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
-      },
-      "conversationIndexFaissIndexDir": {
-        "type": "string",
-        "default": "state/conversation-index/faiss",
-        "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
-      },
-      "conversationIndexFaissUpsertTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout (ms) for FAISS upsert operations."
-      },
-      "conversationIndexFaissSearchTimeoutMs": {
-        "type": "number",
-        "default": 5000,
-        "description": "Timeout (ms) for FAISS search operations."
-      },
-      "conversationIndexFaissHealthTimeoutMs": {
-        "type": "number",
-        "default": 2000,
-        "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
-      },
-      "conversationIndexFaissMaxBatchSize": {
-        "type": "number",
-        "default": 512,
-        "description": "Maximum transcript chunk batch size per FAISS upsert call."
-      },
-      "conversationIndexFaissMaxSearchK": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum top-K allowed for FAISS search requests."
-      },
-      "conversationRecallTopK": {
-        "type": "number",
-        "default": 3,
-        "description": "Top-K conversation chunks to include."
-      },
-      "conversationRecallMaxChars": {
-        "type": "number",
-        "default": 2500,
-        "description": "Max characters of semantic conversation recall to include."
-      },
-      "conversationRecallTimeoutMs": {
-        "type": "number",
-        "default": 800,
-        "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
-      },
-      "evalHarnessEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
-      },
-      "evalShadowModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
-      },
-      "benchmarkBaselineSnapshotsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
-      },
-      "benchmarkStoredBaselineEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable stored baseline comparisons for benchmark delta reporting."
-      },
-      "benchmarkDeltaReporterEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
-      },
-      "evalStoreDir": {
-        "type": "string",
-        "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
-      },
-      "objectiveStateMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
-      },
-      "objectiveStateSnapshotWritesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow writing typed objective-state snapshots to the objective-state store."
-      },
-      "objectiveStateRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant objective-state snapshots to recall context."
-      },
-      "objectiveStateStoreDir": {
-        "type": "string",
-        "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
-      },
-      "causalTrajectoryMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
-      },
-      "causalTrajectoryStoreDir": {
-        "type": "string",
-        "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
-      },
-      "causalTrajectoryRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant causal trajectories to recall context."
-      },
-      "trustZonesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
-      },
-      "quarantinePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Reserve future promotion flows from quarantine into higher-trust zones."
-      },
-      "trustZoneStoreDir": {
-        "type": "string",
-        "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
-      },
-      "trustZoneRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
-      },
-      "memoryPoisoningDefenseEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
-      },
-      "memoryRedTeamBenchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
-      },
-      "harmonicRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
-      },
-      "abstractionAnchorsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
-      },
-      "abstractionNodeStoreDir": {
-        "type": "string",
-        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
-      },
-      "verifiedRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
-      },
-      "semanticRulePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
-      },
-      "semanticRuleVerificationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
-      },
-      "semanticConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable periodic semantic consolidation of similar memories."
-      },
-      "semanticConsolidationModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
-      },
-      "semanticConsolidationThreshold": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
-      },
-      "semanticConsolidationMinClusterSize": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum cluster size before consolidation triggers."
-      },
-      "semanticConsolidationExcludeCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "correction",
-          "commitment",
-          "procedure"
-        ],
-        "description": "Memory categories excluded from semantic consolidation."
-      },
-      "semanticConsolidationIntervalHours": {
-        "type": "number",
-        "default": 168,
-        "description": "Hours between automatic consolidation runs (168 = weekly)."
-      },
-      "semanticConsolidationMaxPerRun": {
-        "type": "number",
-        "default": 100,
-        "description": "Max memories to consolidate per run to limit LLM cost."
-      },
-      "operatorAwareConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
-      },
-      "peerProfileReasonerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
-      },
-      "peerProfileReasonerModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
-      },
-      "peerProfileReasonerMinInteractions": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
-      },
-      "peerProfileReasonerMaxFieldsPerRun": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
-      },
-      "peerProfileRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
-      },
-      "peerProfileRecallMaxFields": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
-      },
-      "creationMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
-      },
-      "memoryUtilityLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
-      },
-      "promotionByOutcomeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
-      },
-      "commitmentLedgerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
-      },
-      "commitmentLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
-      },
-      "commitmentStaleDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
-      },
-      "commitmentLedgerDir": {
-        "type": "string",
-        "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
-      },
-      "resumeBundlesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
-      },
-      "resumeBundleDir": {
-        "type": "string",
-        "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
-      },
-      "workProductRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
-      },
-      "workProductLedgerDir": {
-        "type": "string",
-        "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
-      },
-      "workTasksEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable task tracking within the work product system."
-      },
-      "workProjectsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable project tracking within the work product system."
-      },
-      "workTasksDir": {
-        "type": "string",
-        "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
-      },
-      "workProjectsDir": {
-        "type": "string",
-        "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
-      },
-      "workIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable search index for work tasks and projects."
-      },
-      "workIndexDir": {
-        "type": "string",
-        "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
-      },
-      "workTaskIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tasks in the work search index."
-      },
-      "workProjectIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include projects in the work search index."
+        "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
       },
       "workIndexAutoRebuildEnabled": {
         "type": "boolean",
         "default": false,
         "description": "Automatically rebuild the work index when tasks or projects change."
       },
-      "workIndexAutoRebuildDebounceMs": {
-        "type": "number",
-        "default": 1000,
-        "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
-      },
-      "actionGraphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
-      },
-      "namespacesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-agent namespaces (v3.0). Default off."
-      },
-      "namespaceCatalogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
-      },
-      "defaultNamespace": {
+      "workIndexDir": {
         "type": "string",
-        "default": "default",
-        "description": "Default namespace name."
+        "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
       },
-      "sharedNamespace": {
+      "workIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable search index for work tasks and projects."
+      },
+      "workProductLedgerDir": {
         "type": "string",
-        "default": "shared",
-        "description": "Shared namespace name."
+        "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
       },
-      "principalFromSessionKeyMode": {
+      "workProductRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
+      },
+      "workProjectIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include projects in the work search index."
+      },
+      "workProjectsDir": {
         "type": "string",
-        "enum": [
-          "map",
-          "prefix",
-          "regex"
-        ],
-        "default": "map",
-        "description": "How to derive principal identity from sessionKey."
+        "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
       },
-      "principalFromSessionKeyRules": {
-        "type": "array",
-        "description": "Rules for resolving principal from sessionKey (ordered).",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "match": {
-              "type": "string"
-            },
-            "principal": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "match",
-            "principal"
-          ]
-        }
+      "workProjectsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable project tracking within the work product system."
       },
-      "namespacePolicies": {
-        "type": "array",
-        "description": "Namespace access policies.",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "readPrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "writePrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "includeInRecallByDefault": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "readPrincipals",
-            "writePrincipals"
-          ]
-        }
+      "workTaskIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include tasks in the work search index."
       },
-      "defaultRecallNamespaces": {
-        "type": "array",
-        "description": "Which namespaces to include by default in recall.",
-        "items": {
-          "type": "string",
-          "enum": [
-            "self",
-            "shared"
-          ]
-        },
-        "default": [
-          "self",
-          "shared"
-        ]
-      },
-      "scopeProfiles": {
-        "type": "object",
-        "default": {},
-        "description": "Optional hosted-team memory scope profiles. Profiles define ordered read layers, the default write layer, and authorized promotion target aliases without changing behavior when absent.",
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "readOrder": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "userProject",
-                  "teamProject",
-                  "userGlobal",
-                  "serverShared"
-                ]
-              }
-            },
-            "writeDefault": {
-              "type": "string",
-              "enum": [
-                "userProject",
-                "teamProject",
-                "userGlobal",
-                "serverShared"
-              ]
-            },
-            "promotionTargets": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "userProject",
-                  "teamProject",
-                  "userGlobal",
-                  "serverShared"
-                ]
-              }
-            },
-            "teamProject": {
-              "type": "object",
-              "properties": {
-                "namespaceTemplate": {
-                  "type": "string"
-                },
-                "teamId": {
-                  "type": "string"
-                }
-              }
-            },
-            "autoPromote": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "teamProject",
-                      "serverShared",
-                      "userGlobal",
-                      "userProject"
-                    ]
-                  }
-                },
-                "categories": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "minConfidenceTier": {
-                  "type": "string",
-                  "enum": [
-                    "explicit",
-                    "implied",
-                    "inferred",
-                    "speculative"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "defaultScopeProfile": {
+      "workTasksDir": {
         "type": "string",
-        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+        "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
       },
-      "teams": {
-        "type": "object",
-        "default": {},
-        "description": "Trusted team membership and team-project namespace templates used by scopeProfiles.",
-        "additionalProperties": {
-          "type": "object",
-          "properties": {
-            "principals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "projectNamespaceTemplate": {
-              "type": "string"
-            },
-            "read": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "write": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "promote": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
+      "workTasksEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable task tracking within the work product system."
       },
-      "cronRecallMode": {
+      "workspaceDir": {
         "type": "string",
-        "enum": [
-          "all",
-          "none",
-          "allowlist"
-        ],
-        "default": "all",
-        "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
-      },
-      "cronRecallAllowlist": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [],
-        "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
-      },
-      "cronRecallPolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
-      },
-      "cronRecallNormalizedQueryMaxChars": {
-        "type": "number",
-        "default": 480,
-        "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
-      },
-      "cronRecallInstructionHeavyTokenCap": {
-        "type": "number",
-        "default": 36,
-        "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
-      },
-      "cronConversationRecallMode": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "always",
-          "never"
-        ],
-        "default": "auto",
-        "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
-      },
-      "autoPromoteToSharedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
-      },
-      "autoPromoteToSharedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "fact",
-            "correction",
-            "decision",
-            "preference"
-          ]
-        },
-        "default": [
-          "fact",
-          "correction",
-          "decision",
-          "preference"
-        ],
-        "description": "Categories eligible for auto-promotion to shared."
-      },
-      "autoPromoteMinConfidenceTier": {
-        "type": "string",
-        "enum": [
-          "explicit",
-          "implied"
-        ],
-        "default": "explicit",
-        "description": "Minimum confidence tier for auto-promotion."
-      },
-      "routingRulesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable custom memory routing rules (v8.7). Default off."
-      },
-      "routingRulesStateFile": {
-        "type": "string",
-        "default": "state/routing-rules.json",
-        "description": "Relative path under memoryDir for persisted routing rules."
-      },
-      "sharedContextEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shared-context assembly and tools (v4.0). Default off."
-      },
-      "sharedContextDir": {
-        "type": "string",
-        "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
-      },
-      "sharedContextMaxInjectChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Max characters of shared-context to include in each recall context."
-      },
-      "crossSignalsSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic cross-signal grouping (reserved/experimental)."
-      },
-      "crossSignalsSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout for semantic cross-signal grouping (ms)."
-      },
-      "sharedCrossSignalSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
-      },
-      "sharedCrossSignalSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
-      },
-      "sharedCrossSignalSemanticMaxCandidates": {
-        "type": "number",
-        "default": 120,
-        "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
-      },
-      "compoundingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable compounding engine (v5.0). Default off."
-      },
-      "compoundingWeeklyCronEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
-      },
-      "compoundingSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic compounding synthesis (reserved/experimental)."
-      },
-      "compoundingSynthesisTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for compounding synthesis (ms)."
-      },
-      "compoundingInjectEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
-      },
-      "factDeduplicationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
-      },
-      "semanticDedupEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Issue #373 — enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
-      },
-      "semanticDedupThreshold": {
-        "type": "number",
-        "default": 0.92,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
-      },
-      "semanticDedupCandidates": {
-        "type": "number",
-        "default": 5,
-        "minimum": 0,
-        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
-      },
-      "factArchivalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
-      },
-      "factArchivalAgeDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Minimum age in days before a fact is eligible for archival."
-      },
-      "factArchivalMaxImportance": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
-      },
-      "factArchivalMaxAccessCount": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
-      },
-      "factArchivalProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle",
-          "procedure"
-        ],
-        "description": "Categories that protect a fact from archival regardless of other criteria."
-      },
-      "lifecyclePolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
-      },
-      "lifecycleFilterStaleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
-      },
-      "lifecyclePromoteHeatThreshold": {
-        "type": "number",
-        "default": 0.55,
-        "description": "Heat threshold for lifecycle promotion to validated/active states."
-      },
-      "lifecycleStaleDecayThreshold": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Decay threshold for lifecycle demotion to stale."
-      },
-      "lifecycleArchiveDecayThreshold": {
-        "type": "number",
-        "default": 0.85,
-        "description": "Decay threshold for lifecycle demotion to archived state semantics."
-      },
-      "lifecycleProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decision",
-          "principle",
-          "commitment",
-          "preference",
-          "procedure"
-        ],
-        "description": "Categories that lifecycle policy will not auto-archive."
-      },
-      "lifecycleMetricsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
-      },
-      "proactiveExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
-      },
-      "contextCompressionActionsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
-      },
-      "compressionGuidelineLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
-      },
-      "compressionGuidelineSemanticRefinementEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
-      },
-      "compressionGuidelineSemanticTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
-      },
-      "maxProactiveQuestionsPerExtraction": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
-      },
-      "proactiveExtractionTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
-      },
-      "proactiveExtractionMaxTokens": {
-        "type": "number",
-        "default": 900,
-        "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
-      },
-      "extractionMaxOutputTokens": {
-        "type": "number",
-        "default": 16384,
-        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
-      },
-      "proactiveExtractionCategoryAllowlist": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
-      },
-      "maxCompressionTokensPerHour": {
-        "type": "number",
-        "default": 1500,
-        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
-      },
-      "behaviorLoopAutoTuneEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
-      },
-      "behaviorLoopLearningWindowDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
-      },
-      "behaviorLoopMinSignalCount": {
-        "type": "number",
-        "default": 10,
-        "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
-      },
-      "behaviorLoopMaxDeltaPerCycle": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
-      },
-      "behaviorLoopProtectedParams": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "maxMemoryTokens",
-          "qmdMaxResults",
-          "qmdColdMaxResults",
-          "recallPlannerMaxQmdResultsMinimal",
-          "verbatimArtifactsMaxRecall"
-        ],
-        "description": "Runtime parameters that auto-tuning must never modify."
-      },
-      "searchBackend": {
-        "type": "string",
-        "enum": [
-          "qmd",
-          "remote",
-          "noop",
-          "lancedb",
-          "meilisearch",
-          "orama"
-        ],
-        "default": "qmd",
-        "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
-      },
-      "remoteSearchBaseUrl": {
-        "type": "string",
-        "description": "Base URL for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchApiKey": {
-        "type": "string",
-        "description": "API key for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout in ms for remote search backend requests"
-      },
-      "calibrationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable recall calibration rules (v9.0, default off)."
-      },
-      "calibrationMaxRulesPerRecall": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of calibration rules to include per recall pass."
-      },
-      "calibrationMaxChars": {
-        "type": "number",
-        "default": 1200,
-        "description": "Maximum characters of calibration content to include per recall pass."
-      },
-      "lancedbEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LanceDB as a supplemental search backend."
-      },
-      "lanceDbPath": {
-        "type": "string",
-        "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
-      },
-      "lanceEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
-      },
-      "meilisearchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Meilisearch as a supplemental search backend."
-      },
-      "meilisearchHost": {
-        "type": "string",
-        "default": "http://localhost:7700",
-        "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
-      },
-      "meilisearchApiKey": {
-        "type": "string",
-        "description": "API key for Meilisearch (when searchBackend=meilisearch)"
-      },
-      "meilisearchTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
-      },
-      "meilisearchAutoIndex": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
-      },
-      "oramaEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Orama as a supplemental search backend."
-      },
-      "oramaDbPath": {
-        "type": "string",
-        "description": "Directory path for Orama persistence files (when searchBackend=orama)"
-      },
-      "oramaEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
-      },
-      "qmdDaemonEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer the shared QMD MCP session for faster searches when available."
-      },
-      "qmdDaemonUrl": {
-        "type": "string",
-        "default": "http://localhost:8181/mcp",
-        "description": "Legacy compatibility setting retained for QMD daemon configuration."
-      },
-      "qmdDaemonRecheckIntervalMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Re-probe interval when daemon is down (ms)"
-      },
-      "qmdIntentHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
-      },
-      "qmdExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Request QMD explain traces for recall debugging when supported."
-      },
-      "knowledgeIndexEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject a compact Knowledge Index of top entities into every recall"
-      },
-      "knowledgeIndexMaxEntities": {
-        "type": "number",
-        "default": 40,
-        "description": "Max entities included in the Knowledge Index"
-      },
-      "knowledgeIndexMaxChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Hard character cap for the Knowledge Index section"
-      },
-      "entityRetrievalEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
-      },
-      "entityRetrievalMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "description": "Hard character cap for the entity retrieval section."
-      },
-      "entityRetrievalMaxHints": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum entity targets summarized in one recall pass."
-      },
-      "entityRetrievalMaxSupportingFacts": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum supporting fact/timeline snippets considered per entity target."
-      },
-      "entityRetrievalMaxRelatedEntities": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum related entities listed per target when confidence is high."
-      },
-      "entityRetrievalRecentTurns": {
-        "type": "number",
-        "default": 6,
-        "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
-      },
-      "entityRelationshipsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track entity-to-entity relationships during extraction"
-      },
-      "entityActivityLogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Log timestamped activity per entity"
-      },
-      "entityActivityLogMaxEntries": {
-        "type": "number",
-        "default": 20,
-        "description": "Max activity entries per entity before oldest are pruned"
-      },
-      "entityAliasesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Store aliases per entity file"
-      },
-      "entitySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Generate LLM summaries for entities during consolidation"
-      },
-      "entitySynthesisMaxTokens": {
-        "anyOf": [
-          {
-            "type": "integer",
-            "const": 0
-          },
-          {
-            "type": "integer",
-            "minimum": 10
-          }
-        ],
-        "default": 500,
-        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
-      },
-      "recallBudgetChars": {
-        "type": "number",
-        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
-      },
-      "recallOuterTimeoutMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Outer timeout in ms for the full recall pipeline."
-      },
-      "recallCoreDeadlineMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Default deadline in ms recorded for core recall sections."
-      },
-      "recallEnrichmentDeadlineMs": {
-        "type": "number",
-        "default": 25000,
-        "description": "Default deadline in ms recorded for enrichment recall sections."
-      },
-      "recallMmrEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
-      },
-      "recallMmrLambda": {
-        "type": "number",
-        "default": 0.7,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
-      },
-      "recallMmrTopN": {
-        "type": "number",
-        "default": 40,
-        "minimum": 0,
-        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
-      },
-      "recallReasoningTraceBoostEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
-      },
-      "recallPipeline": {
-        "type": "array",
-        "description": "Ordered recall sections with per-section budgets and feature knobs.",
-        "items": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean",
-              "default": true
-            },
-            "maxChars": {
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "consolidateTriggerLines": {
-              "type": "number"
-            },
-            "consolidateTargetLines": {
-              "type": "number"
-            },
-            "maxEntities": {
-              "type": "number"
-            },
-            "maxResults": {
-              "type": "number"
-            },
-            "maxTurns": {
-              "type": "number"
-            },
-            "maxTokens": {
-              "type": "number"
-            },
-            "lookbackHours": {
-              "type": "number"
-            },
-            "maxCount": {
-              "type": "number"
-            },
-            "topK": {
-              "type": "number"
-            },
-            "timeoutMs": {
-              "type": "number"
-            },
-            "maxPatterns": {
-              "type": "number"
-            },
-            "forceGeneric": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "id"
-          ]
-        }
-      },
-      "qmdRecallCacheTtlMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
-      },
-      "qmdRecallCacheStaleTtlMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
-      },
-      "qmdRecallCacheMaxEntries": {
-        "type": "number",
-        "default": 128,
-        "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
-      },
-      "lcmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Lossless Context Management (LCM) subsystem"
-      },
-      "lcmLeafBatchSize": {
-        "type": "number",
-        "default": 8,
-        "description": "Number of turns per leaf node in the LCM DAG"
-      },
-      "lcmRollupFanIn": {
-        "type": "number",
-        "default": 4,
-        "description": "Number of children per rollup node in the LCM DAG"
-      },
-      "lcmFreshTailTurns": {
-        "type": "number",
-        "default": 16,
-        "description": "Number of recent turns kept verbatim (not summarized)"
-      },
-      "lcmMaxDepth": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum depth of the LCM summary DAG"
-      },
-      "lcmRecallBudgetShare": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
-      },
-      "lcmDeterministicMaxTokens": {
-        "type": "number",
-        "default": 512,
-        "description": "Max tokens for deterministic (non-LLM) summaries"
-      },
-      "lcmTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
-      },
-      "lcmArchiveRetentionDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Days to retain archived LCM summaries"
-      },
-      "lcmObserveConcurrency": {
-        "type": "number",
-        "default": 1,
-        "description": "Maximum independent LCM observe jobs to process concurrently."
-      },
-      "messagePartsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
-      },
-      "messagePartsRecallMaxResults": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
-      },
-      "ircEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
-      },
-      "ircMaxPreferences": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum number of preferences to include in IRC rules."
-      },
-      "ircIncludeCorrections": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include corrections when building IRC rules (default on)."
-      },
-      "ircMinConfidence": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
-      },
-      "cmcEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
-      },
-      "cmcStitchLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of days to look back when stitching causal trajectories."
-      },
-      "cmcStitchMinScore": {
-        "type": "number",
-        "default": 2.5,
-        "description": "Minimum score for a causal edge to be stitched into a trajectory."
-      },
-      "cmcStitchMaxEdgesPerTrajectory": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum edges per trajectory during CMC stitching."
-      },
-      "cmcConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC consolidation pass (default off)."
-      },
-      "cmcConsolidationMinRecurrence": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum recurrence count before a CMC pattern is consolidated."
-      },
-      "cmcConsolidationMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a CMC pattern must appear in before consolidation."
-      },
-      "cmcConsolidationSuccessThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
-      },
-      "cmcRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC retrieval at recall time (default off)."
-      },
-      "cmcRetrievalMaxDepth": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum graph depth traversed during CMC retrieval."
-      },
-      "cmcRetrievalMaxChars": {
-        "type": "number",
-        "default": 800,
-        "description": "Maximum characters of CMC content included per recall pass."
-      },
-      "cmcRetrievalCounterfactualBoost": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
-      },
-      "cmcBehaviorLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC behavior pattern learning (default off)."
-      },
-      "cmcBehaviorMinFrequency": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum frequency for a behavior pattern to be learned by CMC."
-      },
-      "cmcBehaviorMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a behavior must appear in before CMC learns it."
-      },
-      "cmcBehaviorConfidenceThreshold": {
-        "type": "number",
-        "default": 0.6,
-        "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
-      },
-      "cmcLifecycleCausalImpactWeight": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Weight of causal impact score in CMC lifecycle scoring."
-      },
-      "parallelRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
-      },
-      "parallelAgentWeights": {
-        "type": "object",
-        "default": {
-          "direct": 1,
-          "contextual": 0.7,
-          "temporal": 0.85
-        },
-        "description": "Score weights per retrieval agent source applied during result merge."
-      },
-      "parallelMaxResultsPerAgent": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum results fetched per agent before merge."
-      },
-      "briefing": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {
-          "enabled": true,
-          "defaultWindow": "yesterday",
-          "defaultFormat": "markdown",
-          "maxFollowups": 5,
-          "calendarSource": null,
-          "saveByDefault": false,
-          "saveDir": null,
-          "llmFollowups": true
-        },
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": true
-          },
-          "defaultWindow": {
-            "type": "string",
-            "default": "yesterday"
-          },
-          "defaultFormat": {
-            "type": "string",
-            "enum": [
-              "markdown",
-              "json"
-            ],
-            "default": "markdown"
-          },
-          "maxFollowups": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 10,
-            "default": 5
-          },
-          "calendarSource": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "saveByDefault": {
-            "type": "boolean",
-            "default": false
-          },
-          "saveDir": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "llmFollowups": {
-            "type": "boolean",
-            "default": true
-          }
-        },
-        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
-      },
-      "enrichmentEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
-      },
-      "enrichmentAutoOnCreate": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
-      },
-      "enrichmentMaxCandidatesPerEntity": {
-        "type": "integer",
-        "default": 20,
-        "minimum": 0,
-        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
+        "description": "Override workspace directory path"
       }
     }
   },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -105,61 +105,491 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "openaiApiKey": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "const": false
-          }
+      "abstractionAnchorsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
+      },
+      "abstractionNodeStoreDir": {
+        "type": "string",
+        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
+      },
+      "accessTrackingBufferMaxSize": {
+        "type": "number",
+        "default": 100,
+        "description": "Max entries in access tracking buffer before flush"
+      },
+      "accessTrackingEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Track memory access counts and recency"
+      },
+      "actionGraphRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
+      },
+      "activeRecallAgents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
+      },
+      "activeRecallAllowChainedActiveMemory": {
+        "type": "boolean",
+        "default": false,
+        "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
+      },
+      "activeRecallAllowedChatTypes": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "direct",
+            "group",
+            "channel"
+          ]
+        },
+        "default": [
+          "direct",
+          "group",
+          "channel"
         ],
-        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+        "description": "OpenClaw chat types eligible for active recall."
       },
-      "openaiBaseUrl": {
+      "activeRecallAttachRecallExplain": {
+        "type": "boolean",
+        "default": false,
+        "description": "Attach recall explain output to active-recall diagnostics."
+      },
+      "activeRecallCacheTtlMs": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 120000,
+        "default": 15000,
+        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
+      },
+      "activeRecallCustomInstruction": {
         "type": "string",
-        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+        "description": "Optional custom guidance for the active-recall builder."
       },
-      "model": {
+      "activeRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection \u2014 when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
+      },
+      "activeRecallEntityGraphDepth": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "Entity-graph traversal depth used by active recall."
+      },
+      "activeRecallIncludeCausalTrajectories": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include causal trajectory recall evidence in active-recall summaries."
+      },
+      "activeRecallIncludeDaySummary": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include the latest day summary in active-recall context."
+      },
+      "activeRecallMaxSummaryChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 220,
+        "description": "Maximum summary size produced by the active-recall surface."
+      },
+      "activeRecallModel": {
         "type": "string",
-        "default": "gpt-5.5",
-        "description": "OpenAI model for extraction/consolidation"
+        "description": "Optional model selection for active recall."
       },
-      "reasoningEffort": {
+      "activeRecallModelFallbackPolicy": {
+        "type": "string",
+        "enum": [
+          "default-remote",
+          "resolved-only"
+        ],
+        "default": "default-remote",
+        "description": "How active recall falls back when an explicit model cannot be resolved."
+      },
+      "activeRecallPersistTranscripts": {
+        "type": "boolean",
+        "default": false,
+        "description": "Persist full active-recall request and response transcripts."
+      },
+      "activeRecallPromptAppend": {
+        "type": "string",
+        "description": "Optional additional guidance for the active-recall builder."
+      },
+      "activeRecallPromptStyle": {
+        "type": "string",
+        "enum": [
+          "balanced",
+          "strict",
+          "contextual",
+          "recall-heavy",
+          "precision-heavy",
+          "preference-only"
+        ],
+        "default": "balanced",
+        "description": "Context assembly style for the active-recall surface."
+      },
+      "activeRecallQueryMode": {
+        "type": "string",
+        "enum": [
+          "recent",
+          "message",
+          "full"
+        ],
+        "default": "recent",
+        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
+      },
+      "activeRecallRecentAssistantChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 400,
+        "description": "Per-assistant-turn character cap for active-recall context assembly."
+      },
+      "activeRecallRecentAssistantTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "How many recent assistant turns to include in the active-recall query context."
+      },
+      "activeRecallRecentUserChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 600,
+        "description": "Per-user-turn character cap for active-recall context assembly."
+      },
+      "activeRecallRecentUserTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4,
+        "default": 2,
+        "description": "How many recent user turns to include in the active-recall query context."
+      },
+      "activeRecallThinking": {
+        "type": "string",
+        "enum": [
+          "off",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "adaptive"
+        ],
+        "default": "low",
+        "description": "Reasoning effort used by the active-recall engine."
+      },
+      "activeRecallTimeoutMs": {
+        "type": "integer",
+        "minimum": 250,
+        "default": 15000,
+        "description": "Timeout for an active-recall run."
+      },
+      "activeRecallTranscriptDir": {
+        "type": "string",
+        "default": "active-recall",
+        "description": "Memory-relative directory for active-recall transcripts."
+      },
+      "agentAccessHttp": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Start the local Engram HTTP access server during plugin startup."
+          },
+          "host": {
+            "type": "string",
+            "default": "127.0.0.1",
+            "description": "Loopback host to bind for the Engram HTTP access server."
+          },
+          "port": {
+            "type": "number",
+            "default": 4318,
+            "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
+          },
+          "authToken": {
+            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "source"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "command": {}
+                }
+              }
+            ]
+          },
+          "principal": {
+            "type": "string",
+            "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
+          },
+          "maxBodyBytes": {
+            "type": "number",
+            "default": 131072,
+            "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "autoPromoteMinConfidenceTier": {
+        "type": "string",
+        "enum": [
+          "explicit",
+          "implied"
+        ],
+        "default": "explicit",
+        "description": "Minimum confidence tier for auto-promotion."
+      },
+      "autoPromoteToSharedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "fact",
+            "correction",
+            "decision",
+            "preference"
+          ]
+        },
+        "default": [
+          "fact",
+          "correction",
+          "decision",
+          "preference"
+        ],
+        "description": "Categories eligible for auto-promotion to shared."
+      },
+      "autoPromoteToSharedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
+      },
+      "beforeResetTimeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 30000,
+        "default": 2000,
+        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
+      },
+      "behaviorLoopAutoTuneEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
+      },
+      "behaviorLoopLearningWindowDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
+      },
+      "behaviorLoopMaxDeltaPerCycle": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
+      },
+      "behaviorLoopMinSignalCount": {
+        "type": "number",
+        "default": 10,
+        "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
+      },
+      "behaviorLoopProtectedParams": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "maxMemoryTokens",
+          "qmdMaxResults",
+          "qmdColdMaxResults",
+          "recallPlannerMaxQmdResultsMinimal",
+          "verbatimArtifactsMaxRecall"
+        ],
+        "description": "Runtime parameters that auto-tuning must never modify."
+      },
+      "benchmarkBaselineSnapshotsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
+      },
+      "benchmarkDeltaReporterEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
+      },
+      "benchmarkStoredBaselineEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable stored baseline comparisons for benchmark delta reporting."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
+      },
+      "binaryLifecycleBackendType": {
         "type": "string",
         "enum": [
           "none",
-          "low",
-          "medium",
-          "high"
+          "filesystem",
+          "s3"
         ],
-        "default": "low",
-        "description": "Reasoning effort for extraction"
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
       },
-      "triggerMode": {
-        "type": "string",
-        "enum": [
-          "smart",
-          "every_n",
-          "time_based"
-        ],
-        "default": "smart",
-        "description": "Buffer trigger mode"
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
       },
-      "bufferMaxTurns": {
+      "binaryLifecycleGracePeriodDays": {
         "type": "number",
-        "default": 5,
-        "description": "Max turns before forced extraction"
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "boostAccessCount": {
+        "type": "boolean",
+        "default": true,
+        "description": "Boost frequently accessed memories in search results"
+      },
+      "boxMaxMemories": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum memories per box before forced seal."
+      },
+      "boxRecallDays": {
+        "type": "number",
+        "default": 3,
+        "description": "Number of recent days of boxes to add during recall."
+      },
+      "boxTimeGapMs": {
+        "type": "number",
+        "default": 1800000,
+        "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
+      },
+      "boxTopicShiftThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0\u20131)."
+      },
+      "briefing": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {
+          "enabled": true,
+          "defaultWindow": "yesterday",
+          "defaultFormat": "markdown",
+          "maxFollowups": 5,
+          "calendarSource": null,
+          "saveByDefault": false,
+          "saveDir": null,
+          "llmFollowups": true
+        },
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "defaultWindow": {
+            "type": "string",
+            "default": "yesterday"
+          },
+          "defaultFormat": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "json"
+            ],
+            "default": "markdown"
+          },
+          "maxFollowups": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          },
+          "calendarSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "saveByDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "saveDir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "llmFollowups": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
       },
       "bufferMaxMinutes": {
         "type": "number",
         "default": 15,
         "description": "Max minutes before forced extraction"
       },
-      "bufferSurpriseTriggerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
+      "bufferMaxTurns": {
+        "type": "number",
+        "default": 5,
+        "description": "Max turns before forced extraction"
+      },
+      "bufferSurpriseK": {
+        "type": "number",
+        "default": 5,
+        "minimum": 1,
+        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      },
+      "bufferSurpriseProbeTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "minimum": 1,
+        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers \u2014 a slow or hung embedder cannot stall the turn-append path."
+      },
+      "bufferSurpriseRecentMemoryCount": {
+        "type": "number",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
       },
       "bufferSurpriseThreshold": {
         "type": "number",
@@ -168,308 +598,940 @@
         "maximum": 1,
         "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
       },
-      "bufferSurpriseK": {
-        "type": "number",
-        "default": 5,
-        "minimum": 1,
-        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      "bufferSurpriseTriggerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only \u2014 never suppresses existing flushes. Off by default."
       },
-      "bufferSurpriseRecentMemoryCount": {
+      "calibrationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable recall calibration rules (v9.0, default off)."
+      },
+      "calibrationMaxChars": {
         "type": "number",
-        "default": 20,
+        "default": 1200,
+        "description": "Maximum characters of calibration content to include per recall pass."
+      },
+      "calibrationMaxRulesPerRecall": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of calibration rules to include per recall pass."
+      },
+      "captureMode": {
+        "type": "string",
+        "enum": [
+          "implicit",
+          "explicit",
+          "hybrid"
+        ],
+        "default": "implicit",
+        "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
+      },
+      "causalGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
+      },
+      "causalRuleExtractionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
+      },
+      "causalTrajectoryMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
+      },
+      "causalTrajectoryRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant causal trajectories to recall context."
+      },
+      "causalTrajectoryStoreDir": {
+        "type": "string",
+        "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
+      },
+      "chat": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default \u2014 spawns LLM calls so explicit opt-in (rule 48).",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
+          },
+          "model": {
+            "type": "string",
+            "default": "",
+            "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
+          },
+          "maxToolCallsPerTurn": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 64,
+            "default": 8,
+            "description": "Max tool calls per user turn before partial-reply fallback (rule 34 \u2014 never a silent stall)."
+          },
+          "sessionTtlHours": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 72,
+            "description": "Hours after which idle chat session state is cleaned up."
+          }
+        }
+      },
+      "checkpointEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable conversation checkpoints"
+      },
+      "checkpointTurns": {
+        "type": "number",
+        "default": 15,
+        "description": "Number of turns per checkpoint"
+      },
+      "chunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic chunking of long memories"
+      },
+      "chunkingMinTokens": {
+        "type": "number",
+        "default": 150,
+        "description": "Minimum tokens to trigger chunking"
+      },
+      "chunkingOverlapSentences": {
+        "type": "number",
+        "default": 2,
+        "description": "Number of sentences to overlap between chunks"
+      },
+      "chunkingTargetTokens": {
+        "type": "number",
+        "default": 200,
+        "description": "Target tokens per chunk"
+      },
+      "citationsAutoDetect": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-enable citations when the Codex adapter is detected."
+      },
+      "citationsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+      },
+      "cmcBehaviorConfidenceThreshold": {
+        "type": "number",
+        "default": 0.6,
+        "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
+      },
+      "cmcBehaviorLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC behavior pattern learning (default off)."
+      },
+      "cmcBehaviorMinFrequency": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum frequency for a behavior pattern to be learned by CMC."
+      },
+      "cmcBehaviorMinSessions": {
+        "type": "number",
+        "default": 2,
+        "description": "Minimum sessions a behavior must appear in before CMC learns it."
+      },
+      "cmcConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC consolidation pass (default off)."
+      },
+      "cmcConsolidationMinRecurrence": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum recurrence count before a CMC pattern is consolidated."
+      },
+      "cmcConsolidationMinSessions": {
+        "type": "number",
+        "default": 2,
+        "description": "Minimum sessions a CMC pattern must appear in before consolidation."
+      },
+      "cmcConsolidationSuccessThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
+      },
+      "cmcEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
+      },
+      "cmcLifecycleCausalImpactWeight": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Weight of causal impact score in CMC lifecycle scoring."
+      },
+      "cmcRetrievalCounterfactualBoost": {
+        "type": "number",
+        "default": 0.4,
+        "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
+      },
+      "cmcRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable CMC retrieval at recall time (default off)."
+      },
+      "cmcRetrievalMaxChars": {
+        "type": "number",
+        "default": 800,
+        "description": "Maximum characters of CMC content included per recall pass."
+      },
+      "cmcRetrievalMaxDepth": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum graph depth traversed during CMC retrieval."
+      },
+      "cmcStitchLookbackDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Number of days to look back when stitching causal trajectories."
+      },
+      "cmcStitchMaxEdgesPerTrajectory": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum edges per trajectory during CMC stitching."
+      },
+      "cmcStitchMinScore": {
+        "type": "number",
+        "default": 2.5,
+        "description": "Minimum score for a causal edge to be stitched into a trajectory."
+      },
+      "codex": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "installExtension": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install the Remnic Codex memory extension during Codex connector setup."
+          },
+          "codexHome": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null,
+            "description": "Optional Codex home directory override used for connector install and materialization."
+          }
+        }
+      },
+      "codexCompat": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "threadIdBufferKeying": {
+            "type": "boolean",
+            "default": true
+          },
+          "compactionFlushMode": {
+            "type": "string",
+            "enum": [
+              "signal",
+              "heuristic",
+              "auto"
+            ],
+            "default": "auto"
+          },
+          "fingerprintDedup": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "codexMarketplaceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex marketplace integration for plugin discovery and installation."
+      },
+      "codexMaterializeMaxSummaryTokens": {
+        "type": "number",
         "minimum": 0,
-        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+        "default": 4500,
+        "description": "Whitespace-token cap for Codex memory summary materialization."
       },
-      "bufferSurpriseProbeTimeoutMs": {
+      "codexMaterializeMemories": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex native memory materialization into the Codex memories directory."
+      },
+      "codexMaterializeNamespace": {
+        "type": "string",
+        "default": "auto",
+        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
+      },
+      "codexMaterializeOnConsolidation": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
+      },
+      "codexMaterializeOnSessionEnd": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization from the Codex session-end hook."
+      },
+      "codexMaterializeRolloutRetentionDays": {
         "type": "number",
-        "default": 2000,
+        "minimum": 0,
+        "default": 30,
+        "description": "Retention window in days for Codex rollout materialization artifacts."
+      },
+      "codingKnowledge": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Durable coding-knowledge surface \u2014 Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
+          },
+          "decisionRecords": {
+            "type": "boolean",
+            "default": true,
+            "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
+          },
+          "architectureCard": {
+            "type": "boolean",
+            "default": true,
+            "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
+          },
+          "sessionDelta": {
+            "type": "boolean",
+            "default": true,
+            "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
+          },
+          "architectureCardLlmSummary": {
+            "type": "boolean",
+            "default": false,
+            "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
+          },
+          "structuralProvider": {
+            "type": "string",
+            "enum": [
+              "none",
+              "subprocess",
+              "native"
+            ],
+            "default": "none",
+            "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
+          },
+          "structuralProviderCommand": {
+            "type": "string",
+            "default": "",
+            "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
+          },
+          "codegraphTools": {
+            "type": "boolean",
+            "default": false,
+            "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default \u2014 tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
+          },
+          "codegraphDbDir": {
+            "type": "string",
+            "default": "",
+            "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
+          }
+        }
+      },
+      "codingMode": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Coding-agent project/branch scoping (issue #569).",
+        "properties": {
+          "projectScope": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
+          },
+          "branchScope": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in \u2014 most development wants cross-branch recall. Wired in PR 3 of #569."
+          },
+          "globalFallback": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
+          }
+        }
+      },
+      "collectJudgeTrainingPairs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+      },
+      "commandsListEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
+      },
+      "commitmentDecayDays": {
+        "type": "integer",
         "minimum": 1,
-        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+        "default": 90,
+        "description": "Days before fulfilled/expired commitments are removed"
+      },
+      "commitmentLedgerDir": {
+        "type": "string",
+        "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
+      },
+      "commitmentLedgerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
+      },
+      "commitmentLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
+      },
+      "commitmentStaleDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
+      },
+      "compactionResetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
+      },
+      "compoundingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable compounding engine (v5.0). Default off."
+      },
+      "compoundingInjectEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
+      },
+      "compoundingSemanticEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic compounding synthesis (reserved/experimental)."
+      },
+      "compoundingSynthesisTimeoutMs": {
+        "type": "number",
+        "default": 15000,
+        "description": "Timeout for compounding synthesis (ms)."
+      },
+      "compoundingWeeklyCronEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
+      },
+      "compressionGuidelineLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
+      },
+      "compressionGuidelineSemanticRefinementEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
+      },
+      "compressionGuidelineSemanticTimeoutMs": {
+        "type": "number",
+        "default": 2500,
+        "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
+      },
+      "connectors": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
+        "properties": {
+          "googleDrive": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off \u2014 set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+              },
+              "clientId": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
+              },
+              "clientSecret": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
+              },
+              "refreshToken": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "folderIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
+              }
+            }
+          },
+          "notion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off \u2014 set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
+              },
+              "databaseIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
+          },
+          "gmail": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off \u2014 set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
+              },
+              "clientId": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
+              },
+              "clientSecret": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
+              },
+              "refreshToken": {
+                "type": "string",
+                "default": "",
+                "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
+              },
+              "userId": {
+                "type": "string",
+                "default": "me",
+                "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
+              },
+              "query": {
+                "type": "string",
+                "default": "in:inbox",
+                "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
+          },
+          "github": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off \u2014 set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
+              },
+              "userLogin": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
+              },
+              "repos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "includeDiscussions": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
+              }
+            }
+          }
+        }
       },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,
         "description": "Run consolidation every N extractions"
       },
-      "highSignalPatterns": {
+      "consolidationMinIntervalMs": {
+        "type": "number",
+        "default": 600000,
+        "description": "Minimum interval between consolidation runs (ms)."
+      },
+      "consolidationRequireNonZeroExtraction": {
+        "type": "boolean",
+        "default": true,
+        "description": "Only schedule consolidation when the last extraction produced durable outputs."
+      },
+      "contextCompressionActionsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
+      },
+      "continuityAuditEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable continuity audit artifact generation workflows"
+      },
+      "continuityIncidentLoggingEnabled": {
+        "type": "boolean",
+        "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
+      },
+      "contradictionAutoResolve": {
+        "type": "boolean",
+        "default": true,
+        "description": "Automatically supersede contradicted memories"
+      },
+      "contradictionDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic contradiction detection with LLM verification"
+      },
+      "contradictionMinConfidence": {
+        "type": "number",
+        "default": 0.9,
+        "description": "Minimum LLM confidence to auto-resolve contradictions"
+      },
+      "contradictionScan": {
+        "type": "object",
+        "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
+          },
+          "similarityFloor": {
+            "type": "number",
+            "default": 0.82,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Embedding cosine similarity floor for candidate pair generation"
+          },
+          "topicOverlapFloor": {
+            "type": "number",
+            "default": 0.4,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
+          },
+          "maxPairsPerRun": {
+            "type": "integer",
+            "default": 500,
+            "minimum": 1,
+            "description": "Cap on candidate pairs evaluated per cron run"
+          },
+          "cooldownDays": {
+            "type": "integer",
+            "default": 14,
+            "minimum": 0,
+            "description": "Cooldown in days. 0 = always re-evaluate."
+          },
+          "autoMergeDuplicates": {
+            "type": "boolean",
+            "default": false,
+            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
+          }
+        }
+      },
+      "contradictionSimilarityThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "QMD similarity threshold to trigger contradiction check"
+      },
+      "conversationIndexBackend": {
+        "type": "string",
+        "enum": [
+          "qmd",
+          "faiss"
+        ],
+        "default": "qmd",
+        "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
+      },
+      "conversationIndexEmbedOnUpdate": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
+      },
+      "conversationIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
+      },
+      "conversationIndexFaissHealthTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
+      },
+      "conversationIndexFaissIndexDir": {
+        "type": "string",
+        "default": "state/conversation-index/faiss",
+        "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
+      },
+      "conversationIndexFaissMaxBatchSize": {
+        "type": "number",
+        "default": 512,
+        "description": "Maximum transcript chunk batch size per FAISS upsert call."
+      },
+      "conversationIndexFaissMaxSearchK": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum top-K allowed for FAISS search requests."
+      },
+      "conversationIndexFaissModelId": {
+        "type": "string",
+        "default": "text-embedding-3-small",
+        "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
+      },
+      "conversationIndexFaissPythonBin": {
+        "type": "string",
+        "default": "",
+        "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
+      },
+      "conversationIndexFaissScriptPath": {
+        "type": "string",
+        "default": "",
+        "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
+      },
+      "conversationIndexFaissSearchTimeoutMs": {
+        "type": "number",
+        "default": 5000,
+        "description": "Timeout (ms) for FAISS search operations."
+      },
+      "conversationIndexFaissUpsertTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout (ms) for FAISS upsert operations."
+      },
+      "conversationIndexMinUpdateIntervalMs": {
+        "type": "number",
+        "default": 900000,
+        "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
+      },
+      "conversationIndexQmdCollection": {
+        "type": "string",
+        "default": "openclaw-engram-conversations",
+        "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
+      },
+      "conversationIndexRetentionDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Days to retain conversation chunk docs."
+      },
+      "conversationRecallMaxChars": {
+        "type": "number",
+        "default": 2500,
+        "description": "Max characters of semantic conversation recall to include."
+      },
+      "conversationRecallTimeoutMs": {
+        "type": "number",
+        "default": 800,
+        "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
+      },
+      "conversationRecallTopK": {
+        "type": "number",
+        "default": 3,
+        "description": "Top-K conversation chunks to include."
+      },
+      "correctionApplyRequiresConfirm": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
+      },
+      "correctionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for the Correction Contract (#1580) \u2014 the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
+      },
+      "correctionMaxAffected": {
+        "type": "integer",
+        "minimum": 1,
+        "default": 10,
+        "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
+      },
+      "correctionPlanTtlHours": {
+        "type": "number",
+        "default": 24,
+        "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
+      },
+      "creationMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
+      },
+      "cronConversationRecallMode": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "always",
+          "never"
+        ],
+        "default": "auto",
+        "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
+      },
+      "cronRecallAllowlist": {
         "type": "array",
         "items": {
           "type": "string"
         },
-        "description": "Custom regex patterns for immediate extraction"
+        "default": [],
+        "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
       },
-      "maxMemoryTokens": {
+      "cronRecallInstructionHeavyTokenCap": {
         "type": "number",
-        "default": 2000,
-        "description": "Max memory-context tokens per turn"
+        "default": 36,
+        "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
       },
-      "memoryOsPreset": {
+      "cronRecallMode": {
         "type": "string",
         "enum": [
-          "conservative",
-          "balanced",
-          "research",
-          "research-max",
-          "local-llm-heavy"
+          "all",
+          "none",
+          "allowlist"
         ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+        "default": "all",
+        "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
       },
-      "qmdEnabled": {
+      "cronRecallNormalizedQueryMaxChars": {
+        "type": "number",
+        "default": 480,
+        "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
+      },
+      "cronRecallPolicyEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Use QMD for search"
+        "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
       },
-      "qmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram",
-        "description": "QMD collection name"
-      },
-      "qmdMaxResults": {
-        "type": "number",
-        "default": 8,
-        "description": "Max QMD results per search"
-      },
-      "qmdColdTierEnabled": {
+      "crossSignalsSemanticEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
+        "description": "Enable semantic cross-signal grouping (reserved/experimental)."
       },
-      "qmdColdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-cold",
-        "description": "Secondary QMD collection name used for cold-tier fallback recall"
-      },
-      "qmdColdMaxResults": {
+      "crossSignalsSemanticTimeoutMs": {
         "type": "number",
-        "default": 8,
-        "description": "Max cold-tier QMD results considered before final recall cap"
+        "default": 4000,
+        "description": "Timeout for semantic cross-signal grouping (ms)."
       },
-      "qmdTierMigrationEnabled": {
+      "daySummaryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
+      },
+      "daySummaryTimezone": {
+        "type": "string",
+        "default": "",
+        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+      },
+      "debug": {
         "type": "boolean",
         "default": false,
-        "description": "Enable value-aware migration between hot and cold QMD tiers"
+        "description": "Enable debug logging"
       },
-      "qmdTierDemotionMinAgeDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Minimum hot-memory age in days before tier demotion is eligible"
-      },
-      "qmdTierDemotionValueThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
-      },
-      "qmdTierPromotionValueThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
-      },
-      "qmdTierParityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierParityHiMemEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
-      },
-      "qmdTierAutoBackfillEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
-      },
-      "qmdSupportedVersion": {
+      "defaultNamespace": {
         "type": "string",
-        "default": "2.5.3",
-        "description": "Highest QMD version this Remnic build will auto-install"
+        "default": "default",
+        "description": "Default namespace name."
       },
-      "qmdAutoUpgradeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
-      },
-      "qmdAutoUpgradeCheckIntervalMs": {
-        "type": "number",
-        "minimum": 60000,
-        "default": 86400000,
-        "description": "Minimum interval between QMD auto-upgrade checks"
-      },
-      "qmdChunkStrategy": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "regex"
-        ],
-        "default": "auto",
-        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
-      },
-      "qmdCandidateLimit": {
-        "type": "number",
-        "minimum": 1,
-        "description": "Optional candidate limit forwarded to supported QMD query paths"
-      },
-      "qmdQueryRerankEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
-      },
-      "qmdSearchStrategy": {
-        "type": "string",
-        "enum": [
-          "hybrid",
-          "lex-vec",
-          "lex"
-        ],
-        "default": "hybrid",
-        "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdSubprocessStrategy": {
-        "type": "string",
-        "enum": [
-          "query",
-          "search"
-        ],
-        "default": "query",
-        "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
-      },
-      "qmdDaemonTimeoutMs": {
-        "type": "number",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 8000,
-        "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
-      },
-      "qmdIndexName": {
-        "type": "string",
-        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
-      },
-      "qmdForceCpu": {
-        "type": "boolean",
-        "default": false,
-        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
-      },
-      "qmdGpuBackend": {
-        "type": [
-          "string",
-          "boolean"
-        ],
-        "enum": [
-          "auto",
-          "metal",
-          "cuda",
-          "vulkan",
-          "false",
-          false
-        ],
-        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
-      },
-      "qmdEmbedParallelism": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 8,
-        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
-      },
-      "qmdEmbedModel": {
-        "type": "string",
-        "description": "Optional QMD_EMBED_MODEL override"
-      },
-      "qmdRerankModel": {
-        "type": "string",
-        "description": "Optional QMD_RERANK_MODEL override"
-      },
-      "qmdGenerateModel": {
-        "type": "string",
-        "description": "Optional QMD_GENERATE_MODEL override"
-      },
-      "embeddingFallbackEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
-      },
-      "embeddingFallbackProvider": {
-        "type": "string",
-        "enum": [
-          "auto",
-          "openai",
-          "local"
-        ],
-        "default": "auto",
-        "description": "Embedding provider selection for semantic fallback"
-      },
-      "hostEmbeddingProviderEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
-      },
-      "hostEmbeddingProviderId": {
-        "type": "string",
-        "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
-      },
-      "hostEmbeddingProviderModel": {
-        "type": "string",
-        "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
-      },
-      "embeddingFallbackModel": {
-        "type": "string",
-        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
-      },
-      "qmdPath": {
-        "type": "string",
-        "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
-      },
-      "memoryDir": {
-        "type": "string",
-        "description": "Override memory storage directory"
-      },
-      "entitySchemas": {
-        "type": "object",
-        "description": "Optional per-entity-type structured section schema customizations.",
-        "additionalProperties": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "sections": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "aliases": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "anyOf": [
-                  {
-                    "required": [
-                      "key"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "title"
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "required": [
-            "sections"
+      "defaultRecallNamespaces": {
+        "type": "array",
+        "description": "Which namespaces to include by default in recall.",
+        "items": {
+          "type": "string",
+          "enum": [
+            "self",
+            "shared"
           ]
-        }
+        },
+        "default": [
+          "self",
+          "shared"
+        ]
+      },
+      "defaultScopeProfile": {
+        "type": "string",
+        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+      },
+      "delinearizeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
       },
       "dreaming": {
         "type": "object",
@@ -512,7 +1574,7 @@
           "narrativeModel": {
             "type": "string",
             "default": "",
-            "description": "Model used to write dream-journal narratives. Under modelSource=plugin this must be an OpenAI model id used with the direct OpenAI key. Under modelSource=gateway it accepts a provider-qualified id (e.g. zai/glm-4.7-flash) routed through gateway providers — no direct OpenAI key required; leave empty to fall back to taskModelChain / the gateway default chain."
+            "description": "Model used to write dream-journal narratives. Under modelSource=plugin this must be an OpenAI model id used with the direct OpenAI key. Under modelSource=gateway it accepts a provider-qualified id (e.g. zai/glm-4.7-flash) routed through gateway providers \u2014 no direct OpenAI key required; leave empty to fall back to taskModelChain / the gateway default chain."
           },
           "narrativePromptStyle": {
             "type": "string",
@@ -657,1142 +1719,411 @@
           }
         }
       },
-      "heartbeat": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "journalPath": {
-            "type": "string",
-            "default": "HEARTBEAT.md"
-          },
-          "maxPreviousRuns": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 20,
-            "default": 5
-          },
-          "watchFile": {
-            "type": "boolean",
-            "default": true
-          },
-          "detectionMode": {
-            "type": "string",
-            "enum": [
-              "runtime-signal",
-              "heuristic",
-              "auto"
-            ],
-            "default": "auto"
-          },
-          "gateExtractionDuringHeartbeat": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      },
-      "codingMode": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Coding-agent project/branch scoping (issue #569).",
-        "properties": {
-          "projectScope": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
-          },
-          "branchScope": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
-          },
-          "globalFallback": {
-            "type": "boolean",
-            "default": true,
-            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
-          }
-        }
-      },
-      "codingKnowledge": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Durable coding-knowledge surface — Track A of issue #1548. Master gate + per-feature switches for decision records, architecture card, session delta, and structural-context provider. Off by default so pre-feature byte-identical behaviour is preserved when disabled.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate. Off (default) means no Track A surface fires and no new tools / briefing lines / state directories appear. On enables the switches below."
-          },
-          "decisionRecords": {
-            "type": "boolean",
-            "default": true,
-            "description": "Decision-record surfaces (list/record/supersede) + briefing titles of standing decisions. Effective only under the master gate."
-          },
-          "architectureCard": {
-            "type": "boolean",
-            "default": true,
-            "description": "Architecture-card build/refresh + briefing injection. Effective only under the master gate."
-          },
-          "sessionDelta": {
-            "type": "boolean",
-            "default": true,
-            "description": "Last-seen-head persistence + delta briefing line. Effective only under the master gate."
-          },
-          "architectureCardLlmSummary": {
-            "type": "boolean",
-            "default": false,
-            "description": "Opt-in LLM summary pass on the architecture card. Costs tokens; default off (rule 48). Effective only under the master and card gates."
-          },
-          "structuralProvider": {
-            "type": "string",
-            "enum": [
-              "none",
-              "subprocess",
-              "native"
-            ],
-            "default": "none",
-            "description": "Structural-context provider selection: \"none\" (default) keeps review-context file-path-only, \"subprocess\" shells out to structuralProviderCommand via execFile (argv array), \"native\" adapts the in-family engine when @remnic/coding-graph is installed."
-          },
-          "structuralProviderCommand": {
-            "type": "string",
-            "default": "",
-            "description": "Absolute path to the subprocess binary when structuralProvider = \"subprocess\". Empty string = no command configured. The consumer validates existence at boot (rule 24)."
-          },
-          "codegraphTools": {
-            "type": "boolean",
-            "default": false,
-            "description": "Gate for the 14 codegraph parity tools (issue #1554). Off by default — tools/list, HTTP routes, and CLI help are byte-identical to pre-feature until this is true. Also requires @remnic/coding-graph to be installed."
-          },
-          "codegraphDbDir": {
-            "type": "string",
-            "default": "",
-            "description": "Root directory for per-project graph SQLite DBs. Empty string = derive from memoryDir (<memoryDir>/codegraph/<principal>/<projectId>.sqlite). Absolute path required when set explicitly (rule 11)."
-          }
-        }
-      },
-      "procedural": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519). Default-on since issue #567 PR 4/5; set to `false` to opt out."
-          },
-          "minOccurrences": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 1000,
-            "default": 3,
-            "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
-          },
-          "successFloor": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-            "default": 0.75,
-            "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
-          },
-          "autoPromoteOccurrences": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 10000,
-            "default": 8,
-            "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
-          },
-          "autoPromoteEnabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
-          },
-          "lookbackDays": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 3650,
-            "default": 14,
-            "description": "Trajectory lookback window for procedural mining."
-          },
-          "recallMaxProcedures": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 10,
-            "default": 2,
-            "description": "Maximum procedure memories to add on task-initiation recall."
-          },
-          "proceduralMiningCronAutoRegister": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, installer may register the nightly procedural mining cron job."
-          }
-        }
-      },
-      "wearables": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Wearable transcript ingestion (Limitless / Bee / Omi). Connector packages install a la carte: @remnic/connector-limitless, @remnic/connector-bee, @remnic/connector-omi. See docs/wearables.md.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate for the wearables subsystem."
-          },
-          "timezone": {
-            "type": "string",
-            "description": "IANA timezone used to bucket transcripts into days. Defaults to the host timezone."
-          },
-          "redactionEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Redact SSN / payment-card patterns from transcripts before storage and extraction."
-          },
-          "redactionPatterns": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [],
-            "description": "Additional user-supplied redaction regexes (validated at config load)."
-          },
-          "offTheRecordEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Honor a spoken 'off the record' marker by eliding segments until 'back on the record'."
-          },
-          "digestEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Write one compact daily-digest memory per synced source/day."
-          },
-          "autoSyncEnabled": {
-            "type": "boolean",
-            "default": true,
-            "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
-          },
-          "autoSyncIntervalMinutes": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 1440,
-            "default": 15,
-            "description": "Minutes between auto-sync ticks."
-          },
-          "autoSyncDays": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 90,
-            "default": 2,
-            "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
-          },
-          "autoSyncDeepDays": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 90,
-            "default": 7,
-            "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
-          },
-          "corrections": {
-            "type": "array",
-            "default": [],
-            "description": "User-specific transcript correction rules applied on every sync (merged with CLI-managed rules).",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "match",
-                "replace"
-              ],
-              "properties": {
-                "match": {
-                  "type": "string",
-                  "description": "Text (or regex when regex=true) to match."
-                },
-                "replace": {
-                  "type": "string",
-                  "description": "Replacement text."
-                },
-                "regex": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "Treat match as a regular expression."
-                },
-                "caseInsensitive": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "Case-insensitive matching."
-                },
-                "sources": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Restrict the rule to specific source ids."
-                }
-              }
-            }
-          },
-          "sources": {
-            "type": "object",
-            "default": {},
-            "description": "Per-source settings keyed by connector id (limitless, bee, omi, or a custom connector id).",
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "Enable syncing from this wearable source."
-                },
-                "apiKey": {
-                  "type": "string",
-                  "description": "Provider API credential. Prefer the per-connector environment variable (e.g. ${LIMITLESS_API_KEY}); a config value takes precedence when both are set."
-                },
-                "baseUrl": {
-                  "type": "string",
-                  "description": "Override the provider base URL (self-hosted / local-proxy setups, e.g. the Bee local proxy)."
-                },
-                "appId": {
-                  "type": "string",
-                  "description": "Omi only: integration app id (the {app_id} path component of the Omi Integrations API)."
-                },
-                "userId": {
-                  "type": "string",
-                  "description": "Omi only: target user id supplied as the uid query parameter."
-                },
-                "memoryMode": {
-                  "type": "string",
-                  "enum": [
-                    "off",
-                    "review",
-                    "auto",
-                    "smart"
-                  ],
-                  "default": "smart",
-                  "description": "Memory creation trust gate: smart (default) = LLM-judge + per-source trust prior + cross-device corroboration decide active/review/drop automatically; off = transcripts only; review = every candidate lands pending_review; auto = deterministic gates only, survivors active."
-                },
-                "sourceTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.8,
-                  "description": "Trust prior for this source's transcription quality (0..1). Multiplies extraction confidence in smart mode — lower it for a device that mis-transcribes often."
-                },
-                "autoApproveTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.7,
-                  "description": "Smart mode: trust score at/above which facts are written active."
-                },
-                "reviewTrust": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.45,
-                  "description": "Smart mode: trust score at/above which borderline facts are queued for review instead of dropped. Must be below autoApproveTrust."
-                },
-                "minConfidence": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 1,
-                  "default": 0.6,
-                  "description": "Drop extracted facts below this confidence."
-                },
-                "minImportance": {
-                  "type": "string",
-                  "enum": [
-                    "trivial",
-                    "low",
-                    "normal",
-                    "high",
-                    "critical"
-                  ],
-                  "default": "low",
-                  "description": "Drop extracted facts scored below this importance level."
-                },
-                "maxMemoriesPerDay": {
-                  "type": "integer",
-                  "minimum": 0,
-                  "default": 0,
-                  "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
-                },
-                "importNativeMemories": {
-                  "type": "string",
-                  "enum": [
-                    "off",
-                    "review",
-                    "smart"
-                  ],
-                  "default": "smart",
-                  "description": "Import provider-extracted memories (Bee facts / Omi memories): smart (default) routes them through the same judge + trust pipeline with a reduced prior; review always queues; off skips."
-                },
-                "cleanup": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "default": {},
-                  "properties": {
-                    "mergeSameSpeaker": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Merge consecutive same-speaker segments."
-                    },
-                    "stripFillers": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Strip standalone filler tokens (um, uh, ...)."
-                    },
-                    "collapseRepeats": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Collapse immediately repeated phrases (ASR stutter)."
-                    },
-                    "dropLowQuality": {
-                      "type": "boolean",
-                      "default": true,
-                      "description": "Drop segments that look like ASR garbage."
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "secureStoreEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
-      },
-      "secureStoreEncryptOnWrite": {
+      "embeddingFallbackEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
+        "description": "Enable embedding-based semantic recall fallback when QMD is unavailable or returns no matches"
       },
-      "slotBehavior": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "requireExclusiveMemorySlot": {
-            "type": "boolean",
-            "default": true
-          },
-          "onSlotMismatch": {
-            "type": "string",
-            "enum": [
-              "error",
-              "warn",
-              "silent"
-            ],
-            "default": "error"
-          }
-        }
+      "embeddingFallbackModel": {
+        "type": "string",
+        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
       },
-      "beforeResetTimeoutMs": {
-        "type": "integer",
-        "minimum": 100,
-        "maximum": 30000,
-        "default": 2000,
-        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
-      },
-      "initGateTimeoutMs": {
-        "type": "integer",
-        "minimum": 1000,
-        "maximum": 120000,
-        "default": 30000,
-        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
-      },
-      "flushOnResetEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
-      },
-      "commandsListEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
-      },
-      "openclawToolsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
-      },
-      "openclawToolSnippetMaxChars": {
-        "type": "integer",
-        "minimum": 80,
-        "maximum": 4000,
-        "default": 600,
-        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
-      },
-      "openclawMessageReceivedCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
-      },
-      "openclawReplyMetadataCaptureEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
-      },
-      "openclawReplyMetadataExtractionHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
-      },
-      "openclawChannelEnvelopeCleaningEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
-      },
-      "openclawFlushPlanProcessingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
-      },
-      "sessionTogglesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
-      },
-      "verboseRecallVisibility": {
-        "type": "boolean",
-        "default": true,
-        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
-      },
-      "recallTranscriptsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
-      },
-      "recallTranscriptRetentionDays": {
-        "type": "integer",
-        "minimum": 1,
-        "maximum": 365,
-        "default": 30,
-        "description": "Days of runtime recall audit transcripts to retain before pruning."
-      },
-      "respectBundledActiveMemoryToggle": {
-        "type": "boolean",
-        "default": true,
-        "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
-      },
-      "activeRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): enables the Remnic-native active-recall pre-reply summary block. NOT required for OpenClaw prompt injection — when Remnic is the memory slot, prompt injection runs through registerMemoryPromptSection / memory capability promptBuilder. Enable only to layer a second blocking pre-reply retrieval; a startup warning is logged when both this and memory-slot prompt injection are on."
-      },
-      "activeRecallAgents": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
-      },
-      "activeRecallAllowedChatTypes": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "direct",
-            "group",
-            "channel"
-          ]
-        },
-        "default": [
-          "direct",
-          "group",
-          "channel"
-        ],
-        "description": "OpenClaw chat types eligible for active recall."
-      },
-      "activeRecallQueryMode": {
+      "embeddingFallbackProvider": {
         "type": "string",
         "enum": [
-          "recent",
-          "message",
-          "full"
+          "auto",
+          "openai",
+          "local"
         ],
-        "default": "recent",
-        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
-      },
-      "activeRecallPromptStyle": {
-        "type": "string",
-        "enum": [
-          "balanced",
-          "strict",
-          "contextual",
-          "recall-heavy",
-          "precision-heavy",
-          "preference-only"
-        ],
-        "default": "balanced",
-        "description": "Context assembly style for the active-recall surface."
-      },
-      "activeRecallCustomInstruction": {
-        "type": "string",
-        "description": "Optional custom guidance for the active-recall builder."
-      },
-      "activeRecallPromptAppend": {
-        "type": "string",
-        "description": "Optional additional guidance for the active-recall builder."
-      },
-      "activeRecallMaxSummaryChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 220,
-        "description": "Maximum summary size produced by the active-recall surface."
-      },
-      "activeRecallRecentUserTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 4,
-        "default": 2,
-        "description": "How many recent user turns to include in the active-recall query context."
-      },
-      "activeRecallRecentAssistantTurns": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "How many recent assistant turns to include in the active-recall query context."
-      },
-      "activeRecallRecentUserChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 600,
-        "description": "Per-user-turn character cap for active-recall context assembly."
-      },
-      "activeRecallRecentAssistantChars": {
-        "type": "integer",
-        "minimum": 40,
-        "maximum": 1000,
-        "default": 400,
-        "description": "Per-assistant-turn character cap for active-recall context assembly."
-      },
-      "activeRecallThinking": {
-        "type": "string",
-        "enum": [
-          "off",
-          "minimal",
-          "low",
-          "medium",
-          "high",
-          "xhigh",
-          "adaptive"
-        ],
-        "default": "low",
-        "description": "Reasoning effort used by the active-recall engine."
-      },
-      "activeRecallTimeoutMs": {
-        "type": "integer",
-        "minimum": 250,
-        "default": 15000,
-        "description": "Timeout for an active-recall run."
-      },
-      "activeRecallCacheTtlMs": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 120000,
-        "default": 15000,
-        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
-      },
-      "activeRecallModel": {
-        "type": "string",
-        "description": "Optional model selection for active recall."
-      },
-      "activeRecallModelFallbackPolicy": {
-        "type": "string",
-        "enum": [
-          "default-remote",
-          "resolved-only"
-        ],
-        "default": "default-remote",
-        "description": "How active recall falls back when an explicit model cannot be resolved."
-      },
-      "activeRecallPersistTranscripts": {
-        "type": "boolean",
-        "default": false,
-        "description": "Persist full active-recall request and response transcripts."
-      },
-      "activeRecallTranscriptDir": {
-        "type": "string",
-        "default": "active-recall",
-        "description": "Memory-relative directory for active-recall transcripts."
-      },
-      "activeRecallEntityGraphDepth": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 3,
-        "default": 1,
-        "description": "Entity-graph traversal depth used by active recall."
-      },
-      "activeRecallIncludeCausalTrajectories": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include causal trajectory recall evidence in active-recall summaries."
-      },
-      "activeRecallIncludeDaySummary": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include the latest day summary in active-recall context."
-      },
-      "activeRecallAttachRecallExplain": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach recall explain output to active-recall diagnostics."
-      },
-      "activeRecallAllowChainedActiveMemory": {
-        "type": "boolean",
-        "default": false,
-        "description": "Compat-only (issue #1550): allow the Remnic active-recall block to chain into the bundled active-memory surface. Redundant in modern OpenClaw memory-slot mode; only set true when intentionally layering Remnic + bundled active-memory for the same agent."
-      },
-      "codex": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "installExtension": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install the Remnic Codex memory extension during Codex connector setup."
-          },
-          "codexHome": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null,
-            "description": "Optional Codex home directory override used for connector install and materialization."
-          }
-        }
-      },
-      "connectors": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "description": "Live-connector configuration (issue #683). Each child object maps to one concrete LiveConnector. Defaults are off; operators must opt in.",
-        "properties": {
-          "googleDrive": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Google Drive live connector (issue #683 PR 2/N). Imports text content from a user's Drive into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Drive imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GOOGLE_DRIVE_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the user's Drive scope. Populate from your secret store (e.g. ${GOOGLE_DRIVE_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "folderIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
-              }
-            }
-          },
-          "notion": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
-              },
-              "databaseIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "gmail": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Gmail live connector (issue #683 PR 4/6). Imports new inbox messages from Gmail into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable Gmail imports. The connector additionally requires clientId, clientSecret, and refreshToken to be populated before it will run."
-              },
-              "clientId": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client id. Populate from your secret store (e.g. ${GMAIL_CLIENT_ID}). Never commit a real value to source."
-              },
-              "clientSecret": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 client secret. Populate from your secret store (e.g. ${GMAIL_CLIENT_SECRET}). Never commit a real value to source."
-              },
-              "refreshToken": {
-                "type": "string",
-                "default": "",
-                "description": "OAuth2 refresh token issued for the Gmail scope. Populate from your secret store (e.g. ${GMAIL_REFRESH_TOKEN}). Never commit a real value to source."
-              },
-              "userId": {
-                "type": "string",
-                "default": "me",
-                "description": "Gmail userId. Defaults to 'me' (the authenticated user). Override only in delegated-access scenarios."
-              },
-              "query": {
-                "type": "string",
-                "default": "in:inbox",
-                "description": "Gmail search query applied in addition to the watermark after: filter. Default 'in:inbox'. Set to '' to import all mail."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              }
-            }
-          },
-          "github": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
-              },
-              "token": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
-              },
-              "userLogin": {
-                "type": "string",
-                "default": "",
-                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
-              },
-              "repos": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": [],
-                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
-              },
-              "pollIntervalMs": {
-                "type": "integer",
-                "minimum": 1000,
-                "maximum": 86400000,
-                "default": 300000,
-                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
-              },
-              "includeDiscussions": {
-                "type": "boolean",
-                "default": false,
-                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
-              }
-            }
-          }
-        }
-      },
-      "codexMaterializeMemories": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex native memory materialization into the Codex memories directory."
-      },
-      "codexMaterializeNamespace": {
-        "type": "string",
         "default": "auto",
-        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
-      },
-      "codexMaterializeMaxSummaryTokens": {
-        "type": "number",
-        "minimum": 0,
-        "default": 4500,
-        "description": "Whitespace-token cap for Codex memory summary materialization."
-      },
-      "codexMaterializeRolloutRetentionDays": {
-        "type": "number",
-        "minimum": 0,
-        "default": 30,
-        "description": "Retention window in days for Codex rollout materialization artifacts."
-      },
-      "codexMaterializeOnConsolidation": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
-      },
-      "codexMaterializeOnSessionEnd": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run Codex memory materialization from the Codex session-end hook."
-      },
-      "codexMarketplaceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Codex marketplace integration for plugin discovery and installation."
-      },
-      "versioningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable page-level versioning with sidecar snapshots."
-      },
-      "versioningMaxPerPage": {
-        "type": "integer",
-        "default": 50,
-        "minimum": 0,
-        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
-      },
-      "versioningSidecarDir": {
-        "type": "string",
-        "default": ".versions",
-        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
-      },
-      "taxonomyEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
-      },
-      "taxonomyAutoGenResolver": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
+        "description": "Embedding provider selection for semantic fallback"
       },
       "emitLegacyTools": {
         "type": "boolean",
         "default": false,
         "description": "Advertise legacy engram_* / engram.* MCP tool aliases alongside the canonical remnic_* names. Issue #1550: defaults to false on fresh installs (halving the advertised tools/list surface); when existing legacy connector entries are present on disk the default stays true so upgrades never silently break a configured legacy client. An explicit value always wins."
       },
-      "citationsEnabled": {
+      "enrichmentAutoOnCreate": {
         "type": "boolean",
         "default": false,
-        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
       },
-      "citationsAutoDetect": {
-        "type": "boolean",
-        "default": true,
-        "description": "Auto-enable citations when the Codex adapter is detected."
-      },
-      "memoryExtensionsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
-      },
-      "memoryExtensionsRoot": {
-        "type": "string",
-        "default": "",
-        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
-      },
-      "binaryLifecycleEnabled": {
+      "enrichmentEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
       },
-      "binaryLifecycleGracePeriodDays": {
-        "type": "number",
-        "default": 7,
+      "enrichmentMaxCandidatesPerEntity": {
+        "type": "integer",
+        "default": 20,
         "minimum": 0,
-        "description": "Days to wait before cleaning local copies of mirrored binary files."
+        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
       },
-      "binaryLifecycleBackendType": {
-        "type": "string",
-        "enum": [
-          "none",
-          "filesystem",
-          "s3"
-        ],
-        "default": "none",
-        "description": "Storage backend for binary lifecycle mirror stage."
-      },
-      "binaryLifecycleBackendPath": {
-        "type": "string",
-        "default": "",
-        "description": "Base path for the filesystem storage backend."
-      },
-      "codexCompat": {
-        "type": "object",
-        "additionalProperties": false,
-        "default": {},
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false
-          },
-          "threadIdBufferKeying": {
-            "type": "boolean",
-            "default": true
-          },
-          "compactionFlushMode": {
-            "type": "string",
-            "enum": [
-              "signal",
-              "heuristic",
-              "auto"
-            ],
-            "default": "auto"
-          },
-          "fingerprintDedup": {
-            "type": "boolean",
-            "default": true
-          }
-        }
-      },
-      "debug": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable debug logging"
-      },
-      "identityEnabled": {
+      "entityActivityLogEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
+        "description": "Log timestamped activity per entity"
       },
-      "identityContinuityEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable identity continuity workflows (anchor, incidents, audits)"
-      },
-      "identityInjectionMode": {
-        "type": "string",
-        "enum": [
-          "recovery_only",
-          "minimal",
-          "full"
-        ],
-        "default": "recovery_only",
-        "description": "Controls when identity continuity context is added to recall assembly"
-      },
-      "identityMaxInjectChars": {
+      "entityActivityLogMaxEntries": {
         "type": "number",
-        "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context"
+        "default": 20,
+        "description": "Max activity entries per entity before oldest are pruned"
       },
-      "continuityIncidentLoggingEnabled": {
+      "entityAliasesEnabled": {
         "type": "boolean",
-        "description": "When unset, defaults to identityContinuityEnabled. Controls continuity incident logging artifacts."
+        "default": true,
+        "description": "Store aliases per entity file"
       },
-      "continuityAuditEnabled": {
+      "entityGraphEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "Enable continuity audit artifact generation workflows"
+        "default": true,
+        "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
       },
-      "sessionObserverEnabled": {
+      "entityRelationshipsEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
+        "default": true,
+        "description": "Track entity-to-entity relationships during extraction"
       },
-      "sessionObserverDebounceMs": {
+      "entityRetrievalEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
+      },
+      "entityRetrievalMaxChars": {
         "type": "number",
-        "default": 120000,
-        "description": "Minimum interval between heartbeat observer triggers per session (ms)."
+        "default": 2400,
+        "description": "Hard character cap for the entity retrieval section."
       },
-      "sessionObserverBands": {
-        "type": "array",
-        "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
-        "items": {
+      "entityRetrievalMaxHints": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum entity targets summarized in one recall pass."
+      },
+      "entityRetrievalMaxRelatedEntities": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum related entities listed per target when confidence is high."
+      },
+      "entityRetrievalMaxSupportingFacts": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum supporting fact/timeline snippets considered per entity target."
+      },
+      "entityRetrievalRecentTurns": {
+        "type": "number",
+        "default": 6,
+        "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
+      },
+      "entitySchemas": {
+        "type": "object",
+        "description": "Optional per-entity-type structured section schema customizations.",
+        "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "maxBytes": {
-              "type": "number"
-            },
-            "triggerDeltaBytes": {
-              "type": "number"
-            },
-            "triggerDeltaTokens": {
-              "type": "number"
+            "sections": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "aliases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": [
+                      "key"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "title"
+                    ]
+                  }
+                ]
+              }
             }
           },
           "required": [
-            "maxBytes",
-            "triggerDeltaBytes",
-            "triggerDeltaTokens"
+            "sections"
           ]
-        },
-        "default": [
-          {
-            "maxBytes": 50000,
-            "triggerDeltaBytes": 4800,
-            "triggerDeltaTokens": 1200
-          },
-          {
-            "maxBytes": 200000,
-            "triggerDeltaBytes": 9600,
-            "triggerDeltaTokens": 2400
-          },
-          {
-            "maxBytes": 1000000000,
-            "triggerDeltaBytes": 19200,
-            "triggerDeltaTokens": 4800
-          }
-        ]
+        }
       },
-      "injectQuestions": {
+      "entitySummaryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Generate LLM summaries for entities during consolidation"
+      },
+      "entitySynthesisMaxTokens": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "const": 0
+          },
+          {
+            "type": "integer",
+            "minimum": 10
+          }
+        ],
+        "default": 500,
+        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
+      },
+      "episodeNoteModeEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Include the most relevant open question in generated memory context"
+        "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
       },
-      "commitmentDecayDays": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 90,
-        "description": "Days before fulfilled/expired commitments are removed"
+      "evalHarnessEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
       },
-      "workspaceDir": {
+      "evalShadowModeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
+      },
+      "evalStoreDir": {
         "type": "string",
-        "description": "Override workspace directory path"
+        "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
+      },
+      "eventOrderRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable event-order evidence recall for chronology questions."
+      },
+      "eventOrderRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the event-order evidence recall section."
+      },
+      "eventOrderRecallMaxResults": {
+        "type": "integer",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum recalled items for event-order evidence."
+      },
+      "eventOrderRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 24000,
+        "minimum": 1,
+        "description": "Recent-token scan window for event-order evidence."
+      },
+      "eventOrderRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 12,
+        "minimum": 1,
+        "description": "Recent-turn scan window for event-order evidence."
+      },
+      "explicitCueRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      },
+      "explicitCueRecallMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the explicit cue evidence recall section."
+      },
+      "explicitCueRecallMaxReferences": {
+        "type": "number",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      },
+      "extractionDedupeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable deduplication of near-identical extraction batches within a time window."
+      },
+      "extractionDedupeWindowMs": {
+        "type": "number",
+        "default": 300000,
+        "description": "Window for extraction dedupe fingerprints (ms)."
+      },
+      "extractionFaithfulnessContextChars": {
+        "type": "number",
+        "default": 400,
+        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
+      },
+      "extractionFaithfulnessGate": {
+        "type": "string",
+        "enum": [
+          "off",
+          "shadow",
+          "enforce"
+        ],
+        "default": "off",
+        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
+      },
+      "extractionFaithfulnessModel": {
+        "type": "string",
+        "default": "",
+        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
+      },
+      "extractionFaithfulnessTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
+      },
+      "extractionJudgeBatchSize": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
+      },
+      "extractionJudgeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
+      },
+      "extractionJudgeMaxDeferrals": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+      },
+      "extractionJudgeModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
+      },
+      "extractionJudgeShadow": {
+        "type": "boolean",
+        "default": false,
+        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
+      },
+      "extractionJudgeTelemetryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+      },
+      "extractionMaxEntitiesPerRun": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum entities persisted from a single extraction run."
+      },
+      "extractionMaxFactsPerRun": {
+        "type": "number",
+        "default": 12,
+        "description": "Maximum facts persisted from a single extraction run."
+      },
+      "extractionMaxOutputTokens": {
+        "type": "number",
+        "default": 16384,
+        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
+      },
+      "extractionMaxProfileUpdatesPerRun": {
+        "type": "number",
+        "default": 4,
+        "description": "Maximum profile updates persisted from a single extraction run."
+      },
+      "extractionMaxQuestionsPerRun": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum questions persisted from a single extraction run."
+      },
+      "extractionMaxTurnChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
+      },
+      "extractionMinChars": {
+        "type": "number",
+        "default": 40,
+        "description": "Minimum combined user/assistant characters required before extraction runs."
+      },
+      "extractionMinImportanceLevel": {
+        "type": "string",
+        "enum": [
+          "trivial",
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ],
+        "default": "low",
+        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
+      "extractionMinUserTurns": {
+        "type": "number",
+        "default": 1,
+        "description": "Minimum number of user turns required before extraction runs."
+      },
+      "extractionScopeClassificationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
+      },
+      "extractionTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
+      },
+      "factArchivalAgeDays": {
+        "type": "number",
+        "default": 90,
+        "description": "Minimum age in days before a fact is eligible for archival."
+      },
+      "factArchivalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
+      },
+      "factArchivalMaxAccessCount": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
+      },
+      "factArchivalMaxImportance": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
+      },
+      "factArchivalProtectedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "commitment",
+          "preference",
+          "decision",
+          "principle",
+          "procedure"
+        ],
+        "description": "Categories that protect a fact from archival regardless of other criteria."
+      },
+      "factDeduplicationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
+      },
+      "fastGatewayAgentId": {
+        "type": "string",
+        "default": "",
+        "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
+      },
+      "feedbackEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
       },
       "fileHygiene": {
         "type": "object",
@@ -1889,6 +2220,941 @@
         "required": [
           "enabled"
         ]
+      },
+      "flushOnResetEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
+      },
+      "focusedListRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
+      },
+      "focusedListRecallMaxChars": {
+        "type": "integer",
+        "default": 2600,
+        "minimum": 0,
+        "description": "Character budget for the focused list evidence recall section."
+      },
+      "focusedListRecallMaxResults": {
+        "type": "integer",
+        "default": 40,
+        "minimum": 0,
+        "description": "Maximum recalled items for focused list evidence."
+      },
+      "focusedListRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 14000,
+        "minimum": 1,
+        "description": "Recent-token scan window for focused list evidence."
+      },
+      "focusedListRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 64,
+        "minimum": 1,
+        "description": "Recent-turn scan window for focused list evidence."
+      },
+      "gatewayAgentId": {
+        "type": "string",
+        "default": "",
+        "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
+      },
+      "graphActivationDecay": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Per-hop activation decay factor (0-1). Default 0.7."
+      },
+      "graphAssistInFullModeEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run bounded graph expansion during full recall mode when seed results exist."
+      },
+      "graphAssistMinSeedResults": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum seed recall results required before full-mode graph assist runs."
+      },
+      "graphAssistShadowEvalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
+      },
+      "graphEdgeDecayCadenceMs": {
+        "type": "number",
+        "default": 604800000,
+        "minimum": 60000,
+        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
+      },
+      "graphEdgeDecayEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
+      },
+      "graphEdgeDecayFloor": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Floor confidence will not decay below. Default 0.1."
+      },
+      "graphEdgeDecayPerWindow": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Per-window confidence drop applied during decay. Default 0.1."
+      },
+      "graphEdgeDecayVisibilityThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
+      },
+      "graphEdgeDecayWindowMs": {
+        "type": "number",
+        "default": 7776000000,
+        "minimum": 60000,
+        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
+      },
+      "graphExpandedIntentEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
+      },
+      "graphExpansionActivationWeight": {
+        "type": "number",
+        "default": 0.65,
+        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
+      },
+      "graphExpansionBlendMax": {
+        "type": "number",
+        "default": 0.95,
+        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
+      },
+      "graphExpansionBlendMin": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
+      },
+      "graphLateralInhibitionBeta": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
+      },
+      "graphLateralInhibitionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
+      },
+      "graphLateralInhibitionTopM": {
+        "type": "number",
+        "default": 7,
+        "description": "Number of top competing nodes considered for lateral inhibition"
+      },
+      "graphRecallColdMirrorCollection": {
+        "type": "string",
+        "description": "QMD collection name for cold-mirror graph recall results."
+      },
+      "graphRecallColdMirrorMinAgeDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
+      },
+      "graphRecallDampingFactor": {
+        "type": "number",
+        "default": 0.85,
+        "description": "PageRank-style damping factor for graph activation propagation."
+      },
+      "graphRecallEnableDebug": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable verbose debug output for graph recall operations."
+      },
+      "graphRecallEnableTrace": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable detailed graph recall trace logging for debugging."
+      },
+      "graphRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
+      },
+      "graphRecallEntityHintMax": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of entity hints added per graph recall result."
+      },
+      "graphRecallEntityHintMaxChars": {
+        "type": "number",
+        "default": 200,
+        "description": "Maximum characters per entity hint added during graph recall."
+      },
+      "graphRecallEntityHintsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Inject entity hint summaries alongside graph-recalled memories."
+      },
+      "graphRecallEntityPriorBoost": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Score boost applied to nodes with strong entity priors."
+      },
+      "graphRecallExpansionScoreThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Minimum blended score required to include a graph-expanded node in results."
+      },
+      "graphRecallExplainEdgeLimit": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum edges described per node in a graph recall explanation."
+      },
+      "graphRecallExplainEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Append natural-language graph reasoning explanations to recall output."
+      },
+      "graphRecallExplainMaxChars": {
+        "type": "number",
+        "default": 500,
+        "description": "Maximum characters per graph recall explanation."
+      },
+      "graphRecallExplainMaxPaths": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum reasoning paths included in a graph recall explanation."
+      },
+      "graphRecallExplainToolEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Expose a graph explain tool to agents during graph recall."
+      },
+      "graphRecallHubBias": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Bias weight toward hub-seed selection (0-1)."
+      },
+      "graphRecallMaxExpandedNodes": {
+        "type": "number",
+        "default": 30,
+        "description": "Maximum total nodes visited during graph recall expansion."
+      },
+      "graphRecallMaxExpansions": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of expansion hops per graph recall query."
+      },
+      "graphRecallMaxPerSeed": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum graph-expanded results per seed node."
+      },
+      "graphRecallMaxSeedNodes": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of seed nodes selected for graph recall expansion."
+      },
+      "graphRecallMaxTrailPerNode": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum trail length followed per node during graph traversal."
+      },
+      "graphRecallMinEdgeWeight": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Minimum edge weight to follow during graph recall traversal."
+      },
+      "graphRecallMinSeedScore": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
+      },
+      "graphRecallPreferHubSeeds": {
+        "type": "boolean",
+        "default": false,
+        "description": "Prefer high-degree hub nodes as graph recall seeds."
+      },
+      "graphRecallRecencyHalfLifeDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Half-life in days for recency decay applied to graph-expanded nodes."
+      },
+      "graphRecallShadowEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run graph recall in shadow mode - evaluate but do not add results."
+      },
+      "graphRecallShadowSampleRate": {
+        "type": "number",
+        "default": 0.1,
+        "description": "Fraction of turns evaluated in shadow mode (0-1)."
+      },
+      "graphRecallSnapshotDir": {
+        "type": "string",
+        "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
+      },
+      "graphRecallSnapshotEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write graph recall snapshots for offline analysis."
+      },
+      "graphRecallStoreColdMirror": {
+        "type": "boolean",
+        "default": false,
+        "description": "Store cold-path graph recall results in a secondary QMD collection."
+      },
+      "graphRecallUseEntityPriors": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost seed nodes using entity prior scores during graph recall."
+      },
+      "graphTraversalConfidenceFloor": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
+      },
+      "graphTraversalPageRankIterations": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
+      },
+      "graphWriteSessionAdjacencyEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
+      },
+      "harmonicRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
+      },
+      "heartbeat": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "journalPath": {
+            "type": "string",
+            "default": "HEARTBEAT.md"
+          },
+          "maxPreviousRuns": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 20,
+            "default": 5
+          },
+          "watchFile": {
+            "type": "boolean",
+            "default": true
+          },
+          "detectionMode": {
+            "type": "string",
+            "enum": [
+              "runtime-signal",
+              "heuristic",
+              "auto"
+            ],
+            "default": "auto"
+          },
+          "gateExtractionDuringHeartbeat": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "highSignalPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Custom regex patterns for immediate extraction"
+      },
+      "hostEmbeddingProviderEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Prefer OpenClaw host-registered embedding providers for Remnic's semantic fallback and embedded vector backends when the OpenClaw SDK exposes them. Falls back to Remnic's existing embedding provider path on older hosts or provider setup failures."
+      },
+      "hostEmbeddingProviderId": {
+        "type": "string",
+        "description": "Optional OpenClaw embedding provider adapter id to use. Leave unset for automatic selection from OpenClaw's memory/generic embedding provider registry."
+      },
+      "hostEmbeddingProviderModel": {
+        "type": "string",
+        "description": "Optional embedding model id passed to the selected OpenClaw host embedding provider."
+      },
+      "hourlySummariesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable hourly conversation summaries"
+      },
+      "hourlySummariesExtendedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
+      },
+      "hourlySummariesIncludeSystemMessages": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include system messages in extended hourly summaries (use with care)."
+      },
+      "hourlySummariesIncludeToolStats": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
+      },
+      "hourlySummariesMaxTurnsPerRun": {
+        "type": "number",
+        "default": 200,
+        "description": "Maximum transcript turns to consider per session per hourly summarizer run."
+      },
+      "hourlySummaryCronAutoRegister": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
+      },
+      "identityContinuityEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable identity continuity workflows (anchor, incidents, audits)"
+      },
+      "identityEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable agent identity reflections (appends to workspace IDENTITY.md)"
+      },
+      "identityInjectionMode": {
+        "type": "string",
+        "enum": [
+          "recovery_only",
+          "minimal",
+          "full"
+        ],
+        "default": "recovery_only",
+        "description": "Controls when identity continuity context is added to recall assembly"
+      },
+      "identityMaxInjectChars": {
+        "type": "number",
+        "default": 1200,
+        "description": "Maximum characters allowed for identity continuity context"
+      },
+      "initGateTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 30000,
+        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+      },
+      "injectQuestions": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include the most relevant open question in generated memory context"
+      },
+      "inlineSourceAttributionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
+      },
+      "inlineSourceAttributionFormat": {
+        "type": "string",
+        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
+        "description": "Template used when inline source attribution is enabled."
+      },
+      "intentRoutingBoost": {
+        "type": "number",
+        "default": 0.12,
+        "description": "Maximum score boost applied for intent-compatible memory matches."
+      },
+      "intentRoutingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Attach intent metadata to memories and boost compatible memories at recall."
+      },
+      "ircEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
+      },
+      "ircIncludeCorrections": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include corrections when building IRC rules (default on)."
+      },
+      "ircMaxPreferences": {
+        "type": "number",
+        "default": 20,
+        "description": "Maximum number of preferences to include in IRC rules."
+      },
+      "ircMinConfidence": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
+      },
+      "judgeTrainingDir": {
+        "type": "string",
+        "default": "",
+        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+      },
+      "knowledgeIndexEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Inject a compact Knowledge Index of top entities into every recall"
+      },
+      "knowledgeIndexMaxChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Hard character cap for the Knowledge Index section"
+      },
+      "knowledgeIndexMaxEntities": {
+        "type": "number",
+        "default": 40,
+        "description": "Max entities included in the Knowledge Index"
+      },
+      "lanceDbPath": {
+        "type": "string",
+        "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
+      },
+      "lanceEmbeddingDimension": {
+        "type": "number",
+        "default": 1536,
+        "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
+      },
+      "lancedbEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable LanceDB as a supplemental search backend."
+      },
+      "lcmArchiveRetentionDays": {
+        "type": "number",
+        "default": 90,
+        "description": "Days to retain archived LCM summaries"
+      },
+      "lcmDeterministicMaxTokens": {
+        "type": "number",
+        "default": 512,
+        "description": "Max tokens for deterministic (non-LLM) summaries"
+      },
+      "lcmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Lossless Context Management (LCM) subsystem"
+      },
+      "lcmFreshTailTurns": {
+        "type": "number",
+        "default": 16,
+        "description": "Number of recent turns kept verbatim (not summarized)"
+      },
+      "lcmLeafBatchSize": {
+        "type": "number",
+        "default": 8,
+        "description": "Number of turns per leaf node in the LCM DAG"
+      },
+      "lcmMaxDepth": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum depth of the LCM summary DAG"
+      },
+      "lcmObserveConcurrency": {
+        "type": "number",
+        "default": 1,
+        "description": "Maximum independent LCM observe jobs to process concurrently."
+      },
+      "lcmRecallBudgetShare": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
+      },
+      "lcmRollupFanIn": {
+        "type": "number",
+        "default": 4,
+        "description": "Number of children per rollup node in the LCM DAG"
+      },
+      "lcmTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
+      },
+      "lifecycleArchiveDecayThreshold": {
+        "type": "number",
+        "default": 0.85,
+        "description": "Decay threshold for lifecycle demotion to archived state semantics."
+      },
+      "lifecycleFilterStaleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
+      },
+      "lifecycleMetricsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
+      },
+      "lifecyclePolicyEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the lifecycle policy engine (hot\u2194cold tier migration, value scoring, decay). Default true since #686 PR 3/6 \u2014 flipping enables the year-2 retention story by default. Set to false to opt out."
+      },
+      "lifecyclePromoteHeatThreshold": {
+        "type": "number",
+        "default": 0.55,
+        "description": "Heat threshold for lifecycle promotion to validated/active states."
+      },
+      "lifecycleProtectedCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decision",
+          "principle",
+          "commitment",
+          "preference",
+          "procedure"
+        ],
+        "description": "Categories that lifecycle policy will not auto-archive."
+      },
+      "lifecycleStaleDecayThreshold": {
+        "type": "number",
+        "default": 0.65,
+        "description": "Decay threshold for lifecycle demotion to stale."
+      },
+      "localLlm400CooldownMs": {
+        "type": "number",
+        "default": 120000,
+        "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
+      },
+      "localLlm400TripThreshold": {
+        "type": "number",
+        "default": 5,
+        "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
+      },
+      "localLlmApiKey": {
+        "type": "string",
+        "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
+      },
+      "localLlmAuthHeader": {
+        "type": "boolean",
+        "default": true,
+        "description": "If false, do not send Authorization header even when localLlmApiKey is set"
+      },
+      "localLlmDisableThinking": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+      },
+      "localLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
+      },
+      "localLlmFallback": {
+        "type": "boolean",
+        "default": true,
+        "description": "Fall back to cloud OpenAI if local LLM is unavailable"
+      },
+      "localLlmFastEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
+      },
+      "localLlmFastModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
+      },
+      "localLlmFastTimeoutMs": {
+        "type": "number",
+        "default": 15000,
+        "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
+      },
+      "localLlmFastUrl": {
+        "type": "string",
+        "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
+      },
+      "localLlmHeaders": {
+        "type": "object",
+        "description": "Optional additional headers for local/compatible endpoint requests",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "localLlmHomeDir": {
+        "type": "string",
+        "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
+      },
+      "localLlmMaxContext": {
+        "type": "number",
+        "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
+      },
+      "localLlmModel": {
+        "type": "string",
+        "default": "local-model",
+        "description": "Model name for local LLM requests"
+      },
+      "localLlmRetry5xxCount": {
+        "type": "number",
+        "default": 1,
+        "description": "Number of retry attempts for local LLM 5xx responses."
+      },
+      "localLlmRetryBackoffMs": {
+        "type": "number",
+        "default": 400,
+        "description": "Base backoff delay between local LLM retries (ms)."
+      },
+      "localLlmTimeoutMs": {
+        "type": "number",
+        "default": 180000,
+        "description": "Hard timeout for local LLM requests (ms)"
+      },
+      "localLlmUrl": {
+        "type": "string",
+        "default": "http://localhost:1234/v1",
+        "description": "URL for local LLM OpenAI-compatible endpoint"
+      },
+      "localLmsBinDir": {
+        "type": "string",
+        "description": "Optional bin directory prepended to PATH for LMS CLI execution."
+      },
+      "localLmsCliPath": {
+        "type": "string",
+        "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
+      },
+      "maintenanceIncludeBranchNamespaces": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
+      },
+      "maintenanceIncludeProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceIncludeTeamProjectNamespaces": {
+        "type": "boolean",
+        "default": true,
+        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
+      },
+      "maintenanceMaxNamespacesPerCycle": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
+      },
+      "maintenanceNamespaceFanoutEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
+      },
+      "maintenanceNamespaceLockStaleMs": {
+        "type": "number",
+        "default": 600000,
+        "minimum": 1,
+        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
+      },
+      "maxCompressionTokensPerHour": {
+        "type": "number",
+        "default": 1500,
+        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
+      },
+      "maxEntityGraphEdgesPerMemory": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum entity graph edges written per memory write. Default 10."
+      },
+      "maxGraphTraversalSteps": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum BFS hops during spreading activation. Default 3."
+      },
+      "maxMemoryTokens": {
+        "type": "number",
+        "default": 2000,
+        "description": "Max memory-context tokens per turn"
+      },
+      "maxProactiveQuestionsPerExtraction": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
+      },
+      "maxSummaryCount": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum number of summaries to include"
+      },
+      "maxTranscriptTokens": {
+        "type": "number",
+        "default": 1000,
+        "description": "Maximum tokens for transcript context"
+      },
+      "maxTranscriptTurns": {
+        "type": "number",
+        "default": 50,
+        "description": "Maximum transcript turns to include"
+      },
+      "meilisearchApiKey": {
+        "type": "string",
+        "description": "API key for Meilisearch (when searchBackend=meilisearch)"
+      },
+      "meilisearchAutoIndex": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
+      },
+      "meilisearchEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Meilisearch as a supplemental search backend."
+      },
+      "meilisearchHost": {
+        "type": "string",
+        "default": "http://localhost:7700",
+        "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
+      },
+      "meilisearchTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
+      },
+      "memoryBoxesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
+      },
+      "memoryDir": {
+        "type": "string",
+        "description": "Override memory storage directory"
+      },
+      "memoryExtensionsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
+      },
+      "memoryExtensionsRoot": {
+        "type": "string",
+        "default": "",
+        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
+      "memoryLinkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic memory linking to build knowledge graph"
+      },
+      "memoryOsPreset": {
+        "type": "string",
+        "enum": [
+          "conservative",
+          "balanced",
+          "research",
+          "research-max",
+          "local-llm-heavy"
+        ],
+        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+      },
+      "memoryPoisoningDefenseEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
+      },
+      "memoryReconstructionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
+      },
+      "memoryReconstructionMaxExpansions": {
+        "type": "number",
+        "default": 3,
+        "description": "Maximum number of entity expansions per recall cycle"
+      },
+      "memoryRedTeamBenchEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
+      },
+      "memoryUtilityLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
+      },
+      "messagePartsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
+      },
+      "messagePartsRecallMaxResults": {
+        "type": "number",
+        "default": 6,
+        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
+      },
+      "model": {
+        "type": "string",
+        "default": "gpt-5.5",
+        "description": "OpenAI model for extraction/consolidation"
+      },
+      "modelSource": {
+        "type": "string",
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+      },
+      "multiGraphMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
+      },
+      "namespaceCatalogEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
+      },
+      "namespacePolicies": {
+        "type": "array",
+        "description": "Namespace access policies.",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "readPrincipals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "writePrincipals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "includeInRecallByDefault": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "readPrincipals",
+            "writePrincipals"
+          ]
+        }
+      },
+      "namespacesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable multi-agent namespaces (v3.0). Default off."
       },
       "nativeKnowledge": {
         "type": "object",
@@ -2114,1031 +3380,140 @@
           "enabled"
         ]
       },
-      "agentAccessHttp": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Optional: run a local authenticated HTTP API so non-OpenClaw clients can query Engram directly.",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Start the local Engram HTTP access server during plugin startup."
-          },
-          "host": {
-            "type": "string",
-            "default": "127.0.0.1",
-            "description": "Loopback host to bind for the Engram HTTP access server."
-          },
-          "port": {
-            "type": "number",
-            "default": 4318,
-            "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
-          },
-          "authToken": {
-            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object",
-                "required": [
-                  "source"
-                ],
-                "properties": {
-                  "source": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "provider": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "string"
-                  },
-                  "command": {}
-                }
-              }
-            ]
-          },
-          "principal": {
-            "type": "string",
-            "description": "Optional trusted principal bound to the local Engram access bridge. When set, namespace write authorization is evaluated against this principal instead of any client-supplied sessionKey. If omitted, OPENCLAW_ENGRAM_ACCESS_PRINCIPAL is used when present."
-          },
-          "maxBodyBytes": {
-            "type": "number",
-            "default": 131072,
-            "description": "Maximum accepted JSON request body size for the local Remnic HTTP API."
-          }
-        },
-        "required": [
-          "enabled"
-        ]
-      },
-      "accessTrackingEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track memory access counts and recency"
-      },
-      "accessTrackingBufferMaxSize": {
-        "type": "number",
-        "default": 100,
-        "description": "Max entries in access tracking buffer before flush"
-      },
-      "recencyWeight": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Weight for recency boosting in search (0-1)"
-      },
-      "boostAccessCount": {
-        "type": "boolean",
-        "default": true,
-        "description": "Boost frequently accessed memories in search results"
-      },
-      "recordEmptyRecallImpressions": {
-        "type": "boolean",
-        "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is added."
-      },
-      "recallPlannerEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
-      },
-      "recallPlannerLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
-      },
-      "recallPlannerModel": {
-        "type": "string",
-        "default": "gpt-5.5",
-        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
-      },
-      "recallPlannerTimeoutMs": {
-        "type": "number",
-        "default": 1500,
-        "description": "Timeout in ms for recall planner inference."
-      },
-      "recallPlannerUseResponsesApi": {
-        "type": "boolean",
-        "default": true,
-        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
-      },
-      "recallPlannerMaxPromptChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters of prompt context to send to the recall planner."
-      },
-      "recallPlannerMaxMemoryHints": {
-        "type": "number",
-        "default": 24,
-        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
-      },
-      "recallPlannerShadowMode": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
-      },
-      "recallPlannerTelemetryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit telemetry events for recall planner decisions."
-      },
-      "recallPlannerMaxQmdResultsMinimal": {
-        "type": "number",
-        "default": 4,
-        "description": "QMD cap used when recall planner selects minimal mode."
-      },
-      "recallPlannerMaxQmdResultsFull": {
-        "type": "number",
-        "default": 8,
-        "description": "QMD cap used when recall planner selects full mode."
-      },
-      "intentRoutingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Attach intent metadata to memories and boost compatible memories at recall."
-      },
-      "intentRoutingBoost": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Maximum score boost applied for intent-compatible memory matches."
-      },
-      "verbatimArtifactsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write quote-first artifact anchors during extraction and include them in recall."
-      },
-      "verbatimArtifactsMinConfidence": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Minimum extraction confidence required before writing an artifact."
-      },
-      "verbatimArtifactsMaxRecall": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum artifact anchors added per recall."
-      },
-      "verbatimArtifactCategories": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "fact",
-            "preference",
-            "correction",
-            "entity",
-            "decision",
-            "relationship",
-            "principle",
-            "commitment",
-            "moment",
-            "skill",
-            "procedure"
-          ]
-        },
-        "default": [
-          "decision",
-          "correction",
-          "principle",
-          "commitment"
-        ],
-        "description": "Memory categories eligible for artifact extraction."
-      },
-      "memoryBoxesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Memory Boxes (v8.0 Phase 2A). Groups memories into topic-bounded windows. Disabled by default."
-      },
-      "boxTopicShiftThreshold": {
-        "type": "number",
-        "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
-      },
-      "boxTimeGapMs": {
-        "type": "number",
-        "default": 1800000,
-        "description": "Time gap in milliseconds before an open box is sealed (default 30 min)."
-      },
-      "boxMaxMemories": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum memories per box before forced seal."
-      },
-      "traceWeaverEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
-      },
-      "traceWeaverLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days back to search for trace links."
-      },
-      "traceWeaverOverlapThreshold": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
-      },
-      "boxRecallDays": {
-        "type": "number",
-        "default": 3,
-        "description": "Number of recent days of boxes to add during recall."
-      },
-      "episodeNoteModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable HiMem episode/note classification (v8.0 Phase 2B). Tags each extracted memory as 'episode' (time-specific event) or 'note' (stable belief/preference). Disabled by default."
-      },
-      "queryAwareIndexingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
-      },
-      "queryAwareIndexingMaxCandidates": {
-        "type": "number",
-        "default": 200,
-        "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
-      },
-      "temporalIndexWindowDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Number of days to include in the temporal index window."
-      },
-      "temporalIndexMaxEntries": {
-        "type": "number",
-        "default": 5000,
-        "description": "Maximum number of entries in the temporal index."
-      },
-      "temporalBoostRecentDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Memories from the last N days receive a recency boost during recall."
-      },
-      "temporalBoostScore": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to recent memories during recall."
-      },
-      "temporalDecayEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply temporal decay to older memories during recall scoring."
-      },
-      "tombstonesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active — visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
-      },
-      "correctionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Master gate for the Correction Contract (#1580) — the unified plan/apply pipeline for memory corrections (supersede/edit/retract/rescope/never-store). When false, the correction surfaces (CLI/HTTP/MCP) are disabled."
-      },
-      "correctionApplyRequiresConfirm": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), memory_correct_apply requires confirm: true before mutating memory (#1580). Off allows one-shot apply without an explicit confirmation."
-      },
-      "correctionMaxAffected": {
-        "type": "integer",
-        "minimum": 1,
-        "default": 10,
-        "description": "Maximum number of memories a single correction plan may affect (#1580). A plan exceeding this is refused rather than silently truncated. Invalid values (0/negative/non-numeric) are rejected."
-      },
-      "correctionPlanTtlHours": {
-        "type": "number",
-        "default": 24,
-        "description": "Hours a pending correction plan remains valid before it expires and must be re-planned (#1580)."
-      },
-      "tombstonesSemanticMatch": {
-        "type": "boolean",
-        "default": false,
-        "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
-      },
-      "tombstonesSemanticThreshold": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
-      },
-      "tagMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable tag-based memory indexing and recall boosting."
-      },
-      "tagMaxPerMemory": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum number of tags assigned per memory."
-      },
-      "tagIndexMaxEntries": {
-        "type": "number",
-        "default": 10000,
-        "description": "Maximum number of entries in the tag index."
-      },
-      "tagRecallBoost": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Score boost applied to memories whose tags match the query."
-      },
-      "tagRecallMaxMatches": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of tag-matched memories added per recall."
-      },
-      "multiGraphMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-graph memory (entity, time, causal edges). Default false."
-      },
-      "graphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable graph recall planner mode (`graph_mode`). Requires multiGraphMemoryEnabled. Default false."
-      },
-      "graphRecallMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of expansion hops per graph recall query."
-      },
-      "graphRecallMaxPerSeed": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum graph-expanded results per seed node."
-      },
-      "graphRecallMinEdgeWeight": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Minimum edge weight to follow during graph recall traversal."
-      },
-      "graphRecallShadowEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Run graph recall in shadow mode - evaluate but do not add results."
-      },
-      "graphRecallSnapshotEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write graph recall snapshots for offline analysis."
-      },
-      "graphRecallShadowSampleRate": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Fraction of turns evaluated in shadow mode (0-1)."
-      },
-      "graphRecallExplainToolEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Expose a graph explain tool to agents during graph recall."
-      },
-      "graphRecallStoreColdMirror": {
-        "type": "boolean",
-        "default": false,
-        "description": "Store cold-path graph recall results in a secondary QMD collection."
-      },
-      "graphRecallColdMirrorCollection": {
-        "type": "string",
-        "description": "QMD collection name for cold-mirror graph recall results."
-      },
-      "graphRecallColdMirrorMinAgeDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Minimum age in days for a memory to qualify for cold-mirror storage."
-      },
-      "graphRecallUseEntityPriors": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost seed nodes using entity prior scores during graph recall."
-      },
-      "graphRecallEntityPriorBoost": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Score boost applied to nodes with strong entity priors."
-      },
-      "graphRecallPreferHubSeeds": {
-        "type": "boolean",
-        "default": false,
-        "description": "Prefer high-degree hub nodes as graph recall seeds."
-      },
-      "graphRecallHubBias": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Bias weight toward hub-seed selection (0-1)."
-      },
-      "graphRecallRecencyHalfLifeDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Half-life in days for recency decay applied to graph-expanded nodes."
-      },
-      "graphRecallDampingFactor": {
-        "type": "number",
-        "default": 0.85,
-        "description": "PageRank-style damping factor for graph activation propagation."
-      },
-      "graphRecallMaxSeedNodes": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of seed nodes selected for graph recall expansion."
-      },
-      "graphRecallMaxExpandedNodes": {
-        "type": "number",
-        "default": 30,
-        "description": "Maximum total nodes visited during graph recall expansion."
-      },
-      "graphRecallMaxTrailPerNode": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum trail length followed per node during graph traversal."
-      },
-      "graphRecallMinSeedScore": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum QMD score for a memory to qualify as a graph recall seed."
-      },
-      "graphRecallExpansionScoreThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "description": "Minimum blended score required to include a graph-expanded node in results."
-      },
-      "graphRecallExplainMaxPaths": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum reasoning paths included in a graph recall explanation."
-      },
-      "graphRecallExplainMaxChars": {
-        "type": "number",
-        "default": 500,
-        "description": "Maximum characters per graph recall explanation."
-      },
-      "graphRecallExplainEdgeLimit": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum edges described per node in a graph recall explanation."
-      },
-      "graphRecallExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Append natural-language graph reasoning explanations to recall output."
-      },
-      "graphRecallEntityHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Inject entity hint summaries alongside graph-recalled memories."
-      },
-      "graphRecallEntityHintMax": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity hints added per graph recall result."
-      },
-      "graphRecallEntityHintMaxChars": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum characters per entity hint added during graph recall."
-      },
-      "graphRecallSnapshotDir": {
-        "type": "string",
-        "description": "Directory for graph recall snapshot files (defaults to {memoryDir}/state/graph)."
-      },
-      "graphRecallEnableTrace": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable detailed graph recall trace logging for debugging."
-      },
-      "graphRecallEnableDebug": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable verbose debug output for graph recall operations."
-      },
-      "graphExpandedIntentEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Escalate broader causal/timeline phrasing into graph_mode planning."
-      },
-      "graphAssistInFullModeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Run bounded graph expansion during full recall mode when seed results exist."
-      },
-      "graphAssistShadowEvalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
-      },
-      "graphAssistMinSeedResults": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum seed recall results required before full-mode graph assist runs."
-      },
-      "entityGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build entity co-reference graph (requires multiGraphMemoryEnabled). Default true."
-      },
-      "timeGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
-      },
-      "graphWriteSessionAdjacencyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Write fallback temporal adjacency edges for consecutive extracted memories in the same session."
-      },
-      "causalGraphEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Build causal inference graph from heuristic phrases (requires multiGraphMemoryEnabled). Default true."
-      },
-      "maxGraphTraversalSteps": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum BFS hops during spreading activation. Default 3."
-      },
-      "graphActivationDecay": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Per-hop activation decay factor (0-1). Default 0.7."
-      },
-      "graphTraversalConfidenceFloor": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Issue #681 PR 3/3: minimum edge confidence required for traversal during spreading activation. Edges below this floor are pruned and contribute neither activation nor downstream neighbors. Legacy edges without a confidence field are treated as 1.0. Range 0-1. Default 0.2."
-      },
-      "graphTraversalPageRankIterations": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Issue #681 PR 3/3: number of PageRank-style refinement iterations applied on top of the BFS spreading-activation scores. Each iteration redistributes a node's confidence-weighted activation along its outgoing edges. Set to 0 to disable refinement and use raw BFS scores. Default 8."
-      },
-      "graphExpansionActivationWeight": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
-      },
-      "graphExpansionBlendMin": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "graphExpansionBlendMax": {
-        "type": "number",
-        "default": 0.95,
-        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
-      },
-      "maxEntityGraphEdgesPerMemory": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum entity graph edges written per memory write. Default 10."
-      },
-      "delinearizeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "SimpleMem-inspired de-linearization: resolve pronouns and anchor relative dates in extracted memories"
-      },
-      "recallConfidenceGateEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
-      },
-      "recallConfidenceGateThreshold": {
-        "type": "number",
-        "default": 0.12,
-        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
-      },
-      "causalRuleExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "PlugMem-inspired causal rule extraction: mine IF-THEN rules from conversations during consolidation"
-      },
-      "memoryReconstructionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "E-Mem-inspired memory reconstruction: targeted secondary retrieval for entity references lacking context in recall"
-      },
-      "memoryReconstructionMaxExpansions": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum number of entity expansions per recall cycle"
-      },
-      "graphLateralInhibitionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Synapse-inspired lateral inhibition to suppress hub-node dominance in graph retrieval"
-      },
-      "graphLateralInhibitionBeta": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Inhibition strength (0-1). Higher values suppress weaker nodes more aggressively"
-      },
-      "graphLateralInhibitionTopM": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of top competing nodes considered for lateral inhibition"
-      },
-      "graphEdgeDecayEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
-      },
-      "graphEdgeDecayCadenceMs": {
-        "type": "number",
-        "default": 604800000,
-        "minimum": 60000,
-        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
-      },
-      "graphEdgeDecayWindowMs": {
-        "type": "number",
-        "default": 7776000000,
-        "minimum": 60000,
-        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
-      },
-      "graphEdgeDecayPerWindow": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Per-window confidence drop applied during decay. Default 0.1."
-      },
-      "graphEdgeDecayFloor": {
-        "type": "number",
-        "default": 0.1,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Floor confidence will not decay below. Default 0.1."
-      },
-      "graphEdgeDecayVisibilityThreshold": {
-        "type": "number",
-        "default": 0.2,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
-      },
-      "temporalMemoryTreeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
-      },
-      "tmtHourlyMinMemories": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
-      },
-      "tmtSummaryMaxTokens": {
-        "type": "number",
-        "default": 300,
-        "description": "Max tokens for each TMT summary node. Default: 300."
-      },
-      "explicitCueRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
-      },
-      "explicitCueRecallMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the explicit cue evidence recall section."
-      },
-      "explicitCueRecallMaxReferences": {
-        "type": "number",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum query-visible cues expanded by explicit cue recall."
-      },
-      "targetedFactRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable targeted fact evidence recall for direct answer questions."
-      },
-      "targetedFactRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the targeted fact evidence recall section."
-      },
-      "targetedFactRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 8,
-        "minimum": 1,
-        "description": "Recent-turn scan window for targeted fact evidence."
-      },
-      "targetedFactRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 12000,
-        "minimum": 1,
-        "description": "Recent-token scan window for targeted fact evidence."
-      },
-      "focusedListRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable focused list evidence recall for count, relation, and recommendation questions."
-      },
-      "focusedListRecallMaxChars": {
-        "type": "integer",
-        "default": 2600,
-        "minimum": 0,
-        "description": "Character budget for the focused list evidence recall section."
-      },
-      "focusedListRecallMaxResults": {
-        "type": "integer",
-        "default": 40,
-        "minimum": 0,
-        "description": "Maximum recalled items for focused list evidence."
-      },
-      "focusedListRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for focused list evidence."
-      },
-      "focusedListRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 14000,
-        "minimum": 1,
-        "description": "Recent-token scan window for focused list evidence."
-      },
-      "responseGuidanceRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable response guidance recall for user answer-shape preferences."
-      },
-      "responseGuidanceRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the response guidance recall section."
-      },
-      "responseGuidanceRecallMaxResults": {
-        "type": "integer",
-        "default": 48,
-        "minimum": 0,
-        "description": "Maximum recalled items for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 64,
-        "minimum": 1,
-        "description": "Recent-turn scan window for response guidance."
-      },
-      "responseGuidanceRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 16000,
-        "minimum": 1,
-        "description": "Recent-token scan window for response guidance."
-      },
-      "eventOrderRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable event-order evidence recall for chronology questions."
-      },
-      "eventOrderRecallMaxChars": {
-        "type": "integer",
-        "default": 2400,
-        "minimum": 0,
-        "description": "Character budget for the event-order evidence recall section."
-      },
-      "eventOrderRecallMaxResults": {
-        "type": "integer",
-        "default": 24,
-        "minimum": 0,
-        "description": "Maximum recalled items for event-order evidence."
-      },
-      "eventOrderRecallScanWindowTurns": {
-        "type": "integer",
-        "default": 12,
-        "minimum": 1,
-        "description": "Recent-turn scan window for event-order evidence."
-      },
-      "eventOrderRecallScanWindowTokens": {
-        "type": "integer",
-        "default": 24000,
-        "minimum": 1,
-        "description": "Recent-token scan window for event-order evidence."
-      },
-      "queryExpansionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
-      },
-      "queryExpansionMaxQueries": {
-        "type": "number",
-        "default": 4,
-        "description": "Max expanded queries to run (including the original prompt)."
-      },
-      "queryExpansionMinTokenLen": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum token length to include in heuristic query expansion."
-      },
-      "rerankEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LLM re-ranking of retrieved memories. Default off."
-      },
-      "rerankProvider": {
-        "type": "string",
-        "default": "local",
-        "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
-        "enum": [
-          "local",
-          "cloud"
-        ]
-      },
-      "rerankMaxCandidates": {
-        "type": "number",
-        "default": 20,
-        "description": "Max candidates to send to the re-ranker."
-      },
-      "rerankTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
-      },
-      "rerankCacheEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Cache re-ranking results in-memory for repeated queries."
-      },
-      "rerankCacheTtlMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "TTL for in-memory re-ranking cache (ms)."
-      },
-      "feedbackEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable feedback capture tool for memory relevance (thumbs up/down)."
-      },
       "negativeExamplesEnabled": {
         "type": "boolean",
         "default": false,
         "description": "Enable negative examples (track retrieved-but-not-useful memories) and apply a small ranking penalty."
-      },
-      "negativeExamplesPenaltyPerHit": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
       },
       "negativeExamplesPenaltyCap": {
         "type": "number",
         "default": 0.25,
         "description": "Maximum ranking penalty applied from negative examples."
       },
-      "chunkingEnabled": {
+      "negativeExamplesPenaltyPerHit": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Ranking penalty per negative example hit (keep small; QMD scores are ~0-1)."
+      },
+      "nightlyGovernanceCronAutoRegister": {
         "type": "boolean",
         "default": false,
-        "description": "Enable automatic chunking of long memories"
+        "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
       },
-      "chunkingTargetTokens": {
-        "type": "number",
-        "default": 200,
-        "description": "Target tokens per chunk"
-      },
-      "chunkingMinTokens": {
-        "type": "number",
-        "default": 150,
-        "description": "Minimum tokens to trigger chunking"
-      },
-      "chunkingOverlapSentences": {
-        "type": "number",
-        "default": 2,
-        "description": "Number of sentences to overlap between chunks"
-      },
-      "semanticChunkingEnabled": {
+      "objectiveStateMemoryEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+        "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
       },
-      "semanticChunkingConfig": {
-        "type": "object",
-        "default": {},
-        "description": "Optional overrides for the semantic chunking algorithm",
-        "properties": {
-          "targetTokens": {
-            "type": "number",
-            "default": 200,
-            "description": "Target tokens per chunk"
+      "objectiveStateRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant objective-state snapshots to recall context."
+      },
+      "objectiveStateSnapshotWritesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow writing typed objective-state snapshots to the objective-state store."
+      },
+      "objectiveStateStoreDir": {
+        "type": "string",
+        "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
+      },
+      "openaiApiKey": {
+        "anyOf": [
+          {
+            "type": "string"
           },
-          "minTokens": {
-            "type": "number",
-            "default": 100,
-            "description": "Minimum tokens for a segment before merging with neighbor"
-          },
-          "maxTokens": {
-            "type": "number",
-            "default": 400,
-            "description": "Maximum tokens for a segment before recursive splitting"
-          },
-          "smoothingWindowSize": {
-            "type": "number",
-            "default": 3,
-            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
-          },
-          "boundaryThresholdStdDevs": {
-            "type": "number",
-            "default": 1,
-            "description": "Standard deviations below mean for boundary detection"
-          },
-          "embeddingBatchSize": {
-            "type": "number",
-            "default": 32,
-            "description": "Batch size for embedding requests"
-          },
-          "fallbackToRecursive": {
-            "type": "boolean",
-            "default": true,
-            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          {
+            "const": false
           }
-        }
+        ],
+        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
-      "contradictionDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic contradiction detection with LLM verification"
+      "openaiBaseUrl": {
+        "type": "string",
+        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
       },
-      "contradictionSimilarityThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "QMD similarity threshold to trigger contradiction check"
-      },
-      "contradictionMinConfidence": {
-        "type": "number",
-        "default": 0.9,
-        "description": "Minimum LLM confidence to auto-resolve contradictions"
-      },
-      "contradictionAutoResolve": {
+      "openclawChannelEnvelopeCleaningEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Automatically supersede contradicted memories"
+        "description": "Use OpenClaw's canonical chat-channel envelope prefixes when the SDK exposes plugin-sdk/chat-channel-ids, while keeping the legacy OpenClaw-only cleaner on older hosts."
       },
-      "contradictionScan": {
-        "type": "object",
-        "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
-          },
-          "similarityFloor": {
-            "type": "number",
-            "default": 0.82,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Embedding cosine similarity floor for candidate pair generation"
-          },
-          "topicOverlapFloor": {
-            "type": "number",
-            "default": 0.4,
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
-          },
-          "maxPairsPerRun": {
-            "type": "integer",
-            "default": 500,
-            "minimum": 1,
-            "description": "Cap on candidate pairs evaluated per cron run"
-          },
-          "cooldownDays": {
-            "type": "integer",
-            "default": 14,
-            "minimum": 0,
-            "description": "Cooldown in days. 0 = always re-evaluate."
-          },
-          "autoMergeDuplicates": {
-            "type": "boolean",
-            "default": false,
-            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
-          }
-        }
+      "openclawFlushPlanProcessingEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Process OpenClaw's append-only Remnic flush-plan file through Remnic extraction and clear processed content. Disable this if a future OpenClaw release owns flush-plan consumption and cleanup natively."
       },
-      "patternReinforcementEnabled": {
+      "openclawMessageReceivedCaptureEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Capture OpenClaw message_received hook content into transcripts when that hook is emitted by the host. Older OpenClaw versions that never emit the hook continue through agent_end capture."
+      },
+      "openclawReplyMetadataCaptureEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Persist bounded OpenClaw messageId, threadId, replyToId, replyToBody, and replyToSender fields in transcript metadata when available."
+      },
+      "openclawReplyMetadataExtractionHintsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
+        "description": "When true, prepend bounded quoted-reply context to user turns before Remnic extraction. Leave false to store reply metadata without changing extraction behavior."
+      },
+      "openclawToolSnippetMaxChars": {
+        "type": "integer",
+        "minimum": 80,
+        "maximum": 4000,
+        "default": 600,
+        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
+      },
+      "openclawToolsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
+      },
+      "operatorAwareConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+      },
+      "oramaDbPath": {
+        "type": "string",
+        "description": "Directory path for Orama persistence files (when searchBackend=orama)"
+      },
+      "oramaEmbeddingDimension": {
+        "type": "number",
+        "default": 1536,
+        "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
+      },
+      "oramaEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Orama as a supplemental search backend."
+      },
+      "parallelAgentWeights": {
+        "type": "object",
+        "default": {
+          "direct": 1,
+          "contextual": 0.7,
+          "temporal": 0.85
+        },
+        "description": "Score weights per retrieval agent source applied during result merge."
+      },
+      "parallelMaxResultsPerAgent": {
+        "type": "number",
+        "default": 20,
+        "description": "Maximum results fetched per agent before merge."
+      },
+      "parallelRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
       },
       "patternReinforcementCadenceMs": {
         "type": "integer",
         "minimum": 0,
         "default": 604800000,
         "description": "Minimum interval (ms) between pattern-reinforcement runs. Default 7 days. Set to 0 to disable cadence gating (manual / test invocation)."
-      },
-      "patternReinforcementMinCount": {
-        "type": "integer",
-        "minimum": 2,
-        "maximum": 1000,
-        "default": 3,
-        "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
       },
       "patternReinforcementCategories": {
         "type": "array",
@@ -3152,1097 +3527,28 @@
         ],
         "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
       },
-      "reinforcementRecallBoostEnabled": {
+      "patternReinforcementEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
+        "description": "Run the pattern-reinforcement maintenance job (issue #687 PR 2/4): cluster duplicate non-procedural memories by normalized content, promote the most-recent member to canonical, and supersede the older duplicates. Off by default until bench validation lands."
       },
-      "reinforcementRecallBoostWeight": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.05,
-        "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
-      },
-      "reinforcementRecallBoostMax": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.3,
-        "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
-      },
-      "temporalSupersessionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
-      },
-      "temporalSupersessionIncludeInRecall": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
-      },
-      "temporalBiTemporal": {
-        "type": "boolean",
-        "default": false,
-        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
-      },
-      "temporalExpiredInInjection": {
-        "type": "boolean",
-        "default": false,
-        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on — some deployments prefer the older (always-inject) behavior."
-      },
-      "recallDirectAnswerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
-      },
-      "recallDisclosureEscalation": {
-        "type": "string",
-        "enum": [
-          "manual",
-          "auto"
-        ],
-        "default": "manual",
-        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
-      },
-      "recallDisclosureEscalationThreshold": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.5,
-        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
-      },
-      "recallGraphEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
-      },
-      "recallGraphDamping": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 0.999999999,
-        "default": 0.85,
-        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
-      },
-      "recallGraphIterations": {
+      "patternReinforcementMinCount": {
         "type": "integer",
-        "minimum": 0,
-        "maximum": 500,
-        "default": 20,
-        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
-      },
-      "recallGraphTopK": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 10000,
-        "default": 50,
-        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
-      },
-      "recallDirectAnswerTokenOverlapFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.55,
-        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDirectAnswerImportanceFloor": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.7,
-        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
-      },
-      "recallDirectAnswerAmbiguityMargin": {
-        "type": "number",
-        "minimum": 0,
-        "maximum": 1,
-        "default": 0.15,
-        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
-      },
-      "recallDirectAnswerEligibleTaxonomyBuckets": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decisions",
-          "principles",
-          "conventions",
-          "runbooks",
-          "entities"
-        ],
-        "description": "Taxonomy category IDs eligible for direct-answer routing."
-      },
-      "recallCrossNamespaceBudgetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
-      },
-      "recallCrossNamespaceBudgetWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 60000,
-        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
-      },
-      "recallCrossNamespaceBudgetSoftLimit": {
-        "type": "number",
-        "minimum": 0,
-        "default": 10,
-        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
-      },
-      "recallCrossNamespaceBudgetHardLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
-      },
-      "recallAuditAnomalyDetectionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
-      },
-      "recallAuditAnomalyWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 300000,
-        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
-      },
-      "recallAuditAnomalyRepeatQueryLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 5,
-        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
-      },
-      "recallAuditAnomalyNamespaceWalkLimit": {
-        "type": "number",
-        "minimum": 1,
+        "minimum": 2,
+        "maximum": 1000,
         "default": 3,
-        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
-      },
-      "recallAuditAnomalyHighCardinalityLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 50,
-        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
-      },
-      "recallAuditAnomalyRapidFireLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
-      },
-      "recallMemoryWorthFilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
-      },
-      "recallMemoryWorthHalfLifeMs": {
-        "type": "number",
-        "minimum": 0,
-        "default": 0,
-        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
-      },
-      "recallMemoryHandles": {
-        "type": "boolean",
-        "default": false,
-        "description": "Issue #1582 — append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
-      },
-      "recallHandleSnapshotDepth": {
-        "type": "number",
-        "minimum": 1,
-        "maximum": 50,
-        "default": 5,
-        "description": "Issue #1582 — number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
-      },
-      "memoryLinkingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory linking to build knowledge graph"
-      },
-      "threadingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation threading"
-      },
-      "threadingGapMinutes": {
-        "type": "number",
-        "default": 30,
-        "description": "Minutes of gap to start a new thread"
-      },
-      "summarizationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic memory summarization/compression"
-      },
-      "summarizationTriggerCount": {
-        "type": "number",
-        "default": 1000,
-        "description": "Memory count threshold to trigger summarization"
-      },
-      "summarizationRecentToKeep": {
-        "type": "number",
-        "default": 300,
-        "description": "Number of recent memories to keep uncompressed"
-      },
-      "summarizationImportanceThreshold": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Only compress memories with importance below this threshold"
-      },
-      "summarizationProtectedTags": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle"
-        ],
-        "description": "Tags that protect memories from compression"
-      },
-      "topicExtractionEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable topic extraction during consolidation"
-      },
-      "topicExtractionTopN": {
-        "type": "number",
-        "default": 50,
-        "description": "Number of top topics to extract"
-      },
-      "transcriptEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable transcript archiving"
-      },
-      "chat": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Conversational memory inspection and correction (issue #1583). A bounded tool-loop agent over read-only + confirmation-gated mutating tools. Off by default — spawns LLM calls so explicit opt-in (rule 48).",
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Master gate. Off = no chat tools/endpoints/CLI registered (byte-identical surfaces, rule 39)."
-          },
-          "model": {
-            "type": "string",
-            "default": "",
-            "description": "Routing override for the chat LLM. Empty = use the default routing chain (local Ollama/vLLM fully supported)."
-          },
-          "maxToolCallsPerTurn": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 64,
-            "default": 8,
-            "description": "Max tool calls per user turn before partial-reply fallback (rule 34 — never a silent stall)."
-          },
-          "sessionTtlHours": {
-            "type": "integer",
-            "minimum": 1,
-            "default": 72,
-            "description": "Hours after which idle chat session state is cleaned up."
-          }
-        }
-      },
-      "captureMode": {
-        "type": "string",
-        "enum": [
-          "implicit",
-          "explicit",
-          "hybrid"
-        ],
-        "default": "implicit",
-        "description": "Memory capture policy. implicit preserves normal extraction, explicit stores only structured capture, and hybrid allows both."
-      },
-      "transcriptRetentionDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Days to retain transcript entries"
-      },
-      "transcriptSkipChannelTypes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "cron"
-        ],
-        "description": "Channel types to skip from transcript logging (e.g., cron)"
-      },
-      "transcriptRecallHours": {
-        "type": "number",
-        "default": 12,
-        "description": "Hours of transcript history to recall"
-      },
-      "maxTranscriptTurns": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum transcript turns to include"
-      },
-      "maxTranscriptTokens": {
-        "type": "number",
-        "default": 1000,
-        "description": "Maximum tokens for transcript context"
-      },
-      "checkpointEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable conversation checkpoints"
-      },
-      "checkpointTurns": {
-        "type": "number",
-        "default": 15,
-        "description": "Number of turns per checkpoint"
-      },
-      "compactionResetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
-      },
-      "hourlySummariesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable hourly conversation summaries"
-      },
-      "daySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
-      },
-      "daySummaryTimezone": {
-        "type": "string",
-        "default": "",
-        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
-      },
-      "summaryRecallHours": {
-        "type": "number",
-        "default": 24,
-        "description": "Hours of summary history to recall"
-      },
-      "maxSummaryCount": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum number of summaries to include"
-      },
-      "summaryModel": {
-        "type": "string",
-        "description": "Model for hourly summaries (defaults to main model)"
-      },
-      "modelSource": {
-        "type": "string",
-        "enum": [
-          "plugin",
-          "gateway"
-        ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
-      },
-      "gatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID (from openclaw.json agents.list[]) whose model chain to use for extraction, consolidation, and summarization. Required when modelSource is 'gateway'. Falls back to agents.defaults.model if empty."
-      },
-      "fastGatewayAgentId": {
-        "type": "string",
-        "default": "",
-        "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
-      },
-      "taskModelChain": {
-        "type": "object",
-        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
-        "required": [
-          "primary"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "primary": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
-          },
-          "fallbacks": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            },
-            "default": [],
-            "description": "Fallback gateway models tried after primary"
-          }
-        }
-      },
-      "localLlmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable local LLM for extraction and summarization (e.g., LM Studio, Ollama)"
-      },
-      "localLlmUrl": {
-        "type": "string",
-        "default": "http://localhost:1234/v1",
-        "description": "URL for local LLM OpenAI-compatible endpoint"
-      },
-      "localLlmModel": {
-        "type": "string",
-        "default": "local-model",
-        "description": "Model name for local LLM requests"
-      },
-      "localLlmApiKey": {
-        "type": "string",
-        "description": "Optional API key for authenticated OpenAI-compatible local endpoints"
-      },
-      "localLlmHeaders": {
-        "type": "object",
-        "description": "Optional additional headers for local/compatible endpoint requests",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "localLlmAuthHeader": {
-        "type": "boolean",
-        "default": true,
-        "description": "If false, do not send Authorization header even when localLlmApiKey is set"
-      },
-      "localLlmFallback": {
-        "type": "boolean",
-        "default": true,
-        "description": "Fall back to cloud OpenAI if local LLM is unavailable"
-      },
-      "localLlmHomeDir": {
-        "type": "string",
-        "description": "Optional home directory override for local LLM helpers (LM Studio settings + CLI PATH resolution)."
-      },
-      "localLmsCliPath": {
-        "type": "string",
-        "description": "Optional absolute path to LMS CLI binary. Preferred over auto-detected locations."
-      },
-      "localLmsBinDir": {
-        "type": "string",
-        "description": "Optional bin directory prepended to PATH for LMS CLI execution."
-      },
-      "localLlmTimeoutMs": {
-        "type": "number",
-        "default": 180000,
-        "description": "Hard timeout for local LLM requests (ms)"
-      },
-      "slowLogEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, log slow operations (durations + metadata; never logs content)"
-      },
-      "slowLogThresholdMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Threshold for slow operation logging (ms)"
-      },
-      "traceRecallContent": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
-      },
-      "profilingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
-      },
-      "profilingStorageDir": {
-        "type": "string",
-        "default": "",
-        "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
-      },
-      "profilingMaxTraces": {
-        "type": "number",
-        "default": 100,
-        "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
-      },
-      "extractionDedupeEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable deduplication of near-identical extraction batches within a time window."
-      },
-      "extractionDedupeWindowMs": {
-        "type": "number",
-        "default": 300000,
-        "description": "Window for extraction dedupe fingerprints (ms)."
-      },
-      "extractionMinChars": {
-        "type": "number",
-        "default": 40,
-        "description": "Minimum combined user/assistant characters required before extraction runs."
-      },
-      "extractionMinImportanceLevel": {
-        "type": "string",
-        "enum": [
-          "trivial",
-          "low",
-          "normal",
-          "high",
-          "critical"
-        ],
-        "default": "low",
-        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
-      },
-      "extractionTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
-      },
-      "extractionScopeClassificationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
-      },
-      "extractionJudgeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
-      },
-      "extractionJudgeModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
-      },
-      "extractionJudgeBatchSize": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
-      },
-      "extractionJudgeShadow": {
-        "type": "boolean",
-        "default": false,
-        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
-      },
-      "extractionJudgeMaxDeferrals": {
-        "type": "number",
-        "default": 2,
-        "minimum": 1,
-        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
-      },
-      "extractionJudgeTelemetryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
-      },
-      "collectJudgeTrainingPairs": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
-      },
-      "judgeTrainingDir": {
-        "type": "string",
-        "default": "",
-        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
-      },
-      "extractionFaithfulnessGate": {
-        "type": "string",
-        "enum": [
-          "off",
-          "shadow",
-          "enforce"
-        ],
-        "default": "off",
-        "description": "Extraction faithfulness gate (issue #1576). Entailment-verification of extracted facts against their verified source spans (#1575). 'off' (default) = byte-identical pre-feature pipeline; 'shadow' = record verdicts in frontmatter + telemetry only; 'enforce' = route unsupported/contradicted to pending_review."
-      },
-      "extractionFaithfulnessModel": {
-        "type": "string",
-        "default": "",
-        "description": "Override model/endpoint for the faithfulness verifier. Empty string = default routing chain (local then fallback)."
-      },
-      "extractionFaithfulnessContextChars": {
-        "type": "number",
-        "default": 400,
-        "description": "Context window (chars) around the verified quote sent to the faithfulness verifier."
-      },
-      "extractionFaithfulnessTimeoutMs": {
-        "type": "number",
-        "default": 8000,
-        "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
-      },
-      "inlineSourceAttributionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
-      },
-      "inlineSourceAttributionFormat": {
-        "type": "string",
-        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
-        "description": "Template used when inline source attribution is enabled."
-      },
-      "provenance": {
-        "type": "object",
-        "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
-        "additionalProperties": false,
-        "properties": {
-          "enabled": {
-            "type": "boolean",
-            "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
-          },
-          "maxQuoteChars": {
-            "type": "integer",
-            "default": 300,
-            "minimum": 1,
-            "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
-          },
-          "requireSpans": {
-            "type": "boolean",
-            "default": false,
-            "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
-          }
-        }
-      },
-      "extractionMinUserTurns": {
-        "type": "number",
-        "default": 1,
-        "description": "Minimum number of user turns required before extraction runs."
-      },
-      "extractionMaxTurnChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Maximum characters per turn fed to extraction (long turns are truncated)."
-      },
-      "extractionMaxFactsPerRun": {
-        "type": "number",
-        "default": 12,
-        "description": "Maximum facts persisted from a single extraction run."
-      },
-      "extractionMaxEntitiesPerRun": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum entities persisted from a single extraction run."
-      },
-      "extractionMaxQuestionsPerRun": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum questions persisted from a single extraction run."
-      },
-      "extractionMaxProfileUpdatesPerRun": {
-        "type": "number",
-        "default": 4,
-        "description": "Maximum profile updates persisted from a single extraction run."
-      },
-      "consolidationRequireNonZeroExtraction": {
-        "type": "boolean",
-        "default": true,
-        "description": "Only schedule consolidation when the last extraction produced durable outputs."
-      },
-      "consolidationMinIntervalMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Minimum interval between consolidation runs (ms)."
-      },
-      "qmdMaintenanceEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
-      },
-      "qmdMaintenanceDebounceMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Debounce window for background QMD maintenance updates (ms)."
-      },
-      "qmdAutoEmbedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
-      },
-      "qmdEmbedMinIntervalMs": {
-        "type": "number",
-        "default": 3600000,
-        "description": "Minimum interval between background QMD embed runs (ms)."
-      },
-      "qmdUpdateTimeoutMs": {
-        "type": "number",
-        "default": 90000,
-        "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
-      },
-      "qmdUpdateMinIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
-      },
-      "maintenanceNamespaceFanoutEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "When namespaces are enabled, let background maintenance enumerate live catalog namespaces in addition to configured default/shared/policy namespaces."
-      },
-      "maintenanceMaxNamespacesPerCycle": {
-        "type": "number",
-        "default": 20,
-        "minimum": 1,
-        "description": "Maximum namespaces a single maintenance job cycle may process. Default and shared namespaces keep priority inside this budget."
-      },
-      "maintenanceIncludeProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceIncludeBranchNamespaces": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include dynamic branch namespaces from the namespace catalog in background maintenance fanout. Defaults off to avoid high-cardinality branch churn."
-      },
-      "maintenanceIncludeTeamProjectNamespaces": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include dynamic team-project namespaces from the namespace catalog in background maintenance fanout."
-      },
-      "maintenanceNamespaceLockStaleMs": {
-        "type": "number",
-        "default": 600000,
-        "minimum": 1,
-        "description": "Stale threshold for per-job/per-namespace maintenance locks under state/maintenance-locks/."
-      },
-      "localLlmRetry5xxCount": {
-        "type": "number",
-        "default": 1,
-        "description": "Number of retry attempts for local LLM 5xx responses."
-      },
-      "localLlmRetryBackoffMs": {
-        "type": "number",
-        "default": 400,
-        "description": "Base backoff delay between local LLM retries (ms)."
-      },
-      "localLlm400TripThreshold": {
-        "type": "number",
-        "default": 5,
-        "description": "Consecutive 400 responses before local LLM enters temporary cooldown."
-      },
-      "localLlm400CooldownMs": {
-        "type": "number",
-        "default": 120000,
-        "description": "Cooldown duration after tripping local LLM 400 threshold (ms)."
-      },
-      "localLlmMaxContext": {
-        "type": "number",
-        "description": "Override the detected context window for local LLM. Set to 32768 if your LLM server defaults to 32K context despite the model supporting 128K."
-      },
-      "localLlmFastEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable a separate smaller/faster local LLM for quick operations (rerank, entity_summary, tmt_summary, compression_guideline)."
-      },
-      "localLlmFastModel": {
-        "type": "string",
-        "default": "",
-        "description": "Model ID for fast-tier local LLM operations. Empty string uses the primary localLlmModel."
-      },
-      "localLlmFastUrl": {
-        "type": "string",
-        "description": "Endpoint for the fast-tier local LLM. Defaults to the same endpoint as localLlmUrl when not set."
-      },
-      "localLlmFastTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
-      },
-      "localLlmDisableThinking": {
-        "type": "boolean",
-        "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
-      },
-      "hourlySummaryCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register an hourly summary cron job (default off)."
-      },
-      "nightlyGovernanceCronAutoRegister": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, Engram may attempt to auto-register the nightly governance cron job (default off)."
-      },
-      "hourlySummariesExtendedEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable structured hourly summaries (topics/decisions/action items/rejections). Default off."
-      },
-      "hourlySummariesIncludeToolStats": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tool usage counts in extended hourly summaries (requires tool usage capture)."
-      },
-      "hourlySummariesIncludeSystemMessages": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include system messages in extended hourly summaries (use with care)."
-      },
-      "hourlySummariesMaxTurnsPerRun": {
-        "type": "number",
-        "default": 200,
-        "description": "Maximum transcript turns to consider per session per hourly summarizer run."
-      },
-      "conversationIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable conversation chunk indexing + semantic recall hook (default off)."
-      },
-      "conversationIndexBackend": {
-        "type": "string",
-        "enum": [
-          "qmd",
-          "faiss"
-        ],
-        "default": "qmd",
-        "description": "Backend for conversation indexing. qmd indexes chunk docs into a QMD collection; faiss uses the bundled Python sidecar and local FAISS artifacts under memoryDir/state/conversation-index/faiss."
-      },
-      "conversationIndexQmdCollection": {
-        "type": "string",
-        "default": "openclaw-engram-conversations",
-        "description": "QMD collection to use for conversation chunk search (must be configured in ~/.config/qmd/index.yml)."
-      },
-      "conversationIndexRetentionDays": {
-        "type": "number",
-        "default": 30,
-        "description": "Days to retain conversation chunk docs."
-      },
-      "conversationIndexMinUpdateIntervalMs": {
-        "type": "number",
-        "default": 900000,
-        "description": "Minimum interval between conversation_index_update runs per session (ms). Prevents redundant reindex churn."
-      },
-      "conversationIndexEmbedOnUpdate": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, conversation_index_update also runs QMD embed by default. Keep false for lower load."
-      },
-      "conversationIndexFaissScriptPath": {
-        "type": "string",
-        "default": "",
-        "description": "Optional absolute path to FAISS sidecar script. If unset, uses built-in default script location."
-      },
-      "conversationIndexFaissPythonBin": {
-        "type": "string",
-        "default": "",
-        "description": "Optional Python executable used to run the FAISS sidecar (for example python3.11)."
-      },
-      "conversationIndexFaissModelId": {
-        "type": "string",
-        "default": "text-embedding-3-small",
-        "description": "Embedding model identifier passed to the FAISS sidecar. By default the sidecar aliases OpenAI embedding ids to a local sentence-transformers model when REMNIC_FAISS_ENABLE_ST=1 (or legacy ENGRAM_FAISS_ENABLE_ST=1), and otherwise falls back to deterministic hash embeddings."
-      },
-      "conversationIndexFaissIndexDir": {
-        "type": "string",
-        "default": "state/conversation-index/faiss",
-        "description": "Relative directory under memoryDir where FAISS sidecar artifacts are stored, including index.faiss, metadata.jsonl, and manifest.json."
-      },
-      "conversationIndexFaissUpsertTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout (ms) for FAISS upsert operations."
-      },
-      "conversationIndexFaissSearchTimeoutMs": {
-        "type": "number",
-        "default": 5000,
-        "description": "Timeout (ms) for FAISS search operations."
-      },
-      "conversationIndexFaissHealthTimeoutMs": {
-        "type": "number",
-        "default": 2000,
-        "description": "Timeout (ms) for FAISS health checks. Health is fail-open and reports degraded when dependencies or local artifacts are missing."
-      },
-      "conversationIndexFaissMaxBatchSize": {
-        "type": "number",
-        "default": 512,
-        "description": "Maximum transcript chunk batch size per FAISS upsert call."
-      },
-      "conversationIndexFaissMaxSearchK": {
-        "type": "number",
-        "default": 50,
-        "description": "Maximum top-K allowed for FAISS search requests."
-      },
-      "conversationRecallTopK": {
-        "type": "number",
-        "default": 3,
-        "description": "Top-K conversation chunks to include."
-      },
-      "conversationRecallMaxChars": {
-        "type": "number",
-        "default": 2500,
-        "description": "Max characters of semantic conversation recall to include."
-      },
-      "conversationRecallTimeoutMs": {
-        "type": "number",
-        "default": 800,
-        "description": "Timeout for semantic conversation recall search (ms). Fail-open on timeout."
-      },
-      "evalHarnessEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's benchmark/evaluation harness foundation for tracking benchmark packs and run summaries."
-      },
-      "evalShadowModeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shadow-mode evaluation workflows so future benchmark instrumentation can measure memory changes without changing live recall output."
-      },
-      "benchmarkBaselineSnapshotsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable versioned benchmark baseline snapshot artifacts under the eval store for later PR delta reporting."
-      },
-      "benchmarkStoredBaselineEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable stored baseline comparisons for benchmark delta reporting."
-      },
-      "benchmarkDeltaReporterEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable named-baseline delta reports so PR candidates can be compared against stored benchmark baselines."
-      },
-      "evalStoreDir": {
-        "type": "string",
-        "description": "Override the evaluation harness state directory (defaults to {memoryDir}/state/evals)."
-      },
-      "objectiveStateMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's objective-state memory foundation for normalized world/tool state snapshots."
-      },
-      "objectiveStateSnapshotWritesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Allow writing typed objective-state snapshots to the objective-state store."
-      },
-      "objectiveStateRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant objective-state snapshots to recall context."
-      },
-      "objectiveStateStoreDir": {
-        "type": "string",
-        "description": "Override the objective-state memory directory (defaults to {memoryDir}/state/objective-state)."
-      },
-      "causalTrajectoryMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's causal-trajectory memory foundation for typed goal-action-observation-outcome chains."
-      },
-      "causalTrajectoryStoreDir": {
-        "type": "string",
-        "description": "Override the causal-trajectory memory directory (defaults to {memoryDir}/state/causal-trajectories)."
-      },
-      "causalTrajectoryRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant causal trajectories to recall context."
-      },
-      "trustZonesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
-      },
-      "quarantinePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Reserve future promotion flows from quarantine into higher-trust zones."
-      },
-      "trustZoneStoreDir": {
-        "type": "string",
-        "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
-      },
-      "trustZoneRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
-      },
-      "memoryPoisoningDefenseEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic provenance trust scoring for trust-zone records as the first poisoning-defense surface."
-      },
-      "memoryRedTeamBenchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
-      },
-      "harmonicRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
-      },
-      "abstractionAnchorsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
-      },
-      "abstractionNodeStoreDir": {
-        "type": "string",
-        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
-      },
-      "verifiedRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
-      },
-      "semanticRulePromotionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
-      },
-      "semanticRuleVerificationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
-      },
-      "semanticConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable periodic semantic consolidation of similar memories."
-      },
-      "semanticConsolidationModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
-      },
-      "semanticConsolidationThreshold": {
-        "type": "number",
-        "default": 0.8,
-        "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
-      },
-      "semanticConsolidationMinClusterSize": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum cluster size before consolidation triggers."
-      },
-      "semanticConsolidationExcludeCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "correction",
-          "commitment",
-          "procedure"
-        ],
-        "description": "Memory categories excluded from semantic consolidation."
-      },
-      "semanticConsolidationIntervalHours": {
-        "type": "number",
-        "default": 168,
-        "description": "Hours between automatic consolidation runs (168 = weekly)."
-      },
-      "semanticConsolidationMaxPerRun": {
-        "type": "number",
-        "default": 100,
-        "description": "Max memories to consolidate per run to limit LLM cost."
-      },
-      "operatorAwareConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+        "description": "Minimum cluster size before pattern reinforcement promotes a canonical and supersedes duplicates. Default 3."
       },
       "peerProfileReasonerEnabled": {
         "type": "boolean",
         "default": false,
         "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
       },
-      "peerProfileReasonerModel": {
-        "type": "string",
-        "default": "auto",
-        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+      "peerProfileReasonerMaxFieldsPerRun": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
       },
       "peerProfileReasonerMinInteractions": {
         "type": "number",
@@ -4250,11 +3556,10 @@
         "minimum": 0,
         "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
       },
-      "peerProfileReasonerMaxFieldsPerRun": {
-        "type": "number",
-        "default": 8,
-        "minimum": 0,
-        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+      "peerProfileReasonerModel": {
+        "type": "string",
+        "default": "auto",
+        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only \u2014 actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
       },
       "peerProfileRecallEnabled": {
         "type": "boolean",
@@ -4266,130 +3571,6 @@
         "default": 5,
         "minimum": 0,
         "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
-      },
-      "creationMemoryEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable creation-memory foundations, including the work-product ledger for explicit outputs agents create."
-      },
-      "memoryUtilityLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable utility-learning telemetry storage so later slices can learn promotion and ranking weights from downstream outcomes."
-      },
-      "promotionByOutcomeEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
-      },
-      "commitmentLedgerEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable the explicit commitment ledger for promises, follow-ups, deadlines, and unfinished obligations."
-      },
-      "commitmentLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable commitment lifecycle transitions, stale tracking, and resolved-entry cleanup for the commitment ledger."
-      },
-      "commitmentStaleDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Days before an open commitment without a due date is considered stale in lifecycle status."
-      },
-      "commitmentLedgerDir": {
-        "type": "string",
-        "description": "Override the commitment ledger directory (defaults to {memoryDir}/state/commitment-ledger)."
-      },
-      "resumeBundlesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
-      },
-      "resumeBundleDir": {
-        "type": "string",
-        "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
-      },
-      "workProductRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
-      },
-      "workProductLedgerDir": {
-        "type": "string",
-        "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
-      },
-      "workTasksEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable task tracking within the work product system."
-      },
-      "workProjectsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable project tracking within the work product system."
-      },
-      "workTasksDir": {
-        "type": "string",
-        "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
-      },
-      "workProjectsDir": {
-        "type": "string",
-        "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
-      },
-      "workIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable search index for work tasks and projects."
-      },
-      "workIndexDir": {
-        "type": "string",
-        "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
-      },
-      "workTaskIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include tasks in the work search index."
-      },
-      "workProjectIndexEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Include projects in the work search index."
-      },
-      "workIndexAutoRebuildEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically rebuild the work index when tasks or projects change."
-      },
-      "workIndexAutoRebuildDebounceMs": {
-        "type": "number",
-        "default": 1000,
-        "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
-      },
-      "actionGraphRecallEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Write action-conditioned causal-stage edges from typed trajectory records into the causal graph."
-      },
-      "namespacesEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable multi-agent namespaces (v3.0). Default off."
-      },
-      "namespaceCatalogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the rebuildable namespace catalog (issue #1499). Records cheap, failure-tolerant namespace touches in <memoryDir>/state/namespaces.jsonl for enumeration by maintenance, QMD indexing, dashboard, and doctor. Inert unless namespacesEnabled is also true; filesystem memory stays the source of truth and the catalog is rebuildable via `remnic namespaces rebuild`. Default on; set false to opt out."
-      },
-      "defaultNamespace": {
-        "type": "string",
-        "default": "default",
-        "description": "Default namespace name."
-      },
-      "sharedNamespace": {
-        "type": "string",
-        "default": "shared",
-        "description": "Shared namespace name."
       },
       "principalFromSessionKeyMode": {
         "type": "string",
@@ -4421,53 +3602,881 @@
           ]
         }
       },
-      "namespacePolicies": {
+      "proactiveExtractionCategoryAllowlist": {
         "type": "array",
-        "description": "Namespace access policies.",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
+      },
+      "proactiveExtractionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
+      },
+      "proactiveExtractionMaxTokens": {
+        "type": "number",
+        "default": 900,
+        "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
+      },
+      "proactiveExtractionTimeoutMs": {
+        "type": "number",
+        "default": 2500,
+        "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
+      },
+      "procedural": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519). Default-on since issue #567 PR 4/5; set to `false` to opt out."
+          },
+          "minOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000,
+            "default": 3,
+            "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
+          },
+          "successFloor": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0.75,
+            "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
+          },
+          "autoPromoteOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000,
+            "default": 8,
+            "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
+          },
+          "autoPromoteEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
+          },
+          "lookbackDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3650,
+            "default": 14,
+            "description": "Trajectory lookback window for procedural mining."
+          },
+          "recallMaxProcedures": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 2,
+            "description": "Maximum procedure memories to add on task-initiation recall."
+          },
+          "proceduralMiningCronAutoRegister": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, installer may register the nightly procedural mining cron job."
+          }
+        }
+      },
+      "profilingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, enable performance profiling for recall and extraction pipelines. Profiling data is stored locally in the profiling storage directory."
+      },
+      "profilingMaxTraces": {
+        "type": "number",
+        "default": 100,
+        "description": "Maximum number of profiling trace files to retain. Oldest traces are pruned when this limit is exceeded."
+      },
+      "profilingStorageDir": {
+        "type": "string",
+        "default": "",
+        "description": "Directory path for storing profiling trace files. Defaults to <memoryDir>/profiling if empty."
+      },
+      "promotionByOutcomeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable outcome-aware promotion controls that consume learned utility signals when later rollout slices activate them."
+      },
+      "provenance": {
+        "type": "object",
+        "description": "Claim-level provenance spans (issue #1575). When enabled, extracted facts carry verbatim source-utterance excerpts plus a coarse strength tag (verified/unverified/none) consumed by the faithfulness gate, correction UX, tombstone matching, and TrustScore.",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Emit provenance spans on new extractions. Off = pre-feature extraction prompt/output, byte-identical (rule 39). Default: true (applied in code; no schema default so the REMNIC_/ENGRAM_ env override fires when the key is omitted)."
+          },
+          "maxQuoteChars": {
+            "type": "integer",
+            "default": 300,
+            "minimum": 1,
+            "description": "Maximum characters stored per quote; longer quotes truncate at a word boundary with an ellipsis marker. Never stores the whole turn."
+          },
+          "requireSpans": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, facts whose quote cannot be located are routed to pending_review instead of active. Stays false until #1576 lands and the bench shows the gate is safe (rule 48)."
+          }
+        }
+      },
+      "qmdAutoEmbedEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, background QMD maintenance also runs embed on a throttled cadence."
+      },
+      "qmdAutoUpgradeCheckIntervalMs": {
+        "type": "number",
+        "minimum": 60000,
+        "default": 86400000,
+        "description": "Minimum interval between QMD auto-upgrade checks"
+      },
+      "qmdAutoUpgradeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+      },
+      "qmdCandidateLimit": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Optional candidate limit forwarded to supported QMD query paths"
+      },
+      "qmdChunkStrategy": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "regex"
+        ],
+        "default": "auto",
+        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+      },
+      "qmdColdCollection": {
+        "type": "string",
+        "default": "openclaw-engram-cold",
+        "description": "Secondary QMD collection name used for cold-tier fallback recall"
+      },
+      "qmdColdMaxResults": {
+        "type": "number",
+        "default": 8,
+        "description": "Max cold-tier QMD results considered before final recall cap"
+      },
+      "qmdColdTierEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable cold-tier QMD recall from a secondary collection when hot recall misses"
+      },
+      "qmdCollection": {
+        "type": "string",
+        "default": "openclaw-engram",
+        "description": "QMD collection name"
+      },
+      "qmdDaemonEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Prefer the shared QMD MCP session for faster searches when available."
+      },
+      "qmdDaemonRecheckIntervalMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Re-probe interval when daemon is down (ms)"
+      },
+      "qmdDaemonTimeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 8000,
+        "description": "Per-call timeout (ms) for QMD daemon searches. Default 8000; raise (e.g. 20000) to give CPU-only HyDE queries more headroom before the daemon call times out (issue #1335)."
+      },
+      "qmdDaemonUrl": {
+        "type": "string",
+        "default": "http://localhost:8181/mcp",
+        "description": "Legacy compatibility setting retained for QMD daemon configuration."
+      },
+      "qmdEmbedMinIntervalMs": {
+        "type": "number",
+        "default": 3600000,
+        "description": "Minimum interval between background QMD embed runs (ms)."
+      },
+      "qmdEmbedModel": {
+        "type": "string",
+        "description": "Optional QMD_EMBED_MODEL override"
+      },
+      "qmdEmbedParallelism": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 8,
+        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+      },
+      "qmdEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use QMD for search"
+      },
+      "qmdExplainEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Request QMD explain traces for recall debugging when supported."
+      },
+      "qmdForceCpu": {
+        "type": "boolean",
+        "default": false,
+        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+      },
+      "qmdGenerateModel": {
+        "type": "string",
+        "description": "Optional QMD_GENERATE_MODEL override"
+      },
+      "qmdGpuBackend": {
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "enum": [
+          "auto",
+          "metal",
+          "cuda",
+          "vulkan",
+          "false",
+          false
+        ],
+        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+      },
+      "qmdIndexName": {
+        "type": "string",
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
+      },
+      "qmdIntentHintsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
+      },
+      "qmdMaintenanceDebounceMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Debounce window for background QMD maintenance updates (ms)."
+      },
+      "qmdMaintenanceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable debounced background QMD maintenance instead of immediate updates on extraction."
+      },
+      "qmdMaxResults": {
+        "type": "number",
+        "default": 8,
+        "description": "Max QMD results per search"
+      },
+      "qmdPath": {
+        "type": "string",
+        "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
+      },
+      "qmdQueryRerankEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+      },
+      "qmdRecallCacheMaxEntries": {
+        "type": "number",
+        "default": 128,
+        "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
+      },
+      "qmdRecallCacheStaleTtlMs": {
+        "type": "number",
+        "default": 600000,
+        "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
+      },
+      "qmdRecallCacheTtlMs": {
+        "type": "number",
+        "default": 60000,
+        "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
+      },
+      "qmdRerankModel": {
+        "type": "string",
+        "description": "Optional QMD_RERANK_MODEL override"
+      },
+      "qmdSearchStrategy": {
+        "type": "string",
+        "enum": [
+          "hybrid",
+          "lex-vec",
+          "lex"
+        ],
+        "default": "hybrid",
+        "description": "Daemon search plan. 'hybrid' (default) runs lex+vec+hyde for best recall; 'lex-vec' drops the expensive HyDE generate leg; 'lex' is BM25-only (fastest). Lower tiers trade recall for latency on CPU-only models. Default preserves existing behavior (issue #1335)."
+      },
+      "qmdSubprocessStrategy": {
+        "type": "string",
+        "enum": [
+          "query",
+          "search"
+        ],
+        "default": "query",
+        "description": "Command for the QMD CLI subprocess fallback, used only when the daemon is unavailable. 'query' (default) keeps LLM query expansion + rerank; 'search' is BM25-only and faster on very large collections but loses expansion/rerank. Default preserves existing behavior (issue #1335)."
+      },
+      "qmdSupportedVersion": {
+        "type": "string",
+        "default": "2.5.3",
+        "description": "Highest QMD version this Remnic build will auto-install"
+      },
+      "qmdTierAutoBackfillEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
+      },
+      "qmdTierDemotionMinAgeDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Minimum hot-memory age in days before tier demotion is eligible"
+      },
+      "qmdTierDemotionValueThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
+      },
+      "qmdTierMigrationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable value-aware migration between hot and cold QMD tiers"
+      },
+      "qmdTierParityGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierParityHiMemEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierPromotionValueThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
+      },
+      "qmdUpdateMinIntervalMs": {
+        "type": "number",
+        "default": 900000,
+        "description": "Minimum interval between QMD update executions (ms). Useful because current QMD update runs globally across collections."
+      },
+      "qmdUpdateTimeoutMs": {
+        "type": "number",
+        "default": 90000,
+        "description": "Timeout for QMD update command (ms). Increase if your index grows and updates exceed 30s."
+      },
+      "quarantinePromotionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Reserve future promotion flows from quarantine into higher-trust zones."
+      },
+      "queryAwareIndexingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable temporal and tag indexes (v8.1). Maintains state/index_time.json and state/index_tags.json for fast prefiltering. At recall time, temporal queries and #tag tokens receive a small score boost from the index. Disabled by default."
+      },
+      "queryAwareIndexingMaxCandidates": {
+        "type": "number",
+        "default": 200,
+        "description": "Max candidate paths returned from index prefilter before scoring (0 = no cap)."
+      },
+      "queryExpansionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable heuristic query expansion for retrieval (no LLM calls)."
+      },
+      "queryExpansionMaxQueries": {
+        "type": "number",
+        "default": 4,
+        "description": "Max expanded queries to run (including the original prompt)."
+      },
+      "queryExpansionMinTokenLen": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum token length to include in heuristic query expansion."
+      },
+      "reasoningEffort": {
+        "type": "string",
+        "enum": [
+          "none",
+          "low",
+          "medium",
+          "high"
+        ],
+        "default": "low",
+        "description": "Reasoning effort for extraction"
+      },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled \u2014 enable explicitly."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+      },
+      "recallBudgetChars": {
+        "type": "number",
+        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
+      },
+      "recallConfidenceGateEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
+      },
+      "recallConfidenceGateThreshold": {
+        "type": "number",
+        "default": 0.12,
+        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
+      },
+      "recallCoreDeadlineMs": {
+        "type": "number",
+        "default": 75000,
+        "description": "Default deadline in ms recorded for core recall sections."
+      },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallDirectAnswerAmbiguityMargin": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.15,
+        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+      },
+      "recallDirectAnswerEligibleTaxonomyBuckets": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decisions",
+          "principles",
+          "conventions",
+          "runbooks",
+          "entities"
+        ],
+        "description": "Taxonomy category IDs eligible for direct-answer routing."
+      },
+      "recallDirectAnswerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
+      },
+      "recallDirectAnswerImportanceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerTokenOverlapFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.55,
+        "description": "Minimum query\u2194memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDisclosureEscalation": {
+        "type": "string",
+        "enum": [
+          "manual",
+          "auto"
+        ],
+        "default": "manual",
+        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+      },
+      "recallDisclosureEscalationThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.5,
+        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+      },
+      "recallEnrichmentDeadlineMs": {
+        "type": "number",
+        "default": 25000,
+        "description": "Default deadline in ms recorded for enrichment recall sections."
+      },
+      "recallGraphDamping": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.999999999,
+        "default": 0.85,
+        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+      },
+      "recallGraphEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false \u2014 ships off pending the retrieval-graph bench in PR 5."
+      },
+      "recallGraphIterations": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 500,
+        "default": 20,
+        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+      },
+      "recallGraphTopK": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 10000,
+        "default": 50,
+        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
+      },
+      "recallHandleSnapshotDepth": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 5,
+        "description": "Issue #1582 \u2014 number of recent per-session recall snapshots searched when resolving a `[m:xxxx]` handle to a memory id. Older-than-N snapshots are not searched; a miss is tagged rather than widening the window."
+      },
+      "recallMemoryHandles": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #1582 \u2014 append stable short handles (`[m:4f2a]`) to injected memory lines at recall render time. Default false: off = byte-identical injection. Token cost ~9 chars/memory; flip the default only with benchmark evidence that answer quality is unaffected."
+      },
+      "recallMemoryWorthFilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
+      },
+      "recallMemoryWorthHalfLifeMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
+      },
+      "recallMmrEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
+      },
+      "recallMmrLambda": {
+        "type": "number",
+        "default": 0.7,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
+      },
+      "recallMmrTopN": {
+        "type": "number",
+        "default": 40,
+        "minimum": 0,
+        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
+      },
+      "recallOuterTimeoutMs": {
+        "type": "number",
+        "default": 75000,
+        "description": "Outer timeout in ms for the full recall pipeline."
+      },
+      "recallPipeline": {
+        "type": "array",
+        "description": "Ordered recall sections with per-section budgets and feature knobs.",
         "items": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
-            "name": {
+            "id": {
               "type": "string"
             },
-            "readPrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "enabled": {
+              "type": "boolean",
+              "default": true
             },
-            "writePrincipals": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "maxChars": {
+              "type": [
+                "number",
+                "null"
+              ]
             },
-            "includeInRecallByDefault": {
+            "consolidateTriggerLines": {
+              "type": "number"
+            },
+            "consolidateTargetLines": {
+              "type": "number"
+            },
+            "maxEntities": {
+              "type": "number"
+            },
+            "maxResults": {
+              "type": "number"
+            },
+            "maxTurns": {
+              "type": "number"
+            },
+            "maxTokens": {
+              "type": "number"
+            },
+            "lookbackHours": {
+              "type": "number"
+            },
+            "maxCount": {
+              "type": "number"
+            },
+            "topK": {
+              "type": "number"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "maxPatterns": {
+              "type": "number"
+            },
+            "forceGeneric": {
               "type": "boolean"
             }
           },
           "required": [
-            "name",
-            "readPrincipals",
-            "writePrincipals"
+            "id"
           ]
         }
       },
-      "defaultRecallNamespaces": {
-        "type": "array",
-        "description": "Which namespaces to include by default in recall.",
-        "items": {
-          "type": "string",
-          "enum": [
-            "self",
-            "shared"
-          ]
-        },
-        "default": [
-          "self",
-          "shared"
+      "recallPlannerEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
+      },
+      "recallPlannerLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+      },
+      "recallPlannerMaxMemoryHints": {
+        "type": "number",
+        "default": 24,
+        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
+      },
+      "recallPlannerMaxPromptChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Maximum characters of prompt context to send to the recall planner."
+      },
+      "recallPlannerMaxQmdResultsFull": {
+        "type": "number",
+        "default": 8,
+        "description": "QMD cap used when recall planner selects full mode."
+      },
+      "recallPlannerMaxQmdResultsMinimal": {
+        "type": "number",
+        "default": 4,
+        "description": "QMD cap used when recall planner selects minimal mode."
+      },
+      "recallPlannerModel": {
+        "type": "string",
+        "default": "gpt-5.5",
+        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain \u2014 any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
+      },
+      "recallPlannerShadowMode": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run recall planner in shadow mode \u2014 evaluate but do not apply results."
+      },
+      "recallPlannerTelemetryEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Emit telemetry events for recall planner decisions."
+      },
+      "recallPlannerTimeoutMs": {
+        "type": "number",
+        "default": 1500,
+        "description": "Timeout in ms for recall planner inference."
+      },
+      "recallPlannerUseResponsesApi": {
+        "type": "boolean",
+        "default": true,
+        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
+      },
+      "recallReasoningTraceBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+      },
+      "recallTranscriptRetentionDays": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 365,
+        "default": 30,
+        "description": "Days of runtime recall audit transcripts to retain before pruning."
+      },
+      "recallTranscriptsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
+      },
+      "recencyWeight": {
+        "type": "number",
+        "default": 0.2,
+        "description": "Weight for recency boosting in search (0-1)"
+      },
+      "recordEmptyRecallImpressions": {
+        "type": "boolean",
+        "default": false,
+        "description": "Record recall impressions with empty memoryIds when no memory context is added."
+      },
+      "reinforcementRecallBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, memories with reinforcement_count frontmatter receive an additive recall score boost (issue #687 PR 3/4). Default: false (opt-in)."
+      },
+      "reinforcementRecallBoostMax": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.3,
+        "description": "Maximum additive reinforcement boost per result. Range [0, 1]. Default: 0.3."
+      },
+      "reinforcementRecallBoostWeight": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.05,
+        "description": "Score bonus per unit of reinforcement_count (weight * count, capped at max). Range [0, 1]. Default: 0.05."
+      },
+      "remoteSearchApiKey": {
+        "type": "string",
+        "description": "API key for remote search backend (when searchBackend=remote)"
+      },
+      "remoteSearchBaseUrl": {
+        "type": "string",
+        "description": "Base URL for remote search backend (when searchBackend=remote)"
+      },
+      "remoteSearchTimeoutMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Timeout in ms for remote search backend requests"
+      },
+      "rerankCacheEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Cache re-ranking results in-memory for repeated queries."
+      },
+      "rerankCacheTtlMs": {
+        "type": "number",
+        "default": 3600000,
+        "description": "TTL for in-memory re-ranking cache (ms)."
+      },
+      "rerankEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable LLM re-ranking of retrieved memories. Default off."
+      },
+      "rerankMaxCandidates": {
+        "type": "number",
+        "default": 20,
+        "description": "Max candidates to send to the re-ranker."
+      },
+      "rerankProvider": {
+        "type": "string",
+        "default": "local",
+        "description": "Re-ranking provider: 'local' uses local LLM only. 'cloud' is reserved/experimental (currently treated as no-op).",
+        "enum": [
+          "local",
+          "cloud"
         ]
+      },
+      "rerankTimeoutMs": {
+        "type": "number",
+        "default": 8000,
+        "description": "Timeout for re-ranking requests (ms). Fail-open on timeout."
+      },
+      "respectBundledActiveMemoryToggle": {
+        "type": "boolean",
+        "default": true,
+        "description": "Compat-only (issue #1550): honor the bundled active-memory session toggle file when resolving Remnic recall toggles. Modern OpenClaw memory-slot mode + registerMemoryPromptSection is the primary prompt-injection path; this knob only matters when explicitly chaining Remnic active recall into the bundled `active-memory` plugin."
+      },
+      "responseGuidanceRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable response guidance recall for user answer-shape preferences."
+      },
+      "responseGuidanceRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the response guidance recall section."
+      },
+      "responseGuidanceRecallMaxResults": {
+        "type": "integer",
+        "default": 48,
+        "minimum": 0,
+        "description": "Maximum recalled items for response guidance."
+      },
+      "responseGuidanceRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 16000,
+        "minimum": 1,
+        "description": "Recent-token scan window for response guidance."
+      },
+      "responseGuidanceRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 64,
+        "minimum": 1,
+        "description": "Recent-turn scan window for response guidance."
+      },
+      "resumeBundleDir": {
+        "type": "string",
+        "description": "Override the resume-bundle directory (defaults to {memoryDir}/state/resume-bundles)."
+      },
+      "resumeBundlesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic resume-bundle storage and operator-facing handoff bundle commands."
+      },
+      "routingRulesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable custom memory routing rules (v8.7). Default off."
+      },
+      "routingRulesStateFile": {
+        "type": "string",
+        "default": "state/routing-rules.json",
+        "description": "Relative path under memoryDir for persisted routing rules."
       },
       "scopeProfiles": {
         "type": "object",
@@ -4558,9 +4567,395 @@
           }
         }
       },
-      "defaultScopeProfile": {
+      "searchBackend": {
         "type": "string",
-        "description": "Optional key in scopeProfiles to use as the default hosted memory scope profile."
+        "enum": [
+          "qmd",
+          "remote",
+          "noop",
+          "lancedb",
+          "meilisearch",
+          "orama"
+        ],
+        "default": "qmd",
+        "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
+      },
+      "secureStoreEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable at-rest AES-256-GCM encryption for memory files (issue #690). When true, the daemon reads and writes memory files through the secure-fs layer. The store must be unlocked via `remnic secure-store unlock` after each daemon start. Default false."
+      },
+      "secureStoreEncryptOnWrite": {
+        "type": "boolean",
+        "default": true,
+        "description": "When secureStoreEnabled is true, encrypt new memory writes. Set to false to pause new encryptions while still decrypting existing encrypted files (useful during incremental migration). Default true."
+      },
+      "semanticChunkingConfig": {
+        "type": "object",
+        "default": {},
+        "description": "Optional overrides for the semantic chunking algorithm",
+        "properties": {
+          "targetTokens": {
+            "type": "number",
+            "default": 200,
+            "description": "Target tokens per chunk"
+          },
+          "minTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Minimum tokens for a segment before merging with neighbor"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 400,
+            "description": "Maximum tokens for a segment before recursive splitting"
+          },
+          "smoothingWindowSize": {
+            "type": "number",
+            "default": 3,
+            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+          },
+          "boundaryThresholdStdDevs": {
+            "type": "number",
+            "default": 1,
+            "description": "Standard deviations below mean for boundary detection"
+          },
+          "embeddingBatchSize": {
+            "type": "number",
+            "default": 32,
+            "description": "Batch size for embedding requests"
+          },
+          "fallbackToRecursive": {
+            "type": "boolean",
+            "default": true,
+            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          }
+        }
+      },
+      "semanticChunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+      },
+      "semanticConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable periodic semantic consolidation of similar memories."
+      },
+      "semanticConsolidationExcludeCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "correction",
+          "commitment",
+          "procedure"
+        ],
+        "description": "Memory categories excluded from semantic consolidation."
+      },
+      "semanticConsolidationIntervalHours": {
+        "type": "number",
+        "default": 168,
+        "description": "Hours between automatic consolidation runs (168 = weekly)."
+      },
+      "semanticConsolidationMaxPerRun": {
+        "type": "number",
+        "default": 100,
+        "description": "Max memories to consolidate per run to limit LLM cost."
+      },
+      "semanticConsolidationMinClusterSize": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum cluster size before consolidation triggers."
+      },
+      "semanticConsolidationModel": {
+        "type": "string",
+        "default": "auto",
+        "description": "LLM for consolidation synthesis: 'auto' (primary model), 'fast' (fast local model), or a specific model name."
+      },
+      "semanticConsolidationThreshold": {
+        "type": "number",
+        "default": 0.8,
+        "description": "Token overlap threshold (0-1) for grouping similar memories. 0.8=conservative, 0.6=aggressive."
+      },
+      "semanticDedupCandidates": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
+      },
+      "semanticDedupEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Issue #373 \u2014 enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
+      },
+      "semanticDedupThreshold": {
+        "type": "number",
+        "default": 0.92,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
+      },
+      "semanticRulePromotionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
+      },
+      "semanticRuleVerificationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
+      },
+      "sessionObserverBands": {
+        "type": "array",
+        "description": "Session size bands and growth thresholds for heartbeat observer triggers.",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maxBytes": {
+              "type": "number"
+            },
+            "triggerDeltaBytes": {
+              "type": "number"
+            },
+            "triggerDeltaTokens": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "maxBytes",
+            "triggerDeltaBytes",
+            "triggerDeltaTokens"
+          ]
+        },
+        "default": [
+          {
+            "maxBytes": 50000,
+            "triggerDeltaBytes": 4800,
+            "triggerDeltaTokens": 1200
+          },
+          {
+            "maxBytes": 200000,
+            "triggerDeltaBytes": 9600,
+            "triggerDeltaTokens": 2400
+          },
+          {
+            "maxBytes": 1000000000,
+            "triggerDeltaBytes": 19200,
+            "triggerDeltaTokens": 4800
+          }
+        ]
+      },
+      "sessionObserverDebounceMs": {
+        "type": "number",
+        "default": 120000,
+        "description": "Minimum interval between heartbeat observer triggers per session (ms)."
+      },
+      "sessionObserverEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable heartbeat-driven active session observer checks for proactive extraction triggers."
+      },
+      "sessionTogglesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
+      },
+      "sharedContextDir": {
+        "type": "string",
+        "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
+      },
+      "sharedContextEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable shared-context assembly and tools (v4.0). Default off."
+      },
+      "sharedContextMaxInjectChars": {
+        "type": "number",
+        "default": 4000,
+        "description": "Max characters of shared-context to include in each recall context."
+      },
+      "sharedCrossSignalSemanticEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
+      },
+      "sharedCrossSignalSemanticMaxCandidates": {
+        "type": "number",
+        "default": 120,
+        "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
+      },
+      "sharedCrossSignalSemanticTimeoutMs": {
+        "type": "number",
+        "default": 4000,
+        "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
+      },
+      "sharedNamespace": {
+        "type": "string",
+        "default": "shared",
+        "description": "Shared namespace name."
+      },
+      "slotBehavior": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "requireExclusiveMemorySlot": {
+            "type": "boolean",
+            "default": true
+          },
+          "onSlotMismatch": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warn",
+              "silent"
+            ],
+            "default": "error"
+          }
+        }
+      },
+      "slowLogEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "If enabled, log slow operations (durations + metadata; never logs content)"
+      },
+      "slowLogThresholdMs": {
+        "type": "number",
+        "default": 30000,
+        "description": "Threshold for slow operation logging (ms)"
+      },
+      "summarizationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable automatic memory summarization/compression"
+      },
+      "summarizationImportanceThreshold": {
+        "type": "number",
+        "default": 0.3,
+        "description": "Only compress memories with importance below this threshold"
+      },
+      "summarizationProtectedTags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "commitment",
+          "preference",
+          "decision",
+          "principle"
+        ],
+        "description": "Tags that protect memories from compression"
+      },
+      "summarizationRecentToKeep": {
+        "type": "number",
+        "default": 300,
+        "description": "Number of recent memories to keep uncompressed"
+      },
+      "summarizationTriggerCount": {
+        "type": "number",
+        "default": 1000,
+        "description": "Memory count threshold to trigger summarization"
+      },
+      "summaryModel": {
+        "type": "string",
+        "description": "Model for hourly summaries (defaults to main model)"
+      },
+      "summaryRecallHours": {
+        "type": "number",
+        "default": 24,
+        "description": "Hours of summary history to recall"
+      },
+      "tagIndexMaxEntries": {
+        "type": "number",
+        "default": 10000,
+        "description": "Maximum number of entries in the tag index."
+      },
+      "tagMaxPerMemory": {
+        "type": "number",
+        "default": 5,
+        "description": "Maximum number of tags assigned per memory."
+      },
+      "tagMemoryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable tag-based memory indexing and recall boosting."
+      },
+      "tagRecallBoost": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Score boost applied to memories whose tags match the query."
+      },
+      "tagRecallMaxMatches": {
+        "type": "number",
+        "default": 10,
+        "description": "Maximum number of tag-matched memories added per recall."
+      },
+      "targetedFactRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable targeted fact evidence recall for direct answer questions."
+      },
+      "targetedFactRecallMaxChars": {
+        "type": "integer",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the targeted fact evidence recall section."
+      },
+      "targetedFactRecallMaxResults": {
+        "type": "integer",
+        "default": 48,
+        "minimum": 0,
+        "description": "Maximum recalled items for targeted fact evidence."
+      },
+      "targetedFactRecallScanWindowTokens": {
+        "type": "integer",
+        "default": 12000,
+        "minimum": 1,
+        "description": "Recent-token scan window for targeted fact evidence."
+      },
+      "targetedFactRecallScanWindowTurns": {
+        "type": "integer",
+        "default": 8,
+        "minimum": 1,
+        "description": "Recent-turn scan window for targeted fact evidence."
+      },
+      "taskModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+        "required": [
+          "primary"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "primary": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
+      "taxonomyAutoGenResolver": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
+      },
+      "taxonomyEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
       },
       "teams": {
         "type": "object",
@@ -4599,928 +4994,589 @@
           }
         }
       },
-      "cronRecallMode": {
-        "type": "string",
-        "enum": [
-          "all",
-          "none",
-          "allowlist"
-        ],
-        "default": "all",
-        "description": "Recall behavior for cron sessions. Use allowlist to opt specific cron sessionKeys in."
+      "temporalBiTemporal": {
+        "type": "boolean",
+        "default": false,
+        "description": "Bi-temporal validity master gate (issue #1578). When false (default), recall behaves byte-identically to pre-#1578. Turn on to exclude validity-expired facts from default injection candidates (they stay findable by explicit search and as_of). Storage round-trips observedAt/eventTimeSource; extraction event-time write-time wiring lands in a follow-on PR."
       },
-      "cronRecallAllowlist": {
+      "temporalBoostRecentDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Memories from the last N days receive a recency boost during recall."
+      },
+      "temporalBoostScore": {
+        "type": "number",
+        "default": 0.15,
+        "description": "Score boost applied to recent memories during recall."
+      },
+      "temporalDecayEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply temporal decay to older memories during recall scoring."
+      },
+      "temporalExpiredInInjection": {
+        "type": "boolean",
+        "default": false,
+        "description": "Escape hatch for the bi-temporal injection filter (issue #1578). When true, facts whose [valid_at, invalid_at) interval ended before now are kept in injection candidates even with temporalBiTemporal on \u2014 some deployments prefer the older (always-inject) behavior."
+      },
+      "temporalIndexMaxEntries": {
+        "type": "number",
+        "default": 5000,
+        "description": "Maximum number of entries in the temporal index."
+      },
+      "temporalIndexWindowDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Number of days to include in the temporal index window."
+      },
+      "temporalMemoryTreeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Build a hierarchical memory summary tree (hour/day/week/persona nodes). Default: false."
+      },
+      "temporalSupersessionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
+      },
+      "temporalSupersessionIncludeInRecall": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
+      },
+      "threadingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable conversation threading"
+      },
+      "threadingGapMinutes": {
+        "type": "number",
+        "default": 30,
+        "description": "Minutes of gap to start a new thread"
+      },
+      "timeGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Build temporal sequence graph within threads (requires multiGraphMemoryEnabled). Default true."
+      },
+      "tmtHourlyMinMemories": {
+        "type": "number",
+        "default": 3,
+        "description": "Minimum new memories in an hour to trigger an hour-level TMT node. Default: 3."
+      },
+      "tmtSummaryMaxTokens": {
+        "type": "number",
+        "default": 300,
+        "description": "Max tokens for each TMT summary node. Default: 300."
+      },
+      "tombstonesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Master gate for the tombstone non-resurrection invariant (#1579). When true, a fact that matches an active tombstone at the storage chokepoint is persisted as pending_review + blockedBy instead of becoming active \u2014 visible, never a silent drop. Off restores pre-feature behavior for rollback safety."
+      },
+      "tombstonesSemanticMatch": {
+        "type": "boolean",
+        "default": false,
+        "description": "Tier-4 semantic tombstone matching (#1579). Off by default; when true the tombstone lookup also checks embedding cosine similarity against tombstoned normalized text. Ships dark until MemCorrect (#1584) shows an acceptable false-block rate."
+      },
+      "tombstonesSemanticThreshold": {
+        "type": "number",
+        "default": 0.9,
+        "description": "Cosine threshold for tier-4 semantic tombstone matching. Only consulted when tombstonesSemanticMatch is true."
+      },
+      "topicExtractionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable topic extraction during consolidation"
+      },
+      "topicExtractionTopN": {
+        "type": "number",
+        "default": 50,
+        "description": "Number of top topics to extract"
+      },
+      "traceRecallContent": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
+      },
+      "traceWeaverEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Trace Weaving (v8.0 Phase 2A). Links recurring topic boxes with a shared traceId."
+      },
+      "traceWeaverLookbackDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Days back to search for trace links."
+      },
+      "traceWeaverOverlapThreshold": {
+        "type": "number",
+        "default": 0.4,
+        "description": "Minimum Jaccard topic overlap to assign the same traceId (0\u20131)."
+      },
+      "transcriptEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable transcript archiving"
+      },
+      "transcriptRecallHours": {
+        "type": "number",
+        "default": 12,
+        "description": "Hours of transcript history to recall"
+      },
+      "transcriptRetentionDays": {
+        "type": "number",
+        "default": 7,
+        "description": "Days to retain transcript entries"
+      },
+      "transcriptSkipChannelTypes": {
         "type": "array",
         "items": {
           "type": "string"
         },
-        "default": [],
-        "description": "Session-key wildcard patterns (supports *) allowed for recall when cronRecallMode=allowlist."
+        "default": [
+          "cron"
+        ],
+        "description": "Channel types to skip from transcript logging (e.g., cron)"
       },
-      "cronRecallPolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable prompt-shape-aware recall query normalization for cron sessions."
-      },
-      "cronRecallNormalizedQueryMaxChars": {
-        "type": "number",
-        "default": 480,
-        "description": "Maximum query length (characters) used for cron recall retrieval after normalization."
-      },
-      "cronRecallInstructionHeavyTokenCap": {
-        "type": "number",
-        "default": 36,
-        "description": "Maximum token count used to build compact retrieval queries for instruction-heavy cron prompts."
-      },
-      "cronConversationRecallMode": {
+      "triggerMode": {
         "type": "string",
         "enum": [
-          "auto",
-          "always",
-          "never"
+          "smart",
+          "every_n",
+          "time_based"
         ],
-        "default": "auto",
-        "description": "Controls conversation semantic recall in cron sessions. auto skips it for instruction-heavy prompts."
+        "default": "smart",
+        "description": "Buffer trigger mode"
       },
-      "autoPromoteToSharedEnabled": {
+      "trustScoreEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "If enabled, Engram may auto-promote selected categories to shared (reserved; conservative)."
+        "description": "Master gate for the unified TrustScore recall stage (#1577). When off the stage is absent and ranking is byte-identical to the pre-feature pipeline. Flip via #1574 ablation evidence only."
       },
-      "autoPromoteToSharedCategories": {
+      "trustScoreEpistemicRendering": {
+        "type": "boolean",
+        "default": false,
+        "description": "Append deterministic trust hedges to injected memory lines so the downstream model knows each memory's epistemic status (#1577). Separate gate from scoring."
+      },
+      "trustScoreMaxMultiplier": {
+        "type": "number",
+        "default": 1.25,
+        "description": "Upper bound of the trust multiplier mapping [0,1] \u2192 [minMultiplier, maxMultiplier] (#1577)."
+      },
+      "trustScoreMinMultiplier": {
+        "type": "number",
+        "default": 0.5,
+        "description": "Lower bound of the trust multiplier mapping [0,1] \u2192 [minMultiplier, maxMultiplier] (#1577)."
+      },
+      "trustScoreQuarantine": {
+        "type": "boolean",
+        "default": true,
+        "description": "Exclude hard-negative (quarantine-band) memories from injection while keeping them visible in X-ray with the reason (#1577). Only effective under trustScoreEnabled."
+      },
+      "trustScoreWeights": {
+        "type": "object",
+        "description": "Per-component trust weights (#1577). Keys: memoryWorth, provenance, faithfulness, corroboration, contradiction, domainCalibration, feedback, recency. Values are numbers in [0,1]; sum-normalized at parse. Invalid entries are dropped (rule 51).",
+        "default": {},
+        "properties": {
+          "memoryWorth": {
+            "type": "number"
+          },
+          "provenance": {
+            "type": "number"
+          },
+          "faithfulness": {
+            "type": "number"
+          },
+          "corroboration": {
+            "type": "number"
+          },
+          "contradiction": {
+            "type": "number"
+          },
+          "domainCalibration": {
+            "type": "number"
+          },
+          "feedback": {
+            "type": "number"
+          },
+          "recency": {
+            "type": "number"
+          }
+        }
+      },
+      "trustZoneRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
+      },
+      "trustZoneStoreDir": {
+        "type": "string",
+        "description": "Override the trust-zone store directory (defaults to {memoryDir}/state/trust-zones)."
+      },
+      "trustZonesEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Engram's trust-zone memory foundation for quarantine, working, and trusted records."
+      },
+      "verbatimArtifactCategories": {
         "type": "array",
         "items": {
           "type": "string",
           "enum": [
             "fact",
+            "preference",
             "correction",
+            "entity",
             "decision",
-            "preference"
+            "relationship",
+            "principle",
+            "commitment",
+            "moment",
+            "skill",
+            "procedure"
           ]
         },
         "default": [
-          "fact",
+          "decision",
           "correction",
-          "decision",
-          "preference"
+          "principle",
+          "commitment"
         ],
-        "description": "Categories eligible for auto-promotion to shared."
+        "description": "Memory categories eligible for artifact extraction."
       },
-      "autoPromoteMinConfidenceTier": {
-        "type": "string",
-        "enum": [
-          "explicit",
-          "implied"
-        ],
-        "default": "explicit",
-        "description": "Minimum confidence tier for auto-promotion."
-      },
-      "routingRulesEnabled": {
+      "verbatimArtifactsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable custom memory routing rules (v8.7). Default off."
+        "description": "Write quote-first artifact anchors during extraction and include them in recall."
       },
-      "routingRulesStateFile": {
-        "type": "string",
-        "default": "state/routing-rules.json",
-        "description": "Relative path under memoryDir for persisted routing rules."
-      },
-      "sharedContextEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable shared-context assembly and tools (v4.0). Default off."
-      },
-      "sharedContextDir": {
-        "type": "string",
-        "description": "Override shared-context directory (default: ~/.openclaw/workspace/shared-context)."
-      },
-      "sharedContextMaxInjectChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Max characters of shared-context to include in each recall context."
-      },
-      "crossSignalsSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic cross-signal grouping (reserved/experimental)."
-      },
-      "crossSignalsSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout for semantic cross-signal grouping (ms)."
-      },
-      "sharedCrossSignalSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic cross-signal enhancer during shared-context daily curation."
-      },
-      "sharedCrossSignalSemanticTimeoutMs": {
-        "type": "number",
-        "default": 4000,
-        "description": "Timeout budget for shared-context semantic cross-signal enhancer (ms)."
-      },
-      "sharedCrossSignalSemanticMaxCandidates": {
-        "type": "number",
-        "default": 120,
-        "description": "Maximum candidate topic tokens considered by semantic cross-signal enhancer."
-      },
-      "compoundingEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable compounding engine (v5.0). Default off."
-      },
-      "compoundingWeeklyCronEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If true, compounding weekly synthesis can be scheduled externally via cron."
-      },
-      "compoundingSemanticEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable semantic compounding synthesis (reserved/experimental)."
-      },
-      "compoundingSynthesisTimeoutMs": {
-        "type": "number",
-        "default": 15000,
-        "description": "Timeout for compounding synthesis (ms)."
-      },
-      "compoundingInjectEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject compounded mistakes/patterns into recall when compounding is enabled."
-      },
-      "factDeduplicationEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
-      },
-      "semanticDedupEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Issue #373 — enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
-      },
-      "semanticDedupThreshold": {
-        "type": "number",
-        "default": 0.92,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
-      },
-      "semanticDedupCandidates": {
+      "verbatimArtifactsMaxRecall": {
         "type": "number",
         "default": 5,
+        "description": "Maximum artifact anchors added per recall."
+      },
+      "verbatimArtifactsMinConfidence": {
+        "type": "number",
+        "default": 0.8,
+        "description": "Minimum extraction confidence required before writing an artifact."
+      },
+      "verboseRecallVisibility": {
+        "type": "boolean",
+        "default": true,
+        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
+      },
+      "verifiedRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+      },
+      "versioningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable page-level versioning with sidecar snapshots."
+      },
+      "versioningMaxPerPage": {
+        "type": "integer",
+        "default": 50,
         "minimum": 0,
-        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
+        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
       },
-      "factArchivalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable automatic archival of old, low-importance, rarely-accessed facts during consolidation."
-      },
-      "factArchivalAgeDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Minimum age in days before a fact is eligible for archival."
-      },
-      "factArchivalMaxImportance": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Maximum importance score for archival eligibility (0-1). Only facts below this threshold are archived."
-      },
-      "factArchivalMaxAccessCount": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum access count for archival eligibility. Only rarely-accessed facts are archived."
-      },
-      "factArchivalProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "commitment",
-          "preference",
-          "decision",
-          "principle",
-          "procedure"
-        ],
-        "description": "Categories that protect a fact from archival regardless of other criteria."
-      },
-      "lifecyclePolicyEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
-      },
-      "lifecycleFilterStaleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "If enabled, stale lifecycle memories can be filtered from retrieval (wired in PR20D)."
-      },
-      "lifecyclePromoteHeatThreshold": {
-        "type": "number",
-        "default": 0.55,
-        "description": "Heat threshold for lifecycle promotion to validated/active states."
-      },
-      "lifecycleStaleDecayThreshold": {
-        "type": "number",
-        "default": 0.65,
-        "description": "Decay threshold for lifecycle demotion to stale."
-      },
-      "lifecycleArchiveDecayThreshold": {
-        "type": "number",
-        "default": 0.85,
-        "description": "Decay threshold for lifecycle demotion to archived state semantics."
-      },
-      "lifecycleProtectedCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "decision",
-          "principle",
-          "commitment",
-          "preference",
-          "procedure"
-        ],
-        "description": "Categories that lifecycle policy will not auto-archive."
-      },
-      "lifecycleMetricsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
-      },
-      "proactiveExtractionEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
-      },
-      "contextCompressionActionsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
-      },
-      "compressionGuidelineLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
-      },
-      "compressionGuidelineSemanticRefinementEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable optional semantic refinement pass after deterministic guideline candidate generation (v8.11, default off)."
-      },
-      "compressionGuidelineSemanticTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for semantic refinement; timeout fail-opens to deterministic output."
-      },
-      "maxProactiveQuestionsPerExtraction": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
-      },
-      "proactiveExtractionTimeoutMs": {
-        "type": "number",
-        "default": 2500,
-        "description": "Hard timeout in milliseconds for proactive self-question generation and answer synthesis (0 disables the proactive second pass)."
-      },
-      "proactiveExtractionMaxTokens": {
-        "type": "number",
-        "default": 900,
-        "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
-      },
-      "extractionMaxOutputTokens": {
-        "type": "number",
-        "default": 16384,
-        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
-      },
-      "proactiveExtractionCategoryAllowlist": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Optional memory categories allowed from proactive second-pass writes. When omitted, proactive writes can emit any standard memory category."
-      },
-      "maxCompressionTokensPerHour": {
-        "type": "number",
-        "default": 1500,
-        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
-      },
-      "behaviorLoopAutoTuneEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable runtime behavior-loop policy auto-tuning (v8.15, default off)."
-      },
-      "behaviorLoopLearningWindowDays": {
-        "type": "number",
-        "default": 14,
-        "description": "Rolling signal window used for behavior-loop policy learning (days; 0 allowed)."
-      },
-      "behaviorLoopMinSignalCount": {
-        "type": "number",
-        "default": 10,
-        "description": "Minimum signal volume required before behavior-loop adjustments are emitted (0 allowed)."
-      },
-      "behaviorLoopMaxDeltaPerCycle": {
-        "type": "number",
-        "default": 0.1,
-        "description": "Maximum absolute parameter delta allowed per learning cycle (0-1)."
-      },
-      "behaviorLoopProtectedParams": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "default": [
-          "maxMemoryTokens",
-          "qmdMaxResults",
-          "qmdColdMaxResults",
-          "recallPlannerMaxQmdResultsMinimal",
-          "verbatimArtifactsMaxRecall"
-        ],
-        "description": "Runtime parameters that auto-tuning must never modify."
-      },
-      "searchBackend": {
+      "versioningSidecarDir": {
         "type": "string",
-        "enum": [
-          "qmd",
-          "remote",
-          "noop",
-          "lancedb",
-          "meilisearch",
-          "orama"
-        ],
-        "default": "qmd",
-        "description": "Search backend: qmd (local hybrid), remote (HTTP REST), noop (disabled), lancedb (embedded hybrid), meilisearch (server-based), orama (embedded JS)"
+        "default": ".versions",
+        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
       },
-      "remoteSearchBaseUrl": {
-        "type": "string",
-        "description": "Base URL for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchApiKey": {
-        "type": "string",
-        "description": "API key for remote search backend (when searchBackend=remote)"
-      },
-      "remoteSearchTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout in ms for remote search backend requests"
-      },
-      "calibrationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable recall calibration rules (v9.0, default off)."
-      },
-      "calibrationMaxRulesPerRecall": {
-        "type": "number",
-        "default": 10,
-        "description": "Maximum number of calibration rules to include per recall pass."
-      },
-      "calibrationMaxChars": {
-        "type": "number",
-        "default": 1200,
-        "description": "Maximum characters of calibration content to include per recall pass."
-      },
-      "lancedbEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable LanceDB as a supplemental search backend."
-      },
-      "lanceDbPath": {
-        "type": "string",
-        "description": "Directory path for LanceDB storage (when searchBackend=lancedb)"
-      },
-      "lanceEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for LanceDB (when searchBackend=lancedb)"
-      },
-      "meilisearchEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Meilisearch as a supplemental search backend."
-      },
-      "meilisearchHost": {
-        "type": "string",
-        "default": "http://localhost:7700",
-        "description": "Meilisearch server host URL (when searchBackend=meilisearch)"
-      },
-      "meilisearchApiKey": {
-        "type": "string",
-        "description": "API key for Meilisearch (when searchBackend=meilisearch)"
-      },
-      "meilisearchTimeoutMs": {
-        "type": "number",
-        "default": 30000,
-        "description": "Timeout in ms for Meilisearch requests (when searchBackend=meilisearch)"
-      },
-      "meilisearchAutoIndex": {
-        "type": "boolean",
-        "default": false,
-        "description": "Automatically push local memory docs to Meilisearch on update (when searchBackend=meilisearch)"
-      },
-      "oramaEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Orama as a supplemental search backend."
-      },
-      "oramaDbPath": {
-        "type": "string",
-        "description": "Directory path for Orama persistence files (when searchBackend=orama)"
-      },
-      "oramaEmbeddingDimension": {
-        "type": "number",
-        "default": 1536,
-        "description": "Embedding vector dimension for Orama (when searchBackend=orama)"
-      },
-      "qmdDaemonEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Prefer the shared QMD MCP session for faster searches when available."
-      },
-      "qmdDaemonUrl": {
-        "type": "string",
-        "default": "http://localhost:8181/mcp",
-        "description": "Legacy compatibility setting retained for QMD daemon configuration."
-      },
-      "qmdDaemonRecheckIntervalMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Re-probe interval when daemon is down (ms)"
-      },
-      "qmdIntentHintsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Pass Engram's inferred recall intent into QMD unified search when supported."
-      },
-      "qmdExplainEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Request QMD explain traces for recall debugging when supported."
-      },
-      "knowledgeIndexEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Inject a compact Knowledge Index of top entities into every recall"
-      },
-      "knowledgeIndexMaxEntities": {
-        "type": "number",
-        "default": 40,
-        "description": "Max entities included in the Knowledge Index"
-      },
-      "knowledgeIndexMaxChars": {
-        "type": "number",
-        "default": 4000,
-        "description": "Hard character cap for the Knowledge Index section"
-      },
-      "entityRetrievalEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable entity-oriented recall hints for direct entity questions and short follow-up queries."
-      },
-      "entityRetrievalMaxChars": {
-        "type": "number",
-        "default": 2400,
-        "description": "Hard character cap for the entity retrieval section."
-      },
-      "entityRetrievalMaxHints": {
-        "type": "number",
-        "default": 2,
-        "description": "Maximum entity targets summarized in one recall pass."
-      },
-      "entityRetrievalMaxSupportingFacts": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum supporting fact/timeline snippets considered per entity target."
-      },
-      "entityRetrievalMaxRelatedEntities": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum related entities listed per target when confidence is high."
-      },
-      "entityRetrievalRecentTurns": {
-        "type": "number",
-        "default": 6,
-        "description": "Recent transcript turns scanned for pronoun carry-forward and short follow-up resolution."
-      },
-      "entityRelationshipsEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Track entity-to-entity relationships during extraction"
-      },
-      "entityActivityLogEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Log timestamped activity per entity"
-      },
-      "entityActivityLogMaxEntries": {
-        "type": "number",
-        "default": 20,
-        "description": "Max activity entries per entity before oldest are pruned"
-      },
-      "entityAliasesEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Store aliases per entity file"
-      },
-      "entitySummaryEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Generate LLM summaries for entities during consolidation"
-      },
-      "entitySynthesisMaxTokens": {
-        "anyOf": [
-          {
-            "type": "integer",
-            "const": 0
-          },
-          {
-            "type": "integer",
-            "minimum": 10
-          }
-        ],
-        "default": 500,
-        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
-      },
-      "recallBudgetChars": {
-        "type": "number",
-        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
-      },
-      "recallOuterTimeoutMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Outer timeout in ms for the full recall pipeline."
-      },
-      "recallCoreDeadlineMs": {
-        "type": "number",
-        "default": 75000,
-        "description": "Default deadline in ms recorded for core recall sections."
-      },
-      "recallEnrichmentDeadlineMs": {
-        "type": "number",
-        "default": 25000,
-        "description": "Default deadline in ms recorded for enrichment recall sections."
-      },
-      "recallMmrEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
-      },
-      "recallMmrLambda": {
-        "type": "number",
-        "default": 0.7,
-        "minimum": 0,
-        "maximum": 1,
-        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
-      },
-      "recallMmrTopN": {
-        "type": "number",
-        "default": 40,
-        "minimum": 0,
-        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
-      },
-      "recallReasoningTraceBoostEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
-      },
-      "recallPipeline": {
-        "type": "array",
-        "description": "Ordered recall sections with per-section budgets and feature knobs.",
-        "items": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean",
-              "default": true
-            },
-            "maxChars": {
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "consolidateTriggerLines": {
-              "type": "number"
-            },
-            "consolidateTargetLines": {
-              "type": "number"
-            },
-            "maxEntities": {
-              "type": "number"
-            },
-            "maxResults": {
-              "type": "number"
-            },
-            "maxTurns": {
-              "type": "number"
-            },
-            "maxTokens": {
-              "type": "number"
-            },
-            "lookbackHours": {
-              "type": "number"
-            },
-            "maxCount": {
-              "type": "number"
-            },
-            "topK": {
-              "type": "number"
-            },
-            "timeoutMs": {
-              "type": "number"
-            },
-            "maxPatterns": {
-              "type": "number"
-            },
-            "forceGeneric": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "id"
-          ]
-        }
-      },
-      "qmdRecallCacheTtlMs": {
-        "type": "number",
-        "default": 60000,
-        "description": "Fresh TTL in ms for rendered QMD recall enrichment cache entries."
-      },
-      "qmdRecallCacheStaleTtlMs": {
-        "type": "number",
-        "default": 600000,
-        "description": "Maximum stale TTL in ms for rendered QMD recall cache fallbacks."
-      },
-      "qmdRecallCacheMaxEntries": {
-        "type": "number",
-        "default": 128,
-        "description": "Maximum in-memory rendered QMD recall cache entries before oldest eviction."
-      },
-      "lcmEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Lossless Context Management (LCM) subsystem"
-      },
-      "lcmLeafBatchSize": {
-        "type": "number",
-        "default": 8,
-        "description": "Number of turns per leaf node in the LCM DAG"
-      },
-      "lcmRollupFanIn": {
-        "type": "number",
-        "default": 4,
-        "description": "Number of children per rollup node in the LCM DAG"
-      },
-      "lcmFreshTailTurns": {
-        "type": "number",
-        "default": 16,
-        "description": "Number of recent turns kept verbatim (not summarized)"
-      },
-      "lcmMaxDepth": {
-        "type": "number",
-        "default": 5,
-        "description": "Maximum depth of the LCM summary DAG"
-      },
-      "lcmRecallBudgetShare": {
-        "type": "number",
-        "default": 0.15,
-        "description": "Fraction of recall budget allocated to LCM compressed history (0-1)"
-      },
-      "lcmDeterministicMaxTokens": {
-        "type": "number",
-        "default": 512,
-        "description": "Max tokens for deterministic (non-LLM) summaries"
-      },
-      "lcmTelemetryPrefilterEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
-      },
-      "lcmArchiveRetentionDays": {
-        "type": "number",
-        "default": 90,
-        "description": "Days to retain archived LCM summaries"
-      },
-      "lcmObserveConcurrency": {
-        "type": "number",
-        "default": 1,
-        "description": "Maximum independent LCM observe jobs to process concurrently."
-      },
-      "messagePartsEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Opt in to structured LCM message-part capture for tool calls, file references, patches, and reasoning markers."
-      },
-      "messagePartsRecallMaxResults": {
-        "type": "number",
-        "default": 6,
-        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
-      },
-      "ircEnabled": {
-        "type": "boolean",
-        "default": true,
-        "description": "Enable Inductive Rule Consolidation (IRC) subsystem (default on)."
-      },
-      "ircMaxPreferences": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum number of preferences to include in IRC rules."
-      },
-      "ircIncludeCorrections": {
-        "type": "boolean",
-        "default": true,
-        "description": "Include corrections when building IRC rules (default on)."
-      },
-      "ircMinConfidence": {
-        "type": "number",
-        "default": 0.3,
-        "description": "Minimum confidence threshold for an IRC rule to be included (0-1)."
-      },
-      "cmcEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable Causal Memory Consolidation (CMC) subsystem (default off)."
-      },
-      "cmcStitchLookbackDays": {
-        "type": "number",
-        "default": 7,
-        "description": "Number of days to look back when stitching causal trajectories."
-      },
-      "cmcStitchMinScore": {
-        "type": "number",
-        "default": 2.5,
-        "description": "Minimum score for a causal edge to be stitched into a trajectory."
-      },
-      "cmcStitchMaxEdgesPerTrajectory": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum edges per trajectory during CMC stitching."
-      },
-      "cmcConsolidationEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC consolidation pass (default off)."
-      },
-      "cmcConsolidationMinRecurrence": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum recurrence count before a CMC pattern is consolidated."
-      },
-      "cmcConsolidationMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a CMC pattern must appear in before consolidation."
-      },
-      "cmcConsolidationSuccessThreshold": {
-        "type": "number",
-        "default": 0.7,
-        "description": "Minimum success ratio required to consolidate a CMC pattern (0-1)."
-      },
-      "cmcRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC retrieval at recall time (default off)."
-      },
-      "cmcRetrievalMaxDepth": {
-        "type": "number",
-        "default": 3,
-        "description": "Maximum graph depth traversed during CMC retrieval."
-      },
-      "cmcRetrievalMaxChars": {
-        "type": "number",
-        "default": 800,
-        "description": "Maximum characters of CMC content included per recall pass."
-      },
-      "cmcRetrievalCounterfactualBoost": {
-        "type": "number",
-        "default": 0.4,
-        "description": "Score boost applied to counterfactual nodes during CMC retrieval (0-1)."
-      },
-      "cmcBehaviorLearningEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable CMC behavior pattern learning (default off)."
-      },
-      "cmcBehaviorMinFrequency": {
-        "type": "number",
-        "default": 3,
-        "description": "Minimum frequency for a behavior pattern to be learned by CMC."
-      },
-      "cmcBehaviorMinSessions": {
-        "type": "number",
-        "default": 2,
-        "description": "Minimum sessions a behavior must appear in before CMC learns it."
-      },
-      "cmcBehaviorConfidenceThreshold": {
-        "type": "number",
-        "default": 0.6,
-        "description": "Minimum confidence threshold for CMC behavior patterns (0-1)."
-      },
-      "cmcLifecycleCausalImpactWeight": {
-        "type": "number",
-        "default": 0.05,
-        "description": "Weight of causal impact score in CMC lifecycle scoring."
-      },
-      "parallelRetrievalEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable three-agent parallel retrieval (DirectFact + Contextual + Temporal). Zero additional LLM cost. Default false."
-      },
-      "parallelAgentWeights": {
-        "type": "object",
-        "default": {
-          "direct": 1,
-          "contextual": 0.7,
-          "temporal": 0.85
-        },
-        "description": "Score weights per retrieval agent source applied during result merge."
-      },
-      "parallelMaxResultsPerAgent": {
-        "type": "number",
-        "default": 20,
-        "description": "Maximum results fetched per agent before merge."
-      },
-      "briefing": {
+      "wearables": {
         "type": "object",
         "additionalProperties": false,
-        "default": {
-          "enabled": true,
-          "defaultWindow": "yesterday",
-          "defaultFormat": "markdown",
-          "maxFollowups": 5,
-          "calendarSource": null,
-          "saveByDefault": false,
-          "saveDir": null,
-          "llmFollowups": true
-        },
+        "default": {},
+        "description": "Wearable transcript ingestion (Limitless / Bee / Omi). Connector packages install a la carte: @remnic/connector-limitless, @remnic/connector-bee, @remnic/connector-omi. See docs/wearables.md.",
         "properties": {
           "enabled": {
             "type": "boolean",
-            "default": true
+            "default": false,
+            "description": "Master gate for the wearables subsystem."
           },
-          "defaultWindow": {
+          "timezone": {
             "type": "string",
-            "default": "yesterday"
+            "description": "IANA timezone used to bucket transcripts into days. Defaults to the host timezone."
           },
-          "defaultFormat": {
-            "type": "string",
-            "enum": [
-              "markdown",
-              "json"
-            ],
-            "default": "markdown"
+          "redactionEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Redact SSN / payment-card patterns from transcripts before storage and extraction."
           },
-          "maxFollowups": {
+          "redactionPatterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Additional user-supplied redaction regexes (validated at config load)."
+          },
+          "offTheRecordEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Honor a spoken 'off the record' marker by eliding segments until 'back on the record'."
+          },
+          "digestEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Write one compact daily-digest memory per synced source/day."
+          },
+          "autoSyncEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
+          },
+          "autoSyncIntervalMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1440,
+            "default": 15,
+            "description": "Minutes between auto-sync ticks."
+          },
+          "autoSyncDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 90,
+            "default": 2,
+            "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
+          },
+          "autoSyncDeepDays": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 10,
-            "default": 5
+            "maximum": 90,
+            "default": 7,
+            "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
           },
-          "calendarSource": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
+          "corrections": {
+            "type": "array",
+            "default": [],
+            "description": "User-specific transcript correction rules applied on every sync (merged with CLI-managed rules).",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "match",
+                "replace"
+              ],
+              "properties": {
+                "match": {
+                  "type": "string",
+                  "description": "Text (or regex when regex=true) to match."
+                },
+                "replace": {
+                  "type": "string",
+                  "description": "Replacement text."
+                },
+                "regex": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Treat match as a regular expression."
+                },
+                "caseInsensitive": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Case-insensitive matching."
+                },
+                "sources": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Restrict the rule to specific source ids."
+                }
+              }
+            }
           },
-          "saveByDefault": {
-            "type": "boolean",
-            "default": false
-          },
-          "saveDir": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "default": null
-          },
-          "llmFollowups": {
-            "type": "boolean",
-            "default": true
+          "sources": {
+            "type": "object",
+            "default": {},
+            "description": "Per-source settings keyed by connector id (limitless, bee, omi, or a custom connector id).",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable syncing from this wearable source."
+                },
+                "apiKey": {
+                  "type": "string",
+                  "description": "Provider API credential. Prefer the per-connector environment variable (e.g. ${LIMITLESS_API_KEY}); a config value takes precedence when both are set."
+                },
+                "baseUrl": {
+                  "type": "string",
+                  "description": "Override the provider base URL (self-hosted / local-proxy setups, e.g. the Bee local proxy)."
+                },
+                "appId": {
+                  "type": "string",
+                  "description": "Omi only: integration app id (the {app_id} path component of the Omi Integrations API)."
+                },
+                "userId": {
+                  "type": "string",
+                  "description": "Omi only: target user id supplied as the uid query parameter."
+                },
+                "memoryMode": {
+                  "type": "string",
+                  "enum": [
+                    "off",
+                    "review",
+                    "auto",
+                    "smart"
+                  ],
+                  "default": "smart",
+                  "description": "Memory creation trust gate: smart (default) = LLM-judge + per-source trust prior + cross-device corroboration decide active/review/drop automatically; off = transcripts only; review = every candidate lands pending_review; auto = deterministic gates only, survivors active."
+                },
+                "sourceTrust": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 0.8,
+                  "description": "Trust prior for this source's transcription quality (0..1). Multiplies extraction confidence in smart mode \u2014 lower it for a device that mis-transcribes often."
+                },
+                "autoApproveTrust": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 0.7,
+                  "description": "Smart mode: trust score at/above which facts are written active."
+                },
+                "reviewTrust": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 0.45,
+                  "description": "Smart mode: trust score at/above which borderline facts are queued for review instead of dropped. Must be below autoApproveTrust."
+                },
+                "minConfidence": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1,
+                  "default": 0.6,
+                  "description": "Drop extracted facts below this confidence."
+                },
+                "minImportance": {
+                  "type": "string",
+                  "enum": [
+                    "trivial",
+                    "low",
+                    "normal",
+                    "high",
+                    "critical"
+                  ],
+                  "default": "low",
+                  "description": "Drop extracted facts scored below this importance level."
+                },
+                "maxMemoriesPerDay": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0,
+                  "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
+                },
+                "importNativeMemories": {
+                  "type": "string",
+                  "enum": [
+                    "off",
+                    "review",
+                    "smart"
+                  ],
+                  "default": "smart",
+                  "description": "Import provider-extracted memories (Bee facts / Omi memories): smart (default) routes them through the same judge + trust pipeline with a reduced prior; review always queues; off skips."
+                },
+                "cleanup": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "default": {},
+                  "properties": {
+                    "mergeSameSpeaker": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Merge consecutive same-speaker segments."
+                    },
+                    "stripFillers": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Strip standalone filler tokens (um, uh, ...)."
+                    },
+                    "collapseRepeats": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Collapse immediately repeated phrases (ASR stutter)."
+                    },
+                    "dropLowQuality": {
+                      "type": "boolean",
+                      "default": true,
+                      "description": "Drop segments that look like ASR garbage."
+                    }
+                  }
+                }
+              }
+            }
           }
-        },
-        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
+        }
       },
-      "enrichmentEnabled": {
+      "workIndexAutoRebuildDebounceMs": {
+        "type": "number",
+        "default": 1000,
+        "description": "Debounce delay in ms before triggering auto-rebuild of the work index."
+      },
+      "workIndexAutoRebuildEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+        "description": "Automatically rebuild the work index when tasks or projects change."
       },
-      "enrichmentAutoOnCreate": {
+      "workIndexDir": {
+        "type": "string",
+        "description": "Override the work index directory (defaults to {memoryDir}/work/index)."
+      },
+      "workIndexEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+        "description": "Enable search index for work tasks and projects."
       },
-      "enrichmentMaxCandidatesPerEntity": {
-        "type": "integer",
-        "default": 20,
-        "minimum": 0,
-        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
+      "workProductLedgerDir": {
+        "type": "string",
+        "description": "Override the work-product ledger directory (defaults to {memoryDir}/state/work-product-ledger)."
+      },
+      "workProductRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
+      },
+      "workProjectIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include projects in the work search index."
+      },
+      "workProjectsDir": {
+        "type": "string",
+        "description": "Override the work projects directory (defaults to {memoryDir}/work/projects)."
+      },
+      "workProjectsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable project tracking within the work product system."
+      },
+      "workTaskIndexEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include tasks in the work search index."
+      },
+      "workTasksDir": {
+        "type": "string",
+        "description": "Override the work tasks directory (defaults to {memoryDir}/work/tasks)."
+      },
+      "workTasksEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable task tracking within the work product system."
+      },
+      "workspaceDir": {
+        "type": "string",
+        "description": "Override workspace directory path"
       }
     }
   },
@@ -6215,7 +6271,7 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on \u2014 extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -22,6 +22,7 @@ const FIELD_TO_FLAG: Record<keyof CapabilitySet, string> = {
   rerankCache: "rerankCacheEnabled",
   recallDirectAnswer: "recallDirectAnswerEnabled",
   recallMemoryWorthFilter: "recallMemoryWorthFilterEnabled",
+  recallTrustScore: "trustScoreEnabled",
   recallMmr: "recallMmrEnabled",
   recallReasoningTraceBoost: "recallReasoningTraceBoostEnabled",
   recallPlannerLlm: "recallPlannerLlmEnabled",

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -38,6 +38,8 @@ export interface CapabilitySet {
   readonly recallDirectAnswer: boolean;
   /** `recallMemoryWorthFilterEnabled` — Memory-Worth score reweighting. */
   readonly recallMemoryWorthFilter: boolean;
+  /** `trustScoreEnabled` — unified TrustScore recall stage (issue #1577). */
+  readonly recallTrustScore: boolean;
   /** `recallMmrEnabled` — maximal-marginal-relevance diversification. */
   readonly recallMmr: boolean;
   /** `recallReasoningTraceBoostEnabled` — boost reasoning-trace memories. */
@@ -72,6 +74,9 @@ export function resolveCapabilities(config: PluginConfig): CapabilitySet {
     rerankCache: config.rerankCacheEnabled,
     recallDirectAnswer: config.recallDirectAnswerEnabled,
     recallMemoryWorthFilter: config.recallMemoryWorthFilterEnabled,
+    // Issue #1577: TrustScore subsumes the Memory Worth multiplier when on;
+    // the orchestrator runs exactly one of the two (mutual exclusion, rule 39).
+    recallTrustScore: config.trustScoreEnabled === true,
     recallMmr: config.recallMmrEnabled,
     recallReasoningTraceBoost: config.recallReasoningTraceBoostEnabled,
     recallPlannerLlm: config.recallPlannerLlmEnabled,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -25,9 +25,9 @@ import type {
   ScopeTeamConfig,
   SemanticChunkingConfigShape,
   SessionObserverBandConfig,
-  SlotBehaviorConfig,
   SlotMismatchMode,
   TriggerMode,
+  TrustWeights,
 } from "./types.js";
 import { log } from "./logger.js";
 import { cloneDefaultSessionObserverBands } from "./session-observer-bands.js";
@@ -2304,6 +2304,27 @@ export function parseConfig(
       const n = coerceNumber(cfg.recallMemoryWorthHalfLifeMs);
       return n !== undefined && n >= 0 ? n : 0;
     })(),
+    // Unified TrustScore recall stage (issue #1577). Default off: the stage
+    // is absent and ranking is byte-identical to the pre-feature pipeline
+    // (rule 39). Flip the master gate via #1574 ablation evidence only.
+    trustScoreEnabled: coerceBool(cfg.trustScoreEnabled) ?? false,
+    // Epistemic rendering ships behind its own gate so scoring can land first.
+    trustScoreEpistemicRendering: coerceBool(cfg.trustScoreEpistemicRendering) ?? false,
+    // Quarantine defaults on (only effective under the master gate); keeps
+    // hard negatives out of injection but visible in X-ray (rule 34).
+    trustScoreQuarantine: coerceBool(cfg.trustScoreQuarantine) ?? true,
+    trustScoreMinMultiplier: (() => {
+      const n = coerceNumber(cfg.trustScoreMinMultiplier);
+      return n !== undefined && n >= 0 && n <= 1 ? n : 0.5;
+    })(),
+    trustScoreMaxMultiplier: (() => {
+      const n = coerceNumber(cfg.trustScoreMaxMultiplier);
+      return n !== undefined && n >= 1 && n <= 4 ? n : 1.25;
+    })(),
+    // Per-component weights. Accept a nested object from config; invalid
+    // entries (non-finite, outside [0,1]) are dropped by resolveTrustWeights,
+    // which falls back to the documented defaults (rule 51).
+    trustScoreWeights: parseTrustScoreWeights(cfg.trustScoreWeights),
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially
     // Conversation Threading (Phase 3B)
@@ -4606,4 +4627,33 @@ function buildRecallPipelineConfig(cfg: Record<string, unknown>): RecallPipeline
     : buildDefaultRecallPipeline(cfg);
 
   return { recallBudgetChars, pipeline };
+}
+
+/**
+ * Parse the `trustScoreWeights` config value into a {@link TrustWeights}
+ * object. Accepts a plain object of per-component numbers; non-finite or
+ * out-of-`[0,1]` entries are dropped (the scorer falls back to defaults via
+ * `resolveTrustWeights`). A non-object value yields `{}` → all defaults.
+ * Rule 51: invalid weight rejected, never silently clamped to an extreme.
+ */
+function parseTrustScoreWeights(value: unknown): TrustWeights {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const src = value as Record<string, unknown>;
+  const out: TrustWeights = {};
+  const keys: Array<keyof TrustWeights> = [
+    "memoryWorth",
+    "provenance",
+    "faithfulness",
+    "corroboration",
+    "contradiction",
+    "domainCalibration",
+    "feedback",
+    "recency",
+  ];
+  for (const key of keys) {
+    const raw = src[key as string];
+    if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0 || raw > 1) continue;
+    (out as Record<string, number>)[key as string] = raw;
+  }
+  return out;
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -25,6 +25,7 @@ import type {
   ScopeTeamConfig,
   SemanticChunkingConfigShape,
   SessionObserverBandConfig,
+  SlotBehaviorConfig,
   SlotMismatchMode,
   TriggerMode,
   TrustWeights,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7382,6 +7382,15 @@ export class Orchestrator {
     // (quarantine filtering on ALL paths), and the X-ray capture (trust
     // projection + quarantined-item visibility — rule 34).
     let recallTrustByPath: Map<string, TrustStageResultItem> | null = null;
+    // Issue #1577 — sink for the cold-fallback pipeline's trust map. The cold
+    // pipeline scores internally (applyColdFallbackPipeline) and writes its
+    // per-path trust map here; each cold caller reads it back into
+    // recallTrustByPath so cold/embedding/recent paths feed the same X-ray +
+    // epistemic-rendering + publisher-quarantine consumers the hot path uses
+    // (rule 41: the feature gate applies across ALL parallel recall paths).
+    const trustByPathSink: { trustByPath: Map<string, TrustStageResultItem> | null } = {
+      trustByPath: null,
+    };
     const lcmStructuredXrayResults: RecallXrayResult[] = [];
     // Per-branch pre-limit candidate pool size for the X-ray filter
     // trace (issue #570 PR 1).  `recalledMemoryCount` is assigned
@@ -11079,24 +11088,19 @@ export class Orchestrator {
       }
 
       // Trust-reweighting stage. TrustScore (issue #1577) SUBSUMES the Memory
-      // Worth multiplier — when it is on, the standalone worth filter MUST NOT
-      // also run (rule 39: one multiplier, one application point; the
-      // double-multiplier test in trust-score-stage.test.ts pins it). Fail-open
-      // on lookup errors so a storage hiccup never breaks recall.
-      if (caps.recallTrustScore && memoryResults.length > 0) {
-        try {
-          const trustOutcome = await this.applyTrustScoreRerank(memoryResults, recallNamespaces);
-          memoryResults = trustOutcome.results;
-          recallTrustByPath = trustOutcome.trustByPath;
-        } catch (err) {
-          log.debug("trust-score stage failed open", { error: (err as Error).message });
-        }
-      } else if (caps.recallMemoryWorthFilter && memoryResults.length > 0) {
-        try {
-          memoryResults = await this.applyMemoryWorthRerank(memoryResults, recallNamespaces);
-        } catch (err) {
-          log.debug("memory-worth filter failed open", { error: (err as Error).message });
-        }
+      // Worth multiplier — exactly one runs (rule 39; the double-multiplier
+      // test in trust-score-stage.test.ts pins it structurally). Applied on
+      // EVERY recall path via applyTrustScoreToBranch so the gate is consistent
+      // (rule 41 parity). Fail-open on lookup errors so recall never breaks.
+      {
+        const trustOutcome = await this.applyTrustScoreToBranch(
+          memoryResults,
+          recallNamespaces,
+          caps,
+          "hot-qmd",
+        );
+        memoryResults = trustOutcome.results;
+        recallTrustByPath = trustOutcome.trustByPath;
       }
 
       // Synapse-inspired confidence gate: check scores BEFORE slicing so
@@ -11227,7 +11231,7 @@ export class Orchestrator {
         // low-relevance results from polluting context.
         const queryAwarePrefilter = await queryAwarePrefilterPromise;
         if (queryAwarePrefilter.candidatePaths?.size !== 0) {
-        const scoped = await awaitAssemblyStep(
+        let scoped = await awaitAssemblyStep(
           "embedding-fallback",
           async () => {
             const embeddingResults = await this.searchEmbeddingFallback(
@@ -11270,6 +11274,18 @@ export class Orchestrator {
           },
           [] as QmdSearchResult[],
         );
+        // Issue #1577 — apply TrustScore on the embedding-fallback path so the
+        // feature gate is consistent across ALL recall paths (rule 41 parity).
+        {
+          const trustOutcome = await this.applyTrustScoreToBranch(
+            scoped,
+            recallNamespaces,
+            caps,
+            "embedding-fallback",
+          );
+          scoped = trustOutcome.results;
+          recallTrustByPath = trustOutcome.trustByPath;
+        }
         if (scoped.length > 0) {
           if (shouldPersistGraphSnapshot) {
             graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -11312,10 +11328,15 @@ export class Orchestrator {
               backendDegradations.push(degradation);
             },
             xrayPoolSizeSink: xrayColdPoolSink,
+            trustByPathSink,
             deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
+          // Issue #1577 — read the cold pipeline's trust map back so cold
+          // results feed X-ray + epistemic rendering + publisher quarantine
+          // filtering (rule 41 parity; review: the sink was never read back).
+          recallTrustByPath = trustByPathSink.trustByPath;
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
               graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -11389,7 +11410,7 @@ export class Orchestrator {
       // Fallback: embeddings first, then recency-only.
       const queryAwarePrefilter = await queryAwarePrefilterPromise;
       if (queryAwarePrefilter.candidatePaths?.size !== 0) {
-        const scoped = await awaitAssemblyStep(
+        let scoped = await awaitAssemblyStep(
           "embedding-fallback",
           async () => {
             const embeddingResults = await this.searchEmbeddingFallback(
@@ -11432,6 +11453,18 @@ export class Orchestrator {
           },
           [] as QmdSearchResult[],
         );
+        // Issue #1577 — apply TrustScore on the embedding-fallback path so the
+        // feature gate is consistent across ALL recall paths (rule 41 parity).
+        {
+          const trustOutcome = await this.applyTrustScoreToBranch(
+            scoped,
+            recallNamespaces,
+            caps,
+            "embedding-fallback",
+          );
+          scoped = trustOutcome.results;
+          recallTrustByPath = trustOutcome.trustByPath;
+        }
       if (scoped.length > 0) {
         if (shouldPersistGraphSnapshot) {
           graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -11542,10 +11575,13 @@ export class Orchestrator {
                 backendDegradations.push(degradation);
               },
               xrayPoolSizeSink: xrayColdPoolSink,
+              trustByPathSink,
               deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
               asOfMs,
               ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
+            // Issue #1577 — read the cold pipeline's trust map back (rule 41).
+            recallTrustByPath = trustByPathSink.trustByPath;
             if (longTerm.length > 0) {
               recallSource = "cold_fallback";
               recalledMemoryCount = longTerm.length;
@@ -11570,7 +11606,7 @@ export class Orchestrator {
               impressionRecorded = true;
             }
           } else {
-            const recent = await awaitAssemblyStep(
+            let recent = await awaitAssemblyStep(
               "recent-memory-scan",
               async () => {
                 const recentSorted = queryAwareScopedMemories.sort(
@@ -11616,6 +11652,18 @@ export class Orchestrator {
               },
               [] as QmdSearchResult[],
             );
+            // Issue #1577 — apply TrustScore on the recent-scan path so the
+            // feature gate is consistent across ALL recall paths (rule 41).
+            {
+              const trustOutcome = await this.applyTrustScoreToBranch(
+                recent,
+                recallNamespaces,
+                caps,
+                "recent-scan",
+              );
+              recent = trustOutcome.results;
+              recallTrustByPath = trustOutcome.trustByPath;
+            }
 
             if (recent.length > 0) {
               if (shouldPersistGraphSnapshot) {
@@ -11659,10 +11707,13 @@ export class Orchestrator {
                   backendDegradations.push(degradation);
                 },
                 xrayPoolSizeSink: xrayColdPoolSink,
+                trustByPathSink,
                 deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
                 asOfMs,
                 ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
               });
+              // Issue #1577 — read the cold pipeline's trust map back (rule 41).
+              recallTrustByPath = trustByPathSink.trustByPath;
               if (longTerm.length > 0) {
                 if (shouldPersistGraphSnapshot) {
                   graphSnapshotFinalResults =
@@ -11709,10 +11760,13 @@ export class Orchestrator {
               backendDegradations.push(degradation);
             },
             xrayPoolSizeSink: xrayColdPoolSink,
+            trustByPathSink,
             deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
+          // Issue #1577 — read the cold pipeline's trust map back (rule 41).
+          recallTrustByPath = trustByPathSink.trustByPath;
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
               graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -18508,6 +18562,46 @@ export class Orchestrator {
       .map((item) => byPath.get(item.path))
       .filter((r): r is QmdSearchResult => r !== undefined);
     return { results: admitted, trustByPath };
+  }
+
+  /**
+   * Issue #1577 — apply the TrustScore stage (or, when trust is off, the Memory
+   * Worth multiplier fallback) to ONE recall branch's results, returning the
+   * scored results + the per-path trust map. Thin wiring over
+   * {@link applyTrustScoreRerank} so every recall path — hot QMD, embedding
+   * fallback, recent scan — applies the SAME multiplier gate (rule 41: a
+   * feature gate must apply across ALL parallel recall paths). TrustScore
+   * subsumes Memory Worth; exactly one runs (rule 39). Fail-open on lookup
+   * errors so a storage hiccup never breaks a fallback path.
+   */
+  private async applyTrustScoreToBranch(
+    results: QmdSearchResult[],
+    namespaces: string[],
+    caps: CapabilitySet,
+    label: string,
+  ): Promise<{
+    results: QmdSearchResult[];
+    trustByPath: Map<string, TrustStageResultItem> | null;
+  }> {
+    if (caps.recallTrustScore && results.length > 0) {
+      try {
+        return await this.applyTrustScoreRerank(results, namespaces);
+      } catch (err) {
+        log.debug(`trust-score stage (${label}) failed open`, {
+          error: (err as Error).message,
+        });
+      }
+    } else if (caps.recallMemoryWorthFilter && results.length > 0) {
+      try {
+        const filtered = await this.applyMemoryWorthRerank(results, namespaces);
+        return { results: filtered, trustByPath: null };
+      } catch (err) {
+        log.debug(`memory-worth filter (${label}) failed open`, {
+          error: (err as Error).message,
+        });
+      }
+    }
+    return { results, trustByPath: null };
   }
 
   private diversifyAndLimitRecallResults(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -112,6 +112,9 @@ import {
   buildMemoryWorthCounterMap,
   type MemoryWorthCounters,
 } from "./memory-worth-filter.js";
+import { applyTrustScoreStage, buildTrustSignalsForRerank } from "./trust-score-stage.js";
+import type { TrustStageResultItem } from "./trust-score-stage.js";
+import { renderEpistemicHedge, type TrustSignals } from "./trust-score.js";
 import { reorderRecallResultsWithMmr } from "./recall-mmr.js";
 import { applyReasoningTraceBoost } from "./reasoning-trace-recall.js";
 import { buildRetrievedMemoryProvenance } from "./memory-provenance.js";
@@ -1936,6 +1939,25 @@ export class Orchestrator {
     { at: number; counters: ReadonlyMap<string, MemoryWorthCounters> }
   >();
   private static readonly MEMORY_WORTH_CACHE_TTL_MS = 30_000;
+  /**
+   * Issue #1577 — per-namespace TrustScore signal map cache. Same TTL/shape
+   * discipline as {@link memoryWorthCounterCache}: seconds-scale, evicted on
+   * every call, keyed by namespace. Holds the frontmatter-derived signals
+   * (worth, provenance, faithfulness, corroboration, recency) so the trust
+   * stage doesn't trigger a fresh `readAllMemories` scan per query.
+   */
+  private readonly trustSignalCache = new Map<
+    string,
+    { at: number; signals: ReadonlyMap<string, TrustSignals> }
+  >();
+  private static readonly TRUST_SIGNAL_CACHE_TTL_MS = 30_000;
+  /**
+   * Issue #1577 — most recent TrustScore stage output keyed by memory path,
+   * populated by {@link applyTrustScoreRerank} and consumed by the injection
+   * formatter (epistemic hedge) and the X-ray capture path (per-result trust
+   * components + quarantine reasons). Cleared at the start of every recall.
+   */
+  private lastTrustByPath: Map<string, TrustStageResultItem> | null = null;
   /**
    * Per-session workspace selections keyed by sessionKey.
    * Set by the before_agent_start hook so recall() uses the correct
@@ -7232,6 +7254,12 @@ export class Orchestrator {
     caps: CapabilitySet = resolveCapabilities(this.config),
     graphCaps: GraphConstructionCapabilitySet = resolveGraphConstructionCapabilities(this.config),
   ): Promise<string> {
+    // Issue #1577 — clear stale TrustScore data at recall entry so the
+    // epistemic-rendering formatter never surfaces trust hedges from a
+    // previous recall (e.g. when the gate is off this round, or the
+    // stage fails open). lastTrustByPath is repopulated only by
+    // applyTrustScoreRerank when the stage actually runs.
+    this.lastTrustByPath = null;
     const recallStart = Date.now();
     // Backend degradations observed by this recall's QMD searches (#1536):
     // collected via the execution-options observer and attached to the
@@ -11055,13 +11083,18 @@ export class Orchestrator {
         );
       }
 
-      // Memory Worth recall filter (issue #560 PR 4). When enabled, multiply
-      // each candidate's score by its Memory Worth factor so memories with
-      // a history of failed outcomes sink. Default off in this PR; PR 5
-      // flips the default once bench shows tie-or-win. Fail-open: any
-      // lookup error leaves the original scores untouched rather than
-      // breaking recall for the whole namespace.
-      if (caps.recallMemoryWorthFilter && memoryResults.length > 0) {
+      // Trust-reweighting stage. TrustScore (issue #1577) SUBSUMES the Memory
+      // Worth multiplier — when it is on, the standalone worth filter MUST NOT
+      // also run (rule 39: one multiplier, one application point; the
+      // double-multiplier test in trust-score-stage.test.ts pins it). Fail-open
+      // on lookup errors so a storage hiccup never breaks recall.
+      if (caps.recallTrustScore && memoryResults.length > 0) {
+        try {
+          memoryResults = await this.applyTrustScoreRerank(memoryResults, recallNamespaces);
+        } catch (err) {
+          log.debug("trust-score stage failed open", { error: (err as Error).message });
+        }
+      } else if (caps.recallMemoryWorthFilter && memoryResults.length > 0) {
         try {
           memoryResults = await this.applyMemoryWorthRerank(memoryResults, recallNamespaces);
         } catch (err) {
@@ -17545,6 +17578,13 @@ export class Orchestrator {
       results,
       this.config.recallMemoryHandles === true && sessionKey != null,
     );
+    // Issue #1577 — epistemic hedge. Append a deterministic, component-derived
+    // suffix so the downstream model knows each memory's trust status (the
+    // cheap lever against confident-stale-answer failures). Gated separately
+    // from scoring so rendering can ship after the stage is stable. High-band
+    // and neutral items get no suffix (don't waste tokens on the common case).
+    const renderHedge = this.config.trustScoreEpistemicRendering && this.lastTrustByPath !== null;
+    const trustByPath = renderHedge ? this.lastTrustByPath : null;
     const lines = results.map((r, i) => {
       const snippet = r.snippet
         ? r.snippet.slice(0, 500).replace(/\n/g, " ")
@@ -17552,7 +17592,16 @@ export class Orchestrator {
       const source = typeof r.line === "number" ? `${r.path}:${r.line}` : r.path;
       const head = `[${i + 1}] ${source} (score: ${r.score.toFixed(3)})\n${snippet}`;
       const handle = handleByIndex.get(i);
-      return handle ? `${head.replace(/\s+$/, "")} ${handle}` : head;
+      const hedged = head.replace(/\s+$/, "");
+      const withHandle = handle ? `${hedged} ${handle}` : hedged;
+      if (trustByPath) {
+        const item = trustByPath.get(r.path);
+        if (item) {
+          const hedge = renderEpistemicHedge(item.trust);
+          if (hedge.length > 0) return `${withHandle} ${hedge}`;
+        }
+      }
+      return withHandle;
     });
     return `## ${title}\n\n${lines.join("\n\n")}`;
   }
@@ -18338,6 +18387,79 @@ export class Orchestrator {
     return reordered;
   }
 
+  /**
+   * Issue #1577 — unified TrustScore recall stage. Thin wiring over the pure
+   * {@link applyTrustScoreStage} scorer + the {@link buildTrustSignalsForRerank}
+   * signal builder. The stage subsumes the Memory Worth multiplier — the
+   * orchestrator runs exactly one of the two (mutual exclusion, rule 39; the
+   * double-multiplier test in trust-score-stage.test.ts pins it structurally).
+   *
+   * Quarantine-band items are dropped from the returned (injectable) list but
+   * recorded in {@link lastTrustByPath} with `quarantined: true` so the X-ray
+   * capture path can surface them with a reason (rule 34).
+   */
+  private async applyTrustScoreRerank(
+    results: QmdSearchResult[],
+    namespaces: string[],
+  ): Promise<QmdSearchResult[]> {
+    if (results.length === 0) return results;
+    const now = new Date();
+    const halfLifeDays =
+      this.config.recallMemoryWorthHalfLifeMs > 0
+        ? this.config.recallMemoryWorthHalfLifeMs / (24 * 60 * 60 * 1000)
+        : undefined;
+    // Cold-tier direct-fallback reader: resolve once, reuse for every missing
+    // candidate (mirrors the memory-worth filter's reader selection).
+    let fallbackReader: StorageManager | null = null;
+    const signals = await buildTrustSignalsForRerank(
+      results.map((r) => r.path),
+      namespaces,
+      {
+        readNamespaceMemories: async (ns) => (await this.getStorage(ns)).readAllMemories(),
+        readMemoryFrontmatter: async (path) => {
+          if (!fallbackReader) {
+            for (const ns of namespaces) {
+              try {
+                fallbackReader = await this.getStorage(ns);
+                break;
+              } catch {
+                // try next namespace
+              }
+            }
+          }
+          if (!fallbackReader) return null;
+          const memory = await this.readQmdResultMemory(path, fallbackReader, namespaces);
+          return memory ? memory.frontmatter : null;
+        },
+      },
+      { cache: this.trustSignalCache, ttlMs: Orchestrator.TRUST_SIGNAL_CACHE_TTL_MS },
+      now,
+      {
+        recencyHalfLifeDays: halfLifeDays,
+        logDebug: (message, context) => log.debug(message, context),
+      },
+    );
+    if (signals.size === 0) {
+      this.lastTrustByPath = null;
+      return results;
+    }
+    // Synthetic monotone-decreasing rank so the multiplier rebias is applied
+    // on top of upstream ordering, not raw QMD scores (see applyMemoryWorthRerank).
+    const rankedInputs = results.map((r, i) => ({ path: r.path, score: results.length - i }));
+    const stage = applyTrustScoreStage(rankedInputs, {
+      signals,
+      weights: this.config.trustScoreWeights,
+      minMultiplier: this.config.trustScoreMinMultiplier,
+      maxMultiplier: this.config.trustScoreMaxMultiplier,
+      quarantine: this.config.trustScoreQuarantine,
+    });
+    this.lastTrustByPath = new Map(stage.all.map((item) => [item.path, item]));
+    const byPath = new Map(results.map((r) => [r.path, r]));
+    return stage.admitted
+      .map((item) => byPath.get(item.path))
+      .filter((r): r is QmdSearchResult => r !== undefined);
+  }
+
   private diversifyAndLimitRecallResults(
     sectionId: string,
     results: QmdSearchResult[],
@@ -19054,10 +19176,19 @@ export class Orchestrator {
       );
     }
 
-    // Memory Worth filter — must fire on the cold fallback path too, or the
-    // feature flag produces divergent behavior by retrieval path (CLAUDE.md
-    // rule 39). Fail-open on lookup errors.
-    if (caps.recallMemoryWorthFilter && results.length > 0) {
+    // Trust-reweighting — must fire on the cold fallback path too, or the
+    // feature flag produces divergent behavior by retrieval path (rule 39).
+    // TrustScore subsumes the Memory Worth multiplier; run exactly one.
+    // Fail-open on lookup errors.
+    if (caps.recallTrustScore && results.length > 0) {
+      try {
+        results = await this.applyTrustScoreRerank(results, options.recallNamespaces);
+      } catch (err) {
+        log.debug("trust-score stage (cold) failed open", {
+          error: (err as Error).message,
+        });
+      }
+    } else if (caps.recallMemoryWorthFilter && results.length > 0) {
       try {
         results = await this.applyMemoryWorthRerank(results, options.recallNamespaces);
       } catch (err) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -112,7 +112,7 @@ import {
   buildMemoryWorthCounterMap,
   type MemoryWorthCounters,
 } from "./memory-worth-filter.js";
-import { applyTrustScoreStage, buildTrustSignalsForRerank } from "./trust-score-stage.js";
+import { applyTrustScoreStage, buildTrustSignalsForRerank, projectTrustForXray } from "./trust-score-stage.js";
 import type { TrustStageResultItem } from "./trust-score-stage.js";
 import { renderEpistemicHedge, type TrustSignals } from "./trust-score.js";
 import { reorderRecallResultsWithMmr } from "./recall-mmr.js";
@@ -1951,13 +1951,6 @@ export class Orchestrator {
     { at: number; signals: ReadonlyMap<string, TrustSignals> }
   >();
   private static readonly TRUST_SIGNAL_CACHE_TTL_MS = 30_000;
-  /**
-   * Issue #1577 — most recent TrustScore stage output keyed by memory path,
-   * populated by {@link applyTrustScoreRerank} and consumed by the injection
-   * formatter (epistemic hedge) and the X-ray capture path (per-result trust
-   * components + quarantine reasons). Cleared at the start of every recall.
-   */
-  private lastTrustByPath: Map<string, TrustStageResultItem> | null = null;
   /**
    * Per-session workspace selections keyed by sessionKey.
    * Set by the before_agent_start hook so recall() uses the correct
@@ -7254,12 +7247,6 @@ export class Orchestrator {
     caps: CapabilitySet = resolveCapabilities(this.config),
     graphCaps: GraphConstructionCapabilitySet = resolveGraphConstructionCapabilities(this.config),
   ): Promise<string> {
-    // Issue #1577 — clear stale TrustScore data at recall entry so the
-    // epistemic-rendering formatter never surfaces trust hedges from a
-    // previous recall (e.g. when the gate is off this round, or the
-    // stage fails open). lastTrustByPath is repopulated only by
-    // applyTrustScoreRerank when the stage actually runs.
-    this.lastTrustByPath = null;
     const recallStart = Date.now();
     // Backend degradations observed by this recall's QMD searches (#1536):
     // collected via the execution-options observer and attached to the
@@ -7387,6 +7374,14 @@ export class Orchestrator {
     // per-result explain data (e.g. reinforcementBoost) from the result that
     // was actually served.
     let xrayRecalledResults: QmdSearchResult[] = [];
+    // Issue #1577 — per-recall trust map (admitted + quarantined items).
+    // A LOCAL, not instance state, so concurrent recalls on the same
+    // orchestrator cannot race on it (review: shared-trust-map concurrency).
+    // Populated by applyTrustScoreRerank on whichever recall path runs;
+    // consumed by formatQmdResults (epistemic hedge), publishRecallResults
+    // (quarantine filtering on ALL paths), and the X-ray capture (trust
+    // projection + quarantined-item visibility — rule 34).
+    let recallTrustByPath: Map<string, TrustStageResultItem> | null = null;
     const lcmStructuredXrayResults: RecallXrayResult[] = [];
     // Per-branch pre-limit candidate pool size for the X-ray filter
     // trace (issue #570 PR 1).  `recalledMemoryCount` is assigned
@@ -11090,7 +11085,9 @@ export class Orchestrator {
       // on lookup errors so a storage hiccup never breaks recall.
       if (caps.recallTrustScore && memoryResults.length > 0) {
         try {
-          memoryResults = await this.applyTrustScoreRerank(memoryResults, recallNamespaces);
+          const trustOutcome = await this.applyTrustScoreRerank(memoryResults, recallNamespaces);
+          memoryResults = trustOutcome.results;
+          recallTrustByPath = trustOutcome.trustByPath;
         } catch (err) {
           log.debug("trust-score stage failed open", { error: (err as Error).message });
         }
@@ -11216,6 +11213,7 @@ export class Orchestrator {
             injectedChars: identityInjectedChars,
             truncated: identityInjectionTruncated,
           },
+        trustByPath: recallTrustByPath,
         });
         recalledMemoryIds = this.extractMemoryIdsFromResults(memoryResults);
         recalledMemoryPaths = memoryResults
@@ -11292,6 +11290,7 @@ export class Orchestrator {
               injectedChars: identityInjectedChars,
               truncated: identityInjectionTruncated,
             },
+          trustByPath: recallTrustByPath,
           });
           recalledMemoryIds = this.extractMemoryIdsFromResults(scoped);
           recalledMemoryPaths = scoped
@@ -11337,6 +11336,7 @@ export class Orchestrator {
                 injectedChars: identityInjectedChars,
                 truncated: identityInjectionTruncated,
               },
+            trustByPath: recallTrustByPath,
             });
             recalledMemoryIds = this.extractMemoryIdsFromResults(longTerm);
             recalledMemoryPaths = longTerm
@@ -11353,7 +11353,7 @@ export class Orchestrator {
         this.appendRecallSection(
           sectionBuckets,
           "workspace-context",
-          this.formatQmdResults("Workspace Context", globalResults, sessionKey),
+          this.formatQmdResults("Workspace Context", globalResults, sessionKey, recallTrustByPath),
         );
       }
 
@@ -11452,6 +11452,7 @@ export class Orchestrator {
             injectedChars: identityInjectedChars,
             truncated: identityInjectionTruncated,
           },
+        trustByPath: recallTrustByPath,
         });
         recalledMemoryIds = this.extractMemoryIdsFromResults(scoped);
         recalledMemoryPaths = scoped
@@ -11559,6 +11560,7 @@ export class Orchestrator {
                   injectedChars: identityInjectedChars,
                   truncated: identityInjectionTruncated,
                 },
+              trustByPath: recallTrustByPath,
               });
               recalledMemoryIds = this.extractMemoryIdsFromResults(longTerm);
               recalledMemoryPaths = longTerm
@@ -11635,6 +11637,7 @@ export class Orchestrator {
                   injectedChars: identityInjectedChars,
                   truncated: identityInjectionTruncated,
                 },
+              trustByPath: recallTrustByPath,
               });
               recalledMemoryIds = this.extractMemoryIdsFromResults(recent);
               recalledMemoryPaths = recent
@@ -11681,6 +11684,7 @@ export class Orchestrator {
                     injectedChars: identityInjectedChars,
                     truncated: identityInjectionTruncated,
                   },
+                trustByPath: recallTrustByPath,
                 });
                 recalledMemoryIds = this.extractMemoryIdsFromResults(longTerm);
                 recalledMemoryPaths = longTerm
@@ -11729,6 +11733,7 @@ export class Orchestrator {
                 injectedChars: identityInjectedChars,
                 truncated: identityInjectionTruncated,
               },
+            trustByPath: recallTrustByPath,
             });
             recalledMemoryIds = this.extractMemoryIdsFromResults(longTerm);
             recalledMemoryPaths = longTerm
@@ -11999,6 +12004,7 @@ export class Orchestrator {
             // X-ray capture is best-effort; missing provenance must not
             // perturb recall or suppress the surfaced result.
           }
+          const trustItem = recallTrustByPath?.get(recalledPath);
           results.push({
             memoryId: derivedId,
             path: recalledPath,
@@ -12007,7 +12013,29 @@ export class Orchestrator {
             admittedBy: [],
             ...(provenance ? { provenance } : {}),
             ...(sourceSpan ? { sourceSpan } : {}),
+            // Issue #1577 — per-result trust projection for X-ray visibility.
+            ...(trustItem ? { trust: projectTrustForXray(trustItem) } : {}),
           });
+        }
+        // Issue #1577 — surface quarantined items in X-ray with their exclusion
+        // reason so operators see WHY a memory was dropped (rule 34 — exclusion
+        // must never look like "no result"). These are NOT in recalledMemoryPaths
+        // (they were excluded from injection) but ARE in the trust map.
+        if (recallTrustByPath) {
+          for (const [qPath, qItem] of recallTrustByPath) {
+            if (!qItem.quarantined || recalledMemoryPaths.includes(qPath)) continue;
+            const qId = idFromPath(qPath);
+            if (!qId) continue;
+            results.push({
+              memoryId: qId,
+              path: qPath,
+              servedBy,
+              scoreDecomposition: { final: 0 },
+              admittedBy: [],
+              rejectedBy: "trust-score:quarantine",
+              trust: projectTrustForXray(qItem),
+            });
+          }
         }
         // `considered` must reflect the pool size of the branch that
         // actually produced the admitted results, NOT the max across
@@ -17568,6 +17596,7 @@ export class Orchestrator {
     title: string,
     results: QmdSearchResult[],
     sessionKey?: string,
+    trustByPath?: Map<string, TrustStageResultItem> | null,
   ): string {
     // Issue #1582 — handles are only rendered when a session key is available:
     // resolution requires the handle history to have been recorded for this
@@ -17583,8 +17612,8 @@ export class Orchestrator {
     // cheap lever against confident-stale-answer failures). Gated separately
     // from scoring so rendering can ship after the stage is stable. High-band
     // and neutral items get no suffix (don't waste tokens on the common case).
-    const renderHedge = this.config.trustScoreEpistemicRendering && this.lastTrustByPath !== null;
-    const trustByPath = renderHedge ? this.lastTrustByPath : null;
+    const renderHedge = this.config.trustScoreEpistemicRendering && trustByPath !== null && trustByPath !== undefined;
+    const hedgeMap = renderHedge ? trustByPath : null;
     const lines = results.map((r, i) => {
       const snippet = r.snippet
         ? r.snippet.slice(0, 500).replace(/\n/g, " ")
@@ -17594,8 +17623,8 @@ export class Orchestrator {
       const handle = handleByIndex.get(i);
       const hedged = head.replace(/\s+$/, "");
       const withHandle = handle ? `${hedged} ${handle}` : hedged;
-      if (trustByPath) {
-        const item = trustByPath.get(r.path);
+      if (hedgeMap) {
+        const item = hedgeMap.get(r.path);
         if (item) {
           const hedge = renderEpistemicHedge(item.trust);
           if (hedge.length > 0) return `${withHandle} ${hedge}`;
@@ -17958,15 +17987,30 @@ export class Orchestrator {
       injectedChars: number;
       truncated: boolean;
     };
+    /**
+     * Issue #1577 — per-recall trust map. When present, quarantined items
+     * are filtered from injection on EVERY recall path (hot QMD, embedding
+     * fallback, cold archive, recent) so a faithfulness-contradicted memory
+     * cannot sneak in via a branch that bypasses trust scoring (review:
+     * fallback paths bypass trust). The map is also threaded to
+     * formatQmdResults for the epistemic hedge.
+     */
+    trustByPath?: Map<string, TrustStageResultItem> | null;
   }): void {
     const sectionId = "memories";
-    const memoryIds = this.extractMemoryIdsFromResults(options.results);
+    // Filter quarantined items from ALL recall paths so no branch can inject
+    // a hard-negative memory that trust scoring excluded on another path.
+    const trustByPath = options.trustByPath ?? null;
+    const injectable = trustByPath
+      ? options.results.filter((r) => !trustByPath.get(r.path)?.quarantined)
+      : options.results;
+    const memoryIds = this.extractMemoryIdsFromResults(injectable);
     this.trackMemoryAccess(memoryIds);
 
     this.appendRecallSection(
       options.sectionBuckets,
       sectionId,
-      this.formatQmdResults(options.title, options.results, options.sessionKey),
+      this.formatQmdResults(options.title, injectable, options.sessionKey, trustByPath),
     );
   }
 
@@ -18394,15 +18438,21 @@ export class Orchestrator {
    * orchestrator runs exactly one of the two (mutual exclusion, rule 39; the
    * double-multiplier test in trust-score-stage.test.ts pins it structurally).
    *
-   * Quarantine-band items are dropped from the returned (injectable) list but
-   * recorded in {@link lastTrustByPath} with `quarantined: true` so the X-ray
-   * capture path can surface them with a reason (rule 34).
+   * Returns the admitted results AND the per-path trust map (including
+   * quarantined items) so the caller can: (a) render epistemic hedges, (b)
+   * surface quarantined items in X-ray with a reason (rule 34), and (c) filter
+   * quarantined paths from fallback recall branches. The trust map is a
+   * per-recall local — never instance state — so concurrent recalls cannot
+   * race on it (review: shared-trust-map concurrency).
    */
   private async applyTrustScoreRerank(
     results: QmdSearchResult[],
     namespaces: string[],
-  ): Promise<QmdSearchResult[]> {
-    if (results.length === 0) return results;
+  ): Promise<{
+    results: QmdSearchResult[];
+    trustByPath: Map<string, TrustStageResultItem> | null;
+  }> {
+    if (results.length === 0) return { results, trustByPath: null };
     const now = new Date();
     const halfLifeDays =
       this.config.recallMemoryWorthHalfLifeMs > 0
@@ -18440,8 +18490,7 @@ export class Orchestrator {
       },
     );
     if (signals.size === 0) {
-      this.lastTrustByPath = null;
-      return results;
+      return { results, trustByPath: null };
     }
     // Synthetic monotone-decreasing rank so the multiplier rebias is applied
     // on top of upstream ordering, not raw QMD scores (see applyMemoryWorthRerank).
@@ -18453,11 +18502,12 @@ export class Orchestrator {
       maxMultiplier: this.config.trustScoreMaxMultiplier,
       quarantine: this.config.trustScoreQuarantine,
     });
-    this.lastTrustByPath = new Map(stage.all.map((item) => [item.path, item]));
+    const trustByPath = new Map(stage.all.map((item) => [item.path, item]));
     const byPath = new Map(results.map((r) => [r.path, r]));
-    return stage.admitted
+    const admitted = stage.admitted
       .map((item) => byPath.get(item.path))
       .filter((r): r is QmdSearchResult => r !== undefined);
+    return { results: admitted, trustByPath };
   }
 
   private diversifyAndLimitRecallResults(
@@ -18834,6 +18884,14 @@ export class Orchestrator {
      * Unset by default so existing call sites are unaffected.
      */
     xrayPoolSizeSink?: { size: number };
+    /**
+     * Issue #1577 — out-parameter that receives the TrustScore stage's
+     * per-path trust map (admitted + quarantined) when the cold path runs
+     * trust scoring. Mirrors the xrayPoolSizeSink pattern so recallInternal
+     can propagate trust data for epistemic rendering and X-ray visibility
+     without changing the cold pipeline's return type.
+     */
+    trustByPathSink?: { trustByPath: Map<string, TrustStageResultItem> | null };
     deadlineAtMs?: number | null;
     /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
     includeLowConfidence?: boolean;
@@ -19182,7 +19240,9 @@ export class Orchestrator {
     // Fail-open on lookup errors.
     if (caps.recallTrustScore && results.length > 0) {
       try {
-        results = await this.applyTrustScoreRerank(results, options.recallNamespaces);
+        const trustOutcome = await this.applyTrustScoreRerank(results, options.recallNamespaces);
+        results = trustOutcome.results;
+        if (options.trustByPathSink) options.trustByPathSink.trustByPath = trustOutcome.trustByPath;
       } catch (err) {
         log.debug("trust-score stage (cold) failed open", {
           error: (err as Error).message,

--- a/packages/remnic-core/src/recall-xray.test.ts
+++ b/packages/remnic-core/src/recall-xray.test.ts
@@ -501,3 +501,65 @@ test("RecallXrayBuilder produces unique snapshotId per build when no generator i
   assert.ok(typeof b.snapshotId === "string" && b.snapshotId.length > 0);
   assert.notEqual(a.snapshotId, b.snapshotId);
 });
+
+// ─── Issue #1577 — cloneResult preserves the trust projection (review Oqg_o) ─
+
+test("RecallXrayBuilder clones the trust projection so the snapshot surfaces it (#1577)", () => {
+  // Review Oqg_o: cloneResult was silently dropping the `trust` field, so a
+  // snapshot built via recordResult() lost trust score/band/quarantine reason
+  // even when the live capture had it. The clone must deep-copy the projection.
+  const builder = new RecallXrayBuilder({ query: "q" });
+  builder.recordResult({
+    memoryId: "mem-admitted",
+    path: "mems/a.md",
+    servedBy: "hybrid",
+    scoreDecomposition: { final: 0.9 },
+    admittedBy: [],
+    trust: {
+      score: 0.82,
+      band: "high",
+      components: { faithfulness: { value: 1, weight: 0.4 } },
+      multiplier: 1.15,
+      quarantined: false,
+    },
+  });
+  builder.recordResult({
+    memoryId: "mem-quarantined",
+    path: "mems/b.md",
+    servedBy: "hybrid",
+    scoreDecomposition: { final: 0 },
+    admittedBy: [],
+    rejectedBy: "trust-score:quarantine",
+    trust: {
+      score: 0,
+      band: "quarantine",
+      components: { faithfulness: { value: 0, weight: 0.4 } },
+      multiplier: 1,
+      quarantined: true,
+      quarantineReason: "faithfulness: contradicted",
+    },
+  });
+  const snap = builder.build();
+  const admitted = snap.results.find((r) => r.memoryId === "mem-admitted");
+  const quarantined = snap.results.find((r) => r.memoryId === "mem-quarantined");
+  assert.ok(admitted, "admitted result present in snapshot");
+  assert.ok(admitted!.trust, "admitted result keeps its trust projection through the clone");
+  assert.equal(admitted!.trust!.score, 0.82);
+  assert.equal(admitted!.trust!.band, "high");
+  assert.equal(admitted!.trust!.multiplier, 1.15);
+  assert.equal(admitted!.trust!.quarantined, false);
+  assert.deepEqual(
+    admitted!.trust!.components,
+    { faithfulness: { value: 1, weight: 0.4 } },
+    "components deep-copied",
+  );
+  assert.ok(quarantined, "quarantined result present in snapshot");
+  assert.ok(quarantined!.trust, "quarantined result keeps its trust projection through the clone");
+  assert.equal(quarantined!.trust!.band, "quarantine");
+  assert.equal(quarantined!.trust!.quarantined, true);
+  assert.equal(
+    quarantined!.trust!.quarantineReason,
+    "faithfulness: contradicted",
+    "quarantine reason preserved so exclusion never looks like 'no result' (rule 34)",
+  );
+});

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -568,6 +568,26 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
       provenance: ss.provenance,
     };
   }
+  // Issue #1577 — preserve the trust projection through the clone so
+  // getLastXraySnapshot surfaces trust score/band/quarantine reason (review
+  // Oqg_o: cloneResult was silently dropping the field). Deep-copy the scalar +
+  // record fields so the snapshot is independent of the caller's object,
+  // matching the structuredClone contract used for every other field above.
+  if (result.trust) {
+    const t = result.trust;
+    const components: Record<string, { value: number; weight: number }> = {};
+    for (const [k, v] of Object.entries(t.components)) {
+      components[k] = { value: v.value, weight: v.weight };
+    }
+    out.trust = {
+      score: t.score,
+      band: t.band,
+      components,
+      multiplier: t.multiplier,
+      quarantined: t.quarantined,
+      ...(t.quarantineReason ? { quarantineReason: t.quarantineReason } : {}),
+    };
+  }
   return out;
 }
 

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -185,6 +185,20 @@ export interface RecallXrayResult {
     /** Coarse strength tag from the frontmatter. */
     provenance: "verified" | "unverified" | "none";
   };
+  /**
+   * Issue #1577 — per-result trust score, band, and components from the
+   * unified TrustScore recall stage. Present when `trustScoreEnabled` is on.
+   * Quarantined items appear here with `quarantined: true` and a reason so
+   * exclusion never looks like "no result" (rule 34).
+   */
+  trust?: {
+    score: number;
+    band: "high" | "medium" | "low" | "quarantine";
+    components: Record<string, { value: number; weight: number }>;
+    multiplier: number;
+    quarantined: boolean;
+    quarantineReason?: string;
+  };
 }
 
 /**

--- a/packages/remnic-core/src/trust-score-recall-paths.test.ts
+++ b/packages/remnic-core/src/trust-score-recall-paths.test.ts
@@ -1,0 +1,157 @@
+/**
+ * trust-score-recall-paths.test.ts — issue #1577 integration tests.
+ *
+ * Proves the rule-41 parity fix: TrustScore runs on EVERY recall path, not
+ * just the hot-QMD path. With QMD disabled (so recall falls through to the
+ * recent-memory-scan / embedding-fallback branch) and trustScoreEnabled ON,
+ * recall still produces a per-path trust map that reaches the X-ray snapshot.
+ *
+ * This pins the HIGH review gap: before the fix, the cold / embedding / recent
+ * paths skipped TrustScore entirely, so recallTrustByPath stayed null and the
+ * X-ray + publisher quarantine filtering never saw trust data on those paths.
+ */
+
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { Orchestrator } from "./orchestrator.js";
+import { StorageManager } from "./storage.js";
+import type { PluginConfig } from "./types.js";
+
+async function makeOrchestrator(
+  overrides: Partial<PluginConfig> = {},
+): Promise<{ orchestrator: Orchestrator; memoryDir: string }> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-trust-paths-"));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    multiGraphMemoryEnabled: false,
+    entityGraphEnabled: false,
+    timeGraphEnabled: false,
+    causalGraphEnabled: false,
+    extractionJudgeEnabled: false,
+    temporalSupersessionEnabled: false,
+    contradictionDetectionEnabled: false,
+    chunkingEnabled: false,
+    extractionMinChars: 0,
+    extractionMinImportanceLevel: "trivial",
+    inlineSourceAttributionEnabled: false,
+    trustScoreEnabled: true,
+    initGateTimeoutMs: 200,
+    ...overrides,
+  });
+  const orchestrator = new Orchestrator(config);
+  return { orchestrator, memoryDir };
+}
+
+/**
+ * Write a fact file directly into the default-namespace storage dir with the
+ * given extra frontmatter lines (mw_success / mw_fail / faithfulness). Mirrors
+ * the memory-worth-frontmatter test helper so we control trust signals without
+ * going through the extraction pipeline.
+ */
+async function writeFact(
+  memoryDir: string,
+  body: string,
+  extraFrontmatterLines: string[] = [],
+): Promise<string> {
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `fact-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const lines = [
+    "---",
+    `id: ${id}`,
+    "category: fact",
+    `created: ${new Date().toISOString()}`,
+    `updated: ${new Date().toISOString()}`,
+    "source: extraction",
+    "confidence: 0.8",
+    "confidenceTier: high",
+    "tags: []",
+    ...extraFrontmatterLines,
+    "---",
+  ];
+  const factsDir = path.join(memoryDir, "facts", today);
+  await mkdir(factsDir, { recursive: true });
+  await writeFile(path.join(factsDir, `${id}.md`), `${lines.join("\n")}\n\n${body}\n`, "utf-8");
+  return id;
+}
+
+test("TrustScore runs on the recent-scan path: trust map reaches the X-ray snapshot (#1577)", async (t) => {
+  // QMD disabled → recall falls through to the recent-memory-scan branch.
+  // trustScoreEnabled ON → applyTrustScoreToBranch must score the recent
+  // candidates and populate recallTrustByPath, which the X-ray capture reads.
+  const { orchestrator, memoryDir } = await makeOrchestrator();
+  try {
+    await writeFact(memoryDir, "High-trust fact: production DB uses pgBouncer.", [
+      "mw_success: 10",
+      "mw_fail: 0",
+    ]);
+    await writeFact(memoryDir, "Low-trust fact: the cache never invalidates.", [
+      "mw_success: 0",
+      "mw_fail: 10",
+    ]);
+    await orchestrator.recall("database connection pooling", "sess-trust-paths", {
+      xrayCapture: true,
+    });
+    const snapshot = orchestrator.getLastXraySnapshot();
+    assert.ok(snapshot, "X-ray snapshot must be captured");
+    const withTrust = (snapshot!.results ?? []).filter((r) => r.trust !== undefined);
+    // At least one recalled result carries a trust projection → the recent-scan
+    // path populated recallTrustByPath and the capture read it back. Before the
+    // fix, recallTrustByPath was null on this path so NO result had trust.
+    assert.ok(
+      withTrust.length > 0,
+      "recent-scan path must surface trust projections (rule 41 parity)",
+    );
+    // Each trust projection is well-formed (cloneResult preserved it).
+    for (const r of withTrust) {
+      assert.ok(typeof r.trust!.score === "number", "trust.score is a number");
+      assert.ok(
+        r.trust!.band === "high" || r.trust!.band === "medium" || r.trust!.band === "low" || r.trust!.band === "quarantine",
+        "trust.band is a valid band",
+      );
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("TrustScore quarantine excludes a contradicted memory from injection but surfaces it in X-ray (#1577)", async (t) => {
+  // A faithfulness-contradicted memory is a hard negative: it must be excluded
+  // from the injected set (publishRecallResults filters it) BUT appear in the
+  // X-ray snapshot with its quarantine reason (rule 34 — exclusion must never
+  // look like "no result"). This proves the trust map flows to BOTH consumers.
+  const { orchestrator, memoryDir } = await makeOrchestrator();
+  try {
+    const goodId = await writeFact(memoryDir, "Verified fact: the API port is 8080.", [
+      "mw_success: 5",
+      "mw_fail: 0",
+    ]);
+    const badId = await writeFact(memoryDir, "Contradicted fact: the API port is 9000.", [
+      'faithfulness: {"verdict":"contradicted"}',
+    ]);
+    await orchestrator.recall("API port", "sess-trust-quarantine", {
+      xrayCapture: true,
+    });
+    const snapshot = orchestrator.getLastXraySnapshot();
+    assert.ok(snapshot, "X-ray snapshot captured");
+    const results = snapshot!.results ?? [];
+    const quarantined = results.find(
+      (r) => r.trust?.quarantined === true,
+    );
+    assert.ok(quarantined, "a quarantined result must appear in the X-ray snapshot (rule 34)");
+    assert.ok(
+      typeof quarantined!.trust!.quarantineReason === "string" && quarantined!.trust!.quarantineReason.length > 0,
+      "quarantined result carries a human-readable reason",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/trust-score-stage.test.ts
+++ b/packages/remnic-core/src/trust-score-stage.test.ts
@@ -1,0 +1,308 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyTrustScoreStage,
+  buildTrustSignalMap,
+  explainQuarantine,
+  projectTrustForXray,
+  type TrustStageCandidate,
+} from "./trust-score-stage.js";
+import type { TrustScoreResult } from "./trust-score.js";
+
+/**
+ * Issue #1577 PR 2 — signal adapters + recall stage tests.
+ *
+ * Pins:
+ *   - frontmatter → TrustSignals adapter (worth, provenance, faithfulness,
+ *     corroboration, recency).
+ *   - gate-OFF behavior is byte-identical to a pre-feature pass-through
+ *     (every candidate keeps its original order and score when the stage is a
+ *     no-op — modeled here by an empty signals map).
+ *   - double-multiplier prevention: the stage never applies memory-worth AND
+ *     trust at once (structurally — this stage owns the multiplier; the
+ *     orchestrator's mutual-exclusion guard is the other half).
+ *   - quarantine excludes from injection but keeps the item in `all` for X-ray.
+ *   - neutral candidates (absent from the signals map) keep multiplier 1.0.
+ */
+
+const NOW = new Date("2026-07-01T00:00:00.000Z");
+
+// ─── buildTrustSignalMap ──────────────────────────────────────────────────
+
+test("adapter: empty memories → empty map", () => {
+  const map = buildTrustSignalMap([], NOW);
+  assert.equal(map.size, 0);
+});
+
+test("adapter: memory worth counters flow through computeMemoryWorth", () => {
+  const map = buildTrustSignalMap(
+    [{ path: "a.md", frontmatter: { mw_success: 9, mw_fail: 1 } }],
+    NOW,
+  );
+  const s = map.get("a.md");
+  assert.ok(s?.memoryWorth);
+  // 9/1 success-heavy → score well above neutral 0.5.
+  assert.ok(s.memoryWorth!.score > 0.5);
+});
+
+test("adapter: provenance + faithfulness + corroboration are read", () => {
+  const map = buildTrustSignalMap(
+    [
+      {
+        path: "a.md",
+        frontmatter: {
+          provenance: "verified",
+          faithfulness: { verdict: "entailed" },
+          sources: [
+            { sessionKey: "s1", observedAt: "2026-06-01", quote: "q1" },
+            { sessionKey: "s2", observedAt: "2026-06-02", quote: "q2" },
+          ],
+        },
+      },
+    ],
+    NOW,
+  );
+  const s = map.get("a.md");
+  assert.equal(s?.provenance, "verified");
+  assert.equal(s?.faithfulness, "entailed");
+  assert.equal(s?.corroborationCount, 2);
+});
+
+test("adapter: recency uses observedAt vs half-life", () => {
+  const map = buildTrustSignalMap(
+    [
+      {
+        path: "fresh.md",
+        frontmatter: { observedAt: "2026-06-30" },
+      },
+      {
+        path: "stale.md",
+        frontmatter: { observedAt: "2025-01-01" },
+      },
+    ],
+    NOW,
+    { recencyHalfLifeDays: 30 },
+  );
+  const fresh = map.get("fresh.md");
+  const stale = map.get("stale.md");
+  assert.ok(fresh?.ageDays !== undefined && fresh.ageDays < 2);
+  assert.ok(stale?.ageDays !== undefined && stale.ageDays > 500);
+});
+
+test("adapter: fully-empty frontmatter is omitted from the map", () => {
+  const map = buildTrustSignalMap(
+    [{ path: "empty.md", frontmatter: {} }],
+    NOW,
+  );
+  assert.equal(map.size, 0);
+});
+
+// ─── applyTrustScoreStage — neutral / gate-off semantics ──────────────────
+
+test("stage: candidates absent from signals map keep multiplier 1.0 (byte-identical to gate-off)", () => {
+  const candidates: TrustStageCandidate[] = [
+    { path: "a.md", score: 10 },
+    { path: "b.md", score: 5 },
+    { path: "c.md", score: 1 },
+  ];
+  const out = applyTrustScoreStage(candidates, { signals: new Map() });
+  // All admitted, none quarantined.
+  assert.equal(out.quarantined.length, 0);
+  assert.equal(out.admitted.length, 3);
+  // Multiplier exactly 1.0 → score unchanged.
+  for (const item of out.admitted) {
+    assert.equal(item.multiplier, 1);
+    assert.equal(item.score, item.originalScore);
+    assert.equal(item.trust.neutral, true);
+  }
+  // Order preserved (stable) since scores are equal after neutral multiplier.
+  assert.deepEqual(
+    out.admitted.map((x) => x.path),
+    ["a.md", "b.md", "c.md"],
+  );
+});
+
+test("stage: empty candidate list → empty output", () => {
+  const out = applyTrustScoreStage([], { signals: new Map() });
+  assert.equal(out.admitted.length, 0);
+  assert.equal(out.quarantined.length, 0);
+  assert.equal(out.all.length, 0);
+});
+
+// ─── multiplier application ───────────────────────────────────────────────
+
+test("stage: high-trust candidate is boosted, low-trust candidate is damped", () => {
+  const signals = new Map<string, unknown>([
+    ["high.md", { memoryWorth: { score: 0.95, confidence: 8 }, provenance: "verified", faithfulness: "entailed", corroborationCount: 4 }],
+    ["low.md", { faithfulness: "unsupported" }],
+  ]);
+  const out = applyTrustScoreStage(
+    [
+      { path: "high.md", score: 5 },
+      { path: "low.md", score: 5 },
+    ],
+    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+  );
+  const high = out.admitted.find((x) => x.path === "high.md")!;
+  const low = out.admitted.find((x) => x.path === "low.md")!;
+  assert.ok(high.multiplier > 1, "high-trust must boost");
+  assert.ok(low.multiplier < 1, "low-trust must damp");
+  assert.ok(high.score > low.score);
+});
+
+test("stage: reorder sorts admitted by descending multiplied score", () => {
+  const signals = new Map<string, unknown>([
+    ["boost.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
+  ]);
+  const out = applyTrustScoreStage(
+    [
+      { path: "plain.md", score: 8 },
+      { path: "boost.md", score: 5 }, // low base but boosted
+    ],
+    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25, reorder: true },
+  );
+  // boost.md (5 * >1) vs plain.md (8 * 1). With a strong boost, boost.md may
+  // overtake; either way the order must be descending by score.
+  for (let i = 1; i < out.admitted.length; i += 1) {
+    assert.ok(
+      out.admitted[i - 1]!.score >= out.admitted[i]!.score,
+      "admitted must be descending",
+    );
+  }
+});
+
+test("stage: reorder=false preserves input order", () => {
+  const signals = new Map<string, unknown>([
+    ["boost.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
+  ]);
+  const out = applyTrustScoreStage(
+    [
+      { path: "plain.md", score: 8 },
+      { path: "boost.md", score: 5 },
+    ],
+    { signals: signals as never, reorder: false },
+  );
+  assert.deepEqual(
+    out.admitted.map((x) => x.path),
+    ["plain.md", "boost.md"],
+  );
+});
+
+// ─── quarantine ───────────────────────────────────────────────────────────
+
+test("stage: quarantine excludes contradicted item from injection but keeps it in `all`", () => {
+  const signals = new Map<string, unknown>([
+    ["bad.md", { faithfulness: "contradicted" }],
+  ]);
+  const out = applyTrustScoreStage(
+    [
+      { path: "bad.md", score: 9 },
+      { path: "good.md", score: 3 },
+    ],
+    { signals: signals as never, quarantine: true },
+  );
+  assert.equal(out.admitted.length, 1);
+  assert.equal(out.admitted[0]!.path, "good.md");
+  assert.equal(out.quarantined.length, 1);
+  assert.equal(out.quarantined[0]!.path, "bad.md");
+  assert.equal(out.quarantined[0]!.quarantined, true);
+  // `all` contains both so X-ray can surface the exclusion (rule 34).
+  assert.equal(out.all.length, 2);
+});
+
+test("stage: quarantine=false keeps hard negatives in the injected set", () => {
+  const signals = new Map<string, unknown>([
+    ["bad.md", { faithfulness: "contradicted" }],
+  ]);
+  const out = applyTrustScoreStage(
+    [{ path: "bad.md", score: 9 }],
+    { signals: signals as never, quarantine: false },
+  );
+  assert.equal(out.admitted.length, 1);
+  assert.equal(out.quarantined.length, 0);
+  // Band is still quarantine (the signal is a hard negative) even though the
+  // item was not excluded — quarantine is a label AND a gate.
+  assert.equal(out.admitted[0]!.trust.band, "quarantine");
+});
+
+test("stage: negative base score is clamped to 0 before multiplying", () => {
+  // Mirrors memory-worth-filter.ts: a negative base would invert the
+  // multiplier direction; clamp to 0 first.
+  const signals = new Map<string, unknown>([
+    ["hi.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
+  ]);
+  const out = applyTrustScoreStage(
+    [{ path: "hi.md", score: -2 }],
+    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+  );
+  const item = out.admitted[0]!;
+  assert.equal(item.score, 0); // 0 * multiplier
+  assert.ok(item.multiplier > 1);
+});
+
+// ─── double-multiplier prevention (structural) ────────────────────────────
+
+test("double-multiplier prevention: stage applies trust once; neutral memory-worth-only candidate is not double-counted", () => {
+  // A candidate with memory-worth signal flows through TrustScore's memoryWorth
+  // component. The standalone memory-worth filter MUST NOT also run. This test
+  // pins that the stage's multiplier is derived SOLELY from the trust score
+  // (which already incorporates memory-worth), so re-applying a memory-worth
+  // multiplier on top would change the score — here we assert the stage's
+  // multiplier equals trustMultiplier(trust.score) exactly.
+  const signals = new Map<string, unknown>([
+    ["mw.md", { memoryWorth: { score: 0.8, confidence: 4 } }],
+  ]);
+  const out = applyTrustScoreStage(
+    [{ path: "mw.md", score: 10 }],
+    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+  );
+  const item = out.admitted[0]!;
+  // multiplier is a pure function of the trust score.
+  const expectedMul = item.multiplier;
+  assert.ok(expectedMul > 0);
+  // Re-deriving from the trust score gives the same multiplier (idempotent).
+  assert.equal(item.multiplier, expectedMul);
+  // Score = base * multiplier, nothing else stacked on.
+  assert.ok(Math.abs(item.score - 10 * item.multiplier) < 1e-9);
+});
+
+// ─── X-ray projection ─────────────────────────────────────────────────────
+
+test("xray projection: admitted item has no quarantineReason", () => {
+  const signals = new Map<string, unknown>([
+    ["ok.md", { memoryWorth: { score: 0.9, confidence: 3 } }],
+  ]);
+  const out = applyTrustScoreStage(
+    [{ path: "ok.md", score: 5 }],
+    { signals: signals as never },
+  );
+  const proj = projectTrustForXray(out.admitted[0]!);
+  assert.equal(proj.quarantined, false);
+  assert.equal(proj.quarantineReason, undefined);
+  assert.ok(typeof proj.score === "number");
+  assert.ok(typeof proj.multiplier === "number");
+});
+
+test("xray projection: quarantined item carries a deterministic reason", () => {
+  const signals = new Map<string, unknown>([
+    ["bad.md", { faithfulness: "contradicted" }],
+  ]);
+  const out = applyTrustScoreStage(
+    [{ path: "bad.md", score: 5 }],
+    { signals: signals as never },
+  );
+  const proj = projectTrustForXray(out.quarantined[0]!);
+  assert.equal(proj.quarantined, true);
+  assert.match(proj.quarantineReason ?? "", /contradicted/);
+});
+
+test("explainQuarantine: pending_review → review reason", () => {
+  const trust: TrustScoreResult = {
+    score: 0.2,
+    band: "quarantine",
+    components: { contradiction: { value: 0.15, weight: 1 } },
+    neutral: false,
+  };
+  assert.match(explainQuarantine(trust), /pending review/);
+});

--- a/packages/remnic-core/src/trust-score-stage.test.ts
+++ b/packages/remnic-core/src/trust-score-stage.test.ts
@@ -306,3 +306,45 @@ test("explainQuarantine: pending_review → review reason", () => {
   };
   assert.match(explainQuarantine(trust), /pending review/);
 });
+
+test("adapter: memory-worth half-life decays stale observations", () => {
+  // Review P2: TrustScore subsumes the memory-worth filter, so outcome decay
+  // must not be lost. With a half-life, a stale success-heavy memory should
+  // score lower (more decayed → lower confidence) than a fresh one.
+  const now = new Date("2026-07-01T00:00:00.000Z");
+  const fresh = buildTrustSignalMap(
+    [{ path: "fresh.md", frontmatter: { mw_success: 5, mw_fail: 1, lastAccessed: "2026-06-30" } }],
+    now,
+    { recencyHalfLifeDays: 7 },
+  );
+  const stale = buildTrustSignalMap(
+    [{ path: "stale.md", frontmatter: { mw_success: 5, mw_fail: 1, lastAccessed: "2025-01-01" } }],
+    now,
+    { recencyHalfLifeDays: 7 },
+  );
+  const freshWorth = fresh.get("fresh.md")?.memoryWorth;
+  const staleWorth = stale.get("stale.md")?.memoryWorth;
+  assert.ok(freshWorth, "fresh memory has worth signal");
+  assert.ok(staleWorth, "stale memory has worth signal");
+  // Fresh memory retains most of its confidence; stale memory's confidence
+  // is heavily decayed (much less than fresh).
+  assert.ok(
+    staleWorth!.confidence < freshWorth!.confidence,
+    "stale observations must decay → lower confidence than fresh",
+  );
+});
+
+test("adapter: no half-life → no decay (raw counters)", () => {
+  // Without a half-life, computeMemoryWorth uses raw counters — no decay.
+  // This is the pre-TrustScore behavior and must be preserved.
+  const now = new Date("2026-07-01T00:00:00.000Z");
+  const stale = buildTrustSignalMap(
+    [{ path: "old.md", frontmatter: { mw_success: 5, mw_fail: 1, lastAccessed: "2020-01-01" } }],
+    now,
+    {},
+  );
+  const worth = stale.get("old.md")?.memoryWorth;
+  assert.ok(worth);
+  // Without decay, 5/1 success-heavy → confidence ~6 (raw count).
+  assert.ok(worth!.confidence >= 5, "no half-life → raw confidence (no decay)");
+});

--- a/packages/remnic-core/src/trust-score-stage.test.ts
+++ b/packages/remnic-core/src/trust-score-stage.test.ts
@@ -8,7 +8,7 @@ import {
   projectTrustForXray,
   type TrustStageCandidate,
 } from "./trust-score-stage.js";
-import type { TrustScoreResult } from "./trust-score.js";
+import type { TrustScoreResult, TrustSignals } from "./trust-score.js";
 
 /**
  * Issue #1577 PR 2 — signal adapters + recall stage tests.
@@ -133,7 +133,7 @@ test("stage: empty candidate list → empty output", () => {
 // ─── multiplier application ───────────────────────────────────────────────
 
 test("stage: high-trust candidate is boosted, low-trust candidate is damped", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["high.md", { memoryWorth: { score: 0.95, confidence: 8 }, provenance: "verified", faithfulness: "entailed", corroborationCount: 4 }],
     ["low.md", { faithfulness: "unsupported" }],
   ]);
@@ -142,7 +142,7 @@ test("stage: high-trust candidate is boosted, low-trust candidate is damped", ()
       { path: "high.md", score: 5 },
       { path: "low.md", score: 5 },
     ],
-    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+    { signals: signals, minMultiplier: 0.5, maxMultiplier: 1.25 },
   );
   const high = out.admitted.find((x) => x.path === "high.md")!;
   const low = out.admitted.find((x) => x.path === "low.md")!;
@@ -152,7 +152,7 @@ test("stage: high-trust candidate is boosted, low-trust candidate is damped", ()
 });
 
 test("stage: reorder sorts admitted by descending multiplied score", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["boost.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
   ]);
   const out = applyTrustScoreStage(
@@ -160,7 +160,7 @@ test("stage: reorder sorts admitted by descending multiplied score", () => {
       { path: "plain.md", score: 8 },
       { path: "boost.md", score: 5 }, // low base but boosted
     ],
-    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25, reorder: true },
+    { signals: signals, minMultiplier: 0.5, maxMultiplier: 1.25, reorder: true },
   );
   // boost.md (5 * >1) vs plain.md (8 * 1). With a strong boost, boost.md may
   // overtake; either way the order must be descending by score.
@@ -173,7 +173,7 @@ test("stage: reorder sorts admitted by descending multiplied score", () => {
 });
 
 test("stage: reorder=false preserves input order", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["boost.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
   ]);
   const out = applyTrustScoreStage(
@@ -181,7 +181,7 @@ test("stage: reorder=false preserves input order", () => {
       { path: "plain.md", score: 8 },
       { path: "boost.md", score: 5 },
     ],
-    { signals: signals as never, reorder: false },
+    { signals: signals, reorder: false },
   );
   assert.deepEqual(
     out.admitted.map((x) => x.path),
@@ -192,7 +192,7 @@ test("stage: reorder=false preserves input order", () => {
 // ─── quarantine ───────────────────────────────────────────────────────────
 
 test("stage: quarantine excludes contradicted item from injection but keeps it in `all`", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["bad.md", { faithfulness: "contradicted" }],
   ]);
   const out = applyTrustScoreStage(
@@ -200,7 +200,7 @@ test("stage: quarantine excludes contradicted item from injection but keeps it i
       { path: "bad.md", score: 9 },
       { path: "good.md", score: 3 },
     ],
-    { signals: signals as never, quarantine: true },
+    { signals: signals, quarantine: true },
   );
   assert.equal(out.admitted.length, 1);
   assert.equal(out.admitted[0]!.path, "good.md");
@@ -212,12 +212,12 @@ test("stage: quarantine excludes contradicted item from injection but keeps it i
 });
 
 test("stage: quarantine=false keeps hard negatives in the injected set", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["bad.md", { faithfulness: "contradicted" }],
   ]);
   const out = applyTrustScoreStage(
     [{ path: "bad.md", score: 9 }],
-    { signals: signals as never, quarantine: false },
+    { signals: signals, quarantine: false },
   );
   assert.equal(out.admitted.length, 1);
   assert.equal(out.quarantined.length, 0);
@@ -229,12 +229,12 @@ test("stage: quarantine=false keeps hard negatives in the injected set", () => {
 test("stage: negative base score is clamped to 0 before multiplying", () => {
   // Mirrors memory-worth-filter.ts: a negative base would invert the
   // multiplier direction; clamp to 0 first.
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["hi.md", { memoryWorth: { score: 0.95, confidence: 5 } }],
   ]);
   const out = applyTrustScoreStage(
     [{ path: "hi.md", score: -2 }],
-    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+    { signals: signals, minMultiplier: 0.5, maxMultiplier: 1.25 },
   );
   const item = out.admitted[0]!;
   assert.equal(item.score, 0); // 0 * multiplier
@@ -250,12 +250,12 @@ test("double-multiplier prevention: stage applies trust once; neutral memory-wor
   // (which already incorporates memory-worth), so re-applying a memory-worth
   // multiplier on top would change the score — here we assert the stage's
   // multiplier equals trustMultiplier(trust.score) exactly.
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["mw.md", { memoryWorth: { score: 0.8, confidence: 4 } }],
   ]);
   const out = applyTrustScoreStage(
     [{ path: "mw.md", score: 10 }],
-    { signals: signals as never, minMultiplier: 0.5, maxMultiplier: 1.25 },
+    { signals: signals, minMultiplier: 0.5, maxMultiplier: 1.25 },
   );
   const item = out.admitted[0]!;
   // multiplier is a pure function of the trust score.
@@ -270,12 +270,12 @@ test("double-multiplier prevention: stage applies trust once; neutral memory-wor
 // ─── X-ray projection ─────────────────────────────────────────────────────
 
 test("xray projection: admitted item has no quarantineReason", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["ok.md", { memoryWorth: { score: 0.9, confidence: 3 } }],
   ]);
   const out = applyTrustScoreStage(
     [{ path: "ok.md", score: 5 }],
-    { signals: signals as never },
+    { signals: signals },
   );
   const proj = projectTrustForXray(out.admitted[0]!);
   assert.equal(proj.quarantined, false);
@@ -285,12 +285,12 @@ test("xray projection: admitted item has no quarantineReason", () => {
 });
 
 test("xray projection: quarantined item carries a deterministic reason", () => {
-  const signals = new Map<string, unknown>([
+  const signals = new Map<string, TrustSignals>([
     ["bad.md", { faithfulness: "contradicted" }],
   ]);
   const out = applyTrustScoreStage(
     [{ path: "bad.md", score: 5 }],
-    { signals: signals as never },
+    { signals: signals },
   );
   const proj = projectTrustForXray(out.quarantined[0]!);
   assert.equal(proj.quarantined, true);

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -82,7 +82,13 @@ export function buildTrustSignalMap(
     }
 
     if (fm.provenance !== undefined) signals.provenance = fm.provenance;
-    if (fm.faithfulness !== undefined) signals.faithfulness = fm.faithfulness.verdict;
+    if (fm.faithfulness !== undefined) {
+      // `skipped_no_span` (legacy fact lacking a verified source span) carries
+      // no entailment signal — collapse it to `unchecked` so the scorer treats
+      // it as the neutral "no verdict" case rather than a hard negative.
+      signals.faithfulness =
+        fm.faithfulness.verdict === "skipped_no_span" ? "unchecked" : fm.faithfulness.verdict;
+    }
 
     // Corroboration = distinct source sessions/turns backing the fact.
     if (Array.isArray(fm.sources) && fm.sources.length > 0) {
@@ -277,3 +283,108 @@ export function explainQuarantine(trust: TrustScoreResult): string {
   return "hard-negative trust signal";
 }
 
+
+// ─── Recall-stage signal builder (I/O orchestration) ──────────────────────
+
+/**
+ * Narrow callbacks the signal builder needs from its host (the orchestrator).
+ * Kept as interfaces so the module stays pure-testable: the host binds
+ * `getStorage` / `readQmdResultMemory` into these and the builder owns cache
+ * management, namespace iteration, and the cold-tier direct fallback.
+ */
+export interface TrustScoreRerankDeps {
+  /** Read every memory in a namespace for the hot-tier signal scan. */
+  readNamespaceMemories(
+    namespace: string,
+  ): Promise<ReadonlyArray<{ path: string; frontmatter: TrustFrontmatterProjection }>>;
+  /** Read one memory's frontmatter by path (cold-tier direct fallback). */
+  readMemoryFrontmatter(path: string): Promise<TrustFrontmatterProjection | null>;
+}
+
+/** Per-namespace signal cache the host owns and the builder mutates. */
+export interface TrustScoreSignalCache {
+  cache: Map<string, { at: number; signals: ReadonlyMap<string, TrustSignals> }>;
+  ttlMs: number;
+}
+
+/**
+ * Build the `path → TrustSignals` map for recall candidates using a
+ * per-namespace cache plus a direct-path fallback for cold-tier candidates
+ * absent from the hot scan. Extracted from the orchestrator (issue #1577) so
+ * the god file carries only thin wiring — the scoring itself is
+ * {@link applyTrustScoreStage}.
+ *
+ * Fail-open: a single unreadable namespace or memory is logged and skipped so
+ * a storage hiccup never breaks recall (mirrors `memory-worth-filter.ts`).
+ */
+export async function buildTrustSignalsForRerank(
+  candidatePaths: readonly string[],
+  namespaces: readonly string[],
+  deps: TrustScoreRerankDeps,
+  signalCache: TrustScoreSignalCache,
+  now: Date,
+  options: {
+    recencyHalfLifeDays?: number;
+    logDebug?: (message: string, context: Record<string, unknown>) => void;
+  } = {},
+): Promise<Map<string, TrustSignals>> {
+  const nowMs = now.getTime();
+  const logDebug = options.logDebug ?? (() => {});
+  const signals = new Map<string, TrustSignals>();
+
+  // Evict expired cache entries (mirrors the worth-cache discipline).
+  for (const [key, entry] of signalCache.cache) {
+    if (nowMs - entry.at >= signalCache.ttlMs) signalCache.cache.delete(key);
+  }
+
+  // Per-namespace hot scan with cache.
+  const seenNamespaces = new Set<string>();
+  for (const ns of namespaces) {
+    if (seenNamespaces.has(ns)) continue;
+    seenNamespaces.add(ns);
+    try {
+      const cached = signalCache.cache.get(ns);
+      let nsMap: ReadonlyMap<string, TrustSignals> | undefined;
+      if (cached && nowMs - cached.at < signalCache.ttlMs) {
+        nsMap = cached.signals;
+      } else {
+        const memories = await deps.readNamespaceMemories(ns);
+        nsMap = buildTrustSignalMap(memories, now, {
+          recencyHalfLifeDays: options.recencyHalfLifeDays,
+        });
+        signalCache.cache.set(ns, { at: nowMs, signals: nsMap });
+      }
+      for (const [path, s] of nsMap) signals.set(path, s);
+    } catch (err) {
+      logDebug("trust-score: failed to read namespace, skipping", {
+        namespace: ns,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // Direct per-path fallback for cold-tier candidates absent from the hot scan.
+  const missing = candidatePaths.filter((p) => !signals.has(p));
+  if (missing.length > 0) {
+    const fallbackMemories: Array<{ path: string; frontmatter: TrustFrontmatterProjection }> = [];
+    for (const path of missing) {
+      try {
+        const frontmatter = await deps.readMemoryFrontmatter(path);
+        if (frontmatter) fallbackMemories.push({ path, frontmatter });
+      } catch (err) {
+        logDebug("trust-score: direct path lookup failed", {
+          path,
+          error: (err as Error).message,
+        });
+      }
+    }
+    if (fallbackMemories.length > 0) {
+      const fallbackSignals = buildTrustSignalMap(fallbackMemories, now, {
+        recencyHalfLifeDays: options.recencyHalfLifeDays,
+      });
+      for (const [path, s] of fallbackSignals) signals.set(path, s);
+    }
+  }
+
+  return signals;
+}

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -72,11 +72,19 @@ export function buildTrustSignalMap(
     // Memory worth — reuse the exact Laplace computation the standalone filter
     // uses so the two never disagree on the same counters.
     if (fm.mw_success !== undefined || fm.mw_fail !== undefined) {
+      // Pass the half-life through so outcome counters decay at the same
+      // rate as the standalone memory-worth filter (review P2: TrustScore
+      // subsumes the filter, so decay must not be lost). Convert days → ms.
+      const halfLifeMs =
+        options.recencyHalfLifeDays !== undefined
+          ? options.recencyHalfLifeDays * 86_400_000
+          : undefined;
       const worth = computeMemoryWorth({
         mw_success: fm.mw_success,
         mw_fail: fm.mw_fail,
         lastAccessed: fm.lastAccessed,
         now,
+        halfLifeMs,
       });
       signals.memoryWorth = { score: worth.score, confidence: worth.confidence };
     }

--- a/packages/remnic-core/src/trust-score-stage.ts
+++ b/packages/remnic-core/src/trust-score-stage.ts
@@ -1,0 +1,279 @@
+/**
+ * trust-score-stage.ts — signal adapters + recall pipeline stage (issue #1577 PR 2).
+ *
+ * This module sits between the pure {@link computeTrustScore} scorer and the
+ * recall pipeline. It owns TWO jobs:
+ *
+ *   1. **Signal adapters** — read each trust signal via existing readers only
+ *      (`buildMemoryWorthCounterMap`-style frontmatter scan, faithfulness /
+ *      provenance / sources frontmatter from #1575/#1576). No new disk format,
+ *      no new write path. Expensive / optional signals (belief-ledger domain
+ *      calibration, contradiction review queue) are extension points that
+ *      return `undefined` when unwired — the scorer degrades to neutral for
+ *      any absent signal (rule 34).
+ *
+ *   2. **The recall stage** — apply `trustMultiplier(trust.score)` to each
+ *      candidate, exclude `quarantine`-band items from injection, and surface
+ *      the per-result `{ score, band, components }` so X-ray and the epistemic
+ *      renderer can explain the basis.
+ *
+ * Mutual exclusion with the Memory Worth filter (rule 39 — one multiplier, one
+ * application point): when this stage runs, the standalone memory-worth filter
+ * MUST NOT also run. The orchestrator enforces that at the wiring site
+ * (`if (caps.recallTrustScore) … else if (caps.recallMemoryWorthFilter) …`);
+ * the `double-multiplier` test below pins it structurally.
+ */
+
+import { computeMemoryWorth } from "./memory-worth.js";
+import {
+  computeTrustScore,
+  trustMultiplier,
+  type TrustBand,
+  type TrustScoreComponent,
+  type TrustScoreResult,
+  type TrustSignals,
+  type TrustWeights,
+} from "./trust-score.js";
+import type { FaithfulnessFrontmatter, ProvenanceSource } from "./types.js";
+
+/**
+ * Frontmatter projection the adapter reads. Kept narrow + structural so it can
+ * be fed from a `MemoryFrontmatter`, a bench fixture, or a test stub without
+ * pulling the full frontmatter type graph into the stage module.
+ */
+export interface TrustFrontmatterProjection {
+  mw_success?: number;
+  mw_fail?: number;
+  lastAccessed?: string | null;
+  provenance?: "verified" | "unverified" | "none";
+  faithfulness?: FaithfulnessFrontmatter;
+  sources?: ProvenanceSource[];
+  /** Optional ISO creation/observation timestamp used for recency. */
+  observedAt?: string;
+}
+
+/**
+ * Build a `path → TrustSignals` map from an in-memory frontmatter scan. The
+ * caller passes the memories already read for the memory-worth counter map so
+ * we do not re-read the namespace. Pure: no I/O, takes `now` explicitly.
+ */
+export function buildTrustSignalMap(
+  memories: ReadonlyArray<{ path: string; frontmatter: TrustFrontmatterProjection }>,
+  now: Date,
+  options: { recencyHalfLifeDays?: number } = {},
+): Map<string, TrustSignals> {
+  const map = new Map<string, TrustSignals>();
+  const nowMs = now.getTime();
+  const nowUsable = Number.isFinite(nowMs);
+  for (const m of memories) {
+    const fm = m.frontmatter;
+    const signals: TrustSignals = {};
+
+    // Memory worth — reuse the exact Laplace computation the standalone filter
+    // uses so the two never disagree on the same counters.
+    if (fm.mw_success !== undefined || fm.mw_fail !== undefined) {
+      const worth = computeMemoryWorth({
+        mw_success: fm.mw_success,
+        mw_fail: fm.mw_fail,
+        lastAccessed: fm.lastAccessed,
+        now,
+      });
+      signals.memoryWorth = { score: worth.score, confidence: worth.confidence };
+    }
+
+    if (fm.provenance !== undefined) signals.provenance = fm.provenance;
+    if (fm.faithfulness !== undefined) signals.faithfulness = fm.faithfulness.verdict;
+
+    // Corroboration = distinct source sessions/turns backing the fact.
+    if (Array.isArray(fm.sources) && fm.sources.length > 0) {
+      const distinct = new Set(
+        fm.sources.map((s) => `${s.sessionKey ?? ""}|${s.turnId ?? ""}`),
+      );
+      signals.corroborationCount = distinct.size;
+    }
+
+    // Recency: prefer an explicit observation timestamp; fall back to
+    // lastAccessed. Days-old vs the per-category half-life the caller supplies.
+    const ts = fm.observedAt ?? fm.lastAccessed;
+    if (nowUsable && typeof ts === "string" && ts.length > 0) {
+      const parsed = Date.parse(ts);
+      if (Number.isFinite(parsed)) {
+        const ageDays = Math.max(0, (nowMs - parsed) / (24 * 60 * 60 * 1000));
+        signals.ageDays = ageDays;
+        if (options.recencyHalfLifeDays !== undefined) {
+          signals.recencyHalfLifeDays = options.recencyHalfLifeDays;
+        }
+      }
+    }
+
+    // Only record an entry when at least one signal is present — a fully-empty
+    // entry would score neutral anyway, and skipping keeps the map small.
+    if (Object.keys(signals).length > 0) {
+      map.set(m.path, signals);
+    }
+  }
+  return map;
+}
+
+/** A scored recall candidate (mirrors `MemoryWorthFilterCandidate`). */
+export interface TrustStageCandidate {
+  path: string;
+  score: number;
+}
+
+/** One candidate after the TrustScore stage. */
+export interface TrustStageResultItem {
+  path: string;
+  /** Final score after the trust multiplier is applied. */
+  score: number;
+  /** The untouched input score — for telemetry / X-ray. */
+  originalScore: number;
+  /** The multiplier applied (exactly `1.0` for neutral / quarantined-kept). */
+  multiplier: number;
+  /** The full TrustScore result for X-ray + epistemic rendering. */
+  trust: TrustScoreResult;
+  /** `true` when the item was excluded from injection by quarantine. */
+  quarantined: boolean;
+}
+
+export interface TrustStageOptions {
+  /** `path → TrustSignals`. Candidates absent from the map score neutral. */
+  signals: ReadonlyMap<string, TrustSignals>;
+  weights?: TrustWeights;
+  /** Multiplier bounds; see {@link trustMultiplier}. */
+  minMultiplier?: number;
+  maxMultiplier?: number;
+  /**
+   * When `true` (default), `quarantine`-band items are excluded from the
+   * returned (injected) list but still appear in {@link TrustStageOutput.all}
+   * with `quarantined: true` so X-ray can surface them with a reason.
+   * Only effective when the stage is active at all.
+   */
+  quarantine?: boolean;
+  /**
+   * Re-sort admitted candidates by descending multiplied score. Default `true`.
+   * When `false`, admitted items keep input order; quarantined items are still
+   * separated out.
+   */
+  reorder?: boolean;
+}
+
+/** Output of {@link applyTrustScoreStage}. */
+export interface TrustStageOutput {
+  /** Admitted (injectable) candidates, score-multiplied and optionally sorted. */
+  admitted: TrustStageResultItem[];
+  /**
+   * Quarantined candidates — excluded from injection but visible to X-ray with
+   * the reason (rule 34 — exclusion must never look like "no result"). Callers
+   * that only need the injected list read `admitted`; X-ray reads `all`.
+   */
+  quarantined: TrustStageResultItem[];
+  /** Every candidate (admitted + quarantined) in input order, for X-ray. */
+  all: TrustStageResultItem[];
+}
+
+/**
+ * Apply the unified TrustScore stage: score each candidate, multiply its base
+ * score by `trustMultiplier(trust.score)`, and separate hard-negative
+ * (quarantine) items from the injectable set.
+ *
+ * Neutral candidates (no signals → multiplier `1.0`) are mathematically
+ * untouched, preserving byte-identical ranking for uninstrumented memories
+ * when the feature is ON (and the whole stage is skipped when OFF — rule 39).
+ */
+export function applyTrustScoreStage(
+  candidates: readonly TrustStageCandidate[],
+  options: TrustStageOptions,
+): TrustStageOutput {
+  const reorder = options.reorder !== false;
+  const quarantine = options.quarantine !== false;
+  const minMul = options.minMultiplier;
+  const maxMul = options.maxMultiplier;
+
+  const all: TrustStageResultItem[] = [];
+  const admitted: TrustStageResultItem[] = [];
+  const quarantined: TrustStageResultItem[] = [];
+
+  for (let i = 0; i < candidates.length; i += 1) {
+    const c = candidates[i]!;
+    const signals = options.signals.get(c.path);
+    const trust = computeTrustScore(signals, options.weights);
+    const isQuarantined = quarantine && trust.band === "quarantine";
+    // Quarantined items are excluded from injection. Keep their score unchanged
+    // so X-ray shows what the pipeline WOULD have injected — never inflate or
+    // zero the score of a hidden item (rule 34).
+    const multiplier = isQuarantined ? 1 : trustMultiplier(trust.score, minMul, maxMul);
+    // Clamp the base score at zero before multiplying, mirroring the
+    // memory-worth filter: a negative base would invert the multiplier's
+    // intended direction (see memory-worth-filter.ts:145-153).
+    const safeBase = c.score < 0 ? 0 : c.score;
+    const scored = safeBase * multiplier;
+    const item: TrustStageResultItem = {
+      path: c.path,
+      score: scored,
+      originalScore: c.score,
+      multiplier,
+      trust,
+      quarantined: isQuarantined,
+    };
+    all.push(item);
+    if (isQuarantined) quarantined.push(item);
+    else admitted.push(item);
+  }
+
+  if (reorder) {
+    // Stable sort by descending multiplied score, with original input position
+    // as the deterministic tiebreaker (CLAUDE.md rule 19 / checklist §12).
+    admitted.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Tiebreaker: original insertion order. We don't have the index handy on
+      // the item, so derive it from `all` ordering (input order is preserved
+      // there). Equal-score items keep first-seen-first order.
+      return 0;
+    });
+    // Node's sort is stable (ES2019+); the explicit `return 0` documents the
+    // contract for reviewers.
+  }
+
+  return { admitted, quarantined, all };
+}
+
+/**
+ * Compact X-ray projection of one stage item. Kept separate from the full
+ * `TrustScoreResult` so the X-ray snapshot type stays narrow and serializable,
+ * and so the renderer never depends on the scorer's internal component map
+ * shape beyond `{ value, weight }`.
+ */
+export interface TrustXrayProjection {
+  score: number;
+  band: TrustBand;
+  components: Record<string, TrustScoreComponent>;
+  multiplier: number;
+  quarantined: boolean;
+  /** Human-readable exclusion reason, present only when quarantined. */
+  quarantineReason?: string;
+}
+
+/** Build the X-ray projection for one stage result item. */
+export function projectTrustForXray(item: TrustStageResultItem): TrustXrayProjection {
+  const proj: TrustXrayProjection = {
+    score: item.trust.score,
+    band: item.trust.band,
+    components: item.trust.components,
+    multiplier: item.multiplier,
+    quarantined: item.quarantined,
+  };
+  if (item.quarantined) {
+    proj.quarantineReason = explainQuarantine(item.trust);
+  }
+  return proj;
+}
+
+/** Deterministic, component-derived reason a memory was quarantined. */
+export function explainQuarantine(trust: TrustScoreResult): string {
+  const c = trust.components;
+  if (c.faithfulness && c.faithfulness.value === 0) return "faithfulness: contradicted";
+  if (c.contradiction && c.contradiction.value <= 0.2) return "contradiction: pending review";
+  return "hard-negative trust signal";
+}
+

--- a/packages/remnic-core/src/trust-score.test.ts
+++ b/packages/remnic-core/src/trust-score.test.ts
@@ -234,3 +234,49 @@ test("disabled weight: zero-weight component does not contribute to blend", () =
   assert.equal(result.components.memoryWorth?.weight, 0, "zero-weight component echoed with weight 0");
   assert.ok(result.components.provenance?.weight > 0, "active component has non-zero weight");
 });
+
+// ─── Issue #1577 — scoring edges (review Oqg_0 / Op_0X / Op_0b) ─────────────
+
+test("unchecked faithfulness as the ONLY signal → truly neutral (absent, not active 0.5)", () => {
+  // Review Oqg_0: "unchecked" means the gate ran but could not verify — it
+  // carries NO signal. A memory whose ONLY signal is unchecked faithfulness
+  // must score the neutral prior (neutral: true), NOT "active 0.5", so the
+  // epistemic hedge never spuriously fires on an unverifiable memory and the
+  // component never masquerades as measured evidence.
+  const result = computeTrustScore({ faithfulness: "unchecked" });
+  assert.equal(result.neutral, true, "unchecked-only must be truly neutral");
+  assert.equal(result.score, NEUTRAL_TRUST_SCORE);
+  assert.equal(result.band, "medium");
+  assert.equal(Object.keys(result.components).length, 0, "unchecked must not appear as a component");
+  assert.equal(renderEpistemicHedge(result), "", "no hedge on an unverifiable memory");
+});
+
+test("unchecked faithfulness mixed with another signal → dropped (does not dilute)", () => {
+  // When unchecked co-occurs with a real signal, unchecked is ABSENT (not a
+  // neutral 0.5 component pulling toward the middle). The memory scores purely
+  // on the present signal — identical to a memory that never had a faithfulness
+  // verdict at all.
+  const withUnchecked = computeTrustScore({ faithfulness: "unchecked", provenance: "verified" });
+  const justVerified = computeTrustScore({ provenance: "verified" });
+  assert.equal(withUnchecked.score, justVerified.score, "unchecked must not dilute a present signal");
+  assert.equal(withUnchecked.components.faithfulness, undefined, "unchecked dropped from components");
+  assert.ok(withUnchecked.components.provenance !== undefined, "verified provenance present");
+});
+
+test("disabled weight is neutral across all recall paths: present+disabled vs absent", () => {
+  // Review Op_0X: a disabled (weight 0) component must be neutral, not damning.
+  // A memory with provenance=verified AND a zero-weight memoryWorth signal must
+  // score identically to a memory with provenance=verified alone — the disabled
+  // component contributes nothing and the active one is sum-normalized to 1.0.
+  const disabled = computeTrustScore(
+    { memoryWorth: { score: 0.1, confidence: 5 }, provenance: "verified" },
+    { memoryWorth: 0, provenance: 1, faithfulness: 1 },
+  );
+  const absent = computeTrustScore(
+    { provenance: "verified" },
+    { memoryWorth: 0, provenance: 1, faithfulness: 1 },
+  );
+  assert.equal(disabled.score, absent.score, "disabled-weight signal must be neutral (== absent)");
+  assert.equal(disabled.components.memoryWorth?.weight, 0, "disabled component echoed with weight 0");
+  assert.equal(disabled.components.provenance?.weight, 1, "sole active component normalizes to full weight");
+});

--- a/packages/remnic-core/src/trust-score.test.ts
+++ b/packages/remnic-core/src/trust-score.test.ts
@@ -206,3 +206,31 @@ test("epistemic hedge: medium band → names a single weakness", () => {
   // Always deterministic.
   assert.equal(renderEpistemicHedge(medium), hedge);
 });
+
+test("disabled weight: zero-weight-only-signal falls back to neutral, not low", () => {
+  // Review P2: when an operator sets a component weight to 0 to disable it,
+  // and a memory has only that signal, the score must NOT collapse to 0 (low
+  // band). It should be neutral — a disabled signal carries no information.
+  const result = computeTrustScore(
+    { memoryWorth: { score: 0.9, confidence: 5 } },
+    { memoryWorth: 0, provenance: 1, faithfulness: 1 },
+  );
+  assert.equal(result.neutral, true, "zero-weight-only-signal must be neutral");
+  assert.equal(result.score, NEUTRAL_TRUST_SCORE);
+  assert.equal(result.band, "medium");
+  assert.equal(Object.keys(result.components).length, 0);
+});
+
+test("disabled weight: zero-weight component does not contribute to blend", () => {
+  // When a component has weight 0 but other components are active, the active
+  // ones still score normally. The zero-weight component stays in the echo
+  // (with weight 0) for explainability but contributes nothing to the blend.
+  const result = computeTrustScore(
+    { memoryWorth: { score: 0.9, confidence: 5 }, provenance: "verified" },
+    { memoryWorth: 0, provenance: 1, faithfulness: 1 },
+  );
+  assert.equal(result.neutral, false);
+  assert.ok(result.score > NEUTRAL_TRUST_SCORE, "verified provenance should boost");
+  assert.equal(result.components.memoryWorth?.weight, 0, "zero-weight component echoed with weight 0");
+  assert.ok(result.components.provenance?.weight > 0, "active component has non-zero weight");
+});

--- a/packages/remnic-core/src/trust-score.test.ts
+++ b/packages/remnic-core/src/trust-score.test.ts
@@ -1,0 +1,208 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_TRUST_WEIGHTS,
+  NEUTRAL_TRUST_SCORE,
+  TRUST_BAND_THRESHOLDS,
+  bandForScore,
+  computeTrustScore,
+  renderEpistemicHedge,
+  resolveTrustWeights,
+  trustMultiplier,
+  type TrustSignals,
+} from "./trust-score.js";
+
+/**
+ * Issue #1577 PR 1 — unit tests for the pure TrustScore module.
+ *
+ * Pins the contract rules from the module header:
+ *   1. No signals → neutral (0.5, medium, multiplier 1.0).
+ *   2. Corrupt / out-of-range component → that component collapses to neutral.
+ *   3. Deterministic.
+ *   4. Components echoed for explainability.
+ *   5. quarantine reserved for hard negatives.
+ * Plus monotonicity: more corroboration → ≥ score; contradicted → ≤ score.
+ */
+
+test("no signals → neutral prior (score 0.5, band medium, neutral flag)", () => {
+  const r = computeTrustScore({});
+  assert.equal(r.score, NEUTRAL_TRUST_SCORE);
+  assert.equal(r.band, "medium");
+  assert.equal(r.neutral, true);
+  assert.deepEqual(r.components, {});
+  // The multiplier derived from a neutral score is exactly 1.0.
+  assert.equal(trustMultiplier(r.score), 1);
+});
+
+test("neutral multiplier is exactly 1.0 at score 0.5", () => {
+  assert.equal(trustMultiplier(0.5), 1);
+});
+
+test("multiplier is bounded by [min, max] and monotonic in score", () => {
+  // score 0 → min, score 1 → max, strictly increasing through 0.5=1.
+  assert.equal(trustMultiplier(0, 0.5, 1.25), 0.5);
+  assert.equal(trustMultiplier(1, 0.5, 1.25), 1.25);
+  assert.equal(trustMultiplier(0.5, 0.5, 1.25), 1);
+  // Monotonic non-decreasing across the range.
+  let prev = -Infinity;
+  for (let i = 0; i <= 20; i += 1) {
+    const s = i / 20;
+    const m = trustMultiplier(s, 0.5, 1.25);
+    assert.ok(m >= prev - 1e-12, `multiplier not monotonic at ${s}`);
+    prev = m;
+  }
+});
+
+test("multiplier stays in bounds when given an inverted (min>max) contract", () => {
+  // Defensive: pick the tighter bound rather than producing nonsense.
+  const m = trustMultiplier(0.2, 1.25, 0.5);
+  assert.ok(m >= 0.5 - 1e-9 && m <= 1.25 + 1e-9);
+});
+
+test("monotonicity: more corroboration → score does not decrease", () => {
+  const base: TrustSignals = { corroborationCount: 1 };
+  const more: TrustSignals = { corroborationCount: 5 };
+  const a = computeTrustScore(base);
+  const b = computeTrustScore(more);
+  assert.ok(b.score >= a.score - 1e-12, "more corroboration must not lower the score");
+});
+
+test("monotonicity: contradicted faithfulness → score <= unchecked", () => {
+  const unchecked = computeTrustScore({ faithfulness: "unchecked" });
+  const contradicted = computeTrustScore({ faithfulness: "contradicted" });
+  assert.ok(
+    contradicted.score <= unchecked.score + 1e-12,
+    "contradicted must not out-score unchecked",
+  );
+});
+
+test("contradicted faithfulness forces the quarantine band", () => {
+  const r = computeTrustScore({ faithfulness: "contradicted" });
+  assert.equal(r.band, "quarantine");
+});
+
+test("pending_review contradiction forces the quarantine band", () => {
+  const r = computeTrustScore({ contradiction: "pending_review" });
+  assert.equal(r.band, "quarantine");
+});
+
+test("corrupt component collapses to neutral, never to an extreme", () => {
+  // NaN domainCalibration must not push the score to 0 or 1.
+  const r = computeTrustScore({ domainCalibration: NaN });
+  // Only one component present and it is corrupt → neutral prior.
+  assert.equal(r.neutral, true);
+  assert.equal(r.score, NEUTRAL_TRUST_SCORE);
+});
+
+test("corrupt corroborationCount (negative / NaN) is dropped, not damning", () => {
+  const rNegative = computeTrustScore({ corroborationCount: -3 });
+  const rNaN = computeTrustScore({ corroborationCount: NaN });
+  assert.equal(rNegative.neutral, true);
+  assert.equal(rNaN.neutral, true);
+});
+
+test("weights: invalid weight rejected, valid override applied", () => {
+  const resolved = resolveTrustWeights({ memoryWorth: 0.9, faithfulness: NaN });
+  assert.equal(resolved.memoryWorth, 0.9);
+  // NaN faithfulness falls back to the documented default, not NaN.
+  assert.equal(resolved.faithfulness, DEFAULT_TRUST_WEIGHTS.faithfulness);
+});
+
+test("weights: out-of-range weight rejected", () => {
+  const resolved = resolveTrustWeights({ provenance: 5 });
+  assert.equal(resolved.provenance, DEFAULT_TRUST_WEIGHTS.provenance);
+});
+
+test("active weights are sum-normalized so absent components redistribute", () => {
+  // Only memoryWorth present → it carries 100% of the weight.
+  const r = computeTrustScore({ memoryWorth: { score: 1, confidence: 5 } });
+  assert.ok(r.components.memoryWorth);
+  assert.ok(Math.abs(r.components.memoryWorth.weight - 1) < 1e-12);
+  assert.ok(Math.abs(r.score - 1) < 1e-12);
+});
+
+test("components are echoed for explainability", () => {
+  const r = computeTrustScore({
+    memoryWorth: { score: 0.9, confidence: 3 },
+    provenance: "verified",
+  });
+  assert.ok(r.components.memoryWorth);
+  assert.ok(r.components.provenance);
+  // Each component carries value + weight.
+  for (const c of Object.values(r.components)) {
+    assert.ok(typeof c.value === "number" && c.value >= 0 && c.value <= 1);
+    assert.ok(typeof c.weight === "number" && c.weight >= 0 && c.weight <= 1);
+  }
+});
+
+test("determinism: same inputs → identical result (twice)", () => {
+  const signals: TrustSignals = {
+    memoryWorth: { score: 0.8, confidence: 4 },
+    provenance: "verified",
+    faithfulness: "entailed",
+    corroborationCount: 3,
+  };
+  const a = computeTrustScore(signals);
+  const b = computeTrustScore(signals);
+  assert.deepEqual(a, b);
+});
+
+test("band thresholds map scores to the documented bands", () => {
+  assert.equal(bandForScore(0.9, false), "high");
+  assert.equal(bandForScore(0.7, false), "high");
+  assert.equal(bandForScore(0.69, false), "medium");
+  assert.equal(bandForScore(0.45, false), "medium");
+  assert.equal(bandForScore(0.3, false), "low");
+  assert.equal(bandForScore(0.1, false), "low");
+  // Hard negative overrides the score-derived band.
+  assert.equal(bandForScore(0.95, true), "quarantine");
+});
+
+test("band thresholds constant matches the band mapping", () => {
+  assert.equal(TRUST_BAND_THRESHOLDS.high, 0.7);
+  assert.equal(TRUST_BAND_THRESHOLDS.medium, 0.45);
+});
+
+// ─── Epistemic rendering ──────────────────────────────────────────────────
+
+test("epistemic hedge: neutral and high → empty string (no token waste)", () => {
+  const neutral = computeTrustScore({});
+  assert.equal(renderEpistemicHedge(neutral), "");
+  const high = computeTrustScore({
+    memoryWorth: { score: 1, confidence: 10 },
+    provenance: "verified",
+    faithfulness: "entailed",
+    corroborationCount: 4,
+  });
+  assert.equal(high.band, "high");
+  assert.equal(renderEpistemicHedge(high), "");
+});
+
+test("epistemic hedge: low band → non-empty, deterministic hedge", () => {
+  const low = computeTrustScore({ faithfulness: "unsupported" });
+  const hedge = renderEpistemicHedge(low);
+  assert.ok(hedge.length > 0);
+  assert.ok(hedge.startsWith("(low confidence"));
+  // Deterministic.
+  assert.equal(renderEpistemicHedge(low), hedge);
+});
+
+test("epistemic hedge: quarantine band → names the hard negative", () => {
+  const q = computeTrustScore({ faithfulness: "contradicted" });
+  const hedge = renderEpistemicHedge(q);
+  assert.ok(hedge.length > 0);
+  assert.match(hedge, /contradicted/);
+});
+
+test("epistemic hedge: medium band → names a single weakness", () => {
+  const medium = computeTrustScore({ corroborationCount: 1 });
+  // single mention alone lands around neutral-ish; force medium by checking it
+  // produced a hedge only when band is medium/low. Verify determinism either way.
+  const hedge = renderEpistemicHedge(medium);
+  if (medium.band === "medium") {
+    assert.ok(hedge.startsWith("(unconfirmed"));
+  }
+  // Always deterministic.
+  assert.equal(renderEpistemicHedge(medium), hedge);
+});

--- a/packages/remnic-core/src/trust-score.ts
+++ b/packages/remnic-core/src/trust-score.ts
@@ -191,11 +191,17 @@ function provenanceValue(tag: TrustSignals["provenance"]): number | undefined {
   return undefined;
 }
 
-/** Map a faithfulness verdict to a `[0,1]` contribution. Absent → neutral. */
+/** Map a faithfulness verdict to a `[0,1]` contribution. Absent → dropped. */
 function faithfulnessValue(verdict: TrustSignals["faithfulness"]): number | undefined {
   if (verdict === undefined) return undefined;
   if (verdict === "entailed") return 1;
-  if (verdict === "unchecked") return NEUTRAL_TRUST_SCORE;
+  // "unchecked" means the gate ran but could not verify — it carries NO signal.
+  // Return undefined (absent) so a memory whose ONLY signal is unchecked
+  // faithfulness scores truly neutral, not "active 0.5". This stops the
+  // epistemic hedge from spuriously firing on unverifiable memories (review
+  // Oqg_0: unchecked-as-absent for hedging) and stops the component from
+  // masquerading as measured evidence.
+  if (verdict === "unchecked") return undefined;
   if (verdict === "unsupported") return 0.35;
   // "contradicted" is a hard negative — it also forces quarantine (see below),
   // but as a component it contributes 0 so the blended score sinks.

--- a/packages/remnic-core/src/trust-score.ts
+++ b/packages/remnic-core/src/trust-score.ts
@@ -1,0 +1,446 @@
+/**
+ * trust-score.ts — unified TrustScore pure module (issue #1577 PR 1).
+ *
+ * Combines the trust-relevant signals Remnic already computes — memory worth
+ * (Laplace-smoothed outcome probability + recency decay), provenance strength,
+ * faithfulness verdict, corroboration count, contradiction status, and optional
+ * domain calibration — into ONE deterministic score in `[0, 1]` plus a band
+ * (`high` / `medium` / `low` / `quarantine`) and a fully-explained component
+ * breakdown for X-ray.
+ *
+ * Contract rules (mirror the battle-tested `memory-worth.ts` "corrupt inputs
+ * fail safely" header — read it before changing anything here):
+ *
+ *   1. **No signals → neutral.** An empty `TrustSignals` yields score `0.5`,
+ *      band `medium`, and a recall multiplier of exactly `1.0`. Uninstrumented
+ *      memories are NEVER penalized (rule 39 — byte-identical ranking when the
+ *      feature is off; neutral prior when on but a memory has no data).
+ *   2. **Corrupt / out-of-range component → that component collapses to
+ *      neutral**, never to an extreme. A `NaN` weight or a `corroborationCount`
+ *      of `-3` is treated as "no signal", not as damning evidence. Precedent:
+ *      `memory-worth.ts` `classifyCounter`.
+ *   3. **Deterministic.** Same inputs → identical result. All weights come from
+ *      the caller (config); no wall clock, no RNG, no hidden constants.
+ *   4. **Explainable.** Every active component is echoed in the result with its
+ *      normalized weight and contribution, so X-ray can render the basis
+ *      without re-deriving the math.
+ *   5. **`quarantine` is reserved for hard negatives** — `faithfulness:
+ *      "contradicted"` or `contradiction: "pending_review"`. Quarantined items
+ *      are excluded from injection but MUST stay visible in X-ray with the
+ *      reason (rule 34 — exclusion must never look like "no result").
+ *
+ * This module is deliberately framework-free: it takes already-collected
+ * signals and config weights, returns a score. The signal ADAPTERS (reading
+ * frontmatter / counters / review queues) live in `trust-score-stage.ts` so
+ * this file stays pure and trivially property-testable.
+ */
+
+/**
+ * Per-component weights. Every field is optional and defaults to the
+ * `DEFAULT_TRUST_WEIGHTS` value; the caller passes the config-resolved object.
+ * Weights are sum-normalized at score time, so their absolute scale is
+ * irrelevant — only their relative magnitudes matter (rule 51: invalid weight
+ * rejected at config parse, here we only defend against runtime corruption).
+ */
+export interface TrustWeights {
+  /** Laplace-smoothed outcome probability (memory worth `score`). */
+  memoryWorth?: number;
+  /** Provenance strength tag mapped to `[0,1]` (verified→1, unverified→0.5, none→neutral). */
+  provenance?: number;
+  /** Faithfulness verdict mapped to `[0,1]` (entailed→1, unchecked→neutral, contradicted→0). */
+  faithfulness?: number;
+  /** Independent corroboration count, log-saturated. */
+  corroboration?: number;
+  /** Contradiction review status (pending_review / resolved_superseded push toward 0). */
+  contradiction?: number;
+  /** Belief-ledger per-domain accuracy calibration (`0..1`), when available. */
+  domainCalibration?: number;
+  /** Feedback balance (thumbs up/down), when available. */
+  feedback?: number;
+  /** Recency vs per-category half-life (newer → higher). */
+  recency?: number;
+}
+
+/**
+ * Default per-component weights. Chosen so that, with all signals at neutral,
+ * the score is exactly `0.5`. Sum-normalized at compute time. These are the
+ * documented defaults; operators override via `trustScore.weights.*` config.
+ */
+export const DEFAULT_TRUST_WEIGHTS: Required<TrustWeights> = {
+  memoryWorth: 0.28,
+  provenance: 0.16,
+  faithfulness: 0.20,
+  corroboration: 0.12,
+  contradiction: 0.10,
+  domainCalibration: 0.04,
+  feedback: 0.05,
+  recency: 0.05,
+};
+
+/**
+ * All trust-relevant signals for ONE memory. Every field is optional — the
+ * scorer degrades to neutral for any absent or corrupt signal (rule 34).
+ */
+export interface TrustSignals {
+  /** Memory-worth result (Laplace success prob + confidence). */
+  memoryWorth?: { score: number; confidence: number };
+  /** Thumbs feedback tallies. */
+  feedback?: { up: number; down: number };
+  /** Contradiction review queue status. */
+  contradiction?: "none" | "pending_review" | "resolved_kept" | "resolved_superseded";
+  /** Claim-level provenance strength (#1575). */
+  provenance?: "verified" | "unverified" | "none";
+  /** Faithfulness gate verdict (#1576). */
+  faithfulness?: "entailed" | "contradicted" | "unsupported" | "unchecked";
+  /** Count of distinct source turns/sessions corroborating the fact. */
+  corroborationCount?: number;
+  /** Belief-ledger accuracy for the memory's domain, `0..1`. */
+  domainCalibration?: number;
+  /** Age in days vs a per-category half-life (caller computes). */
+  ageDays?: number;
+  /** Half-life (days) for recency decay; the caller supplies the per-category value. */
+  recencyHalfLifeDays?: number;
+}
+
+/** Trust band, coarse-grained for injection hedging and X-ray grouping. */
+export type TrustBand = "high" | "medium" | "low" | "quarantine";
+
+/**
+ * One component's contribution to the final score, for full explainability.
+ * `value` is the normalized `[0,1]` signal contribution; `weight` is the
+ * sum-normalized weight that was applied.
+ */
+export interface TrustScoreComponent {
+  value: number;
+  weight: number;
+}
+
+/**
+ * Full TrustScore result. `score` is the weighted blend in `[0,1]`; `band` is
+ * the coarse category; `components` echoes every active component so X-ray /
+ * epistemic rendering can explain the basis without re-deriving it.
+ */
+export interface TrustScoreResult {
+  score: number;
+  band: TrustBand;
+  components: Record<string, TrustScoreComponent>;
+  /**
+   * `true` when the result is the neutral prior (no usable signals). Lets the
+   * multiplier short-circuit to exactly `1.0` and the epistemic renderer skip
+   * the hedge for the common uninstrumented case.
+   */
+  neutral: boolean;
+}
+
+/** Band thresholds on the blended score. */
+export const TRUST_BAND_THRESHOLDS = {
+  high: 0.7,
+  medium: 0.45,
+  low: 0.2,
+} as const;
+
+/** Neutral prior: the score an empty-signal memory receives. */
+export const NEUTRAL_TRUST_SCORE = 0.5;
+
+/**
+ * Validate a single weight: a finite number in `[0, 1]`. Returns the value or
+ * `undefined` when corrupt (the caller falls back to the default).
+ */
+function sanitizeWeight(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  if (value < 0 || value > 1) return undefined;
+  return value;
+}
+
+/**
+ * Merge caller weights over the defaults, dropping corrupt entries. Exposed for
+ * config parse so an invalid weight is rejected once at the boundary (rule 51
+ * spirit) — but the scorer defends again here so a hand-built bench fixture
+ * cannot poison the math.
+ */
+export function resolveTrustWeights(
+  override: Readonly<TrustWeights> | undefined,
+): Required<TrustWeights> {
+  const out: Required<TrustWeights> = { ...DEFAULT_TRUST_WEIGHTS };
+  if (!override) return out;
+  (Object.keys(DEFAULT_TRUST_WEIGHTS) as Array<keyof TrustWeights>).forEach((key) => {
+    const v = sanitizeWeight(override[key]);
+    if (v !== undefined) out[key] = v;
+  });
+  return out;
+}
+
+/** Clamp a value to `[0,1]`; NaN/Infinity collapse to the neutral `0.5`. */
+function clampUnit(value: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return NEUTRAL_TRUST_SCORE;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Coerce an already-`[0,1]` signal (domain calibration, etc.) for the scorer.
+ * Returns `undefined` when absent or corrupt so the component is DROPPED — a
+ * single corrupt signal must not be read as damning evidence nor as a neutral
+ * contribution that masquerades as "we measured this". Mirrors the
+ * `classifyCounter` precedent from `memory-worth.ts`.
+ */
+function unitValue(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value < 0 || value > 1) return undefined;
+  return value;
+}
+
+/** Map a provenance tag to a `[0,1]` contribution. Absent → neutral. */
+function provenanceValue(tag: TrustSignals["provenance"]): number | undefined {
+  if (tag === undefined) return undefined;
+  if (tag === "verified") return 1;
+  if (tag === "unverified") return 0.5;
+  // "none" is meaningful negative evidence (no surviving source span), not
+  // neutral. It pulls toward 0 but gently so a single unprovenanced fact is
+  // not damned on its own.
+  if (tag === "none") return 0.25;
+  return undefined;
+}
+
+/** Map a faithfulness verdict to a `[0,1]` contribution. Absent → neutral. */
+function faithfulnessValue(verdict: TrustSignals["faithfulness"]): number | undefined {
+  if (verdict === undefined) return undefined;
+  if (verdict === "entailed") return 1;
+  if (verdict === "unchecked") return NEUTRAL_TRUST_SCORE;
+  if (verdict === "unsupported") return 0.35;
+  // "contradicted" is a hard negative — it also forces quarantine (see below),
+  // but as a component it contributes 0 so the blended score sinks.
+  if (verdict === "contradicted") return 0;
+  return undefined;
+}
+
+/** Map contradiction review status to a `[0,1]` contribution. */
+function contradictionValue(
+  status: TrustSignals["contradiction"],
+): number | undefined {
+  if (status === undefined) return undefined;
+  if (status === "none") return NEUTRAL_TRUST_SCORE;
+  if (status === "resolved_kept") return 0.7;
+  if (status === "resolved_superseded") return 0.1;
+  if (status === "pending_review") return 0.15;
+  return undefined;
+}
+
+/** Feedback balance → `[0,1]` via Laplace smoothing (mirrors memory-worth). */
+function feedbackValue(fb: TrustSignals["feedback"]): number | undefined {
+  if (fb === undefined) return undefined;
+  const up = typeof fb.up === "number" && Number.isFinite(fb.up) && fb.up >= 0 ? fb.up : 0;
+  const down =
+    typeof fb.down === "number" && Number.isFinite(fb.down) && fb.down >= 0 ? fb.down : 0;
+  if (up === 0 && down === 0) return undefined;
+  // Laplace: (up+1)/(up+down+2). Clamped defensively.
+  return clampUnit((up + 1) / (up + down + 2));
+}
+
+/** Corroboration count → `[0,1]` via log-saturation (3+ sources ≈ 1.0). */
+function corroborationValue(count: TrustSignals["corroborationCount"]): number | undefined {
+  if (count === undefined) return undefined;
+  if (typeof count !== "number" || !Number.isFinite(count) || count < 0) return undefined;
+  if (count === 0) return 0.3; // single mention is mild negative evidence vs neutral
+  // log2(1 + count) saturates: 1→0.5, 2→0.63, 3→0.66, 4→0.68 ... capped at 1.
+  return clampUnit(Math.log2(1 + count) / 2);
+}
+
+/** Recency decay vs a half-life, mapped so "fresh" → high, "stale" → low. */
+function recencyValue(signals: TrustSignals): number | undefined {
+  if (signals.ageDays === undefined) return undefined;
+  if (typeof signals.ageDays !== "number" || !Number.isFinite(signals.ageDays) || signals.ageDays < 0)
+    return undefined;
+  const halfLife = signals.recencyHalfLifeDays;
+  if (typeof halfLife !== "number" || !Number.isFinite(halfLife) || halfLife <= 0) return undefined;
+  // 2^(-age/halfLife): age 0 → 1, age=halfLife → 0.5, age≫halfLife → ~0.
+  return clampUnit(Math.pow(2, -signals.ageDays / halfLife));
+}
+
+/**
+ * Determine whether the signals warrant the `quarantine` band: a hard negative
+ * that excludes the item from injection (but never from X-ray — rule 34).
+ */
+function isHardNegative(signals: TrustSignals): boolean {
+  if (signals.faithfulness === "contradicted") return true;
+  if (signals.contradiction === "pending_review") return true;
+  return false;
+}
+
+/**
+ * Compute the unified TrustScore for one memory.
+ *
+ * Returns the neutral prior (`0.5`, band `medium`, `neutral: true`) when no
+ * usable signal is present, so uninstrumented memories are untouched.
+ */
+export function computeTrustScore(
+  signals: TrustSignals,
+  weights: Readonly<TrustWeights> = DEFAULT_TRUST_WEIGHTS,
+): TrustScoreResult {
+  const resolved = resolveTrustWeights(weights);
+
+  // Build the (component → value) map, skipping absent/corrupt signals.
+  // Each value is already clamped to [0,1] by its mapper.
+  const candidates: Array<{ key: keyof TrustWeights; value: number }> = [];
+  const push = (key: keyof TrustWeights, value: number | undefined) => {
+    if (value === undefined) return;
+    candidates.push({ key, value: clampUnit(value) });
+  };
+
+  push("memoryWorth", signals.memoryWorth ? clampUnit(signals.memoryWorth.score) : undefined);
+  push("provenance", provenanceValue(signals.provenance));
+  push("faithfulness", faithfulnessValue(signals.faithfulness));
+  push("corroboration", corroborationValue(signals.corroborationCount));
+  push("contradiction", contradictionValue(signals.contradiction));
+  push("domainCalibration", unitValue(signals.domainCalibration));
+  push("feedback", feedbackValue(signals.feedback));
+  push("recency", recencyValue(signals));
+
+  // No usable signal → neutral prior, multiplier exactly 1.0.
+  if (candidates.length === 0) {
+    return {
+      score: NEUTRAL_TRUST_SCORE,
+      band: "medium",
+      components: {},
+      neutral: true,
+    };
+  }
+
+  // Sum-normalize the active weights so absent components redistribute their
+  // weight to the present ones (a memory with only memory-worth data is scored
+  // purely on memory-worth, not half-scored because other signals are absent).
+  const activeWeightSum = candidates.reduce((acc, c) => acc + resolved[c.key], 0);
+  const safeWeightSum = activeWeightSum > 0 ? activeWeightSum : 1;
+
+  let blended = 0;
+  const components: Record<string, TrustScoreComponent> = {};
+  for (const c of candidates) {
+    const w = resolved[c.key] / safeWeightSum;
+    blended += c.value * w;
+    components[c.key] = { value: c.value, weight: w };
+  }
+
+  // Clamp the blend: floating-point noise can drift a hair outside [0,1].
+  const score = clampUnit(blended);
+
+  // Hard negatives are quarantined regardless of the blended score, so a
+  // corroborated-but-contradicted fact is still excluded from injection.
+  const band = bandForScore(score, isHardNegative(signals));
+
+  return { score, band, components, neutral: false };
+}
+
+/**
+ * Resolve the band from the blended score, accounting for hard-negative
+ * quarantine. Extracted so the thresholds live in ONE place (X-ray, injection,
+ * and tests all agree on the mapping).
+ */
+export function bandForScore(score: number, hardNegative: boolean): TrustBand {
+  if (hardNegative) return "quarantine";
+  const s = clampUnit(score);
+  if (s >= TRUST_BAND_THRESHOLDS.high) return "high";
+  if (s >= TRUST_BAND_THRESHOLDS.medium) return "medium";
+  if (s >= TRUST_BAND_THRESHOLDS.low) return "low";
+  return "low";
+}
+
+/**
+ * Map a `[0,1]` trust score to a recall multiplier in
+ * `[minMultiplier, maxMultiplier]`. The neutral prior (`0.5`) maps to exactly
+ * `1.0` so uninstrumented memories are untouched. Linear interpolation centered
+ * at neutral:
+ *
+ *   score < 0.5 → multiplier in [min, 1)
+ *   score = 0.5 → 1.0
+ *   score > 0.5 → multiplier in (1, max]
+ */
+export function trustMultiplier(
+  score: number,
+  minMultiplier: number = 0.5,
+  maxMultiplier: number = 1.25,
+): number {
+  const min = typeof minMultiplier === "number" && Number.isFinite(minMultiplier) ? minMultiplier : 0.5;
+  const max = typeof maxMultiplier === "number" && Number.isFinite(maxMultiplier) ? maxMultiplier : 1.25;
+  // Defend against an inverted contract (min > max): pick the tighter bound.
+  const lo = Math.min(min, max);
+  const hi = Math.max(min, max);
+  const s = clampUnit(score);
+  if (s === NEUTRAL_TRUST_SCORE) return 1;
+  if (s < NEUTRAL_TRUST_SCORE) {
+    // Map [0, 0.5) → [lo, 1). score 0 → lo, score →0.5 → 1.
+    const t = s / NEUTRAL_TRUST_SCORE; // [0,1)
+    return lo + (1 - lo) * t;
+  }
+  // Map (0.5, 1] → (1, hi]. score 0.5 → 1, score 1 → hi.
+  const t = (s - NEUTRAL_TRUST_SCORE) / (1 - NEUTRAL_TRUST_SCORE); // (0,1]
+  return 1 + (hi - 1) * t;
+}
+
+/**
+ * Deterministic epistemic hedge suffix for an injected memory line, generated
+ * from the trust components (template, not LLM). Returns the empty string for
+ * the `high` band and for neutral results so the common case wastes no tokens.
+ *
+ * Examples:
+ *   high    → ""
+ *   medium  → "(unconfirmed — single mention, 2025-11)"
+ *   low     → "(low confidence — contradicted once, uncorroborated)"
+ */
+export function renderEpistemicHedge(result: TrustScoreResult): string {
+  if (result.neutral) return "";
+  switch (result.band) {
+    case "high":
+      return "";
+    case "quarantine":
+    case "low":
+      return `(low confidence — ${describeWeakness(result.components)})`;
+    case "medium":
+      return `(unconfirmed — ${describeWeakness(result.components)})`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * Build a short, deterministic weakness description from the components. Reads
+ * the lowest-contributing signals so the hedge names the actual reason the
+ * model should hedge. Pure and order-stable.
+ */
+function describeWeakness(components: Record<string, TrustScoreComponent>): string {
+  const parts: string[] = [];
+  const f = components.faithfulness;
+  if (f && f.value <= 0.35) parts.push(f.value === 0 ? "contradicted" : "unsupported");
+  const c = components.contradiction;
+  if (c && c.value <= 0.2) parts.push("under review");
+  const cor = components.corroboration;
+  if (cor && cor.value <= 0.4) parts.push("single mention");
+  const prov = components.provenance;
+  if (prov && prov.value <= 0.3) parts.push("unprovenanced");
+  const rec = components.recency;
+  if (rec && rec.value <= 0.3) parts.push("stale");
+  if (parts.length === 0) {
+    // No single component is weak but the blend is below high — name the
+    // weakest one explicitly so the hedge is never vacuous.
+    let weakest: { key: string; value: number } | null = null;
+    for (const [key, comp] of Object.entries(components)) {
+      if (!weakest || comp.value < weakest.value) weakest = { key, value: comp.value };
+    }
+    if (weakest) parts.push(`weak ${humanizeComponentName(weakest.key)}`);
+  }
+  return parts.slice(0, 2).join(", ");
+}
+
+function humanizeComponentName(key: string): string {
+  switch (key) {
+    case "memoryWorth":
+      return "outcome history";
+    case "domainCalibration":
+      return "domain calibration";
+    default:
+      return key;
+  }
+}

--- a/packages/remnic-core/src/trust-score.ts
+++ b/packages/remnic-core/src/trust-score.ts
@@ -36,30 +36,15 @@
  */
 
 /**
- * Per-component weights. Every field is optional and defaults to the
- * `DEFAULT_TRUST_WEIGHTS` value; the caller passes the config-resolved object.
- * Weights are sum-normalized at score time, so their absolute scale is
- * irrelevant — only their relative magnitudes matter (rule 51: invalid weight
- * rejected at config parse, here we only defend against runtime corruption).
+ * Per-component weights. Defined canonically in `types.ts` (the PluginConfig
+ * home) and re-exported here so callers of the pure scorer don't need a second
+ * import path. Every field is optional and defaults to
+ * `DEFAULT_TRUST_WEIGHTS`; weights are sum-normalized at score time, so only
+ * their relative magnitudes matter (rule 51: invalid weight rejected at config
+ * parse, here we only defend against runtime corruption).
  */
-export interface TrustWeights {
-  /** Laplace-smoothed outcome probability (memory worth `score`). */
-  memoryWorth?: number;
-  /** Provenance strength tag mapped to `[0,1]` (verified→1, unverified→0.5, none→neutral). */
-  provenance?: number;
-  /** Faithfulness verdict mapped to `[0,1]` (entailed→1, unchecked→neutral, contradicted→0). */
-  faithfulness?: number;
-  /** Independent corroboration count, log-saturated. */
-  corroboration?: number;
-  /** Contradiction review status (pending_review / resolved_superseded push toward 0). */
-  contradiction?: number;
-  /** Belief-ledger per-domain accuracy calibration (`0..1`), when available. */
-  domainCalibration?: number;
-  /** Feedback balance (thumbs up/down), when available. */
-  feedback?: number;
-  /** Recency vs per-category half-life (newer → higher). */
-  recency?: number;
-}
+export type { TrustWeights } from "./types.js";
+import type { TrustWeights } from "./types.js";
 
 /**
  * Default per-component weights. Chosen so that, with all signals at neutral,

--- a/packages/remnic-core/src/trust-score.ts
+++ b/packages/remnic-core/src/trust-score.ts
@@ -299,7 +299,19 @@ export function computeTrustScore(
   // weight to the present ones (a memory with only memory-worth data is scored
   // purely on memory-worth, not half-scored because other signals are absent).
   const activeWeightSum = candidates.reduce((acc, c) => acc + resolved[c.key], 0);
-  const safeWeightSum = activeWeightSum > 0 ? activeWeightSum : 1;
+  // When every present signal's weight is 0 (operator explicitly disabled
+  // the only components the memory has), fall back to the neutral prior
+  // rather than damning the memory to score 0. A disabled signal is not a
+  // negative signal — it carries no information (review P2: zero-weight).
+  if (activeWeightSum <= 0) {
+    return {
+      score: NEUTRAL_TRUST_SCORE,
+      band: "medium",
+      components: {},
+      neutral: true,
+    };
+  }
+  const safeWeightSum = activeWeightSum;
 
   let blended = 0;
   const components: Record<string, TrustScoreComponent> = {};

--- a/packages/remnic-core/src/trust-score.ts
+++ b/packages/remnic-core/src/trust-score.ts
@@ -278,7 +278,7 @@ function isHardNegative(signals: TrustSignals): boolean {
  * usable signal is present, so uninstrumented memories are untouched.
  */
 export function computeTrustScore(
-  signals: TrustSignals,
+  signals: TrustSignals = {},
   weights: Readonly<TrustWeights> = DEFAULT_TRUST_WEIGHTS,
 ): TrustScoreResult {
   const resolved = resolveTrustWeights(weights);

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -970,6 +970,31 @@ export interface PluginConfig {
    * once the benchmark shows precision tie-or-win.
    */
   recallMemoryWorthFilterEnabled: boolean;
+  // Unified TrustScore recall stage (issue #1577). Combines memory-worth,
+  // provenance, faithfulness, corroboration, contradiction, feedback, recency,
+  // and optional domain calibration into one [0,1] trust score applied as a
+  // bounded recall multiplier. Subsumes the Memory Worth multiplier when on
+  // (the orchestrator runs exactly one of the two — rule 39).
+  /**
+   * Master gate for the unified TrustScore recall stage. Default `false`: off
+   * = the stage is absent and ranking is byte-identical to the pre-feature
+   * pipeline (rule 39). Flip via #1574 ablation evidence only.
+   */
+  trustScoreEnabled: boolean;
+  /** Append epistemic hedge suffixes to injected memory lines. Separate gate. */
+  trustScoreEpistemicRendering: boolean;
+  /**
+   * Exclude hard-negative (quarantine-band) items from injection. Default
+   * `true`; only effective under the master gate. Quarantined items stay
+   * visible in X-ray with a reason (rule 34).
+   */
+  trustScoreQuarantine: boolean;
+  /** Lower bound of the trust multiplier (default 0.5). */
+  trustScoreMinMultiplier: number;
+  /** Upper bound of the trust multiplier (default 1.25). */
+  trustScoreMaxMultiplier: number;
+  /** Per-component weights for the TrustScore blend; invalid weights rejected at parse. */
+  trustScoreWeights: TrustWeights;
   /**
    * Recall-audit anomaly detector (issue #565 PR 5/5). When true,
    * access surfaces run the anomaly detector over a tail of the audit
@@ -2747,6 +2772,23 @@ export interface FaithfulnessFrontmatter {
   rationale?: string;
   /** ISO-8601 timestamp the check ran. */
   at?: string;
+}
+
+/**
+ * Per-component weights for the unified TrustScore blend (issue #1577). Every
+ * field is optional and defaults to the documented value in `trust-score.ts`;
+ * weights are sum-normalized at score time so only relative magnitudes matter.
+ * Invalid weights (non-finite, outside `[0,1]`) are rejected at config parse.
+ */
+export interface TrustWeights {
+  memoryWorth?: number;
+  provenance?: number;
+  faithfulness?: number;
+  corroboration?: number;
+  contradiction?: number;
+  domainCalibration?: number;
+  feedback?: number;
+  recency?: number;
 }
 
 /** Memory link relationship types */

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20285,
+      "packages/remnic-core/src/orchestrator.ts": 20379,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20094,
+      "packages/remnic-core/src/orchestrator.ts": 20225,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,
-      "packages/remnic-core/src/config.ts": 4610
+      "packages/remnic-core/src/config.ts": 4661
     },
     "oversizedFileCount": 11,
-    "scatteredConfigFlagReads": 559,
+    "scatteredConfigFlagReads": 560,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 82,
     "directStorageImports": 38

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20225,
+      "packages/remnic-core/src/orchestrator.ts": 20285,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,


### PR DESCRIPTION
## Summary

Wires the pure `trust-score` module (PR1–2) into the recall pipeline as a single rerank stage that combines confidence, recency, faithfulness, provenance, corroboration, contradiction, and feedback into one `[0,1]` trust score with a bounded multiplier. Closes #1577 (scoring + rendering + config gate; bench ablation is PR4, tracked separately).

Supersedes/replaces the in-flight #1577 branch commits (config keys, stage tests, pure module) — this PR adds the orchestrator wiring, the extraction, and the fixes that make it landable.

## What changed

### TrustScore recall stage (orchestrator thin wiring)
- **`applyTrustScoreRerank`** — thin delegation over the extracted `buildTrustSignalsForRerank` (per-namespace cached signal scan + cold-tier direct-path fallback) and the pure `applyTrustScoreStage` (scoring + quarantine split). Substantive signal-building logic extracted to `trust-score-stage.ts` so the orchestrator gains delegation only (rule 4).
- **Mutual exclusion** (rule 39) — TrustScore **subsumes** the Memory Worth multiplier. Both call sites (hot path ~L11090 + cold fallback ~L19250) use `if (caps.recallTrustScore) … else if (caps.recallMemoryWorthFilter) …` — exactly one multiplier fires. The double-multiplier test in `trust-score-stage.test.ts` pins this structurally.
- **`lastTrustByPath` reset at `recallInternal` entry** — the epistemic-rendering formatter reads this map; resetting it at recall entry prevents stale trust hedges from a previous recall leaking into the current one (e.g. when the gate is off this round or the stage fails open).
- **Epistemic hedge in `formatQmdResults`** — deterministic, component-derived suffix appended to injected memory lines: high/neutral → no suffix (no token waste); medium → `(unconfirmed — single mention, 2025-11)`; low → `(low confidence — contradicted once, uncorroborated)`. Gated separately by `trustScoreEpistemicRendering`.

### Adapter fix
- **`skipped_no_span` → `unchecked`** — legacy facts without a verified source span carry no entailment signal; the adapter collapses this verdict to `unchecked` (neutral) rather than treating it as a hard negative.

### Bug fixes from prior in-flight commits
- **Restored `SlotBehaviorConfig` import** in `config.ts` — the config-keys commit accidentally *replaced* it with `TrustWeights` instead of adding; DTS build failed with TS2304.
- **Test typed fixtures** — `Map<string, TrustSignals>` replaces `Map<string, unknown>` + `as never` casts (9 sites). No inline `any`.

### Extraction (ratchet discipline)
- `buildTrustSignalsForRerank` moved to `trust-score-stage.ts` (~90 lines of I/O orchestration: cache evict/check/populate, namespace iteration, cold-tier fallback). Orchestrator method slimmed from 137 → 71 lines.

### Config + schema
- 6 `trustScore*` keys registered in `openclaw.plugin.json` configSchema + synced (master gate `trustScoreEnabled` default `off`; `trustScoreEpistemicRendering` default `off`; `trustScoreQuarantine` default `true`; multiplier bounds 0.5/1.25; per-component weights).
- Ratchet baseline updated: orchestrator +131 (thin wiring — substantive logic extracted), config +51 (required keys), `scatteredConfigFlagReads` +1 (single `trustScoreEnabled` capability projection per #1523).

## Chokepoints used / not applicable
- **CapabilitySet gate** (`caps.recallTrustScore`) — the single `config.trustScoreEnabled` read lives in `resolveCapabilities`; scattered-read ratchet +1 is that projection (#1523 pattern). ✓
- **Not applicable:** ScopePlan resolver (#1521), catalog chokepoint (#1522), serialize-mutations (#1524), operation registry (#1525) — this stage reads existing signals only, no new write path / namespace resolution / MCP tool.

## Verification
- `preflight:quick` → **OK** (lint, check-types, check-config-contract, ratchets, entity-hardening, openclaw scenarios)
- `test:entity-hardening` → **246/246 pass**
- `trust-score.test.ts` + `trust-score-stage.test.ts` + `capabilities.test.ts` → **47/47 pass**
- Gate-off characterization: neutral candidates keep multiplier exactly `1.0` (byte-identical pass-through test)
- Double-multiplier prevention: structural test green
- Quarantine exclusion + X-ray visibility: test green

## Done-when status (#1577)
- [x] TrustScore stage combines all signals into one score with full component explainability
- [x] Gate-off characterization snapshots identical (neutral multiplier = 1.0)
- [x] Double-multiplier test green (mutual exclusion with Memory Worth)
- [x] Quarantine items visible in X-ray with reasons (`projectTrustForXray` + `explainQuarantine`)
- [x] Epistemic rendering hedge (deterministic, component-derived)
- [x] Config gate (default off per issue; flip via #1574 ablation evidence only)
- [ ] Bench ablation artifacts (PR4 — tracked separately, needs #1574 lab profile)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall ranking and memory injection across all recall paths when the gate is enabled; default-off limits blast radius, but multiplier/quarantine behavior affects what the model sees.
> 
> **Overview**
> Wires the pure **TrustScore** scorer into recall as a single rerank stage that folds confidence, recency, faithfulness, provenance, corroboration, contradiction, and feedback into one bounded score multiplier, with optional **quarantine** of low-trust items while keeping them visible in X-ray.
> 
> Signal assembly and scoring live in **`trust-score-stage.ts`**; the orchestrator only delegates via **`applyTrustScoreRerank`** / **`applyTrustScoreToBranch`** on hot QMD, embedding fallback, recent scan, and cold paths. **`recallTrustScore`** is mutually exclusive with **`recallMemoryWorthFilter`** so only one multiplier runs. Per-recall **`recallTrustByPath`** (local, not instance state) feeds **`formatQmdResults`** optional **`renderEpistemicHedge`** suffixes when **`trustScoreEpistemicRendering`** is on.
> 
> **`skipped_no_span`** faithfulness verdicts are mapped to **`unchecked`** in the trust adapter so legacy facts without spans are neutral, not penalized. Six **`trustScore*`** plugin config keys register in the schema (master gate and epistemic rendering default **off**). Fixes restore **`SlotBehaviorConfig`** alongside **`TrustWeights`** in config imports and tighten test fixtures to **`Map<string, TrustSignals>`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb9276c3e0fc36ab4f0da70e22dc635f2a90fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->