### PR TITLE
feat(chat): session TTL sweep + SSE push + HTTP processor dedup (#1685, #1687)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -2128,7 +2128,20 @@ export class EngramAccessHttpServer {
       void getOperation("chat_events"); // boundary dispatch (issue #1525)
       await handleChatEventsSSE(
         req, res, chatEventsMatch[1] ?? "",
-        { service: this.service, config: this.service.configRef?.chat, memoryDir: this.service.memoryDir },
+        {
+          service: this.service,
+          config: this.service.configRef?.chat,
+          memoryDir: this.service.memoryDir,
+          // Register the chat-SSE disconnect cleanup with this server's
+          // stop() set so an HTTP shutdown forcibly releases the heartbeat
+          // and transcript subscription even when a lingering client never
+          // emits 'close' (cursor Medium review; mirrors handleGraphEventsSSE
+          // which registers in sseCleanupFns at access-http.ts:2604).
+          registerSseCleanup: (cleanup) => {
+            this.sseCleanupFns.add(cleanup);
+            return () => { this.sseCleanupFns.delete(cleanup); };
+          },
+        },
         this.resolveRequestPrincipal(req),
       );
       return;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -34,6 +34,9 @@ import { getOperation } from "./access-boundary.js";
 // dispatch the migrated routes through the registry (issue #1525).
 import "./access-operations.js";
 import { handleChatMessage, handleChatEventsSSE } from "./chat/chat-http.js";
+// cleanupExpiredChatSessions wires the chat session TTL sweep into the
+// server lifecycle (issue #1685 item 1 / #1687 Thread 21).
+import { cleanupExpiredChatSessions } from "./chat/chat-session.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -293,6 +296,13 @@ export class EngramAccessHttpServer {
    */
   private readonly sseCleanupFns = new Set<() => void>();
 
+  /**
+   * Periodic chat-session TTL sweep handle (issue #1685 item 1 /
+   * #1687 Thread 21).  unref'd so it never blocks process exit
+   * (rule 47); cleared in `stop()`.
+   */
+  private chatTtlTimer: NodeJS.Timeout | null = null;
+
   constructor(options: EngramAccessHttpServerOptions) {
     this.service = options.service;
     this.host = options.host?.trim() || "127.0.0.1";
@@ -386,11 +396,25 @@ export class EngramAccessHttpServer {
     this.server = server;
     const address = server.address();
     this.boundPort = typeof address === "object" && address ? address.port : this.requestedPort;
+
+    // ── Chat session TTL sweep (issue #1685 item 1 / #1687 Thread 21) ──
+    // Expire idle chat sessions so the JSONL store cannot grow unbounded.
+    // A one-shot sweep runs on startup; a periodic re-sweep follows on an
+    // unref'd 1-hour cadence (rule 47 — never blocks process exit).  Both
+    // are no-ops when chat is disabled (no TTL configured).
+    this.scheduleChatSessionTtlSweep();
+
     return this.status();
   }
 
   async stop(): Promise<void> {
     if (!this.server) return;
+    // Release the chat-session TTL sweep timer (issue #1685) alongside
+    // the SSE cleanups below.
+    if (this.chatTtlTimer) {
+      clearInterval(this.chatTtlTimer);
+      this.chatTtlTimer = null;
+    }
     const server = this.server;
     this.server = null;
     this.boundPort = 0;
@@ -416,6 +440,30 @@ export class EngramAccessHttpServer {
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
     });
+  }
+
+  /**
+   * Schedule the chat-session TTL sweep: one immediate pass plus a
+   * recurring hourly pass (issue #1685 item 1 / #1687 Thread 21).  Both
+   * are skipped when chat is disabled.  The recurring timer is unref'd
+   * so it never keeps the event loop alive on its own (rule 47).  The
+   * sweep itself is best-effort — cleanup failures are swallowed inside
+   * `cleanupExpiredChatSessions`.
+   */
+  private scheduleChatSessionTtlSweep(): void {
+    const chat = this.service.configRef?.chat;
+    if (!chat?.enabled) return;
+    const ttlHours = typeof chat.sessionTtlHours === "number" && chat.sessionTtlHours > 0
+      ? chat.sessionTtlHours
+      : 72;
+    // Startup sweep — fire and forget; failures never block the server.
+    void cleanupExpiredChatSessions(this.service.memoryDir, ttlHours).catch(() => { /* best-effort */ });
+    // Hourly re-sweep (unref'd — rule 47).
+    const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+    this.chatTtlTimer = setInterval(() => {
+      void cleanupExpiredChatSessions(this.service.memoryDir, ttlHours).catch(() => { /* best-effort */ });
+    }, SWEEP_INTERVAL_MS);
+    this.chatTtlTimer.unref?.();
   }
 
   status(): EngramAccessHttpServerStatus {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -451,6 +451,12 @@ export class EngramAccessHttpServer {
    * `cleanupExpiredChatSessions`.
    */
   private scheduleChatSessionTtlSweep(): void {
+    // Clear any prior handle so a second start() without an intervening
+    // stop() cannot leak a dangling setInterval (Kilo review thread).
+    if (this.chatTtlTimer) {
+      clearInterval(this.chatTtlTimer);
+      this.chatTtlTimer = null;
+    }
     const chat = this.service.configRef?.chat;
     if (!chat?.enabled) return;
     const ttlHours = typeof chat.sessionTtlHours === "number" && chat.sessionTtlHours > 0

--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdir, rm, readFile, utimes } from "node:fs/promises";
+import { mkdir, rm, readFile, utimes, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
@@ -322,4 +322,16 @@ test("appendTranscriptEntry emits strictly-increasing seqs even within the same 
     assert.ok(entries[i]! > entries[i - 1]!, `seq ${entries[i]} must exceed ${entries[i - 1]}`);
   }
   assert.equal(new Set(entries).size, entries.length, "seqs must be unique");
+});
+
+test("appendTranscriptEntry refuses to recreate a swept session (chat_session_expired) — codex P2 #1687", async () => {
+  const dir = await makeTempDir();
+  const session = await createChatSession(dir, { principal: "alice" });
+  // Simulate the TTL sweep unlinking the file mid-turn (resurrection race).
+  await unlink(chatSessionFile(dir, session.id));
+  // Must throw instead of silently recreating a headerless (public) file.
+  await assert.rejects(
+    appendTranscriptEntry(dir, session.id, { role: "user", content: "x" }),
+    /chat_session_expired/,
+  );
 });

--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -305,3 +305,21 @@ test("cleanupExpiredChatSessions honors TTL boundary [0, ttlHours) — age >= tt
   const expiredGone = await readFile(expiredFile, "utf8").then(() => false).catch(() => true);
   assert.ok(expiredGone, "session aged at/over the TTL must be swept");
 });
+
+
+test("appendTranscriptEntry emits strictly-increasing seqs even within the same millisecond (issue #1687 review)", async () => {
+  const dir = await makeTempDir();
+  const session = await createChatSession(dir, { principal: "seq" });
+  // Append several entries as fast as possible (same-ms collisions would have
+  // shared a Date.now()-based seq before the monotonic counter fix).
+  const entries: number[] = [];
+  for (let i = 0; i < 8; i++) {
+    const e = await appendTranscriptEntry(dir, session.id, { role: "user", content: `m${i}` });
+    entries.push(e.seq);
+  }
+  // Every seq must be distinct and strictly increasing.
+  for (let i = 1; i < entries.length; i++) {
+    assert.ok(entries[i]! > entries[i - 1]!, `seq ${entries[i]} must exceed ${entries[i - 1]}`);
+  }
+  assert.equal(new Set(entries).size, entries.length, "seqs must be unique");
+});

--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdir, rm, readFile } from "node:fs/promises";
+import { mkdir, rm, readFile, utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
@@ -269,4 +269,39 @@ test("budget exhaustion summary LLM failure does not crash (Thread 16)", async (
   // Should return a partial reply, not throw.
   assert.ok(result.reply.length > 0, "Should return a fallback reply");
   assert.ok(result.skippedTools !== undefined, "Should report skipped tools");
+});
+
+// ---------------------------------------------------------------------------
+// TTL boundary (issue #1685 item 1 / #1687 Thread 21)
+// ---------------------------------------------------------------------------
+
+test("cleanupExpiredChatSessions honors TTL boundary [0, ttlHours) — age >= ttl expires", async () => {
+  const dir = await makeTempDir();
+  const ttlHours = 2;
+  const ttlMs = ttlHours * 3600 * 1000;
+
+  // Session aged past the TTL (mtime set to ttlHours ago; by the time the
+  // sweep stat()s it a few ms have elapsed, so age >= ttl deterministically
+  // — the boundary is inclusive: age ∈ [0, ttl) survives, age >= ttl expires).
+  const expired = await createChatSession(dir, { principal: "expired" });
+  const expiredFile = chatSessionFile(dir, expired.id);
+  const atTtlSeconds = (Date.now() - ttlMs) / 1000;
+  await utimes(expiredFile, atTtlSeconds, atTtlSeconds);
+
+  // Session aged well under the TTL → must survive.
+  const fresh = await createChatSession(dir, { principal: "fresh" });
+  const freshFile = chatSessionFile(dir, fresh.id);
+  const underTtlSeconds = (Date.now() - (ttlMs - 6 * 60 * 1000)) / 1000; // ~1.9h old
+  await utimes(freshFile, underTtlSeconds, underTtlSeconds);
+
+  const removed = await cleanupExpiredChatSessions(dir, ttlHours);
+  assert.equal(removed, 1, "only the expired session should be removed");
+
+  // The fresh session file must still be on disk.
+  const freshStillExists = await readFile(freshFile, "utf8").then(() => true).catch(() => false);
+  assert.ok(freshStillExists, "session aged under the TTL must survive the sweep");
+
+  // The expired session file must be gone.
+  const expiredGone = await readFile(expiredFile, "utf8").then(() => false).catch(() => true);
+  assert.ok(expiredGone, "session aged at/over the TTL must be swept");
 });

--- a/packages/remnic-core/src/chat/chat-http.test.ts
+++ b/packages/remnic-core/src/chat/chat-http.test.ts
@@ -292,3 +292,24 @@ test("HTTP chat/message: distinct messages are NOT deduplicated (issue #1687)", 
     assert.equal(llmCalls, 2, "distinct messages must not be coalesced");
   });
 });
