### PR TITLE
refactor(orchestrator): extract tier-migration cycle into TierMigrationCoordinator (#1526)

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -161,7 +161,12 @@ type OrchestratorDrainDiagnosticsView = {
     isQmdMaintenancePending(): boolean;
     isQmdMaintenanceInFlight(): boolean;
   };
-  tierMigrationInFlight?: boolean;
+  /** Tier migration coordinator owns the in-flight guard after the #1526
+   *  extraction; read it through the coordinator's public accessor (the
+   *  orchestrator no longer exposes this field directly). */
+  tierMigrationCoordinator?: {
+    isInFlight(): boolean;
+  };
 };
 
 type BenchOrchestratorState = {
@@ -2562,7 +2567,7 @@ function describeDrainState(orchestrator: Orchestrator): string {
     `consolidationInFlight=${view.maintenanceScheduler?.isConsolidationInFlight() === true}`,
     `qmdMaintenancePending=${view.maintenanceScheduler?.isQmdMaintenancePending() === true}`,
     `qmdMaintenanceInFlight=${view.maintenanceScheduler?.isQmdMaintenanceInFlight() === true}`,
-    `tierMigrationInFlight=${view.tierMigrationInFlight === true}`,
+    `tierMigrationInFlight=${view.tierMigrationCoordinator?.isInFlight() === true}`,
   ].join(", ");
 }
 

