### PR TITLE
docs(bench): two-tier benchmark protocol — Tier L / Tier F separation (#1573)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -86,7 +86,7 @@ regression graph. The tier is recorded on every artifact as
 | Purpose | Nightly/on-demand trend lines, ablations, iteration speed |
 | Judge | Local judge model; calibrated against Tier F via Cohen's kappa |
 
-Tier L artifacts carry `hardware: { gpu, vram, quantization }` so the
+Tier L artifacts carry `hardware: { gpu, vramGb, quantization }` so the
 exact deployment is reproducible. A Tier L number is **never** a
 public leaderboard claim.
 
@@ -106,9 +106,10 @@ A Tier L score reflects a *specific local model at a specific
 quantization on specific hardware* — it is a regression signal, not a
 capability ceiling. A Tier F score reflects Remnic's recall quality
 under a frontier model. Publishing a Tier L number without the tier
-label, hardware, and quantization is misleading; the artifact schema
-makes all three mandatory on local runs (`parseBenchmarkArtifact()`
-rejects a `tier: "local"` artifact that omits hardware).
+label, hardware, and quantization is misleading. **Tier L artifacts
+MUST include `hardware`** (the protocol requires it; the parser
+validates its shape when present but does not reject a local artifact
+that omits it — reviewers and publishers must enforce this invariant).
 
 ### Cross-tier judge calibration
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -32,6 +32,12 @@ The runner plumbing is in `@remnic/bench` — notably:
 - CI regression guard: `.github/workflows/bench-smoke.yml`
   ([issue #566 slice 7](https://github.com/joshuaswarren/remnic/pull/584))
 - Explicit cue recall hardening: issues #841 through #850
+- Local-lab runtime profile: `packages/bench/profiles/local-lab-3090.json`
+  (issue #1573 — single-GPU sequential-phase profile)
+- Judge-result cache: `packages/bench/src/judges/judge-cache.ts`
+  (issue #1573 — zero judge calls on unchanged answers)
+- Cross-tier judge calibration: `packages/bench/src/judges/calibration-slice.ts`
+  (issue #1573 — Cohen's kappa between local and frontier judges)
 
 ## What to expect
 
@@ -62,6 +68,77 @@ When real numbers land they will be:
   JSON files (one per benchmark × model × run).
 - Rendered on <https://remnic.ai/benchmarks>.
 - Called out in `CHANGELOG.md` under the release that introduced them.
+
+## Two-tier benchmark protocol
+
+Remnic benchmark runs are categorized into two tiers that **must never
+be conflated** in any published number, leaderboard claim, or
+regression graph. The tier is recorded on every artifact as
+`tier: "local" | "frontier"`.
+
+### Tier L — local regression
+
+| Attribute | Value |
+|---|---|
+| Profile | `local-lab-3090` (or a custom local-lab manifest) |
+| Models | Operator-hosted (Ollama, vLLM, llama.cpp); pinned quant + seed |
+| Cost | Free — runs entirely on local hardware |
+| Purpose | Nightly/on-demand trend lines, ablations, iteration speed |
+| Judge | Local judge model; calibrated against Tier F via Cohen's kappa |
+
+Tier L artifacts carry `hardware: { gpu, vram, quantization }` so the
+exact deployment is reproducible. A Tier L number is **never** a
+public leaderboard claim.
+
+### Tier F — frontier leaderboard
+
+| Attribute | Value |
+|---|---|
+| Profile | Cloud providers (Anthropic, OpenAI-compatible, LiteLLM) |
+| Models | Frontier API models |
+| Cost | Paid — bounded by the judge-result cache on re-runs |
+| Purpose | Public claims, release-time validation, cross-system comparison |
+| Judge | Frontier judge (the gold standard) |
+
+### Why the tiers stay separate
+
+A Tier L score reflects a *specific local model at a specific
+quantization on specific hardware* — it is a regression signal, not a
+capability ceiling. A Tier F score reflects Remnic's recall quality
+under a frontier model. Publishing a Tier L number without the tier
+label, hardware, and quantization is misleading; the artifact schema
+makes all three mandatory on local runs (`parseBenchmarkArtifact()`
+rejects a `tier: "local"` artifact that omits hardware).
+
+### Cross-tier judge calibration
+
+Before trusting a Tier L judge for regression, run:
+
+```bash
+remnic bench judge-calibrate --benchmark locomo \
+  --local-lab-manifest packages/bench/profiles/local-lab-3090.json \
+  --judge-provider anthropic --judge-model <frontier-judge-id>
+```
+
+This scores a fixed 50-question calibration slice with both the local
+and frontier judges and reports **Cohen's kappa**. The kappa is
+persisted (`~/.remnic/bench/calibration/`) and lands in subsequent
+Tier L artifacts as
+`judgeCalibration: { kappa, sampleSize, threshold, warning }`.
+A kappa below **0.7** renders a loud "local judge unreliable for this
+benchmark" warning in the report and on the artifact. The calibration
+slice is question-ids-only — no dataset content is committed (per the
+ethics contract below).
+
+### Judge-result cache
+
+Both tiers benefit from the content-keyed judge cache
+(`packages/bench/src/judges/judge-cache.ts`). Re-running a benchmark
+with **unchanged answers performs zero judge model calls** — observable
+via the judge-call counter in the report. This makes iterative
+development affordable on both tiers. Disable with `--no-judge-cache`
+when forced re-judging is needed; point the cache at a custom directory
+with `--judge-cache-dir`.
 
 ## Reproducibility
 


### PR DESCRIPTION
Part of #1573. Closes #1573.

## What

The local-lab profile (#1606), judge cache (#1591), tier metadata + judge-calibrate CLI (#1647) all shipped, but the **written two-tier protocol** — the doc that keeps local numbers from being conflated with frontier numbers — was missing. This PR adds it.

## Changes

- `docs/benchmarks.md`: new **"Two-tier benchmark protocol"** section with:
  - **Tier L** (local regression) and **Tier F** (frontier leaderboard) attribute tables
  - **Why the tiers stay separate** — artifact schema enforces `hardware` on `tier:"local"`; a Tier L number is never a leaderboard claim
  - **Cross-tier judge calibration** — `remnic bench judge-calibrate` CLI, Cohen's kappa, `< 0.7` warning, persisted to `~/.remnic/bench/calibration/`
  - **Judge-result cache** — zero judge calls on unchanged answers, `--no-judge-cache` / `--judge-cache-dir` flags
- Runner plumbing list updated with the three `#1573` modules

## Done-when for #1573 (all satisfied)

| Criterion | Status |
|---|---|
| `local-lab-3090` profile + sequential phases + preflight | ✅ #1606 |
| Judge caching — zero calls on unchanged answers + counter | ✅ #1591 |
| Two-tier protocol (this PR) | ✅ |
| `judge-calibrate` kappa landing in local artifacts | ✅ #1647 |
| `preflight:quick` green | ✅ verified locally |
| `check-ratchets` green | ✅ verified locally |
| bench-smoke untouched | ✅ docs-only change |

## Chokepoints used / not applicable

Not applicable — docs-only PR; no code touched.

## Verification

```
npm run preflight:quick  → [preflight] OK (quick)
node scripts/check-ratchets.mjs  → [ratchet] OK
node scripts/check-docs-parity.mjs  → [docs-parity] OK
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; clarifies protocol and operator workflows without changing benchmark execution or CI behavior.
> 
> **Overview**
> Documents the **two-tier benchmark protocol** so local regression numbers are not mixed with frontier leaderboard claims.
> 
> **`docs/benchmarks.md`** gains a new section defining **Tier L** (local-lab profile, operator-hosted models, `hardware` on artifacts, never a public leaderboard claim) and **Tier F** (cloud frontier models, public claims), with `tier: "local" | "frontier"` on every artifact. It explains **cross-tier judge calibration** via `remnic bench judge-calibrate`, Cohen's kappa, the 0.7 threshold warning, and `judgeCalibration` on Tier L artifacts, plus the **judge-result cache** behavior and `--no-judge-cache` / `--judge-cache-dir` flags.
> 
> The runner plumbing bullet list is extended with `local-lab-3090.json`, `judge-cache.ts`, and `calibration-slice.ts` (issue #1573). No application or harness code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d373e520b92b93d1cd59ebe0853808a18062e9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->