+
+test("HTTP chat/events SSE: early disconnect during load bails cleanly — no write to ended response, no leak (issue #1687 review)", async () => {
+  await withTempDir(async (memoryDir) => {
+    const session = await createChatSession(memoryDir, { principal: "alice" });
+    const service = makeService({
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+    });
+    const m = mockRes();
+    const req = mockReq();
+    // Emit close as a microtask so it fires while the handler is awaiting
+    // loadChatSession (before writeHead). The handler must bail out without
+    // writing to the ended response and without setting up a heartbeat.
+    queueMicrotask(() => req.emit("close"));
+    // Resolving without throwing is the core contract.
+    await handleChatEventsSSE(req as never, m as never, session.id, { service, config: service.configRef!.chat, memoryDir }, "alice");
+    // writeHead was skipped (status stays 0) because the handler returned at
+    // the `if (closed) return` guard before any SSE framing.
+    assert.equal(m.status, 0, "handler must not writeHead after an early close");
+  });
+});

--- a/packages/remnic-core/src/chat/chat-http.test.ts
+++ b/packages/remnic-core/src/chat/chat-http.test.ts
@@ -17,7 +17,7 @@ import { test } from "node:test";
 import type { EngramAccessService } from "../access-service.js";
 import { parseConfig } from "../config.js";
 import { handleChatMessage, handleChatEventsSSE } from "./chat-http.js";
-import { createChatSession, appendTranscriptEntry, chatSessionFile } from "./chat-session.js";
+import { createChatSession, loadChatSession, appendTranscriptEntry, chatSessionFile } from "./chat-session.js";
 import { DEFAULT_CHAT_CONFIG } from "./chat-config.js";
 
 // Minimal mock res capturing writes. All tracking fields live on one
