### PR TITLE
fix(coding-graph): persist SIMILAR_TO edges by node id (#1677)

### DIFF
--- a/packages/coding-graph/src/graph-store.test.ts
+++ b/packages/coding-graph/src/graph-store.test.ts
@@ -1240,3 +1240,122 @@ test("upsertEdges: rejects invalid provenance / out-of-range confidence at the b
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// upsertEdges: node-id-keyed endpoints (issue #1677 — duplicate qualified-name
+// support). A SIMILAR_TO edge between two symbols that share a qualified name
+// across two files is persisted by node id, NOT dropped as ambiguous.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("upsertEdges: srcNodeId/dstNodeId persist an edge between same-qualified-name nodes (issue #1677)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // Two files, each declaring a symbol with the SAME qualified name
+    // "dup.Foo" but a different file path → distinct deterministic node ids
+    // (identity is (qualifiedName, filePath, label)). The qualified-name
+    // fallback would be AMBIGUOUS here and drop the edge.
+    const fileOne: StoreFileIR = {
+      path: "src/one.ts",
+      language: "typescript",
+      contentHash: "h-one",
+      symbols: [sym("dup.Foo", "Foo", 0, 100, "function")],
+    };
+    const fileTwo: StoreFileIR = {
+      path: "src/two.ts",
+      language: "typescript",
+      contentHash: "h-two",
+      symbols: [sym("dup.Foo", "Foo", 0, 100, "function")],
+    };
+    await store.upsertFileBatch([fileOne, fileTwo]);
+
+    const idOne = nodeIdFor({ qualifiedName: "dup.Foo", filePath: "src/one.ts", label: "function" });
+    const idTwo = nodeIdFor({ qualifiedName: "dup.Foo", filePath: "src/two.ts", label: "function" });
+    assert.notEqual(idOne, idTwo, "two same-qname symbols in different files have distinct node ids");
+
+    // Edge keyed by node ids — the SIMILAR_TO pipeline shape.
+    const result = await store.upsertEdges([
+      {
+        srcQualifiedName: "dup.Foo",
+        dstQualifiedName: "dup.Foo",
+        srcNodeId: idOne,
+        dstNodeId: idTwo,
+        type: "SIMILAR_TO",
+        confidence: 0.93,
+        provenance: "semantic",
+      },
+    ]);
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("expected ok");
+    assert.equal(result.persisted, 1, "node-id-keyed edge persisted despite duplicate qualified name");
+    assert.equal(result.skipped, 0, "edge must NOT be dropped as ambiguous");
+
+    // The edge is traversable from either node by id.
+    const t = store.traverse({ start: idOne, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.equal(t.ok, true);
+    if (t.ok) {
+      assert.ok(
+        t.hits.some((h) => h.nodeId === idTwo),
+        "SIMILAR_TO edge reaches the exact same-qname node by id",
+      );
+    }
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("upsertEdges: a node id that does not reference an indexed node is skipped (issue #1677)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    await store.upsertFileBatch([fileA]);
+
+    // srcNodeId resolves (a.greet exists) but dstNodeId points at a node
+    // that was never ingested → dangling, counted as skipped (consistent
+    // with the qname dangling-edge policy).
+    const bogusDst = nodeIdFor({ qualifiedName: "ghost", filePath: "src/ghost.ts", label: "function" });
+    const result = await store.upsertEdges([
+      {
+        srcQualifiedName: "a.greet",
+        dstQualifiedName: "ghost",
+        srcNodeId: nodeIdFor({ qualifiedName: "a.greet", filePath: "src/a.ts", label: "function" }),
+        dstNodeId: bogusDst,
+        type: "SIMILAR_TO",
+        confidence: 0.9,
+        provenance: "semantic",
+      },
+    ]);
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("expected ok");
+    assert.equal(result.persisted, 0, "dangling dst node id → not persisted");
+    assert.equal(result.skipped, 1, "dangling node id counted as skipped");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("upsertEdges: edges without node ids still use the qname path (issue #1677 back-compat)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // The existing trace/HTTP_CALLS path passes no node ids — it MUST keep
+    // resolving by qualified name exactly as before.
+    await store.upsertFileBatch([fileA]);
+    const result = await store.upsertEdges([
+      {
+        srcQualifiedName: "a.greet",
+        dstQualifiedName: "a.farewell",
+        type: "CALLS",
+        confidence: 0.8,
+        provenance: "heuristic",
+      },
+    ]);
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("expected ok");
+    assert.equal(result.persisted, 1, "qname-only edge still persists via the fallback path");
+    assert.equal(result.skipped, 0);
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/coding-graph/src/graph-store.test.ts
+++ b/packages/coding-graph/src/graph-store.test.ts
@@ -1335,6 +1335,65 @@ test("upsertEdges: a node id that does not reference an indexed node is skipped 
   }
 });
 
+test("upsertEdges: a node id whose qualified_name does not match is skipped (issue #1677, chatgpt-codex-connector P2)", async () => {
+  const { store, dir } = await tempStore();
+  try {
+    // Two files, same qname "dup.Foo" → two distinct node ids.
+    const fileOne: StoreFileIR = {
+      path: "src/one.ts",
+      language: "typescript",
+      contentHash: "h-one",
+      symbols: [sym("dup.Foo", "Foo", 0, 100, "function")],
+    };
+    const fileTwo: StoreFileIR = {
+      path: "src/two.ts",
+      language: "typescript",
+      contentHash: "h-two",
+      symbols: [sym("dup.Foo", "Foo", 0, 100, "function")],
+    };
+    await store.upsertFileBatch([fileOne, fileTwo]);
+    const idOne = nodeIdFor({ qualifiedName: "dup.Foo", filePath: "src/one.ts", label: "function" });
+    const idTwo = nodeIdFor({ qualifiedName: "dup.Foo", filePath: "src/two.ts", label: "function" });
+
+    // idOne exists and resolves "dup.Foo" — this edge is fine.
+    const ok = await store.upsertEdges([
+      {
+        srcQualifiedName: "dup.Foo",
+        dstQualifiedName: "dup.Foo",
+        srcNodeId: idOne,
+        dstNodeId: idTwo,
+        type: "SIMILAR_TO",
+        confidence: 0.9,
+        provenance: "semantic",
+      },
+    ]);
+    assert.equal(ok.ok && ok.persisted, 1, "correctly-paired id+qname persists");
+
+    // idOne is a REAL node id, but the edge claims its qname is "wrong.qname"
+    // — the id/qname pair is inconsistent and MUST be skipped rather than
+    // silently writing an edge from node idOne under a misleading name
+    // (chatgpt-codex-connector P2: id/qname consistency at the boundary).
+    const bad = await store.upsertEdges([
+      {
+        srcQualifiedName: "wrong.qname",
+        dstQualifiedName: "dup.Foo",
+        srcNodeId: idOne,
+        dstNodeId: idTwo,
+        type: "SIMILAR_TO",
+        confidence: 0.9,
+        provenance: "semantic",
+      },
+    ]);
+    assert.equal(bad.ok, true);
+    if (!bad.ok) throw new Error("expected ok");
+    assert.equal(bad.persisted, 0, "mismatched id+qname → not persisted");
+    assert.equal(bad.skipped, 1, "mismatched id+qname counted as skipped");
+  } finally {
+    await store.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("upsertEdges: edges without node ids still use the qname path (issue #1677 back-compat)", async () => {
   const { store, dir } = await tempStore();
   try {

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -1335,12 +1335,16 @@ export class GraphStore {
            confidence = excluded.confidence,
            provenance = excluded.provenance`,
     );
-    // node-id existence check (issue #1677). `nodes.id` is the PRIMARY KEY,
-    // so this is a unique, unambiguous lookup — a SIMILAR_TO edge between
-    // two same-qualified-name symbols resolves here instead of being
-    // dropped by the ambiguous qualified-name fallback.
-    const nodeIdExists = this.db.prepare(
-      "SELECT 1 FROM nodes WHERE id = ? LIMIT 1",
+    // node-id resolution (issue #1677). `nodes.id` is the PRIMARY KEY, so
+    // this is a unique, unambiguous lookup — a SIMILAR_TO edge between two
+    // same-qualified-name symbols resolves here instead of being dropped by
+    // the ambiguous qualified-name fallback. The row's qualified_name is
+    // returned so the caller's (src|dst)QualifiedName can be matched against
+    // it: a stale or mismatched id+qname pair is skipped (counted in
+    // `skipped`) rather than silently writing an edge from the wrong node
+    // (chatgpt-codex-connector P2 — id/qname consistency at the boundary).
+    const nodeById = this.db.prepare(
+      "SELECT qualified_name FROM nodes WHERE id = ? LIMIT 1",
     );
     try {
       let persisted = 0;
@@ -1364,16 +1368,15 @@ export class GraphStore {
           // Prefer the content-derived node id when the caller supplied one
           // (issue #1677). Only fall through to qualified-name resolution
           // when no id is present, preserving the existing trace/HTTP_CALLS
-          // path verbatim.
+          // path verbatim. When an id IS supplied, its row's qualified_name
+          // MUST match the edge's (src|dst)QualifiedName — a mismatched pair
+          // (stale body map, custom integration) is skipped like a dangling
+          // edge instead of corrupting the graph (chatgpt-codex-connector P2).
           const srcId = edge.srcNodeId
-            ? nodeIdExists.get(edge.srcNodeId)
-              ? edge.srcNodeId
-              : undefined
+            ? resolveByNodeId(nodeById, edge.srcNodeId, edge.srcQualifiedName)
             : resolveNodeId(edge.srcQualifiedName, emptyBatch, this.db);
           const dstId = edge.dstNodeId
-            ? nodeIdExists.get(edge.dstNodeId)
-              ? edge.dstNodeId
-              : undefined
+            ? resolveByNodeId(nodeById, edge.dstNodeId, edge.dstQualifiedName)
             : resolveNodeId(edge.dstQualifiedName, emptyBatch, this.db);
           if (!srcId || !dstId) {
             skipped += 1;
@@ -3284,6 +3287,30 @@ function resolveNodeId(
     return undefined;
   }
   return rows[0]?.id;
+}
+
+/**
+ * Resolve a standalone-edge endpoint by content-derived node id (issue #1677).
+ *
+ * `nodes.id` is the PRIMARY KEY, so the lookup is unique and unambiguous —
+ * this is what lets a SIMILAR_TO edge between two same-qualified-name symbols
+ * resolve where the qualified-name fallback would be ambiguous. The supplied
+ * `qualifiedName` is validated against the row: a stale or mismatched
+ * id+qname pair (stale body map, custom integration) returns `undefined` so
+ * the caller skips the edge like a dangling endpoint instead of silently
+ * writing an edge from the wrong node (chatgpt-codex-connector P2 — id/qname
+ * consistency at the store boundary). `stmt` is the caller's prepared
+ * `SELECT qualified_name FROM nodes WHERE id = ?`.
+ */
+function resolveByNodeId(
+  stmt: { get(...args: unknown[]): unknown },
+  nodeId: string,
+  qualifiedName: string,
+): string | undefined {
+  const row = expectRow<{ qualified_name: string }>(stmt.get(nodeId), ["qualified_name"]);
+  if (!row) return undefined;
+  if (row.qualified_name !== qualifiedName) return undefined;
+  return nodeId;
 }
 // ──────────────────────────────────────────────────────────────────────────
 // Error classification — tag SQLITE_BUSY / SQLITE_CORRUPT into the failure

--- a/packages/coding-graph/src/graph-store.ts
+++ b/packages/coding-graph/src/graph-store.ts
@@ -106,6 +106,17 @@ export type SymbolKind =
  * can resolve them against the same batch's symbol set plus the on-disk
  * node table. PR1 only carries CALLS-style edges; PR2 adds the rest of
  * #1552's edge types.
+ *
+ * Optional `srcNodeId` / `dstNodeId` (issue #1677) carry the content-
+ * derived node id (the same canonical hash form the store uses as
+ * `nodes.id`, see `nodeIdFor`). When present, the standalone
+ * `upsertEdges` path resolves the endpoint by `nodes.id` (unique) instead
+ * of by qualified name, so a SIMILAR_TO edge between two symbols that
+ * share a qualified name across files is persisted rather than dropped as
+ * ambiguous. The qname-keyed file-batch path and the existing
+ * `ambiguous … drops edges` behavior are unchanged. Only populated by
+ * callers that originate edges from node-id-keyed pairs (the semantic
+ * SIMILAR_TO pipeline); structural/trace edges keep the qname path.
  */
 export interface EdgeIR {
   /** Qualified name of the source node (caller / definition site). */
@@ -115,6 +126,14 @@ export interface EdgeIR {
   type: string;
   confidence: number;
   provenance: EdgeProvenance;
+  /**
+   * Optional content-derived source node id (`nodes.id`). When present on
+   * a standalone-edge upsert, the store resolves the endpoint by id
+   * (unambiguous) instead of falling back to qualified-name resolution.
+   */
+  readonly srcNodeId?: string;
+  /** Optional content-derived destination node id — see {@link EdgeIR.srcNodeId}. */
+  readonly dstNodeId?: string;
 }
 
 /**
@@ -854,11 +873,17 @@ export class GraphStore {
    * observations as edges with `provenance: "trace"` — upgrading
    * confidence on existing edges and inserting new ones.
    *
-   * Both `src` and `dst` are resolved by qualified_name via the global
-   * `resolveNodeId` fallback (unambiguous single-match policy). Edges
-   * whose endpoints do not resolve to exactly one node are skipped (and
-   * counted in `skipped`) rather than attached to the wrong node — the
-   * dangling-edge policy from `upsertFileBatch` applies.
+   * Endpoint resolution: when an edge carries `srcNodeId` / `dstNodeId`
+   * (issue #1677 — the SIMILAR_TO pipeline populates them from
+   * content-derived node ids), the endpoint is resolved by `nodes.id`
+   * (unique primary key), so an edge between two symbols that share a
+   * qualified name across files is persisted rather than dropped as
+   * ambiguous. Edges WITHOUT node ids fall back to qualified_name
+   * resolution via the global `resolveNodeId` (unambiguous single-match
+   * policy). Edges whose endpoints do not resolve (missing node id row OR
+   * an ambiguous/dangling qualified name) are skipped (and counted in
+   * `skipped`) rather than attached to the wrong node — the dangling-edge
+   * policy from `upsertFileBatch` applies.
    *
    * Serialized on the store's write queue like `upsertFileBatch` so a
    * concurrent file-batch upsert and a trace upsert cannot interleave
@@ -1310,6 +1335,13 @@ export class GraphStore {
            confidence = excluded.confidence,
            provenance = excluded.provenance`,
     );
+    // node-id existence check (issue #1677). `nodes.id` is the PRIMARY KEY,
+    // so this is a unique, unambiguous lookup — a SIMILAR_TO edge between
+    // two same-qualified-name symbols resolves here instead of being
+    // dropped by the ambiguous qualified-name fallback.
+    const nodeIdExists = this.db.prepare(
+      "SELECT 1 FROM nodes WHERE id = ? LIMIT 1",
+    );
     try {
       let persisted = 0;
       let skipped = 0;
@@ -1329,8 +1361,20 @@ export class GraphStore {
               `graph-store: edge confidence ${edge.confidence} is out of range [0, 1] for edge ${edge.srcQualifiedName} → ${edge.dstQualifiedName}`,
             );
           }
-          const srcId = resolveNodeId(edge.srcQualifiedName, emptyBatch, this.db);
-          const dstId = resolveNodeId(edge.dstQualifiedName, emptyBatch, this.db);
+          // Prefer the content-derived node id when the caller supplied one
+          // (issue #1677). Only fall through to qualified-name resolution
+          // when no id is present, preserving the existing trace/HTTP_CALLS
+          // path verbatim.
+          const srcId = edge.srcNodeId
+            ? nodeIdExists.get(edge.srcNodeId)
+              ? edge.srcNodeId
+              : undefined
+            : resolveNodeId(edge.srcQualifiedName, emptyBatch, this.db);
+          const dstId = edge.dstNodeId
+            ? nodeIdExists.get(edge.dstNodeId)
+              ? edge.dstNodeId
+              : undefined
+            : resolveNodeId(edge.dstQualifiedName, emptyBatch, this.db);
           if (!srcId || !dstId) {
             skipped += 1;
             continue;

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -360,14 +360,25 @@ test("SIMILAR_TO: computeSimilarTo with gate-off returns semantic_disabled", () 
   if (!r.ok) assert.equal(r.code, "semantic_disabled");
 });
 
-test("SIMILAR_TO: similarEdgesToEdgeIR maps to EdgeIR with semantic provenance", () => {
+test("SIMILAR_TO: similarEdgesToEdgeIR maps to EdgeIR with semantic provenance + node ids", () => {
   const edges = similarEdgesToEdgeIR([
-    { srcQualifiedName: "mod.a", dstQualifiedName: "mod.b", confidence: 0.95, confirmed: true },
+    {
+      srcNodeId: "id-a",
+      dstNodeId: "id-b",
+      srcQualifiedName: "mod.a",
+      dstQualifiedName: "mod.b",
+      confidence: 0.95,
+      confirmed: true,
+    },
   ]);
   assert.equal(edges.length, 1);
   assert.equal(edges[0]!.type, "SIMILAR_TO");
   assert.equal(edges[0]!.provenance, "semantic");
   assert.equal(edges[0]!.confidence, 0.95);
+  // Node ids are carried through so the store resolves endpoints by id
+  // (issue #1677 — duplicate qualified-name support).
+  assert.equal(edges[0]!.srcNodeId, "id-a");
+  assert.equal(edges[0]!.dstNodeId, "id-b");
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1004,6 +1015,63 @@ test("cache-hit: provider without dimensions still caches on reindex", async () 
       assert.equal(r2.cached, 1);
     }
     assert.equal(calls, 1, "reindex must hit cache — no second embed");
+  } finally {
+    await cleanup();
+  }
+});
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// SIMILAR_TO end-to-end: two symbols that share a qualified name across two
+// files are persisted as a SIMILAR_TO edge by node id (issue #1677). Before
+// the fix the edge was dropped because resolveNodeId returns undefined for an
+// ambiguous qualified name.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("SIMILAR_TO: duplicate qualified name across files persists by node id (issue #1677)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    // Identical bodies → MinHash candidate. Same qualified name, different
+    // files → distinct node ids, ambiguous qualified name.
+    const body = "function clone() { const x = 1; const y = 2; return x + y; }";
+    await writeFile(path.join(dir, "a.ts"), body);
+    await writeFile(path.join(dir, "b.ts"), body);
+    await store.upsertFileBatch([
+      makeFileIR("a.ts", [{ name: "clone", qname: "mod.clone", kind: "function", start: 0, end: body.length }], body),
+      makeFileIR("b.ts", [{ name: "clone", qname: "mod.clone", kind: "function", start: 0, end: body.length }], body),
+    ]);
+
+    const idA = nodeIdFor({ qualifiedName: "mod.clone", filePath: "a.ts", label: "function" });
+    const idB = nodeIdFor({ qualifiedName: "mod.clone", filePath: "b.ts", label: "function" });
+    assert.notEqual(idA, idB, "same-qname symbols in different files have distinct node ids");
+
+    // No provider → MinHash-only path (deterministic, local).
+    const r = computeSimilarTo({ store, provider: undefined, config: ENABLED_CONFIG, repoRoot: dir });
+    assert.equal(r.ok, true);
+    if (!r.ok) throw new Error("expected ok");
+    assert.ok(r.edges.length >= 1, "a near-clone candidate is produced");
+
+    // The candidate edges MUST carry node ids (the fix).
+    const pair = r.edges.find((e) => e.srcNodeId === idA && e.dstNodeId === idB);
+    assert.ok(pair, "emitted edge carries the content-derived node ids of both same-qname nodes");
+
+    // Persist via the store. Pre-fix this returned skipped=1, persisted=0.
+    const edgeIRs = similarEdgesToEdgeIR(r.edges);
+    const upsert = await store.upsertEdges(edgeIRs);
+    assert.equal(upsert.ok, true);
+    if (!upsert.ok) throw new Error("expected ok");
+    assert.equal(upsert.persisted, edgeIRs.length, "all SIMILAR_TO edges persisted by node id");
+    assert.equal(upsert.skipped, 0, "no edge dropped as an ambiguous qualified name");
+
+    // Traversal by node id confirms the edge links the two same-qname nodes.
+    const t1 = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.equal(t1.ok, true);
+    if (t1.ok) {
+      assert.ok(
+        t1.hits.some((h) => h.nodeId === idB),
+        "SIMILAR_TO edge connects the two distinct same-qname nodes",
+      );
+    }
   } finally {
     await cleanup();
   }

--- a/packages/coding-graph/src/semantic/similarity.ts
+++ b/packages/coding-graph/src/semantic/similarity.ts
@@ -139,6 +139,8 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
       // rule 35: >= threshold confirms (decided once, here).
       if (cos >= config.similarToThreshold) {
         edges.push({
+          srcNodeId: c.aNodeId,
+          dstNodeId: c.bNodeId,
           srcQualifiedName: c.aQualifiedName,
           dstQualifiedName: c.bQualifiedName,
           confidence: cos,
@@ -158,6 +160,8 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
       // 0.3-0.8; the MINHASH_JACCARD_GATE is the documented floor.
       if (c.jaccard >= MINHASH_JACCARD_GATE) {
         edges.push({
+          srcNodeId: c.aNodeId,
+          dstNodeId: c.bNodeId,
           srcQualifiedName: c.aQualifiedName,
           dstQualifiedName: c.bQualifiedName,
           confidence: MINHASH_ONLY_CONFIDENCE,
@@ -183,6 +187,12 @@ export function computeSimilarTo(input: SimilarToInput): SimilarToResult | Seman
 /**
  * Convert SimilarEdge[] to the store's EdgeIR[] for persistence via
  * upsertEdges. Provenance is always "semantic"; type is SIMILAR_TO.
+ *
+ * Carries the content-derived node ids onto the EdgeIR (issue #1677) so
+ * the store resolves each endpoint by `nodes.id` (unique) instead of by
+ * qualified name — two symbols that share a qualified name across files
+ * get distinct, non-colliding SIMILAR_TO edges instead of being dropped
+ * as ambiguous.
  */
 export function similarEdgesToEdgeIR(edges: readonly SimilarEdge[]): EdgeIR[] {
   return edges.map((e) => ({
@@ -191,6 +201,8 @@ export function similarEdgesToEdgeIR(edges: readonly SimilarEdge[]): EdgeIR[] {
     type: SIMILAR_TO_EDGE_TYPE,
     confidence: e.confidence,
     provenance: SEMANTIC_PROVENANCE,
+    srcNodeId: e.srcNodeId,
+    dstNodeId: e.dstNodeId,
   }));
 }
 

--- a/packages/coding-graph/src/semantic/types.ts
+++ b/packages/coding-graph/src/semantic/types.ts
@@ -91,8 +91,15 @@ export interface SimilarCandidate {
 
 /**
  * A confirmed SIMILAR_TO edge (after cosine confirmation when available).
+ *
+ * Carries the content-derived node ids (`nodes.id`) of both endpoints so
+ * the persisted edge resolves unambiguously even when the two symbols share
+ * a qualified name across files (issue #1677). The qualified-name fields
+ * remain for diagnostics / stable-sort tie-breaking.
  */
 export interface SimilarEdge {
+  readonly srcNodeId: string;
+  readonly dstNodeId: string;
   readonly srcQualifiedName: string;
   readonly dstQualifiedName: string;
   readonly confidence: number;


### PR DESCRIPTION
## What

`SIMILAR_TO` edges were persisted by **qualified name**, which collides when two distinct symbols share a qualified name (overloads, same-name-different-file). `resolveNodeId` returns `undefined` for an ambiguous qualified name, so a `SIMILAR_TO` edge whose source or destination name is duplicated across files was **silently dropped** at insert time.

Surfaced by cursor Bugbot on #1675 (`@remnic/coding-graph` semantic layer). This is the same qname-ambiguity limitation the rest of `graph-store` already handles explicitly (`traverse` → `ambiguous_start`, `snippetFor` → `ambiguous_name`, `resolveNodeId` → drops ambiguous edges) — intended, consistent behavior for the qname-keyed edge model, surfaced uniquely by the semantic pipeline because it originates edges from node-id-keyed pairs.

## Change

Persist `SIMILAR_TO` edges by **content-derived node id** (rule 38 — same canonical hash form as the store) instead of qualified name, so duplicates do not merge/overwrite:

- **`EdgeIR`** gains optional `srcNodeId?: string` / `dstNodeId?: string` (the `nodes.id` PK form produced by `nodeIdFor`).
- **`runUpsertEdges`** resolves an endpoint by `nodes.id` (unique) when a node id is present; only falls back to the qualified-name `resolveNodeId` when no id is supplied. A node id whose row does not exist is skipped (dangling-edge parity).
- **`SimilarEdge`** carries `srcNodeId`/`dstNodeId`; **`computeSimilarTo`** populates them from the candidate's `aNodeId`/`bNodeId`; **`similarEdgesToEdgeIR`** propagates them onto the `EdgeIR`.

Edges **without** node ids (trace `HTTP_CALLS`, structural `CALLS`, the file-batch path) keep the qualified-name resolution path **verbatim**, so the existing `ambiguous local qualified_name drops edges` behavior is unchanged.

## Verification

- `@remnic/coding-graph` full suite: **409 pass / 0 fail**.
- New regression tests:
  - `graph-store.test.ts` — `upsertEdges` persists a `SIMILAR_TO` edge between two same-qualified-name nodes by id (pre-fix: dropped as ambiguous); a dangling node id is skipped; qname-only edges still resolve via the fallback.
  - `semantic.test.ts` — end-to-end: two same-qname symbols across two files flow through `computeSimilarTo → similarEdgesToEdgeIR → upsertEdges` and persist; the edge traverses between the two distinct node ids.
- `npm run check-types` clean; `preflight:quick` → `[preflight] OK (quick)`; `check-ratchets` → `[ratchet] OK`.

## Chokepoints

Used: none new (the `upsertEdges` boundary already exists; this adds an id-keyed resolution path parallel to the qname path). Not applicable: `check-config-contract` (no `PluginConfig` key added), `test:entity-hardening` (no core orchestrator/storage/intent/config touched — isolated `@remnic/coding-graph` package).

Closes #1677.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches graph edge persistence and semantic SIMILAR_TO writes; behavior is scoped and regression-tested, but wrong id+qname pairing or callers omitting ids could still skip or mis-route edges.
> 
> **Overview**
> Fixes **silent loss** of `SIMILAR_TO` edges when two symbols share a qualified name across files: standalone `upsertEdges` used qualified-name resolution, which treats duplicates as ambiguous and skips the insert.
> 
> **`EdgeIR`** gains optional `srcNodeId` / `dstNodeId`. **`runUpsertEdges`** resolves endpoints by `nodes.id` when those fields are set, with **`resolveByNodeId`** requiring the stored `qualified_name` to match the edge (mismatches count as skipped). Edges without node ids still use the existing qname path (trace / `HTTP_CALLS` / file-batch unchanged).
> 
> The semantic pipeline now carries content-derived ids end-to-end: **`SimilarEdge`**, **`computeSimilarTo`**, and **`similarEdgesToEdgeIR`** populate and forward them so persistence and traversal hit the correct distinct nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4ee57d5f9bd485a984e558683ce1a4033581bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->