### PR TITLE
fix(model-lab): deferred review nits from #1698/#1585 (#1700)

### DIFF
--- a/model-lab/README.md
+++ b/model-lab/README.md
@@ -94,7 +94,7 @@ python model-lab/faithfulness-gate/train.py   --version-tag v1          # → mo
 python model-lab/faithfulness-gate/eval.py    --version-tag v1          # → manifest eval block
 ```
 
-`train.py` / `eval.py` lazy-import the GPU stack so `--help` works on a bare machine; the training entry point exits with code 2 and an install hint if `torch`/`transformers` are missing. **They never run in CI.**
+`train.py` / `eval.py` lazy-import the GPU stack so `--help` works on a bare machine. `train.py` exits with code 2 and an install hint if `torch`/`transformers` are missing. `eval.py`'s GPU gate is scoped to the inference path (no `--predictions`): offline scoring of pre-computed predictions is JSONL + stdlib only and runs CPU-only; the inline inference loop (which loads the checkpoint) gates the GPU stack. **They never run in CI.**
 
 ## Reproducibility model
 

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -56,6 +56,21 @@ VALID_STATUSES: tuple[str, ...] = ("pending-training", "trained", "stale")
 #: mislabeled manifest fails.
 KNOWN_TASKS: tuple[str, ...] = ("faithfulness-gate", "correction-intent")
 
+#: Per-task minimum lib set a reproducible run MUST pin, beyond the universal
+#: ``torch`` + ``transformers`` (issue #1700 nit #2). Source of truth: each
+#: task's ``train.py`` required-imports + ``model-lab/requirements.txt``. A
+#: manifest that OMITS a task-required lib (not merely one left null) now fails
+#: strict validation -- a correction-intent run without ``trl``/``peft``, or a
+#: faithfulness-gate run without its encoder Trainer stack, cannot reproduce
+#: its eval numbers. ``bitsandbytes`` is intentionally NOT required for
+#: correction-intent (it is the optional <=8B QLoRA escape hatch; a <=4B LoRA run
+#: does not import it). ``datasets`` + ``huggingface-hub`` are universal
+#: (data loading + weight publish) so they appear in both rows.
+TASK_REQUIRED_LIBS: Mapping[str, tuple[str, ...]] = {
+    "faithfulness-gate": ("datasets", "huggingface-hub", "accelerate", "sentencepiece"),
+    "correction-intent": ("trl", "peft", "datasets", "huggingface-hub"),
+}
+
 
 def _is_pending(value: Any) -> bool:
     """True when a value is the PR-scaffold placeholder for 'not yet run'."""
@@ -113,7 +128,9 @@ def validate_manifest(
     elif not isinstance(stack, Mapping):
         errors.append("trainingStack must be an object (or null when pending)")
     else:
-        stack_errs = _validate_training_stack(stack, allow_pending=allow_pending)
+        stack_errs = _validate_training_stack(
+            stack, allow_pending=allow_pending, task=manifest.get("task")
+        )
         errors.extend(stack_errs)
 
     # eval + artifact + dataRecipe blocks: structural presence only.
@@ -137,8 +154,15 @@ def validate_manifest(
         if isinstance(eval_block, Mapping) and _is_pending(eval_block.get("heldOut")):
             errors.append("eval.heldOut is pending — a real run must record held-out metrics")
         artifact_block = manifest.get("artifact")
-        if isinstance(artifact_block, Mapping) and _is_pending(artifact_block.get("hfRepo")):
-            errors.append("artifact.hfRepo is pending — a real run must publish weights")
+        if isinstance(artifact_block, Mapping):
+            if _is_pending(artifact_block.get("hfRepo")):
+                errors.append("artifact.hfRepo is pending — a real run must publish weights")
+            # artifact.revision pins the exact published weights commit (issue
+            # #1700 nit #3). A status:"trained" manifest with revision:null is
+            # half-recorded -- hf_push.py published to hfRepo but never recorded
+            # which commit, so the eval can't be reproduced from the manifest.
+            if _is_pending(artifact_block.get("revision")):
+                errors.append("artifact.revision is pending — a real run must pin the published weights revision")
         # dataRecipe provenance (codex P2 PRRT_kwDORJXyws6Otp-E): a published run
         # must carry the dataset hash + generator git-sha so the eval split is
         # reproducible. The committed scaffold leaves them null (no canonical
@@ -180,8 +204,21 @@ def validate_manifest(
     return errors
 
 
-def _validate_training_stack(stack: Mapping[str, Any], *, allow_pending: bool) -> list[str]:
-    """Validate the pinned training-stack block (exact lib versions)."""
+def _validate_training_stack(
+    stack: Mapping[str, Any],
+    *,
+    allow_pending: bool,
+    task: str | None = None,
+) -> list[str]:
+    """Validate the pinned training-stack block (exact lib versions).
+
+    "task" enables the per-task required-lib matrix (issue #1700 nit #2): a
+    real run must pin not only the universal torch/transformers and the libs it
+    DECLARES, but also the libs its task's recipe imports -- otherwise a
+    manifest that silently OMITS trl/peft (correction-intent) or the encoder
+    Trainer stack (faithfulness-gate) passes strict validation despite being
+    unable to reproduce its eval numbers.
+    """
     errors: list[str] = []
     required = ("python", "libs")
     for key in required:
@@ -197,14 +234,17 @@ def _validate_training_stack(stack: Mapping[str, Any], *, allow_pending: bool) -
     if not isinstance(libs, Mapping):
         errors.append("trainingStack.libs must be an object mapping lib → exact version")
     elif not allow_pending:
-        # A real run must pin an exact version for torch + transformers
-        # (universal across both tasks) AND for every other lib the manifest
-        # DECLARES. The previous check only covered torch/transformers, so a
-        # correction-intent manifest with trl/peft/bitsandbytes left null passed
-        # strict validation and undermined the no-half-recorded-run gate (kilo
-        # WARNING PRRT_kwDORJXyws6OtyS-). Iterating over declared libs also
-        # respects that the two tasks pin different stacks (encoder vs causal-LM).
-        check_libs = dict.fromkeys(("torch", "transformers", *libs.keys()))
+        # A real run must pin an exact version for the UNIVERSAL minimum
+        # (torch + transformers) PLUS the task-specific minimum (issue #1700
+        # nit #2 -- a correction-intent run must pin trl/peft/datasets; a
+        # faithfulness-gate run must pin its encoder Trainer stack) PLUS every
+        # other lib the manifest DECLARES. The previous check only covered
+        # torch/transformers + declared keys, so a manifest that OMITTED a
+        # task-required lib passed strict validation (kilo WARNING
+        # PRRT_kwDORJXyws6OtyS- for the null-declared case; this closes the
+        # omitted-key case). dict.fromkeys dedupes the three sources.
+        task_libs = TASK_REQUIRED_LIBS.get(task, ()) if task else ()
+        check_libs = dict.fromkeys(("torch", "transformers", *task_libs, *libs.keys()))
         for lib in check_libs:
             ver = libs.get(lib)
             if _is_pending(ver) or not isinstance(ver, str):

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -65,10 +65,13 @@ KNOWN_TASKS: tuple[str, ...] = ("faithfulness-gate", "correction-intent")
 #: its eval numbers. ``bitsandbytes`` is intentionally NOT required for
 #: correction-intent (it is the optional <=8B QLoRA escape hatch; a <=4B LoRA run
 #: does not import it). ``datasets`` + ``huggingface-hub`` are universal
-#: (data loading + weight publish) so they appear in both rows.
+#: (data loading + weight publish) so they appear in both rows. ``accelerate``
+#: is also required for BOTH tasks: transformers Trainer / TrainingArguments
+#: import it for device management, and the correction-intent TRL SFTTrainer
+#: depends on it transitively at runtime (codex P2 PRRT_kwDORJXyws6O7kTC).
 TASK_REQUIRED_LIBS: Mapping[str, tuple[str, ...]] = {
     "faithfulness-gate": ("datasets", "huggingface-hub", "accelerate", "sentencepiece"),
-    "correction-intent": ("trl", "peft", "datasets", "huggingface-hub"),
+    "correction-intent": ("trl", "peft", "datasets", "huggingface-hub", "accelerate"),
 }
 
 

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -260,7 +260,10 @@ def _validate_training_stack(
         check_libs = dict.fromkeys(("torch", "transformers", *task_libs, *libs.keys()))
         for lib in check_libs:
             ver = libs.get(lib)
-            if _is_pending(ver) or not isinstance(ver, str):
+            # A blank/whitespace version is as useless as a pending/null one for
+            # reproducibility, so reject it too (codex P2 PRRT_kwDORJXyws6O7vGo:
+            # previously only pending/non-string values were rejected).
+            if _is_pending(ver) or not isinstance(ver, str) or not ver.strip():
                 errors.append(f"trainingStack.libs.{lib} must pin an exact version for a real run")
     return errors
 

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -161,8 +161,13 @@ def validate_manifest(
             # #1700 nit #3). A status:"trained" manifest with revision:null is
             # half-recorded -- hf_push.py published to hfRepo but never recorded
             # which commit, so the eval can't be reproduced from the manifest.
-            if _is_pending(artifact_block.get("revision")):
-                errors.append("artifact.revision is pending — a real run must pin the published weights revision")
+            # A blank/whitespace string is just as useless as a pending
+            # placeholder for a reproducibility pin, so reject both (codex P2
+            # PRRT_kwDORJXyws6O7cKg: previously only null/"pending-*" was
+            # rejected, letting an empty revision slip through the gate).
+            revision = artifact_block.get("revision")
+            if _is_pending(revision) or not (isinstance(revision, str) and revision.strip()):
+                errors.append("artifact.revision is pending or blank — a real run must pin the published weights revision")
         # dataRecipe provenance (codex P2 PRRT_kwDORJXyws6Otp-E): a published run
         # must carry the dataset hash + generator git-sha so the eval split is
         # reproducible. The committed scaffold leaves them null (no canonical

--- a/model-lab/common/manifest_schema.py
+++ b/model-lab/common/manifest_schema.py
@@ -243,7 +243,12 @@ def _validate_training_stack(
         # task-required lib passed strict validation (kilo WARNING
         # PRRT_kwDORJXyws6OtyS- for the null-declared case; this closes the
         # omitted-key case). dict.fromkeys dedupes the three sources.
-        task_libs = TASK_REQUIRED_LIBS.get(task, ()) if task else ()
+        # Guard against an unhashable 'task' (array/object): the validator is
+        # documented to RETURN human-readable errors, not raise. A bad task is
+        # already reported via the KNOWN_TASKS check above; here we just skip the
+        # per-task matrix so a malformed manifest cannot TypeError out of strict
+        # validation (codex P2 PRRT_kwDORJXyws6O6gBM).
+        task_libs = TASK_REQUIRED_LIBS.get(task, ()) if isinstance(task, str) else ()
         check_libs = dict.fromkeys(("torch", "transformers", *task_libs, *libs.keys()))
         for lib in check_libs:
             ver = libs.get(lib)

--- a/model-lab/correction-intent/eval.py
+++ b/model-lab/correction-intent/eval.py
@@ -209,7 +209,20 @@ def main(argv: list[str] | None = None) -> int:
     # NOT called here. The inference path below is the one that loads the
     # trained checkpoint and runs forward passes, which is what actually needs
     # torch/transformers; the gate is scoped to that path.
-    if args.predictions and args.predictions.is_file():
+    if args.predictions is not None:
+        # predictions was SUPPLIED. The offline-scoring path does not need the
+        # GPU stack, so a missing/not-a-file path must surface as a bad-path
+        # error -- not a missing-torch error on a CPU-only host (codex P2
+        # PRRT_kwDORJXyws6O6gBM: a typoed --predictions path used to fall through
+        # to the inference branch and gate the GPU stack first).
+        if not args.predictions.is_file():
+            print(
+                "eval.py: --predictions <model-output.jsonl> is not a readable file.\n"
+                f"  supplied path: {args.predictions}\n"
+                "  Check the path and re-run; offline scoring needs pre-computed predictions.",
+                file=sys.stderr,
+            )
+            return 2
         return _score_offline(args)
 
     # Inference path (no --predictions): generate predictions by running the

--- a/model-lab/correction-intent/eval.py
+++ b/model-lab/correction-intent/eval.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -121,51 +122,41 @@ def _held_out_is_predictions(held_out: Path, predictions: Path) -> bool:
     """True when --predictions resolves to the same file as --held-out.
 
     Pure (no torch) so the guard is unit-testable; ``main`` calls this before
-    loading rows. Uses resolve() so a symlink or a rel/abs alias can't bypass the
-    guard (codex P1 — scoring gold against itself fabricates a perfect eval that
-    could be copied into the manifest, rule 55).
+    loading rows. ``resolve()`` catches same-path and symlink circular eval;
+    a HARD LINK (different path, same inode) is caught via ``os.path.samefile``
+    which compares ``(st_dev, st_ino)`` (issue #1700 nit #4). Without it a hard
+    link to the held-out file scores gold against itself and fabricates a
+    perfect eval that could be copied into the manifest (codex P1, rule 55).
     """
     try:
-        return held_out.resolve() == predictions.resolve()
+        if held_out.resolve() == predictions.resolve():
+            return True
     except OSError:
-        # A broken symlink shouldn't crash eval; the is_file() checks above
+        # A broken symlink should not crash eval; the is_file() checks above
         # already rejected a missing predictions file.
         return False
+    # Hard link: different path, same inode. resolve() misses it because the
+    # two paths differ; os.path.samefile stats both and compares the inode
+    # pair so it bites. (samefile follows symlinks, so a symlinked pair is
+    # already handled by the resolve() check above.)
+    try:
+        if os.path.samefile(held_out, predictions):
+            return True
+    except OSError:
+        pass
+    return False
 
+def _score_offline(args: argparse.Namespace) -> int:
+    """Offline scoring: --predictions are pre-computed model-inference JSONL.
 
-def main(argv: list[str] | None = None) -> int:
-    parser = build_arg_parser()
-    args = parser.parse_args(argv)
-
-    require_eval_deps()
-
-    if not args.held_out or not args.held_out.is_file():
-        print(
-            "eval.py: --held-out <gold.jsonl> is required to score the model.\n"
-            "  No manifest eval block is written without a real run (rule 55).",
-            file=sys.stderr,
-        )
-        return 2
-
-    # Predictions MUST come from model inference. Scoring gold against itself
-    # (pred == gold) would emit perfect detection/span metrics with no trained
-    # checkpoint loaded — a fabrication that could be copied into the manifest
-    # (codex P1). Refuse it; the model-inference loop lands in the #1585 GPU-run
-    # follow-up, or an operator supplies --predictions from a served model.
-    if not args.predictions or not args.predictions.is_file():
-        print(
-            "eval.py: --predictions <model-output.jsonl> is required to score the model.\n"
-            "  Run the trained checkpoint's inference over the held-out split first;\n"
-            "  scoring gold labels against themselves is refused (no fabricated evals, rule 55).",
-            file=sys.stderr,
-        )
-        return 2
-
+    Pure JSONL + stdlib metrics — no GPU stack needed (issue #1700 nit #1). The
+    inference path (no --predictions) is gated separately in ``main``.
+    """
     # Refuse the held-out file (or a symlink/hardlink to it) as --predictions:
     # scoring gold against itself emits perfect detection/span metrics with no
     # inference — a fabrication that could be copied into the manifest (codex
-    # P1). _held_out_is_predictions compares RESOLVED paths so a symlink or a
-    # relative/absolute alias can't bypass the guard.
+    # P1). _held_out_is_predictions compares RESOLVED paths AND inode equality
+    # so a symlink, a relative/absolute alias, or a hard link cannot bypass it.
     if _held_out_is_predictions(args.held_out, args.predictions):
         print(
             "eval.py: --predictions resolves to the same file as --held-out.\n"
@@ -199,6 +190,44 @@ def main(argv: list[str] | None = None) -> int:
     )
     return 0
 
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if not args.held_out or not args.held_out.is_file():
+        print(
+            "eval.py: --held-out <gold.jsonl> is required to score the model.\n"
+            "  No manifest eval block is written without a real run (rule 55).",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Offline-scoring path (issue #1700 nit #1): pre-computed model-inference
+    # predictions are supplied. The scoring math is JSONL + stdlib only, so it
+    # runs on a CPU-only host WITHOUT the GPU stack — require_eval_deps() is
+    # NOT called here. The inference path below is the one that loads the
+    # trained checkpoint and runs forward passes, which is what actually needs
+    # torch/transformers; the gate is scoped to that path.
+    if args.predictions and args.predictions.is_file():
+        return _score_offline(args)
+
+    # Inference path (no --predictions): generate predictions by running the
+    # trained checkpoint over the held-out split. This is the GPU-gated path —
+    # require_eval_deps() fires here so the stack is checked before any model
+    # load. The inline inference loop lands in the #1585 GPU-run follow-up;
+    # until then, refuse with a clear pointer so a half-wired inference cannot
+    # be scored as a real eval (rule 55). An operator with a served model passes
+    # its JSONL output via --predictions (the offline path above).
+    require_eval_deps()
+    print(
+        "eval.py: --predictions <model-output.jsonl> is required to score.\n"
+        "  Offline scoring needs pre-computed predictions; the inline inference\n"
+        "  loop (trained checkpoint -> held-out predictions) lands in the #1585\n"
+        "  GPU-run follow-up. Run inference first and pass its JSONL here.",
+        file=sys.stderr,
+    )
+    return 2
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/model-lab/correction-intent/manifest.json
+++ b/model-lab/correction-intent/manifest.json
@@ -41,6 +41,7 @@
       "peft": null,
       "datasets": null,
       "huggingface-hub": null,
+      "accelerate": null,
       "bitsandbytes": null
     },
     "pipFreezeSha256": null,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2005,6 +2005,11 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessLocalParseFallback": {
+        "type": "boolean",
+        "default": false,
+        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
+      },
       "extractionFaithfulnessBaseUrl": {
         "type": "string",
         "default": "",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2005,6 +2005,11 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessLocalParseFallback": {
+        "type": "boolean",
+        "default": false,
+        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
+      },
       "extractionFaithfulnessBaseUrl": {
         "type": "string",
         "default": "",

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1555,6 +1555,53 @@ test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback does NOT 
   }
 });
 
+test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback falls back when the local response is a PARTIAL verdict array (codex P2 PRRT_kwDORJXyws6O6zwZ)", async () => {
+  // Flag ON: a local endpoint that returns a valid-but-INCOMPLETE verdict
+  // array (1 of N entries) must fall through to the configured chain, NOT be
+  // accepted as-is. parseFaithfulnessResponse is truthy as soon as ONE entry
+  // is valid, so the previous guard accepted the partial response and the
+  // missing indexes surfaced as malformed_output downstream -- defeating the
+  // resilient fallback. Accept the local response only when it covers every
+  // expected index.
+  const inputs = [
+    { factText: "Fact A", quote: "Quote A" },
+    { factText: "Fact B", quote: "Quote B" },
+  ];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+    extractionFaithfulnessLocalParseFallback: true,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  // Local endpoint returns only index 0 -- index 1 is missing (partial).
+  const { fetch: partialFetch } = fakeFetchFor("http://localhost:11434/v1", () => ({
+    model: "remnic-faithfulness-gate-v1",
+    choices: [{ message: { content: JSON.stringify([{ index: 0, verdict: "contradicted" }]) } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(
+      JSON.stringify([
+        { index: 0, verdict: "entailed" },
+        { index: 1, verdict: "unsupported" },
+      ]),
+      fallbackCalls,
+    ),
+    partialFetch,
+  );
+  assert.equal(
+    fallbackCalls.length,
+    1,
+    "a partial local verdict array must fall through to the configured chain",
+  );
+  // The chain's complete verdict array is used for both indexes.
+  assert.equal(result.results[0]?.ok && result.results[0].verdict, "entailed");
+  assert.equal(result.results[1]?.ok && result.results[1].verdict, "unsupported");
+});
+
 test('parseConfig: extractionFaithfulnessLocalParseFallback coerces CLI string "true" (#1700 review — coerceBool parity)', () => {
   // A CLI override reaches the parser as the string "true"; === true would
   // silently leave the flag disabled. coerceBool must turn it on (gotcha 36).

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -26,6 +26,7 @@ import type { FaithfulnessResult } from "./extraction-faithfulness.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { MemoryFrontmatter } from "./types.js";
+import { callOpenAiCompatibleChat } from "./local-model-endpoint.js";
 
 // ---------------------------------------------------------------------------
 // Helpers — stub LLM clients
@@ -1428,4 +1429,128 @@ test("checkFaithfulnessBatch: local-endpoint failure does NOT leak the local mod
     "local-only model name must NOT leak into the fallback chain on endpoint failure",
   );
   assert.equal(result.results[0]?.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1700 nits #5 + #6: probe signal forwarding + local parse-fallback
+// ---------------------------------------------------------------------------
+
+test("callOpenAiCompatibleChat: a pre-aborted batch signal aborts the probe immediately, not after timeoutMs (#1700 nit #5)", async () => {
+  // The batch signal is ALREADY aborted when the probe starts. With nit #5 the
+  // probe forwards it and aborts instantly; without it the probe would wait for
+  // its own timeoutMs (5000ms here). Assert the probe returns null fast.
+  const endpoint = { baseUrl: "http://localhost:11434/v1", model: "remnic-faithfulness-gate-v1" };
+  const batchController = new AbortController();
+  batchController.abort();
+  const spy = ((_url: string, init: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      const sig = init.signal;
+      if (!sig) return reject(new Error("no signal"));
+      if (sig.aborted) return reject(new Error("aborted"));
+      sig.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    })) as unknown as typeof fetch;
+  const start = Date.now();
+  const result = await callOpenAiCompatibleChat(
+    endpoint,
+    [{ role: "user", content: "hi" }],
+    { timeoutMs: 5000, signal: batchController.signal },
+    spy,
+  );
+  const elapsed = Date.now() - start;
+  assert.equal(result, null, "a pre-aborted signal must fail the probe closed (null)");
+  assert.ok(
+    elapsed < 1000,
+    `probe must abort immediately on a pre-aborted signal (${elapsed}ms), not wait timeoutMs`,
+  );
+});
+
+test("checkFaithfulnessBatch: default surfaces malformed_output for a 200-with-garbage local response (#1700 nit #6)", async () => {
+  // extractionFaithfulnessLocalParseFallback unset (default false): a local
+  // endpoint returning 200 with non-verdict JSON surfaces malformed_output so a
+  // misconfigured endpoint is visible. The configured chain must NOT run.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  const { fetch: garbageFetch } = fakeFetchFor("http://localhost:11434/v1", () => ({
+    model: "remnic-faithfulness-gate-v1",
+    choices: [{ message: { content: "this is not a verdict array" } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    garbageFetch,
+  );
+  assert.equal(fallbackCalls.length, 0, "chain must NOT run when flag is off — garbage surfaces loudly");
+  assert.equal(result.results[0]?.ok, false);
+  if (!result.results[0]?.ok) {
+    assert.equal(result.results[0].error.code, "malformed_output");
+  }
+});
+
+test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback falls back to the chain on local parse failure (#1700 nit #6)", async () => {
+  // Flag ON: the same 200-with-garbage local response now falls through to the
+  // configured chain instead of surfacing malformed_output (resilient fallback).
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+    extractionFaithfulnessLocalParseFallback: true,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  const { fetch: garbageFetch } = fakeFetchFor("http://localhost:11434/v1", () => ({
+    model: "remnic-faithfulness-gate-v1",
+    choices: [{ message: { content: "this is not a verdict array" } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    garbageFetch,
+  );
+  assert.equal(
+    fallbackCalls.length,
+    1,
+    "chain MUST run when flag is on and the local response is unparseable",
+  );
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "entailed", "fallback chain verdict is used");
+  }
+});
+
+test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback does NOT fall back when the local response is valid (#1700 nit #6 regression)", async () => {
+  // Flag ON but the local response IS a valid verdict array → use it, do not
+  // call the chain. Guards against the flag over-triggering on good responses.
+  const inputs = [{ factText: "Fact", quote: "Quote" }];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+    extractionFaithfulnessLocalParseFallback: true,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  const { fetch: goodFetch } = fakeFetchFor("http://localhost:11434/v1", () => ({
+    model: "remnic-faithfulness-gate-v1",
+    choices: [{ message: { content: JSON.stringify([{ index: 0, verdict: "contradicted" }]) } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(JSON.stringify([{ index: 0, verdict: "entailed" }]), fallbackCalls),
+    goodFetch,
+  );
+  assert.equal(fallbackCalls.length, 0, "chain must NOT run when the local response is valid, even with the flag on");
+  assert.equal(result.results[0]?.ok, true);
+  if (result.results[0]?.ok) {
+    assert.equal(result.results[0].verdict, "contradicted", "valid local verdict is used");
+  }
 });

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1602,6 +1602,55 @@ test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback falls bac
   assert.equal(result.results[1]?.ok && result.results[1].verdict, "unsupported");
 });
 
+test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback falls back when local indexes are fractional/non-contiguous (codex P2 PRRT_kwDORJXyws6O7PfY)", async () => {
+  // Flag ON: a malformed local response with expectedCount distinct but
+  // NON-INTEGER indexes (e.g. 0 and 0.5 for a two-item batch) must NOT be
+  // accepted. parseFaithfulnessResponse used to admit any numeric index, so a
+  // size-only check passed while index 1 stayed missing -> malformed_output.
+  // parseEntries now rejects non-integer indexes, and the gate requires every
+  // integer key 0..N-1 before accepting the local response.
+  const inputs = [
+    { factText: "Fact A", quote: "Quote A" },
+    { factText: "Fact B", quote: "Quote B" },
+  ];
+  const config = parseConfig({
+    extractionFaithfulnessModel: "remnic-faithfulness-gate-v1",
+    extractionFaithfulnessBaseUrl: "http://localhost:11434/v1",
+    extractionFaithfulnessTimeoutMs: 5000,
+    extractionFaithfulnessLocalParseFallback: true,
+  });
+  const fallbackCalls: Array<{ messages: unknown; options: unknown }> = [];
+  // Local endpoint returns indexes 0 and 0.5 -- two distinct keys, but index 1
+  // is missing (fractional index is invalid).
+  const { fetch: fracFetch } = fakeFetchFor("http://localhost:11434/v1", () => ({
+    model: "remnic-faithfulness-gate-v1",
+    choices: [{ message: { content: JSON.stringify([
+      { index: 0, verdict: "contradicted" },
+      { index: 0.5, verdict: "entailed" },
+    ]) } }],
+  }));
+  const result = await checkFaithfulnessBatch(
+    inputs,
+    config,
+    null,
+    stubFallbackLlm(
+      JSON.stringify([
+        { index: 0, verdict: "entailed" },
+        { index: 1, verdict: "unsupported" },
+      ]),
+      fallbackCalls,
+    ),
+    fracFetch,
+  );
+  assert.equal(
+    fallbackCalls.length,
+    1,
+    "a fractional/non-contiguous local response must fall through to the chain",
+  );
+  assert.equal(result.results[0]?.ok && result.results[0].verdict, "entailed");
+  assert.equal(result.results[1]?.ok && result.results[1].verdict, "unsupported");
+});
+
 test('parseConfig: extractionFaithfulnessLocalParseFallback coerces CLI string "true" (#1700 review — coerceBool parity)', () => {
   // A CLI override reaches the parser as the string "true"; === true would
   // silently leave the flag disabled. coerceBool must turn it on (gotcha 36).

--- a/packages/remnic-core/src/extraction-faithfulness.test.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.test.ts
@@ -1554,3 +1554,22 @@ test("checkFaithfulnessBatch: extractionFaithfulnessLocalParseFallback does NOT 
     assert.equal(result.results[0].verdict, "contradicted", "valid local verdict is used");
   }
 });
+
+test('parseConfig: extractionFaithfulnessLocalParseFallback coerces CLI string "true" (#1700 review — coerceBool parity)', () => {
+  // A CLI override reaches the parser as the string "true"; === true would
+  // silently leave the flag disabled. coerceBool must turn it on (gotcha 36).
+  const onByString = parseConfig({
+    extractionFaithfulnessLocalParseFallback: "true",
+  });
+  assert.equal(onByString.extractionFaithfulnessLocalParseFallback, true);
+  const onByBool = parseConfig({
+    extractionFaithfulnessLocalParseFallback: true,
+  });
+  assert.equal(onByBool.extractionFaithfulnessLocalParseFallback, true);
+  const offDefault = parseConfig({});
+  assert.equal(offDefault.extractionFaithfulnessLocalParseFallback, false);
+  const offByString = parseConfig({
+    extractionFaithfulnessLocalParseFallback: "false",
+  });
+  assert.equal(offByString.extractionFaithfulnessLocalParseFallback, false);
+});

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -220,6 +220,27 @@ export function parseFaithfulnessResponse(
   return null;
 }
 
+/**
+ * True when `map` contains an entry for every integer index in
+ * [0, expectedCount). The local parse-fallback gate uses this to accept a
+ * local model-lab response only when it is COMPLETE: size alone is
+ * insufficient because a malformed response with duplicate/fractional indexes
+ * can yield expectedCount distinct map keys without covering index 0..N-1
+ * (codex P2 PRRT_kwDORJXyws6O7PfY). parseEntries now rejects non-integer
+ * indexes so the two checks agree, but the explicit coverage loop documents
+ * the invariant and stays robust to any future parser relaxation.
+ */
+function coversAllIndexes(
+  map: Map<number, ParsedFaithfulnessEntry>,
+  expectedCount: number,
+): boolean {
+  if (map.size < expectedCount) return false;
+  for (let i = 0; i < expectedCount; i++) {
+    if (!map.has(i)) return false;
+  }
+  return true;
+}
+
 function parseEntries(
   data: unknown,
   expectedCount: number,
@@ -243,7 +264,7 @@ function parseEntries(
     if (!entry || typeof entry !== "object") continue;
     const obj = entry as Record<string, unknown>;
     const idx = typeof obj.index === "number" ? obj.index : undefined;
-    if (idx === undefined || idx < 0 || idx >= expectedCount) continue;
+    if (idx === undefined || !Number.isInteger(idx) || idx < 0 || idx >= expectedCount) continue;
     const verdictRaw = typeof obj.verdict === "string" ? obj.verdict : undefined;
     if (!verdictRaw || !VALID_VERDICTS.has(verdictRaw)) continue;
     const rationale =
@@ -339,7 +360,7 @@ async function callFaithfulnessLlm(
         return { content: result.content, modelUsed: result.modelUsed };
       }
       const parsedLocal = parseFaithfulnessResponse(result.content, expectedCount);
-      if (parsedLocal && parsedLocal.size === expectedCount) {
+      if (parsedLocal && coversAllIndexes(parsedLocal, expectedCount)) {
         return { content: result.content, modelUsed: result.modelUsed };
       }
       log.debug(

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -279,6 +279,7 @@ interface LlmCallResult {
 async function callFaithfulnessLlm(
   systemPrompt: string,
   userPrompt: string,
+  expectedCount: number,
   config: PluginConfig,
   localLlm: LocalLlmClient | null,
   fallbackLlm: FallbackLlmClient | null,
@@ -311,15 +312,38 @@ async function callFaithfulnessLlm(
     const result = await callOpenAiCompatibleChat(
       localEndpoint,
       messages,
-      { temperature: 0.1, maxTokens: 2048, responseFormatJson: true, timeoutMs: probeBudgetMs },
+      {
+        temperature: 0.1,
+        maxTokens: 2048,
+        responseFormatJson: true,
+        timeoutMs: probeBudgetMs,
+        // Forward the batch signal so the probe aborts the instant the batch
+        // budget elapses, not after probeBudgetMs (issue #1700 nit #5).
+        ...(signal ? { signal } : {}),
+      },
       fetchImpl,
     );
     if (result?.content) {
-      return { content: result.content, modelUsed: result.modelUsed };
+      // Issue #1700 nit #6: pre-validate the local endpoint response shape.
+      // Default (extractionFaithfulnessLocalParseFallback=false) returns the
+      // content as-is -- a 200-with-garbage local response surfaces
+      // malformed_output, alerting the operator to a misconfigured endpoint.
+      // When the operator opts into resilient fallback, an unparseable local
+      // response falls through to the configured chain instead of surfacing.
+      if (
+        !config.extractionFaithfulnessLocalParseFallback ||
+        parseFaithfulnessResponse(result.content, expectedCount)
+      ) {
+        return { content: result.content, modelUsed: result.modelUsed };
+      }
+      log.debug(
+        "extraction-faithfulness: local endpoint returned unparseable output; falling back to configured chain",
+      );
+    } else {
+      log.debug(
+        "extraction-faithfulness: local model-lab endpoint unavailable, trying configured chain",
+      );
     }
-    log.debug(
-      "extraction-faithfulness: local model-lab endpoint unavailable, trying configured chain",
-    );
   }
 
   // extractionFaithfulnessModel is the LOCAL served model's name (e.g.
@@ -532,6 +556,7 @@ export async function checkFaithfulnessBatch(
     const callPromise = callFaithfulnessLlm(
       FAITHFULNESS_SYSTEM_PROMPT,
       userPrompt,
+      checkableInputs.length,
       config,
       localLlm,
       fallbackLlm,

--- a/packages/remnic-core/src/extraction-faithfulness.ts
+++ b/packages/remnic-core/src/extraction-faithfulness.ts
@@ -328,16 +328,22 @@ async function callFaithfulnessLlm(
       // Default (extractionFaithfulnessLocalParseFallback=false) returns the
       // content as-is -- a 200-with-garbage local response surfaces
       // malformed_output, alerting the operator to a misconfigured endpoint.
-      // When the operator opts into resilient fallback, an unparseable local
-      // response falls through to the configured chain instead of surfacing.
-      if (
-        !config.extractionFaithfulnessLocalParseFallback ||
-        parseFaithfulnessResponse(result.content, expectedCount)
-      ) {
+      // When the operator opts into resilient fallback, an unparseable OR
+      // PARTIAL local response falls through to the configured chain instead
+      // of surfacing. parseFaithfulnessResponse is truthy as soon as ONE entry
+      // is valid, so accept the local response only when the parsed verdict
+      // map covers every expected index -- otherwise the missing indexes would
+      // surface as malformed_output downstream, defeating the resilient
+      // fallback (codex P2 PRRT_kwDORJXyws6O6zwZ).
+      if (!config.extractionFaithfulnessLocalParseFallback) {
+        return { content: result.content, modelUsed: result.modelUsed };
+      }
+      const parsedLocal = parseFaithfulnessResponse(result.content, expectedCount);
+      if (parsedLocal && parsedLocal.size === expectedCount) {
         return { content: result.content, modelUsed: result.modelUsed };
       }
       log.debug(
-        "extraction-faithfulness: local endpoint returned unparseable output; falling back to configured chain",
+        "extraction-faithfulness: local endpoint returned incomplete/unparseable output; falling back to configured chain",
       );
     } else {
       log.debug(

--- a/packages/remnic-core/src/faithfulness-config.ts
+++ b/packages/remnic-core/src/faithfulness-config.ts
@@ -67,6 +67,7 @@ export function parseFaithfulnessGateConfig(cfg: Record<string, unknown>): {
   extractionFaithfulnessBaseUrl: string;
   extractionFaithfulnessContextChars: number;
   extractionFaithfulnessTimeoutMs: number;
+  extractionFaithfulnessLocalParseFallback: boolean;
 } {
   const gateValue = cfg.extractionFaithfulnessGate;
   let extractionFaithfulnessGate: "off" | "shadow" | "enforce";
@@ -105,12 +106,20 @@ export function parseFaithfulnessGateConfig(cfg: Record<string, unknown>): {
     60_000,
   );
 
+  // Issue #1700 nit #6: resilient-fallback toggle for the local model-lab
+  // endpoint. Default false preserves the loud-signal behavior (a 200-with-
+  // garbage local response surfaces malformed_output so a misconfigured
+  // endpoint is visible); true falls back to the configured chain on local
+  // parse failure. Byte-identical pre-feature when unset (rule 39).
+  const extractionFaithfulnessLocalParseFallback = cfg.extractionFaithfulnessLocalParseFallback === true;
+
   return {
     extractionFaithfulnessGate,
     extractionFaithfulnessModel,
     extractionFaithfulnessBaseUrl,
     extractionFaithfulnessContextChars,
     extractionFaithfulnessTimeoutMs,
+    extractionFaithfulnessLocalParseFallback,
   };
 }
 

--- a/packages/remnic-core/src/faithfulness-config.ts
+++ b/packages/remnic-core/src/faithfulness-config.ts
@@ -17,7 +17,7 @@
  * `config.ts` spread the result in one line.
  */
 
-import { coerceNumber } from "./connectors/coerce.js";
+import { coerceBool, coerceNumber } from "./connectors/coerce.js";
 
 /**
  * Parse a value as a strict integer >= `min`, throwing on anything else.
@@ -111,7 +111,13 @@ export function parseFaithfulnessGateConfig(cfg: Record<string, unknown>): {
   // garbage local response surfaces malformed_output so a misconfigured
   // endpoint is visible); true falls back to the configured chain on local
   // parse failure. Byte-identical pre-feature when unset (rule 39).
-  const extractionFaithfulnessLocalParseFallback = cfg.extractionFaithfulnessLocalParseFallback === true;
+  // coerceBool for CLI-string parity: a CLI override like
+  // --config extractionFaithfulnessLocalParseFallback=true reaches here as the
+  // string "true"; === true would silently leave the flag disabled. Matches
+  // every other CLI-settable boolean in config.ts (gotcha 36, codex P2
+  // PRRT_kwDORJXyws6O6gDQ / cursor BUGBOT e273b22c).
+  const extractionFaithfulnessLocalParseFallback =
+    coerceBool(cfg.extractionFaithfulnessLocalParseFallback) === true;
 
   return {
     extractionFaithfulnessGate,

--- a/packages/remnic-core/src/local-model-endpoint.ts
+++ b/packages/remnic-core/src/local-model-endpoint.ts
@@ -42,10 +42,15 @@ export interface EndpointChatMessage {
 
 /** Options for a single local-endpoint chat call. */
 export interface EndpointChatOptions {
-  /** Per-call timeout in ms. The caller's batch AbortSignal is NOT forwarded
-   *  (matches the local-LLM precedent: each attempt is bounded by its own
-   *  timer so one slow server can't starve the batch). */
+  /** Per-call timeout in ms. Bounds each attempt so one slow server can't
+   *  starve the batch (matches the local-LLM precedent). */
   timeoutMs: number;
+  /** Optional batch AbortSignal forwarded into the probe (issue #1700 nit #5).
+   *  When the batch budget elapses (or the caller aborts), the in-flight probe
+   *  aborts immediately instead of waiting for its own `timeoutMs` — a
+   *  micro-optimization, not a correctness fix (the outer race already bounds
+   *  the total). Undefined preserves the prior per-attempt-only behavior. */
+  signal?: AbortSignal;
   /** Sampling temperature — classification wants low entropy (0.0–0.2). */
   temperature?: number;
   /** Max output tokens. */
@@ -119,6 +124,21 @@ export async function callOpenAiCompatibleChat(
   const url = joinBaseUrl(endpoint.baseUrl, "/chat/completions");
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+  // Forward the batch AbortSignal into the probe (issue #1700 nit #5): if the
+  // batch budget already elapsed, abort the in-flight probe immediately rather
+  // than waiting for the probe's own timeoutMs. AbortSignal.any is ES2024
+  // (forbidden here); wire the listener manually + guard the already-aborted
+  // case. The fetch still uses the probe's controller, so clearing the timer
+  // below is the only cleanup needed.
+  const batchSignal = options.signal;
+  const onBatchAbort = () => controller.abort();
+  if (batchSignal) {
+    if (batchSignal.aborted) {
+      controller.abort();
+    } else {
+      batchSignal.addEventListener("abort", onBatchAbort, { once: true });
+    }
+  }
   try {
     const body: Record<string, unknown> = {
       model: endpoint.model,
@@ -150,6 +170,7 @@ export async function callOpenAiCompatibleChat(
     return { content, modelUsed: extractModel(parsed) ?? endpoint.model };
   } finally {
     clearTimeout(timer);
+    if (batchSignal) batchSignal.removeEventListener("abort", onBatchAbort);
   }
 }
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1223,6 +1223,14 @@ export interface PluginConfig {
   /** Per-batch timeout in ms; timeout → tagged error, never blocks writes. Default 8000. */
   extractionFaithfulnessTimeoutMs: number;
   /**
+   * Resilient-fallback toggle for the local model-lab endpoint (issue #1700
+   * nit #6). When the local endpoint returns 200 with non-verdict JSON, the
+   * default (false) surfaces `malformed_output` so a misconfigured endpoint is
+   * visible to the operator. Set true to instead fall back to the configured
+   * chain on local parse failure (pre-validated via parseFaithfulnessResponse).
+   */
+  extractionFaithfulnessLocalParseFallback: boolean;
+  /**
    * Correction-intent model-lab pointer (issue #1581 / #1585). When both this
    * and `correctionIntentBaseUrl` are set, the detection path can route to a
    * local fine-tuned correction-intent classifier. Empty default keeps the

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2005,6 +2005,11 @@
         "default": 8000,
         "description": "Per-batch timeout in ms for the faithfulness check. Timeout produces a tagged error and never blocks memory writes (graceful degradation)."
       },
+      "extractionFaithfulnessLocalParseFallback": {
+        "type": "boolean",
+        "default": false,
+        "description": "Resilient-fallback toggle for the local model-lab faithfulness endpoint (issue #1700). Default false surfaces malformed_output when the local endpoint returns 200 with non-verdict JSON (alerts the operator to a misconfigured endpoint). Set true to instead fall back to the configured chain on local parse failure."
+      },
       "extractionFaithfulnessBaseUrl": {
         "type": "string",
         "default": "",

--- a/tests/model-lab-eval-guard.test.mjs
+++ b/tests/model-lab-eval-guard.test.mjs
@@ -67,20 +67,38 @@ test(
   { skip: skipReason },
   () => {
     const r = runEvalProbe(`