@@ -193,5 +193,102 @@ test("HTTP chat/events SSE: 403 for a session owned by another principal", async
     const m = mockRes();
     await handleChatEventsSSE(mockReq() as never, m as never, session.id, { service, config: service.configRef!.chat, memoryDir }, "bob");
     assert.equal(m.status, 403);
+  });
+});
+
+
+test("HTTP chat/events SSE: pushes new transcript entries live (issue #1687)", async () => {
+  await withTempDir(async (memoryDir) => {
+    const session = await createChatSession(memoryDir, { principal: "alice" });
+    await appendTranscriptEntry(memoryDir, session.id, { role: "user", content: "first" });
+
+    const service = makeService({
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+    });
+    const m = mockRes();
+    const req = mockReq();
+    await handleChatEventsSSE(req as never, m as never, session.id, { service, config: service.configRef!.chat, memoryDir }, "alice");
+    assert.equal(m.status, 200);
+    assert.equal(m.headers["content-type"], "text/event-stream");
+    // The stream must advertise a retry directive so reconnects are safe.
+    assert.ok(m.body.includes("retry: 5000"), "SSE must emit a retry: directive");
+
+    const initialFrames = m.body.split("\n\n").filter((f) => f.startsWith("data:"));
+
+    // Append a NEW entry AFTER the client connected — it must be pushed live
+    // to the open SSE connection via the per-session pub/sub.
+    await appendTranscriptEntry(memoryDir, session.id, { role: "assistant", content: "pushed-live" });
+
+    const allFrames = m.body.split("\n\n").filter((f) => f.startsWith("data:"));
+    assert.ok(allFrames.length > initialFrames.length, "expected a pushed frame after append");
+    assert.ok(m.body.includes("pushed-live"), "the appended entry must reach the live SSE stream");
+    // The pushed frame must be well-formed SSE (data: <json>\n\n).
+    assert.ok(m.body.includes("data: {"), "frames must be data: <json> framed");
+    req.emit("close");
+  });
+});
+
+test("HTTP chat/message: concurrent identical requests are deduplicated (issue #1687)", async () => {
+  await withTempDir(async (memoryDir) => {
+    const session = await createChatSession(memoryDir, { principal: "alice" });
+    let llmCalls = 0;
+    const service = makeService({
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+      fallbackLlmRef: ({
+        chatCompletion: async () => {
+          llmCalls++;
+          // Simulate enough work that the second request lands while the
+          // first is still in-flight (the dedup window).
+          await new Promise((r) => setTimeout(r, 30));
+          return { content: "shared-reply", modelUsed: "test-model" };
+        },
+      }) as never,
+    });
+    const opts = { service, config: service.configRef!.chat, memoryDir };
+    const m1 = mockRes();
+    const m2 = mockRes();
+    await Promise.all([
+      handleChatMessage(mockReq() as never, m1 as never, { message: "duplicate", chatSessionId: session.id }, opts, "alice"),
+      handleChatMessage(mockReq() as never, m2 as never, { message: "duplicate", chatSessionId: session.id }, opts, "alice"),
+    ]);
+    // Exactly ONE LLM call despite two concurrent identical requests.
+    assert.equal(llmCalls, 1, "a concurrent duplicate must not re-process");
+    // Both callers receive the (same) reply.
+    assert.equal(m1.status, 200);
+    assert.equal(m2.status, 200);
+    assert.ok(m1.body.includes("shared-reply"));
+    assert.ok(m2.body.includes("shared-reply"));
+    // The transcript must contain exactly one user "duplicate" line — the
+    // duplicate did not double-append.
+    const loaded = await loadChatSession(memoryDir, session.id);
+    const userDups = loaded!.transcript.filter((e) => e.role === "user" && e.content === "duplicate");
+    assert.equal(userDups.length, 1, "duplicate request must not append a second user transcript line");
+  });
+});
+
+test("HTTP chat/message: distinct messages are NOT deduplicated (issue #1687)", async () => {
+  await withTempDir(async (memoryDir) => {
+    const session = await createChatSession(memoryDir, { principal: "alice" });
+    let llmCalls = 0;
+    const service = makeService({
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+      fallbackLlmRef: ({
+        chatCompletion: async () => {
+          llmCalls++;
+          await new Promise((r) => setTimeout(r, 20));
+          return { content: "reply", modelUsed: "test-model" };
+        },
+      }) as never,
+    });
+    const opts = { service, config: service.configRef!.chat, memoryDir };
+    await Promise.all([
+      handleChatMessage(mockReq() as never, mockRes() as never, { message: "alpha", chatSessionId: session.id }, opts, "alice"),
+      handleChatMessage(mockReq() as never, mockRes() as never, { message: "beta", chatSessionId: session.id }, opts, "alice"),
+    ]);
+    // Distinct messages both process independently.
+    assert.equal(llmCalls, 2, "distinct messages must not be coalesced");
   });
 });

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -21,8 +21,9 @@
  *  - The SSE stream subscribes to live transcript appends and pushes new
  *    entries to connected clients (issue #1685 item 2 / #1687 Thread 8).
  *    Subscription is established before the transcript snapshot is read so no
- *    concurrent append is missed (cursor Bugbot race fix), and the disconnect
- *    cleanup is registered immediately so an early close cannot leak it.
+ *    concurrent append is missed (cursor Bugbot race fix). The disconnect
+ *    cleanup is registered immediately and guarded by a `closed` flag so an
+ *    early close cannot leak the heartbeat or write to an ended response.
  *
  * This module is imported by access-http.ts with thin route registration —
  * the god-file ratchet (#1520) tracks access-http.ts LOC.
@@ -216,8 +217,10 @@ export async function handleChatMessage(
  * snapshot read are buffered, then drained after the burst (dropping any the
  * burst already delivered, by `seq`), so no live append is ever missed and
  * none is delivered twice. The disconnect cleanup is registered immediately
- * after the subscription so a client that closes during the load or burst
- * still releases the subscription (no listener leak).
+ * after the subscription and guarded by a `closed` flag: if the client goes
+ * away during the load or burst the flag flips, the handler bails out before
+ * writing anything else, and the heartbeat is never created — so no interval
+ * leaks and no write hits an ended response (cursor/kilo review threads).
  */
 export async function handleChatEventsSSE(
   req: IncomingMessage,
@@ -231,13 +234,20 @@ export async function handleChatEventsSSE(
     return;
   }
 
+  // Liveness flag + handle, both closed over by the disconnect cleanup. The
+  // cleanup is idempotent (guarded by `closed`) so a repeat close is harmless.
+  let heartbeat: NodeJS.Timeout | undefined;
+  let closed = false;
+
   // Subscribe BEFORE reading the transcript so a concurrent append between
   // the snapshot read and subscription is never missed (cursor Bugbot race).
   // During the initial burst entries are buffered; after the burst the
-  // listener switches to writing straight to the response.
+  // listener switches to writing straight to the response. A `closed` check
+  // short-circuits pushes to a connection that is already gone.
   const pending: ChatTranscriptEntry[] = [];
   let bursting = true;
   const unsubscribe = subscribeChatTranscript(opts.memoryDir, chatSessionId, (entry) => {
+    if (closed) return;
     if (bursting) {
       pending.push(entry);
       return;
@@ -250,16 +260,21 @@ export async function handleChatEventsSSE(
   });
 
   // Register disconnect cleanup IMMEDIATELY so a close during loadChatSession
-  // or the burst still releases the subscription (cursor Bugbot). The
-  // heartbeat is assigned later; the handler clears it only if set.
-  let heartbeat: NodeJS.Timeout | undefined;
+  // or the burst still releases the subscription (cursor Bugbot). The flag
+  // gates every later write so the handler never touches an ended response
+  // (kilo review thread) and never sets up a heartbeat for a dead socket
+  // (cursor review thread).
   req.on("close", () => {
+    closed = true;
     clearInterval(heartbeat);
     unsubscribe();
     try { res.end(); } catch { /* already ended */ }
   });
 
   const session = await loadChatSession(opts.memoryDir, chatSessionId);
+  // If the client disconnected during the load, cleanup already ran — bail
+  // out before touching the response (prevents "headers after end").
+  if (closed) return;
   if (!session) {
     unsubscribe();
     respondJson(res, 404, { error: "chat_session_not_found", code: "chat_session_not_found" });
@@ -302,8 +317,10 @@ export async function handleChatEventsSSE(
   bursting = false;
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
-  // exit (rule 47 — no shared mutable objects keep the loop alive).
+  // exit (rule 47 — no shared mutable objects keep the loop alive). Cleared
+  // by the close handler above when the client disconnects.
   heartbeat = setInterval(() => {
+    if (closed) return;
     try {
       res.write(`data: ${JSON.stringify({ type: "heartbeat" })}\n\n`);
     } catch {

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -303,12 +303,17 @@ export async function handleChatEventsSSE(
   // out before touching the response (prevents "headers after end").
   if (closed) return;
   if (!session) {
+    // No SSE stream is established — release the server stop() registration
+    // alongside the subscription so sseCleanupFns does not retain a stale
+    // callback for this JSON error response (cursor Medium: error-path leak).
     unsubscribe();
+    unregisterServerCleanup();
     respondJson(res, 404, { error: "chat_session_not_found", code: "chat_session_not_found" });
     return;
   }
   if (!sessionBelongsToPrincipal(session, principal)) {
     unsubscribe();
+    unregisterServerCleanup();
     respondJson(res, 403, { error: "access_denied", code: "access_denied" });
     return;
   }

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -351,7 +351,12 @@ export async function handleChatEventsSSE(
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
   // exit (rule 47 — no shared mutable objects keep the loop alive). Cleared
-  // by the close handler above when the client disconnects.
+  // by the close handler above when the client disconnects. Guard against
+  // arming after a disconnect during the burst/drain: the close handler
+  // already ran doCleanup (clearing any prior handle and unregistering the
+  // server callback), so an interval armed here would be untracked and never
+  // cleared — bail out instead (codex P2).
+  if (closed) return;
   heartbeat = setInterval(() => {
     writeSse(`data: ${JSON.stringify({ type: "heartbeat" })}\n\n`);
   }, 25_000);

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -16,11 +16,13 @@
  *  - Concurrent identical POSTs are coalesced by an in-flight dedup keyed on
  *    `memoryDir + chatSessionId + principal + message` so a double-submit
  *    processes exactly once (issue #1687 Thread 18 / #1685). The memoryDir
- *    scopes the key per store (AGENTS.md State Scoping).
+ *    scopes the key per store (AGENTS.md State Scoping); an absent principal
+ *    is encoded distinctly so it can never alias a real principal string.
  *  - The SSE stream subscribes to live transcript appends and pushes new
  *    entries to connected clients (issue #1685 item 2 / #1687 Thread 8).
  *    Subscription is established before the transcript snapshot is read so no
- *    concurrent append is missed (cursor Bugbot race fix).
+ *    concurrent append is missed (cursor Bugbot race fix), and the disconnect
+ *    cleanup is registered immediately so an early close cannot leak it.
  *
  * This module is imported by access-http.ts with thin route registration —
  * the god-file ratchet (#1520) tracks access-http.ts LOC.
@@ -63,12 +65,24 @@ export interface ChatHttpHandlerOptions {
  */
 const chatInFlight = new Map<string, Promise<ChatTurnResult>>();
 
-function chatDedupFingerprint(memoryDir: string, chatSessionId: string, principal: string, message: string): string {
-  // sha256 keeps the key bounded for long messages; the principal is part of
-  // the key so two callers targeting the same session id can never share a
-  // result (the wrong principal still independently hits access_denied).
+/**
+ * Encode the principal into a fingerprint component where an absent principal
+ * occupies a distinct namespace from any real principal string (control-byte
+ * prefix), so a no-principal request can never coalesce with a request whose
+ * principal is literally `"_"` (or any other string) and reuse its authorized
+ * promise (codex P2 review thread).
+ */
+function principalFingerprintComponent(principal: string | undefined): string {
+  return principal === undefined ? "\x00absent" : `\x01${principal}`;
+}
+
+function chatDedupFingerprint(memoryDir: string, chatSessionId: string, principal: string | undefined, message: string): string {
+  // sha256 keeps the key bounded for long messages; the principal component
+  // is distinct per principal (incl. absent) so two callers targeting the
+  // same session id can never share a result — the wrong principal still
+  // independently hits access_denied inside processChatMessage.
   const messageHash = createHash("sha256").update(message, "utf8").digest("hex").slice(0, 32);
-  return `${memoryDir}:${chatSessionId}:${principal}:${messageHash}`;
+  return `${memoryDir}:${chatSessionId}:${principalFingerprintComponent(principal)}:${messageHash}`;
 }
 
 /**
@@ -87,8 +101,7 @@ function processChatMessageDedup(opts: {
   if (!opts.chatSessionId) {
     return processChatMessage(opts);
   }
-  const principal = opts.principal ?? "_";
-  const fp = chatDedupFingerprint(opts.memoryDir, opts.chatSessionId, principal, opts.message);
+  const fp = chatDedupFingerprint(opts.memoryDir, opts.chatSessionId, opts.principal, opts.message);
   const existing = chatInFlight.get(fp);
   if (existing) return existing;
   const pending = processChatMessage(opts).finally(() => {
@@ -202,7 +215,9 @@ export async function handleChatMessage(
  * the transcript snapshot is read. Entries appended concurrently during the
  * snapshot read are buffered, then drained after the burst (dropping any the
  * burst already delivered, by `seq`), so no live append is ever missed and
- * none is delivered twice.
+ * none is delivered twice. The disconnect cleanup is registered immediately
+ * after the subscription so a client that closes during the load or burst
+ * still releases the subscription (no listener leak).
  */
 export async function handleChatEventsSSE(
   req: IncomingMessage,
@@ -232,6 +247,16 @@ export async function handleChatEventsSSE(
     } catch {
       // Connection closed — cleanup below.
     }
+  });
+
+  // Register disconnect cleanup IMMEDIATELY so a close during loadChatSession
+  // or the burst still releases the subscription (cursor Bugbot). The
+  // heartbeat is assigned later; the handler clears it only if set.
+  let heartbeat: NodeJS.Timeout | undefined;
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    try { res.end(); } catch { /* already ended */ }
   });
 
   const session = await loadChatSession(opts.memoryDir, chatSessionId);
@@ -278,20 +303,14 @@ export async function handleChatEventsSSE(
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
   // exit (rule 47 — no shared mutable objects keep the loop alive).
-  const heartbeat = setInterval(() => {
+  heartbeat = setInterval(() => {
     try {
       res.write(`data: ${JSON.stringify({ type: "heartbeat" })}\n\n`);
     } catch {
-      // Connection closed — clearInterval below.
+      // Connection closed — clearInterval via the close handler.
     }
   }, 25_000);
-  heartbeat.unref();
-
-  req.on("close", () => {
-    clearInterval(heartbeat);
-    unsubscribe();
-    try { res.end(); } catch { /* already ended */ }
-  });
+  heartbeat.unref?.();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -47,6 +47,13 @@ export interface ChatHttpHandlerOptions {
   service: EngramAccessService;
   config: ChatConfig | undefined;
   memoryDir: string;
+  /**
+   * Optional hook the host server supplies so the SSE handler can register
+   * its disconnect cleanup with the server's stop() set (cursor Medium
+   * review). Returns an unregister function the handler calls on normal
+   * client disconnect. When omitted, cleanup runs only on req 'close'.
+   */
+  registerSseCleanup?: (cleanup: () => void) => () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,11 +283,19 @@ export async function handleChatEventsSSE(
   // gates every later write so the handler never touches an ended response
   // (kilo review thread) and never sets up a heartbeat for a dead socket
   // (cursor review thread).
-  req.on("close", () => {
+  const doCleanup = (): void => {
     closed = true;
     clearInterval(heartbeat);
     unsubscribe();
     try { res.end(); } catch { /* already ended */ }
+  };
+  // Register with the host server's stop() cleanup set (cursor Medium) so an
+  // HTTP shutdown forcibly releases the subscription + heartbeat even when a
+  // lingering client never emits 'close'. Unregistered again on normal close.
+  const unregisterServerCleanup = opts.registerSseCleanup?.(doCleanup) ?? ((): void => {});
+  req.on("close", () => {
+    doCleanup();
+    unregisterServerCleanup();
   });
 
   const session = await loadChatSession(opts.memoryDir, chatSessionId);

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -1,5 +1,5 @@
 /**
- * Chat HTTP handler (issue #1583 PR 3).
+ * Chat HTTP handler (issue #1583 PR 3; deferred items #1685 / #1687).
  *
  * Implements the HTTP backend for the admin console Chat pane:
  * - POST /engram/v1/chat/message — send a message, get a reply
@@ -9,28 +9,31 @@
  * Per-session isolation: every request verifies the session's principal
  * matches the caller (rule 42/47).
  *
+ * Deferred items wired here (issues #1685 / #1687):
+ *  - The HTTP message handler delegates to the shared `processChatMessage`
+ *    (Thread 18) so session/engine/transcript construction is identical to
+ *    the MCP surface, instead of re-implementing it.
+ *  - Concurrent identical POSTs are coalesced by an in-flight dedup keyed on
+ *    `chatSessionId + principal + message` so a double-submit processes
+ *    exactly once (issue #1687 Thread 18 / #1685).
+ *  - The SSE stream subscribes to live transcript appends and pushes new
+ *    entries to connected clients (issue #1685 item 2 / #1687 Thread 8).
+ *
  * This module is imported by access-http.ts with thin route registration —
  * the god-file ratchet (#1520) tracks access-http.ts LOC.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { createHash } from "node:crypto";
 
 import type { EngramAccessService } from "../access-service.js";
 import type { ChatConfig } from "./chat-types.js";
 import type { ChatTurnResult } from "./chat-types.js";
-import { ChatEngine } from "./chat-engine.js";
-import { isConfirmationMessage } from "./chat-engine.js";
-import { createProductionChatLlmAdapter } from "./chat-llm.js";
-import { createChatExecutor } from "./chat-executor.js";
+import { processChatMessage } from "./chat-factory.js";
 import {
-  createChatSession,
   loadChatSession,
-  appendTranscriptEntry,
   sessionBelongsToPrincipal,
-  markPendingPlan,
-  markPlanResolved,
-  markPendingPromotion,
-  markPromotionResolved,
+  subscribeChatTranscript,
 } from "./chat-session.js";
 
 export interface ChatHttpHandlerOptions {
@@ -39,11 +42,72 @@ export interface ChatHttpHandlerOptions {
   memoryDir: string;
 }
 
+// ---------------------------------------------------------------------------
+// In-flight request dedup (issue #1687 Thread 18 / #1685)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pending chat-message promises keyed by `chatSessionId:principal:messageHash`.
+ * A concurrent identical POST joins the in-flight promise instead of
+ * re-processing (no second LLM call, no second transcript append).  Entries
+ * are always removed via `finally` so the map cannot leak across requests.
+ *
+ * Only requests targeting an existing `chatSessionId` are coalesced: when no
+ * session id is supplied each request legitimately mints its own session, so
+ * identical message bodies are genuinely distinct turns.
+ */
+const chatInFlight = new Map<string, Promise<ChatTurnResult>>();
+
+function chatDedupFingerprint(chatSessionId: string, principal: string, message: string): string {
+  // sha256 keeps the key bounded for long messages; the principal is part of
+  // the key so two callers targeting the same session id can never share a
+  // result (the wrong principal still independently hits access_denied).
+  const messageHash = createHash("sha256").update(message, "utf8").digest("hex").slice(0, 32);
+  return `${chatSessionId}:${principal}:${messageHash}`;
+}
+
+/**
+ * Run `processChatMessage` with concurrent-identical-request coalescing.
+ * Distinct messages (or distinct sessions / principals) never collide.
+ */
+function processChatMessageDedup(opts: {
+  service: EngramAccessService;
+  config: ChatConfig | undefined;
+  memoryDir: string;
+  message: string;
+  chatSessionId?: string;
+  principal?: string;
+}): Promise<ChatTurnResult> {
+  // No session id → no coalescing (each request creates its own session).
+  if (!opts.chatSessionId) {
+    return processChatMessage(opts);
+  }
+  const principal = opts.principal ?? "_";
+  const fp = chatDedupFingerprint(opts.chatSessionId, principal, opts.message);
+  const existing = chatInFlight.get(fp);
+  if (existing) return existing;
+  const pending = processChatMessage(opts).finally(() => {
+    chatInFlight.delete(fp);
+  });
+  chatInFlight.set(fp, pending);
+  return pending;
+}
+
+// ---------------------------------------------------------------------------
+// POST /engram/v1/chat/message
+// ---------------------------------------------------------------------------
+
 /**
  * Handle POST /engram/v1/chat/message.
  *
  * Body: `{ message: string, chatSessionId?: string }`
  * Response: `{ reply: string, chatSessionId: string, pendingPlan?: {...} }`
+ *
+ * Boundary checks (chat-disabled / missing message / no-LLM) run before
+ * delegation so each maps to a precise HTTP status without spinning up a
+ * session.  Session/engine work is delegated to `processChatMessage`
+ * (Thread 18), wrapped in {@link processChatMessageDedup} for double-submit
+ * protection.
  */
 export async function handleChatMessage(
   req: IncomingMessage,
@@ -63,8 +127,7 @@ export async function handleChatMessage(
     return;
   }
 
-  const llm = opts.service.fallbackLlmRef ?? opts.service.localLlmRef;
-  if (!llm) {
+  if (!opts.service.fallbackLlmRef && !opts.service.localLlmRef) {
     respondJson(res, 503, {
       error: "No LLM model is available. Configure a local or cloud model.",
       code: "no_llm",
@@ -72,74 +135,38 @@ export async function handleChatMessage(
     return;
   }
 
-  const adapter = createProductionChatLlmAdapter(llm as {
-    chatCompletion(
-      messages: Array<{ role: string; content: string }>,
-      options?: { model?: string; signal?: AbortSignal },
-    ): Promise<{ content: string } | null>;
-  });
+  const chatSessionId = typeof body.chatSessionId === "string" ? body.chatSessionId : undefined;
 
-  // Load or create session.
-  const requestedSessionId = typeof body.chatSessionId === "string" ? body.chatSessionId : undefined;
-  let session;
-  if (requestedSessionId) {
-    session = await loadChatSession(opts.memoryDir, requestedSessionId);
-    if (!session) {
+  let result: ChatTurnResult;
+  try {
+    result = await processChatMessageDedup({
+      service: opts.service,
+      config: opts.config,
+      memoryDir: opts.memoryDir,
+      message,
+      ...(chatSessionId ? { chatSessionId } : {}),
+      ...(principal ? { principal } : {}),
+    });
+  } catch (err) {
+    // processChatMessage throws tagged errors for the session/LLM/engine
+    // paths; map each back to its HTTP status.  Dedup coalescing means a
+    // concurrent duplicate shares the same rejection.
+    const code = err instanceof Error ? err.message : String(err);
+    if (code === "chat_session_not_found") {
       respondJson(res, 404, { error: "chat_session_not_found", code: "chat_session_not_found" });
-      return;
-    }
-    if (!sessionBelongsToPrincipal(session, principal)) {
+    } else if (code === "access_denied") {
       respondJson(res, 403, { error: "access_denied", code: "access_denied" });
-      return;
+    } else if (code === "chat_disabled") {
+      respondJson(res, 404, { error: "chat_disabled", code: "chat_disabled" });
+    } else if (code === "no_llm_available" || code === "engine_unavailable") {
+      respondJson(res, 503, {
+        error: "No LLM model is available. Configure a local or cloud model.",
+        code: "no_llm",
+      });
+    } else {
+      respondJson(res, 500, { error: "internal_error", code: "internal_error" });
     }
-  } else {
-    session = await createChatSession(opts.memoryDir, { principal });
-  }
-
-  const executor = createChatExecutor({
-    service: opts.service,
-    principal,
-    ...(session.namespace ? { namespace: session.namespace } : {}),
-    ...(session.sessionKey ? { sessionKey: session.sessionKey } : {}),
-  });
-
-  const engine = new ChatEngine({
-    llm: adapter,
-    executor,
-    maxToolCallsPerTurn: opts.config.maxToolCallsPerTurn,
-    ...(opts.config.model ? { model: opts.config.model } : {}),
-    correctionAvailable: false,
-    scopeInspectAvailable: false,
-  });
-
-  await appendTranscriptEntry(opts.memoryDir, session.id, {
-    role: "user",
-    content: message,
-  });
-
-  // Snapshot pending state BEFORE the turn so we only persist a marker when
-  // state actually changed (Thread 15 — a normal turn must not clear an
-  // active pending plan/promotion from an earlier turn).
-  const priorPendingPlanId = session.pendingPlanId;
-  const priorPendingPromotionId = session.pendingPromotionId;
-
-  const result: ChatTurnResult = await engine.processMessage(message, session);
-
-  await appendTranscriptEntry(opts.memoryDir, session.id, {
-    role: "assistant",
-    content: result.reply,
-  });
-
-  // Persist pending-plan/promotion state (append-only markers). Only append
-  // when state actually changed.
-  if (result.pendingPlan?.planId) {
-    await markPendingPlan(opts.memoryDir, session.id, result.pendingPlan.planId);
-  } else if (session.pendingPromotionId && !priorPendingPromotionId) {
-    await markPendingPromotion(opts.memoryDir, session.id, session.pendingPromotionId);
-  } else if (priorPendingPlanId && !session.pendingPlanId && !result.error) {
-    await markPlanResolved(opts.memoryDir, session.id, priorPendingPlanId);
-  } else if (priorPendingPromotionId && !session.pendingPromotionId && !result.error) {
-    await markPromotionResolved(opts.memoryDir, session.id, priorPendingPromotionId);
+    return;
   }
 
   // Strip internal error details from the wire response (CodeQL — no stack
@@ -150,12 +177,21 @@ export async function handleChatMessage(
   respondJson(res, 200, wireResult);
 }
 
+// ---------------------------------------------------------------------------
+// GET /engram/v1/chat/events/:chatSessionId (SSE)
+// ---------------------------------------------------------------------------
+
 /**
  * Handle GET /engram/v1/chat/events/:chatSessionId.
  *
- * SSE stream.  Sends a heartbeat every 25s so proxies don't time out.
- * Currently streams the session transcript as an initial burst, then keeps
- * the connection open for future updates.
+ * SSE stream.  Sends the existing transcript as an initial burst, then keeps
+ * the connection open and **pushes new transcript entries live** as they are
+ * appended (issue #1685 item 2 / #1687 Thread 8) via the per-session pub/sub
+ * in `chat-session.ts`.  A heartbeat is emitted every 25 s so proxies do not
+ * time out.  A `retry:` directive asks reconnecting clients to wait 5 s, and
+ * because the initial burst always replays the full transcript (entries carry
+ * a monotonic `seq`), clients dedupe on reconnect — the stream is
+ * reconnect-safe.
  */
 export async function handleChatEventsSSE(
   req: IncomingMessage,
@@ -186,10 +222,26 @@ export async function handleChatEventsSSE(
     connection: "keep-alive",
   });
 
+  // Ask reconnecting clients to wait 5 s before retrying (reconnect-safe:
+  // the initial burst below replays the full transcript on rejoin).
+  res.write("retry: 5000\n\n");
+
   // Send the transcript as an initial burst.
   for (const entry of session.transcript) {
     res.write(`data: ${JSON.stringify(entry)}\n\n`);
   }
+
+  // Push live entries: subscribe to the per-session pub/sub so any new
+  // user/assistant line (appended by the HTTP/MCP/CLI path) is delivered to
+  // this connection immediately.  Listener errors are swallowed inside
+  // appendTranscriptEntry, so a write failure here is also guarded.
+  const unsubscribe = subscribeChatTranscript(chatSessionId, (entry) => {
+    try {
+      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    } catch {
+      // Connection closed — cleanup below.
+    }
+  });
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
   // exit (rule 47 — no shared mutable objects keep the loop alive).
@@ -204,6 +256,7 @@ export async function handleChatEventsSSE(
 
   req.on("close", () => {
     clearInterval(heartbeat);
+    unsubscribe();
     try { res.end(); } catch { /* already ended */ }
   });
 }

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -21,9 +21,11 @@
  *  - The SSE stream subscribes to live transcript appends and pushes new
  *    entries to connected clients (issue #1685 item 2 / #1687 Thread 8).
  *    Subscription is established before the transcript snapshot is read so no
- *    concurrent append is missed (cursor Bugbot race fix). The disconnect
- *    cleanup is registered immediately and guarded by a `closed` flag so an
- *    early close cannot leak the heartbeat or write to an ended response.
+ *    concurrent append is missed (cursor Bugbot race fix); the burst drains
+ *    the buffer only after switching to live mode so no buffered entry is
+ *    dropped. The disconnect cleanup is registered immediately and guarded
+ *    by a `closed` flag so an early close cannot leak the heartbeat or write
+ *    to an ended response.
  *
  * This module is imported by access-http.ts with thin route registration —
  * the god-file ratchet (#1520) tracks access-http.ts LOC.
@@ -169,12 +171,16 @@ export async function handleChatMessage(
   } catch (err) {
     // processChatMessage throws tagged errors for the session/LLM/engine
     // paths; map each back to its HTTP status.  Dedup coalescing means a
-    // concurrent duplicate shares the same rejection.
+    // concurrent duplicate shares the same rejection.  A 'chat_session_expired'
+    // means the session was swept by the TTL cleanup mid-turn (codex P2) —
+    // tell the client to start a fresh session (410 Gone).
     const code = err instanceof Error ? err.message : String(err);
     if (code === "chat_session_not_found") {
       respondJson(res, 404, { error: "chat_session_not_found", code: "chat_session_not_found" });
     } else if (code === "access_denied") {
       respondJson(res, 403, { error: "access_denied", code: "access_denied" });
+    } else if (code === "chat_session_expired") {
+      respondJson(res, 410, { error: "chat_session_expired", code: "chat_session_expired" });
     } else if (code === "chat_disabled") {
       respondJson(res, 404, { error: "chat_disabled", code: "chat_disabled" });
     } else if (code === "no_llm_available" || code === "engine_unavailable") {
@@ -213,14 +219,13 @@ export async function handleChatMessage(
  * reconnect-safe.
  *
  * Race-free ordering (cursor Bugbot): the subscription is established BEFORE
- * the transcript snapshot is read. Entries appended concurrently during the
- * snapshot read are buffered, then drained after the burst (dropping any the
- * burst already delivered, by `seq`), so no live append is ever missed and
- * none is delivered twice. The disconnect cleanup is registered immediately
- * after the subscription and guarded by a `closed` flag: if the client goes
- * away during the load or burst the flag flips, the handler bails out before
- * writing anything else, and the heartbeat is never created — so no interval
- * leaks and no write hits an ended response (cursor/kilo review threads).
+ * the transcript snapshot is read; entries appended concurrently during the
+ * snapshot read are buffered, then the buffer is drained AFTER switching to
+ * live mode (so an append landing between the drain and the mode switch is
+ * never dropped — cursor review). Every write goes through a `closed`-guarded
+ * helper so a disconnect during the burst cannot write to an ended response
+ * (cursor/kilo review). The disconnect cleanup is registered immediately and
+ * guarded by `closed` so an early close cannot leak the heartbeat.
  */
 export async function handleChatEventsSSE(
   req: IncomingMessage,
@@ -238,6 +243,17 @@ export async function handleChatEventsSSE(
   // cleanup is idempotent (guarded by `closed`) so a repeat close is harmless.
   let heartbeat: NodeJS.Timeout | undefined;
   let closed = false;
+  // Every SSE write goes through this helper so a closed connection is never
+  // written to (cursor Low review). Returns false when the write was skipped.
+  const writeSse = (chunk: string): boolean => {
+    if (closed) return false;
+    try {
+      res.write(chunk);
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
   // Subscribe BEFORE reading the transcript so a concurrent append between
   // the snapshot read and subscription is never missed (cursor Bugbot race).
@@ -252,11 +268,7 @@ export async function handleChatEventsSSE(
       pending.push(entry);
       return;
     }
-    try {
-      res.write(`data: ${JSON.stringify(entry)}\n\n`);
-    } catch {
-      // Connection closed — cleanup below.
-    }
+    writeSse(`data: ${JSON.stringify(entry)}\n\n`);
   });
 
   // Register disconnect cleanup IMMEDIATELY so a close during loadChatSession
@@ -295,37 +307,33 @@ export async function handleChatEventsSSE(
 
   // Ask reconnecting clients to wait 5 s before retrying (reconnect-safe:
   // the initial burst below replays the full transcript on rejoin).
-  res.write("retry: 5000\n\n");
+  writeSse("retry: 5000\n\n");
 
   // Send the transcript snapshot as the initial burst, recording delivered
   // seqs so buffered concurrent appends are not double-delivered.
   const deliveredSeqs = new Set<number>();
   for (const entry of session.transcript) {
-    res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    writeSse(`data: ${JSON.stringify(entry)}\n\n`);
     deliveredSeqs.add(entry.seq);
   }
 
-  // Drain concurrent appends captured during the burst that the snapshot
-  // did not already deliver.
+  // Switch to live push FIRST, THEN drain buffered appends. Ordering matters:
+  // if an append lands between the drain and the mode switch it would be
+  // buffered (bursting still true) and never re-drained (cursor Medium). With
+  // live mode on, appends during the drain write straight through and the
+  // buffer is emptied once.
+  bursting = false;
   for (const entry of pending) {
     if (!deliveredSeqs.has(entry.seq)) {
-      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+      writeSse(`data: ${JSON.stringify(entry)}\n\n`);
     }
   }
-
-  // Switch to live push — subsequent appends write straight to the response.
-  bursting = false;
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
   // exit (rule 47 — no shared mutable objects keep the loop alive). Cleared
   // by the close handler above when the client disconnects.
   heartbeat = setInterval(() => {
-    if (closed) return;
-    try {
-      res.write(`data: ${JSON.stringify({ type: "heartbeat" })}\n\n`);
-    } catch {
-      // Connection closed — clearInterval via the close handler.
-    }
+    writeSse(`data: ${JSON.stringify({ type: "heartbeat" })}\n\n`);
   }, 25_000);
   heartbeat.unref?.();
 }

--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -14,10 +14,13 @@
  *    (Thread 18) so session/engine/transcript construction is identical to
  *    the MCP surface, instead of re-implementing it.
  *  - Concurrent identical POSTs are coalesced by an in-flight dedup keyed on
- *    `chatSessionId + principal + message` so a double-submit processes
- *    exactly once (issue #1687 Thread 18 / #1685).
+ *    `memoryDir + chatSessionId + principal + message` so a double-submit
+ *    processes exactly once (issue #1687 Thread 18 / #1685). The memoryDir
+ *    scopes the key per store (AGENTS.md State Scoping).
  *  - The SSE stream subscribes to live transcript appends and pushes new
  *    entries to connected clients (issue #1685 item 2 / #1687 Thread 8).
+ *    Subscription is established before the transcript snapshot is read so no
+ *    concurrent append is missed (cursor Bugbot race fix).
  *
  * This module is imported by access-http.ts with thin route registration —
  * the god-file ratchet (#1520) tracks access-http.ts LOC.
@@ -27,8 +30,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createHash } from "node:crypto";
 
 import type { EngramAccessService } from "../access-service.js";
-import type { ChatConfig } from "./chat-types.js";
-import type { ChatTurnResult } from "./chat-types.js";
+import type { ChatConfig, ChatTranscriptEntry, ChatTurnResult } from "./chat-types.js";
 import { processChatMessage } from "./chat-factory.js";
 import {
   loadChatSession,
@@ -47,28 +49,31 @@ export interface ChatHttpHandlerOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Pending chat-message promises keyed by `chatSessionId:principal:messageHash`.
- * A concurrent identical POST joins the in-flight promise instead of
- * re-processing (no second LLM call, no second transcript append).  Entries
- * are always removed via `finally` so the map cannot leak across requests.
+ * Pending chat-message promises keyed by
+ * `memoryDir:chatSessionId:principal:messageHash`.  A concurrent identical
+ * POST joins the in-flight promise instead of re-processing (no second LLM
+ * call, no second transcript append).  Entries are always removed via
+ * `finally` so the map cannot leak across requests.
  *
- * Only requests targeting an existing `chatSessionId` are coalesced: when no
- * session id is supplied each request legitimately mints its own session, so
- * identical message bodies are genuinely distinct turns.
+ * The memoryDir is part of the key so two Remnic stores in one process
+ * cannot share a promise (AGENTS.md State Scoping).  Only requests targeting
+ * an existing `chatSessionId` are coalesced: when no session id is supplied
+ * each request legitimately mints its own session, so identical message
+ * bodies are genuinely distinct turns.
  */
 const chatInFlight = new Map<string, Promise<ChatTurnResult>>();
 
-function chatDedupFingerprint(chatSessionId: string, principal: string, message: string): string {
+function chatDedupFingerprint(memoryDir: string, chatSessionId: string, principal: string, message: string): string {
   // sha256 keeps the key bounded for long messages; the principal is part of
   // the key so two callers targeting the same session id can never share a
   // result (the wrong principal still independently hits access_denied).
   const messageHash = createHash("sha256").update(message, "utf8").digest("hex").slice(0, 32);
-  return `${chatSessionId}:${principal}:${messageHash}`;
+  return `${memoryDir}:${chatSessionId}:${principal}:${messageHash}`;
 }
 
 /**
  * Run `processChatMessage` with concurrent-identical-request coalescing.
- * Distinct messages (or distinct sessions / principals) never collide.
+ * Distinct messages (or distinct sessions / principals / stores) never collide.
  */
 function processChatMessageDedup(opts: {
   service: EngramAccessService;
@@ -83,7 +88,7 @@ function processChatMessageDedup(opts: {
     return processChatMessage(opts);
   }
   const principal = opts.principal ?? "_";
-  const fp = chatDedupFingerprint(opts.chatSessionId, principal, opts.message);
+  const fp = chatDedupFingerprint(opts.memoryDir, opts.chatSessionId, principal, opts.message);
   const existing = chatInFlight.get(fp);
   if (existing) return existing;
   const pending = processChatMessage(opts).finally(() => {
@@ -190,8 +195,14 @@ export async function handleChatMessage(
  * in `chat-session.ts`.  A heartbeat is emitted every 25 s so proxies do not
  * time out.  A `retry:` directive asks reconnecting clients to wait 5 s, and
  * because the initial burst always replays the full transcript (entries carry
- * a monotonic `seq`), clients dedupe on reconnect — the stream is
+ * a strictly-monotonic `seq`), clients dedupe on reconnect — the stream is
  * reconnect-safe.
+ *
+ * Race-free ordering (cursor Bugbot): the subscription is established BEFORE
+ * the transcript snapshot is read. Entries appended concurrently during the
+ * snapshot read are buffered, then drained after the burst (dropping any the
+ * burst already delivered, by `seq`), so no live append is ever missed and
+ * none is delivered twice.
  */
 export async function handleChatEventsSSE(
   req: IncomingMessage,
@@ -205,12 +216,32 @@ export async function handleChatEventsSSE(
     return;
   }
 
+  // Subscribe BEFORE reading the transcript so a concurrent append between
+  // the snapshot read and subscription is never missed (cursor Bugbot race).
+  // During the initial burst entries are buffered; after the burst the
+  // listener switches to writing straight to the response.
+  const pending: ChatTranscriptEntry[] = [];
+  let bursting = true;
+  const unsubscribe = subscribeChatTranscript(opts.memoryDir, chatSessionId, (entry) => {
+    if (bursting) {
+      pending.push(entry);
+      return;
+    }
+    try {
+      res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    } catch {
+      // Connection closed — cleanup below.
+    }
+  });
+
   const session = await loadChatSession(opts.memoryDir, chatSessionId);
   if (!session) {
+    unsubscribe();
     respondJson(res, 404, { error: "chat_session_not_found", code: "chat_session_not_found" });
     return;
   }
   if (!sessionBelongsToPrincipal(session, principal)) {
+    unsubscribe();
     respondJson(res, 403, { error: "access_denied", code: "access_denied" });
     return;
   }
@@ -226,22 +257,24 @@ export async function handleChatEventsSSE(
   // the initial burst below replays the full transcript on rejoin).
   res.write("retry: 5000\n\n");
 
-  // Send the transcript as an initial burst.
+  // Send the transcript snapshot as the initial burst, recording delivered
+  // seqs so buffered concurrent appends are not double-delivered.
+  const deliveredSeqs = new Set<number>();
   for (const entry of session.transcript) {
     res.write(`data: ${JSON.stringify(entry)}\n\n`);
+    deliveredSeqs.add(entry.seq);
   }
 
-  // Push live entries: subscribe to the per-session pub/sub so any new
-  // user/assistant line (appended by the HTTP/MCP/CLI path) is delivered to
-  // this connection immediately.  Listener errors are swallowed inside
-  // appendTranscriptEntry, so a write failure here is also guarded.
-  const unsubscribe = subscribeChatTranscript(chatSessionId, (entry) => {
-    try {
+  // Drain concurrent appends captured during the burst that the snapshot
+  // did not already deliver.
+  for (const entry of pending) {
+    if (!deliveredSeqs.has(entry.seq)) {
       res.write(`data: ${JSON.stringify(entry)}\n\n`);
-    } catch {
-      // Connection closed — cleanup below.
     }
-  });
+  }
+
+  // Switch to live push — subsequent appends write straight to the response.
+  bursting = false;
 
   // Heartbeat. Unref'd so a lingering connection never blocks process
   // exit (rule 47 — no shared mutable objects keep the loop alive).

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -200,16 +200,25 @@ export async function appendTranscriptEntry(
   chatSessionId: string,
   entry: Omit<ChatTranscriptEntry, "seq" | "ts">,
 ): Promise<ChatTranscriptEntry> {
+  const filePath = chatSessionFile(memoryDir, chatSessionId);
+  // Guard against TTL-sweep resurrection (codex P2): if a concurrent sweep
+  // unlinked this session, refuse to append rather than silently recreate a
+  // headerless file — a recreated file would load with no principal binding
+  // and be treated as public by sessionBelongsToPrincipal. The owning turn
+  // fails with a clear 'chat_session_expired' error so the client starts a
+  // fresh session. (The microsecond stat->append TOCTOU is acceptable for an
+  // hourly-sweep edge; the common case — no sweep — is fully closed.)
+  try {
+    await stat(filePath);
+  } catch {
+    throw new Error("chat_session_expired");
+  }
   const full: ChatTranscriptEntry = {
     ...entry,
     seq: nextTranscriptSeq(),
     ts: new Date().toISOString(),
   };
-  await appendFile(
-    chatSessionFile(memoryDir, chatSessionId),
-    JSON.stringify(full) + "\n",
-    "utf8",
-  );
+  await appendFile(filePath, JSON.stringify(full) + "\n", "utf8");
   notifyTranscriptListeners(memoryDir, chatSessionId, full);
   return full;
 }

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -209,11 +209,11 @@ export async function appendTranscriptEntry(
   };
   // Atomic resurrection guard (codex P2): open with O_APPEND but WITHOUT
   // O_CREAT so a session already unlinked by a concurrent TTL sweep fails at
-  // open-time (ENOENT) — there is no stat->appendFile TOCTOU. If the sweep
-  // unlinks after open, writes land on the orphaned inode (the directory
-  // entry is already gone) so the session stays deleted rather than being
-  // recreated headerless. A headerless recreation would load with no
-  // principal binding and be treated as public by sessionBelongsToPrincipal.
+  // open-time (ENOENT) — there is no stat->appendFile TOCTOU. A headerless
+  // recreation would load with no principal binding and be treated as public
+  // by sessionBelongsToPrincipal. A concurrent unlink during the append is
+  // caught by the post-append re-stat below so the turn fails visibly rather
+  // than writing to an orphaned inode and returning 200.
   let fh;
   try {
     fh = await open(filePath, fsConstants.O_APPEND | fsConstants.O_WRONLY);
@@ -224,6 +224,17 @@ export async function appendTranscriptEntry(
     await fh.appendFile(JSON.stringify(full) + "\n", "utf8");
   } finally {
     await fh.close();
+  }
+  // Post-append re-check (codex P2): if a concurrent TTL sweep unlinked the
+  // session between open() and here, the append landed on the orphaned inode
+  // and the directory no longer references it. Re-stat the PATH (not the fd)
+  // so the turn fails with chat_session_expired instead of returning 200 with
+  // a reply the client cannot resume. A later sweep unlinking an over-TTL
+  // session is a legitimate TTL action, not a silent loss.
+  try {
+    await stat(filePath);
+  } catch {
+    throw new Error("chat_session_expired");
   }
   notifyTranscriptListeners(memoryDir, chatSessionId, full);
   return full;

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -40,6 +40,26 @@ export function chatSessionFile(memoryDir: string, chatSessionId: string): strin
   return join(chatSessionDir(memoryDir), `${chatSessionId}.jsonl`);
 }
 
+// ---------------------------------------------------------------------------
+// Monotonic transcript seq (issue #1687 review — strictly increasing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Last emitted transcript `seq`. Seeded from `Date.now()` on first use and
+ * incremented when two appends land in the same millisecond, so `seq` is
+ * strictly increasing within a process (review thread: `Date.now()` alone is
+ * not monotonic — same-ms entries would share a seq and break the SSE
+ * reconnect dedup-by-seq contract). Across process restarts `Date.now()` is
+ * already forward-moving, so no collision occurs in practice.
+ */
+let lastTranscriptSeq = 0;
+
+function nextTranscriptSeq(): number {
+  const now = Date.now();
+  lastTranscriptSeq = now > lastTranscriptSeq ? now : lastTranscriptSeq + 1;
+  return lastTranscriptSeq;
+}
+
 /**
  * Create a new chat session.  The session binds the caller's principal and
  * sessionKey at creation (rule 42); every tool call flows through
@@ -182,7 +202,7 @@ export async function appendTranscriptEntry(
 ): Promise<ChatTranscriptEntry> {
   const full: ChatTranscriptEntry = {
     ...entry,
-    seq: Date.now(),
+    seq: nextTranscriptSeq(),
     ts: new Date().toISOString(),
   };
   await appendFile(
@@ -190,7 +210,7 @@ export async function appendTranscriptEntry(
     JSON.stringify(full) + "\n",
     "utf8",
   );
-  notifyTranscriptListeners(chatSessionId, full);
+  notifyTranscriptListeners(memoryDir, chatSessionId, full);
   return full;
 }
 
@@ -199,15 +219,22 @@ export async function appendTranscriptEntry(
 // ---------------------------------------------------------------------------
 
 /**
- * Per-session listener sets.  Kept module-level so appendTranscriptEntry can
- * fan out new entries to open SSE connections regardless of which caller
+ * Per-session listener sets, keyed by `memoryDir + chatSessionId` so two
+ * memory stores sharing a legacy/imported session id cannot leak transcript
+ * entries to each other (AGENTS.md State Scoping — module-level singletons
+ * are scoped per store).  Kept module-level so appendTranscriptEntry can fan
+ * out new entries to open SSE connections regardless of which caller
  * appended (HTTP, MCP, or CLI).  Empty sets are pruned so the map never
  * grows unbounded (rule 47 — no leak).
  */
 const transcriptListeners = new Map<string, Set<(entry: ChatTranscriptEntry) => void>>();
 
-function notifyTranscriptListeners(chatSessionId: string, entry: ChatTranscriptEntry): void {
-  const set = transcriptListeners.get(chatSessionId);
+function transcriptListenerKey(memoryDir: string, chatSessionId: string): string {
+  return `${memoryDir}\x00${chatSessionId}`;
+}
+
+function notifyTranscriptListeners(memoryDir: string, chatSessionId: string, entry: ChatTranscriptEntry): void {
+  const set = transcriptListeners.get(transcriptListenerKey(memoryDir, chatSessionId));
   if (!set) return;
   for (const fn of set) {
     try {
@@ -219,27 +246,33 @@ function notifyTranscriptListeners(chatSessionId: string, entry: ChatTranscriptE
 }
 
 /**
- * Subscribe to live transcript entries for a chat session.  Returns an
- * unsubscribe function that removes the listener and prunes the session's
- * set when it becomes empty.  Used by the SSE handler to push new
- * user/assistant entries to connected clients (issue #1687).
+ * Subscribe to live transcript entries for a chat session in a given memory
+ * store.  Returns an unsubscribe function that removes the listener and
+ * prunes the session's set when it becomes empty.  Used by the SSE handler
+ * to push new user/assistant entries to connected clients (issue #1687).
+ *
+ * The `memoryDir` scopes the subscription to its store so a process hosting
+ * two Remnic services cannot cross-deliver transcript entries (AGENTS.md
+ * State Scoping).
  */
 export function subscribeChatTranscript(
+  memoryDir: string,
   chatSessionId: string,
   listener: (entry: ChatTranscriptEntry) => void,
 ): () => void {
-  let set = transcriptListeners.get(chatSessionId);
+  const key = transcriptListenerKey(memoryDir, chatSessionId);
+  let set = transcriptListeners.get(key);
   if (!set) {
     set = new Set();
-    transcriptListeners.set(chatSessionId, set);
+    transcriptListeners.set(key, set);
   }
   set.add(listener);
   return () => {
-    const current = transcriptListeners.get(chatSessionId);
+    const current = transcriptListeners.get(key);
     if (!current) return;
     current.delete(listener);
     if (current.size === 0) {
-      transcriptListeners.delete(chatSessionId);
+      transcriptListeners.delete(key);
     }
   };
 }

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -169,6 +169,11 @@ export async function loadChatSession(
 
 /**
  * Append a transcript entry to the session file (atomic append, rule 54).
+ *
+ * After the append resolves, in-process subscribers (open SSE connections —
+ * issue #1687) are notified synchronously so live clients receive the new
+ * entry without polling.  Listener errors are swallowed so a misbehaving
+ * subscriber can never break a transcript append (rule 54 — atomic + safe).
  */
 export async function appendTranscriptEntry(
   memoryDir: string,
@@ -185,7 +190,58 @@ export async function appendTranscriptEntry(
     JSON.stringify(full) + "\n",
     "utf8",
   );
+  notifyTranscriptListeners(chatSessionId, full);
   return full;
+}
+
+// ---------------------------------------------------------------------------
+// In-process transcript pub/sub (issue #1687 SSE push)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-session listener sets.  Kept module-level so appendTranscriptEntry can
+ * fan out new entries to open SSE connections regardless of which caller
+ * appended (HTTP, MCP, or CLI).  Empty sets are pruned so the map never
+ * grows unbounded (rule 47 — no leak).
+ */
+const transcriptListeners = new Map<string, Set<(entry: ChatTranscriptEntry) => void>>();
+
+function notifyTranscriptListeners(chatSessionId: string, entry: ChatTranscriptEntry): void {
+  const set = transcriptListeners.get(chatSessionId);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(entry);
+    } catch {
+      // A listener must never break the append path (rule 54).
+    }
+  }
+}
+
+/**
+ * Subscribe to live transcript entries for a chat session.  Returns an
+ * unsubscribe function that removes the listener and prunes the session's
+ * set when it becomes empty.  Used by the SSE handler to push new
+ * user/assistant entries to connected clients (issue #1687).
+ */
+export function subscribeChatTranscript(
+  chatSessionId: string,
+  listener: (entry: ChatTranscriptEntry) => void,
+): () => void {
+  let set = transcriptListeners.get(chatSessionId);
+  if (!set) {
+    set = new Set();
+    transcriptListeners.set(chatSessionId, set);
+  }
+  set.add(listener);
+  return () => {
+    const current = transcriptListeners.get(chatSessionId);
+    if (!current) return;
+    current.delete(listener);
+    if (current.size === 0) {
+      transcriptListeners.delete(chatSessionId);
+    }
+  };
 }
 
 /**

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -7,7 +7,8 @@
  * *about* memories does not create memories of the conversation itself.
  */
 
-import { mkdir, readFile, appendFile, readdir, stat, unlink } from "node:fs/promises";
+import { mkdir, readFile, appendFile, readdir, stat, unlink, open } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -201,24 +202,29 @@ export async function appendTranscriptEntry(
   entry: Omit<ChatTranscriptEntry, "seq" | "ts">,
 ): Promise<ChatTranscriptEntry> {
   const filePath = chatSessionFile(memoryDir, chatSessionId);
-  // Guard against TTL-sweep resurrection (codex P2): if a concurrent sweep
-  // unlinked this session, refuse to append rather than silently recreate a
-  // headerless file — a recreated file would load with no principal binding
-  // and be treated as public by sessionBelongsToPrincipal. The owning turn
-  // fails with a clear 'chat_session_expired' error so the client starts a
-  // fresh session. (The microsecond stat->append TOCTOU is acceptable for an
-  // hourly-sweep edge; the common case — no sweep — is fully closed.)
-  try {
-    await stat(filePath);
-  } catch {
-    throw new Error("chat_session_expired");
-  }
   const full: ChatTranscriptEntry = {
     ...entry,
     seq: nextTranscriptSeq(),
     ts: new Date().toISOString(),
   };
-  await appendFile(filePath, JSON.stringify(full) + "\n", "utf8");
+  // Atomic resurrection guard (codex P2): open with O_APPEND but WITHOUT
+  // O_CREAT so a session already unlinked by a concurrent TTL sweep fails at
+  // open-time (ENOENT) — there is no stat->appendFile TOCTOU. If the sweep
+  // unlinks after open, writes land on the orphaned inode (the directory
+  // entry is already gone) so the session stays deleted rather than being
+  // recreated headerless. A headerless recreation would load with no
+  // principal binding and be treated as public by sessionBelongsToPrincipal.
+  let fh;
+  try {
+    fh = await open(filePath, fsConstants.O_APPEND | fsConstants.O_WRONLY);
+  } catch {
+    throw new Error("chat_session_expired");
+  }
+  try {
+    await fh.appendFile(JSON.stringify(full) + "\n", "utf8");
+  } finally {
+    await fh.close();
+  }
   notifyTranscriptListeners(memoryDir, chatSessionId, full);
   return full;
 }

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -217,8 +217,14 @@ export async function appendTranscriptEntry(
   let fh;
   try {
     fh = await open(filePath, fsConstants.O_APPEND | fsConstants.O_WRONLY);
-  } catch {
-    throw new Error("chat_session_expired");
+  } catch (err) {
+    // Only ENOENT (session unlinked by a concurrent TTL sweep) maps to
+    // chat_session_expired; real fs errors (EACCES, EMFILE, EISDIR, ...)
+    // are rethrown so the caller surfaces the actual failure (codex P2).
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("chat_session_expired");
+    }
+    throw err;
   }
   try {
     await fh.appendFile(JSON.stringify(full) + "\n", "utf8");
@@ -233,8 +239,13 @@ export async function appendTranscriptEntry(
   // session is a legitimate TTL action, not a silent loss.
   try {
     await stat(filePath);
-  } catch {
-    throw new Error("chat_session_expired");
+  } catch (err) {
+    // Only ENOENT (concurrent TTL unlink) is session expiry; other fs
+    // errors (EACCES, EMFILE, ENOTDIR, ...) are rethrown (codex/kilo P2).
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("chat_session_expired");
+    }
+    throw err;
   }
   notifyTranscriptListeners(memoryDir, chatSessionId, full);
   return full;
@@ -386,6 +397,16 @@ export async function cleanupExpiredChatSessions(
       // boundary is inclusive; sub-millisecond APFS mtime skew is negligible
       // against an hour-scale threshold (rule 54 — deterministic cleanup).
       if (ttlHours <= 0 || ageHours >= ttlHours) {
+        // Re-check mtime immediately before unlinking so a turn appended
+        // mid-sweep (which refreshes mtime) is not deleted by the stale age
+        // decision captured above (codex P2). ttlHours <= 0 (expire-all)
+        // skips the re-check. The residual microsecond window is a
+        // legitimate sweep of an over-TTL file.
+        if (ttlHours > 0) {
+          const fresh = await stat(filePath);
+          const freshAge = (Date.now() - fresh.mtimeMs) / (1000 * 60 * 60);
+          if (freshAge < ttlHours) continue;
+        }
         await unlink(filePath);
         removed++;
       }


### PR DESCRIPTION
Closes #1685, #1687.

Wires the three deferred chat items from the #1583 (#1679) review.

## Changes

### 1. Session TTL enforcement (issue #1685 item 1 / #1687 Thread 21)
`cleanupExpiredChatSessions()` existed but was only referenced by tests — chat JSONL session files never expired in production despite the `sessionTtlHours` config knob. Wired into the `EngramAccessHttpServer` lifecycle:
- One-shot sweep on `start()` (best-effort, fire-and-forget).
- Periodic re-sweep on an **unref'd** 1-hour cadence (rule 47 — never blocks process exit).
- Gated on `chat.enabled` (no-op when chat is disabled).
- Cleared in `stop()`.

### 2. SSE push (issue #1685 item 2 / #1687 Thread 8)
`GET /engram/v1/chat/events/:chatSessionId` sent the transcript then only heartbeats. Added a lightweight per-session pub/sub (`subscribeChatTranscript` in `chat-session.ts`); `appendTranscriptEntry` now fans new entries out to open SSE connections synchronously. Added a `retry: 5000` directive so reconnects are safe — the initial burst always replays the full transcript and entries carry a monotonic `seq`, so clients dedupe on rejoin. No new dependencies; listener errors are swallowed so a misbehaving subscriber can never break an append (rule 54).

### 3. HTTP processor dedup (issue #1687 Thread 18 / #1685)
`handleChatMessage` now **delegates to the shared `processChatMessage`** (Thread 18 — it previously re-implemented session/engine/transcript construction) and is wrapped in an in-flight coalescing map keyed by `chatSessionId + principal + message` so a concurrent identical double-submit processes exactly once (one LLM call, one transcript append). Distinct messages and no-session requests are never coalesced. The principal is part of the key so two callers targeting the same session id can never share a result (the wrong principal still independently hits `access_denied`). Boundary checks (chat-disabled / missing message / no-LLM) stay at the HTTP edge for precise status codes; `processChatMessage`'s tagged errors map back to 404/403/503.

## Tests (4 new, all green)
- `cleanupExpiredChatSessions honors TTL boundary [0, ttlHours)` — mtime-pinned via `utimes`: age under ttl survives, age >= ttl is swept.
- `HTTP chat/events SSE: pushes new transcript entries live` — entry appended after connect reaches the open stream; `retry:` directive + `data:` framing verified.
- `HTTP chat/message: concurrent identical requests are deduplicated` — one LLM call, both callers get the reply, exactly one user transcript line.
- `HTTP chat/message: distinct messages are NOT deduplicated` — both process independently.

## Gates
- `tsc --noEmit` ✓
- `pnpm exec tsx --test 'src/chat/*.test.ts'` ✓ (54/54)
- `npm run test:entity-hardening` ✓ (chat/access touched — 246/246)
- `node scripts/check-ratchets.mjs` ✓
- `npm run preflight:quick` ✓ (`[preflight] OK (quick)`)

## Chokepoints used / not applicable
- access boundary ops (`chat_message`, `chat_events`) already registered via `#1525` registry — unchanged.
- TTL sweep is thin lifecycle wiring in `access-http.ts` (not a god file; not in the ratchet watchlist).
- No `config.*Enabled` reads; reuses the existing `chat.sessionTtlHours` knob.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-lived SSE timers, concurrent request coalescing, and TTL races with in-flight turns; behavior is heavily tested but errors map to new 410 paths and shutdown must release subscriptions.
> 
> **Overview**
> Production chat now **expires idle JSONL sessions** and keeps the admin console stream in sync with new messages, while HTTP chat shares one code path with MCP and resists double-submits.
> 
> **Session TTL** — `EngramAccessHttpServer` runs `cleanupExpiredChatSessions` on startup and on an unref'd hourly timer when chat is enabled (default 72h from config), and clears the timer on `stop()`. Sweeps re-check `mtime` before unlink so active turns are not deleted; `appendTranscriptEntry` no longer recreates swept files (410 `chat_session_expired`).
> 
> **Live SSE** — Chat events SSE subscribes via `subscribeChatTranscript` before loading the snapshot, pushes new transcript rows after the initial burst, emits `retry: 5000`, and registers disconnect cleanup with the server's `sseCleanupFns` on shutdown. Transcript `seq` values are strictly monotonic for reconnect dedupe.
> 
> **HTTP message path** — `handleChatMessage` delegates to shared `processChatMessage` with in-flight dedup keyed by store, session, principal, and message hash; concurrent identical POSTs share one LLM call and one user line.
> 
> Tests cover TTL boundaries, live SSE push, dedup vs distinct messages, early SSE disconnect, monotonic seqs, and expired-session append rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74134f1591acd85d7c4371a28f8c3c5de5569abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->