--- a/packages/remnic-core/src/orchestration/tier-migration-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/tier-migration-coordinator.ts
@@ -1,0 +1,286 @@
+/**
+ * Tier migration coordinator — extracted from the orchestrator (issue #1526).
+ *
+ * Owns the hot/cold tier-migration lifecycle for a single cycle:
+ *   - gating (config flags, in-flight guard, min-interval throttle)
+ *   - budget selection (compounding override or config default)
+ *   - candidate scanning across hot + cold storage
+ *   - promotion/demotion execution via TierMigrationExecutor
+ *   - status recording through TierMigrationStatusStore
+ *
+ * The orchestrator constructs one instance and delegates the three public
+ * entrypoints (`runTierMigrationCycle`, `runTierMigrationNow`,
+ * `getTierMigrationStatus`) to it. Storage is passed per-call so extraction
+ * (which writes to a namespace-scoped storage) and maintenance/manual (which
+ * use the default storage) share one coordinator.
+ *
+ * Behavior-preserving move from orchestrator.ts. No logic changes — the
+ * orchestrator keeps thin delegating methods so existing call sites and
+ * tests that exercise the public API continue to work.
+ */
+
+import path from "node:path";
+
+// StorageManager type comes from the package barrel (type-only) so this
+// module does not add a direct storage.ts import (#1533 ratchet).
+import type { StorageManager } from "../index.js";
+import type { SearchBackend } from "../search/port.js";
+import { TierMigrationExecutor } from "../tier-migration.js";
+import { decideTierTransition, type MemoryTier } from "../tier-routing.js";
+import {
+  TierMigrationStatusStore,
+  type TierMigrationCycleSummary,
+  type TierMigrationStatusSnapshot,
+} from "../recall-state.js";
+import {
+  type CompoundingEngine,
+  defaultTierMigrationCycleBudget,
+} from "../compounding/engine.js";
+import {
+  applyUtilityPromotionRuntimePolicy,
+  type UtilityRuntimeValues,
+} from "../utility-runtime.js";
+import type { PluginConfig, MemoryFile } from "../types.js";
+import { log } from "../logger.js";
+
+/** Dependencies injected by the orchestrator. All stable references or live
+ *  accessors (the orchestrator reassigns `qmd` to NoopSearchBackend and
+ *  `utilityRuntimeValues` after async init, so those arrive as getters). */
+export interface TierMigrationCoordinatorDeps {
+  config: PluginConfig;
+  /** Live accessor — the orchestrator reassigns this.qmd to NoopSearchBackend
+   *  after construction when the collection is missing. */
+  getQmd: () => SearchBackend;
+  tierMigrationStatus: TierMigrationStatusStore;
+  /** Live accessor — loaded asynchronously during init, null before that. */
+  getUtilityRuntimeValues: () => UtilityRuntimeValues | null;
+  /** Live accessor — undefined when compounding is disabled. */
+  getCompounding: () => CompoundingEngine | undefined;
+  /** Constructs the cold-tier StorageManager for a given parent memory dir.
+   *  Injected so this module owns no direct storage.ts import (#1533). */
+  createColdStorage: (parentDir: string) => StorageManager;
+}
+
+/**
+ * Coordinates a single tier-migration cycle. Owns the in-flight guard and
+ * last-run timestamp that previously lived as private orchestrator fields.
+ */
+export class TierMigrationCoordinator {
+  private inFlight = false;
+  private lastRunAtMs = 0;
+
+  constructor(private readonly deps: TierMigrationCoordinatorDeps) {}
+
+  /** Whether a migration cycle is currently executing (diagnostics). */
+  isInFlight(): boolean {
+    return this.inFlight;
+  }
+
+  /** Latest status snapshot (delegates to the status store). */
+  getStatus(): TierMigrationStatusSnapshot {
+    return this.deps.tierMigrationStatus.get();
+  }
+
+  /**
+   * Run one tier-migration cycle. Behavior-preserving move of the
+   * orchestrator's former `runTierMigrationCycle`.
+   */
+  async runCycle(
+    storage: StorageManager,
+    trigger: "extraction" | "maintenance" | "manual",
+    options?: {
+      dryRun?: boolean;
+      limitOverride?: number;
+      force?: boolean;
+    },
+  ): Promise<TierMigrationCycleSummary> {
+    const { config, tierMigrationStatus } = this.deps;
+    const dryRun = options?.dryRun === true;
+    const persistSkipped = options?.force === true || trigger === "manual";
+    if (!config.qmdTierMigrationEnabled && options?.force !== true) {
+      const skipped: TierMigrationCycleSummary = {
+        trigger,
+        scanned: 0,
+        migrated: 0,
+        promoted: 0,
+        demoted: 0,
+        limit: 0,
+        dryRun,
+        skipped: "tier_migration_disabled",
+      };
+      if (persistSkipped) await tierMigrationStatus.recordCycle(skipped);
+      return skipped;
+    }
+    if (
+      trigger === "maintenance" &&
+      !config.qmdTierAutoBackfillEnabled &&
+      options?.force !== true
+    ) {
+      const skipped: TierMigrationCycleSummary = {
+        trigger,
+        scanned: 0,
+        migrated: 0,
+        promoted: 0,
+        demoted: 0,
+        limit: 0,
+        dryRun,
+        skipped: "maintenance_backfill_disabled",
+      };
+      if (persistSkipped) await tierMigrationStatus.recordCycle(skipped);
+      return skipped;
+    }
+    if (this.inFlight) {
+      const skipped: TierMigrationCycleSummary = {
+        trigger,
+        scanned: 0,
+        migrated: 0,
+        promoted: 0,
+        demoted: 0,
+        limit: 0,
+        dryRun,
+        skipped: "migration_in_flight",
+      };
+      if (persistSkipped) await tierMigrationStatus.recordCycle(skipped);
+      return skipped;
+    }
+
+    const budgetTrigger = trigger === "manual" ? "maintenance" : trigger;
+    const budget =
+      this.deps.getCompounding()?.tierMigrationCycleBudget(budgetTrigger) ??
+      defaultTierMigrationCycleBudget(config, budgetTrigger);
+    const limit =
+      options?.limitOverride !== undefined
+        ? Math.max(0, Math.floor(options.limitOverride))
+        : budget.limit;
+    const nowMs = Date.now();
+    if (
+      options?.force !== true &&
+      nowMs - this.lastRunAtMs < budget.minIntervalMs
+    ) {
+      const skipped: TierMigrationCycleSummary = {
+        trigger,
+        scanned: 0,
+        migrated: 0,
+        promoted: 0,
+        demoted: 0,
+        limit,
+        dryRun,
+        skipped: "min_interval",
+      };
+      if (persistSkipped) await tierMigrationStatus.recordCycle(skipped);
+      return skipped;
+    }
+
+    const policy = applyUtilityPromotionRuntimePolicy(
+      {
+        enabled: config.qmdTierMigrationEnabled,
+        demotionMinAgeDays: config.qmdTierDemotionMinAgeDays,
+        demotionValueThreshold: config.qmdTierDemotionValueThreshold,
+        promotionValueThreshold: config.qmdTierPromotionValueThreshold,
+      },
+      this.deps.getUtilityRuntimeValues(),
+    );
+
+    this.inFlight = true;
+    try {
+      const coldStorage = this.deps.createColdStorage(
+        path.join(storage.dir, "cold"),
+      );
+      const [hotMemories, coldMemories] = await Promise.all([
+        storage.readAllMemories(),
+        coldStorage.readAllMemories(),
+      ]);
+      const now = new Date();
+      const scanLimit = Math.max(0, Math.floor(budget.scanLimit));
+      const hotScanLimit = Math.min(
+        hotMemories.length,
+        Math.ceil(scanLimit * 0.75),
+      );
+      const coldScanLimit = Math.min(
+        coldMemories.length,
+        Math.max(0, scanLimit - hotScanLimit),
+      );
+      const toTimestamp = (memory: MemoryFile): number =>
+        Date.parse(memory.frontmatter.updated ?? memory.frontmatter.created);
+      const hotCandidates = hotMemories
+        .map((memory) => ({ memory, tier: "hot" as MemoryTier }))
+        .sort((a, b) => toTimestamp(a.memory) - toTimestamp(b.memory))
+        .slice(0, hotScanLimit);
+      const coldCandidates = coldMemories
+        .map((memory) => ({ memory, tier: "cold" as MemoryTier }))
+        .sort((a, b) => toTimestamp(b.memory) - toTimestamp(a.memory))
+        .slice(0, coldScanLimit);
+      const candidates = [...hotCandidates, ...coldCandidates];
+
+      const migration = new TierMigrationExecutor({
+        storage,
+        qmd: this.deps.getQmd(),
+        hotCollection: config.qmdCollection,
+        coldCollection:
+          config.qmdColdCollection ?? `${config.qmdCollection}-cold`,
+        autoEmbed: config.qmdAutoEmbedEnabled,
+      });
+
+      let migrated = 0;
+      let promoted = 0;
+      let demoted = 0;
+      for (const candidate of candidates) {
+        if (migrated >= limit) break;
+        const decision = decideTierTransition(
+          candidate.memory,
+          candidate.tier,
+          policy,
+          now,
+        );
+        if (!decision.changed) continue;
+
+        if (!dryRun) {
+          const res = await migration.migrateMemory({
+            memory: candidate.memory,
+            fromTier: candidate.tier,
+            toTier: decision.nextTier,
+            reason: `${trigger}:${decision.reason}`,
+          });
+          if (!res.changed) continue;
+        }
+        migrated += 1;
+        if (decision.nextTier === "cold") demoted += 1;
+        if (decision.nextTier === "hot") promoted += 1;
+      }
+
+      if (!dryRun) this.lastRunAtMs = Date.now();
+      log.debug(
+        `tier migration cycle completed: trigger=${trigger} scanned=${candidates.length} migrated=${migrated} limit=${limit}${dryRun ? " dryRun=true" : ""}`,
+      );
+      const summary: TierMigrationCycleSummary = {
+        trigger,
+        scanned: candidates.length,
+        migrated,
+        promoted,
+        demoted,
+        limit,
+        dryRun,
+      };
+      const shouldPersistCycle = trigger === "manual" || migrated > 0;
+      if (shouldPersistCycle) await tierMigrationStatus.recordCycle(summary);
+      return summary;
+    } catch (err) {
+      this.lastRunAtMs = Date.now();
+      log.warn(`tier migration cycle failed (${trigger}, fail-open): ${err}`);
+      const failed: TierMigrationCycleSummary = {
+        trigger,
+        scanned: 0,
+        migrated: 0,
+        promoted: 0,
+        demoted: 0,
+        limit,
+        dryRun,
+        errorCount: 1,
+      };
+      await tierMigrationStatus.recordCycle(failed);
+      return failed;
+    } finally {
+      this.inFlight = false;
+    }
+  }
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -93,6 +93,7 @@ import {
   gatewayTaskChainOptions,
 } from "./fallback-llm.js";
 import { MaintenanceScheduler } from "./orchestration/maintenance.js";
+import { TierMigrationCoordinator } from "./orchestration/tier-migration-coordinator.js";
 import {
   runLiveConnectorsOnce,
   type LiveConnectorsRunSummary,
@@ -1905,6 +1906,7 @@ export class Orchestrator {
   readonly lastRecall: LastRecallStore;
   readonly handleHistory: RecallHandleHistoryStore;
   readonly tierMigrationStatus: TierMigrationStatusStore;
+  readonly tierMigrationCoordinator: TierMigrationCoordinator;
   /**
    * In-memory X-ray snapshot from the most recent `recall()` call that
    * was invoked with `xrayCapture: true` (issue #570 PR 1).  Scope is
@@ -2022,8 +2024,6 @@ export class Orchestrator {
   private wearablesServiceInstance: WearablesService | null = null;
   private wearablesAutoSyncHandle: { stop(): Promise<void> } | null = null;
   private lastQmdReprobeAtMs = 0;
-  private tierMigrationInFlight = false;
-  private lastTierMigrationRunAtMs = 0;
   private readonly conversationIndexLastUpdateAtMs = new Map<string, number>();
   private lastFileHygieneRunAtMs = 0;
   // Pattern-reinforcement cadence gate (issue #687 PR 2/4).  Tracks the
@@ -2848,6 +2848,14 @@ export class Orchestrator {
       maxDepth: config.recallHandleSnapshotDepth,
     });
     this.tierMigrationStatus = new TierMigrationStatusStore(config.memoryDir);
+    this.tierMigrationCoordinator = new TierMigrationCoordinator({
+      config,
+      getQmd: () => this.qmd,
+      tierMigrationStatus: this.tierMigrationStatus,
+      getUtilityRuntimeValues: () => this.utilityRuntimeValues,
+      getCompounding: () => this.compounding,
+      createColdStorage: (parentDir) => new StorageManager(parentDir),
+    });
     this.sessionObserver = new SessionObserverState({
       memoryDir: config.memoryDir,
       debounceMs: config.sessionObserverDebounceMs ?? 120_000,
@@ -13866,192 +13874,7 @@ export class Orchestrator {
       force?: boolean;
     },
   ): Promise<TierMigrationCycleSummary> {
-    const dryRun = options?.dryRun === true;
-    const persistSkipped = options?.force === true || trigger === "manual";
-    if (!this.config.qmdTierMigrationEnabled && options?.force !== true) {
-      const skipped: TierMigrationCycleSummary = {
-        trigger,
-        scanned: 0,
-        migrated: 0,
-        promoted: 0,
-        demoted: 0,
-        limit: 0,
-        dryRun,
-        skipped: "tier_migration_disabled",
-      };
-      if (persistSkipped) await this.tierMigrationStatus.recordCycle(skipped);
-      return skipped;
-    }
-    if (
-      trigger === "maintenance" &&
-      !this.config.qmdTierAutoBackfillEnabled &&
-      options?.force !== true
-    ) {
-      const skipped: TierMigrationCycleSummary = {
-        trigger,
-        scanned: 0,
-        migrated: 0,
-        promoted: 0,
-        demoted: 0,
-        limit: 0,
-        dryRun,
-        skipped: "maintenance_backfill_disabled",
-      };
-      if (persistSkipped) await this.tierMigrationStatus.recordCycle(skipped);
-      return skipped;
-    }
-    if (this.tierMigrationInFlight) {
-      const skipped: TierMigrationCycleSummary = {
-        trigger,
-        scanned: 0,
-        migrated: 0,
-        promoted: 0,
-        demoted: 0,
-        limit: 0,
-        dryRun,
-        skipped: "migration_in_flight",
-      };
-      if (persistSkipped) await this.tierMigrationStatus.recordCycle(skipped);
-      return skipped;
-    }
-
-    const budgetTrigger = trigger === "manual" ? "maintenance" : trigger;
-    const budget =
-      this.compounding?.tierMigrationCycleBudget(budgetTrigger) ??
-      defaultTierMigrationCycleBudget(this.config, budgetTrigger);
-    const limit =
-      options?.limitOverride !== undefined
-        ? Math.max(0, Math.floor(options.limitOverride))
-        : budget.limit;
-    const nowMs = Date.now();
-    if (
-      options?.force !== true &&
-      nowMs - this.lastTierMigrationRunAtMs < budget.minIntervalMs
-    ) {
-      const skipped: TierMigrationCycleSummary = {
-        trigger,
-        scanned: 0,
-        migrated: 0,
-        promoted: 0,
-        demoted: 0,
-        limit,
-        dryRun,
-        skipped: "min_interval",
-      };
-      if (persistSkipped) await this.tierMigrationStatus.recordCycle(skipped);
-      return skipped;
-    }
-
-    const policy = applyUtilityPromotionRuntimePolicy(
-      {
-        enabled: this.config.qmdTierMigrationEnabled,
-        demotionMinAgeDays: this.config.qmdTierDemotionMinAgeDays,
-        demotionValueThreshold: this.config.qmdTierDemotionValueThreshold,
-        promotionValueThreshold: this.config.qmdTierPromotionValueThreshold,
-      },
-      this.utilityRuntimeValues,
-    );
-
-    this.tierMigrationInFlight = true;
-    try {
-      const coldStorage = new StorageManager(path.join(storage.dir, "cold"));
-      const [hotMemories, coldMemories] = await Promise.all([
-        storage.readAllMemories(),
-        coldStorage.readAllMemories(),
-      ]);
-      const now = new Date();
-      const scanLimit = Math.max(0, Math.floor(budget.scanLimit));
-      const hotScanLimit = Math.min(
-        hotMemories.length,
-        Math.ceil(scanLimit * 0.75),
-      );
-      const coldScanLimit = Math.min(
-        coldMemories.length,
-        Math.max(0, scanLimit - hotScanLimit),
-      );
-      const toTimestamp = (memory: MemoryFile): number =>
-        Date.parse(memory.frontmatter.updated ?? memory.frontmatter.created);
-      const hotCandidates = hotMemories
-        .map((memory) => ({ memory, tier: "hot" as MemoryTier }))
-        .sort((a, b) => toTimestamp(a.memory) - toTimestamp(b.memory))
-        .slice(0, hotScanLimit);
-      const coldCandidates = coldMemories
-        .map((memory) => ({ memory, tier: "cold" as MemoryTier }))
-        .sort((a, b) => toTimestamp(b.memory) - toTimestamp(a.memory))
-        .slice(0, coldScanLimit);
-      const candidates = [...hotCandidates, ...coldCandidates];
-
-      const migration = new TierMigrationExecutor({
-        storage,
-        qmd: this.qmd,
-        hotCollection: this.config.qmdCollection,
-        coldCollection:
-          this.config.qmdColdCollection ?? `${this.config.qmdCollection}-cold`,
-        autoEmbed: this.config.qmdAutoEmbedEnabled,
-      });
-
-      let migrated = 0;
-      let promoted = 0;
-      let demoted = 0;
-      for (const candidate of candidates) {
-        if (migrated >= limit) break;
-        const decision = decideTierTransition(
-          candidate.memory,
-          candidate.tier,
-          policy,
-          now,
-        );
-        if (!decision.changed) continue;
-
-        if (!dryRun) {
-          const res = await migration.migrateMemory({
-            memory: candidate.memory,
-            fromTier: candidate.tier,
-            toTier: decision.nextTier,
-            reason: `${trigger}:${decision.reason}`,
-          });
-          if (!res.changed) continue;
-        }
-        migrated += 1;
-        if (decision.nextTier === "cold") demoted += 1;
-        if (decision.nextTier === "hot") promoted += 1;
-      }
-
-      if (!dryRun) this.lastTierMigrationRunAtMs = Date.now();
-      log.debug(
-        `tier migration cycle completed: trigger=${trigger} scanned=${candidates.length} migrated=${migrated} limit=${limit}${dryRun ? " dryRun=true" : ""}`,
-      );
-      const summary: TierMigrationCycleSummary = {
-        trigger,
-        scanned: candidates.length,
-        migrated,
-        promoted,
-        demoted,
-        limit,
-        dryRun,
-      };
-      const shouldPersistCycle = trigger === "manual" || migrated > 0;
-      if (shouldPersistCycle)
-        await this.tierMigrationStatus.recordCycle(summary);
-      return summary;
-    } catch (err) {
-      this.lastTierMigrationRunAtMs = Date.now();
-      log.warn(`tier migration cycle failed (${trigger}, fail-open): ${err}`);
-      const failed: TierMigrationCycleSummary = {
-        trigger,
-        scanned: 0,
-        migrated: 0,
-        promoted: 0,
-        demoted: 0,
-        limit,
-        dryRun,
-        errorCount: 1,
-      };
-      await this.tierMigrationStatus.recordCycle(failed);
-      return failed;
-    } finally {
-      this.tierMigrationInFlight = false;
-    }
+    return this.tierMigrationCoordinator.runCycle(storage, trigger, options);
   }
 
   async getTierMigrationStatus(): Promise<TierMigrationStatusSnapshot> {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20563,
+      "packages/remnic-core/src/orchestrator.ts": 20386,
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,


### PR DESCRIPTION
Part of #1526 (Phase 2 — extract-when-touched). Follow-up to PR1 (#1625, MaintenanceScheduler).

## What

Behavior-preserving extraction of the **hot/cold tier-migration lifecycle** out of `orchestrator.ts` into a new cohesive module `orchestration/tier-migration-coordinator.ts`:

- config gating (tier-migration flag, maintenance-backfill flag)
- in-flight guard (`tierMigrationInFlight`)
- min-interval throttle (`lastTierMigrationRunAtMs`)
- budget selection (compounding override or config default)
- candidate scanning across hot + cold storage
- promotion/demotion execution via `TierMigrationExecutor`
- status recording via `TierMigrationStatusStore`

The orchestrator constructs one `TierMigrationCoordinator` and keeps **thin delegating methods** (`runTierMigrationCycle` / `runTierMigrationNow` / `getTierMigrationStatus`) so all call sites and the public API are unchanged. The in-flight guard and last-run timestamp move entirely to the coordinator.

## Why this seam

Lowest remaining coupling after maintenance (PR1): `tierMigrationInFlight` / `lastTierMigrationRunAtMs` are touched by **zero** external tests (only a diagnostics read in the bench adapter, updated here to go through `coordinator.isInFlight()` — same pattern PR1 used for `maintenanceScheduler`). Cohesive lifecycle cluster (~196 LOC) with a clean DI boundary.

## Ratchet

`orchestrator.ts`: **20563 → 20386 LOC** (baseline tightened via `check-ratchets --update`).
`directStorageImports` **unchanged at 38** — cold-storage construction is injected (`createColdStorage`) and `StorageManager` is a type-only import from the package barrel, so the new module adds no direct `storage.ts` import (#1533).

## Verification

- [x] `npm run preflight:quick` → `[preflight] OK (quick)`
- [x] `npm run test:entity-hardening` → **246/246 pass**
- [x] `node scripts/check-ratchets.mjs` → OK (improvement recorded)
- [x] `@remnic/core` build (ESM + DTS) clean
- [x] `@remnic/bench` typecheck clean
- [x] orchestrator extraction-queue + flush tests (42/42) green
- [x] characterization suite (#1531) green

**Chokepoints used:** none new — pure extract-when-touched move, no feature change.

## Done-when (#1526, per extraction)

- [x] orchestrator.ts LOC strictly lower (ratchet-proven)
- [x] moved subsystem has its own DI boundary + thin delegating surface
- [x] #1531 characterization unchanged-green
- [x] zero behavior diffs (move, not rewrite)

This is an incremental seam; further extractions (extraction pipeline, recall assembly) land as separate PRs on top per the #1526 order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches memory tier promotion/demotion and QMD-backed migration paths, but the PR is an explicit behavior-preserving move with the same public entrypoints and characterization tests called out as green.
> 
> **Overview**
> Hot/cold **tier-migration cycle** logic moves out of `orchestrator.ts` into a new `TierMigrationCoordinator` (`orchestration/tier-migration-coordinator.ts`). The coordinator owns gating, in-flight guard, min-interval throttle, budget selection, hot/cold scanning, `TierMigrationExecutor` runs, and status recording; the orchestrator wires it via DI (live `getQmd` / compounding / utility getters, injected `createColdStorage`) and keeps **thin delegates** on `runTierMigrationCycle` / existing public APIs.
> 
> Private fields `tierMigrationInFlight` and `lastTierMigrationRunAtMs` are removed from the orchestrator; diagnostics use `tierMigrationCoordinator.isInFlight()` instead (bench adapter updated the same way as maintenance scheduler in PR1). `orchestrator.ts` ratchet baseline drops **20563 → 20386** LOC; `directStorageImports` stays at 38 (type-only barrel import + injected cold storage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d734abdd016e540f490ebcb5f009780cd5e078e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->