+# Stub the GPU gate so the test is independent of whether torch/transformers
+# are installed on this host (codex P2 PRRT_kwDORJXyws6O7vG1). The offline
+# --predictions path must NOT call require_eval_deps at all; the stub records
+# any call and raises SystemExit(99) so a regression is observable even on a
+# GPU box where the real gate returns normally.
+gate_calls = []
+_orig_gate = m.require_eval_deps
+def _stub_gate():
+    gate_calls.append(1)
+    raise SystemExit(99)
+m.require_eval_deps = _stub_gate
 with contextlib.redirect_stdout(open(os.devnull, "w")):
     try:
         rc = m.main(["--held-out", str(gold), "--predictions", str(preds)])
         result["offline_rc"] = rc
     except SystemExit as e:
         result["offline_systemexit"] = e.code
+    finally:
+        m.require_eval_deps = _orig_gate
+result["gate_called"] = len(gate_calls)
 `);
+    assert.equal(
+      r.gate_called,
+      0,
+      "offline scoring (--predictions) must NOT call require_eval_deps (no GPU-stack dependency)",
+    );
     assert.equal(
       r.offline_systemexit,
       undefined,
-      "offline scoring must NOT call require_eval_deps (no SystemExit); " +
-        "got SystemExit — the GPU gate leaked onto the offline path",
+      "offline scoring must not raise SystemExit (the GPU gate must not run)",
     );
-    assert.equal(r.offline_rc, 0, "offline scoring must return 0 (success) on a CPU-only host");
+    assert.equal(r.offline_rc, 0, "offline scoring must return 0 (success)");
   },
 );
 

--- a/tests/model-lab-eval-guard.test.mjs
+++ b/tests/model-lab-eval-guard.test.mjs
@@ -89,16 +89,34 @@ test(
   { skip: skipReason },
   () => {
     const r = runEvalProbe(`
