### PR TITLE
feat(model-lab): reproducible fine-tuning lab — faithfulness-gate + correction-intent (#1585)

### DIFF
--- a/docs/model-lab.md
+++ b/docs/model-lab.md
@@ -1,0 +1,123 @@
+# model-lab: reproducible fine-tuning lab
+
+The `model-lab/` tree holds reproducible recipes to fine-tune the two small
+classification models Remnic's extraction pipeline can consume locally:
+
+- **faithfulness-gate** (`remnic-faithfulness-gate-v1`) — (factText, quote, context)
+  → {entailed, contradicted, unsupported}. Backs the extraction faithfulness
+  gate (#1576 / #1585).
+- **correction-intent** (`remnic-correction-intent-v1`) — turn text + a small
+  prior-turn window → the #1581 `corrections[]` block (or none). Backs passive-
+  correction detection (#1581 / #1585).
+
+Everything reproduces from manifests; **no datasets or weights are ever
+committed to this repo** (git carries recipes and hashes, never blobs).
+
+## Status: software landed, eval numbers GPU-gated
+
+This document describes the reproducible software shipped for #1585:
+
+| Piece | Status |
+|---|---|
+| Manifest schema + version-pin (`common/manifest_schema.py`, `common/training_stack.py`) | ✅ landed (both manifests committed as `pending-training` schema examples) |
+| Seeded data generators (faithfulness perturbations + correction-intent morphology) | ✅ landed (CI-tested: determinism + selfcheck, pure CPU) |
+| Train recipes (`train.py`, lazy-imported GPU stack) | ✅ landed (recipe + reproducibility contract) |
+| Eval harness (held-out p95 latency + F1) | ✅ landed (`common/latency.py`, `common/eval_runner.py`) |
+| Remnic config pointers | ✅ landed (`extractionFaithfulnessBaseUrl`, `correctionIntent*`) |
+| **Actual training runs + eval-number manifests** | ⏳ **GPU-gated** — #1585 follow-up when the lab frees |
+| **Downstream bench artifacts (gate quality vs prompted LLM; MemCorrect false_apply)** | ⏳ **GPU-gated** — #1585 follow-up |
+
+Per rule 55 (#1520): **no accuracy/latency number appears here without an
+artifact from a real run.** Every committed manifest is explicitly
+`pending-training` until the GPU-run follow-up fills `eval.heldOut`,
+`eval.downstream`, and `trainingStack` with real values.
+
+## Hardware envelope (sets the model-size policy)
+
+| Operation | RTX 3090 (24 GB, Ampere — bf16 yes, FP8 no) |
+|---|---|
+| Encoder classifier fine-tune (DeBERTa-v3-large class, ~0.4B) | Trivial: full fine-tune, minutes–1h |
+| Full fine-tune, causal LM | ≤ ~1.5B comfortably |
+| LoRA (bf16 base) | ≤ ~8B |
+| QLoRA (4-bit base + paged optimizer) | ≤ ~14B; ~30B-class technically possible but too slow — out of policy |
+| Inference serving (Ollama / vLLM, 4-bit) | ~14B dense or ~30B-class MoE, one model at a time |
+
+**Policy: target models ≤ 4B for these two tasks** (classification, not
+generation). An 8B LoRA is an escape hatch if evals demand it; anything larger
+needs a written justification in the manifest's `policyCompliance` block.
+
+## Reproducing a model on a 3090-class GPU
+
+```bash
+# 1. Bootstrap the version-pinned training stack (the manifest's trainingStack
+#    must reproduce these exact versions).
+bash model-lab/setup.sh
+source model-lab/.venv/bin/activate
+
+# 2. Faithfulness-gate (encoder baseline):
+python model-lab/faithfulness-gate/generate-data.py --seed 1337 --yes   # → faithfulness-gate/data/
+python model-lab/faithfulness-gate/train.py   --version-tag v1          # → model-lab/runs/faithfulness-gate/v1/
+python model-lab/faithfulness-gate/eval.py    --version-tag v1 --held-out <gold.jsonl> --latency-samples <ms.txt>
+
+# 3. Correction-intent (≤4B instruct LM, LoRA):
+python model-lab/correction-intent/generate-data.py --seed 1337 --yes   # → correction-intent/data/
+python model-lab/correction-intent/train.py   --version-tag v1
+python model-lab/correction-intent/eval.py    --held-out <gold.jsonl> --latency-samples <ms.txt>
+```
+
+`train.py`/`eval.py` lazy-import the GPU stack so `--help` works on a bare
+machine; each exits with code 2 + an install hint if `torch`/`transformers`
+(and `trl`/`peft` for correction-intent) are missing. **They never run in CI.**
+
+After a real run, `train.py` captures the exact interpreter + lib versions into
+the manifest's `trainingStack` block (`common/training_stack.capture_training_stack`),
+and `eval.py` writes the `eval.heldOut` block (held-out p95 latency +
+faithfulness macro/per-class F1, or correction-intent detection F1 + span
+overlap). The manifest must pass `validate_manifest(..., allow_pending=False)`
+before publish — a half-recorded run cannot ship as complete.
+
+## Pointing Remnic at a fine-tuned local model
+
+Remnic consumes the models through config only — **zero core code changes
+beyond the config pointers**. Serve the trained + quantized model via Ollama or
+vLLM on the lab box, then:
+
+```jsonc
+// .openclaw/workspace/config.json (or --config)
+{
+  // Faithfulness gate → local fine-tuned encoder:
+  "extractionFaithfulnessGate": "enforce",            // or "shadow" to record only
+  "extractionFaithfulnessModel": "remnic-faithfulness-gate-v1",
+  "extractionFaithfulnessBaseUrl": "http://localhost:11434/v1",  // Ollama; or vLLM :8000/v1
+
+  // Correction-intent classifier (optional; rule-based detector is the default):
+  "correctionIntentModel": "remnic-correction-intent-v1",
+  "correctionIntentBaseUrl": "http://localhost:11434/v1"
+}
+```
+
+When `extractionFaithfulnessBaseUrl` + `extractionFaithfulnessModel` are both
+set, the gate routes to that local endpoint **first**, falling back to the
+configured LLM chain on any failure (graceful degradation — a down local model
+never blocks writes). Empty/unset values preserve the existing routing exactly
+(byte-identical pre-feature path, rule 39).
+
+The `correctionIntent*` pointer is the hook the model-backed detector consumes;
+the rule-based `detectPassiveCorrections` (#1581) remains the default path until
+a model-backed detector lands in the consuming child.
+
+## Privacy + consent
+
+- The **harvest stream** (teacher labels from shadow mode) is opt-in, local-only,
+  and documented. `harvest-shadow-logs.py` requires `--i-consent-local-data` and
+  prints exactly what it will read. It is a **stub** until the relevant shadow
+  telemetry lands (#1576 for the gate, #1581 for correction-intent).
+- Teacher-model outputs ("LLM traces") live under the gitignored data dir like
+  everything else.
+
+## Repo ethics
+
+`model-lab/**/data/`, `model-lab/**/runs/`, `model-lab/.venv/`, `*.safetensors`,
+and `*.gguf` are gitignored. The committed manifests are the **only** model-lab
+artifacts in git; everything else reproduces from the recipes + the version-pinned
+`requirements.txt`.

--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -9,23 +9,38 @@ This is **not** an npm workspace package. It is a standalone Python tree that fo
 ```
 model-lab/
   README.md                       this file
-  requirements.txt                version-pinned GPU training stack (PR2 onward)
+  requirements.txt                version-pinned GPU training stack (both models)
   setup.sh                        bootstrap a venv on the lab box
   common/                         shared, stdlib-only helpers
     seeding.py                    deterministic RNG + sha256 + JSONL writer
     jsonl_schema.py               FaithfulnessRecord + validators (the #1576 contract)
-    eval_runner.py                per-class / macro F1 (identical math in CI and on GPU)
-    hf_push.py                    HF Hub upload — STUB, lands in PR2 (honestly labeled)
+    eval_runner.py                per-class/macro F1 (faithfulness) + detection F1 +
+                                  span overlap (correction-intent) — identical math in CI and on GPU
+    latency.py                    held-out p95 latency harness + percentile math
+    manifest_schema.py            the reproducibility-manifest validator (both models)
+    training_stack.py             version-pin capture (requirements parse + pip-freeze hash)
+    hf_push.py                    HF Hub upload — STUB (honestly labeled; GPU-run follow-up)
   faithfulness-gate/
     generate-data.py              synthetic perturbation generator (the CI-tested piece)
     perturbations.py              pure perturbation primitives + the selfcheck case table
     train.py                      encoder-baseline training recipe (GPU + deps at runtime)
     eval.py                       held-out eval recipe; emits the manifest eval block
     harvest-shadow-logs.py        shadow-log harvest — STUB; waits for #1576 shadow mode
-    manifest.json                 THE reproducibility artifact (schema example in PR1)
+    manifest.json                 THE reproducibility artifact (schema example; pending-training)
+  correction-intent/
+    generate-data.py              synthetic morphology generator (CI-tested; mirrors #1581)
+    morphology.py                 seed grammar: #1581 polarities + anti-fixtures
+    train.py                      ≤4B instruct-LM LoRA recipe (GPU + deps at runtime)
+    eval.py                       held-out detection F1 + span quality + p95 latency
+    harvest-shadow-logs.py        shadow-log harvest — STUB; waits for #1581 telemetry
+    manifest.json                 THE reproducibility artifact (schema example; pending-training)
 ```
 
-`correction-intent/` is **not** in this PR — it lands in PR3.
+Both task trees share the same shape: a CI-tested seeded data generator (pure
+CPU, small N), lazy-imported GPU train/eval recipes, and a pending `manifest.json`.
+The actual GPU training runs + committed eval-number manifests are the
+GPU-gated part — they land in the #1585 follow-up when the lab frees (see
+`docs/model-lab.md`).
 
 ## Hardware envelope (sets the model-size policy)
 
@@ -38,6 +53,20 @@ model-lab/
 | Inference serving (Ollama / vLLM, 4-bit) | ~14B dense or ~30B-class MoE, one model at a time |
 
 **Policy: target models ≤ 4B for these two tasks** — they are classification, not generation, so small models + good data win. An 8B LoRA is an escape hatch if evals demand it. Anything larger needs a written justification in the manifest's `policyCompliance` block.
+
+## Reproducibility status (this PR vs the GPU-run follow-up)
+
+This PR ships the **reproducible software**: recipes, the version-pinned training
+stack, the manifest schema, the data generators (both models), the eval harness
+(held-out p95 latency + faithfulness F1 / correction-intent detection F1), and
+the Remnic config pointers (`extractionFaithfulnessBaseUrl`, `correctionIntent*`).
+Everything is unit-tested on CPU; **no GPU is required to land this PR.**
+
+The **actual training runs + committed eval-number manifests are GPU-gated** —
+they land in the #1585 follow-up when the lab box (RTX 3090) frees. Per rule 55
+(#1520), no eval/accuracy/latency number appears in docs or a manifest without an
+artifact from a real run; every committed manifest is explicitly `pending-training`
+until then.
 
 ## Quickstart
 
@@ -70,7 +99,7 @@ python model-lab/faithfulness-gate/eval.py    --version-tag v1          # → ma
 ## Reproducibility model
 
 * **git carries recipes + hashes, never blobs.** `model-lab/**/data/`, `model-lab/**/runs/`, `*.safetensors`, `*.gguf` are gitignored.
-* **The manifest is the only committed artifact for a trained model.** `manifest.json` carries `{task, baseModel, dataRecipe: {seed, datasetSha256, …}, hyperparams, hardware, eval, artifact}`. PR1 ships it as the **schema example** with every eval/weight field explicitly `null`/`pending` (rule 55: no fabricated numbers); PR2 fills the real values.
+* **The manifest is the only committed artifact for a trained model.** `manifest.json` carries `{task, baseModel, dataRecipe, trainingStack, hyperparams, hardware, eval, artifact, policyCompliance}` — validated by `common/manifest_schema.py`. The committed manifests ship as the **schema example** with every eval/weight/training-stack field explicitly `null`/`pending` (rule 55: no fabricated numbers); a real GPU run fills them and `validate_manifest(..., allow_pending=False)` must pass before publish.
 * **The sha256 is the reproducibility check.** Re-running `generate-data.py --seed <s>` must reproduce `datasetSha256`; the manifest records it so a future operator can verify the dataset they regenerated matches the one a model was trained on.
 
 ## Privacy + consent

--- a/model-lab/common/eval_runner.py
+++ b/model-lab/common/eval_runner.py
@@ -71,3 +71,105 @@ def held_out_block(gold: list[str], pred: list[str]) -> dict[str, object]:
         "perClass": per_class,
         "examples": len(gold),
     }
+
+
+# ---------------------------------------------------------------------------
+# Correction-intent metrics (issue #1581 / #1585 PR3)
+# ---------------------------------------------------------------------------
+#
+# The correction-intent task is a detection problem at heart: given a turn
+# (with a small prior-turn window), does it express a correction? The label
+# space the model emits is the #1581 ``corrections[]`` block (or none), so the
+# held-out metric is binary-detection F1 over {correction, none} PLUS span
+# quality (does the model's correctedAssertion/targetHint overlap the gold
+# span?). Detection F1 is the gate; span quality is the tiebreaker.
+
+
+def detection_metrics(
+    gold: list[str],
+    pred: list[str],
+    *,
+    positive: str = "correction",
+    negative: str = "none",
+) -> dict[str, dict[str, float]]:
+    """Binary detection precision/recall/F1 for {correction, none}.
+
+    ``gold`` / ``pred`` are label sequences over {``positive``, ``negative``}.
+    Returns ``{positive: {precision, recall, f1, support}, negative: {...}}``.
+    A label not in the two-value set raises so a malformed dataset fails
+    loudly rather than scoring as a silent third class.
+    """
+    if len(gold) != len(pred):
+        raise ValueError(f"length mismatch: gold={len(gold)} pred={len(pred)}")
+    valid = {positive, negative}
+    tp = fp = fn = tn = 0
+    for g, p in zip(gold, pred, strict=True):
+        if g not in valid:
+            raise ValueError(f"unknown gold label {g!r}; expected one of {valid!r}")
+        if p not in valid:
+            raise ValueError(f"unknown pred label {p!r}; expected one of {valid!r}")
+        if p == positive and g == positive:
+            tp += 1
+        elif p == positive and g == negative:
+            fp += 1
+        elif p == negative and g == positive:
+            fn += 1
+        else:
+            tn += 1
+
+    def prf(tp_: int, fp_: int, fn_: int) -> dict[str, float]:
+        precision = tp_ / (tp_ + fp_) if (tp_ + fp_) else 0.0
+        recall = tp_ / (tp_ + fn_) if (tp_ + fn_) else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        return {
+            "precision": round(precision, 6),
+            "recall": round(recall, 6),
+            "f1": round(f1, 6),
+        }
+
+    return {
+        positive: {**prf(tp, fp, fn), "support": float(tp + fn)},
+        negative: {**prf(tn, fn, fp), "support": float(fp + tn)},
+    }
+
+
+def span_overlap(pred: str, gold: str) -> float:
+    """Token-overlap ratio (Jaccard) between a predicted span and the gold span.
+
+    Correction-intent extraction emits ``correctedAssertion`` + ``targetHint``
+    spans; a faithful model reproduces the gold span's tokens. Returns 1.0 on
+    exact match, 0.0 on disjoint token sets. Case-insensitive, whitespace-split.
+    """
+    pt = set(pred.lower().split())
+    gt = set(gold.lower().split())
+    if not pt and not gt:
+        return 1.0
+    if not pt or not gt:
+        return 0.0
+    return round(len(pt & gt) / len(pt | gt), 6)
+
+
+def correction_held_out_block(
+    gold_labels: list[str],
+    pred_labels: list[str],
+    *,
+    span_overlaps: list[float] | None = None,
+) -> dict[str, object]:
+    """Assemble the manifest ``eval.heldOut`` block for correction-intent.
+
+    Detection F1 (the gate) + optional mean span-overlap (the tiebreaker).
+    The downstream number (MemCorrect false_apply / uptake@next) comes from
+    the #1584 ablation, not this function — ``eval.py`` only computes the
+    held-out block and points at where the downstream number comes from.
+    """
+    metrics = detection_metrics(gold_labels, pred_labels)
+    block: dict[str, object] = {
+        "detection": metrics,
+        "macroF1": round(
+            sum(metrics[label]["f1"] for label in metrics) / len(metrics), 6
+        ),
+        "examples": len(gold_labels),
+    }
+    if span_overlaps:
+        block["meanSpanOverlap"] = round(sum(span_overlaps) / len(span_overlaps), 6)
+    return block

--- a/model-lab/common/latency.py
+++ b/model-lab/common/latency.py
@@ -1,0 +1,108 @@
+"""Held-out latency harness (issue #1585).
+
+The eval contract for both model-lab tasks is **held-out p95 latency** plus
+classification accuracy (faithfulness F1 / correction-intent detection F1).
+The accuracy math lives in ``eval_runner.py``; this module owns the latency
+side. Pure stdlib so the percentile definitions are identical between the CI
+sanity probe and the GPU eval script — the p95 that lands in a manifest is
+computable from a hand-checked fixture.
+
+The actual measurement requires a served model (GPU-gated); this module
+provides the ``measure_endpoint_latencies`` harness that drives a served
+openai-compatible endpoint and the ``summarize`` / ``percentile`` math. The
+math is unit-tested on synthetic samples now; the live measurement runs only
+on the lab box (issue #1585 follow-up when the GPU frees).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Sequence
+
+
+def percentile(values: Sequence[float], p: float) -> float:
+    """Linear-interpolation percentile of ``values`` in [0, 100].
+
+    Mirrors numpy's default ('linear') so the GPU script and this stdlib
+    helper agree. ``p`` outside (0, 100] raises; an empty input raises.
+    """
+    if not values:
+        raise ValueError("percentile of an empty sequence is undefined")
+    if not 0 < p <= 100:
+        raise ValueError(f"p must be in (0, 100], got {p}")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (p / 100) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return float(ordered[lo] + (ordered[hi] - ordered[lo]) * frac)
+
+
+def summarize(samples_ms: Sequence[float]) -> dict[str, float]:
+    """Summarize a latency sample set into the manifest's p95 block.
+
+    Returns ``{count, min, mean, p50, p95, p99, max}``. All values in
+    milliseconds. An empty input raises (a measurement with no samples is a
+    bug, not a zero).
+    """
+    if not samples_ms:
+        raise ValueError("cannot summarize an empty latency sample set")
+    xs = [float(x) for x in samples_ms]
+    return {
+        "count": float(len(xs)),
+        "min": round(min(xs), 3),
+        "mean": round(sum(xs) / len(xs), 3),
+        "p50": round(percentile(xs, 50), 3),
+        "p95": round(percentile(xs, 95), 3),
+        "p99": round(percentile(xs, 99), 3),
+        "max": round(max(xs), 3),
+    }
+
+
+def measure_endpoint_latencies(
+    base_url: str,
+    model: str,
+    payloads: Sequence[Mapping[str, Any]],
+    *,
+    timeout_ms: int = 10_000,
+) -> dict[str, float]:
+    """Drive a served openai-compatible endpoint and summarize per-call latency.
+
+    POSTs each payload (an openai-compatible chat body, minus ``model`` which is
+    injected) to ``${base_url}/chat/completions`` and records wall-clock ms.
+    Network errors / non-2xx / timeouts are counted under ``errorCount`` but do
+    NOT contribute to the latency summary — a failed request has no latency.
+
+    GPU-gated: only meaningful against a served model (issue #1585 follow-up).
+    Returns ``{count, errorCount, min, mean, p50, p95, p99, max}``.
+    """
+    url = base_url.rstrip("/") + "/chat/completions"
+    latencies: list[float] = []
+    errors = 0
+    for payload in payloads:
+        body = dict(payload)
+        body["model"] = model
+        started = time.perf_counter()
+        try:
+            req = urllib.request.Request(
+                url,
+                data=json.dumps(body).encode("utf-8"),
+                headers={"content-type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=timeout_ms / 1000) as resp:  # noqa: S310 — lab box, local endpoint
+                if 200 <= resp.status < 300:
+                    latencies.append((time.perf_counter() - started) * 1000)
+                else:
+                    errors += 1
+        except (urllib.error.URLError, TimeoutError, OSError):
+            errors += 1
+    out: dict[str, float] = {"count": float(len(latencies)), "errorCount": float(errors)}
+    if latencies:
+        out.update(summarize(latencies))
+    return out

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -116,9 +116,9 @@ def validate_manifest(
         stack_errs = _validate_training_stack(stack, allow_pending=allow_pending)
         errors.extend(stack_errs)
 
-    # eval + artifact blocks: structural presence only. allow_pending controls
-    # whether the null/pending placeholder is accepted.
-    for block_key in ("eval", "artifact"):
+    # eval + artifact + dataRecipe blocks: structural presence only.
+    # allow_pending controls whether the null/pending placeholder is accepted.
+    for block_key in ("eval", "artifact", "dataRecipe"):
         block = manifest.get(block_key)
         if _is_pending(block):
             if not allow_pending:
@@ -139,6 +139,18 @@ def validate_manifest(
         artifact_block = manifest.get("artifact")
         if isinstance(artifact_block, Mapping) and _is_pending(artifact_block.get("hfRepo")):
             errors.append("artifact.hfRepo is pending — a real run must publish weights")
+        # dataRecipe provenance (codex P2 PRRT_kwDORJXyws6Otp-E): a published run
+        # must carry the dataset hash + generator git-sha so the eval split is
+        # reproducible. The committed scaffold leaves them null (no canonical
+        # dataset in git); a real run fills them. Without this gate a
+        # status:"trained" manifest with dataRecipe present but unhashed passes.
+        data_recipe = manifest.get("dataRecipe")
+        if isinstance(data_recipe, Mapping):
+            for field_key in ("generatorGitSha", "datasetSha256"):
+                if _is_pending(data_recipe.get(field_key)):
+                    errors.append(
+                        f"dataRecipe.{field_key} is pending — a real run must record dataset provenance"
+                    )
 
     # Real-run top-level fields (issue #1585): baseModel / hyperparams /
     # trainedAt / hardware must be CONCRETE when allow_pending=False so a
@@ -185,8 +197,15 @@ def _validate_training_stack(stack: Mapping[str, Any], *, allow_pending: bool) -
     if not isinstance(libs, Mapping):
         errors.append("trainingStack.libs must be an object mapping lib → exact version")
     elif not allow_pending:
-        # A real run must pin at least the load-bearing libs the recipes import.
-        for lib in ("torch", "transformers"):
+        # A real run must pin an exact version for torch + transformers
+        # (universal across both tasks) AND for every other lib the manifest
+        # DECLARES. The previous check only covered torch/transformers, so a
+        # correction-intent manifest with trl/peft/bitsandbytes left null passed
+        # strict validation and undermined the no-half-recorded-run gate (kilo
+        # WARNING PRRT_kwDORJXyws6OtyS-). Iterating over declared libs also
+        # respects that the two tasks pin different stacks (encoder vs causal-LM).
+        check_libs = dict.fromkeys(("torch", "transformers", *libs.keys()))
+        for lib in check_libs:
             ver = libs.get(lib)
             if _is_pending(ver) or not isinstance(ver, str):
                 errors.append(f"trainingStack.libs.{lib} must pin an exact version for a real run")

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -1,0 +1,174 @@
+"""Reproducibility manifest schema + validator (issue #1585).
+
+The manifest is the ONLY committed artifact for a trained model — git carries
+recipes + hashes, never blobs (datasets, weights, LLM traces are gitignored).
+This module is the single source of truth for what a manifest MUST contain so
+that a future operator can reproduce a model's eval numbers from the pinned
+training stack (issue #1585 pitfall: "a manifest that can't reproduce its own
+eval numbers is a bug").
+
+Pure stdlib. Consumed by the CI manifest-schema probe (no GPU) and by the
+train/eval recipes (which call ``validate_manifest(..., allow_pending=False)``
+before committing a real run's manifest).
+
+Two states are first-class:
+
+* ``allow_pending=True``  — the committed SCHEMA EXAMPLE. Every eval/weight/
+  training-stack field is ``null``/``"pending-*"`` because no model has been
+  trained yet (rule 55: no fabricated numbers). This is what lives in git now.
+* ``allow_pending=False`` — a manifest produced by a real GPU run. Every field
+  must carry a concrete value; a missing/null value is a validation error so a
+  half-recorded run can't be published as complete.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping
+
+#: Bumped when the required-field set changes. Old manifests fail loudly on a
+#: mismatch instead of silently passing a shape they don't satisfy.
+SCHEMA_VERSION: int = 1
+
+#: Top-level keys every manifest MUST carry (order-independent).
+REQUIRED_KEYS: tuple[str, ...] = (
+    "task",
+    "schemaVersion",
+    "status",
+    "contract",
+    "baseModel",
+    "dataRecipe",
+    "trainingStack",
+    "hyperparams",
+    "trainedAt",
+    "hardware",
+    "eval",
+    "artifact",
+    "policyCompliance",
+)
+
+#: Statuses a manifest may carry. ``pending-training`` is the committed
+#: scaffold; ``trained`` is a real run; ``stale`` marks a superseded model.
+VALID_STATUSES: tuple[str, ...] = ("pending-training", "trained", "stale")
+
+#: The two tasks this lab trains. The validator is task-agnostic about the
+#: inner contract shape, but the ``task`` string must name a known task so a
+#: mislabeled manifest fails.
+KNOWN_TASKS: tuple[str, ...] = ("faithfulness-gate", "correction-intent")
+
+
+def _is_pending(value: Any) -> bool:
+    """True when a value is the PR-scaffold placeholder for 'not yet run'."""
+    if value is None:
+        return True
+    if isinstance(value, str) and value.startswith("pending-"):
+        return True
+    return False
+
+
+def validate_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    allow_pending: bool = True,
+) -> list[str]:
+    """Validate ``manifest`` against the schema; return human-readable errors.
+
+    Empty list == valid. ``allow_pending`` toggles the scaffold-vs-run check
+    (see module docstring). The validator checks STRUCTURE, not semantic
+    correctness of metric values — a macro-F1 outside [0, 1] is a bug in the
+    eval recipe, caught there, not here.
+    """
+    errors: list[str] = []
+
+    if not isinstance(manifest, Mapping):
+        return ["manifest must be a JSON object"]
+
+    for key in REQUIRED_KEYS:
+        if key not in manifest:
+            errors.append(f"missing required key: {key!r}")
+
+    if errors:
+        return errors  # Don't cascade into the inner blocks of a half-shape.
+
+    if manifest.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(
+            f"schemaVersion must be {SCHEMA_VERSION}, got {manifest.get('schemaVersion')!r}"
+        )
+
+    task = manifest.get("task")
+    if task not in KNOWN_TASKS:
+        errors.append(f"task must be one of {KNOWN_TASKS!r}, got {task!r}")
+
+    status = manifest.get("status")
+    if status not in VALID_STATUSES:
+        errors.append(f"status must be one of {VALID_STATUSES!r}, got {status!r}")
+
+    # The trainingStack block is the version-pin (issue #1585). When a run has
+    # happened it MUST record the exact lib versions so the eval reproduces;
+    # the scaffold leaves it null/pending.
+    stack = manifest.get("trainingStack")
+    if _is_pending(stack):
+        if not allow_pending:
+            errors.append("trainingStack is pending — a real run must pin exact lib versions")
+    elif not isinstance(stack, Mapping):
+        errors.append("trainingStack must be an object (or null when pending)")
+    else:
+        stack_errs = _validate_training_stack(stack, allow_pending=allow_pending)
+        errors.extend(stack_errs)
+
+    # eval + artifact blocks: structural presence only. allow_pending controls
+    # whether the null/pending placeholder is accepted.
+    for block_key in ("eval", "artifact"):
+        block = manifest.get(block_key)
+        if _is_pending(block):
+            if not allow_pending:
+                errors.append(f"{block_key} is pending — a real run must record it")
+        elif not isinstance(block, Mapping):
+            errors.append(f"{block_key} must be an object (or null when pending)")
+
+    # policyCompliance must always be concrete — even the scaffold states the
+    # target ceiling, so a reviewer can see the model-size guardrail up front.
+    policy = manifest.get("policyCompliance")
+    if not isinstance(policy, Mapping):
+        errors.append("policyCompliance must be an object")
+    elif "targetMaxParamsB" not in policy:
+        errors.append("policyCompliance.targetMaxParamsB is required (the size guardrail)")
+
+    return errors
+
+
+def _validate_training_stack(stack: Mapping[str, Any], *, allow_pending: bool) -> list[str]:
+    """Validate the pinned training-stack block (exact lib versions)."""
+    errors: list[str] = []
+    required = ("python", "libs")
+    for key in required:
+        if key not in stack:
+            errors.append(f"trainingStack.{key} is required")
+    if errors:
+        return errors
+
+    if _is_pending(stack.get("python")) and not allow_pending:
+        errors.append("trainingStack.python must record the exact interpreter version")
+
+    libs = stack.get("libs")
+    if not isinstance(libs, Mapping):
+        errors.append("trainingStack.libs must be an object mapping lib → exact version")
+    elif not allow_pending:
+        # A real run must pin at least the load-bearing libs the recipes import.
+        for lib in ("torch", "transformers"):
+            ver = libs.get(lib)
+            if _is_pending(ver) or not isinstance(ver, str):
+                errors.append(f"trainingStack.libs.{lib} must pin an exact version for a real run")
+    return errors
+
+
+def stack_block_sha256(stack: Mapping[str, Any]) -> str:
+    """Stable sha256 over the training-stack block.
+
+    Recorded in the manifest so a reviewer can see the exact pinned set changed
+    (or didn't) between runs. Deterministic encoding mirrors ``seeding.py``.
+    """
+    import json
+
+    payload = json.dumps(stack, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -126,6 +126,20 @@ def validate_manifest(
         elif not isinstance(block, Mapping):
             errors.append(f"{block_key} must be an object (or null when pending)")
 
+    # Nested real-run fields (cursor review): strict mode must also reject a
+    # trained manifest whose eval/artifact object is present but leaves the
+    # load-bearing nested field null — eval.heldOut (the script-produced metric)
+    # and artifact.hfRepo (where the weights published). Without this a
+    # status:"trained" manifest with eval: {heldOut: null} slips past the
+    # top-level object check and undermines the no-half-recorded-run gate.
+    if not allow_pending:
+        eval_block = manifest.get("eval")
+        if isinstance(eval_block, Mapping) and _is_pending(eval_block.get("heldOut")):
+            errors.append("eval.heldOut is pending — a real run must record held-out metrics")
+        artifact_block = manifest.get("artifact")
+        if isinstance(artifact_block, Mapping) and _is_pending(artifact_block.get("hfRepo")):
+            errors.append("artifact.hfRepo is pending — a real run must publish weights")
+
     # Real-run top-level fields (issue #1585): baseModel / hyperparams /
     # trainedAt / hardware must be CONCRETE when allow_pending=False so a
     # reviewer can reproduce the eval. The scaffold leaves them null; a

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -126,6 +126,23 @@ def validate_manifest(
         elif not isinstance(block, Mapping):
             errors.append(f"{block_key} must be an object (or null when pending)")
 
+    # Real-run top-level fields (issue #1585): baseModel / hyperparams /
+    # trainedAt / hardware must be CONCRETE when allow_pending=False so a
+    # reviewer can reproduce the eval. The scaffold leaves them null; a
+    # half-recorded run (concrete trainingStack/eval/artifact but no base model
+    # or hardware) must not validate as a complete run. baseModel/hyperparams/
+    # hardware are objects; trainedAt is a string timestamp.
+    _OBJECT_RUN_FIELDS = ("baseModel", "hyperparams", "hardware")
+    for field_key in ("baseModel", "hyperparams", "trainedAt", "hardware"):
+        value = manifest.get(field_key)
+        if _is_pending(value):
+            if not allow_pending:
+                errors.append(
+                    f"{field_key} is pending — a real run must record it for reproducibility"
+                )
+        elif field_key in _OBJECT_RUN_FIELDS and not isinstance(value, Mapping):
+            errors.append(f"{field_key} must be an object (or null when pending)")
+
     # policyCompliance must always be concrete — even the scaffold states the
     # target ceiling, so a reviewer can see the model-size guardrail up front.
     policy = manifest.get("policyCompliance")

--- a/model-lab/common/training_stack.py
+++ b/model-lab/common/training_stack.py
@@ -1,0 +1,138 @@
+"""Training-stack capture (issue #1585 reproducibility).
+
+A manifest that can't reproduce its own eval numbers is a bug (issue #1585
+pitfall). The version-pin has two halves:
+
+1. ``model-lab/requirements.txt`` is the PIN — the exact versions an operator
+   installs. ``requirements_versions`` parses it stdlib-only.
+2. ``capture_training_stack`` records what the interpreter ACTUALLY had
+   installed at train time (``pip freeze``), so a silent drift between the pin
+   and the run is visible. This runs only on the lab box (needs the installed
+   GPU stack); ``pending_stack`` is the committed scaffold placeholder.
+
+Pure stdlib. The CI probe exercises ``requirements_versions`` + the parser on
+the committed ``requirements.txt``; ``capture_training_stack`` is GPU-gated.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Mapping
+
+#: Libs whose exact versions a reproducible run MUST record. The load-bearing
+#: training stack; anything else is ancillary. Keep in sync with requirements.txt.
+PINNED_LIBS: tuple[str, ...] = (
+    "torch",
+    "transformers",
+    "datasets",
+    "huggingface-hub",
+    "accelerate",
+    "sentencepiece",
+    # Correction-intent causal-LM stack (uncommented in requirements.txt for PR3):
+    "trl",
+    "peft",
+    "bitsandbytes",
+)
+
+
+def requirements_versions(requirements_path: Path) -> dict[str, str]:
+    """Parse a pip ``requirements.txt`` into ``{lib: version}``.
+
+    Handles ``name==1.2.3`` and ``name==1.2.3+cu126`` (local-version tags).
+    Lines without ``==`` (comments, ``--extra-index-url``, blank) are skipped.
+    Raises ``FileNotFoundError`` if the file is missing — a missing pin file is
+    a reproducibility bug, not a silent empty dict.
+    """
+    if not requirements_path.is_file():
+        raise FileNotFoundError(f"requirements file not found: {requirements_path}")
+    versions: dict[str, str] = {}
+    for raw in requirements_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        if "==" not in line:
+            continue
+        name, _, version = line.partition("==")
+        # ``name`` may carry extras (``torch[foo]==...``) — drop them.
+        name = name.split("[", 1)[0].strip()
+        version = version.split("#", 1)[0].strip()
+        if name and version:
+            versions[name] = version
+    return versions
+
+
+def pending_stack() -> dict[str, object]:
+    """The committed scaffold placeholder for ``manifest.trainingStack``.
+
+    Every field is ``None`` / ``"pending-*"`` because no GPU run has happened
+    (rule 55). The real values are filled by ``capture_training_stack`` on the
+    lab box; the pin source is ``requirements.txt`` today.
+    """
+    return {
+        "python": None,
+        "libs": {lib: None for lib in PINNED_LIBS},
+        "pipFreezeSha256": None,
+        "capturedAt": None,
+        "$comment": (
+            "SCHEMA EXAMPLE. The exact interpreter + lib versions a real run "
+            "used; captured by capture_training_stack() at train time. The pin "
+            "source is model-lab/requirements.txt. Filled in the #1585 GPU-run "
+            "follow-up (rule 55: no fabricated versions)."
+        ),
+    }
+
+
+def capture_training_stack() -> dict[str, object]:
+    """Record the live interpreter + ``pip freeze`` of the current environment.
+
+    GPU-gated: meaningful only inside the model-lab venv after
+    ``setup.sh`` + a train run. Returns the ``trainingStack`` block a manifest
+    commits for a real run. ``pip freeze`` is hashed so a reviewer can see the
+    full environment changed (or didn't) without reading 100 lines.
+    """
+    import hashlib
+    import subprocess
+
+    freeze_text = subprocess.check_output(
+        [sys.executable, "-m", "pip", "freeze"], text=True, stderr=subprocess.STDOUT
+    )
+    libs: dict[str, str] = {}
+    for raw in freeze_text.splitlines():
+        line = raw.strip()
+        if "==" not in line:
+            continue
+        name, _, version = line.partition("==")
+        name = name.split("[", 1)[0].strip().lower()
+        if name in PINNED_LIBS:
+            libs[name] = version
+    return {
+        "python": ".".join(map(str, sys.version_info[:3])),
+        "libs": libs,
+        "pipFreezeSha256": hashlib.sha256(freeze_text.encode("utf-8")).hexdigest(),
+        "capturedAt": "train-run",  # eval.py stamps the ISO timestamp
+    }
+
+
+def assert_stack_matches_requirements(
+    stack: Mapping[str, object],
+    requirements_path: Path,
+) -> list[str]:
+    """Return errors where a captured stack's lib versions diverge from the pin.
+
+    A real run's manifest should match ``requirements.txt``. Drift is a warning
+    (the run is still reproducible from ``pipFreezeSha256``) but it means the
+    pin file is stale — surface it so the operator updates the pin.
+    """
+    pinned = requirements_versions(requirements_path)
+    errors: list[str] = []
+    libs = stack.get("libs")
+    if not isinstance(libs, Mapping):
+        return ["stack.libs must be an object"]
+    for lib, want in pinned.items():
+        got = libs.get(lib)
+        if got is None:
+            errors.append(f"stack.libs.{lib} missing (pinned at {want})")
+        elif got != want:
+            errors.append(f"stack.libs.{lib}={got!r} diverges from pin {want!r}")
+    return errors

--- a/model-lab/common/training_stack.py
+++ b/model-lab/common/training_stack.py
@@ -103,7 +103,12 @@ def capture_training_stack() -> dict[str, object]:
         if "==" not in line:
             continue
         name, _, version = line.partition("==")
-        name = name.split("[", 1)[0].strip().lower()
+        # PEP 503: distribution names are case-insensitive and treat "-", "_",
+        # and "." as equivalent. pip freeze may emit either form (e.g.
+        # huggingface_hub) while PINNED_LIBS + requirements.txt use hyphens, so
+        # normalize before matching or the version is silently omitted from
+        # stack.libs (cursor review PRRT_kwDORJXyws6Otn36).
+        name = name.split("[", 1)[0].strip().lower().replace("_", "-")
         if name in PINNED_LIBS:
             libs[name] = version
     return {
@@ -129,8 +134,15 @@ def assert_stack_matches_requirements(
     libs = stack.get("libs")
     if not isinstance(libs, Mapping):
         return ["stack.libs must be an object"]
+
+    def _norm(lib_name: str) -> str:
+        # PEP 503 equivalence: a stack captured with underscore keys must still
+        # match a hyphen-form pin (cursor review PRRT_kwDORJXyws6Otn36).
+        return lib_name.strip().lower().replace("_", "-")
+
+    normalized = {_norm(str(k)): v for k, v in libs.items()}
     for lib, want in pinned.items():
-        got = libs.get(lib)
+        got = normalized.get(_norm(lib))
         if got is None:
             errors.append(f"stack.libs.{lib} missing (pinned at {want})")
         elif got != want:

--- a/model-lab/correction-intent/eval.py
+++ b/model-lab/correction-intent/eval.py
@@ -44,7 +44,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--held-out",
         type=Path,
-        help="Held-out JSONL (gold labels). If omitted, eval is not run.",
+        help="Held-out JSONL (gold labels). Required to score.",
+    )
+    parser.add_argument(
+        "--predictions",
+        type=Path,
+        help=(
+            "Model-inference output JSONL (one row per held-out turn, with a "
+            "'label' and optional 'corrections[]'). REQUIRED: scoring gold "
+            "labels against themselves is refused (no fabricated evals, rule 55)."
+        ),
     )
     parser.add_argument(
         "--latency-samples",
@@ -112,17 +121,27 @@ def main(argv: list[str] | None = None) -> int:
     if not args.held_out or not args.held_out.is_file():
         print(
             "eval.py: --held-out <gold.jsonl> is required to score the model.\n"
-            "  The actual scoring loop lands in the #1585 GPU-run follow-up.\n"
             "  No manifest eval block is written without a real run (rule 55).",
             file=sys.stderr,
         )
         return 2
 
+    # Predictions MUST come from model inference. Scoring gold against itself
+    # (pred == gold) would emit perfect detection/span metrics with no trained
+    # checkpoint loaded — a fabrication that could be copied into the manifest
+    # (codex P1). Refuse it; the model-inference loop lands in the #1585 GPU-run
+    # follow-up, or an operator supplies --predictions from a served model.
+    if not args.predictions or not args.predictions.is_file():
+        print(
+            "eval.py: --predictions <model-output.jsonl> is required to score the model.\n"
+            "  Run the trained checkpoint's inference over the held-out split first;\n"
+            "  scoring gold labels against themselves is refused (no fabricated evals, rule 55).",
+            file=sys.stderr,
+        )
+        return 2
+
     gold_rows = load_jsonl(args.held_out)
-    # The model-inference loop is GPU-gated. Demonstrate the held-out block
-    # assembly against the GOLD labels (pred == gold) so the metric shape is
-    # exercised; a real run replaces this with model predictions.
-    pred_rows = gold_rows
+    pred_rows = load_jsonl(args.predictions)
     block = correction_held_out_block(
         _gold_labels(gold_rows),
         _gold_labels(pred_rows),
@@ -132,7 +151,10 @@ def main(argv: list[str] | None = None) -> int:
     out: dict[str, Any] = {"heldOut": block}
     if args.latency_samples and args.latency_samples.is_file():
         samples = [float(x) for x in args.latency_samples.read_text().splitlines() if x.strip()]
-        out["heldOutLatencyMs"] = summarize(samples)
+        if samples:
+            out["heldOutLatencyMs"] = summarize(samples)
+        else:
+            print("eval.py: --latency-samples file has no non-blank lines; skipping latency block.", file=sys.stderr)
 
     print(json.dumps({"task": "correction-intent", "eval": out}, indent=2))
     print(

--- a/model-lab/correction-intent/eval.py
+++ b/model-lab/correction-intent/eval.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Correction-intent evaluation recipe (issue #1585 PR3; scaffold grammar in morphology.py).
+
+Scores a trained checkpoint on the held-out split and emits the manifest's
+``eval.heldOut`` block: detection F1 (correction vs none) + mean span overlap.
+The downstream number (MemCorrect #1584 ``false_apply`` and ``uptake@next`` in
+passive-queue mode) is orchestrated by the bench harness, not this script —
+``eval.py`` only computes the held-out metrics and prints a clear pointer to
+where the downstream number comes from.
+
+Hardware + dependencies: requires the GPU stack from
+``model-lab/requirements.txt``; heavy imports are lazy so ``--help`` works on
+a bare machine. Never runs in CI.
+
+The detection-F1 + span-overlap math itself lives in ``common/eval_runner.py``
+(stdlib-only) so the metric definitions are identical between this script and
+any offline/CI sanity check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_MODEL_LAB_ROOT = Path(__file__).resolve().parents[1]
+if str(_MODEL_LAB_ROOT) not in sys.path:
+    sys.path.insert(0, str(_MODEL_LAB_ROOT))
+
+from common.eval_runner import correction_held_out_block, span_overlap  # noqa: E402
+from common.latency import summarize  # noqa: E402
+
+DEFAULT_RUNS_DIR = Path(__file__).resolve().parents[1] / "runs" / "correction-intent"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Correction-intent held-out evaluation (issue #1585 PR3).",
+    )
+    parser.add_argument("--runs-dir", type=Path, default=DEFAULT_RUNS_DIR)
+    parser.add_argument("--version-tag", default="v1")
+    parser.add_argument(
+        "--held-out",
+        type=Path,
+        help="Held-out JSONL (gold labels). If omitted, eval is not run.",
+    )
+    parser.add_argument(
+        "--latency-samples",
+        type=Path,
+        help="Optional file of per-call latency samples (ms, one per line) for the p95 block.",
+    )
+    return parser
+
+
+def require_eval_deps() -> None:
+    """Lazy-import the eval stack; exit(2) with an install hint if missing."""
+    missing: list[str] = []
+    for mod in ("torch", "transformers"):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(mod)
+    if missing:
+        print(
+            "eval.py: eval stack missing (" + ", ".join(missing) + ").\n"
+            "  install with:  bash model-lab/setup.sh && source model-lab/.venv/bin/activate\n"
+            "  This script never runs in CI (issue #1585).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def _gold_labels(rows: list[dict[str, Any]]) -> list[str]:
+    return [str(r.get("label", "")) for r in rows]
+
+
+def _span_overlaps(rows: list[dict[str, Any]], pred_rows: list[dict[str, Any]]) -> list[float]:
+    """Token overlap between predicted + gold correctedAssertion (corrections only)."""
+    overlaps: list[float] = []
+    for gold, pred in zip(rows, pred_rows, strict=True):
+        if gold.get("label") != "correction":
+            continue
+        g_assert = ""
+        p_assert = ""
+        gold_corr = gold.get("corrections") or []
+        pred_corr = pred.get("corrections") or []
+        if gold_corr:
+            g_assert = str(gold_corr[0].get("correctedAssertion", ""))
+        if pred_corr:
+            p_assert = str(pred_corr[0].get("correctedAssertion", ""))
+        overlaps.append(span_overlap(p_assert, g_assert))
+    return overlaps
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    require_eval_deps()
+
+    if not args.held_out or not args.held_out.is_file():
+        print(
+            "eval.py: --held-out <gold.jsonl> is required to score the model.\n"
+            "  The actual scoring loop lands in the #1585 GPU-run follow-up.\n"
+            "  No manifest eval block is written without a real run (rule 55).",
+            file=sys.stderr,
+        )
+        return 2
+
+    gold_rows = load_jsonl(args.held_out)
+    # The model-inference loop is GPU-gated. Demonstrate the held-out block
+    # assembly against the GOLD labels (pred == gold) so the metric shape is
+    # exercised; a real run replaces this with model predictions.
+    pred_rows = gold_rows
+    block = correction_held_out_block(
+        _gold_labels(gold_rows),
+        _gold_labels(pred_rows),
+        span_overlaps=_span_overlaps(gold_rows, pred_rows),
+    )
+
+    out: dict[str, Any] = {"heldOut": block}
+    if args.latency_samples and args.latency_samples.is_file():
+        samples = [float(x) for x in args.latency_samples.read_text().splitlines() if x.strip()]
+        out["heldOutLatencyMs"] = summarize(samples)
+
+    print(json.dumps({"task": "correction-intent", "eval": out}, indent=2))
+    print(
+        "\nNOTE: downstream number (MemCorrect #1584 false_apply / uptake@next) "
+        "comes from the #1574 bench ablation, not this script. See docs/model-lab.md.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/model-lab/correction-intent/eval.py
+++ b/model-lab/correction-intent/eval.py
@@ -96,8 +96,13 @@ def _gold_labels(rows: list[dict[str, Any]]) -> list[str]:
 
 def _span_overlaps(rows: list[dict[str, Any]], pred_rows: list[dict[str, Any]]) -> list[float]:
     """Token overlap between predicted + gold correctedAssertion (corrections only)."""
+    if len(rows) != len(pred_rows):
+        raise ValueError(
+            f"length mismatch: gold={len(rows)} pred={len(pred_rows)} "
+            "(--held-out and --predictions must have one row per turn)"
+        )
     overlaps: list[float] = []
-    for gold, pred in zip(rows, pred_rows, strict=True):
+    for gold, pred in zip(rows, pred_rows):
         if gold.get("label") != "correction":
             continue
         g_assert = ""
@@ -110,6 +115,22 @@ def _span_overlaps(rows: list[dict[str, Any]], pred_rows: list[dict[str, Any]]) 
             p_assert = str(pred_corr[0].get("correctedAssertion", ""))
         overlaps.append(span_overlap(p_assert, g_assert))
     return overlaps
+
+
+def _held_out_is_predictions(held_out: Path, predictions: Path) -> bool:
+    """True when --predictions resolves to the same file as --held-out.
+
+    Pure (no torch) so the guard is unit-testable; ``main`` calls this before
+    loading rows. Uses resolve() so a symlink or a rel/abs alias can't bypass the
+    guard (codex P1 — scoring gold against itself fabricates a perfect eval that
+    could be copied into the manifest, rule 55).
+    """
+    try:
+        return held_out.resolve() == predictions.resolve()
+    except OSError:
+        # A broken symlink shouldn't crash eval; the is_file() checks above
+        # already rejected a missing predictions file.
+        return False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -136,6 +157,20 @@ def main(argv: list[str] | None = None) -> int:
             "eval.py: --predictions <model-output.jsonl> is required to score the model.\n"
             "  Run the trained checkpoint's inference over the held-out split first;\n"
             "  scoring gold labels against themselves is refused (no fabricated evals, rule 55).",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Refuse the held-out file (or a symlink/hardlink to it) as --predictions:
+    # scoring gold against itself emits perfect detection/span metrics with no
+    # inference — a fabrication that could be copied into the manifest (codex
+    # P1). _held_out_is_predictions compares RESOLVED paths so a symlink or a
+    # relative/absolute alias can't bypass the guard.
+    if _held_out_is_predictions(args.held_out, args.predictions):
+        print(
+            "eval.py: --predictions resolves to the same file as --held-out.\n"
+            "  Scoring gold labels against themselves is refused (no fabricated "
+            "evals, rule 55). Point --predictions at model-inference output.",
             file=sys.stderr,
         )
         return 2

--- a/model-lab/correction-intent/generate-data.py
+++ b/model-lab/correction-intent/generate-data.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Correction-intent synthetic data generator (issue #1585 PR3).
+
+Generates a labeled conversation dataset by instantiating the #1581 morphology
+grammar (``morphology.py``) against a substitution table. Every record's label
+is derivable from the grammar — corrections come from the correction-signal
+bank, ``none`` labels come from the anti-example + clean-turn banks — so the
+labels are trustworthy by construction (no human annotation, no LLM traces).
+
+Determinism contract (identical to the faithfulness generator): *same seed →
+byte-identical dataset → identical sha256*. The CI determinism probe asserts
+this without committing any data (generate small-N in a temp dir, hash it).
+
+Pure stdlib — ``python model-lab/correction-intent/generate-data.py`` works on
+a bare machine with no ``pip install``. The only CI-testable piece of the
+model-lab correction-intent pipeline.
+
+Usage:
+    python model-lab/correction-intent/generate-data.py --selfcheck
+    python model-lab/correction-intent/generate-data.py --seed 1337 --out /tmp/ci --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_MODEL_LAB_ROOT = Path(__file__).resolve().parents[1]
+if str(_MODEL_LAB_ROOT) not in sys.path:
+    sys.path.insert(0, str(_MODEL_LAB_ROOT))
+
+from common.seeding import deterministic_rng, write_jsonl  # noqa: E402
+
+import morphology  # noqa: E402  (sibling module, same dir)
+
+DEFAULT_SEED = 1337
+DEFAULT_OUT = Path(__file__).resolve().parent / "data"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Correction-intent synthetic data generator (issue #1585 PR3).",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="RNG seed (default 1337).")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT, help="Output directory.")
+    parser.add_argument("--yes", action="store_true", help="Skip the overwrite confirmation.")
+    parser.add_argument(
+        "--selfcheck",
+        action="store_true",
+        help="Run the morphology selftest against hand-written cases and exit.",
+    )
+    return parser
+
+
+def run_selfcheck() -> int:
+    """Run SELFTEST_CASES; emit JSON; exit 0 iff every case matches."""
+    result = run_morphology_selftest()
+    print(json.dumps(result, indent=2))
+    return 0 if result["allPassed"] else 1
+
+
+def run_morphology_selftest() -> dict[str, object]:
+    """Assert every selftest morphology produces its expected label.
+
+    Pure — no I/O. Exported so the CI node probe can call it via ``--selfcheck``
+    AND so the GPU train script can sanity-check the grammar before a run.
+    """
+    by_morph: dict[str, str] = {}
+    for sc in morphology.CORRECTION_SCENARIOS:
+        by_morph[sc.morphology] = "correction"
+    for ae in morphology.ANTI_EXAMPLES:
+        by_morph[ae.morphology] = "none"
+
+    cases: list[dict[str, object]] = []
+    all_passed = True
+    for case in morphology.SELFTEST_CASES:
+        got = by_morph.get(case.morphology)
+        passed = got == case.expected_label
+        if not passed:
+            all_passed = False
+        cases.append({
+            "morphology": case.morphology,
+            "expected": case.expected_label,
+            "actual": got,
+            "passed": passed,
+            "description": case.description,
+        })
+    return {"allPassed": all_passed, "cases": cases}
+
+
+def _prior_window(rng) -> list[dict[str, str]]:
+    """A small non-correction prior window so the model sees context."""
+    clean = morphology.CLEAN_TURNS
+    templates = rng.sample(list(clean), k=min(2, len(clean)))
+    pair = rng.choice(morphology.SUBSTITUTIONS)
+    return [{"role": "user", "content": t.replace("{old}", pair[0]).replace("{new}", pair[1])}
+            for t in templates]
+
+
+def generate_dataset(seed: int) -> list[morphology.ConversationRecord]:
+    """Instantiate the grammar into a labeled, balanced dataset.
+
+    Corrections: every scenario × every substitution pair.
+    None: every anti-example × every pair + every clean turn × every pair.
+    Deterministic in ``seed`` (the RNG only shuffles the prior window).
+    """
+    rng = deterministic_rng(seed)
+    records: list[morphology.ConversationRecord] = []
+
+    # Corrections: scenario × substitution.
+    for sc in morphology.CORRECTION_SCENARIOS:
+        for pair in morphology.SUBSTITUTIONS:
+            turn = morphology._fill(sc.template, pair)
+            correction = sc.build_correction(turn)
+            records.append(morphology.ConversationRecord(
+                turns=_prior_window(rng) + [{"role": "user", "content": turn}],
+                label="correction",
+                corrections=[correction],
+                morphology=sc.morphology,
+                sourceId=f"{sc.morphology}:{pair[0]}->{pair[1]}",
+            ))
+
+    # Anti-examples → none.
+    for ae in morphology.ANTI_EXAMPLES:
+        for pair in morphology.SUBSTITUTIONS:
+            turn = morphology._fill(ae.template, pair)
+            records.append(morphology.ConversationRecord(
+                turns=_prior_window(rng) + [{"role": "user", "content": turn}],
+                label="none",
+                corrections=[],
+                morphology=ae.morphology,
+                sourceId=f"{ae.morphology}:{pair[0]}->{pair[1]}",
+            ))
+
+    # Clean turns → none.
+    for clean in morphology.CLEAN_TURNS:
+        for pair in morphology.SUBSTITUTIONS:
+            turn = morphology._fill(clean, pair)
+            records.append(morphology.ConversationRecord(
+                turns=_prior_window(rng) + [{"role": "user", "content": turn}],
+                label="none",
+                corrections=[],
+                morphology="clean",
+                sourceId=f"clean:{clean}:{pair[0]}->{pair[1]}",
+            ))
+
+    morphology.assert_dataset(records)
+    return records
+
+
+def label_counts(records: list[morphology.ConversationRecord]) -> dict[str, int]:
+    counts = {label: 0 for label in morphology.LABELS}
+    for r in records:
+        counts[r.label] = counts.get(r.label, 0) + 1
+    counts["total"] = len(records)
+    return counts
+
+
+def generate(args: argparse.Namespace) -> int:
+    if args.out.exists() and not args.yes:
+        print(f"output directory exists: {args.out}\npass --yes to overwrite", file=sys.stderr)
+        return 2
+    args.out.mkdir(parents=True, exist_ok=True)
+    records = generate_dataset(args.seed)
+    train_path = args.out / "train.jsonl"
+    rows = [r.to_jsonl_dict() for r in records]
+    sha = write_jsonl(rows, train_path)
+    counts = label_counts(records)
+    print(f"wrote {len(rows)} records → {train_path}")
+    print(f"counts: {counts}")
+    print(f"DATASET_SHA256={sha}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.selfcheck:
+        return run_selfcheck()
+    return generate(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/model-lab/correction-intent/harvest-shadow-logs.py
+++ b/model-lab/correction-intent/harvest-shadow-logs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Correction-intent shadow-log harvest STUB (issue #1585 PR3).
+
+The harvest stream reads an operator's own #1581 passive-correction telemetry
+(the detector's captured corrections, plus an optional frontier-teacher label
+on a sampled slice for generator label-quality validation) and turns it into
+additional training data. It is **opt-in, local-only, and documented** — the
+operator consents with ``--i-consent-local-data`` and the script prints exactly
+what it will read.
+
+This PR (PR3) does NOT implement harvest: it depends on #1581 telemetry
+landed + a teacher-labeling pass. The script exits with a clear message so an
+operator cannot accidentally invoke a half-wired pipeline. The follow-up wires
+the real reader once the shadow stream is producing teacher labels.
+
+Exit code 2 distinguishes "not yet implemented" from a normal failure.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    consent = "--i-consent-local-data" in argv
+    if not consent:
+        print(
+            "harvest-shadow-logs.py requires explicit, informed consent.\n"
+            "  re-run with: --i-consent-local-data\n"
+            "This flag is intentional friction: harvest reads your own passive-\n"
+            "correction telemetry from your own memoryDir and nothing leaves the\n"
+            "machine, but the operator must opt in per session (issue #1585).",
+            file=sys.stderr,
+        )
+        return 2
+    print(
+        "harvest-shadow-logs.py is not implemented in PR3.\n"
+        "  requires: #1581 telemetry (captured corrections) + a teacher-labeling pass\n"
+        "  lands in: the #1585 GPU-run follow-up once the shadow stream produces labels\n"
+        "  reads:    passive-correction captures from <memoryDir> (local only)\n"
+        "  emits:    additional JSONL rows under correction-intent/data/harvest/\n"
+        "  reports:  teacher-vs-generator label agreement in the manifest\n"
+        "No data was read. See model-lab/README.md.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/model-lab/correction-intent/manifest.json
+++ b/model-lab/correction-intent/manifest.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": [
+    "Correction-intent reproducibility manifest (issue #1585 PR3).",
+    "This file is the SCHEMA EXAMPLE only: every eval/weight/training-stack",
+    "field is null/pending because no model has been trained yet. The exact",
+    "lib versions a real run used are captured into trainingStack at train",
+    "time; the pin source is model-lab/requirements.txt. Rule 55 (#1520):",
+    "no fabricated numbers — the eval block is explicitly empty until a real",
+    "GPU run produces it. The committed manifest is the ONLY artifact in git;",
+    "datasets, weights, and LLM traces are gitignored."
+  ],
+  "task": "correction-intent",
+  "schemaVersion": 1,
+  "status": "pending-training",
+  "contract": {
+    "inputFields": ["turns"],
+    "outputShape": "corrections[]: {targetHint, correctedAssertion, polarity, confidence} or []",
+    "source": "PassiveCorrection + PassiveCorrectionPolarity (issue #1581)"
+  },
+  "baseModel": null,
+  "dataRecipe": {
+    "generatorPath": "model-lab/correction-intent/generate-data.py",
+    "generatorGitSha": null,
+    "seed": 1337,
+    "sources": ["synthetic-morphology"],
+    "counts": {
+      "correction": null,
+      "none": null,
+      "total": null
+    },
+    "datasetSha256": null,
+    "$comment": "Counts/hash are filled by the GPU-run follow-up from a real generate-data run; PR3 leaves them null because no canonical training dataset is committed (data is gitignored)."
+  },
+  "trainingStack": {
+    "python": null,
+    "libs": {
+      "torch": null,
+      "transformers": null,
+      "trl": null,
+      "peft": null,
+      "datasets": null,
+      "huggingface-hub": null,
+      "bitsandbytes": null
+    },
+    "pipFreezeSha256": null,
+    "capturedAt": null,
+    "$comment": "SCHEMA EXAMPLE. Exact interpreter + lib versions a real run used; captured by common.training_stack.capture_training_stack() at train time. Pin source: model-lab/requirements.txt (the correction-intent causal-LM stack). Filled in the #1585 GPU-run follow-up (rule 55)."
+  },
+  "hyperparams": null,
+  "trainedAt": null,
+  "hardware": null,
+  "eval": {
+    "heldOut": null,
+    "downstream": null,
+    "$comment": "NOT YET RUN. The GPU-run follow-up fills heldOut (detection F1 + mean span overlap + held-out p95 latency); the downstream number comes from the MemCorrect (#1584) false_apply / uptake@next ablation. Rule 55 forbids fabricating either."
+  },
+  "artifact": {
+    "hfRepo": null,
+    "revision": null,
+    "quantizations": null,
+    "$comment": "Weights publish to the operator's HF account in the GPU-run follow-up (common/hf_push.py); git carries recipes and hashes, never blobs."
+  },
+  "policyCompliance": {
+    "targetMaxParamsB": 4,
+    "actualParamsB": null,
+    "escapeHatchUsed": false,
+    "$comment": "Issue #1585 policy: target models <=4B for correction-intent (structured extraction, not generation). 8B LoRA is an escape hatch requiring written justification here. Default base: Qwen/Qwen2.5-3B-Instruct."
+  }
+}

--- a/model-lab/correction-intent/morphology.py
+++ b/model-lab/correction-intent/morphology.py
@@ -1,0 +1,237 @@
+"""Correction-intent morphology grammar (issue #1581 / #1585 PR3).
+
+This is the seed grammar for the correction-intent synthetic data generator.
+It mirrors the **exact morphology** of ``packages/remnic-core/src/correction/
+passive-correction-detector.ts`` (#1581) — the three polarities
+(update / retract / stop_storing), the strong correction signals, and the four
+anti-fixture guards (self_resolving / hypothetical / third_party / tool_output)
+that the production detector rejects. Deriving the grammar from that existing
+extraction artifact is what makes the synthetic labels trustworthy: the model
+is trained on the same distinctions the rule-based detector encodes, so
+"correct" is derivable from code, not annotated.
+
+The output record shape matches the #1581 ``PassiveCorrection`` contract:
+``{targetHint, correctedAssertion, polarity, confidence}``.
+
+Pure stdlib. Imported by ``generate-data.py`` (writer), ``train.py`` /
+``eval.py`` (readers), and the CI determinism probe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, Sequence
+
+# The three correction polarities — exactly ``PassiveCorrectionPolarity`` (#1581).
+Polarity = Literal["update", "retract", "stop_storing"]
+
+#: Detection labels. ``correction`` = the turn expresses a correction to stored
+#: memory; ``none`` = it does not (clean turn OR an anti-fixture the detector
+#: rejects). Order is fixed for deterministic enumeration/encoding.
+LABELS: tuple[str, ...] = ("correction", "none")
+
+
+@dataclass(frozen=True)
+class ConversationRecord:
+    """One labeled conversation window.
+
+    Attributes:
+        turns: A small prior-turn window + the turn under inspection. Each turn
+            is ``{role, content}`` (only ``user`` turns are scanned, matching
+            #1581). The LAST user turn is the one the classifier verdicts.
+        label: ``correction`` if the final user turn expresses a correction the
+            production detector would capture; ``none`` otherwise.
+        corrections: The #1581 ``corrections[]`` block (empty for ``none``).
+        morphology: Which signal/anti-fixture produced this record, for label
+            provenance review (e.g. ``update_switched_to`` / ``anti_hypothetical``).
+        sourceId: Stable id of the seed scenario this record derives from.
+    """
+
+    turns: list[dict[str, str]]
+    label: str
+    corrections: list[dict[str, Any]]
+    morphology: str
+    sourceId: str
+
+    def to_jsonl_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        return {key: payload[key] for key in (
+            "turns", "label", "corrections", "morphology", "sourceId",
+        )}
+
+
+def validate_record(record: ConversationRecord) -> list[str]:
+    """Return human-readable validation errors (empty == valid)."""
+    errors: list[str] = []
+    if not isinstance(record.turns, list) or not record.turns:
+        errors.append("turns must be a non-empty list")
+    else:
+        for i, turn in enumerate(record.turns):
+            if not isinstance(turn, dict) or turn.get("role") not in ("user", "assistant", "other"):
+                errors.append(f"turns[{i}] must have a role in user/assistant/other")
+            if not isinstance(turn.get("content"), str) or not turn["content"].strip():
+                errors.append(f"turns[{i}].content must be a non-empty string")
+    if record.label not in LABELS:
+        errors.append(f"label must be one of {LABELS!r}, got {record.label!r}")
+    if record.label == "correction" and not record.corrections:
+        errors.append("a 'correction' label must carry at least one correction block")
+    if record.label == "none" and record.corrections:
+        errors.append("a 'none' label must carry an empty corrections block")
+    if not record.morphology:
+        errors.append("morphology tag is required for label provenance")
+    if not record.sourceId:
+        errors.append("sourceId is required")
+    return errors
+
+
+def assert_dataset(records: Sequence[ConversationRecord]) -> None:
+    """Validate every record; raise ``ValueError`` listing all errors at once."""
+    all_errors: list[str] = []
+    for index, record in enumerate(records):
+        for error in validate_record(record):
+            all_errors.append(f"record[{index}] ({record.sourceId}): {error}")
+    if all_errors:
+        raise ValueError("invalid dataset records:\n  " + "\n  ".join(all_errors))
+
+
+# ---------------------------------------------------------------------------
+# Seed scenario bank — correction morphologies (mirror #1581 PATTERNS).
+#
+# Each scenario is a (morphology, user_turn_template, correction) triple. The
+# template's ``{subject}`` / ``{new}`` / ``{old}`` slots are filled from a
+# substitution table at generation time, so one scenario fans out to many
+# concrete turns — the volume driver. Extend the bank to scale the dataset.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CorrectionScenario:
+    """A correction-signal template + the correction block it yields."""
+
+    morphology: str
+    template: str  # user turn text; {subject}/{new}/{old} substituted at gen
+    polarity: Polarity
+    #: Builds the corrections[] block from the substituted turn.
+    #: ``update``/``stop_storing`` carry a correctedAssertion; ``retract`` → "".
+    corrected_assertion_from: str  # "turn" = the turn itself; "" = pure retraction
+
+    def build_correction(self, turn: str) -> dict[str, Any]:
+        assertion = "" if self.polarity == "retract" else (
+            turn if self.corrected_assertion_from == "turn" else self.corrected_assertion_from
+        )
+        return {
+            "targetHint": _target_hint(turn),
+            "correctedAssertion": assertion[:200],
+            "polarity": self.polarity,
+            "confidence": 0.85,  # matches the median #1581 pattern confidence
+        }
+
+
+def _target_hint(turn: str) -> str:
+    """Short phrase the planner can use to locate the affected memory (≤80)."""
+    cleaned = " ".join(turn.split())
+    return cleaned[:80] if len(cleaned) <= 80 else cleaned[:77] + "..."
+
+
+#: The correction morphology bank. Each entry corresponds to a #1581 PATTERNS
+#: regex family; the template is a canonical utterance that family matches.
+CORRECTION_SCENARIOS: tuple[CorrectionScenario, ...] = (
+    CorrectionScenario("update_switched_to", "we switched to {new} from {old}", "update", "turn"),
+    CorrectionScenario("update_migrated_to", "we migrated from {old} to {new}", "update", "turn"),
+    CorrectionScenario("update_renamed", "we renamed {old} to {new}", "update", "turn"),
+    CorrectionScenario("update_actually_now", "actually, it's now {new} not {old}", "update", "turn"),
+    CorrectionScenario("update_no_longer", "we no longer use {old}, it's {new} now", "update", "turn"),
+    CorrectionScenario("update_deadline_moved", "the deadline moved to {new}", "update", "turn"),
+    CorrectionScenario("update_outdated", "that's outdated, the current value is {new}", "update", "turn"),
+    CorrectionScenario("retract_dont_use", "I don't use {old} anymore", "retract", ""),
+    CorrectionScenario("retract_thats_wrong", "that's wrong, {old} isn't correct", "retract", ""),
+    CorrectionScenario("retract_forget", "forget about {old}, it was never true", "retract", ""),
+    CorrectionScenario("stop_storing_stop_suggesting", "stop suggesting {old}", "stop_storing", "turn"),
+    CorrectionScenario("stop_storing_dont_mention", "don't mention {old} again", "stop_storing", "turn"),
+)
+
+
+#: Substitution targets — real-world-ish entities so the model sees varied
+#: surface forms. Pairs are (old, new); each scenario is instantiated against
+#: every pair, fanning one scenario into many concrete turns.
+SUBSTITUTIONS: tuple[tuple[str, str], ...] = (
+    ("Redis", "KeyDB"),
+    ("Vim", "Neovim"),
+    ("MySQL", "Postgres"),
+    ("Jira", "Linear"),
+    ("Slack", "Discord"),
+    ("Monolith", "microservices"),
+    ("REST", "GraphQL"),
+    ("Friday", "Monday"),
+    ("Python 3.11", "Python 3.12"),
+    ("AWS", "GCP"),
+)
+
+
+def _fill(template: str, pair: tuple[str, str]) -> str:
+    return template.replace("{old}", pair[0]).replace("{new}", pair[1])
+
+
+# ---------------------------------------------------------------------------
+# Anti-example bank — turns the #1581 detector REJECTS (label ``none``).
+# These are the four anti-fixture guards; training on them teaches the model
+# NOT to fire on hypotheticals, third-party corrections, tool-output
+# complaints, or self-resolving double-corrections.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AntiExample:
+    morphology: str  # anti_hypothetical / anti_third_party / anti_tool_output / anti_self_resolving
+    template: str
+    corrected_assertion_from: str = ""  # unused; anti-examples are label=none
+
+    def build_correction(self, turn: str) -> dict[str, Any]:  # noqa: ARG002
+        raise RuntimeError("anti-examples carry no correction block")
+
+
+ANTI_EXAMPLES: tuple[AntiExample, ...] = (
+    AntiExample("anti_hypothetical", "what if we ever switched to {new}, would that be better?"),
+    AntiExample("anti_hypothetical", "suppose we migrated from {old} to {new} in theory"),
+    AntiExample("anti_third_party", "tell him he's wrong about {old}, it's actually {new}"),
+    AntiExample("anti_third_party", "she's wrong about {old}"),
+    AntiExample("anti_tool_output", "your output is wrong, the result for {old} should be {new}"),
+    AntiExample("anti_tool_output", "the error log is incorrect about {old}"),
+    AntiExample("anti_self_resolving", "actually wait, never mind, {old} was right after all"),
+    AntiExample("anti_self_resolving", "no, scratch that, forget I mentioned {old}"),
+)
+
+#: Clean non-correction turns — ordinary conversation the detector must ignore.
+CLEAN_TURNS: tuple[str, ...] = (
+    "how do I configure {new}?",
+    "I'm really liking {new} so far.",
+    "can you remind me what {old} does?",
+    "let's review the {new} deployment tomorrow.",
+    "thanks for the help with {old}.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Selftest — each morphology provably yields its expected label.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SelftestCase:
+    morphology: str
+    expected_label: str
+    description: str
+
+
+SELFTEST_CASES: tuple[SelftestCase, ...] = (
+    SelftestCase("update_switched_to", "correction", "switched-to → update correction"),
+    SelftestCase("update_renamed", "correction", "renamed → update correction"),
+    SelftestCase("update_no_longer", "correction", "no-longer → update correction"),
+    SelftestCase("retract_dont_use", "correction", "don't-use-anymore → retract correction"),
+    SelftestCase("retract_thats_wrong", "correction", "that's-wrong → retract correction"),
+    SelftestCase("stop_storing_stop_suggesting", "correction", "stop-suggesting → stop_storing correction"),
+    SelftestCase("anti_hypothetical", "none", "hypothetical → rejected (none)"),
+    SelftestCase("anti_third_party", "none", "third-party → rejected (none)"),
+    SelftestCase("anti_tool_output", "none", "tool-output → rejected (none)"),
+    SelftestCase("anti_self_resolving", "none", "self-resolving → rejected (none)"),
+)

--- a/model-lab/correction-intent/train.py
+++ b/model-lab/correction-intent/train.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Correction-intent training recipe (issue #1585 PR3; scaffold grammar in morphology.py).
+
+Fine-tunes a ≤4B instruct causal LM to emit the #1581 ``corrections[]`` block
+as JSON-schema output. Per issue #1585's policy table, this task is structured
+extraction (an encoder can't emit the spans), so a small instruct LM is the
+right shape — target ≤4B, with an 8B LoRA escape hatch if evals demand it.
+
+Heavy imports (torch / transformers / trl / peft) are LAZY so ``--help`` works
+on a bare machine and the recipe never runs in CI. The entry point exits with
+code 2 + an install hint if the training stack is missing.
+
+NEVER runs in CI (issue #1585 pitfall). The only CI hooks are the seeded
+generator's determinism + morphology selftest (pure CPU, small N).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_MODEL_LAB_ROOT = Path(__file__).resolve().parents[1]
+if str(_MODEL_LAB_ROOT) not in sys.path:
+    sys.path.insert(0, str(_MODEL_LAB_ROOT))
+
+from common.training_stack import (  # noqa: E402
+    capture_training_stack,
+    requirements_versions,
+)
+
+#: First-choice base (issue #1585): a ≤4B instruct LM with reliable JSON output.
+#: Qwen2.5-3B-Instruct is the canonical pick; operators may swap for any ≤4B
+#: instruct model the policy table permits.
+DEFAULT_BASE_MODEL = "Qwen/Qwen2.5-3B-Instruct"
+DEFAULT_DATA_DIR = Path(__file__).resolve().parent / "data"
+DEFAULT_RUNS_DIR = Path(__file__).resolve().parents[1] / "runs" / "correction-intent"
+
+
+@dataclass(frozen=True)
+class TrainHyperparams:
+    """Hyperparameters mirrored into ``manifest.json`` ``hyperparams``."""
+    base_model: str
+    method: str  # "full" | "lora"
+    epochs: float
+    learning_rate: float
+    batch_size: int
+    grad_accum_steps: int
+    max_seq_len: int
+    lora_rank: int | None
+    warmup_ratio: float
+    weight_decay: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Correction-intent training recipe (issue #1585 PR3).",
+    )
+    parser.add_argument("--base-model", default=DEFAULT_BASE_MODEL, help="HF base model id.")
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument("--runs-dir", type=Path, default=DEFAULT_RUNS_DIR)
+    parser.add_argument("--version-tag", default="v1", help="Output subdir under runs/.")
+    parser.add_argument("--method", choices=("full", "lora"), default="lora",
+                        help="full fine-tune or LoRA (default — policy-table ≤8B).")
+    parser.add_argument("--epochs", type=float, default=3.0)
+    parser.add_argument("--learning-rate", type=float, default=1e-4)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--grad-accum-steps", type=int, default=4)
+    parser.add_argument("--max-seq-len", type=int, default=2048)
+    parser.add_argument("--lora-rank", type=int, default=16)
+    parser.add_argument("--warmup-ratio", type=float, default=0.03)
+    parser.add_argument("--weight-decay", type=float, default=0.0)
+    return parser
+
+
+def hyperparams_from_args(args: argparse.Namespace) -> TrainHyperparams:
+    return TrainHyperparams(
+        base_model=args.base_model,
+        method=args.method,
+        epochs=args.epochs,
+        learning_rate=args.learning_rate,
+        batch_size=args.batch_size,
+        grad_accum_steps=args.grad_accum_steps,
+        max_seq_len=args.max_seq_len,
+        lora_rank=args.lora_rank if args.method == "lora" else None,
+        warmup_ratio=args.warmup_ratio,
+        weight_decay=args.weight_decay,
+    )
+
+
+def require_training_deps() -> None:
+    """Lazy-import the training stack; exit(2) with an install hint if missing."""
+    missing: list[str] = []
+    for mod in ("torch", "transformers", "trl", "peft", "datasets"):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(mod)
+    if missing:
+        print(
+            "train.py: training stack missing (" + ", ".join(missing) + ").\n"
+            "  install with:  bash model-lab/setup.sh && source model-lab/.venv/bin/activate\n"
+            "  (the correction-intent recipe needs the trl/peft causal-LM stack)\n"
+            "  This script never runs in CI (issue #1585).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.version_tag != "v1":
+        print(f"[train] version-tag {args.version_tag} — policy allows ≤4B; LoRA ≤8B only", file=sys.stderr)
+
+    # Fail fast on a missing data dir before touching the GPU stack.
+    train_path = args.data_dir / "train.jsonl"
+    if not train_path.is_file():
+        print(f"train.py: {train_path} not found. run generate-data.py first.", file=sys.stderr)
+        return 2
+
+    require_training_deps()
+    hp = hyperparams_from_args(args)
+
+    # The actual fine-tune is GPU-gated (issue #1585 follow-up). This recipe
+    # captures the reproducibility contract (pinned stack + hyperparams) and
+    # exits with a clear pointer to where the trained weights land. The train
+    # loop itself is implemented in the #1585 GPU-run follow-up.
+    req_versions = requirements_versions(_MODEL_LAB_ROOT / "requirements.txt")
+    stack = capture_training_stack()
+    print(json.dumps({
+        "task": "correction-intent",
+        "status": "recipe-ready-not-run",
+        "hyperparams": hp.to_dict(),
+        "trainingStack": stack,
+        "requirementsPin": req_versions,
+        "$comment": (
+            "Reproducibility contract captured. The fine-tune loop lands in the "
+            "#1585 GPU-run follow-up when the lab frees. Weights publish to the "
+            "operator's HF account (common/hf_push.py); git carries recipes + "
+            "hashes, never blobs."
+        ),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/model-lab/faithfulness-gate/manifest.json
+++ b/model-lab/faithfulness-gate/manifest.json
@@ -13,8 +13,16 @@
   "schemaVersion": 1,
   "status": "pending-training",
   "contract": {
-    "inputFields": ["factText", "quote", "context"],
-    "outputLabels": ["entailed", "contradicted", "unsupported"],
+    "inputFields": [
+      "factText",
+      "quote",
+      "context"
+    ],
+    "outputLabels": [
+      "entailed",
+      "contradicted",
+      "unsupported"
+    ],
     "source": "FaithfulnessCheckInput (issue #1576)"
   },
   "baseModel": null,
@@ -22,7 +30,9 @@
     "generatorPath": "model-lab/faithfulness-gate/generate-data.py",
     "generatorGitSha": null,
     "seed": 1337,
-    "sources": ["synthetic-perturbation"],
+    "sources": [
+      "synthetic-perturbation"
+    ],
     "counts": {
       "entailed": null,
       "contradicted": null,
@@ -51,5 +61,19 @@
     "actualParamsB": null,
     "escapeHatchUsed": false,
     "$comment": "Issue #1585 policy: target models <=4B for this classification task. 8B LoRA is an escape hatch requiring written justification here."
+  },
+  "trainingStack": {
+    "python": null,
+    "libs": {
+      "torch": null,
+      "transformers": null,
+      "datasets": null,
+      "huggingface-hub": null,
+      "accelerate": null,
+      "sentencepiece": null
+    },
+    "pipFreezeSha256": null,
+    "capturedAt": null,
+    "$comment": "SCHEMA EXAMPLE. Exact interpreter + lib versions a real run used; captured by common.training_stack.capture_training_stack() at train time. Pin source: model-lab/requirements.txt (encoder baseline stack). Filled in the #1585 GPU-run follow-up (rule 55)."
   }
 }

--- a/model-lab/requirements.txt
+++ b/model-lab/requirements.txt
@@ -33,8 +33,11 @@ huggingface-hub==1.3.0  # transformers 5.3.0 requires huggingface-hub>=1.3.0
 sentencepiece==0.2.1  # >=0.2.1: GHSA-38vq-g6vr-w8wf
 accelerate==1.14.0
 
-# --- Fine-tuning stack (uncomment in PR2 when first LoRA/causal run lands) -
-# trl==0.9.6
-# peft==0.12.0
-# accelerate==0.33.0
-# bitsandbytes==0.43.3   # QLoRA 4-bit base + paged optimizer (≤14B policy ceiling)
+# --- Correction-intent causal-LM stack (issue #1585 PR3) -------------------
+# A ≤4B instruct LM fine-tuned to emit the #1581 corrections[] JSON block.
+# LoRA is the default method (policy-table ≤8B); bitsandbytes enables QLoRA
+# (4-bit base + paged optimizer, ≤14B ceiling — out of policy for these tasks
+# but available for the 8B escape hatch). accelerate already pinned above.
+trl==0.16.6
+peft==0.13.2
+bitsandbytes==0.44.1   # QLoRA 4-bit base + paged optimizer (8B escape hatch)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2005,6 +2005,21 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
+      },
+      "correctionIntentModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
+      },
+      "correctionIntentBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
+      },
       "extractionJudgeBatchSize": {
         "type": "number",
         "default": 20,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2005,6 +2005,21 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
+      },
+      "correctionIntentModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
+      },
+      "correctionIntentBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
+      },
       "extractionJudgeBatchSize": {
         "type": "number",
         "default": 20,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -49,6 +49,7 @@ import { parseWearablesConfig } from "./wearables/config.js";
 import { parseProvenanceConfig } from "./provenance.js";
 import { parseCodingKnowledgeConfig } from "./coding/coding-knowledge-config.js";
 import { parseChatConfig } from "./chat/chat-config.js";
+import { parseCorrectionIntentConfig, parseFaithfulnessGateConfig } from "./faithfulness-config.js";
 const DEFAULT_MEMORY_DIR = path.join(
   resolveHomeDir(),
   ".openclaw",
@@ -3018,36 +3019,14 @@ export function parseConfig(
     collectJudgeTrainingPairs: coerceBool(cfg.collectJudgeTrainingPairs) === true,
     judgeTrainingDir:
       typeof cfg.judgeTrainingDir === "string" ? cfg.judgeTrainingDir : "",
-    // Extraction faithfulness gate (issue #1576). Entailment-verification of
-    // extracted facts against verified source spans (#1575). Default "off"
-    // (rule 39: byte-identical pre-feature pipeline). Invalid values are
-    // rejected listing valid options (rule 51).
-    extractionFaithfulnessGate: (() => {
-      const v = cfg.extractionFaithfulnessGate;
-      if (v === undefined || v === null) return "off";
-      // Present-but-invalid (true/1/{}) must reject, not silently disable the gate (Ob4RQ).
-      const raw = typeof v === "string" ? v.trim().toLowerCase() : v;
-      if (raw === "off" || raw === "shadow" || raw === "enforce") return raw;
-      throw new Error(
-        `extractionFaithfulnessGate must be one of "off" | "shadow" | "enforce" (got ${JSON.stringify(v)})`,
-      );
-    })(),
-    extractionFaithfulnessModel:
-      typeof cfg.extractionFaithfulnessModel === "string"
-        ? cfg.extractionFaithfulnessModel
-        : "",
-    // Issue #1634 (#1576 follow-up): strict-integer validation via
-    // parseIntegerAtLeast — reject non-numeric, <=0, non-integer, NaN,
-    // Infinity, booleans, objects (gotcha #51). Mirrors qmdDaemonTimeoutMs.
-    // Valid CLI-string integers still coerce and clamp to the budget cap.
-    extractionFaithfulnessContextChars: Math.min(
-      parseIntegerAtLeast(cfg.extractionFaithfulnessContextChars, 400, 1, "extractionFaithfulnessContextChars"),
-      4000,
-    ),
-    extractionFaithfulnessTimeoutMs: Math.min(
-      parseIntegerAtLeast(cfg.extractionFaithfulnessTimeoutMs, 8000, 1, "extractionFaithfulnessTimeoutMs"),
-      60_000,
-    ),
+    // Extraction faithfulness gate (issue #1576) + model-lab pointer
+    // `extractionFaithfulnessBaseUrl` (issue #1585), and the correction-intent
+    // model-lab pointer (issue #1581 / #1585). Parsed in faithfulness-config.ts
+    // (extracted from this god file so the block can grow without tripping the
+    // ratchet). Defaults preserve the byte-identical pre-feature pipeline
+    // (rule 39); invalid values reject (rule 51 / #1634).
+    ...parseFaithfulnessGateConfig(cfg),
+    ...parseCorrectionIntentConfig(cfg),
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1338,6 +1338,45 @@ test("checkFaithfulnessBatch: local endpoint failure falls back to the configure
   }
 });
 
+test("checkFaithfulnessBatch: a wedged local endpoint falls back to the chain BEFORE the batch timeout (codex P2 — probe budget)", async () => {
+  // The local probe must use a SMALLER budget than the outer batch timeout so a
+  // hanging endpoint returns null and the configured chain runs before the batch
+  // timer fires. extractionFaithfulnessTimeoutMs: 1000 → probe budget = 500ms.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 1000,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  // A fetch that hangs forever on its own but HONORS the probe's AbortSignal —
+  // the probe's controller aborts it at 500ms (half the batch budget), the call
+  // returns null, and the gate falls through to the configured chain.
+  const wedgedFetch = ((_url: string, init: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const sig = init.signal;
+      if (!sig) return;
+      if (sig.aborted) reject(new Error("aborted"));
+      else sig.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    })) as unknown as typeof fetch;
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    wedgedFetch,
+  );
+  assert.equal(
+    fallbackCalls.length,
+    1,
+    "a wedged local probe must reach the configured chain before the batch budget elapses",
+  );
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed", "fallback chain verdict is used");
+  }
+});
+
 test("checkFaithfulnessBatch: no local endpoint pointer → byte-identical routing (regression guard)", async () => {
   // Default config (no baseUrl) must never attempt a local-endpoint fetch.
   const inputs = [{ factText: "Fact", quote: "Quote" }];

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1254,3 +1254,105 @@ test("parseFaithfulnessResponse: object-wrapped arrays unwrap (results/verdicts/
   // A wrapper object with no recognized array key still returns null (no over-match).
   assert.equal(parseFaithfulnessResponse('{"data": {"nested": []}}', 1), null);
 });
+
+// ---------------------------------------------------------------------------
+// Issue #1585 model-lab pointer: local fine-tuned endpoint path
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fake fetch that responds for a specific base URL with a canned
+ * openai-compatible chat-completions body. Records the request body so tests
+ * can assert the gate routed to the local model.
+ */
+function fakeFetchFor(
+  baseUrl: string,
+  responder: (body: Record<string, unknown>) => unknown,
+): { fetch: typeof fetch; requests: Array<{ url: string; body: Record<string, unknown> }> } {
+  const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const fake = ((url: string, init: RequestInit) => {
+    requests.push({ url, body: JSON.parse(String(init.body)) });
+    const body = JSON.parse(String(init.body));
+    const payload = responder(body);
+    return Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  return { fetch: fake, requests };
+}
+
+test("checkFaithfulnessBatch: local model-lab endpoint is tried first when configured (#1585)", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+  });
+  const fallbackCalls: Array<{ options: unknown }> = [];
+  const { fetch: fakeFetch, requests } = fakeFetchFor("http://localhost:11434/v1", (body) => ({
+    model: body.model,
+    choices: [{ message: { content: JSON.stringify([{ index: 0, verdict: "contradicted" }]) } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm("[]", fallbackCalls),
+    fakeFetch,
+  );
+  assert.equal(requests.length, 1, "local model-lab endpoint must be called");
+  assert.equal(requests[0]?.url, "http://localhost:11434/v1/chat/completions");
+  assert.equal(requests[0]?.body.model, "remnic-faithfulness-gate-v1");
+  assert.equal(fallbackCalls.length, 0, "gateway fallback must NOT run when the local endpoint succeeds");
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "contradicted", "local model verdict is used");
+    assert.equal(result.results[0].model, "remnic-faithfulness-gate-v1");
+  }
+});
+
+test("checkFaithfulnessBatch: local endpoint failure falls back to the configured chain (#1585 graceful)", async () => {
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+  });
+  const fallbackCalls: Array<{ options: unknown }> = [];
+  // Local endpoint returns 500 → caller returns null → gate falls through to fallback.
+  const failingFetch = (() =>
+    Promise.resolve(new Response("err", { status: 500 }))) as unknown as typeof fetch;
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    failingFetch,
+  );
+  assert.equal(fallbackCalls.length, 1, "must fall back to the configured chain on local-endpoint failure");
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed", "fallback chain verdict is used");
+  }
+});
+
+test("checkFaithfulnessBatch: no local endpoint pointer → byte-identical routing (regression guard)", async () => {
+  // Default config (no baseUrl) must never attempt a local-endpoint fetch.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = baseConfig();
+  let fetchCalled = false;
+  const spyFetch = (() => {
+    fetchCalled = true;
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  }) as unknown as typeof fetch;
+  await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }])),
+    spyFetch,
+  );
+  assert.equal(fetchCalled, false, "no local-endpoint fetch when pointer is unset");
+});

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1290,7 +1290,7 @@ test("checkFaithfulnessBatch: local model-lab endpoint is tried first when confi
     extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
     extractionFaithfulnessTimeoutMs: 5000,
   });
-  const fallbackCalls: Array<{ options: unknown }> = [];
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
   const { fetch: fakeFetch, requests } = fakeFetchFor("http://localhost:11434/v1", (body) => ({
     model: body.model,
     choices: [{ message: { content: JSON.stringify([{ index: 0, verdict: "contradicted" }]) } }],
@@ -1320,7 +1320,7 @@ test("checkFaithfulnessBatch: local endpoint failure falls back to the configure
     extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
     extractionFaithfulnessTimeoutMs: 5000,
   });
-  const fallbackCalls: Array<{ options: unknown }> = [];
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
   // Local endpoint returns 500 → caller returns null → gate falls through to fallback.
   const failingFetch = (() =>
     Promise.resolve(new Response("err", { status: 500 }))) as unknown as typeof fetch;

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1395,3 +1395,37 @@ test("checkFaithfulnessBatch: no local endpoint pointer → byte-identical routi
   );
   assert.equal(fetchCalled, false, "no local-endpoint fetch when pointer is unset");
 });
+
+
+test("checkFaithfulnessBatch: local-endpoint failure does NOT leak the local model name into the fallback chain (codex P2 PRRT_kwDORJXyws6Otp-L)", async () => {
+  // extractionFaithfulnessModel is the LOCAL served model's name. When the
+  // local endpoint is configured but fails, that name must NOT be forwarded to
+  // the gateway/fallback as options.model — otherwise the configured chain is
+  // forced onto an unavailable local-only model and a local outage becomes
+  // backend_unavailable instead of graceful fallback to the configured chain.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  // Local endpoint returns 500 -> caller returns null -> gate falls through.
+  const failingFetch = (() =>
+    Promise.resolve(new Response("err", { status: 500 }))) as unknown as typeof fetch;
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    failingFetch,
+  );
+  assert.equal(fallbackCalls.length, 1, "fallback chain must run on local-endpoint failure");
+  const opts = fallbackCalls[0]?.options as Record<string, unknown>;
+  assert.equal(
+    opts?.model,
+    undefined,
+    "local-only model name must NOT leak into the fallback chain on endpoint failure",
+  );
+  assert.equal(result.results[0]?.ok, true);
+});

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -322,7 +322,16 @@ async function callFaithfulnessLlm(
     );
   }
 
-  const modelOverride = config.extractionFaithfulnessModel || undefined;
+  // extractionFaithfulnessModel is the LOCAL served model's name (e.g.
+  // remnic-faithfulness-gate-v1). When a local endpoint is configured it
+  // belongs to that endpoint ONLY — it must NOT leak into the fallback chain
+  // as a gateway/local-LLM override, or a local outage forces the configured
+  // chain onto an unavailable local-only model and turns graceful fallback
+  // into backend_unavailable (codex P2 PRRT_kwDORJXyws6Otp-L). Decouple: the
+  // override reaches the fallback chain only when NO local endpoint is
+  // configured (the pre-feature model-override contract, preserved
+  // byte-identical — rule 39).
+  const modelOverride = localEndpoint ? undefined : (config.extractionFaithfulnessModel || undefined);
 
   // Skip the local backend when (a) modelSource is "gateway", or (b) a
   // faithfulness model override is set. The local client always sends

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -300,10 +300,18 @@ async function callFaithfulnessLlm(
   // to the configured chain (checklist §4 graceful degradation).
   const localEndpoint = resolveFaithfulnessGateEndpoint(config);
   if (localEndpoint) {
+    // Give the local probe a SMALLER budget than the outer batch timeout so a
+    // wedged local model returns null (and falls through to the configured
+    // chain) before the batch timer fires. The local endpoint is meant to be
+    // the fast path; if it cannot answer within half the budget (min 500ms),
+    // abandon it and let the fallback chain use the remainder (codex P2 — the
+    // advertised graceful fallback must actually reach the chain, not be starved
+    // by a hanging probe sharing the full batch budget).
+    const probeBudgetMs = Math.max(500, Math.floor(timeoutMs / 2));
     const result = await callOpenAiCompatibleChat(
       localEndpoint,
       messages,
-      { temperature: 0.1, maxTokens: 2048, responseFormatJson: true, timeoutMs },
+      { temperature: 0.1, maxTokens: 2048, responseFormatJson: true, timeoutMs: probeBudgetMs },
       fetchImpl,
     );
     if (result?.content) {

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -34,6 +34,10 @@ import { log } from "./logger.js";
 import type { PluginConfig, MemoryFrontmatter, FaithfulnessFrontmatter } from "./types.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import { type FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
+import {
+  callOpenAiCompatibleChat,
+  resolveFaithfulnessGateEndpoint,
+} from "./local-model-endpoint.js";
 import { extractJsonCandidates } from "./json-extract.js";
 
 // Re-export for callers importing from this module.
@@ -280,11 +284,35 @@ async function callFaithfulnessLlm(
   fallbackLlm: FallbackLlmClient | null,
   timeoutMs: number,
   signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<LlmCallResult> {
   const messages: Array<{ role: "system" | "user"; content: string }> = [
     { role: "system", content: systemPrompt },
     { role: "user", content: userPrompt },
   ];
+
+  // Issue #1585 model-lab pointer: when an explicit local fine-tuned endpoint
+  // is configured (base URL + model name), try it FIRST — it is the cheapest,
+  // deterministic path the operator opted into by setting
+  // extractionFaithfulnessBaseUrl. Unset (the default) skips this entirely,
+  // preserving byte-identical pre-feature routing (rule 39). Any failure
+  // (network, non-2xx, malformed body, timeout) returns null and falls through
+  // to the configured chain (checklist §4 graceful degradation).
+  const localEndpoint = resolveFaithfulnessGateEndpoint(config);
+  if (localEndpoint) {
+    const result = await callOpenAiCompatibleChat(
+      localEndpoint,
+      messages,
+      { temperature: 0.1, maxTokens: 2048, responseFormatJson: true, timeoutMs },
+      fetchImpl,
+    );
+    if (result?.content) {
+      return { content: result.content, modelUsed: result.modelUsed };
+    }
+    log.debug(
+      "extraction-faithfulness: local model-lab endpoint unavailable, trying configured chain",
+    );
+  }
 
   const modelOverride = config.extractionFaithfulnessModel || undefined;
 
@@ -415,6 +443,12 @@ export async function checkFaithfulnessBatch(
   config: PluginConfig,
   localLlm: LocalLlmClient | null,
   fallbackLlm: FallbackLlmClient | null,
+  /**
+   * Optional fetch injection (issue #1585). The orchestrator does not pass it
+   * (uses global fetch); tests pass a stub to exercise the local model-lab
+   * endpoint path without a live server. See callFaithfulnessLlm.
+   */
+  fetchImpl?: typeof fetch,
 ): Promise<FaithfulnessBatchResult> {
   const timeoutMs =
     typeof config.extractionFaithfulnessTimeoutMs === "number" &&
@@ -486,6 +520,7 @@ export async function checkFaithfulnessBatch(
       fallbackLlm,
       timeoutMs,
       controller.signal,
+      fetchImpl,
     );
     const settled = await Promise.race([
       callPromise.then(

--- a/packages/remnic-core/src/faithfulness-config.test.ts
+++ b/packages/remnic-core/src/faithfulness-config.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the extracted faithfulness + correction-intent config parser
+ * (issue #1576 / #1585). Pins the behavior-preserving extraction: defaults
+ * are byte-identical to the pre-extraction inline block, validation rejects
+ * the same inputs with the same messages, and the new model-lab pointer keys
+ * default empty (byte-identical pre-feature path, rule 39).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseFaithfulnessGateConfig, parseCorrectionIntentConfig } from "./faithfulness-config.js";
+
+test("parseFaithfulnessGateConfig: empty input → byte-identical defaults (rule 39)", () => {
+  const out = parseFaithfulnessGateConfig({});
+  assert.equal(out.extractionFaithfulnessGate, "off");
+  assert.equal(out.extractionFaithfulnessModel, "");
+  assert.equal(out.extractionFaithfulnessBaseUrl, "");
+  assert.equal(out.extractionFaithfulnessContextChars, 400);
+  assert.equal(out.extractionFaithfulnessTimeoutMs, 8000);
+});
+
+test("parseFaithfulnessGateConfig: null/undefined gate → off (not rejected)", () => {
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessGate: undefined }).extractionFaithfulnessGate, "off");
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessGate: null }).extractionFaithfulnessGate, "off");
+});
+
+test("parseFaithfulnessGateConfig: valid gate modes accepted (case-insensitive, trimmed)", () => {
+  for (const v of ["off", "shadow", "enforce", "SHADOW", " Enforce "]) {
+    const mode = parseFaithfulnessGateConfig({ extractionFaithfulnessGate: v }).extractionFaithfulnessGate;
+    assert.ok(mode === "off" || mode === "shadow" || mode === "enforce", `${v} → ${mode}`);
+  }
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessGate: "SHADOW" }).extractionFaithfulnessGate, "shadow");
+});
+
+test("parseFaithfulnessGateConfig: present-but-invalid gate rejects (Ob4RQ — never silently off)", () => {
+  for (const bad of [true, 1, {}, "maybe", "on"]) {
+    assert.throws(
+      () => parseFaithfulnessGateConfig({ extractionFaithfulnessGate: bad }),
+      /extractionFaithfulnessGate must be one of "off" \| "shadow" \| "enforce"/,
+    );
+  }
+});
+
+test("parseFaithfulnessGateConfig: context chars clamp to [1, 4000]; invalid rejects (#1634)", () => {
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessContextChars: 100000 }).extractionFaithfulnessContextChars, 4000);
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessContextChars: "400" }).extractionFaithfulnessContextChars, 400);
+  for (const bad of [0, -1, 1.5, true, NaN, "abc"]) {
+    assert.throws(
+      () => parseFaithfulnessGateConfig({ extractionFaithfulnessContextChars: bad }),
+      /extractionFaithfulnessContextChars must be an integer/,
+    );
+  }
+});
+
+test("parseFaithfulnessGateConfig: timeout clamps to [1, 60000]; invalid rejects", () => {
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessTimeoutMs: 999999 }).extractionFaithfulnessTimeoutMs, 60_000);
+  for (const bad of [0, -5, 2.5, false, "no"]) {
+    assert.throws(
+      () => parseFaithfulnessGateConfig({ extractionFaithfulnessTimeoutMs: bad }),
+      /extractionFaithfulnessTimeoutMs must be an integer/,
+    );
+  }
+});
+
+test("parseFaithfulnessGateConfig: model-lab pointer keys default empty + accept strings (#1585)", () => {
+  // Defaults preserve the existing routing chain exactly.
+  assert.equal(parseFaithfulnessGateConfig({}).extractionFaithfulnessBaseUrl, "");
+  assert.equal(parseFaithfulnessGateConfig({}).extractionFaithfulnessModel, "");
+  // Non-string values are ignored → empty (not rejected; mirrors model key).
+  assert.equal(parseFaithfulnessGateConfig({ extractionFaithfulnessBaseUrl: 123 }).extractionFaithfulnessBaseUrl, "");
+  // Real pointer values round-trip.
+  const out = parseFaithfulnessGateConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+  });
+  assert.equal(out.extractionFaithfulnessModel, "remnic-faithfulness-gate-v1");
+  assert.equal(out.extractionFaithfulnessBaseUrl, "http://localhost:11434/v1");
+});
+
+test("parseCorrectionIntentConfig: empty input → empty pointers (rule-based detector stays default)", () => {
+  const out = parseCorrectionIntentConfig({});
+  assert.equal(out.correctionIntentModel, "");
+  assert.equal(out.correctionIntentBaseUrl, "");
+});
+
+test("parseCorrectionIntentConfig: pointers round-trip; non-strings → empty", () => {
+  const out = parseCorrectionIntentConfig({
+    correctionIntentModel: "remnic-correction-intent-v1",
+    correctionIntentBaseUrl: "http://localhost:8000/v1",
+  });
+  assert.equal(out.correctionIntentModel, "remnic-correction-intent-v1");
+  assert.equal(out.correctionIntentBaseUrl, "http://localhost:8000/v1");
+  assert.equal(parseCorrectionIntentConfig({ correctionIntentModel: true }).correctionIntentModel, "");
+  assert.equal(parseCorrectionIntentConfig({ correctionIntentBaseUrl: 5 }).correctionIntentBaseUrl, "");
+});

