### PR TITLE
feat(coding-graph): path-enumerating traversal for exact variable-length paths (#1650)

### DIFF
--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -899,6 +899,46 @@ test("INVARIANT: every documented label maps to a db label", () => {
   }
 });
 
+
+test("ACCEPT: truncated flag surfaces when variable-length enumeration hits the path cap (cursor Bugbot)", async () => {
+  // A complete directed graph on 23 nodes (no self-loops): 506 edges.
+  // *1..3 from one node enumerates 22 + 22*22 + 22*22*22 = 11_154 paths,
+  // exceeding the DEFAULT_TRAVERSE_PATHS_MAX (10_000) cap. The executor
+  // must surface `truncated: true` rather than silently returning a
+  // partial endpoint set.
+  const N = 23;
+  const symbols: SymbolIR[] = [];
+  for (let i = 0; i < N; i += 1) {
+    symbols.push(sym("cp." + i, String(i), i * 10, i * 10 + 9));
+  }
+  const edges: EdgeIR[] = [];
+  for (let i = 0; i < N; i += 1) {
+    for (let j = 0; j < N; j += 1) {
+      if (i !== j) edges.push(edge("cp." + i, "cp." + j));
+    }
+  }
+  const completeFile: StoreFileIR = {
+    path: "src/complete.ts",
+    language: "typescript",
+    contentHash: "h-complete",
+    symbols,
+    edges,
+  };
+  const { store, dir } = await tempStoreWithFile(completeFile);
+  try {
+    const r = executeCypher(
+      store,
+      'MATCH (a:Function {name: "0"})-[:CALLS*1..3]->(b) RETURN b.qualifiedName',
+    );
+    assert.equal(r.ok, true, "query should succeed (partial result, not failure)");
+    if (!r.ok) throw new Error("expected ok");
+    assert.equal(r.truncated, true, "truncated must be true when the path cap is hit");
+    assert.ok(r.rows.length > 0, "partial endpoint set is still returned");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 test("INVARIANT: the 13 documented labels are all present", () => {
   // Project, Package, Folder, File, Module, Class, Function, Method,
   // Interface, Enum, Type, Route, Resource (issue #1552 body).

--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -919,3 +919,134 @@ test("INVARIANT: the 13 documented labels are all present", () => {
   ];
   assert.deepEqual([...VALID_CYPHER_LABELS].sort(), expected);
 });
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// ACCEPT — variable-length path enumeration (issue #1650).
+// Exact `*N` (N > 1) must include nodes reachable at BOTH a shorter and a
+// length-N path. The fixture has two paths to b (a->b at len 1, a->c->b at
+// len 2) and a diamond to d (a->b->d, a->c->d, both len 2).
+//
+//   a -> b
+//   a -> c
+//   c -> b
+//   b -> d
+//   c -> d
+// ──────────────────────────────────────────────────────────────────────────
+
+const multiPathCypherFile: StoreFileIR = {
+  path: "src/mp.ts",
+  language: "typescript",
+  contentHash: "h-mp",
+  symbols: [
+    sym("mp.a", "a", 0, 10),
+    sym("mp.b", "b", 10, 20),
+    sym("mp.c", "c", 20, 30),
+    sym("mp.d", "d", 30, 40),
+  ],
+  edges: [
+    edge("mp.a", "mp.b"),
+    edge("mp.a", "mp.c"),
+    edge("mp.c", "mp.b"),
+    edge("mp.b", "mp.d"),
+    edge("mp.c", "mp.d"),
+  ],
+};
+
+async function tempStoreWithFile(
+  file: StoreFileIR,
+): Promise<{ store: GraphStore; dir: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "cypher-1650-"));
+  const store = await GraphStore.open({
+    dbPath: path.join(dir, "graph.sqlite"),
+    repoRoot: dir,
+  });
+  const r = await store.upsertFileBatch([file]);
+  assert.equal(r.ok, true, "fixture ingest must succeed");
+  return { store, dir };
+}
+
+test("ACCEPT: *N (N>1) includes a node reachable at a shorter AND a length-N path (issue #1650)", async () => {
+  const { store, dir } = await tempStoreWithFile(multiPathCypherFile);
+  try {
+    // b is reachable at len 1 (a->b) AND len 2 (a->c->b). Under the old
+    // BFS compile target, b was visited at depth 1 and dropped by the
+    // depth==2 filter; the length-2 path a->c->b now qualifies it.
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "a"})-[:CALLS*2]->(b) RETURN b.qualifiedName',
+    );
+    const qnames = rows.map((r) => r["b.qualifiedName"] as string).sort();
+    assert.deepEqual(qnames, ["mp.b", "mp.d"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: *1..N unchanged — returns reachable nodes, no regression (issue #1650)", async () => {
+  const { store, dir } = await tempStoreWithFile(multiPathCypherFile);
+  try {
+    // *1..2 from a: b (len1), c (len1), d (len2). Endpoint-dedup keeps
+    // this identical to the prior BFS shortest-depth behavior.
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "a"})-[:CALLS*1..2]->(b) RETURN b.qualifiedName',
+    );
+    const qnames = rows.map((r) => r["b.qualifiedName"] as string).sort();
+    assert.deepEqual(qnames, ["mp.b", "mp.c", "mp.d"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: diamond *2 reaches the far node via either length-2 path", async () => {
+  const { store, dir } = await tempStoreWithFile(multiPathCypherFile);
+  try {
+    // d is reachable only via length-2 paths (a->b->d, a->c->d). It must
+    // appear in *2 results (deduped to one row).
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "a"})-[:CALLS*2]->(b) RETURN b.name',
+    );
+    const names = rows.map((r) => r["b.name"] as string).sort();
+    assert.deepEqual(names, ["b", "d"]);
+    // d appears exactly once (endpoint-dedup), not once per path.
+    const dRows = rows.filter((r) => r["b.name"] === "d");
+    assert.equal(dRows.length, 1);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("ACCEPT: *N on a cyclic graph terminates (cycle safety via relationship-uniqueness)", async () => {
+  // a -> b -> c -> a (cycle) plus a self-edge on b.
+  const cyclicFile: StoreFileIR = {
+    path: "src/cyc.ts",
+    language: "typescript",
+    contentHash: "h-cyc",
+    symbols: [
+      sym("cyc.a", "a", 0, 10),
+      sym("cyc.b", "b", 10, 20),
+      sym("cyc.c", "c", 20, 30),
+    ],
+    edges: [
+      edge("cyc.a", "cyc.b"),
+      edge("cyc.b", "cyc.c"),
+      edge("cyc.c", "cyc.a"),
+      edge("cyc.b", "cyc.b"),
+    ],
+  };
+  const { store, dir } = await tempStoreWithFile(cyclicFile);
+  try {
+    // Must complete (relationship-uniqueness bounds enumeration) and
+    // return only nodes in the cycle.
+    const { rows } = await run(
+      store,
+      'MATCH (a:Function {name: "a"})-[:CALLS*1..4]->(b) RETURN b.qualifiedName',
+    );
+    const qnames = rows.map((r) => r["b.qualifiedName"] as string).sort();
+    assert.deepEqual(qnames, ["cyc.a", "cyc.b", "cyc.c"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});

--- a/packages/coding-graph/src/cypher/query-parser.test.ts
+++ b/packages/coding-graph/src/cypher/query-parser.test.ts
@@ -900,6 +900,21 @@ test("INVARIANT: every documented label maps to a db label", () => {
 });
 
 
+test("REJECT: variable-length depth above the supported cap fails with invalid_query (not a silent empty result)", async () => {
+  const { store, dir } = await tempStoreWithFile(multiPathCypherFile);
+  try {
+    const r = executeCypher(
+      store,
+      'MATCH (a:Function {name: "a"})-[:CALLS*2000]->(b) RETURN b',
+    );
+    assert.equal(r.ok, false, "*2000 must fail, not silently return an empty success");
+    if (r.ok) throw new Error("expected failure");
+    assert.equal(r.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 test("ACCEPT: truncated flag surfaces when variable-length enumeration hits the path cap (cursor Bugbot)", async () => {
   // A complete directed graph on 23 nodes (no self-loops): 506 edges.
   // *1..3 from one node enumerates 22 + 22*22 + 22*22*22 = 11_154 paths,

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -41,20 +41,25 @@
  *
  * ## Compile target
  *
- * Single-node patterns compile to `searchGraph({ label })`. Relationship
- * patterns compile to `traverse({ start, direction, edgeTypes, maxDepth })`,
- * filtering the returned hits to the relationship's depth range. Property
- * filters in node patterns (`{name: "foo"}`) and WHERE conditions are
- * applied in JS as post-filters on the bound nodes.
+ * Single-node patterns compile to `searchGraph({ label })`. Fixed-length
+ * relationship patterns compile to `traverse({ start, direction, edgeTypes,
+ * maxDepth })`, filtering the returned hits to the relationship's depth
+ * range. VARIABLE-length patterns (`*M..N` / `*N`) compile to the path-
+ * enumerating primitive `traversePaths` (issue #1650) so an exact `*N`
+ * honors concrete length-N paths; endpoints are filtered by PATH LENGTH
+ * and deduped by node id. Property filters in node patterns
+ * (`{name: "foo"}`) and WHERE conditions are applied in JS as post-filters
+ * on the bound nodes.
  *
- * Variable-length depth uses `traverse`'s BFS, which visits each node ONCE
- * at its shortest-path depth. So `*M..N` returns nodes whose SHORTEST path
- * from the start is in `[M, N]` — correct for "reachable within N hops".
- * Exact `*N` (N > 1) is honored only for nodes whose shortest path is
- * exactly N; a node reachable at both a shorter and a length-N path is
- * returned at the shorter depth only. True path-enumeration semantics
- * (returning a node once per distinct length-N path) needs a path-
- * enumerating store primitive and is tracked as a follow-up.
+ * Variable-length patterns enumerate concrete relationship-simple paths via
+ * `traversePaths` (issue #1650). Each path is cycle-safe under RELATIONSHIP
+ * UNIQUENESS (a single path never reuses an edge), capped at `maxHops` and a
+ * total-path cap. `*M..N` returns a node when a path of length in `[M, N]`
+ * reaches it; exact `*N` (N > 1) thus includes a node reachable at BOTH a
+ * shorter and a length-N path (the length-N path qualifies). The result is
+ * deduped by node id, so `*1..N` ("reachable within N hops") is unchanged
+ * from the prior BFS behavior — only exact `*N` (N > 1) gains paths the
+ * shortest-depth BFS dropped.
  *
  * ## Read-only by construction
  *
@@ -95,14 +100,16 @@
  * clauses are NOT pushed down — they fall back to the capped scan, so on
  * graphs with more than 1000 nodes of the starting label such queries can
  * still false-negative; use the inline literal form for guaranteed
- * resolution. Relationship expansion uses `traverse` (BFS, full reachable
- * subgraph up to maxDepth) — see the compile-target note for the BFS
- * shortest-depth semantics of variable-length `*N`.
+ * Relationship expansion uses `traverse` (fixed hops) or `traversePaths`
+ * (variable length, issue #1650); both are cycle-safe and depth/length
+ * capped. See the compile-target note for the path-length semantics of
+ * variable-length `*N`.
  */
 import type {
   GraphStore,
   SearchHit,
   TraverseHit,
+  TraversePathHit,
 } from "../graph-store.js";
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -225,6 +232,8 @@ interface RelPattern {
   minHops: number;
   /** Inclusive maximum hop count. Equal to minHops when `*N` form used. */
   maxHops: number;
+  /** True when a `*` range was parsed (variable-length). Drives the path-enumerating compile target (issue #1650). */
+  isVarLength: boolean;
 }
 
 interface Comparison {
@@ -727,11 +736,13 @@ class Parser {
     }
     let minHops = 1;
     let maxHops = 1;
+    let isVarLength = false;
     if (this.peek().type === "STAR") {
       this.advance();
       const range = this.parseRange();
       minHops = range.min;
       maxHops = range.max;
+      isVarLength = true;
     }
     this.expect("RBRACK", "closing `]` of the relationship bracket");
 
@@ -750,7 +761,7 @@ class Parser {
         `Relationship range max (${maxHops}) is less than min (${minHops}).`,
       );
     }
-    return { direction, types, minHops, maxHops };
+    return { direction, types, minHops, maxHops, isVarLength };
   }
 
   private parseRange(): { min: number; max: number } {
@@ -1266,7 +1277,7 @@ const PROP_ALIASES: Record<string, keyof CypherNodeValue> = {
   id: "nodeId",
 };
 
-function nodeToValue(hit: SearchHit | TraverseHit): CypherNodeValue {
+function nodeToValue(hit: SearchHit | TraverseHit | TraversePathHit): CypherNodeValue {
   return {
     nodeId: hit.nodeId,
     qualifiedName: hit.qualifiedName,
@@ -1432,34 +1443,75 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     const nodePattern = ast.match.nodes[idx + 1]!;
     const nextBindings: Binding[] = [];
     for (const binding of bindings) {
-      const t = store.traverse({
-        start: binding.lastNode.nodeId,
-        direction: rel.direction,
-        ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
-        maxDepth: rel.maxHops,
-      });
-      if (!t.ok) {
-        // unknown_start can happen if the node vanished between search
-        // and traverse — skip this binding rather than fail the whole
-        // query. Genuine db errors propagate.
-        if (
-          t.code === "unknown_start" ||
-          t.code === "ambiguous_start" ||
-          t.code === "invalid_query"
-        ) {
-          continue;
+      // Collect candidate endpoint nodes for THIS binding + rel.
+      const candidates: CypherNodeValue[] = [];
+      if (rel.isVarLength) {
+        // Variable-length (`*M..N` / `*N`) compiles to the path-enumerating
+        // primitive (issue #1650) so an exact `*N` honors concrete length-N
+        // paths, not just BFS shortest-depth reachability. A node reachable
+        // at both a shorter and a length-N path is now returned for the
+        // length-N path, fixing the dropped-endpoint bug.
+        const tp = store.traversePaths({
+          start: binding.lastNode.nodeId,
+          direction: rel.direction,
+          ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
+          maxHops: rel.maxHops,
+        });
+        if (!tp.ok) {
+          // unknown_start can happen if the node vanished between search
+          // and traverse -- skip this binding rather than fail the whole
+          // query. Genuine db errors propagate.
+          if (
+            tp.code === "unknown_start" ||
+            tp.code === "ambiguous_start" ||
+            tp.code === "invalid_query"
+          ) {
+            continue;
+          }
+          return storeFailureToCypher(tp);
         }
-        return storeFailureToCypher(t);
+        // A `*0..N` bound includes the trivial length-0 path (the start
+        // node itself) -- traversePaths only yields length >= 1 paths.
+        if (rel.minHops === 0) candidates.push(binding.lastNode);
+        for (const hit of tp.hits) {
+          if (hit.length < rel.minHops || hit.length > rel.maxHops) continue;
+          candidates.push(nodeToValue(hit));
+        }
+      } else {
+        // Fixed-length single hop (no `*`): BFS traverse is exact for
+        // direct neighbors -- the original compile target, unchanged.
+        const t = store.traverse({
+          start: binding.lastNode.nodeId,
+          direction: rel.direction,
+          ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
+          maxDepth: rel.maxHops,
+        });
+        if (!t.ok) {
+          if (
+            t.code === "unknown_start" ||
+            t.code === "ambiguous_start" ||
+            t.code === "invalid_query"
+          ) {
+            continue;
+          }
+          return storeFailureToCypher(t);
+        }
+        // Depth filter: traverse's depth is inclusive; the relationship's
+        // minHops/maxHops are inclusive bounds (depth in [minHops, maxHops]).
+        for (const hit of t.hits) {
+          if (hit.depth < rel.minHops || hit.depth > rel.maxHops) continue;
+          candidates.push(nodeToValue(hit));
+        }
       }
-      // Depth filter: half-open per traverse, but the relationship's
-      // minHops/maxHops are inclusive bounds (depth ∈ [minHops, maxHops]).
-      // The start node itself is at depth 0; for hops we want depth >= 1.
+      // Shared: dedupe by node id (one binding per distinct endpoint),
+      // apply the target node pattern, then bind. Deduping by node id
+      // preserves the read-subset's reachability contract for `*1..N`
+      // (one row per reachable node), even though var-length now
+      // enumerates paths internally (issue #1650).
       const seen = new Set<string>();
-      for (const hit of t.hits) {
-        if (hit.depth < rel.minHops || hit.depth > rel.maxHops) continue;
-        if (seen.has(hit.nodeId)) continue;
-        seen.add(hit.nodeId);
-        const node = nodeToValue(hit);
+      for (const node of candidates) {
+        if (seen.has(node.nodeId)) continue;
+        seen.add(node.nodeId);
         if (!matchesNodePattern(node, nodePattern)) continue;
         const varByName = new Map(binding.varByName);
         if (nodePattern.varName) {

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -114,6 +114,8 @@ import type {
   TraversePathHit,
 } from "../graph-store.js";
 
+import { MAX_TRAVERSE_PATHS_HOPS } from "../graph-store.js";
+
 // ──────────────────────────────────────────────────────────────────────────
 // Label universe — the documented schema's node labels.
 //
@@ -1456,6 +1458,23 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     const rel = ast.match.rels[idx]!;
     const nodePattern = ast.match.nodes[idx + 1]!;
     const nextBindings: Binding[] = [];
+    // Surface an oversized variable-length depth as a query-level failure
+    // instead of letting the store cap silently drop results: the store
+    // rejects maxHops > MAX_TRAVERSE_PATHS_HOPS, but this loop's invalid_query
+    // skip would otherwise hide it and return an empty success
+    // (cursor Bugbot: 'Hop cap yields silent drops'; chatgpt-codex-
+    // connector P2: 'Propagate oversized variable-length').
+    if (rel.isVarLength && rel.maxHops > MAX_TRAVERSE_PATHS_HOPS) {
+      const range =
+        rel.minHops === rel.maxHops
+          ? `*${rel.maxHops}`
+          : `*${rel.minHops}..${rel.maxHops}`;
+      return {
+        ok: false,
+        code: "invalid_query",
+        message: `Variable-length ${range} exceeds the maximum supported traversal depth (${MAX_TRAVERSE_PATHS_HOPS}). Narrow the range.`,
+      };
+    }
     for (const binding of bindings) {
       // Collect candidate endpoint nodes for THIS binding + rel.
       const candidates: CypherNodeValue[] = [];

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -59,7 +59,9 @@
  * shorter and a length-N path (the length-N path qualifies). The result is
  * deduped by node id, so `*1..N` ("reachable within N hops") is unchanged
  * from the prior BFS behavior — only exact `*N` (N > 1) gains paths the
- * shortest-depth BFS dropped.
+ * shortest-depth BFS dropped. If enumeration hits the store's maxPaths cap,
+ * the success result carries `truncated: true` so callers can detect a
+ * partial endpoint set instead of silently dropping reachable nodes.
  *
  * ## Read-only by construction
  *
@@ -205,6 +207,14 @@ export interface CypherSuccess {
   /** Column names in RETURN order; each row has these keys. */
   columns: string[];
   rows: CypherRow[];
+  /**
+   * Present and `true` ONLY when a variable-length expansion hit the
+   * `traversePaths` maxPaths cap — the rows are a PARTIAL endpoint set and
+   * some reachable nodes may be omitted. Callers that must know the result
+   * is complete should treat `truncated: true` as unreliable. Absent means
+   * the enumeration completed (issue #1650).
+   */
+  truncated?: boolean;
 }
 
 export type CypherResult = CypherSuccess | CypherFailure;
@@ -1434,6 +1444,10 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
       return { varByName, lastNode: node };
     });
 
+  // OR-across every variable-length expansion: any traversePaths cap hit
+  // makes the final result a partial endpoint set (issue #1650).
+  let truncated = false;
+
   // 2. Walk the remaining (rel, node) pairs, expanding each binding via
   //    traverse. The traverse start is the binding's POSITIONAL lastNode,
   //    not a named variable — so anonymous nodes anywhere in the path
@@ -1470,6 +1484,11 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
           }
           return storeFailureToCypher(tp);
         }
+        // Path enumeration may have stopped at the maxPaths cap -- surface
+        // that so callers can detect an incomplete result instead of
+        // silently omitting reachable nodes (cursor Bugbot: 'Ignores path
+        // enumeration truncation').
+        if (tp.truncated) truncated = true;
         // A `*0..N` bound includes the trivial length-0 path (the start
         // node itself) -- traversePaths only yields length >= 1 paths.
         if (rel.minHops === 0) candidates.push(binding.lastNode);
@@ -1558,7 +1577,9 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
     return row;
   });
 
-  return { ok: true, columns, rows };
+  return truncated
+    ? { ok: true, columns, rows, truncated: true }
+    : { ok: true, columns, rows };
 }
 
 function matchesNodePattern(node: CypherNodeValue, pattern: NodePattern): boolean {

--- a/packages/coding-graph/src/cypher/query-parser.ts
+++ b/packages/coding-graph/src/cypher/query-parser.ts
@@ -1469,6 +1469,10 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
           start: binding.lastNode.nodeId,
           direction: rel.direction,
           ...(rel.types.length > 0 ? { edgeTypes: rel.types } : {}),
+          // Push minHops into the store so its maxPaths cap counts only
+          // in-range paths, not the shorter prefixes an exact *N must walk
+          // (cursor Bugbot: 'Path cap ignores hop minimum').
+          minHops: Math.max(1, rel.minHops),
           maxHops: rel.maxHops,
         });
         if (!tp.ok) {
@@ -1492,8 +1496,9 @@ export function executeAst(store: GraphStore, ast: CypherAst): CypherResult {
         // A `*0..N` bound includes the trivial length-0 path (the start
         // node itself) -- traversePaths only yields length >= 1 paths.
         if (rel.minHops === 0) candidates.push(binding.lastNode);
+        // traversePaths already restricts emitted paths to
+        // [max(1, minHops), maxHops], so no length filter is needed here.
         for (const hit of tp.hits) {
-          if (hit.length < rel.minHops || hit.length > rel.maxHops) continue;
           candidates.push(nodeToValue(hit));
         }
       } else {

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -603,7 +603,12 @@ test("traversePaths: endpoint reachable at len 1 AND len 2 yields a hit for each
     // The length-2 hit to b must trace a->c->b.
     const bLen2 = bHits.find((h) => h.length === 2)!;
     assert.equal(bLen2.nodeIds.length, 3);
-    assert.equal(bLen2.nodeIds[0], bLen2.nodeIds[0]); // start-first
+    // The length-2 path to b is a->c->b: middle node is c, and every hop
+    // is a CALLS edge (kilo-code-bot: the prior line was a tautology).
+    const cHit = out.hits.find((h) => h.qualifiedName === "mp.c" && h.length === 1)!;
+    assert.equal(bLen2.nodeIds[1], cHit.nodeId, "length-2 path to b is a->c->b");
+    assert.equal(bLen2.nodeIds[0], out.hits[0]!.nodeIds[0], "path starts at the start node");
+    assert.deepEqual(bLen2.edgeTypes, ["CALLS", "CALLS"]);
   } finally {
     await dispose(store, dir);
   }
@@ -665,6 +670,108 @@ test("traversePaths: maxPaths cap sets truncated and bounds the hit count", asyn
     if (!out.ok) throw new Error("expected ok");
     assert.equal(out.truncated, true, "enumeration must flag truncation");
     assert.equal(out.hits.length, 2, "hit count must not exceed the cap");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: minHops gates the cap -- shorter prefixes do not consume maxPaths (cursor Bugbot)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    // *2 (minHops 2, maxHops 2) with a tight maxPaths. Three length-2 paths
+    // exist (a->b->d, a->c->b, a->c->d); two length-1 paths exist (a->b,
+    // a->c) but must NOT count toward the cap. With maxPaths 2 we expect 2
+    // LENGTH-2 hits (truncated), and zero length-1 hits.
+    const out = store.traversePaths({ start: "mp.a", minHops: 2, maxHops: 2, maxPaths: 2 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.truncated, true, "cap is hit by in-range length-2 paths");
+    assert.equal(out.hits.length, 2);
+    assert.ok(out.hits.every((h) => h.length === 2), "no shorter prefix consumes the cap");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: minHops emits only in-range paths (no cap)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    // minHops 2, maxHops 2, default cap: all three length-2 paths, no length-1.
+    const out = store.traversePaths({ start: "mp.a", minHops: 2, maxHops: 2 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.truncated, false);
+    assert.equal(out.hits.length, 3);
+    assert.ok(out.hits.every((h) => h.length === 2));
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: edgeTypes exposes the relationship type per hop (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const mixed: StoreFileIR = {
+      path: "src/mixed2.ts",
+      language: "typescript",
+      contentHash: "h-mixed2",
+      symbols: [sym("mx.a", "a", 0, 10), sym("mx.b", "b", 10, 20)],
+      edges: [
+        edge("mx.a", "mx.b", "CALLS"),
+        edge("mx.a", "mx.b", "USES_TYPE"),
+      ],
+    };
+    const r = await store.upsertFileBatch([mixed]);
+    assert.equal(r.ok, true);
+    // Two distinct relationships a->b (CALLS, USES_TYPE) yield two distinct
+    // relationship-simple paths with identical nodeIds but different edgeTypes.
+    const out = store.traversePaths({ start: "mx.a", maxHops: 1 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 2, "two distinct edges -> two distinct paths");
+    const typeSets = out.hits.map((h) => h.edgeTypes).sort();
+    assert.deepEqual(typeSets, [["CALLS"], ["USES_TYPE"]]);
+    // nodeIds are identical; only edgeTypes distinguishes them.
+    assert.deepEqual(out.hits[0]!.nodeIds, out.hits[1]!.nodeIds);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: malformed maxPaths rejected with 'invalid_query' (chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    for (const v of [-1, 1.5, Number.NaN, "100" as never, true as never] as const) {
+      const out = store.traversePaths({ start: "mp.a", maxHops: 2, maxPaths: v });
+      assert.equal(out.ok, false, `maxPaths ${JSON.stringify(v)} should fail`);
+      if (out.ok) throw new Error("expected failure");
+      assert.equal(out.code, "invalid_query");
+    }
+    // undefined still defaults (no rejection).
+    const ok = store.traversePaths({ start: "mp.a", maxHops: 1, maxPaths: undefined });
+    assert.equal(ok.ok, true);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: malformed minHops rejected with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    for (const v of [0, -1, 1.5, Number.NaN] as const) {
+      const out = store.traversePaths({ start: "mp.a", minHops: v, maxHops: 3 });
+      assert.equal(out.ok, false, `minHops ${v} should fail`);
+      if (out.ok) throw new Error("expected failure");
+      assert.equal(out.code, "invalid_query");
+    }
   } finally {
     await dispose(store, dir);
   }

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -761,6 +761,54 @@ test("traversePaths: malformed maxPaths rejected with 'invalid_query' (chatgpt-c
   }
 });
 
+test("traversePaths: maxHops above MAX_TRAVERSE_PATHS_HOPS rejected (stack-overflow guard)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    // A pathological depth (e.g. *15000) would overflow the recursive DFS;
+    // the store rejects it instead of crashing (chatgpt-codex-connector P2).
+    const out = store.traversePaths({ start: "mp.a", maxHops: 15000 });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: edgeEndpoints disambiguates antiparallel edges under direction both", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // A <-> B (both CALLS): two antiparallel edges. From A, direction both,
+    // maxHops 1: hop A->B can be via edge (A,B) outgoing OR edge (B,A)
+    // incoming -- same nodeIds [A,B], same edgeTypes [CALLS], distinct
+    // edgeEndpoints (chatgpt-codex-connector P2: 'Include edge endpoints').
+    const antiFile: StoreFileIR = {
+      path: "src/anti.ts",
+      language: "typescript",
+      contentHash: "h-anti",
+      symbols: [sym("an.a", "a", 0, 10), sym("an.b", "b", 10, 20)],
+      edges: [edge("an.a", "an.b"), edge("an.b", "an.a")],
+    };
+    const r = await store.upsertFileBatch([antiFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({ start: "an.a", direction: "both", maxHops: 1 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 2, "two distinct antiparallel edges -> two paths");
+    // Same node sequence + edge type, but distinct per-hop endpoints.
+    assert.deepEqual(out.hits[0]!.nodeIds, out.hits[1]!.nodeIds);
+    assert.deepEqual(out.hits[0]!.edgeTypes, out.hits[1]!.edgeTypes);
+    const ep = out.hits.map((h) => h.edgeEndpoints[0]).sort((x, y) =>
+      x.src < y.src ? -1 : x.src > y.src ? 1 : 0);
+    assert.equal(ep.length, 2);
+    assert.notDeepEqual(ep[0], ep[1], "edge endpoints must differ");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 test("traversePaths: malformed minHops rejected with 'invalid_query'", async () => {
   const { store, dir } = await tempStore();
   try {

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -552,6 +552,270 @@ test("traverse: malformed edgeTypes (non-array or non-string element) rejected w
 });
 
 // ──────────────────────────────────────────────────────────────────────────
+// traversePaths(): path-enumerating traversal (issue #1650). Unlike
+// traverse()'s BFS (one hit per node at shortest depth), this primitive
+// yields one hit per distinct relationship-simple path, so an exact `*N`
+// (N > 1) honors length-N paths to nodes also reachable at a shorter depth.
+// ──────────────────────────────────────────────────────────────────────────
+
+// Fixture: a graph with multiple paths to the same endpoint.
+//   a -> b          (b reachable at len 1)
+//   a -> c
+//   c -> b          (b ALSO reachable at len 2 via a->c->b)
+//   b -> d
+//   c -> d          (d reachable at len 2 via TWO paths: a->b->d, a->c->d)
+const multiPathFile: StoreFileIR = {
+  path: "src/multipath.ts",
+  language: "typescript",
+  contentHash: "h-multipath",
+  symbols: [
+    sym("mp.a", "a", 0, 10),
+    sym("mp.b", "b", 10, 20),
+    sym("mp.c", "c", 20, 30),
+    sym("mp.d", "d", 30, 40),
+  ],
+  edges: [
+    edge("mp.a", "mp.b"),
+    edge("mp.a", "mp.c"),
+    edge("mp.c", "mp.b"),
+    edge("mp.b", "mp.d"),
+    edge("mp.c", "mp.d"),
+  ],
+};
+
+test("traversePaths: endpoint reachable at len 1 AND len 2 yields a hit for each path (issue #1650 core)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({ start: "mp.a", maxHops: 2 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.truncated, false);
+    // len1: a->b, a->c ; len2: a->b->d, a->c->b, a->c->d  => 5 paths.
+    assert.equal(out.hits.length, 5);
+    // b is an endpoint at BOTH length 1 (a->b) and length 2 (a->c->b).
+    // BFS traverse would visit b only once at depth 1.
+    const bHits = out.hits.filter((h) => h.qualifiedName === "mp.b");
+    assert.equal(bHits.length, 2, "b must appear once per distinct path");
+    const bLengths = bHits.map((h) => h.length).sort();
+    assert.deepEqual(bLengths, [1, 2]);
+    // The length-2 hit to b must trace a->c->b.
+    const bLen2 = bHits.find((h) => h.length === 2)!;
+    assert.equal(bLen2.nodeIds.length, 3);
+    assert.equal(bLen2.nodeIds[0], bLen2.nodeIds[0]); // start-first
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: diamond yields two length-2 paths to the far node", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({ start: "mp.a", maxHops: 2 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    const dHits = out.hits.filter((h) => h.qualifiedName === "mp.d");
+    assert.equal(dHits.length, 2, "d reachable via two distinct len-2 paths");
+    assert.ok(dHits.every((h) => h.length === 2));
+    // The two paths are a->b->d and a->c->d (distinct middle node).
+    const middles = new Set(dHits.map((h) => h.nodeIds[1]));
+    assert.equal(middles.size, 2, "two distinct middle nodes (b and c)");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: relationship-uniqueness terminates on a cyclic graph and caps path length", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([cyclicFile]);
+    assert.equal(r.ok, true);
+    // cyclicFile: a->b->c->a plus a self-edge on b. Relationship-uniqueness
+    // must bound enumeration (each edge used once per path) so this completes.
+    const out = store.traversePaths({ start: "cyc.a", maxHops: 5 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.ok(out.hits.length > 0, "should enumerate at least the len-1 path");
+    // No path exceeds maxHops.
+    assert.ok(out.hits.every((h) => h.length <= 5));
+    // Every hit's nodeIds reconstructs to length+1 entries.
+    assert.ok(out.hits.every((h) => h.nodeIds.length === h.length + 1));
+    // relationship-uniqueness allows revisiting a node via a DISTINCT edge:
+    // a->b->c->a is valid (edges a-b, b-c, c-a all different) and reaches a
+    // at length 3. Node-uniqueness would block this.
+    const backToA = out.hits.find((h) => h.qualifiedName === "cyc.a" && h.length === 3);
+    assert.ok(backToA, "a->b->c->a (len 3) must be enumerated under relationship-uniqueness");
+    assert.deepEqual(backToA!.nodeIds.length, 4);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: maxPaths cap sets truncated and bounds the hit count", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    // 5 distinct paths of length <= 2 exist from a; cap at 2.
+    const out = store.traversePaths({ start: "mp.a", maxHops: 2, maxPaths: 2 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.truncated, true, "enumeration must flag truncation");
+    assert.equal(out.hits.length, 2, "hit count must not exceed the cap");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: maxHops 0 yields no paths (every path has length >= 1)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({ start: "mp.a", maxHops: 0 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 0);
+    assert.equal(out.truncated, false);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: direction=incoming follows edges backward", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    // Who points at b within 1 hop? a (a->b) and c (c->b).
+    const out = store.traversePaths({
+      start: "mp.b",
+      direction: "incoming",
+      maxHops: 1,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 2);
+    const qnames = out.hits.map((h) => h.qualifiedName).sort();
+    assert.deepEqual(qnames, ["mp.a", "mp.c"]);
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: edgeTypes filter restricts enumerated paths", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({
+      start: "mp.a",
+      edgeTypes: ["USES_TYPE"],
+      maxHops: 2,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 0, "no USES_TYPE edges => no paths");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: unknown start returns tagged failure (rule 34)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const out = store.traversePaths({ start: "does.not.exist", maxHops: 3 });
+    assert.equal(out.ok, false);
+    if (out.ok) throw new Error("expected failure");
+    assert.equal(out.code, "unknown_start");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: invalid maxHops rejected with 'invalid_query' (rule 51)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    for (const v of [-1, 1.5, Number.NaN] as const) {
+      const out = store.traversePaths({ start: "mp.a", maxHops: v });
+      assert.equal(out.ok, false);
+      if (out.ok) throw new Error("expected failure");
+      assert.equal(out.code, "invalid_query");
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: invalid direction / edgeTypes / start rejected with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    const badDir = store.traversePaths({
+      start: "mp.a",
+      direction: "sideways" as never,
+      maxHops: 2,
+    });
+    assert.equal(badDir.ok, false);
+    if (badDir.ok) throw new Error("expected failure");
+    assert.equal(badDir.code, "invalid_query");
+
+    const badTypes = store.traversePaths({
+      start: "mp.a",
+      edgeTypes: "CALLS" as never,
+      maxHops: 2,
+    });
+    assert.equal(badTypes.ok, false);
+    if (badTypes.ok) throw new Error("expected failure");
+    assert.equal(badTypes.code, "invalid_query");
+
+    const badStart = store.traversePaths({ start: "", maxHops: 2 });
+    assert.equal(badStart.ok, false);
+    if (badStart.ok) throw new Error("expected failure");
+    assert.equal(badStart.code, "invalid_query");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+test("traversePaths: store_closed when the store is closed", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+  } finally {
+    await dispose(store, dir);
+  }
+  // store is now closed after dispose.
+  const out = store.traversePaths({ start: "mp.a", maxHops: 2 });
+  assert.equal(out.ok, false);
+  if (out.ok) throw new Error("expected failure");
+  assert.equal(out.code, "store_closed");
+});
+
+test("traversePaths: rejects a null/undefined query object with 'invalid_query'", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    const r = await store.upsertFileBatch([multiPathFile]);
+    assert.equal(r.ok, true);
+    for (const bad of [null, undefined] as const) {
+      const out = store.traversePaths(bad as never);
+      assert.equal(out.ok, false);
+      if (out.ok) throw new Error("expected failure");
+      assert.equal(out.code, "invalid_query");
+    }
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
 // searchGraph(): label / name / file patterns + degree filters + limit.
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/packages/coding-graph/src/graph-store-pr2.test.ts
+++ b/packages/coding-graph/src/graph-store-pr2.test.ts
@@ -706,6 +706,33 @@ test("traversePaths: direction=incoming follows edges backward", async () => {
   }
 });
 
+test("traversePaths: direction=both does not double a self-loop (one hit per distinct path)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // A single self-loop edge s->s is matched by BOTH the outgoing and
+    // incoming SELECTs under direction "both"; without dedup the same
+    // relationship-simple path is emitted twice (chatgpt-codex-connector
+    // P2: 'Deduplicate self-loop edges for both-direction traversal').
+    const selfFile: StoreFileIR = {
+      path: "src/self.ts",
+      language: "typescript",
+      contentHash: "h-self",
+      symbols: [sym("sl.s", "s", 0, 10)],
+      edges: [edge("sl.s", "sl.s")],
+    };
+    const r = await store.upsertFileBatch([selfFile]);
+    assert.equal(r.ok, true);
+    const out = store.traversePaths({ start: "sl.s", direction: "both", maxHops: 1 });
+    assert.equal(out.ok, true);
+    if (!out.ok) throw new Error("expected ok");
+    assert.equal(out.hits.length, 1, "self-loop must yield exactly one path under direction both");
+    assert.equal(out.hits[0]?.length, 1);
+    assert.equal(out.hits[0]?.qualifiedName, "sl.s");
+  } finally {
+    await dispose(store, dir);
+  }
+});
+
 test("traversePaths: edgeTypes filter restricts enumerated paths", async () => {
   const { store, dir } = await tempStore();
   try {

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -2274,7 +2274,25 @@ export class GraphStore {
                 "type",
               ])
             : [];
-        return [...out, ...inn];
+        // Dedupe by the canonical (src, dst, type) key. Under
+        // direction "both" a SELF-LOOP (src == dst) is matched by BOTH
+        // the outgoing and incoming SELECTs, and because usedEdges is
+        // cleared after each branch the same relationship-simple path
+        // would otherwise be emitted twice -- violating the one-hit-per-
+        // distinct-path contract and double-consuming the maxPaths cap
+        // (chatgpt-codex-connector P2: 'Deduplicate self-loop edges for
+        // both-direction traversal'). The UNIQUE(src,dst,type) table
+        // constraint guarantees no dup within a single direction, so this
+        // only ever collapses the both-direction self-loop overlap.
+        const seenEdge = new Set<string>();
+        const deduped: EdgeRow[] = [];
+        for (const e of [...out, ...inn]) {
+          const k = e.src + "\u0000" + e.dst + "\u0000" + e.type;
+          if (seenEdge.has(k)) continue;
+          seenEdge.add(k);
+          deduped.push(e);
+        }
+        return deduped;
       };
 
       const hits: TraversePathHit[] = [];

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -277,6 +277,15 @@ export type TraverseResult =
 export const DEFAULT_TRAVERSE_PATHS_MAX = 10_000;
 
 /**
+ * Hard upper bound on {@link TraversePathsQuery.maxHops}. The DFS recurses
+ * once per hop; an unbounded depth (e.g. a Cypher `*15000`) would overflow
+ * the call stack before `maxPaths` could stop it. 1000 is ~100x any
+ * realistic code-graph depth and recurses safely (chatgpt-codex-connector
+ * P2: 'Avoid recursive DFS for deep bounded paths').
+ */
+export const MAX_TRAVERSE_PATHS_HOPS = 1000;
+
+/**
  * Path-enumerating traversal query (issue #1650). Mirrors {@link TraverseQuery}
  * but yields CONCRETE paths rather than BFS-shortest-depth reachability, so an
  * exact `*N` (N > 1) hop count is honored for nodes reachable at both a shorter
@@ -337,6 +346,15 @@ export interface TraversePathHit {
    * hits').
    */
   edgeTypes: string[];
+  /**
+   * Per-hop edge endpoints, parallel to {@link nodeIds} (`length` entries).
+   * Under `direction: "both"` antiparallel same-type edges (A->B and B->A)
+   * yield distinct relationship-simple paths that share nodeIds + edgeTypes;
+   * the src/dst per hop disambiguates which edge was traversed and in which
+   * direction (chatgpt-codex-connector P2: 'Include edge endpoints in path
+   * hits').
+   */
+  edgeEndpoints: Array<{ src: string; dst: string }>;
 }
 
 export type TraversePathsResult =
@@ -2176,6 +2194,12 @@ export class GraphStore {
     ) {
       return { ok: false, code: "invalid_query" };
     }
+    // Reject depths that would overflow the recursive DFS before maxPaths
+    // can bind it (chatgpt-codex-connector P2: 'Avoid recursive DFS for deep
+    // bounded paths').
+    if (query.maxHops > MAX_TRAVERSE_PATHS_HOPS) {
+      return { ok: false, code: "invalid_query" };
+    }
     const direction: TraverseDirection =
       query.direction === undefined ? "outgoing" : query.direction;
     if (
@@ -2338,6 +2362,7 @@ export class GraphStore {
       const usedEdges = new Set<string>();
       const pathNodes: string[] = [startId];
       const pathEdgeTypes: string[] = [];
+      const pathEndpoints: Array<{ src: string; dst: string }> = [];
 
       // Recursive DFS. `length` is the current path's hop count (edges taken).
       // We EXPLORE while length < maxHops (shorter prefixes must be walked to
@@ -2355,6 +2380,7 @@ export class GraphStore {
           usedEdges.add(key);
           pathNodes.push(e.neighbor);
           pathEdgeTypes.push(e.type);
+          pathEndpoints.push({ src: e.src, dst: e.dst });
           const newLength = length + 1;
           if (newLength >= minHops) {
             // Cap check on EMITTED (in-range) hits only.
@@ -2372,11 +2398,13 @@ export class GraphStore {
                   length: newLength,
                   nodeIds: pathNodes.slice(),
                   edgeTypes: pathEdgeTypes.slice(),
+                  edgeEndpoints: pathEndpoints.slice(),
                 });
               }
             }
           }
           if (!truncated) dfs(e.neighbor, newLength);
+          pathEndpoints.pop();
           pathEdgeTypes.pop();
           pathNodes.pop();
           usedEdges.delete(key);

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -268,6 +268,65 @@ export type TraverseResult =
   | { ok: false; code: "unknown_start" | "ambiguous_start" | "invalid_query" };
 
 /**
+ * Default cap on the number of concrete paths {@link GraphStore.traversePaths}
+ * enumerates before stopping and flagging `truncated`. Bounds the worst-case
+ * exponential blowup of relationship-simple path enumeration on dense
+ * subgraphs (issue #1650). Callers may override per-query via
+ * {@link TraversePathsQuery.maxPaths}.
+ */
+export const DEFAULT_TRAVERSE_PATHS_MAX = 10_000;
+
+/**
+ * Path-enumerating traversal query (issue #1650). Mirrors {@link TraverseQuery}
+ * but yields CONCRETE paths rather than BFS-shortest-depth reachability, so an
+ * exact `*N` (N > 1) hop count is honored for nodes reachable at both a shorter
+ * and a length-N path.
+ */
+export interface TraversePathsQuery {
+  /** Start node id or qualified name (same resolution rules as {@link TraverseQuery.start}). */
+  start: string;
+  /** Default `"outgoing"`. */
+  direction?: TraverseDirection;
+  /** Edge types to follow; omitted/empty means every type. */
+  edgeTypes?: readonly string[];
+  /**
+   * Inclusive upper bound on enumerated path LENGTH (hop count). MUST be a
+   * non-negative integer. A `maxHops` of 0 yields no paths (every enumerated
+   * path has length >= 1); callers that need the length-0 trivial path add it
+   * themselves.
+   */
+  maxHops: number;
+  /**
+   * Safety cap on total enumerated paths. Defaults to
+   * {@link DEFAULT_TRAVERSE_PATHS_MAX}. When the cap is reached, enumeration
+   * STOPS and the result carries `truncated: true` so callers can detect that
+   * the result is incomplete (e.g. to narrow the query or raise the cap).
+   */
+  maxPaths?: number;
+}
+
+/**
+ * One enumerated path. The endpoint node is fully resolved; the full node-id
+ * sequence lets callers reconstruct the path (issue #1650 acceptance).
+ */
+export interface TraversePathHit {
+  nodeId: string;
+  qualifiedName: string;
+  name: string;
+  label: string;
+  filePath: string;
+  /** Length of this path in hops (>= 1). */
+  length: number;
+  /** Full path as node ids, start-first (`length + 1` entries). */
+  nodeIds: string[];
+}
+
+export type TraversePathsResult =
+  | { ok: true; hits: TraversePathHit[]; truncated: boolean }
+  | ({ ok: false } & GraphStoreFailure)
+  | { ok: false; code: "unknown_start" | "ambiguous_start" | "invalid_query" };
+
+/**
  * Structured node search. All filters are AND-combined; every filter
  * is optional so the bare query `{}` returns the whole graph (capped
  * by `limit`). Patterns use SQLite `LIKE` semantics — `%` matches any
@@ -2063,6 +2122,207 @@ export class GraphStore {
     } catch (error) {
       logWriteFailure(error);
       return classifyReadError(error) as TraverseResult;
+    }
+  }
+  /**
+   * Path-enumerating traversal (issue #1650). Unlike {@link traverse}'s BFS —
+   * which visits each node ONCE at its shortest-path depth and so cannot honor
+   * an exact `*N` (N > 1) hop count for nodes reachable at both a shorter and a
+   * length-N path — this primitive enumerates concrete relationship-simple
+   * paths from the start, yielding one hit per distinct (path, endpoint) pair
+   * up to {@link TraversePathsQuery.maxHops}.
+   *
+   * Cycle safety uses RELATIONSHIP UNIQUENESS (the real Cypher rule): a single
+   * path never traverses the same edge twice, keyed by the edge's canonical
+   * `(src, dst, type)` identity. A node MAY recur in a path via distinct edges
+   * (e.g. A->B->A over two different edges) — that is correct Cypher behavior.
+   * The {@link TraversePathsQuery.maxHops} cap bounds each path's length;
+   * {@link TraversePathsQuery.maxPaths} bounds the total enumerated count so a
+   * dense subgraph cannot blow enumeration up exponentially without notice
+   * (when hit, enumeration stops and the result carries `truncated: true`).
+   *
+   * Every yielded path has length >= 1 (at least one edge). A length-0 "path"
+   * (the trivial start->start) is NOT enumerated; callers that need the start
+   * node for a `*0..N` bound add it themselves.
+   */
+  traversePaths(query: TraversePathsQuery): TraversePathsResult {
+    if (this.closed) return { ok: false, code: "store_closed" };
+    // Guard the query object before any dereference (mirrors traverse).
+    if (query == null || typeof query !== "object") {
+      return { ok: false, code: "invalid_query" };
+    }
+    if (
+      typeof query.maxHops !== "number" ||
+      !Number.isInteger(query.maxHops) ||
+      query.maxHops < 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    const direction: TraverseDirection =
+      query.direction === undefined ? "outgoing" : query.direction;
+    if (
+      direction !== "outgoing" &&
+      direction !== "incoming" &&
+      direction !== "both"
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    if (
+      query.edgeTypes !== undefined &&
+      (!Array.isArray(query.edgeTypes) ||
+        !query.edgeTypes.every((e) => typeof e === "string"))
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    if (typeof query.start !== "string" || query.start.length === 0) {
+      return { ok: false, code: "invalid_query" };
+    }
+    const maxPaths =
+      typeof query.maxPaths === "number" &&
+      Number.isInteger(query.maxPaths) &&
+      query.maxPaths >= 0
+        ? query.maxPaths
+        : DEFAULT_TRAVERSE_PATHS_MAX;
+
+    try {
+      // Resolve the start node — same split id/qualified_name policy as
+      // traverse (cursor Bugbot: 'Traverse start conflates id and name').
+      const isNodeId = /^[0-9a-f]{64}$/.test(query.start);
+      const rows = expectRows<{ id: string }>(
+        this.db
+          .prepare(
+            isNodeId
+              ? "SELECT id FROM nodes WHERE id = ?"
+              : "SELECT id FROM nodes WHERE qualified_name = ?",
+          )
+          .all(query.start),
+        ["id"],
+      );
+      if (rows.length === 0) return { ok: false, code: "unknown_start" };
+      if (rows.length > 1) return { ok: false, code: "ambiguous_start" };
+      const startId = rows[0]!.id;
+
+      // maxHops === 0 -> no edge paths exist.
+      if (query.maxHops === 0) {
+        return { ok: true, hits: [], truncated: false };
+      }
+
+      const edgeTypes = query.edgeTypes ?? [];
+      const typeClause =
+        edgeTypes.length > 0
+          ? `AND type IN (${edgeTypes.map(() => "?").join(", ")})`
+          : "";
+      // Return the canonical (src, dst, type) so relationship-uniqueness keys
+      // are direction-independent: traversing edge A->B outgoing then B->A
+      // incoming reuses the SAME relationship and is blocked.
+      const outgoingStmt = this.db.prepare(
+        `SELECT dst AS neighbor, src, dst, type FROM edges WHERE src = ? ${typeClause}`,
+      );
+      const incomingStmt = this.db.prepare(
+        `SELECT src AS neighbor, src, dst, type FROM edges WHERE dst = ? ${typeClause}`,
+      );
+      const nodeStmt = this.db.prepare(
+        "SELECT n.id, n.qualified_name, n.name, n.label, f.path AS file_path FROM nodes n JOIN files f ON n.file_id = f.id WHERE n.id = ?",
+      );
+
+      type NodeRow = {
+        id: string;
+        qualified_name: string;
+        name: string;
+        label: string;
+        file_path: string;
+      };
+      type EdgeRow = {
+        neighbor: string;
+        src: string;
+        dst: string;
+        type: string;
+      };
+
+      const nodeCache = new Map<string, NodeRow>();
+      const getNode = (id: string): NodeRow | undefined => {
+        const cached = nodeCache.get(id);
+        if (cached) return cached;
+        const row = expectRow<NodeRow>(nodeStmt.get(id), [
+          "id",
+          "qualified_name",
+          "name",
+          "label",
+          "file_path",
+        ]);
+        if (row) nodeCache.set(id, row);
+        return row;
+      };
+
+      const neighborsOf = (id: string): EdgeRow[] => {
+        const params = [id, ...edgeTypes];
+        const out: EdgeRow[] =
+          direction === "outgoing" || direction === "both"
+            ? expectRows<EdgeRow>(outgoingStmt.all(...params), [
+                "neighbor",
+                "src",
+                "dst",
+                "type",
+              ])
+            : [];
+        const inn: EdgeRow[] =
+          direction === "incoming" || direction === "both"
+            ? expectRows<EdgeRow>(incomingStmt.all(...params), [
+                "neighbor",
+                "src",
+                "dst",
+                "type",
+              ])
+            : [];
+        return [...out, ...inn];
+      };
+
+      const hits: TraversePathHit[] = [];
+      let truncated = false;
+      const usedEdges = new Set<string>();
+      const pathNodes: string[] = [startId];
+
+      // Recursive DFS. `length` is the current path's hop count (edges taken).
+      // We can extend while length < maxHops.
+      const dfs = (currentId: string, length: number): void => {
+        if (truncated) return;
+        if (length >= query.maxHops) return;
+        for (const e of neighborsOf(currentId)) {
+          if (truncated) return;
+          const key = `${e.src}\u0000${e.dst}\u0000${e.type}`;
+          if (usedEdges.has(key)) continue;
+          // Cap check BEFORE committing this path so the count never exceeds
+          // maxPaths.
+          if (hits.length >= maxPaths) {
+            truncated = true;
+            return;
+          }
+          usedEdges.add(key);
+          pathNodes.push(e.neighbor);
+          const newLength = length + 1;
+          const info = getNode(e.neighbor);
+          if (info) {
+            hits.push({
+              nodeId: info.id,
+              qualifiedName: info.qualified_name,
+              name: info.name,
+              label: info.label,
+              filePath: info.file_path,
+              length: newLength,
+              nodeIds: pathNodes.slice(),
+            });
+          }
+          dfs(e.neighbor, newLength);
+          pathNodes.pop();
+          usedEdges.delete(key);
+        }
+      };
+
+      dfs(startId, 0);
+      return { ok: true, hits, truncated };
+    } catch (error) {
+      logWriteFailure(error);
+      return classifyReadError(error) as TraversePathsResult;
     }
   }
   /**

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -297,6 +297,15 @@ export interface TraversePathsQuery {
    */
   maxHops: number;
   /**
+   * Inclusive LOWER bound on EMITTED path length (hop count). Defaults
+   * to 1. The DFS still EXPLORES shorter prefixes to reach longer paths,
+   * but only EMITS (and counts toward {@link maxPaths}) paths whose length
+   * is in `[minHops, maxHops]` -- so an exact `*N` cap is not consumed by
+   * the shorter prefixes (cursor Bugbot: 'Path cap ignores hop minimum').
+   * MUST be a positive integer (>= 1) when present.
+   */
+  minHops?: number;
+  /**
    * Safety cap on total enumerated paths. Defaults to
    * {@link DEFAULT_TRAVERSE_PATHS_MAX}. When the cap is reached, enumeration
    * STOPS and the result carries `truncated: true` so callers can detect that
@@ -319,6 +328,15 @@ export interface TraversePathHit {
   length: number;
   /** Full path as node ids, start-first (`length + 1` entries). */
   nodeIds: string[];
+  /**
+   * Edge type per hop, parallel to {@link nodeIds} (`length` entries). Two
+   * distinct relationships can connect the same node pair with different
+   * types (the edges table is UNIQUE on `(src, dst, type)`); exposing the
+   * type per hop lets callers distinguish those otherwise-identical-node
+   * paths (chatgpt-codex-connector P2: 'Include edge identity in path
+   * hits').
+   */
+  edgeTypes: string[];
 }
 
 export type TraversePathsResult =
@@ -2177,12 +2195,32 @@ export class GraphStore {
     if (typeof query.start !== "string" || query.start.length === 0) {
       return { ok: false, code: "invalid_query" };
     }
-    const maxPaths =
-      typeof query.maxPaths === "number" &&
-      Number.isInteger(query.maxPaths) &&
-      query.maxPaths >= 0
-        ? query.maxPaths
-        : DEFAULT_TRAVERSE_PATHS_MAX;
+    // minHops: validate only when explicitly provided; default 1. MUST be a
+    // positive integer -- the primitive never emits length-0 paths.
+    const minHops = query.minHops === undefined ? 1 : query.minHops;
+    if (
+      typeof minHops !== "number" ||
+      !Number.isInteger(minHops) ||
+      minHops < 1
+    ) {
+      return { ok: false, code: "invalid_query" };
+    }
+    // maxPaths: reject a malformed EXPLICIT value rather than silently
+    // defaulting (rule 51 -- surface what's wrong). Only `undefined` defaults
+    // (chatgpt-codex-connector P2: 'Reject malformed maxPaths instead of
+    // defaulting').
+    let maxPaths: number;
+    if (query.maxPaths === undefined) {
+      maxPaths = DEFAULT_TRAVERSE_PATHS_MAX;
+    } else if (
+      typeof query.maxPaths !== "number" ||
+      !Number.isInteger(query.maxPaths) ||
+      query.maxPaths < 0
+    ) {
+      return { ok: false, code: "invalid_query" };
+    } else {
+      maxPaths = query.maxPaths;
+    }
 
     try {
       // Resolve the start node — same split id/qualified_name policy as
@@ -2299,9 +2337,14 @@ export class GraphStore {
       let truncated = false;
       const usedEdges = new Set<string>();
       const pathNodes: string[] = [startId];
+      const pathEdgeTypes: string[] = [];
 
       // Recursive DFS. `length` is the current path's hop count (edges taken).
-      // We can extend while length < maxHops.
+      // We EXPLORE while length < maxHops (shorter prefixes must be walked to
+      // reach longer paths) but EMIT only when newLength >= minHops, so the
+      // maxPaths cap protects the in-range result set instead of being
+      // consumed by discarded shorter prefixes (cursor Bugbot: 'Path cap
+      // ignores hop minimum').
       const dfs = (currentId: string, length: number): void => {
         if (truncated) return;
         if (length >= query.maxHops) return;
@@ -2309,28 +2352,32 @@ export class GraphStore {
           if (truncated) return;
           const key = `${e.src}\u0000${e.dst}\u0000${e.type}`;
           if (usedEdges.has(key)) continue;
-          // Cap check BEFORE committing this path so the count never exceeds
-          // maxPaths.
-          if (hits.length >= maxPaths) {
-            truncated = true;
-            return;
-          }
           usedEdges.add(key);
           pathNodes.push(e.neighbor);
+          pathEdgeTypes.push(e.type);
           const newLength = length + 1;
-          const info = getNode(e.neighbor);
-          if (info) {
-            hits.push({
-              nodeId: info.id,
-              qualifiedName: info.qualified_name,
-              name: info.name,
-              label: info.label,
-              filePath: info.file_path,
-              length: newLength,
-              nodeIds: pathNodes.slice(),
-            });
+          if (newLength >= minHops) {
+            // Cap check on EMITTED (in-range) hits only.
+            if (hits.length >= maxPaths) {
+              truncated = true;
+            } else {
+              const info = getNode(e.neighbor);
+              if (info) {
+                hits.push({
+                  nodeId: info.id,
+                  qualifiedName: info.qualified_name,
+                  name: info.name,
+                  label: info.label,
+                  filePath: info.file_path,
+                  length: newLength,
+                  nodeIds: pathNodes.slice(),
+                  edgeTypes: pathEdgeTypes.slice(),
+                });
+              }
+            }
           }
-          dfs(e.neighbor, newLength);
+          if (!truncated) dfs(e.neighbor, newLength);
+          pathEdgeTypes.pop();
           pathNodes.pop();
           usedEdges.delete(key);
         }

--- a/packages/coding-graph/src/index.ts
+++ b/packages/coding-graph/src/index.ts
@@ -165,6 +165,7 @@ export {
   GraphStore,
   nodeIdFor,
   DEFAULT_TRAVERSE_PATHS_MAX,
+  MAX_TRAVERSE_PATHS_HOPS,
   DEAD_CODE_EXCLUSION,
   type ByteSpan,
   type DeadCodeHit,

--- a/packages/coding-graph/src/index.ts
+++ b/packages/coding-graph/src/index.ts
@@ -164,6 +164,7 @@ export {
 export {
   GraphStore,
   nodeIdFor,
+  DEFAULT_TRAVERSE_PATHS_MAX,
   DEAD_CODE_EXCLUSION,
   type ByteSpan,
   type DeadCodeHit,
@@ -189,6 +190,9 @@ export {
   type TraverseDirection,
   type TraverseHit,
   type TraverseQuery,
+  type TraversePathHit,
+  type TraversePathsQuery,
+  type TraversePathsResult,
   type TraverseResult,
   type ReadCoChangeEdge,
   type ReadCoChangesResult,


### PR DESCRIPTION
Closes #1650.

## Problem

`executeAst` compiled variable-length relationships (`-[:TYPE*M..N]->`) to `GraphStore.traverse`, an iterative frontier **BFS keyed by node id** — each node is returned ONCE at its shortest-path depth, then the executor filters to `[minHops, maxHops]`. This is correct for `*1..N` ("reachable within N hops") but **wrong for exact `*N` (N > 1)**: a node reachable at BOTH a shorter path and a length-N path is returned only at the shorter depth and dropped by the depth filter.

Example: with `A->B` and `A->C->B`, `MATCH (a {name:"A"})-[:CALLS*2]->(b) RETURN b` should include `B` (length-2 path `A->C->B`) but returned nothing for it (`B` was visited at BFS depth 1).

This was raised as a P2 in review round 2 on #1646 and won't-fixed there because the fix is architectural — it needs a path-enumerating store primitive, not an executor-only change.

## Change

**`GraphStore.traversePaths`** — a new read primitive that enumerates concrete relationship-simple paths via DFS, yielding one hit per distinct (path, endpoint) pair up to `maxHops`:
- **Cycle safety via RELATIONSHIP UNIQUENESS** (real Cypher semantics): a single path never traverses the same edge twice, keyed by the edge's canonical `(src, dst, type)` identity. A node MAY recur in a path via distinct edges.
- **Bounded blowup**: `maxHops` caps each path's length; `maxPaths` (default `DEFAULT_TRAVERSE_PATHS_MAX = 10_000`) caps the total enumerated count, flipping `truncated: true` when hit.
- Same tagged-failure contract as `traverse` (`unknown_start` / `ambiguous_start` / `invalid_query` / `store_closed` / db failures).

**Executor** (`executeAst`) — variable-length relationships (`*M..N` / `*N`, flagged via a new `RelPattern.isVarLength`) now compile to `traversePaths` and filter on **path LENGTH** rather than BFS depth. Fixed-length single hops (no `*`) keep the original `traverse` path unchanged. Endpoints are **deduped by node id**, so:
- `*1..N` ("reachable within N hops") results are **unchanged** — every node the BFS found, path enumeration also finds (the shortest path is itself a valid relationship-simple path).
- Only exact `*N` (N > 1) gains the length-N paths the shortest-depth BFS dropped.
- A `*0..N` bound additionally includes the trivial length-0 path (the start node), preserving prior behavior.

## Files
- `packages/coding-graph/src/graph-store.ts` — `TraversePathsQuery` / `TraversePathHit` / `TraversePathsResult` types + `traversePaths()` + `DEFAULT_TRAVERSE_PATHS_MAX`.
- `packages/coding-graph/src/cypher/query-parser.ts` — `RelPattern.isVarLength`; executor var-length branch uses `traversePaths` + length filter; module doc updated.
- `packages/coding-graph/src/index.ts` — export the new types + constant.
- `packages/coding-graph/src/graph-store-pr2.test.ts` — 12 `traversePaths` tests (multi-path endpoint enumeration, diamond, relationship-uniqueness cycle safety + node revisit, `maxPaths` truncation, `maxHops:0`, direction, edgeTypes, all failure codes).
- `packages/coding-graph/src/cypher/query-parser.test.ts` — 4 cypher acceptance tests (`*2` includes the dual-path node, diamond `*2`, cyclic `*1..4` terminates, `*1..2` no-regression).

## Acceptance (#1650 done-when)
- ✅ `MATCH (a {name:"A"})-[:CALLS*2]->(b) RETURN b` includes `B` when both `A->B` and `A->C->B` exist.
- ✅ `*1..N` results unchanged (no regression to blast-radius consumers).
- ✅ Cycle safety preserved (relationship-uniqueness terminates on cyclic + self-edge graphs).

## Verification
- `pnpm --filter @remnic/coding-graph build` (+ dts) ✅
- `tsx --test` on both affected files: **118/118 pass** (incl. 16 new tests) ✅
- `npm run preflight:quick` → `[preflight] OK (quick)` (lint, check-types, check-config-contract, plugin:inspect, review-patterns, **ratchets OK**, docs-parity, all quick suites) ✅

## Chokepoints used / not applicable
- **Not applicable** — this is an isolated `@remnic/coding-graph` change. It touches no god files (`orchestrator.ts` / `cli.ts` / `storage.ts`), adds no config flag, registers no MCP/HTTP/CLI surface, and uses no catalog write path. Ratchets pass without `--update`.

## External report
Follow-up to the review thread "Honor exact variable-length path depths" on PR #1646 (issue #1552, openCypher read-subset).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cypher variable-length semantics and adds bounded DFS enumeration; behavior is well-tested but dense graphs can return partial results via `truncated`.
> 
> **Overview**
> Adds **`GraphStore.traversePaths`**, a DFS path enumerator with relationship-uniqueness, `minHops`/`maxHops`, default **`maxPaths`** (10k), **`truncated`**, and hard caps on depth—replacing BFS-only semantics for variable-length Cypher.
> 
> The Cypher executor routes patterns with `*` through **`traversePaths`** (`RelPattern.isVarLength`), dedupes endpoints by node id, surfaces **`truncated`** on partial results, and returns **`invalid_query`** for depths above **`MAX_TRAVERSE_PATHS_HOPS`** instead of silent empty sets. Single-hop patterns still use **`traverse`**.
> 
> Exports new types/constants from **`index.ts`**. Broad test coverage for store primitive and Cypher acceptance (exact `*N`, `*1..N` regression, cycles, truncation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fc276d20fd0ed82caaec9255f26711a967a8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->