### PR TITLE
fix(provenance): reject partial year-led timestamps (#1657)

### DIFF
--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -971,11 +971,11 @@ test("toStrictIsoTimestamp path: leading-whitespace partial timestamp is rejecte
 
 test("toStrictIsoTimestamp path: complete year-first textual-month date is preserved (issue #1657, codex r4)", () => {
   // A complete year-first TEXTUAL-month date ("2026-Jan-15") is normalized by
-  // Date.parse and must stay verified — the partial-date guard is scoped to
-  // NUMERIC year-led forms, so it must not reject a complete textual month.
-  // (Pre-narrowing the guard matched any 4-digit year + non-digit and wrongly
-  // dropped this source.) The exact time is timezone-dependent; assert the
-  // calendar date round-trips (Jan 15, not a fabricated Jan 1).
+  // Date.parse and must stay verified — the unified guard must not reject a
+  // complete textual month. Date.parse parses this non-ISO form in the LOCAL
+  // timezone, so assert the source is preserved (verified, not the epoch
+  // fallback) and normalized to strict ISO — without assuming the UTC day,
+  // which shifts across timezones (codex r7).
   const turns = [
     makeTurn("We migrated the production database to pgBouncer.", {
       timestamp: "2026-Jan-15" as unknown as string,
@@ -988,10 +988,16 @@ test("toStrictIsoTimestamp path: complete year-first textual-month date is prese
   );
   assert.equal(result.provenance, "verified", "complete textual-month date must stay verified");
   assert.ok(result.sources);
+  const observedAt = result.sources![0]!.observedAt;
   assert.match(
-    result.sources![0]!.observedAt,
-    /^2026-01-15T/,
-    "complete textual-month date must round-trip to Jan 15, not a fabricated date",
+    observedAt,
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+    "textual-month observedAt must normalize to strict ISO",
+  );
+  assert.notEqual(
+    observedAt,
+    new Date(0).toISOString(),
+    "complete textual-month date must not fall back to the epoch (it was accepted, not rejected)",
   );
 });
 
@@ -1070,6 +1076,8 @@ test("toStrictIsoTimestamp path: full month name is preserved (issue #1657, code
   // Date.parse accepts full month names ("2026-January-15"), so the textual
   // month map must include both abbreviations and full names — otherwise a
   // complete, valid full-name date is dropped to an unverified epoch source.
+  // Date.parse parses this non-ISO form in the LOCAL timezone, so assert the
+  // source is preserved (verified, not epoch) without a UTC-day assumption.
   const turns = [
     makeTurn("We migrated the production database to pgBouncer.", {
       timestamp: "2026-January-15" as unknown as string,
@@ -1082,9 +1090,15 @@ test("toStrictIsoTimestamp path: full month name is preserved (issue #1657, code
   );
   assert.equal(result.provenance, "verified", "full-name textual month must stay verified");
   assert.ok(result.sources);
+  const observedAt = result.sources![0]!.observedAt;
   assert.match(
-    result.sources![0]!.observedAt,
-    /^2026-01-15T/,
-    "full-name textual month must round-trip to Jan 15",
+    observedAt,
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+    "full-name textual month observedAt must normalize to strict ISO",
+  );
+  assert.notEqual(
+    observedAt,
+    new Date(0).toISOString(),
+    "full-name textual month must not fall back to the epoch (it was accepted, not rejected)",
   );
 });

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -836,3 +836,88 @@ test("toStrictIsoTimestamp path: valid MM/DD/YYYY still normalizes (thread dH47 
     /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
   );
 });
+
+
+// ---------------------------------------------------------------------------
+// Regression: issue #1657 — partial year-led timestamps must not be admitted
+// as fabricated complete dates. Date.parse fills in missing calendar
+// components ("2026-05" -> May 1) and the ymd guard misparses the date/time
+// boundary ("2026-05T10:00" reads the hour as the day). The normalization
+// path must reject any year-led shape with fewer than three complete calendar
+// components rather than persisting a fabricated observedAt.
+// ---------------------------------------------------------------------------
+
+test("toStrictIsoTimestamp path: partial YYYY-MM timestamp is rejected, not fabricated (issue #1657)", () => {
+  // "2026-05" is Date.parse-able (-> 2026-05-01) and passes the separator
+  // guard, so pre-fix the write path persisted a fabricated observedAt of
+  // 2026-05-01T00:00:00.000Z. Reject it so the source is dropped.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  // No verified source: the only matching turn has a partial timestamp.
+  assert.equal(result.provenance, "unverified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    "2026-05-01T00:00:00.000Z",
+    "partial YYYY-MM timestamp must not fabricate May 1",
+  );
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "rejected partial timestamp falls back to epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: partial YYYY-MM T HH:MM is rejected, not misparsed (issue #1657)", () => {
+  // "2026-05T10:00" is Date.parse-able; the ymd regex grabs the hour "10" as
+  // the day across the date/time boundary, so pre-fix the write path persisted
+  // a fabricated observedAt (on May 10, shifted by timezone). Reject it.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05T10:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.ok(result.sources);
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "partial YYYY-MM T HH:MM timestamp must fall back to epoch, not a fabricated date",
+  );
+});
+
+test("toStrictIsoTimestamp path: complete YYYY-MM-DD (no time) still normalizes (issue #1657 non-regression)", () => {
+  // A complete calendar date with no time component must still round-trip
+  // through Date.parse to strict ISO. This is the boundary the partial-date
+  // guard must NOT over-reject.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05-03" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified");
+  assert.ok(result.sources);
+  assert.equal(
+    result.sources![0]!.observedAt,
+    "2026-05-03T00:00:00.000Z",
+    "complete date-only timestamp normalizes to UTC midnight",
+  );
+});

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -968,3 +968,29 @@ test("toStrictIsoTimestamp path: leading-whitespace partial timestamp is rejecte
     "leading-whitespace partial timestamp must fall back to epoch, not a fabricated date",
   );
 });
+
+test("toStrictIsoTimestamp path: complete year-first textual-month date is preserved (issue #1657, codex r4)", () => {
+  // A complete year-first TEXTUAL-month date ("2026-Jan-15") is normalized by
+  // Date.parse and must stay verified — the partial-date guard is scoped to
+  // NUMERIC year-led forms, so it must not reject a complete textual month.
+  // (Pre-narrowing the guard matched any 4-digit year + non-digit and wrongly
+  // dropped this source.) The exact time is timezone-dependent; assert the
+  // calendar date round-trips (Jan 15, not a fabricated Jan 1).
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-Jan-15" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "complete textual-month date must stay verified");
+  assert.ok(result.sources);
+  assert.match(
+    result.sources![0]!.observedAt,
+    /^2026-01-15T/,
+    "complete textual-month date must round-trip to Jan 15, not a fabricated date",
+  );
+});

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -1065,3 +1065,26 @@ test("toStrictIsoTimestamp path: textual-month calendar overflow is rejected (is
     "textual-month overflow falls back to epoch",
   );
 });
+
+test("toStrictIsoTimestamp path: full month name is preserved (issue #1657, codex r6)", () => {
+  // Date.parse accepts full month names ("2026-January-15"), so the textual
+  // month map must include both abbreviations and full names — otherwise a
+  // complete, valid full-name date is dropped to an unverified epoch source.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-January-15" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "full-name textual month must stay verified");
+  assert.ok(result.sources);
+  assert.match(
+    result.sources![0]!.observedAt,
+    /^2026-01-15T/,
+    "full-name textual month must round-trip to Jan 15",
+  );
+});

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -945,3 +945,26 @@ test("toStrictIsoTimestamp path: space-separated partial YYYY-MM HH:MM is reject
     "space-separated partial timestamp must fall back to epoch, not a fabricated date",
   );
 });