+# Stub the GPU gate so the test outcome does NOT depend on whether
+# torch/transformers happen to be installed on this host (codex P2
+# PRRT_kwDORJXyws6O6zwe). The stub records the call and raises
+# SystemExit(2) to mirror the real gate on a missing GPU stack.
+gate_calls = []
+_orig_gate = m.require_eval_deps
+def _stub_gate():
+    gate_calls.append(1)
+    raise SystemExit(2)
+m.require_eval_deps = _stub_gate
 try:
     rc = m.main(["--held-out", str(gold)])
     result["inference_rc"] = rc
 except SystemExit as e:
     result["inference_systemexit"] = e.code
+finally:
+    m.require_eval_deps = _orig_gate
+result["gate_called"] = len(gate_calls)
 `);
+    assert.equal(
+      r.gate_called,
+      1,
+      "the inference path (no --predictions) must call the GPU gate (require_eval_deps)",
+    );
     assert.equal(
       r.inference_systemexit,
       2,
-      "the inference path (no --predictions) must gate the GPU stack (SystemExit 2 when torch missing)",
+      "the GPU gate must fire on the inference path (SystemExit 2), independent of installed deps",
     );
   },
 );

--- a/tests/model-lab-eval-guard.test.mjs
+++ b/tests/model-lab-eval-guard.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Correction-intent eval.py guards (issue #1700 nits #1 + #4).
+ *
+ * Nit #1: require_eval_deps() is scoped to the inference path — offline
+ * scoring via --predictions runs CPU-only; the no-predictions path gates the
+ * GPU stack.
+ *
+ * Nit #4: _held_out_is_predictions detects a HARD LINK to the held-out file
+ * (os.path.samefile), not just same-path / symlink.
+ *
+ * Shells out to the Python eval module (stdlib-only — no torch needed for the
+ * offline path or the pure guard), capability-guarded on python3 — same pattern
+ * as tests/model-lab-manifest-schema.test.mjs.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { skipUnlessCommand } from "./helpers/capability-probe.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pythonBin = process.env.PYTHON_BIN || "python3";
+const skipReason = skipUnlessCommand(
+  pythonBin,
+  "install Python 3.12+ (model-lab eval guards run stdlib-only Python)",
+);
+
+/**
+ * Run a Python snippet that imports the correction-intent eval module and
+ * reports a JSON result. The snippet is responsible for catching SystemExit
+ * (require_eval_deps raises it) and converting it to a code field.
+ */
+function runEvalProbe(body) {
+  const script = `
+import json, os, sys, tempfile, contextlib
+sys.path.insert(0, "model-lab")
+from pathlib import Path
+import importlib.util
+spec = importlib.util.spec_from_file_location("cieval", "model-lab/correction-intent/eval.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+d = Path(tempfile.mkdtemp())
+gold = d / "gold.jsonl"
+preds = d / "preds.jsonl"
+gold.write_text(json.dumps({"label": "correction", "corrections": [{"correctedAssertion": "we use postgres"}]}) + "\\n")
+preds.write_text(json.dumps({"label": "none"}) + "\\n")
+
+result = {}
+${body}
+print(json.dumps(result))
+`;
+  const res = spawnSync(pythonBin, ["-c", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (res.status !== 0) {
+    throw new Error(`probe exited ${res.status}:\n${res.stderr}\n${res.stdout}`);
+  }
+  return JSON.parse(res.stdout);
+}
+test(
+  "eval.py: offline scoring via --predictions SUCCEEDS with no GPU stack (#1700 nit #1)",
+  { skip: skipReason },
+  () => {
+    const r = runEvalProbe(`
+with contextlib.redirect_stdout(open(os.devnull, "w")):
+    try:
+        rc = m.main(["--held-out", str(gold), "--predictions", str(preds)])
+        result["offline_rc"] = rc
+    except SystemExit as e:
+        result["offline_systemexit"] = e.code
+`);
+    assert.equal(
+      r.offline_systemexit,
+      undefined,
+      "offline scoring must NOT call require_eval_deps (no SystemExit); " +
+        "got SystemExit — the GPU gate leaked onto the offline path",
+    );
+    assert.equal(r.offline_rc, 0, "offline scoring must return 0 (success) on a CPU-only host");
+  },
+);
+
+test(
+  "eval.py: no --predictions -> inference path gates the GPU stack (SystemExit 2) (#1700 nit #1)",
+  { skip: skipReason },
+  () => {
+    const r = runEvalProbe(`
+try:
+    rc = m.main(["--held-out", str(gold)])
+    result["inference_rc"] = rc
+except SystemExit as e:
+    result["inference_systemexit"] = e.code
+`);
+    assert.equal(
+      r.inference_systemexit,
+      2,
+      "the inference path (no --predictions) must gate the GPU stack (SystemExit 2 when torch missing)",
+    );
+  },
+);
+
+test(
+  "eval.py: _held_out_is_predictions detects a HARD LINK to the held-out file (#1700 nit #4)",
+  { skip: skipReason },
+  () => {
+    const r = runEvalProbe(`
+hard = d / "hardlink.jsonl"
+os.link(gold, hard)  # different path, same inode
+result["hardlink_detected"] = m._held_out_is_predictions(gold, hard)
+result["distinct_not_detected"] = m._held_out_is_predictions(gold, preds)
+`);
+    assert.equal(
+      r.hardlink_detected,
+      true,
+      "a hard link to the held-out file must be detected (same inode via os.path.samefile)",
+    );
+    assert.equal(
+      r.distinct_not_detected,
+      false,
+      "two genuinely-distinct files must NOT be flagged as the same file",
+    );
+  },
+);

--- a/tests/model-lab-eval-guard.test.mjs
+++ b/tests/model-lab-eval-guard.test.mjs
@@ -125,3 +125,26 @@ result["distinct_not_detected"] = m._held_out_is_predictions(gold, preds)
     );
   },
 );
+
+test(
+  "eval.py: a supplied-but-missing --predictions path reports a bad-path error, NOT a GPU-gate error (#1700 review PRRT_kwDORJXyws6O6gBM)",
+  { skip: skipReason },
+  () => {
+    const r = runEvalProbe(`
+missing = d / "does-not-exist.jsonl"
+try:
+    rc = m.main(["--held-out", str(gold), "--predictions", str(missing)])
+    result["badpath_rc"] = rc
+except SystemExit as e:
+    result["badpath_systemexit"] = e.code
+`);
+    // A typoed predictions path must NOT trigger the GPU gate (no SystemExit);
+    // it must return 2 with a clear bad-path message on a CPU-only host.
+    assert.equal(
+      r.badpath_systemexit,
+      undefined,
+      "a missing predictions path must not gate the GPU stack (no SystemExit)",
+    );
+    assert.equal(r.badpath_rc, 2, "a missing predictions path must return 2");
+  },
+);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -174,7 +174,8 @@ function makeValidTrainedManifest() {
       python: "3.12.3",
       libs: {
         torch: "2.12.1", transformers: "5.3.0", trl: "0.11.1", peft: "0.10.0",
-        datasets: "2.18.0", "huggingface-hub": "0.25.0", bitsandbytes: "0.43.1",
+        datasets: "2.18.0", "huggingface-hub": "0.25.0", accelerate: "1.14.0",
+        bitsandbytes: "0.43.1",
       },
       pipFreezeSha256: "freezehash",
       capturedAt: "2026-07-06",
@@ -341,8 +342,9 @@ test(
       fs.unlinkSync(tmp);
     }
 
-    // Same for datasets (named explicitly in #1700) and peft.
-    for (const lib of ["datasets", "peft"]) {
+    // Same for datasets (named explicitly in #1700), peft, and accelerate
+    // (Trainer/TRL runtime dep — required for both tasks, codex P2 PRRT_kwDORJXyws6O7kTC).
+    for (const lib of ["datasets", "peft", "accelerate"]) {
       const m2 = makeValidTrainedManifest();
       delete m2.trainingStack.libs[lib];
       const t = path.join(os.tmpdir(), `remnic-ci-tasklibs-${lib}-${process.pid}.json`);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -323,6 +323,29 @@ test(
 );
 
 test(
+  "manifest schema: strict mode REJECTS a task-required lib pinned to a BLANK string (codex P2 PRRT_kwDORJXyws6O7vGo)",
+  { skip: skipReason },
+  () => {
+    // A blank/whitespace version pin is as useless as a null one for
+    // reproducibility, but check_libs used to reject only pending/non-string
+    // values, letting "" / "  " slip through.
+    const m = makeValidTrainedManifest();
+    m.trainingStack.libs.accelerate = "   ";
+    const tmp = path.join(os.tmpdir(), `remnic-ci-blank-lib-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("trainingStack.libs.accelerate")),
+        `strict mode must reject a blank lib pin, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);
+
+test(
   "manifest schema: strict mode REJECTS a correction-intent manifest that OMITS a task-required lib (#1700 nit #2)",
   { skip: skipReason },
   () => {

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -300,6 +300,28 @@ test(
 );
 
 test(
+  "manifest schema: strict mode REJECTS a 'trained' manifest with a BLANK artifact.revision (codex P2 PRRT_kwDORJXyws6O7cKg)",
+  { skip: skipReason },
+  () => {
+    // A whitespace-only revision is a useless reproducibility pin; the gate
+    // used to reject only null/"pending-*" and let "  " through.
+    const m = makeValidTrainedManifest();
+    m.artifact.revision = "   ";
+    const tmp = path.join(os.tmpdir(), `remnic-ci-revision-blank-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("artifact.revision")),
+        `strict mode must reject a blank artifact.revision, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);
+
+test(
   "manifest schema: strict mode REJECTS a correction-intent manifest that OMITS a task-required lib (#1700 nit #2)",
   { skip: skipReason },
   () => {

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -238,3 +238,135 @@ test(
     }
   },
 );
+
+/** A fully-valid "trained" faithfulness-gate manifest (encoder baseline stack). */
+function makeValidTrainedFaithfulnessManifest() {
+  return JSON.parse(JSON.stringify({
+    task: "faithfulness-gate",
+    schemaVersion: 1,
+    status: "trained",
+    contract: { inputFields: ["factText", "quote", "context"], outputLabels: ["entailed", "contradicted", "unsupported"], source: "FaithfulnessCheckInput" },
+    baseModel: { name: "microsoft/deberta-v3-large" },
+    dataRecipe: {
+      generatorPath: "model-lab/faithfulness-gate/generate-data.py",
+      generatorGitSha: "deadbeef",
+      seed: 1337,
+      sources: ["synthetic-perturbation"],
+      counts: { entailed: 40, contradicted: 40, unsupported: 20, total: 100 },
+      datasetSha256: "abc123hash",
+    },
+    trainingStack: {
+      python: "3.12.3",
+      libs: {
+        torch: "2.12.1", transformers: "5.3.0", datasets: "3.6.0",
+        "huggingface-hub": "1.3.0", accelerate: "1.14.0", sentencepiece: "0.2.1",
+      },
+      pipFreezeSha256: "freezehash",
+      capturedAt: "2026-07-06",
+    },
+    hyperparams: { lr: 2e-5, epochs: 3 },
+    trainedAt: "2026-07-06T00:00:00Z",
+    hardware: { gpu: "RTX 3090" },
+    eval: { heldOut: { macroF1: 0.9 }, downstream: null },
+    artifact: { hfRepo: "op/faithfulness-gate-v1", revision: "abc", quantizations: ["fp16"] },
+    policyCompliance: { targetMaxParamsB: 4, actualParamsB: 0.4, escapeHatchUsed: false },
+  }));
+}
+
+test(
+  "manifest schema: strict mode REJECTS a 'trained' manifest with artifact.revision null (#1700 nit #3)",
+  { skip: skipReason },
+  () => {
+    const m = makeValidTrainedManifest();
+    m.artifact.revision = null; // hfRepo stays set; revision missing
+    const tmp = path.join(os.tmpdir(), `remnic-ci-revision-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("artifact.revision")),
+        `strict mode must reject a null artifact.revision, got: ${JSON.stringify(errors)}`,
+      );
+      // A fully-valid trained manifest (revision set) must still pass.
+      const tmp2 = path.join(os.tmpdir(), `remnic-ci-revision-ok-${process.pid}.json`);
+      fs.writeFileSync(tmp2, JSON.stringify(makeValidTrainedManifest()));
+      const { errors: okErrors } = validateManifest(tmp2, false);
+      assert.deepEqual(okErrors, [], `fully-recorded manifest must be valid, got: ${JSON.stringify(okErrors)}`);
+      fs.unlinkSync(tmp2);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);
+
+test(
+  "manifest schema: strict mode REJECTS a correction-intent manifest that OMITS a task-required lib (#1700 nit #2)",
+  { skip: skipReason },
+  () => {
+    // Omitting trl entirely (not just null) must fail strict — the per-task
+    // minimum matrix requires it for the causal-LM stack.
+    const m = makeValidTrainedManifest();
+    delete m.trainingStack.libs.trl;
+    const tmp = path.join(os.tmpdir(), `remnic-ci-tasklibs-ci-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      assert.ok(
+        errors.some((e) => e.includes("trainingStack.libs.trl")),
+        `strict mode must reject an omitted trl, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+
+    // Same for datasets (named explicitly in #1700) and peft.
+    for (const lib of ["datasets", "peft"]) {
+      const m2 = makeValidTrainedManifest();
+      delete m2.trainingStack.libs[lib];
+      const t = path.join(os.tmpdir(), `remnic-ci-tasklibs-${lib}-${process.pid}.json`);
+      fs.writeFileSync(t, JSON.stringify(m2));
+      try {
+        const { errors } = validateManifest(t, false);
+        assert.ok(
+          errors.some((e) => e.includes(`trainingStack.libs.${lib}`)),
+          `strict mode must reject an omitted ${lib}, got: ${JSON.stringify(errors)}`,
+        );
+      } finally {
+        fs.unlinkSync(t);
+      }
+    }
+  },
+);
+
+test(
+  "manifest schema: strict mode REJECTS a faithfulness-gate manifest missing its task-specific libs (#1700 nit #2)",
+  { skip: skipReason },
+  () => {
+    // The encoder baseline needs accelerate + sentencepiece (Trainer/tokenizer
+    // runtime deps). Omitting them must fail strict via the per-task matrix.
+    for (const lib of ["accelerate", "sentencepiece"]) {
+      const m = makeValidTrainedFaithfulnessManifest();
+      delete m.trainingStack.libs[lib];
+      const t = path.join(os.tmpdir(), `remnic-ci-fg-tasklibs-${lib}-${process.pid}.json`);
+      fs.writeFileSync(t, JSON.stringify(m));
+      try {
+        const { errors } = validateManifest(t, false);
+        assert.ok(
+          errors.some((e) => e.includes(`trainingStack.libs.${lib}`)),
+          `strict mode must reject a faithfulness-gate manifest omitting ${lib}, got: ${JSON.stringify(errors)}`,
+        );
+      } finally {
+        fs.unlinkSync(t);
+      }
+    }
+    // A fully-valid faithfulness-gate trained manifest must still pass.
+    const ok = path.join(os.tmpdir(), `remnic-ci-fg-ok-${process.pid}.json`);
+    fs.writeFileSync(ok, JSON.stringify(makeValidTrainedFaithfulnessManifest()));
+    try {
+      const { errors } = validateManifest(ok, false);
+      assert.deepEqual(errors, [], `fully-recorded faithfulness-gate manifest must be valid, got: ${JSON.stringify(errors)}`);
+    } finally {
+      fs.unlinkSync(ok);
+    }
+  },
+);

--- a/tests/model-lab-manifest-schema.test.mjs
+++ b/tests/model-lab-manifest-schema.test.mjs
@@ -370,3 +370,27 @@ test(
     }
   },
 );