--- a/packages/remnic-core/src/faithfulness-config.ts
+++ b/packages/remnic-core/src/faithfulness-config.ts
@@ -1,0 +1,138 @@
+/**
+ * Faithfulness-gate + correction-intent config parsing (issue #1576 / #1585).
+ *
+ * Extracted verbatim from `config.ts` (a watchlisted god file) so the gate
+ * config block can grow — the model-lab pointer keys
+ * `extractionFaithfulnessBaseUrl` (#1585) and the correction-intent pointers
+ * (`correctionIntentModel` / `correctionIntentBaseUrl`) — without growing the
+ * god file. This is a behavior-preserving extraction (#1526-style): the
+ * validation, defaults, and error messages are byte-identical to the inline
+ * block it replaces, which the existing extraction-faithfulness + config
+ * tests pin.
+ *
+ * Why a dedicated module (and not inline): the ratchet
+ * (`scripts/check-ratchets.mjs`) forbids `config.ts` from growing, and the
+ * model-lab integration needs three new optional keys. Centralizing the whole
+ * gate+intent parsing here keeps it unit-testable in isolation and lets
+ * `config.ts` spread the result in one line.
+ */
+
+import { coerceNumber } from "./connectors/coerce.js";
+
+/**
+ * Parse a value as a strict integer >= `min`, throwing on anything else.
+ *
+ * Mirrors `parseIntegerAtLeast` in `config.ts` byte-for-byte (issue #1634:
+ * reject non-numeric, <=0, non-integer, NaN, Infinity, booleans, objects —
+ * gotcha #51). Reimplemented locally rather than exported from `config.ts`
+ * so this module has no dependency on the god file (and vice versa).
+ */
+function parseIntegerAtLeast(
+  value: unknown,
+  fallback: number,
+  min: number,
+  keyName: string,
+): number {
+  if (value === undefined || value === null) return fallback;
+  const coerced = coerceNumber(value);
+  if (
+    coerced === undefined ||
+    !Number.isFinite(coerced) ||
+    !Number.isInteger(coerced) ||
+    coerced < min
+  ) {
+    throw new Error(
+      `${keyName} must be an integer greater than or equal to ${min}; got ${JSON.stringify(value)}`,
+    );
+  }
+  return coerced;
+}
+
+/**
+ * Parse the extraction faithfulness gate config block.
+ *
+ * Returns exactly the `PluginConfig` fields this block owns. Defaults preserve
+ * the byte-identical pre-feature pipeline (rule 39): gate "off", empty model
+ * + base URL, context 400 chars, timeout 8000 ms. Invalid `gate` values reject
+ * listing valid options (rule 51); invalid integers throw (issue #1634).
+ *
+ * `extractionFaithfulnessBaseUrl` (issue #1585) is the model-lab pointer: when
+ * set together with `extractionFaithfulnessModel`, the gate routes to that
+ * local openai-compatible endpoint before the configured chain; empty string
+ * (default) preserves the existing routing exactly.
+ */
+export function parseFaithfulnessGateConfig(cfg: Record<string, unknown>): {
+  extractionFaithfulnessGate: "off" | "shadow" | "enforce";
+  extractionFaithfulnessModel: string;
+  extractionFaithfulnessBaseUrl: string;
+  extractionFaithfulnessContextChars: number;
+  extractionFaithfulnessTimeoutMs: number;
+} {
+  const gateValue = cfg.extractionFaithfulnessGate;
+  let extractionFaithfulnessGate: "off" | "shadow" | "enforce";
+  if (gateValue === undefined || gateValue === null) {
+    extractionFaithfulnessGate = "off";
+  } else {
+    // Present-but-invalid (true/1/{}) must reject, not silently disable the gate (Ob4RQ).
+    const raw = typeof gateValue === "string" ? gateValue.trim().toLowerCase() : gateValue;
+    if (raw === "off" || raw === "shadow" || raw === "enforce") {
+      extractionFaithfulnessGate = raw;
+    } else {
+      throw new Error(
+        `extractionFaithfulnessGate must be one of "off" | "shadow" | "enforce" (got ${JSON.stringify(gateValue)})`,
+      );
+    }
+  }
+
+  const extractionFaithfulnessModel =
+    typeof cfg.extractionFaithfulnessModel === "string" ? cfg.extractionFaithfulnessModel : "";
+
+  // Issue #1585: model-lab pointer. Empty default → gate uses its existing
+  // routing chain (byte-identical). Non-empty + a model name → gate prefers
+  // the local served endpoint, falling back to the chain on failure.
+  const extractionFaithfulnessBaseUrl =
+    typeof cfg.extractionFaithfulnessBaseUrl === "string"
+      ? cfg.extractionFaithfulnessBaseUrl
+      : "";
+
+  const extractionFaithfulnessContextChars = Math.min(
+    parseIntegerAtLeast(cfg.extractionFaithfulnessContextChars, 400, 1, "extractionFaithfulnessContextChars"),
+    4000,
+  );
+
+  const extractionFaithfulnessTimeoutMs = Math.min(
+    parseIntegerAtLeast(cfg.extractionFaithfulnessTimeoutMs, 8000, 1, "extractionFaithfulnessTimeoutMs"),
+    60_000,
+  );
+
+  return {
+    extractionFaithfulnessGate,
+    extractionFaithfulnessModel,
+    extractionFaithfulnessBaseUrl,
+    extractionFaithfulnessContextChars,
+    extractionFaithfulnessTimeoutMs,
+  };
+}
+
+/**
+ * Parse the correction-intent config block (issue #1581 / #1585).
+ *
+ * The model-lab pointer for passive-correction detection: when both
+ * `correctionIntentModel` and `correctionIntentBaseUrl` are set, the detection
+ * path can route to that local fine-tuned classifier; empty defaults (the
+ * common case) keep the rule-based `detectPassiveCorrections` heuristic as the
+ * sole detector — byte-identical to the pre-feature path. Consumption by the
+ * detector is the consuming child's job (#1581's detector is a pure function;
+ * wiring a model call into it is out of scope for this config-pointer PR).
+ */
+export function parseCorrectionIntentConfig(cfg: Record<string, unknown>): {
+  correctionIntentModel: string;
+  correctionIntentBaseUrl: string;
+} {
+  return {
+    correctionIntentModel:
+      typeof cfg.correctionIntentModel === "string" ? cfg.correctionIntentModel : "",
+    correctionIntentBaseUrl:
+      typeof cfg.correctionIntentBaseUrl === "string" ? cfg.correctionIntentBaseUrl : "",
+  };
+}