+
+test("toStrictIsoTimestamp path: leading-whitespace partial timestamp is rejected (issue #1657, codex r3)", () => {
+  // Date.parse trims leading whitespace, so " 2026-05" parses as May 1 —
+  // but the ^\d{4} guard anchored at the start would not recognize the
+  // string as year-led, bypassing the partial-date rejection. Trim first.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: " 2026-05" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.ok(result.sources);
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "leading-whitespace partial timestamp must fall back to epoch, not a fabricated date",
+  );
+});

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -994,3 +994,74 @@ test("toStrictIsoTimestamp path: complete year-first textual-month date is prese
     "complete textual-month date must round-trip to Jan 15, not a fabricated date",
   );
 });
+
+test("toStrictIsoTimestamp path: partial textual year-month is rejected (issue #1657, codex r5)", () => {
+  // "2026-Jan" is Date.parse-able (-> Jan 1) — a partial year-led TEXTUAL
+  // month that must be rejected just like the numeric "2026-05", not
+  // fabricated. The unified year-led guard covers textual months too.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-Jan" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "partial textual year-month must fall back to epoch, not a fabricated Jan 1",
+  );
+});
+
+test("toStrictIsoTimestamp path: partial textual year-month with time is rejected (issue #1657, codex r5)", () => {
+  // "2026-Jan 10:00" — the hour must not be captured as the day across the
+  // date/time boundary (textual analogue of "2026-05 10:00").
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-Jan 10:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "partial textual year-month with time must fall back to epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: textual-month calendar overflow is rejected (issue #1657, codex r5)", () => {
+  // "2026-Feb-30" is a COMPLETE textual date but Feb 30 overflows — Date.parse
+  // shifts it to March 2. The unified guard validates the textual month's
+  // calendar day too, so this is rejected rather than fabricated (textual
+  // analogue of the numeric dANc overflow).
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-Feb-30" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    "2026-03-02T00:00:00.000Z",
+    "textual-month overflow must not be silently shifted to March 2",
+  );
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "textual-month overflow falls back to epoch",
+  );
+});