+
+test(
+  "manifest schema: strict mode does not crash on an unhashable task value (#1700 review PRRT_kwDORJXyws6O6gBM)",
+  { skip: skipReason },
+  () => {
+    // A manifest whose 'task' is an array/object must not TypeError out of
+    // strict validation (the validator returns human-readable errors). Reuse a
+    // valid trained shape but set task to an unhashable array.
+    const m = makeValidTrainedManifest();
+    m.task = ["not", "a", "string"];
+    const tmp = path.join(os.tmpdir(), `remnic-ci-unhashable-${process.pid}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(m));
+    try {
+      const { errors } = validateManifest(tmp, false);
+      // Must return errors (bad task) WITHOUT throwing.
+      assert.ok(
+        Array.isArray(errors) && errors.length > 0,
+        `strict mode must return errors (not crash) for an unhashable task, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  },
+);


### PR DESCRIPTION
Closes #1700.

Batches the 6 deferred review nits from PR #1698 (issue #1585). All 6 are code/validation changes testable **without a GPU** (unit tests + the model-lab selfcheck); none require a live GPU run, so there is no GPU-gated remainder within #1700's scope.

## Nits

1. **Scope `eval.py require_eval_deps()` to inference mode** — `correction-intent/eval.py`'s GPU gate now fires only on the inference path (no `--predictions`). Offline scoring of pre-computed predictions is JSONL + stdlib only and runs CPU-only. Acceptance: `eval.py --held-out gold.jsonl --predictions preds.jsonl` succeeds on a CPU-only host; the inference path still gates the GPU stack.
2. **Task-aware required-lib matrix for strict manifests** — `manifest_schema.py` declares `TASK_REQUIRED_LIBS` (correction-intent → trl/peft/datasets/huggingface-hub; faithfulness-gate → datasets/huggingface-hub/accelerate/sentencepiece). A manifest that OMITS a task-required lib (not just one left null) now fails strict. `bitsandbytes` stays optional (the ≤8B QLoRA escape hatch).
3. **Require `artifact.revision` in strict manifests** — strict mode now rejects `artifact.revision: null` for a `status:"trained"` manifest (alongside the existing `hfRepo` check).
4. **Detect hard-linked held-out files** — `_held_out_is_predictions` adds `os.path.samefile` (`st_dev`/`st_ino`) so a hard link to the held-out file is caught, not just same-path/symlink.
5. **Forward the batch AbortSignal into the local probe** — `EndpointChatOptions.signal` is wired into the probe's controller so it aborts the instant the batch signal fires, before `probeBudgetMs`. Micro-optimization (the outer race already bounds the total), as the issue notes.
6. **Fall back on local-endpoint parse failure** — new `extractionFaithfulnessLocalParseFallback` config flag (default false). When on, a 200-with-garbage local response falls through to the configured chain (pre-validated via `parseFaithfulnessResponse`) instead of surfacing `malformed_output`. Default preserves the loud-signal path for a misconfigured endpoint.

## Config contract
New `PluginConfig` key `extractionFaithfulnessLocalParseFallback` (boolean, default false) synced to all 3 `openclaw.plugin.json` files (root, plugin-openclaw, shim). `check-config-contract` green.

## Chokepoints used / not applicable
- `parseFaithfulnessGateConfig` spread (the #1526 config extraction) owns the new key — no `config.ts` growth (ratchet respected).
- manifest validator task-awareness is a declared matrix in the validator module, not ad-hoc.
- No orchestrator/storage/access/core-god-file substantive edits (thin-wiring rule n/a).

## Tests
- `tests/model-lab-manifest-schema.test.mjs`: +3 tests (task matrix for both tasks, `artifact.revision`) + a faithfulness-gate valid-manifest helper.
- `tests/model-lab-eval-guard.test.mjs` (new): 3 tests for nit #1 (offline vs inference) + nit #4 (hardlink), capability-guarded on `python3`.
- `packages/remnic-core/src/extraction-faithfulness.test.ts`: +4 tests (pre-aborted signal, default malformed_output, fallback-on, valid-not-fallback regression).

## Verification
- `preflight:quick` green (lint, check-types, check-config-contract, check-review-patterns, check-ratchets, check-docs-parity, registration/sdk/access/cli surface tests).
- All touched-file tests pass: extraction-faithfulness 77/77, model-lab-manifest-schema 9/9, model-lab-eval-guard 3/3.
- No GPU-gated remainder: every nit is a code/validation change exercised CPU-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten manifest publishing gates and alter faithfulness local-endpoint failure modes (default stays loud; opt-in fallback). Core extraction routing and eval anti-fabrication guards are touched but covered by new tests.
> 
> **Overview**
> Implements six deferred review nits from #1698, all testable on CPU without a GPU run.
> 
> **Model-lab:** `correction-intent/eval.py` now runs offline scoring with `--predictions` using JSONL/stdlib only (no `require_eval_deps`); GPU gating applies only when inference would load a checkpoint. `_held_out_is_predictions` also rejects hard links via `os.path.samefile`. **Manifest strict validation** adds `TASK_REQUIRED_LIBS` per task (omitted keys fail, not just null pins), requires non-blank `artifact.revision`, and rejects blank lib version strings; malformed `task` types no longer crash validation.
> 
> **Remnic faithfulness routing:** New `extractionFaithfulnessLocalParseFallback` (default **false**) — garbage local HTTP 200 responses surface `malformed_output`; when **true**, incomplete or unparseable local verdict JSON falls through to the configured chain. Local acceptance requires integer indexes `0..N-1` via `coversAllIndexes` and stricter `parseEntries`. The batch `AbortSignal` is forwarded into `callOpenAiCompatibleChat` so probes abort with the batch budget.
> 
> **Tests/docs:** New `tests/model-lab-eval-guard.test.mjs`, expanded manifest-schema tests, and extraction-faithfulness tests for signal forwarding and parse-fallback behavior. Plugin JSON schemas and correction-intent manifest scaffold include `accelerate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa4342b65826c68da335ce0107bdea2448aa725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->