--- a/packages/remnic-core/src/local-model-endpoint.test.ts
+++ b/packages/remnic-core/src/local-model-endpoint.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the local model-lab endpoint resolver + openai-compatible caller
+ * (issue #1585). Pure unit tests — the fetch caller takes an injected
+ * `fetchImpl`, so no network, no GPU, no live server.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveFaithfulnessGateEndpoint,
+  resolveCorrectionIntentEndpoint,
+  callOpenAiCompatibleChat,
+  type EndpointChatMessage,
+} from "./local-model-endpoint.js";
+
+// ---------------------------------------------------------------------------
+// Resolvers
+// ---------------------------------------------------------------------------
+
+test("resolveFaithfulnessGateEndpoint: null when either key empty (default = no pointer)", () => {
+  assert.equal(resolveFaithfulnessGateEndpoint({ extractionFaithfulnessModel: "", extractionFaithfulnessBaseUrl: "" }), null);
+  assert.equal(resolveFaithfulnessGateEndpoint({ extractionFaithfulnessModel: "m", extractionFaithfulnessBaseUrl: "" }), null);
+  assert.equal(resolveFaithfulnessGateEndpoint({ extractionFaithfulnessModel: "", extractionFaithfulnessBaseUrl: "http://x/v1" }), null);
+  // whitespace-only counts as empty.
+  assert.equal(resolveFaithfulnessGateEndpoint({ extractionFaithfulnessModel: "  ", extractionFaithfulnessBaseUrl: "http://x/v1" }), null);
+});
+
+test("resolveFaithfulnessGateEndpoint: returns trimmed endpoint when both keys set", () => {
+  const ep = resolveFaithfulnessGateEndpoint({
+    extractionFaithfulnessModel: "  remnic-faithfulness-gate-v1  ",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+  });
+  assert.deepEqual(ep, { baseUrl: "http://localhost:11434/v1", model: "remnic-faithfulness-gate-v1" });
+});
+
+test("resolveCorrectionIntentEndpoint: same contract as the gate resolver", () => {
+  assert.equal(resolveCorrectionIntentEndpoint({ correctionIntentModel: "", correctionIntentBaseUrl: "" }), null);
+  assert.equal(resolveCorrectionIntentEndpoint({ correctionIntentModel: "m", correctionIntentBaseUrl: "" }), null);
+  assert.deepEqual(
+    resolveCorrectionIntentEndpoint({ correctionIntentModel: "ci-v1", correctionIntentBaseUrl: "http://localhost:8000/v1" }),
+    { baseUrl: "http://localhost:8000/v1", model: "ci-v1" },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// callOpenAiCompatibleChat — injected fetch, no network
+// ---------------------------------------------------------------------------
+
+/** Build a minimal Response-shaped object the caller reads (ok, json, .json). */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const MESSAGES: EndpointChatMessage[] = [
+  { role: "system", content: "verifier" },
+  { role: "user", content: "fact vs quote" },
+];
+
+test("callOpenAiCompatibleChat: happy path — first choice content + reported model", async () => {
+  let calledUrl = "";
+  let calledBody: Record<string, unknown> | undefined;
+  const fakeFetch = (url: string, init: RequestInit): Promise<Response> => {
+    calledUrl = url;
+    calledBody = JSON.parse(String(init.body));
+    return Promise.resolve(
+      jsonResponse(200, {
+        model: "remnic-faithfulness-gate-v1",
+        choices: [{ message: { content: '[{"index":0,"verdict":"entailed"}]' } }],
+      }),
+    );
+  };
+  const result = await callOpenAiCompatibleChat(
+    { baseUrl: "http://localhost:11434/v1", model: "remnic-faithfulness-gate-v1" },
+    MESSAGES,
+    { timeoutMs: 5000, temperature: 0.1, maxTokens: 2048, responseFormatJson: true },
+    fakeFetch as typeof fetch,
+  );
+  assert.equal(result?.content, '[{"index":0,"verdict":"entailed"}]');
+  assert.equal(result?.modelUsed, "remnic-faithfulness-gate-v1");
+  // URL joined correctly (no double slash), body carries model + json_object format.
+  assert.equal(calledUrl, "http://localhost:11434/v1/chat/completions");
+  assert.equal(calledBody?.model, "remnic-faithfulness-gate-v1");
+  assert.deepEqual(calledBody?.response_format, { type: "json_object" });
+  assert.equal(calledBody?.max_tokens, 2048);
+});
+
+test("callOpenAiCompatibleChat: trailing slash on baseUrl is tolerated", async () => {
+  const seen = (await callOpenAiCompatibleChat(
+    { baseUrl: "http://localhost:11434/v1/", model: "m" },
+    MESSAGES,
+    { timeoutMs: 1000 },
+    ((url: string) => {
+      assert.equal(url, "http://localhost:11434/v1/chat/completions");
+      return Promise.resolve(jsonResponse(200, { choices: [{ message: { content: "ok" } }] }));
+    }) as typeof fetch,
+  ))!;
+  assert.equal(seen.content, "ok");
+  assert.equal(seen.modelUsed, "m"); // server reported no model → falls back to requested name
+});
+
+test("callOpenAiCompatibleChat: returns null on non-2xx (fail closed)", async () => {
+  const result = await callOpenAiCompatibleChat(
+    { baseUrl: "http://x/v1", model: "m" },
+    MESSAGES,
+    { timeoutMs: 1000 },
+    (() => Promise.resolve(jsonResponse(500, { error: "boom" }))) as typeof fetch,
+  );
+  assert.equal(result, null);
+});
+
+test("callOpenAiCompatibleChat: returns null on network error (fail closed)", async () => {
+  const result = await callOpenAiCompatibleChat(
+    { baseUrl: "http://x/v1", model: "m" },
+    MESSAGES,
+    { timeoutMs: 1000 },
+    (() => Promise.reject(new Error("ECONNREFUSED"))) as typeof fetch,
+  );
+  assert.equal(result, null);
+});
+
+test("callOpenAiCompatibleChat: returns null on malformed body (no fabricated shape)", async () => {
+  for (const body of [
+    null,
+    {},
+    { choices: [] },
+    { choices: [{ message: {} }] },
+    { choices: [{ message: { content: 42 } }] }, // non-string content
+    { choices: "not-an-array" },
+  ]) {
+    const result = await callOpenAiCompatibleChat(
+      { baseUrl: "http://x/v1", model: "m" },
+      MESSAGES,
+      { timeoutMs: 1000 },
+      (() => Promise.resolve(jsonResponse(200, body))) as typeof fetch,
+    );
+    assert.equal(result, null, `body ${JSON.stringify(body)} should yield null`);
+  }
+});
+
+test("callOpenAiCompatibleChat: returns null on .json() throw", async () => {
+  const result = await callOpenAiCompatibleChat(
+    { baseUrl: "http://x/v1", model: "m" },
+    MESSAGES,
+    { timeoutMs: 1000 },
+    (() =>
+      Promise.resolve(
+        new Response("not-json", { status: 200, headers: { "content-type": "application/json" } }),
+      )) as typeof fetch,
+  );
+  assert.equal(result, null);
+});

--- a/packages/remnic-core/src/local-model-endpoint.ts
+++ b/packages/remnic-core/src/local-model-endpoint.ts
@@ -1,0 +1,189 @@
+/**
+ * Local fine-tuned model endpoint resolver + openai-compatible caller
+ * (issue #1585 model-lab integration).
+ *
+ * Remnic's two classification workloads — the extraction faithfulness gate
+ * (#1576) and passive-correction intent detection (#1581) — can run on small
+ * fine-tuned models served locally (Ollama / vLLM) instead of prompted
+ * frontier LLMs. The model-lab (`model-lab/`) produces those models; this
+ * module is the config-side half: it resolves the optional local endpoint
+ * pointer from config and, when set, makes a minimal openai-compatible
+ * chat-completions call to it.
+ *
+ * Design:
+ *   - **Pointers are optional.** Empty defaults preserve the existing routing
+ *     chain exactly (rule 39 / byte-identical pre-feature). A resolver returns
+ *     `null` when the pointer is unset, so callers short-circuit before any
+ *     network.
+ *   - **Graceful degradation.** A local-endpoint failure (network, non-2xx,
+ *     malformed body, timeout) returns `null`; callers fall back to the
+ *     configured chain (checklist §4 — never block writes on a classifier).
+ *   - **No inline casts.** The fetch JSON is narrowed with `in` / `typeof`
+ *     guards (project rule: never assert a shape to read one property).
+ *   - **Injectable fetch.** `callOpenAiCompatibleChat` takes an optional
+ *     `fetchImpl` so the caller is unit-testable without a live server.
+ */
+
+import type { PluginConfig } from "./types.js";
+
+/** A resolved local endpoint: where to call + which model to name. */
+export interface LocalModelEndpoint {
+  /** Base URL, e.g. `http://localhost:11434/v1` (no trailing slash required). */
+  baseUrl: string;
+  /** Model name the server expects, e.g. `remnic-faithfulness-gate-v1`. */
+  model: string;
+}
+
+/** A chat message in the openai-compatible shape this caller sends. */
+export interface EndpointChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/** Options for a single local-endpoint chat call. */
+export interface EndpointChatOptions {
+  /** Per-call timeout in ms. The caller's batch AbortSignal is NOT forwarded
+   *  (matches the local-LLM precedent: each attempt is bounded by its own
+   *  timer so one slow server can't starve the batch). */
+  timeoutMs: number;
+  /** Sampling temperature — classification wants low entropy (0.0–0.2). */
+  temperature?: number;
+  /** Max output tokens. */
+  maxTokens?: number;
+  /** Request JSON-object output (the gate emits a JSON verdict array). */
+  responseFormatJson?: boolean;
+}
+
+/** Result of a local-endpoint chat call. */
+export interface EndpointChatResult {
+  content: string;
+  /** The model the server reports it used (falls back to the requested name). */
+  modelUsed: string;
+}
+
+/**
+ * Resolve the faithfulness-gate local endpoint from config (issue #1585).
+ *
+ * Returns the endpoint only when BOTH a base URL and a model name are
+ * configured; otherwise `null` (gate uses its existing routing chain). The
+ * gate's verifier needs a model identity, so a base URL alone is intentionally
+ * insufficient — silently calling whatever the server's default model is would
+ * be an unreviewed behavioral change.
+ */
+export function resolveFaithfulnessGateEndpoint(
+  config: Pick<PluginConfig, "extractionFaithfulnessModel" | "extractionFaithfulnessBaseUrl">,
+): LocalModelEndpoint | null {
+  const baseUrl = config.extractionFaithfulnessBaseUrl.trim();
+  const model = config.extractionFaithfulnessModel.trim();
+  if (!baseUrl || !model) return null;
+  return { baseUrl, model };
+}
+
+/**
+ * Resolve the correction-intent local endpoint from config (issue #1581/#1585).
+ *
+ * Same contract as the gate resolver. Consumption by the model-backed
+ * detector is the consuming child's job — the rule-based
+ * `detectPassiveCorrections` remains the default path; this pointer lets a
+ * future model-backed detector route to a fine-tuned local classifier when an
+ * operator configures one.
+ */
+export function resolveCorrectionIntentEndpoint(
+  config: Pick<PluginConfig, "correctionIntentModel" | "correctionIntentBaseUrl">,
+): LocalModelEndpoint | null {
+  const baseUrl = config.correctionIntentBaseUrl.trim();
+  const model = config.correctionIntentModel.trim();
+  if (!baseUrl || !model) return null;
+  return { baseUrl, model };
+}
+
+type FetchLike = typeof fetch;
+
+/**
+ * Make an openai-compatible chat-completions call to a local endpoint.
+ *
+ * POSTs to `${baseUrl}/chat/completions` with `{ model, messages, ... }` and
+ * returns the first choice's content. Any failure (non-2xx, network error,
+ * malformed body, timeout) returns `null` so callers fall back gracefully.
+ *
+ * The response is narrowed with runtime guards — never an unchecked cast — so
+ * a surprising server response fails closed (`null`) rather than reading a
+ * fabricated field.
+ */
+export async function callOpenAiCompatibleChat(
+  endpoint: LocalModelEndpoint,
+  messages: EndpointChatMessage[],
+  options: EndpointChatOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<EndpointChatResult | null> {
+  const url = joinBaseUrl(endpoint.baseUrl, "/chat/completions");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const body: Record<string, unknown> = {
+      model: endpoint.model,
+      messages,
+      temperature: options.temperature ?? 0.1,
+    };
+    if (typeof options.maxTokens === "number") {
+      body.max_tokens = options.maxTokens;
+    }
+    if (options.responseFormatJson) {
+      body.response_format = { type: "json_object" };
+    }
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch {
+      // Network error or abort — fail closed, let the caller fall back.
+      return null;
+    }
+    if (!response.ok) return null;
+    const parsed: unknown = await response.json().catch(() => null);
+    const content = extractFirstChoiceContent(parsed);
+    if (content === null) return null;
+    return { content, modelUsed: extractModel(parsed) ?? endpoint.model };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Join a base URL and a path, tolerating a trailing slash on the base. */
+function joinBaseUrl(base: string, path: string): string {
+  return base.endsWith("/") ? `${base.slice(0, -1)}${path}` : `${base}${path}`;
+}
+
+/**
+ * Narrow the openai-compatible response and pull the first choice's content.
+ *
+ * `in` / `typeof` guards only — no `as` cast (project rule). Returns `null`
+ * for any shape that isn't `{ choices: [{ message: { content: string } }, …] }`.
+ */
+function extractFirstChoiceContent(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null;
+  // After `in`, TS narrows the property to `unknown` — read it directly, no cast.
+  if (!("choices" in data) || !Array.isArray(data.choices)) return null;
+  const choices: unknown[] = data.choices;
+  for (const choice of choices) {
+    if (!choice || typeof choice !== "object") continue;
+    if (!("message" in choice)) continue;
+    const message = choice.message;
+    if (!message || typeof message !== "object") continue;
+    if (!("content" in message)) continue;
+    const content = message.content;
+    if (typeof content === "string" && content.length > 0) return content;
+  }
+  return null;
+}
+
+/** Narrow the `model` field from the response (best-effort, may be absent). */
+function extractModel(data: unknown): string | null {
+  if (!data || typeof data !== "object" || !("model" in data)) return null;
+  const model = data.model;
+  return typeof model === "string" && model.length > 0 ? model : null;
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1207,12 +1207,30 @@ export interface PluginConfig {
   // extracted facts against their verified source spans from #1575.
   /** Gate mode: "off" (default, byte-identical pre-feature), "shadow" (record only), "enforce" (route to pending_review). */
   extractionFaithfulnessGate: "off" | "shadow" | "enforce";
-  /** Override model/endpoint; empty string = default routing chain. */
+  /** Override model name; empty string = default routing chain. */
   extractionFaithfulnessModel: string;
+  /**
+   * Base URL of a local openai-compatible endpoint serving a fine-tuned
+   * faithfulness gate (issue #1585 model-lab), e.g.
+   * `http://localhost:11434/v1` (Ollama) or `http://localhost:8000/v1` (vLLM).
+   * Empty string (default) preserves the existing routing chain exactly;
+   * set together with `extractionFaithfulnessModel` to route the gate to the
+   * local model first, falling back to the chain on failure.
+   */
+  extractionFaithfulnessBaseUrl: string;
   /** Context window (chars) around the quote sent to the verifier. Default 400. */
   extractionFaithfulnessContextChars: number;
   /** Per-batch timeout in ms; timeout → tagged error, never blocks writes. Default 8000. */
   extractionFaithfulnessTimeoutMs: number;
+  /**
+   * Correction-intent model-lab pointer (issue #1581 / #1585). When both this
+   * and `correctionIntentBaseUrl` are set, the detection path can route to a
+   * local fine-tuned correction-intent classifier. Empty default keeps the
+   * rule-based passive-correction detector as the sole path (byte-identical).
+   */
+  correctionIntentModel: string;
+  /** Base URL of a local openai-compatible endpoint serving the correction-intent classifier (issue #1585). Empty default = rule-based detection. */
+  correctionIntentBaseUrl: string;
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3784,6 +3784,21 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned faithfulness gate (model-lab, issue #1585). When set AND extractionFaithfulnessModel is set, the gate routes there first and falls back to the configured chain on any failure. Empty = existing routing (byte-identical pre-feature path)."
+      },
+      "correctionIntentModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model name of a local fine-tuned correction-intent classifier (model-lab, issue #1581 / #1585). When set AND correctionIntentBaseUrl is set, passive-correction detection can route to it. Empty = rule-based detectPassiveCorrections is the sole detector."
+      },
+      "correctionIntentBaseUrl": {
+        "type": "string",
+        "default": "",
+        "description": "Base URL of a local openai-compatible endpoint serving a fine-tuned correction-intent classifier (model-lab, issue #1585). Empty = rule-based detector only."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -8,7 +8,7 @@
       "packages/remnic-core/src/cli.ts": 9384,
       "packages/remnic-core/src/access-service.ts": 8989,
       "packages/remnic-core/src/storage.ts": 7730,
-      "packages/remnic-core/src/config.ts": 4693
+      "packages/remnic-core/src/config.ts": 4672
     },
     "oversizedFileCount": 11,
     "scatteredConfigFlagReads": 562,

--- a/scripts/validate-config-contract.ts
+++ b/scripts/validate-config-contract.ts
@@ -53,7 +53,49 @@ function getPluginConfigKeys(source: ts.SourceFile): Set<string> {
   throw new Error("Could not find interface PluginConfig in packages/remnic-core/src/types.ts");
 }
 
-function getParseConfigReturnKeys(source: ts.SourceFile): Set<string> {
+function collectObjectLiteralKeys(expr: ts.ObjectLiteralExpression): Set<string> {
+  const keys = new Set<string>();
+  for (const prop of expr.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      const name = prop.name;
+      if (ts.isIdentifier(name) || ts.isStringLiteral(name)) keys.add(name.text);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      keys.add(prop.name.text);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Resolve keys contributed by a `...parseXxxConfig(cfg)` spread in
+ * parseConfig's return. Supports the #1526 extraction pattern: a god-file
+ * helper is extracted to its own module and spread back into parseConfig, so
+ * the contract validator must follow the spread to the helper's own
+ * object-literal return or it would report every extracted key as missing.
+ * Searches every non-declaration source file in the program for a
+ * FunctionDeclaration with the callee name whose body returns an object
+ * literal, and merges those keys.
+ */
+function resolveSpreadKeys(expr: ts.Expression, program: ts.Program): Set<string> {
+  const keys = new Set<string>();
+  if (!ts.isCallExpression(expr)) return keys;
+  const callee = expr.expression;
+  if (!ts.isIdentifier(callee)) return keys;
+  const fnName = callee.text;
+  for (const sf of program.getSourceFiles()) {
+    if (sf.isDeclarationFile) continue;
+    for (const stmt of sf.statements) {
+      if (!ts.isFunctionDeclaration(stmt) || stmt.name?.text !== fnName || !stmt.body) continue;
+      for (const s of stmt.body.statements) {
+        if (!ts.isReturnStatement(s) || !s.expression || !ts.isObjectLiteralExpression(s.expression)) continue;
+        for (const k of collectObjectLiteralKeys(s.expression)) keys.add(k);
+      }
+    }
+  }
+  return keys;
+}
+
+function getParseConfigReturnKeys(source: ts.SourceFile, program: ts.Program): Set<string> {
   for (const stmt of source.statements) {
     if (!ts.isFunctionDeclaration(stmt) || stmt.name?.text !== "parseConfig" || !stmt.body) continue;
     for (const s of stmt.body.statements) {
@@ -65,6 +107,8 @@ function getParseConfigReturnKeys(source: ts.SourceFile): Set<string> {
           if (ts.isIdentifier(name) || ts.isStringLiteral(name)) keys.add(name.text);
         } else if (ts.isShorthandPropertyAssignment(prop)) {
           keys.add(prop.name.text);
+        } else if (ts.isSpreadAssignment(prop)) {
+          for (const k of resolveSpreadKeys(prop.expression, program)) keys.add(k);
         }
       }
       return keys;
@@ -222,7 +266,7 @@ function main() {
   }
 
   const pluginConfigKeys = getPluginConfigKeys(typesSf);
-  const parseConfigReturnKeys = getParseConfigReturnKeys(configSf);
+  const parseConfigReturnKeys = getParseConfigReturnKeys(configSf, program);
   const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
   const schemaKeys = new Set<string>(Object.keys(pluginJson?.configSchema?.properties ?? {}));
 

--- a/tests/model-lab-correction-intent-data.test.mjs
+++ b/tests/model-lab-correction-intent-data.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * Correction-intent data generator determinism + morphology selfcheck
+ * (issue #1585 PR3).
+ *
+ * Mirrors tests/model-lab-faithfulness-data.test.mjs: shells out to the
+ * Python generator (stdlib-only), capability-guarded on `python3`. CI sets
+ * REMNIC_REQUIRE_CAPABILITY_TESTS=1 to forbid the skip. No data is committed —
+ * datasets are generated in a temp dir and hashed.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
+
+import { skipUnlessCommand } from "./helpers/capability-probe.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const generateData = path.join(repoRoot, "model-lab", "correction-intent", "generate-data.py");
+
+const pythonBin = process.env.PYTHON_BIN || "python3";
+const skipReason = skipUnlessCommand(
+  pythonBin,
+  "install Python 3.12+ (model-lab correction-intent data generation is stdlib-only)",
+);
+
+const ALLOWED_LABELS = new Set(["correction", "none"]);
+
+function runGenerator(args) {
+  return spawnSync(pythonBin, [generateData, ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+}
+
+function extractSha256(stdout) {
+  const m = stdout.match(/DATASET_SHA256=([0-9a-f]{64})/);
+  assert.ok(m, `expected DATASET_SHA256=<hex> on stdout, got: ${stdout.slice(0, 200)}`);
+  return m[1];
+}
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remnic-ci-"));
+}
+
+test(
+  "correction-intent generator: morphology selfcheck — every signal/anti-example yields its expected label",
+  { skip: skipReason },
+  () => {
+    const res = runGenerator(["--selfcheck"]);
+    assert.equal(res.status, 0, `selfcheck exited ${res.status}:\n${res.stderr}`);
+    const payload = JSON.parse(res.stdout);
+    assert.equal(payload.allPassed, true);
+    // The grammar must exercise all three polarities AND all four anti-fixtures.
+    const morphologies = new Set(payload.cases.map((c) => c.morphology));
+    for (const required of [
+      "update_switched_to",
+      "retract_dont_use",
+      "stop_storing_stop_suggesting",
+      "anti_hypothetical",
+      "anti_third_party",
+      "anti_tool_output",
+      "anti_self_resolving",
+    ]) {
+      assert.ok(morphologies.has(required), `selfcheck missing morphology ${required}`);
+    }
+  },
+);
+
+test(
+  "correction-intent generator: same seed ⇒ identical dataset sha256 (byte-stable)",
+  { skip: skipReason },
+  () => {
+    const a = tempDir();
+    const b = tempDir();
+    const ra = runGenerator(["--seed", "1337", "--out", a, "--yes"]);
+    const rb = runGenerator(["--seed", "1337", "--out", b, "--yes"]);
+    assert.equal(ra.status, 0, `gen A exited ${ra.status}:\n${ra.stderr}`);
+    assert.equal(rb.status, 0, `gen B exited ${rb.status}:\n${rb.stderr}`);
+    assert.equal(extractSha256(ra.stdout), extractSha256(rb.stdout));
+  },
+);
+
+test(
+  "correction-intent generator: different seed ⇒ different dataset sha256",
+  { skip: skipReason },
+  () => {
+    const a = tempDir();
+    const c = tempDir();
+    const ra = runGenerator(["--seed", "1337", "--out", a, "--yes"]);
+    const rc = runGenerator(["--seed", "9999", "--out", c, "--yes"]);
+    assert.equal(ra.status, 0);
+    assert.equal(rc.status, 0);
+    assert.notEqual(extractSha256(ra.stdout), extractSha256(rc.stdout));
+  },
+);
+
+test(
+  "correction-intent generator: emits a valid 2-label dataset matching the #1581 contract",
+  { skip: skipReason },
+  () => {
+    const out = tempDir();
+    const res = runGenerator(["--seed", "1337", "--out", out, "--yes"]);
+    assert.equal(res.status, 0, `gen exited ${res.status}:\n${res.stderr}`);
+    const trainPath = path.join(out, "train.jsonl");
+    assert.ok(fs.existsSync(trainPath), "train.jsonl not written");
+    const lines = fs.readFileSync(trainPath, "utf-8").trim().split("\n");
+    assert.ok(lines.length > 0, "dataset is empty");
+    const records = lines.map((l) => JSON.parse(l));
+    for (const r of records) {
+      assert.ok(ALLOWED_LABELS.has(r.label), `bad label ${r.label}`);
+      assert.ok(Array.isArray(r.turns) && r.turns.length > 0, "turns must be non-empty");
+      // The #1581 contract: correction labels carry a corrections[] block; none don't.
+      if (r.label === "correction") {
+        assert.ok(r.corrections.length > 0, "correction label must carry corrections[]");
+        const c = r.corrections[0];
+        assert.ok(["update", "retract", "stop_storing"].includes(c.polarity), `bad polarity ${c.polarity}`);
+      } else {
+        assert.equal(r.corrections.length, 0, "none label must have empty corrections[]");
+      }
+    }
+    // Both labels must be present (a one-class dataset is a generator bug).
+    const labels = new Set(records.map((r) => r.label));
+    assert.ok(labels.has("correction") && labels.has("none"), `dataset missing a label class: ${[...labels]}`);
+  },
+);

--- a/tests/model-lab-integrity-guards.test.mjs
+++ b/tests/model-lab-integrity-guards.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * Integrity-guard tests for the model-lab eval recipe + stack capture (#1585).
+ *
+ * These cover the thread-resolution fixes:
+ *  - eval._span_overlaps raises a CLEAR length-mismatch error (kilo
+ *    PRRT_kwDORJXyws6OtyS8) instead of a cryptic zip(strict=True) ValueError.
+ *  - eval._held_out_is_predictions refuses the held-out file (or a symlink to
+ *    it) as --predictions so gold can't be scored against itself (codex P1
+ *    PRRT_kwDORJXyws6Otp-I).
+ *  - training_stack.assert_stack_matches_requirements normalizes underscore /
+ *    hyphen distribution names so a pip-freeze capture isn't falsely reported
+ *    missing (cursor PRRT_kwDORJXyws6Otn36).
+ *
+ * Pure stdlib Python via spawnSync (no GPU, no torch) — mirrors the manifest
+ * schema probe's style.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { skipUnlessCommand } from "./helpers/capability-probe.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pythonBin = process.env.PYTHON_BIN || "python3";
+const skipReason = skipUnlessCommand(
+  pythonBin,
+  "install Python 3.12+ (model-lab integrity guards run stdlib-only Python)",
+);
+
+function runPython(script) {
+  const res = spawnSync(pythonBin, ["-c", script], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+  if (res.status !== 0) {
+    throw new Error(`python exited ${res.status}:\n${res.stderr}\n${res.stdout}`);
+  }
+  return res.stdout;
+}
+
+test(
+  "eval: _span_overlaps raises a clear length-mismatch error, not a cryptic zip ValueError (kilo PRRT_kwDORJXyws6OtyS8)",
+  { skip: skipReason },
+  () => {
+    const out = runPython(`
+import json, sys
+sys.path.insert(0, "model-lab")
+sys.path.insert(0, "model-lab/correction-intent")
+import eval as evmod
+try:
+    evmod._span_overlaps([{"label": "correction", "corrections": []}], [])
+    print(json.dumps({"raised": False}))
+except ValueError as e:
+    print(json.dumps({"raised": True, "msg": str(e)}))
+`);
+    const { raised, msg } = JSON.parse(out);
+    assert.equal(raised, true, "_span_overlaps must raise on mismatched lengths");
+    assert.match(msg, /length mismatch/, "error must be descriptive");
+    assert.ok(msg.includes("gold=1") && msg.includes("pred=0"), `must name both lengths: ${msg}`);
+  },
+);
+
+test(
+  "eval: _held_out_is_predictions refuses the held-out file as predictions, including symlinks (codex P1 PRRT_kwDORJXyws6Otp-I)",
+  { skip: skipReason },
+  () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-eval-guard-"));
+    const gold = path.join(dir, "gold.jsonl");
+    const preds = path.join(dir, "preds.jsonl");
+    fs.writeFileSync(gold, '{"label":"none"}\n');
+    fs.writeFileSync(preds, '{"label":"none"}\n');
+    const link = path.join(dir, "link.jsonl");
+    try {
+      fs.symlinkSync(gold, link);
+    } catch {
+      fs.rmSync(dir, { recursive: true, force: true });
+      return; // FS without symlink support — skip rather than fail.
+    }
+    try {
+      const out = runPython(`
+import json, sys
+sys.path.insert(0, "model-lab")
+sys.path.insert(0, "model-lab/correction-intent")
+from pathlib import Path
+import eval as evmod
+gold = Path(${JSON.stringify(gold)})
+preds = Path(${JSON.stringify(preds)})
+link = Path(${JSON.stringify(link)})
+print(json.dumps({
+    "same": evmod._held_out_is_predictions(gold, gold),
+    "distinct": evmod._held_out_is_predictions(gold, preds),
+    "symlink": evmod._held_out_is_predictions(gold, link),
+}))
+`);
+      const { same, distinct, symlink } = JSON.parse(out);
+      assert.equal(same, true, "same file must be detected");
+      assert.equal(distinct, false, "distinct files must NOT be flagged");
+      assert.equal(symlink, true, "a symlink to the held-out file must be detected");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "training_stack: assert_stack_matches_requirements normalizes underscore/hyphen names (cursor PRRT_kwDORJXyws6Otn36)",
+  { skip: skipReason },
+  () => {
+    const reqDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-stack-"));
+    const reqFile = path.join(reqDir, "requirements.txt");
+    // requirements.txt uses the canonical hyphen form.
+    fs.writeFileSync(reqFile, "huggingface-hub==0.25.0\ntorch==2.12.1\n");
+    try {
+      const out = runPython(`
+import json, sys
+sys.path.insert(0, "model-lab")
+from common.training_stack import assert_stack_matches_requirements
+from pathlib import Path
+# A pip-freeze capture that recorded the underscore form for one lib.
+stack = {"libs": {"huggingface_hub": "0.25.0", "torch": "2.12.1"}}
+errs = assert_stack_matches_requirements(stack, Path(${JSON.stringify(reqFile)}))
+print(json.dumps({"errors": errs}))
+`);
+      const { errors } = JSON.parse(out);
+      assert.deepEqual(
+        errors,
+        [],
+        `underscore-form capture must match hyphen-form pin, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.rmSync(reqDir, { recursive: true, force: true });
+    }
+  },
+);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -152,3 +152,89 @@ test(
     }
   },
 );
+
+
+/** A fully-valid "trained" correction-intent manifest; mutate one field to seed a violation. */
+function makeValidTrainedManifest() {
+  return JSON.parse(JSON.stringify({
+    task: "correction-intent",
+    schemaVersion: 1,
+    status: "trained",
+    contract: { inputFields: ["turns"], outputShape: "corrections[]", source: "PassiveCorrection" },
+    baseModel: { name: "Qwen/Qwen2.5-3B-Instruct" },
+    dataRecipe: {
+      generatorPath: "model-lab/correction-intent/generate-data.py",
+      generatorGitSha: "deadbeef",
+      seed: 1337,
+      sources: ["synthetic-morphology"],
+      counts: { correction: 50, none: 50, total: 100 },
+      datasetSha256: "abc123hash",
+    },
+    trainingStack: {
+      python: "3.12.3",
+      libs: {
+        torch: "2.12.1", transformers: "5.3.0", trl: "0.11.1", peft: "0.10.0",
+        datasets: "2.18.0", "huggingface-hub": "0.25.0", bitsandbytes: "0.43.1",
+      },
+      pipFreezeSha256: "freezehash",
+      capturedAt: "2026-07-06",
+    },
+    hyperparams: { lr: 1e-4, epochs: 3 },
+    trainedAt: "2026-07-06T00:00:00Z",
+    hardware: { gpu: "RTX 3090" },
+    eval: { heldOut: { macroF1: 0.91 }, downstream: null },
+    artifact: { hfRepo: "op/correction-intent-v1", revision: "abc", quantizations: ["fp16"] },
+    policyCompliance: { targetMaxParamsB: 4, actualParamsB: 3, escapeHatchUsed: false },
+  }));
+}
+
+test(
+  "manifest schema: strict mode REJECTS a declared trainingStack lib left null (kilo PRRT_kwDORJXyws6OtyS-)",
+  { skip: skipReason },
+  () => {
+    const m = makeValidTrainedManifest();
+    m.trainingStack.libs.trl = null; // declared but unpinned — must not pass strict
+    const tmp = path.join(os.tmpdir(), `remnic-ci-libs-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("trainingStack.libs.trl")),
+        `strict mode must reject a null trl pin, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);
+
+test(
+  "manifest schema: strict mode REJECTS a 'trained' manifest whose dataRecipe lacks provenance (codex P2 PRRT_kwDORJXyws6Otp-E)",
+  { skip: skipReason },
+  () => {
+    const m = makeValidTrainedManifest();
+    m.dataRecipe.datasetSha256 = null; // unhashed dataset must not pass strict
+    m.dataRecipe.generatorGitSha = null;
+    const tmp = path.join(os.tmpdir(), `remnic-ci-datarecipe-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("dataRecipe.datasetSha256")),
+        `strict mode must reject a null dataRecipe.datasetSha256, got: ${JSON.stringify(errors)}`,
+      );
+      assert.ok(
+        errors.some((e) => e.includes("dataRecipe.generatorGitSha")),
+        `strict mode must reject a null dataRecipe.generatorGitSha, got: ${JSON.stringify(errors)}`,
+      );
+      // A fully-valid trained manifest must still pass (no false positives).
+      const tmp2 = path.join(os.tmpdir(), `remnic-ci-datarecipe-ok-${process.pid}.json`);
+      fs.writeFileSync(tmp2, JSON.stringify(makeValidTrainedManifest()));
+      const { errors: okErrors } = validateManifest(tmp2, false);
+      assert.deepEqual(okErrors, [], `a fully-recorded trained manifest must be valid, got: ${JSON.stringify(okErrors)}`);
+      fs.unlinkSync(tmp2);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Manifest schema validation (issue #1585).
+ *
+ * Both committed manifests (faithfulness-gate + correction-intent) are the
+ * SCHEMA EXAMPLE only — every eval/weight/training-stack field is pending
+ * (rule 55: no fabricated numbers). This test asserts they validate against
+ * the schema in `allow_pending` mode, AND that the validator REJECTS a
+ * manifest missing the required trainingStack version-pin block (proving the
+ * ratchet actually bites — rule 6: prove-fail-before).
+ *
+ * Shells out to the Python validator (stdlib-only), capability-guarded on
+ * `python3` — same pattern as the data-generator determinism probes.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { skipUnlessCommand } from "./helpers/capability-probe.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pythonBin = process.env.PYTHON_BIN || "python3";
+const skipReason = skipUnlessCommand(
+  pythonBin,
+  "install Python 3.12+ (manifest schema validation runs stdlib-only Python)",
+);
+
+/** Run the Python validator on a JSON manifest; return {errors, ok}. */
+function validateManifest(manifestPath, allowPending) {
+  const script = `
+import json, sys
+sys.path.insert(0, "model-lab")
+from common.manifest_schema import validate_manifest
+m = json.load(open(${JSON.stringify(manifestPath)}))
+errs = validate_manifest(m, allow_pending=${allowPending ? "True" : "False"})
+print(json.dumps({"errors": errs}))
+`;
+  const res = spawnSync(pythonBin, ["-c", script], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+  });
+  if (res.status !== 0) {
+    throw new Error(`validator exited ${res.status}:\n${res.stderr}\n${res.stdout}`);
+  }
+  return JSON.parse(res.stdout);
+}
+
+test(
+  "manifest schema: both committed manifests validate in allow_pending (scaffold) mode",
+  { skip: skipReason },
+  () => {
+    for (const rel of [
+      "model-lab/faithfulness-gate/manifest.json",
+      "model-lab/correction-intent/manifest.json",
+    ]) {
+      const full = path.join(repoRoot, rel);
+      const { errors, ok } = validateManifest(full, true);
+      assert.equal(ok, undefined); // validator returns errors list; ok is incidental
+      assert.deepEqual(errors, [], `${rel} should be valid in scaffold mode, got: ${JSON.stringify(errors)}`);
+    }
+  },
+);
+
+test(
+  "manifest schema: validator REJECTS a manifest missing the trainingStack version-pin (prove-fail-before)",
+  { skip: skipReason },
+  () => {
+    // A manifest with no trainingStack must fail validation — the version-pin
+    // is a required field, so a half-recorded run can't be published silently.
+    const script = `
+import json, sys
+sys.path.insert(0, "model-lab")
+from common.manifest_schema import validate_manifest
+m = {
+    "task": "faithfulness-gate", "schemaVersion": 1, "status": "pending-training",
+    "contract": {}, "baseModel": None, "dataRecipe": {}, "hyperparams": None,
+    "trainedAt": None, "hardware": None, "eval": None, "artifact": None,
+    "policyCompliance": {"targetMaxParamsB": 4},
+    # NOTE: no trainingStack
+}
+errs = validate_manifest(m, allow_pending=True)
+print(json.dumps({"errors": errs}))
+`;
+    const res = spawnSync(pythonBin, ["-c", script], { cwd: repoRoot, encoding: "utf-8" });
+    assert.equal(res.status, 0, res.stderr);
+    const { errors } = JSON.parse(res.stdout);
+    assert.ok(
+      errors.some((e) => e.includes("trainingStack")),
+      `expected a trainingStack error, got: ${JSON.stringify(errors)}`,
+    );
+  },
+);
+
+test(
+  "manifest schema: validator REJECTS pending fields when allow_pending=False (a real run must pin everything)",
+  { skip: skipReason },
+  () => {
+    const full = path.join(repoRoot, "model-lab/faithfulness-gate/manifest.json");
+    const { errors } = validateManifest(full, false);
+    // The committed scaffold must FAIL strict mode — it's pending by design.
+    assert.ok(
+      errors.some((e) => e.includes("pending") || e.includes("trainingStack")),
+      `strict mode should reject the pending scaffold, got: ${JSON.stringify(errors)}`,
+    );
+  },
+);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -17,6 +17,8 @@ import test from "node:test";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
 
 import { skipUnlessCommand } from "./helpers/capability-probe.mjs";
 
@@ -104,5 +106,49 @@ test(
       errors.some((e) => e.includes("pending") || e.includes("trainingStack")),
       `strict mode should reject the pending scaffold, got: ${JSON.stringify(errors)}`,
     );
+  },
+);
+
+test(
+  "manifest schema: validator REJECTS a 'trained' manifest missing real-run fields (baseModel/hyperparams/trainedAt/hardware) in strict mode (codex P2)",
+  { skip: skipReason },
+  () => {
+    // A half-recorded run: concrete version-pin + eval + artifact, but the
+    // reproducibility fields left null. Strict mode must reject it so a
+    // half-recorded run cannot ship as complete.
+    const scaffold = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "model-lab/faithfulness-gate/manifest.json"),
+        "utf8",
+      ),
+    );
+    const half = {
+      ...scaffold,
+      status: "trained",
+      trainingStack: {
+        python: "3.12.3",
+        libs: { torch: "2.12.1", transformers: "5.3.0" },
+        pipFreezeSha256: "abc123",
+        capturedAt: "2026-07-06",
+      },
+      eval: { heldOut: { macroF1: 0.92 }, downstream: null },
+      artifact: { hfRepo: "op/model", revision: "abc", quantizations: ["fp16"] },
+      // baseModel / hyperparams / trainedAt / hardware intentionally left null.
+    };
+    const tmp = path.join(os.tmpdir(), `remnic-ci-manifest-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(half));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("baseModel")),
+        `strict mode must reject a null baseModel, got: ${JSON.stringify(errors)}`,
+      );
+      assert.ok(
+        errors.some((e) => e.includes("hardware")),
+        `strict mode must reject null hardware, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
   },
 );


### PR DESCRIPTION
Closes #1585 (software half). Part of #1572.

## What this lands

The **reproducible software** for the model-lab: recipes, the version-pinned training stack, the manifest schema, both seeded data generators, the eval harness (held-out p95 latency + faithfulness F1 / correction-intent detection F1), and the Remnic config pointers that let the gate + passive-correction detection route to a fine-tuned local model when available. **No GPU is required to land this PR.** Everything is unit-tested on CPU.

Per rule 55 (#1520): **no accuracy/latency/eval number appears anywhere** without a real-run artifact. Both committed manifests ship as `pending-training` schema examples; the actual training runs + eval-number manifests are the **GPU-gated #1585 follow-up** (see *GPU follow-up* below).

### Pieces
- **Manifest schema** (`common/manifest_schema.py`) — the ONLY committed artifact for a trained model. Two first-class states: `allow_pending=True` (committed scaffold, every eval/weight/training-stack field null/pending) and `allow_pending=False` (a real run must pin everything). Proven to reject a manifest missing the `trainingStack` version-pin block (rule 6: prove-fail-before).
- **Training-stack pin** (`common/training_stack.py`) — `requirements_versions` parses the committed `requirements.txt` (exact lib versions); `capture_training_stack` records `pip freeze` at train time (GPU-gated); `assert_stack_matches_requirements` surfaces silent drift between the pin and the run. *A manifest that can't reproduce its own eval numbers is a bug.*
- **Data generators** — faithfulness perturbations (`faithfulness-gate/`) + correction-intent morphology (`correction-intent/`). Seeded determinism: same seed → byte-identical dataset → identical sha256 (asserted in CI). Harvest stream is a consent-gated stub (`--i-consent-local-data`) waiting for #1576/#1581 shadow mode.
- **Eval harness** (`common/eval_runner.py` + `common/latency.py`) — per-class/macro F1 (faithfulness) + detection F1 + span overlap (correction-intent) + held-out p95 latency percentile math. Identical math in CI and on GPU.
- **Config pointers** (`extractionFaithfulnessBaseUrl`, `correctionIntentModel`, `correctionIntentBaseUrl`) — when the gate pointer keys are both set, the gate routes to the local served endpoint first and falls back to the configured chain on any failure (graceful degradation; a down local model never blocks writes). Empty defaults preserve byte-identical pre-feature routing (rule 39). Response narrowing uses in/typeof guards, no inline casts.
- **Docs** (`docs/model-lab.md`, `model-lab/README.md`) — reproducible recipe + hardware envelope + policy table + how to point Remnic config at a served model.

### Wiring fixes (so the committed config pointers pass the gates)
- `validate-config-contract.ts`: teach `getParseConfigReturnKeys` to follow `...parseXxxConfig(cfg)` spreads to the helper's own object-literal return. Supports the #1526 extraction pattern that keeps `config.ts` from growing; without it every extracted key looked "missing" from `parseConfig`'s return. General improvement.
- `openclaw.plugin.json`: declare the 3 new model-lab pointer keys in `configSchema` so the PluginConfig ↔ schema contract holds.
- `extraction-faithfulness.test.ts`: fix `fallbackCalls` array type to match `stubFallbackLlm`'s captured-parameter shape.

## Chokepoints used / not applicable
- **not applicable** — model-lab is a standalone Python tree, not an npm workspace package; it consumes Remnic only through existing config keys. The config pointers are empty-default optional keys (no new `config.*Enabled` reads, no new MCP/HTTP/CLI surfaces).
- ratchet: `config.ts` 4642 → 4621 (extraction improvement; baseline tightened).
- config-contract: validator now spread-aware; schema synchronized.

## Repo ethics
`model-lab/**/data/`, `model-lab/**/runs/`, `model-lab/.venv/`, `*.safetensors`, `*.gguf` are gitignored. The committed manifests are the ONLY model-lab artifacts in git. Verified: no data/weights/LLM-traces tracked.

## Verification (no GPU)
- `npm run preflight:quick` → **OK (quick)** (lint, check-types, check-config-contract, plugin:inspect, check-review-patterns, check-ratchets, check-docs-parity, entity-hardening, quick tests).
- `node scripts/check-ratchets.mjs` → OK.
- Model-lab node:test suite (11 tests, capability-guarded on `python3`): faithfulness + correction-intent determinism/selfcheck, manifest-schema validate + prove-fail-before → all pass.
- Config-pointer unit suite (89 tests): `faithfulness-config`, `local-model-endpoint`, `extraction-faithfulness` → all pass.

## GPU follow-up (NOT in this PR — explicitly gated)
The **actual training runs + committed eval-number manifests + downstream bench artifacts** are GPU-gated. They land in a separate follow-up when the lab box (RTX 3090) frees:
1. Train encoder baseline → fill `faithfulness-gate/manifest.json` `eval.heldOut` + `trainingStack` (`allow_pending=False` must pass).
2. Train ≤4B instruct-LM correction-intent model → fill `correction-intent/manifest.json`.
3. Downstream: #1574 LoCoMo adversarial-category ablation (gate quality vs prompted-LLM baseline, p95 latency); MemCorrect (#1584) `false_apply` / `uptake@next`.
4. Publish weights to operator HF account; reference in manifest `artifact` block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extraction faithfulness LLM routing and config parsing; behavior is gated on new optional keys with extensive tests, but misconfiguration or timeout edge cases could affect gate availability until fallback runs.
> 
> **Overview**
> Adds the **CPU-landed software half** of `model-lab/` for faithfulness-gate and correction-intent: manifest schema + `trainingStack` pinning, shared eval/latency math, correction-intent synthetic data + train/eval recipes, and `pending-training` manifests (no fabricated eval numbers).
> 
> **Remnic wiring:** optional config keys `extractionFaithfulnessBaseUrl`, `correctionIntentModel`, and `correctionIntentBaseUrl` (parsed via extracted `faithfulness-config.ts`); the faithfulness gate **prefers** a local OpenAI-compatible endpoint when both URL and model are set, with half-batch probe timeout, fallback to the existing LLM chain, and no leaking of the local model name into fallback on outage. Plugin JSON + spread-aware `validate-config-contract` keep the config contract honest.
> 
> **Tests/docs:** Node probes for correction-intent determinism, manifest strict validation, and eval integrity guards; expanded `docs/model-lab.md` / README. Actual GPU training runs and eval-filled manifests remain explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612c159dcfa450f8416ea0b970b06abf28f1714c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->