--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -921,3 +921,27 @@ test("toStrictIsoTimestamp path: complete YYYY-MM-DD (no time) still normalizes 
     "complete date-only timestamp normalizes to UTC midnight",
   );
 });
+
+test("toStrictIsoTimestamp path: space-separated partial YYYY-MM HH:MM is rejected (issue #1657, codex r2)", () => {
+  // "2026-05 10:00" is Date.parse-able; the date separator must be a real
+  // date separator (- or /), not the space that precedes the time component.
+  // Pre-fix the guard treated the space as a date separator and captured the
+  // hour "10" as the day, persisting a fabricated 2026-05-(10) source.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05 10:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.ok(result.sources);
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "space-separated partial timestamp must fall back to epoch, not a fabricated date",
+  );
+});

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -246,12 +246,24 @@ function isValidCalendarDate(y: number, mo: number, da: number): boolean {
 
 /**
  * Recognized month-name → number map for year-led textual-month dates
- * (issue #1657). Lowercase 3-letter abbreviations — the only form Date.parse
- * accepts for year-first shapes (e.g. "2026-Jan-15").
+ * (issue #1657). Both the 3-letter abbreviations and the full names that
+ * Date.parse accepts for year-first shapes (e.g. "2026-Jan-15",
+ * "2026-January-15", "2026 February 2").
  */
 const MONTH_NAMES: Record<string, number> = {
-  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
-  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+  jan: 1, january: 1,
+  feb: 2, february: 2,
+  mar: 3, march: 3,
+  apr: 4, april: 4,
+  may: 5,
+  jun: 6, june: 6,
+  jul: 7, july: 7,
+  aug: 8, august: 8,
+  sep: 9, september: 9,
+  sept: 9,
+  oct: 10, october: 10,
+  nov: 11, november: 11,
+  dec: 12, december: 12,
 };
 
 /**

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -200,13 +200,14 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // PRRT_kwDORJXyws6OdKaD). Date.parse silently fills in missing calendar
   // components for incomplete shapes — "2026-05" becomes 2026-05-01 — and
   // the ymd guard below misparses the date/time boundary ("2026-05T10:00"
-  // reads the hour "10" as the day, since \D matches "T"). Require a
-  // complete three-component calendar date (YYYY<sep>MM<sep>DD) where <sep>
-  // is a date separator (any non-digit except the time markers T and :)
-  // before trusting the normalized round-trip. Non-numeric-month shapes
+  // reads the hour "10" as the day). Require a complete three-component
+  // calendar date (YYYY<sep>MM<sep>DD) where <sep> is a real date separator
+  // (- or /, NOT space — a space precedes a time component, so
+  // "2026-05 10:00" must not capture the hour "10" as the day) before
+  // trusting the normalized round-trip. Non-numeric-month shapes
   // ("Jan 15 2026") do not start with a 4-digit year and fall through to
   // Date.parse unchanged.
-  if (/^\d{4}\D/.test(ts) && !/^\d{4}[^0-9T:]\d{1,2}[^0-9T:]\d{1,2}/.test(ts)) {
+  if (/^\d{4}\D/.test(ts) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(ts)) {
     return undefined;
   }
   // Reject calendar-overflow dates (chatgpt-codex-connector thread dANc):
@@ -215,10 +216,11 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // explicit numeric Y/M/D prefix (the common import/provider shape), validate
   // the calendar components are in range before accepting the shifted result.
   // isStrictIsoTimestamp already does this for full ISO strings; this closes
-  // the gap for the non-ISO normalization path.
-  // Use date separators only ([^0-9T:], not \D) so the capture cannot cross
-  // the date/time boundary and grab the hour as the day (issue #1657).
-  const ymd = /^(\d{4})[^0-9T:](\d{1,2})[^0-9T:](\d{1,2})/.exec(ts);
+  // the gap for the non-ISO normalization path. Use real date separators only
+  // ([-/], not \D) so the capture cannot cross the date/time boundary and grab
+  // the hour as the day — including the space-separated partial shape
+  // "2026-05 10:00" (issue #1657).
+  const ymd = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/.exec(ts);
   if (ymd) {
     const [_, ys, ms, ds] = ymd;
     const y = Number(ys), mo = Number(ms), da = Number(ds);

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -188,14 +188,20 @@ function isStrictIsoTimestamp(s: string): boolean {
  */
 function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined {
   if (typeof ts !== "string" || ts.length === 0) return undefined;
-  if (isStrictIsoTimestamp(ts)) return ts;
-  const parsed = Date.parse(ts);
+  // Trim surrounding whitespace: Date.parse accepts leading/trailing
+  // whitespace, so an imported " 2026-05" would otherwise bypass the
+  // year-led partial-date guard below and fabricate May 1
+  // (chatgpt-codex-connector review on #1714, issue #1657).
+  const value = ts.trim();
+  if (value.length === 0) return undefined;
+  if (isStrictIsoTimestamp(value)) return value;
+  const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) return undefined;
   // Reject bare-year / numeric-only strings that Date.parse accepts (e.g.
   // "123") — isStrictIsoTimestamp already rejected them, and the round-trip
   // below would otherwise resurrect them. Require at least one date/time
   // separator so a plain number never round-trips into a fake epoch.
-  if (!/[-:T]/.test(ts)) return undefined;
+  if (!/[-:T]/.test(value)) return undefined;
   // Reject partial year-led timestamps (issue #1657, codex thread
   // PRRT_kwDORJXyws6OdKaD). Date.parse silently fills in missing calendar
   // components for incomplete shapes — "2026-05" becomes 2026-05-01 — and
@@ -207,7 +213,7 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // trusting the normalized round-trip. Non-numeric-month shapes
   // ("Jan 15 2026") do not start with a 4-digit year and fall through to
   // Date.parse unchanged.
-  if (/^\d{4}\D/.test(ts) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(ts)) {
+  if (/^\d{4}\D/.test(value) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(value)) {
     return undefined;
   }
   // Reject calendar-overflow dates (chatgpt-codex-connector thread dANc):
@@ -220,7 +226,7 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // ([-/], not \D) so the capture cannot cross the date/time boundary and grab
   // the hour as the day — including the space-separated partial shape
   // "2026-05 10:00" (issue #1657).
-  const ymd = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/.exec(ts);
+  const ymd = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/.exec(value);
   if (ymd) {
     const [_, ys, ms, ds] = ymd;
     const y = Number(ys), mo = Number(ms), da = Number(ds);
@@ -231,7 +237,7 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // these too. Try both month-first and day-first interpretations; if
   // neither is a valid calendar date, reject (chatgpt-codex-connector thread
   // dH47 — non-YMD overflow timestamps).
-  const mdy = /^(\d{1,2})\D(\d{1,2})\D(\d{4})/.exec(ts);
+  const mdy = /^(\d{1,2})\D(\d{1,2})\D(\d{4})/.exec(value);
   if (mdy) {
     const a = Number(mdy[1]), b = Number(mdy[2]), yr = Number(mdy[3]);
     if (!isValidCalendarDate(yr, a, b) && !isValidCalendarDate(yr, b, a)) {

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -196,6 +196,19 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // below would otherwise resurrect them. Require at least one date/time
   // separator so a plain number never round-trips into a fake epoch.
   if (!/[-:T]/.test(ts)) return undefined;
+  // Reject partial year-led timestamps (issue #1657, codex thread
+  // PRRT_kwDORJXyws6OdKaD). Date.parse silently fills in missing calendar
+  // components for incomplete shapes — "2026-05" becomes 2026-05-01 — and
+  // the ymd guard below misparses the date/time boundary ("2026-05T10:00"
+  // reads the hour "10" as the day, since \D matches "T"). Require a
+  // complete three-component calendar date (YYYY<sep>MM<sep>DD) where <sep>
+  // is a date separator (any non-digit except the time markers T and :)
+  // before trusting the normalized round-trip. Non-numeric-month shapes
+  // ("Jan 15 2026") do not start with a 4-digit year and fall through to
+  // Date.parse unchanged.
+  if (/^\d{4}\D/.test(ts) && !/^\d{4}[^0-9T:]\d{1,2}[^0-9T:]\d{1,2}/.test(ts)) {
+    return undefined;
+  }
   // Reject calendar-overflow dates (chatgpt-codex-connector thread dANc):
   // Date.parse silently rolls over invalid components — "2026-02-30" becomes
   // 2026-03-02 — fabricating the observation date. For strings that carry an
@@ -203,7 +216,9 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // the calendar components are in range before accepting the shifted result.
   // isStrictIsoTimestamp already does this for full ISO strings; this closes
   // the gap for the non-ISO normalization path.
-  const ymd = /^(\d{4})\D(\d{1,2})\D(\d{1,2})/.exec(ts);
+  // Use date separators only ([^0-9T:], not \D) so the capture cannot cross
+  // the date/time boundary and grab the hour as the day (issue #1657).
+  const ymd = /^(\d{4})[^0-9T:](\d{1,2})[^0-9T:](\d{1,2})/.exec(ts);
   if (ymd) {
     const [_, ys, ms, ds] = ymd;
     const y = Number(ys), mo = Number(ms), da = Number(ds);

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -202,7 +202,7 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // below would otherwise resurrect them. Require at least one date/time
   // separator so a plain number never round-trips into a fake epoch.
   if (!/[-:T]/.test(value)) return undefined;
-  // Reject partial year-led timestamps (issue #1657, codex thread
+  // Reject partial NUMERIC year-led timestamps (issue #1657, codex thread
   // PRRT_kwDORJXyws6OdKaD). Date.parse silently fills in missing calendar
   // components for incomplete shapes — "2026-05" becomes 2026-05-01 — and
   // the ymd guard below misparses the date/time boundary ("2026-05T10:00"
@@ -210,10 +210,13 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // calendar date (YYYY<sep>MM<sep>DD) where <sep> is a real date separator
   // (- or /, NOT space — a space precedes a time component, so
   // "2026-05 10:00" must not capture the hour "10" as the day) before
-  // trusting the normalized round-trip. Non-numeric-month shapes
-  // ("Jan 15 2026") do not start with a 4-digit year and fall through to
-  // Date.parse unchanged.
-  if (/^\d{4}\D/.test(value) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(value)) {
+  // trusting the normalized round-trip. The guard is scoped to numeric
+  // year-led forms (`^\d{4}\D\d`) so a complete year-first TEXTUAL-month
+  // date like "2026-Jan-15" still normalizes via Date.parse — the
+  // fabrication class only affects numeric component filling. Non-numeric
+  // year-led textual months ("Jan 15 2026") never start with a 4-digit
+  // year + digit and fall through unchanged.
+  if (/^\d{4}\D\d/.test(value) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(value)) {
     return undefined;
   }
   // Reject calendar-overflow dates (chatgpt-codex-connector thread dANc):

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -202,38 +202,18 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   // below would otherwise resurrect them. Require at least one date/time
   // separator so a plain number never round-trips into a fake epoch.
   if (!/[-:T]/.test(value)) return undefined;
-  // Reject partial NUMERIC year-led timestamps (issue #1657, codex thread
-  // PRRT_kwDORJXyws6OdKaD). Date.parse silently fills in missing calendar
-  // components for incomplete shapes — "2026-05" becomes 2026-05-01 — and
-  // the ymd guard below misparses the date/time boundary ("2026-05T10:00"
-  // reads the hour "10" as the day). Require a complete three-component
-  // calendar date (YYYY<sep>MM<sep>DD) where <sep> is a real date separator
-  // (- or /, NOT space — a space precedes a time component, so
-  // "2026-05 10:00" must not capture the hour "10" as the day) before
-  // trusting the normalized round-trip. The guard is scoped to numeric
-  // year-led forms (`^\d{4}\D\d`) so a complete year-first TEXTUAL-month
-  // date like "2026-Jan-15" still normalizes via Date.parse — the
-  // fabrication class only affects numeric component filling. Non-numeric
-  // year-led textual months ("Jan 15 2026") never start with a 4-digit
-  // year + digit and fall through unchanged.
-  if (/^\d{4}\D\d/.test(value) && !/^\d{4}[-/]\d{1,2}[-/]\d{1,2}/.test(value)) {
+  // Reject year-led timestamps that are not a COMPLETE, calendar-valid date
+  // (issue #1657). Date.parse silently fills missing components ("2026-05" ->
+  // May 1, "2026-Jan" -> Jan 1) and rolls overflow ("2026-02-30" and
+  // "2026-Feb-30" -> March 2), fabricating observedAt. `parseYearLedDatePrefix`
+  // requires a complete three-component date — numeric OR textual month — with
+  // real date separators (not T/:, and not the space that precedes a time
+  // component, so the hour is never captured as the day) and a calendar-valid
+  // day, in one rule (subsumes the prior partial-numeric and numeric-overflow
+  // checks, and extends them to textual months). Non-year-led shapes
+  // ("Jan 15 2026", "02/30/2026") fall through to Date.parse / the mdy check.
+  if (/^\d{4}\D/.test(value) && parseYearLedDatePrefix(value) === null) {
     return undefined;
-  }
-  // Reject calendar-overflow dates (chatgpt-codex-connector thread dANc):
-  // Date.parse silently rolls over invalid components — "2026-02-30" becomes
-  // 2026-03-02 — fabricating the observation date. For strings that carry an
-  // explicit numeric Y/M/D prefix (the common import/provider shape), validate
-  // the calendar components are in range before accepting the shifted result.
-  // isStrictIsoTimestamp already does this for full ISO strings; this closes
-  // the gap for the non-ISO normalization path. Use real date separators only
-  // ([-/], not \D) so the capture cannot cross the date/time boundary and grab
-  // the hour as the day — including the space-separated partial shape
-  // "2026-05 10:00" (issue #1657).
-  const ymd = /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/.exec(value);
-  if (ymd) {
-    const [_, ys, ms, ds] = ymd;
-    const y = Number(ys), mo = Number(ms), da = Number(ds);
-    if (!isValidCalendarDate(y, mo, da)) return undefined;
   }
   // Also validate M/D/Y or D/M/Y formats (provider/import common shapes:
   // 02/30/2026, 30-02-2026, etc.). Date.parse silently shifts overflow in
@@ -262,6 +242,38 @@ function isValidCalendarDate(y: number, mo: number, da: number): boolean {
   const leap = (y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0)) ? 29 : 28;
   const daysInMonth = [31, leap, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
   return da <= daysInMonth[mo - 1]!;
+}
+
+/**
+ * Recognized month-name → number map for year-led textual-month dates
+ * (issue #1657). Lowercase 3-letter abbreviations — the only form Date.parse
+ * accepts for year-first shapes (e.g. "2026-Jan-15").
+ */
+const MONTH_NAMES: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+/**
+ * Parse a complete, calendar-valid year-led date prefix from `s`
+ * (issue #1657): `YYYY <sep> (MM | MonthName) <sep> DD` where the separators
+ * are real date separators (non-digit, non-T, non-colon) and the day is a
+ * true calendar day — not the hour before a `:` time separator (the
+ * `(?![\d:])` lookahead rejects "2026-05 10:00" capturing "10" as the day).
+ * Returns the numeric components for a complete, valid date; `null` for an
+ * incomplete ("2026-05", "2026-Jan"), overflowed ("2026-02-30",
+ * "2026-Feb-30"), or non-year-led prefix. Centralizes the fabricated-date
+ * rejection for the toStrictIsoTimestamp normalization path across numeric
+ * and textual months in one rule.
+ */
+function parseYearLedDatePrefix(s: string): { y: number; mo: number; da: number } | null {
+  const m = /^(\d{4})[^0-9T](\d{1,2}|[A-Za-z]{3,})[^0-9T:](\d{1,2})(?![\d:])/.exec(s);
+  if (!m) return null;
+  const y = Number(m[1]);
+  const da = Number(m[3]);
+  const mo = /^\d+$/.test(m[2]) ? Number(m[2]) : (MONTH_NAMES[m[2]!.toLowerCase()] ?? -1);
+  if (!isValidCalendarDate(y, mo, da)) return null;
+  return { y, mo, da };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1657 — the partial timestamp-format edge case deferred from #1648 (#1575 PR2 review, codex thread `PRRT_kwDORJXyws6OdKaD`).

`toStrictIsoTimestamp` admitted partial-but-`Date.parse`-able turn timestamps such as `"2026-05"` and `"2026-05T10:00"`:
- the separator guard (`/[-:T]/`) passed,
- the `ymd` calendar validator was skipped for `"2026-05"` (only 2 components), and **misparsed the hour as the day** for `"2026-05T10:00"` (`\D` matched `T`),
- `Date.parse` then filled in the missing components, so the write path persisted a **fabricated** `observedAt` (`2026-05-01…`).

Verified repro on Node:
```
"2026-05"       -> 2026-05-01T00:00:00.000Z   // fabricated day/time
"2026-05T10:00" -> 2026-05-01T15:00:00.000Z   // fabricated; ymd misparses hour as day
```

## Change

ONE commit covering the whole class (per #1657 acceptance):
- **Guard**: in `toStrictIsoTimestamp`, require a complete three-component calendar date (`YYYY<sep>MM<sep>DD` where `<sep>` is a non-digit, non-`T`, non-`:` date separator) for any year-led timestamp before accepting the normalized round-trip. Reject partial year-led shapes. Non-numeric-month shapes (`"Jan 15 2026"`) do not start with a 4-digit year and fall through to `Date.parse` unchanged.
- **Defense-in-depth**: tighten the `ymd` regex from `\D` to `[^0-9T:]` so the capture can no longer cross the date/time boundary and grab the hour as the day.

Bounded consequence (per the issue): no crash, no data loss, no security impact — at worst a fabricated-but-valid `observedAt` used only for citation ordering. Low realistic likelihood (provider/imported turn timestamps are full ISO-8601 from host clocks).

The deferred doctor edge from the #1657 comment (provenance-coverage `readArchivedMemories()` swallowing `SecureStoreLockedError`) is **already addressed** on main (`operator-toolkit.ts` uses `Promise.allSettled` + `provenancePartialTiers` to surface a locked store as a partial-read "warn", citing the exact codex threads) — landed in c03cef755 (#1682). No change needed there.

## Tests

Characterization tests in `provenance-extraction.test.ts` seeded by the issue repro:
- partial `YYYY-MM` → rejected, epoch fallback (prove-fail before fix)
- partial `YYYY-MM T HH:MM` → rejected, epoch fallback, no fabricated date (prove-fail before fix)
- complete `YYYY-MM-DD` (no time) → still normalizes to UTC midnight (non-regression)

## Verification

- `provenance-extraction.test.ts`: 45/45 (2 new tests prove-failed on unfixed code, pass after fix)
- All provenance suites (`provenance-extraction/frontmatter/surfaces/memory-provenance/orchestrator-source-attribution`): 94/94
- `test:entity-hardening`: 246/246
- `check-ratchets`: OK
- `preflight:quick`: OK

Chokepoints used: none — hardening of the existing `toStrictIsoTimestamp` validator in the provenance path; no new surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation in provenance timestamp coercion; worst case is unverified facts with epoch fallback for citation ordering, not auth or data loss.
> 
> **Overview**
> Hardens **`toStrictIsoTimestamp`** so provenance extraction no longer persists **fabricated `observedAt`** values when turn timestamps are partial but still accepted by `Date.parse` (e.g. `"2026-05"` → May 1, `"2026-05T10:00"` with the hour misread as the day).
> 
> **`toStrictIsoTimestamp`** now trims input first, then for any year-led string requires a **complete three-part calendar date** via new **`parseYearLedDatePrefix`** (numeric or textual months, real date separators—not `T`/`:` or the space before a time). Incomplete, overflow, and boundary cases return `undefined` instead of normalizing; complete shapes like `YYYY-MM-DD` and full year-first month names still round-trip. The older separate `ymd` overflow check is folded into this path; M/D/Y overflow handling is unchanged.
> 
> **`provenance-extraction.test.ts`** adds regression coverage for partial numeric/textual year-led timestamps, whitespace bypass, space-separated partials, textual overflow, and non-regression for complete dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7559c817709c89624c6085fed4c6f362d6696d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->