### PR TITLE
fix(coding-graph): #1659 + #1680 + #1688 export-capture nits, semantic-layer nits, bench follow-ups

### DIFF
--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -211,7 +211,8 @@ A dedicated benchmark suite for [`@remnic/coding-graph`](https://www.npmjs.com/p
 |---|---|
 | `fullIndexMs` | Wall time to index the entire fixture in one batch. |
 | `fullIndexLocsPerSecond` | Sustained LOC/s during full index (higher is better). |
-| `incrementalUpdateP50Ms` / `incrementalUpdateP95Ms` | Single-file re-ingest latency (p50/p95 over ≥20 iterations). |
+| `incrementalUpdateP50Ms` / `incrementalUpdateP95Ms` | Single-file re-ingest latency for UNCHANGED content (the common-case no-op path; p50/p95 over ≥20 iterations). |
+| `incrementalModifiedUpdateP50Ms` / `incrementalModifiedUpdateP95Ms` | Single-file re-ingest latency for MODIFIED content — the change-heavy path (edge deletion/creation, symbol re-resolution). Complementary to `incrementalUpdate` (#1688). |
 | `tracePathP95Ms` | `trace_path` (BFS, depth ≤ 5) p95. |
 | `searchGraphP95Ms` | `search_graph` name-pattern p95. |
 | `deadCodeMs` | Dead-code query wall time. |
@@ -225,18 +226,21 @@ The harness ships a **deterministic** synthetic repo generator (`generateSynthet
 
 The measured numbers live in [`baselines/coding-graph-baseline.json`](./baselines/coding-graph-baseline.json) — bench-owned, separate from the structural ratchets in `scripts/ratchet-baseline.json`. The regression gate (`checkCodingGraphRegression`) compares a report against the baseline with a generous tolerance (default 30%). It hard-fails on gross regression — a real failing step, not a warning (rule 50). Tightening the baseline is a deliberate PR act (mirrors `check-ratchets --update`).
 
+The gate carries a **machine-fingerprint guard** (`compareMachineFingerprints`): when the report's machine class differs from the baseline's (arch/platform/Node major/cpuModel/cores), the comparison is *skipped* (`passed: true`, `skipped: true`, `machineMismatch` populated) rather than failed, so a cross-machine CI run does not false-positive on legitimate hardware variance (#1688). Regenerate the baseline on the target machine class for a real comparison.
+
 ### Measured numbers (first baseline)
 
 > Numbers below are from the **baseline JSON file** — this section is checked against it so prose can't drift from measurement. Run `remnic bench coding-graph` to reproduce.
 
 | Metric | Value | Machine |
 |---|---|---|
-| Full index | ~17.6 ms, ~115k LOC/s | Apple M2 Max, Node v22 |
-| Incremental update p95 | ~0.26 ms | Apple M2 Max |
-| trace_path p95 | ~0.14 ms | Apple M2 Max |
-| search_graph p95 | ~0.29 ms | Apple M2 Max |
-| dead_code | ~0.67 ms | Apple M2 Max |
-| DB size | ~2 KB/KLOC | Apple M2 Max |
+| Full index | ~15 ms, ~131k LOC/s | Apple M2 Max, Node v22 |
+| Incremental update p95 (idempotent) | ~0.24 ms | Apple M2 Max |
+| Incremental modified update p95 (change-heavy) | ~0.96 ms | Apple M2 Max |
+| trace_path p95 | ~0.13 ms | Apple M2 Max |
+| search_graph p95 | ~0.18 ms | Apple M2 Max |
+| dead_code | ~0.53 ms | Apple M2 Max |
+| DB size | ~270 KB/KLOC | Apple M2 Max |
 
 These are **working targets on a small fixture (20 files, 200 symbols)**, NOT parity claims against codebase-memory-mcp's published numbers (28M LOC in 3 min, <1ms Cypher). Scale targets at 1M+ LOC are tracked as stretch goals — the harness will measure them when Tier-L fixtures are wired (issue #1557 PR2).
 
@@ -245,9 +249,14 @@ These are **working targets on a small fixture (20 files, 200 symbols)**, NOT pa
 ```typescript
 import { runCodingGraphBenchmark, checkCodingGraphRegression } from "@remnic/bench";
 
+// Use the SAME fixture as the bundled baseline (20×10, density 0.3, seed
+// 42) so the regression gate compares like-for-like. A custom fixture
+// (different fileCount/symbolsPerFile/callDensity/seed/language) needs its
+// OWN baseline — build one with buildBaselineFromReport(report, note) and
+// commit it, otherwise checkCodingGraphRegression reports a fixture mismatch.
 const report = await runCodingGraphBenchmark({
-  fixture: { fileCount: 1000, symbolsPerFile: 10, callDensity: 0.2 },
-  iterations: 25,
+  fixture: { seed: 42, fileCount: 20, symbolsPerFile: 10, callDensity: 0.3, language: "typescript" },
+  iterations: 20,
 });
 
 const baseline = require("@remnic/bench/baselines/coding-graph-baseline.json");
@@ -256,4 +265,7 @@ if (!gate.passed) {
   console.error(gate.summary);
   process.exit(1);
 }
+// gate.skipped === true when the report's machine fingerprint differs from
+// the baseline's (different CPU/arch/Node major) — the comparison is skipped
+// rather than failed so cross-machine CI does not false-positive (#1688).
 ```

--- a/packages/bench/baselines/coding-graph-baseline.json
+++ b/packages/bench/baselines/coding-graph-baseline.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "machine": {
     "arch": "arm64",
     "platform": "darwin",
@@ -16,15 +16,17 @@
     "language": "typescript"
   },
   "metrics": {
-    "fullIndexMs": 14.864042000000154,
-    "fullIndexLocsPerSecond": 136302,
-    "incrementalUpdateP50Ms": 0.19358299999998962,
-    "incrementalUpdateP95Ms": 0.26237500000002,
-    "tracePathP95Ms": 0.15750000000002728,
-    "searchGraphP95Ms": 0.19700000000011642,
-    "deadCodeMs": 2.29424999999992,
-    "dbBytesPerKloc": 280636
+    "fullIndexMs": 15.452540999999655,
+    "fullIndexLocsPerSecond": 131111,
+    "incrementalUpdateP50Ms": 0.173167000000376,
+    "incrementalUpdateP95Ms": 0.23908399999982066,
+    "incrementalModifiedUpdateP50Ms": 0.6047909999997501,
+    "incrementalModifiedUpdateP95Ms": 0.9565000000002328,
+    "tracePathP95Ms": 0.13425000000006548,
+    "searchGraphP95Ms": 0.1764170000001286,
+    "deadCodeMs": 0.5299169999998412,
+    "dbBytesPerKloc": 270468
   },
-  "createdAt": "2026-07-06T10:50:56.821Z",
-  "note": "Initial baseline — first harness run with WAL-aware DB sizing (issue #1557 PR1)."
+  "createdAt": "2026-07-07T12:35:48.738Z",
+  "note": "Regenerated baseline — adds incrementalModifiedUpdate metric (#1688 item 1) + machine-fingerprint guard (#1688 item 2). WAL-aware DB sizing retained (#1557 PR1)."
 }

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -814,3 +814,21 @@ test("modified-loop restore: full-fixture re-ingest restores cascade-deleted cro
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("guard ordering: corrupt v2 report missing a metric field fails instead of crashing", () => {
+  // schemaVersion matches the baseline (both 2) but the v2-only field is
+  // absent (a truncated/hand-edited report). Before the field-presence
+  // guard, extractMetrics dereferenced the missing field and threw an
+  // uncaught TypeError (cursor #1688 review: 'v2 report crashes gate').
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const corruptReport: CodingGraphBenchReport = {
+    ...report,
+    incrementalModifiedUpdate:
+      undefined as unknown as CodingGraphBenchReport["incrementalModifiedUpdate"],
+  };
+  const result = checkCodingGraphRegression(corruptReport, baseline, 30);
+  assert.equal(result.passed, false, "corrupt v2 report must fail, not crash");
+  assert.equal(result.skipped, undefined);
+  assert.ok(result.summary.includes("missing"), "summary must explain the missing field");
+});

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -887,5 +887,24 @@ test("guard ordering: corrupt v2 report missing p50 (but has p95) fails the gate
   assert.ok(result.summary.includes("incrementalModifiedUpdate.p50"), "summary must name the missing p50 field");
 });
 
+test("guard ordering: corrupt v2 report missing scalar metrics fails before machine skip", () => {
+  // The field-presence guard must also validate scalar/complex metrics
+  // (fullIndexMs.ms, fullIndexLocsPerSecond, deadCodeMs.ms, dbBytesPerKloc),
+  // not just nested micro-metrics. A report missing these on a different
+  // machine would otherwise fall through to the skip as hardware variance
+  // (chatgpt-codex-connector #1688 P2: "Validate scalar report metrics").
+  const report = reportWithMachine({ ...SAME_MACHINE, arch: "x64" });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const missingScalar: CodingGraphBenchReport = {
+    ...report,
+    fullIndexMs: undefined as unknown as CodingGraphBenchReport["fullIndexMs"],
+  };
+  const result = checkCodingGraphRegression(missingScalar, baseline, 30);
+  assert.equal(result.passed, false, "missing scalar metric must fail");
+  assert.equal(result.skipped, undefined, "must not reach machine skip");
+  assert.ok(result.summary.includes("fullIndexMs.ms"), "summary must name the missing scalar field");
+});
+
+
 
 

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -852,4 +852,23 @@ test("guard ordering: corrupt v2 report on a DIFFERENT machine fails before the 
   assert.equal(result.skipped, undefined, "must NOT reach the machine skip — corrupt-report guard runs first");
   assert.ok(result.summary.includes("missing"), "summary must explain the missing field, not the machine mismatch");
 });
+test("guard ordering: corrupt v2 report with truncated nested metric field fails", () => {
+  // schemaVersion matches (both 2) and the top-level field exists, but a
+  // nested sub-field is missing (e.g. incrementalModifiedUpdate: { p50: 1 }
+  // with no p95). Before the deepened guard, extractMetrics produced
+  // undefined for the missing p95 and the comparison loop silently skipped
+  // it — letting corrupt artifacts pass as passed:true.
+  // (chatgpt-codex-connector #1688 P2: 'Validate nested metric fields'.)
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const truncatedReport: CodingGraphBenchReport = {
+    ...report,
+    incrementalModifiedUpdate: { p50: 1, p95: undefined as unknown as number, iterations: 20, samplesMs: [] },
+  };
+  const result = checkCodingGraphRegression(truncatedReport, baseline, 30);
+  assert.equal(result.passed, false, "truncated nested field must fail the gate");
+  assert.equal(result.skipped, undefined);
+  assert.ok(result.summary.includes("incrementalModifiedUpdate.p95"), "summary must name the missing nested field");
+});
+
 

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -870,5 +870,22 @@ test("guard ordering: corrupt v2 report with truncated nested metric field fails
   assert.equal(result.skipped, undefined);
   assert.ok(result.summary.includes("incrementalModifiedUpdate.p95"), "summary must name the missing nested field");
 });
+test("guard ordering: corrupt v2 report missing p50 (but has p95) fails the gate", () => {
+  // The deepened guard must check BOTH p50 and p95, not just p95.
+  // extractMetrics reads both percentiles; a report with p95 present
+  // but p50 missing previously passed the guard and the comparison loop
+  // silently skipped the undefined p50 metric (cursor Bugbot: 'Regression
+  // gate skips missing p50').
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const missingP50Report: CodingGraphBenchReport = {
+    ...report,
+    incrementalModifiedUpdate: { p50: undefined as unknown as number, p95: 3, iterations: 20, samplesMs: [] },
+  };
+  const result = checkCodingGraphRegression(missingP50Report, baseline, 30);
+  assert.equal(result.passed, false, "missing p50 must fail the gate");
+  assert.ok(result.summary.includes("incrementalModifiedUpdate.p50"), "summary must name the missing p50 field");
+});
+
 
 

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -20,11 +20,13 @@ import {
   checkCodingGraphRegression,
   buildBaselineFromReport,
   extractMetrics,
+  compareMachineFingerprints,
   createSeededRng,
   DEFAULT_SMOKE_FIXTURE,
   CODING_GRAPH_BENCH_SCHEMA_VERSION,
   type CodingGraphBenchReport,
   type CodingGraphBaseline,
+  type MachineFingerprint,
 } from "./index.js";
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -138,6 +140,18 @@ test("harness smoke: small fixture produces complete report with all metric keys
     "p95 must be >= p50",
   );
   assert.equal(report.incrementalUpdate.samplesMs.length, 20);
+
+  // Incremental MODIFIED-content update distribution (#1688 item 1) — the
+  // change-heavy path. It does strictly more work than the idempotent no-op,
+  // so p50 should be >= the idempotent p50 (defensive lower bound; not a
+  // strict perf assertion since both are sub-ms and noisy).
+  assert.equal(report.incrementalModifiedUpdate.iterations, 20);
+  assert.ok(report.incrementalModifiedUpdate.p50 >= 0);
+  assert.ok(
+    report.incrementalModifiedUpdate.p95 >= report.incrementalModifiedUpdate.p50,
+    "modified p95 must be >= modified p50",
+  );
+  assert.equal(report.incrementalModifiedUpdate.samplesMs.length, 20);
 
   // Trace path.
   assert.equal(report.tracePath.iterations, 20);
@@ -275,6 +289,7 @@ test("regression gate: higherIsBetter metric regresses when throughput drops", (
     fullIndexMs: { ms: 100 },
     fullIndexLocsPerSecond: 10000, // baseline was 20000 — 50% drop
     incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    incrementalModifiedUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     deadCodeMs: { ms: 5 },
@@ -338,6 +353,7 @@ test("regression gate: fixture mismatch fails the gate", () => {
     fullIndexMs: { ms: 500 },
     fullIndexLocsPerSecond: 200000,
     incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    incrementalModifiedUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     deadCodeMs: { ms: 5 },
@@ -398,6 +414,7 @@ test("regression gate: seed-only fixture mismatch fails the gate", () => {
     fullIndexMs: { ms: 10 },
     fullIndexLocsPerSecond: 100000,
     incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    incrementalModifiedUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
     deadCodeMs: { ms: 1 },
@@ -430,4 +447,150 @@ test("regression gate: seed-only fixture mismatch fails the gate", () => {
   const result = checkCodingGraphRegression(baseReport, baseline, 30);
   assert.equal(result.passed, false, "seed-only mismatch must fail the gate");
   assert.ok(result.summary.includes("seed"), "summary must name the mismatched knob (seed)");
+});
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// 7. Machine-fingerprint guard (#1688 item 2) — a baseline from a different
+//    machine class must SKIP the comparison (passed: true + skipped: true),
+//    not fail CI on legitimate hardware variance.
+// ──────────────────────────────────────────────────────────────────────────
+
+const SAME_MACHINE: MachineFingerprint = {
+  arch: "arm64",
+  platform: "darwin",
+  nodeVersion: "v22.20.0",
+  cpuModel: "Apple M2 Max",
+  cpuCores: 12,
+  totalMemoryMb: 98304,
+};
+
+function reportWithMachine(machine: MachineFingerprint): CodingGraphBenchReport {
+  return {
+    schemaVersion: CODING_GRAPH_BENCH_SCHEMA_VERSION,
+    timestamp: "2026-07-07T00:00:00.000Z",
+    machine,
+    fixture: {
+      config: DEFAULT_SMOKE_FIXTURE,
+      approximateLoc: 1000,
+      fileCount: 20,
+      symbolCount: 200,
+      edgeCount: 60,
+    },
+    fullIndexMs: { ms: 10 },
+    fullIndexLocsPerSecond: 100000,
+    incrementalUpdate: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    incrementalModifiedUpdate: { p50: 2, p95: 3, iterations: 20, samplesMs: [] },
+    tracePath: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    searchGraph: { p50: 1, p95: 2, iterations: 20, samplesMs: [] },
+    deadCodeMs: { ms: 1 },
+    dbBytesPerKloc: 280000,
+    peakRssBytes: 1000000,
+    dbBytes: 1000,
+    graphNodeCount: 200,
+    graphEdgeCount: 60,
+  };
+}
+
+function baselineWithMachine(machine: MachineFingerprint): CodingGraphBaseline {
+  return {
+    schemaVersion: CODING_GRAPH_BENCH_SCHEMA_VERSION,
+    machine,
+    fixtureConfig: DEFAULT_SMOKE_FIXTURE,
+    metrics: {
+      fullIndexMs: 10,
+      fullIndexLocsPerSecond: 100000,
+      incrementalUpdateP50Ms: 1,
+      incrementalUpdateP95Ms: 2,
+      incrementalModifiedUpdateP50Ms: 2,
+      incrementalModifiedUpdateP95Ms: 3,
+      tracePathP95Ms: 2,
+      searchGraphP95Ms: 2,
+      deadCodeMs: 1,
+      dbBytesPerKloc: 280000,
+    },
+    createdAt: "2026-07-07T00:00:00.000Z",
+    note: "machine-guard baseline",
+  };
+}
+
+test("machine guard: same fingerprint → normal comparison (no skip)", () => {
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, true, "same machine + identical metrics pass");
+  assert.equal(result.skipped, undefined, "same machine must NOT skip");
+  assert.equal(result.machineMismatch, undefined, "no mismatch detail on same machine");
+});
+
+test("machine guard: different arch SKIPS comparison (not a CI failure)", () => {
+  const report = reportWithMachine({ ...SAME_MACHINE, arch: "x64" });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, true, "hardware variance must not fail CI");
+  assert.equal(result.skipped, true, "mismatched machine skips comparison");
+  assert.equal(result.regressions.length, 0, "no regressions computed on skip");
+  assert.ok(result.machineMismatch, "mismatch detail present");
+  assert.ok(
+    result.machineMismatch!.differingFields.includes("arch"),
+    "differingFields names arch",
+  );
+  assert.ok(
+    result.summary.includes("Machine-fingerprint mismatch"),
+    "summary explains the skip",
+  );
+});
+
+test("machine guard: different cpuModel SKIPS comparison", () => {
+  const report = reportWithMachine({ ...SAME_MACHINE, cpuModel: "Apple M3 Pro" });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.skipped, true);
+  assert.ok(result.machineMismatch!.differingFields.includes("cpuModel"));
+});
+
+test("machine guard: different node MAJOR version SKIPS (minor does not)", () => {
+  // Major differs (v23 vs v22) → skip.
+  const majorDiff = reportWithMachine({ ...SAME_MACHINE, nodeVersion: "v23.0.0" });
+  const r1 = checkCodingGraphRegression(majorDiff, baselineWithMachine(SAME_MACHINE), 30);
+  assert.equal(r1.skipped, true, "different node major skips");
+  assert.ok(r1.machineMismatch!.differingFields.includes("nodeVersion(major)"));
+
+  // Minor differs only (v22.5.0 vs v22.20.0) → same major → comparable, no skip.
+  const minorDiff = reportWithMachine({ ...SAME_MACHINE, nodeVersion: "v22.5.0" });
+  const r2 = checkCodingGraphRegression(minorDiff, baselineWithMachine(SAME_MACHINE), 30);
+  assert.equal(r2.skipped, undefined, "same node major does not skip");
+  assert.equal(r2.machineMismatch, undefined);
+});
+
+test("machine guard: totalMemoryMb difference alone does NOT skip", () => {
+  // Memory alone rarely moves sub-ms SQLite ops; over-triggering the skip
+  // on memory would hide real regressions. Only memory differs here.
+  const report = reportWithMachine({ ...SAME_MACHINE, totalMemoryMb: 16384 });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.skipped, undefined, "memory-only difference must not skip");
+  assert.equal(result.passed, true, "still comparable → normal comparison");
+});
+
+test("compareMachineFingerprints: empty diff for identical fingerprints", () => {
+  const diff = compareMachineFingerprints(SAME_MACHINE, SAME_MACHINE);
+  assert.deepEqual(diff.differingFields, []);
+});
+
+test("compareMachineFingerprints: lists every load-bearing differing field", () => {
+  const a: MachineFingerprint = { ...SAME_MACHINE };
+  const b: MachineFingerprint = {
+    ...SAME_MACHINE,
+    arch: "x64",
+    platform: "linux",
+    nodeVersion: "v23.0.0",
+    cpuModel: "Intel Xeon",
+    cpuCores: 32,
+  };
+  const diff = compareMachineFingerprints(a, b);
+  assert.deepEqual(
+    [...diff.differingFields].sort(),
+    ["arch", "cpuCores", "cpuModel", "nodeVersion(major)", "platform"],
+  );
 });

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -675,7 +675,7 @@ test("extractMetrics: throws on a report missing incrementalModifiedUpdate (guar
   const staleReport = {
     ...report,
     incrementalModifiedUpdate: undefined,
-  } as CodingGraphBenchReport;
+  } as unknown as CodingGraphBenchReport;
   assert.throws(() => extractMetrics(staleReport));
 });
 
@@ -735,7 +735,7 @@ test("modified-loop restore: full-fixture re-ingest restores cascade-deleted cro
         const hasIncoming = storeFiles.some(
           (f, j) =>
             j !== i &&
-            f.edges.some((e) => symSet.has(e.dstQualifiedName)),
+            (f.edges ?? []).some((e) => symSet.has(e.dstQualifiedName)),
         );
         if (hasIncoming) {
           targetIdx = i;

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -759,6 +759,45 @@ test("fingerprint guard: an empty machine object {} fails (present but fieldless
   assert.ok(result.summary.includes("arch"), "summary must name a missing field");
 });
 
+test("fingerprint guard: a non-string non-null cpuModel fails (type validation)", () => {
+  // cpuModel is nullable but must be string-or-null. A numeric/object
+  // value is corruption (cursor Bugbot: 'Fingerprint skip omits cpuModel
+  // validation').
+  const report = reportWithMachine({
+    ...SAME_MACHINE,
+    cpuModel: 123 as unknown as string,
+  });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, false, "non-string non-null cpuModel must fail the gate");
+  assert.equal(result.skipped, undefined, "must not reach the machine skip");
+  assert.ok(result.summary.includes("cpuModel"), "summary must name cpuModel");
+});
+
+test("fingerprint guard: a null cpuModel is 'unknown', not a skip-triggering difference", () => {
+  // report.cpuModel=null (undetected) vs baseline.cpuModel="Apple M2 Max".
+  // Before the fix, null !== "Apple M2 Max" pushed a cpuModel difference
+  // and SKIPPED the gate, hiding a real regression. Now null is treated as
+  // "unknown" — with every other field matching, the gate compares normally
+  // (cursor Bugbot: 'Fingerprint skip omits cpuModel validation').
+  const report = reportWithMachine({ ...SAME_MACHINE, cpuModel: null });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.skipped, undefined, "a null cpuModel must NOT trigger the machine skip");
+  assert.equal(result.machineMismatch, undefined, "no mismatch recorded for an unknown cpuModel");
+  assert.equal(result.passed, true, "identical metrics still pass under normal comparison");
+});
+
+test("fingerprint guard: two differing concrete cpuModels still SKIP", () => {
+  // Regression guard for the cpuModel change: when BOTH sides report a
+  // concrete (non-null) but different model, the designed skip still fires.
+  const report = reportWithMachine({ ...SAME_MACHINE, cpuModel: "Apple M3 Pro" });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.skipped, true, "two different concrete cpuModels still skip");
+  assert.ok(result.machineMismatch!.differingFields.includes("cpuModel"));
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // 9. Modified-loop restore (#1688 review) — re-ingesting the full fixture
 //    restores cross-file edges that the churn prune cascade-deleted.

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -832,3 +832,24 @@ test("guard ordering: corrupt v2 report missing a metric field fails instead of 
   assert.equal(result.skipped, undefined);
   assert.ok(result.summary.includes("missing"), "summary must explain the missing field");
 });
+test("guard ordering: corrupt v2 report on a DIFFERENT machine fails before the machine skip", () => {
+  // Before the field-presence-before-machine-fingerprint reorder, a corrupt
+  // v2 report (schema matches but incrementalModifiedUpdate is absent) on a
+  // different machine would hit the machine-fingerprint skip FIRST and
+  // return {passed:true, skipped:true} — silently passing a malformed
+  // artifact through cross-machine CI. The field-presence guard must run
+  // before the machine skip so corrupt reports always fail
+  // (chatgpt-codex-connector #1688 review: 'Validate corrupt reports
+  // before machine skips').
+  const corruptReport: CodingGraphBenchReport = {
+    ...reportWithMachine({ ...SAME_MACHINE, arch: "x64" }),
+    incrementalModifiedUpdate:
+      undefined as unknown as CodingGraphBenchReport["incrementalModifiedUpdate"],
+  };
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(corruptReport, baseline, 30);
+  assert.equal(result.passed, false, "corrupt report must fail even on a different machine");
+  assert.equal(result.skipped, undefined, "must NOT reach the machine skip — corrupt-report guard runs first");
+  assert.ok(result.summary.includes("missing"), "summary must explain the missing field, not the machine mismatch");
+});
+

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -13,6 +13,9 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import {
   generateSyntheticRepo,
@@ -28,6 +31,13 @@ import {
   type CodingGraphBaseline,
   type MachineFingerprint,
 } from "./index.js";
+import {
+  GraphStore,
+  type StoreFileIR,
+  type EdgeIR,
+  type SymbolKind,
+  type CodingGraphLanguage,
+} from "@remnic/coding-graph";
 
 // ──────────────────────────────────────────────────────────────────────────
 // 1. Generator determinism (rule 38).
@@ -603,4 +613,204 @@ test("compareMachineFingerprints: lists every load-bearing differing field", () 
     [...diff.differingFields].sort(),
     ["arch", "cpuCores", "cpuModel", "nodeVersion(major)", "platform"],
   );
+});
+
+
+// ──────────────────────────────────────────────────────────────────────────
+// 8. Guard ordering (#1688 review) — structural invariants beat the
+//    machine-fingerprint skip. A misconfigured run (wrong fixture or
+//    incompatible schema) on a different machine must FAIL on its real
+//    problem, not be silently skipped as "hardware variance".
+// ──────────────────────────────────────────────────────────────────────────
+
+test("guard ordering: fixture mismatch beats machine-fingerprint skip", () => {
+  // Report is on a DIFFERENT machine (arch x64) AND has a different
+  // fixture (fileCount 1000 vs 20). Before the reorder this returned
+  // {passed:true, skipped:true} — the machine skip masked the fixture
+  // mismatch. Now the structural fixture check must fail first.
+  const report = reportWithMachine({ ...SAME_MACHINE, arch: "x64" });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const mismatchedReport: CodingGraphBenchReport = {
+    ...report,
+    fixture: {
+      ...report.fixture,
+      config: { ...report.fixture.config, fileCount: 1000 },
+    },
+  };
+  const result = checkCodingGraphRegression(mismatchedReport, baseline, 30);
+  assert.equal(result.passed, false, "fixture mismatch must fail, not skip");
+  assert.equal(result.skipped, undefined, "must not reach the machine skip");
+  assert.ok(
+    result.summary.includes("Fixture mismatch"),
+    "summary must explain the fixture mismatch",
+  );
+});
+
+test("guard ordering: schema-version mismatch fails instead of crashing", () => {
+  // A pre-v2 report (schemaVersion 1) compared against a v2 baseline.
+  // Before the schema guard, extractMetrics dereferenced the v2-only
+  // incrementalModifiedUpdate field and threw a TypeError. Now the
+  // schema guard fails the gate with an actionable message.
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const staleReport: CodingGraphBenchReport = {
+    ...report,
+    schemaVersion: 1,
+    incrementalModifiedUpdate:
+      undefined as unknown as CodingGraphBenchReport["incrementalModifiedUpdate"],
+  };
+  const result = checkCodingGraphRegression(staleReport, baseline, 30);
+  assert.equal(result.passed, false, "schema mismatch must fail the gate");
+  assert.equal(result.skipped, undefined, "schema mismatch is a hard fail, not a skip");
+  assert.ok(
+    result.summary.includes("Schema-version mismatch"),
+    "summary must explain the schema mismatch",
+  );
+});
+
+test("extractMetrics: throws on a report missing incrementalModifiedUpdate (guard is load-bearing)", () => {
+  // Proves the schema guard above is necessary: without it, extractMetrics
+  // deref-crashes on the v2-only field.
+  const report = reportWithMachine(SAME_MACHINE);
+  const staleReport = {
+    ...report,
+    incrementalModifiedUpdate: undefined,
+  } as CodingGraphBenchReport;
+  assert.throws(() => extractMetrics(staleReport));
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 9. Modified-loop restore (#1688 review) — re-ingesting the full fixture
+//    restores cross-file edges that the churn prune cascade-deleted.
+//    Restoring only the churned file leaves peer files' incoming edges
+//    gone, so the graph would shrink each pass.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("modified-loop restore: full-fixture re-ingest restores cascade-deleted cross-file edges", async () => {
+  const repo = generateSyntheticRepo({
+    ...DEFAULT_SMOKE_FIXTURE,
+    callDensity: 0.5,
+  });
+  const storeFiles: StoreFileIR[] = repo.files.map((f) => ({
+    path: f.path,
+    language: f.language as CodingGraphLanguage,
+    contentHash: f.contentHash,
+    symbols: f.symbols.map((s) => ({
+      qualifiedName: s.qualifiedName,
+      name: s.name,
+      kind: s.kind as SymbolKind,
+      span: { startByte: s.startByte, endByte: s.endByte },
+    })),
+    edges: f.edges.map(
+      (e): EdgeIR => ({
+        srcQualifiedName: e.srcQualifiedName,
+        dstQualifiedName: e.dstQualifiedName,
+        type: e.type,
+        confidence: e.confidence,
+        provenance: e.provenance as EdgeIR["provenance"],
+      }),
+    ),
+  }));
+
+  const dir = await mkdtemp(path.join(tmpdir(), "cg-restore-test-"));
+  const dbPath = path.join(dir, "restore.sqlite");
+  try {
+    const store = await GraphStore.open({ dbPath });
+    try {
+      const indexResult = await store.upsertFileBatch(storeFiles);
+      assert.equal(indexResult.ok, true, "full index must succeed");
+
+      const baselineStats = store.schemaStats();
+      assert.ok(baselineStats.ok, "schemaStats must succeed after index");
+      const baselineEdges = baselineStats.ok ? baselineStats.stats.edges : 0;
+      assert.ok(baselineEdges > 0, "fixture must have edges to exercise the restore");
+
+      // Pick a target that has INCOMING cross-file edges so the
+      // single-file-restore defect is observable below.
+      let targetIdx = -1;
+      for (let i = 0; i < storeFiles.length; i++) {
+        const symSet = new Set(
+          storeFiles[i]!.symbols.map((s) => s.qualifiedName),
+        );
+        const hasIncoming = storeFiles.some(
+          (f, j) =>
+            j !== i &&
+            f.edges.some((e) => symSet.has(e.dstQualifiedName)),
+        );
+        if (hasIncoming) {
+          targetIdx = i;
+          break;
+        }
+      }
+      assert.ok(
+        targetIdx >= 0,
+        "fixture must have a file with incoming cross-file edges",
+      );
+      const target = storeFiles[targetIdx]!;
+
+      // Churn: replace the target with a single churn symbol + no edges.
+      const modified: StoreFileIR = {
+        ...target,
+        contentHash: target.contentHash + "-churn",
+        symbols: [
+          {
+            qualifiedName: "mod.churnSymbol",
+            name: "churnSymbol",
+            kind: "function" as SymbolKind,
+            span: { startByte: 0, endByte: 0 },
+          },
+        ],
+        edges: [],
+      };
+      const churnResult = await store.upsertFileBatch([modified]);
+      assert.equal(churnResult.ok, true, "churn upsert must succeed");
+
+      const afterChurn = store.schemaStats();
+      const afterChurnEdges = afterChurn.ok ? afterChurn.stats.edges : 0;
+      assert.ok(
+        afterChurnEdges < baselineEdges,
+        "churn must shed edges via cascade (after=" +
+          afterChurnEdges +
+          ", baseline=" +
+          baselineEdges +
+          ")",
+      );
+
+      // FIX: restore by re-ingesting the FULL fixture.
+      const restoreResult = await store.upsertFileBatch(storeFiles);
+      assert.equal(restoreResult.ok, true, "full-fixture restore must succeed");
+      const afterRestore = store.schemaStats();
+      const afterRestoreEdges = afterRestore.ok ? afterRestore.stats.edges : 0;
+      assert.equal(
+        afterRestoreEdges,
+        baselineEdges,
+        "full-fixture restore returns the graph to baseline edge count (after=" +
+          afterRestoreEdges +
+          ", baseline=" +
+          baselineEdges +
+          ")",
+      );
+
+      // DEFECT PROOF: re-churn, then restore ONLY the target file (the
+      // old behavior). Cross-file incoming edges stay gone.
+      const churnAgain = await store.upsertFileBatch([modified]);
+      assert.equal(churnAgain.ok, true);
+      const singleRestore = await store.upsertFileBatch([target]);
+      assert.equal(singleRestore.ok, true);
+      const afterSingle = store.schemaStats();
+      const afterSingleEdges = afterSingle.ok ? afterSingle.stats.edges : 0;
+      assert.ok(
+        afterSingleEdges < baselineEdges,
+        "single-file restore must NOT fully restore cross-file edges (after=" +
+          afterSingleEdges +
+          ", baseline=" +
+          baselineEdges +
+          ") — the defect the full-fixture fix closes",
+      );
+    } finally {
+      await store.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -210,11 +210,21 @@ test("regression gate: passes within 30% tolerance on natural variance", async (
 
   const baseline = buildBaselineFromReport(report1, "run 1");
   const result = checkCodingGraphRegression(report2, baseline, 30);
-  // Time metrics may vary, but the gate should be lenient enough for
-  // back-to-back runs on the same machine.
+  // Natural back-to-back variance must not trip the gate as a GROSS
+  // regression. The sub-ms p95 metrics (incrementalUpdate /
+  // incrementalModifiedUpdate / tracePath / searchGraph) are excluded from
+  // this check: their p95 over ~20 sub-ms samples is outlier-dominated — a
+  // single GC/scheduler spike swings a 0.2 ms p95 by 10×+ — so a relative
+  // bound is meaningless there (a known property of micro-benchmark p95, not
+  // a gate defect). Only metrics with a baseline ≥ 2 ms (fullIndexMs) are
+  // stable enough for a relative-variance comparison. dbBytesPerKloc is
+  // deterministic on the same machine and never regresses. A REAL regression
+  // on the stable metrics is ~10× (see the prove-fail test), well above the
+  // 50% bound used here (#1688).
+  const stableRegressions = result.regressions.filter((r) => r.baseline >= 2);
   assert.ok(
-    result.passed || result.regressions.every((r) => r.percentChange < 50),
-    "natural variance should not trigger gross regression",
+    result.passed || stableRegressions.every((r) => r.percentChange < 50),
+    "natural variance should not trigger gross regression on stable (≥2ms) metrics",
   );
 });
 

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -905,6 +905,23 @@ test("guard ordering: corrupt v2 report missing scalar metrics fails before mach
   assert.ok(result.summary.includes("fullIndexMs.ms"), "summary must name the missing scalar field");
 });
 
+test("guard ordering: report with non-numeric metric value fails (NaN guard)", () => {
+  // A JSON-loaded report may carry a string where a number is expected
+  // (fullIndexLocsPerSecond: "oops"). Without Number.isFinite validation,
+  // the NaN ratio passes the tolerance check and the gate returns true.
+  // (chatgpt-codex-connector #1688 P2: "Validate metric values as finite").
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const nonNumericReport: CodingGraphBenchReport = {
+    ...report,
+    fullIndexLocsPerSecond: "oops" as unknown as number,
+  };
+  const result = checkCodingGraphRegression(nonNumericReport, baseline, 30);
+  assert.equal(result.passed, false, "non-numeric metric must fail the gate");
+  assert.ok(result.summary.includes("fullIndexLocsPerSecond"), "summary must name the bad field");
+});
+
+
 
 
 

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -679,6 +679,86 @@ test("extractMetrics: throws on a report missing incrementalModifiedUpdate (guar
   assert.throws(() => extractMetrics(staleReport));
 });
 
+test("baseline guard: a non-numeric baseline metric fails instead of silently passing via NaN", () => {
+  // A corrupt baseline JSON carries fullIndexLocsPerSecond as a string.
+  // Before the guard, measVal / baseVal = number / "oops" = NaN, and
+  // NaN > tolerance is false so the gate silently PASSED. Now a
+  // present-but-non-finite baseline value fails loudly
+  // (chatgpt-codex-connector #1688 P2: 'Validate baseline metrics').
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline: CodingGraphBaseline = {
+    ...baselineWithMachine(SAME_MACHINE),
+    metrics: {
+      ...baselineWithMachine(SAME_MACHINE).metrics,
+      fullIndexLocsPerSecond: "oops" as unknown as number,
+    },
+  };
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, false, "non-numeric baseline metric must fail the gate");
+  assert.equal(result.skipped, undefined, "must not reach the machine skip");
+  assert.ok(
+    result.summary.includes("non-numeric"),
+    "summary must flag the corrupt baseline metric",
+  );
+  assert.ok(result.summary.includes("fullIndexLocsPerSecond"), "summary must name the bad field");
+});
+
+test("baseline guard: a simply-absent baseline metric stays additive (skipped, not failed)", () => {
+  // A baseline that omits a metric (vs. carrying a non-number) is the
+  // documented additive case — the missing key is skipped, not treated as
+  // corruption. This guards against the validation over-reaching and
+  // breaking the "keys present in BOTH" contract.
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline: CodingGraphBaseline = {
+    ...baselineWithMachine(SAME_MACHINE),
+    metrics: {
+      fullIndexMs: 10,
+      fullIndexLocsPerSecond: 100000,
+      incrementalUpdateP50Ms: 1,
+      incrementalUpdateP95Ms: 2,
+      // incrementalModifiedUpdateP50Ms / P95Ms deliberately absent.
+      tracePathP95Ms: 2,
+      searchGraphP95Ms: 2,
+      deadCodeMs: 1,
+      dbBytesPerKloc: 280000,
+    },
+  };
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, true, "absent metrics are additive — gate still passes on identical present metrics");
+  assert.equal(result.skipped, undefined);
+});
+
+test("fingerprint guard: a non-string nodeVersion fails instead of throwing in nodeMajor", () => {
+  // A corrupt JSON report carries nodeVersion as a number. Before the
+  // type guard, compareMachineFingerprints → nodeMajor called .replace on
+  // a number and threw. Now the wrong-typed field fails the gate with a
+  // structured message (chatgpt-codex-connector #1688 P2: 'Validate
+  // fingerprint field types').
+  const report = reportWithMachine({
+    ...SAME_MACHINE,
+    nodeVersion: 22 as unknown as string,
+  });
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, false, "non-string nodeVersion must fail the gate");
+  assert.equal(result.skipped, undefined, "must not reach the machine skip");
+  assert.ok(
+    result.summary.includes("nodeVersion"),
+    "summary must name the invalid fingerprint field",
+  );
+});
+
+test("fingerprint guard: an empty machine object {} fails (present but fieldless)", () => {
+  // machine: {} passes the old null check but carries no typed fields.
+  const report = reportWithMachine({} as MachineFingerprint);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const result = checkCodingGraphRegression(report, baseline, 30);
+  assert.equal(result.passed, false, "empty fingerprint must fail the gate");
+  assert.equal(result.skipped, undefined, "must not reach the machine skip");
+  assert.ok(result.summary.includes("report"), "summary must point at the report fingerprint");
+  assert.ok(result.summary.includes("arch"), "summary must name a missing field");
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // 9. Modified-loop restore (#1688 review) — re-ingesting the full fixture
 //    restores cross-file edges that the churn prune cascade-deleted.

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -921,6 +921,22 @@ test("guard ordering: report with non-numeric metric value fails (NaN guard)", (
   assert.ok(result.summary.includes("fullIndexLocsPerSecond"), "summary must name the bad field");
 });
 
+test("guard ordering: report with null machine fingerprint fails before compare", () => {
+  // A corrupt JSON report may have machine: null. Without the guard,
+  // compareMachineFingerprints dereferences the null and crashes.
+  // (chatgpt-codex-connector #1688 P2: "Validate machine fingerprints").
+  const report = reportWithMachine(SAME_MACHINE);
+  const baseline = baselineWithMachine(SAME_MACHINE);
+  const nullMachineReport: CodingGraphBenchReport = {
+    ...report,
+    machine: undefined as unknown as CodingGraphBenchReport["machine"],
+  };
+  const result = checkCodingGraphRegression(nullMachineReport, baseline, 30);
+  assert.equal(result.passed, false, "null machine must fail the gate");
+  assert.ok(result.summary.includes("machine"), "summary must mention the missing machine fingerprint");
+});
+
+
 
 
 

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -298,9 +298,21 @@ export async function runCodingGraphBenchmark(
           throw new Error(`modified update failed: ${modResult.result.code}`);
         }
         modifiedSamples.push(modResult.ms);
-        // Restore the original file so the graph state is stable across
-        // iterations.
-        await store.upsertFileBatch([original]);
+        // Restore the FULL fixture so the graph returns to baseline.
+        // Restoring only this file leaves peer files' incoming edges —
+        // cascade-deleted by the churn prune (the store's FK ON DELETE
+        // CASCADE drops every edge whose endpoint is a pruned node) —
+        // unrecreated: the graph would shed cross-file edges each pass
+        // and later samples would time a progressively smaller graph
+        // (chatgpt-codex-connector + cursor review of #1688). Inspect
+        // the result so a failed restore throws instead of leaving the
+        // graph on the churn symbol set (cursor review of #1688). The
+        // restore is NOT timed — only the churn upsert above is
+        // measured.
+        const restoreResult = await store.upsertFileBatch(storeFiles);
+        if (!restoreResult.ok) {
+          throw new Error(`restore failed: ${restoreResult.code}`);
+        }
         sampleRss();
       }
 

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -278,18 +278,30 @@ export async function runCodingGraphBenchmark(
         // Modified variant: a single churn symbol with a fresh qualified
         // name + bumped content hash forces the store to delete the file's
         // prior symbols/edges and create new ones (the change-heavy path).
+        // Carry a couple of the original's CROSS-FILE edges (re-pointed at
+        // the churn symbol) so the timed upsert also measures edge CREATION
+        // + resolution, not just pruning + a node insert — matching the
+        // metric's "edge deletion/creation" contract (#1688 review: codex).
+        // Cross-file dsts are filtered so the edges resolve against symbols
+        // that survive the churn (the file's own symbols are pruned).
+        const ownSyms = new Set(original.symbols.map((sym) => sym.qualifiedName));
+        const churnName = `mod.benchChurnSymbol${i}`;
+        const representativeEdges: EdgeIR[] = original.edges
+          .filter((e) => !ownSyms.has(e.dstQualifiedName))
+          .slice(0, 2)
+          .map((e) => ({ ...e, srcQualifiedName: churnName }));
         const modified: StoreFileIR = {
           ...original,
           contentHash: `${original.contentHash}-mod-${i}`,
           symbols: [
             {
-              qualifiedName: `mod.benchChurnSymbol${i}`,
+              qualifiedName: churnName,
               name: `benchChurnSymbol${i}`,
               kind: "function" as SymbolKind,
               span: { startByte: 0, endByte: 0 },
             },
           ],
-          edges: [],
+          edges: representativeEdges,
         };
         const modResult = await timeAsync(() =>
           store.upsertFileBatch([modified]),

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -261,6 +261,49 @@ export async function runCodingGraphBenchmark(
       const kloc = Math.max(1, repo.approximateLoc / 1000);
       const dbBytesPerKloc = dbBytes / kloc;
 
+      // ── Metric 3b: incremental MODIFIED-content re-ingest p50/p95 ──
+      // Complementary to metric 3 (idempotent no-op): measures the
+      // change-heavy path — edge deletion/creation + symbol re-resolution —
+      // by re-ingesting a file whose symbol set has changed, then restoring
+      // the original so the graph returns to baseline (#1688 item 1). Runs
+      // AFTER the steady-state DB-size measurement: each churn upsert moves
+      // pages to the SQLite free-list without shrinking the file, so a
+      // pre-DB-size churn would inflate dbBytesPerKloc with churn residue
+      // rather than reflecting the indexed fixture's steady-state footprint.
+      const modifiedSamples: number[] = [];
+      for (let i = 0; i < iterations; i++) {
+        const fileIdx = i % storeFiles.length;
+        const original = storeFiles[fileIdx];
+        if (!original) continue;
+        // Modified variant: a single churn symbol with a fresh qualified
+        // name + bumped content hash forces the store to delete the file's
+        // prior symbols/edges and create new ones (the change-heavy path).
+        const modified: StoreFileIR = {
+          ...original,
+          contentHash: `${original.contentHash}-mod-${i}`,
+          symbols: [
+            {
+              qualifiedName: `mod.benchChurnSymbol${i}`,
+              name: `benchChurnSymbol${i}`,
+              kind: "function" as SymbolKind,
+              span: { startByte: 0, endByte: 0 },
+            },
+          ],
+          edges: [],
+        };
+        const modResult = await timeAsync(() =>
+          store.upsertFileBatch([modified]),
+        );
+        if (!modResult.result.ok) {
+          throw new Error(`modified update failed: ${modResult.result.code}`);
+        }
+        modifiedSamples.push(modResult.ms);
+        // Restore the original file so the graph state is stable across
+        // iterations.
+        await store.upsertFileBatch([original]);
+        sampleRss();
+      }
+
       // ── Metric 8: peak RSS (tracked across the run) ──
       sampleRss();
       const peakRssBytes = peakRss;
@@ -279,6 +322,9 @@ export async function runCodingGraphBenchmark(
         fullIndexMs: { ms: fullIndex.ms },
         fullIndexLocsPerSecond: Math.round(locsPerSecond),
         incrementalUpdate: computeMicroMetric(incrementalSamples),
+        incrementalModifiedUpdate: computeMicroMetric(
+          modifiedSamples.length > 0 ? modifiedSamples : [0],
+        ),
         tracePath: computeMicroMetric(traceSamples.length > 0 ? traceSamples : [0]),
         searchGraph: computeMicroMetric(searchSamples),
         deadCodeMs: { ms: deadCode.ms },

--- a/packages/bench/src/coding-graph/harness.ts
+++ b/packages/bench/src/coding-graph/harness.ts
@@ -286,7 +286,7 @@ export async function runCodingGraphBenchmark(
         // that survive the churn (the file's own symbols are pruned).
         const ownSyms = new Set(original.symbols.map((sym) => sym.qualifiedName));
         const churnName = `mod.benchChurnSymbol${i}`;
-        const representativeEdges: EdgeIR[] = original.edges
+        const representativeEdges: EdgeIR[] = (original.edges ?? [])
           .filter((e) => !ownSyms.has(e.dstQualifiedName))
           .slice(0, 2)
           .map((e) => ({ ...e, srcQualifiedName: churnName }));

--- a/packages/bench/src/coding-graph/index.ts
+++ b/packages/bench/src/coding-graph/index.ts
@@ -21,6 +21,7 @@ export {
   checkCodingGraphRegression,
   extractMetrics,
   buildBaselineFromReport,
+  compareMachineFingerprints,
 } from "./regression.js";
 export type { RegressionMetricKey } from "./regression.js";
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -158,11 +158,6 @@ export function checkCodingGraphRegression(
   }
 
   // Field-presence guard: a corrupt/partial v2 report may carry
-  // schemaVersion 2 yet lack a v2-only field (a hand-edited or truncated
-  // JSON). extractMetrics dereferences these fields; without this guard
-  // it throws an uncaught TypeError instead of a structured gate failure
-  // (cursor #1688 review: 'v2 report crashes regression gate').
-  // Field-presence guard: a corrupt/partial v2 report may carry
   // schemaVersion 2 yet lack a required metric field OR a nested sub-field
   // (a hand-edited or truncated JSON). extractMetrics dereferences both the
   // top-level field and its nested p50/p95; without this guard a missing
@@ -172,7 +167,9 @@ export function checkCodingGraphRegression(
   const missingFields: string[] = [];
   if (report.incrementalUpdate == null) missingFields.push("incrementalUpdate");
   if (report.incrementalModifiedUpdate == null) missingFields.push("incrementalModifiedUpdate");
+  if (report.incrementalUpdate?.p50 == null) missingFields.push("incrementalUpdate.p50");
   if (report.incrementalUpdate?.p95 == null) missingFields.push("incrementalUpdate.p95");
+  if (report.incrementalModifiedUpdate?.p50 == null) missingFields.push("incrementalModifiedUpdate.p50");
   if (report.incrementalModifiedUpdate?.p95 == null) missingFields.push("incrementalModifiedUpdate.p95");
   if (report.tracePath?.p95 == null) missingFields.push("tracePath.p95");
   if (report.searchGraph?.p95 == null) missingFields.push("searchGraph.p95");

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -99,6 +99,26 @@ export function compareMachineFingerprints(
   if (report.cpuCores !== baseline.cpuCores) differing.push("cpuCores");
   return { differingFields: differing };
 }
+
+/**
+ * Validate the load-bearing fields of a machine fingerprint. JSON-loaded
+ * fingerprints bypass TS's nominal types, so a corrupt artifact may carry
+ * `machine: {}` or `nodeVersion` as a non-string; compareMachineFingerprints
+ * → nodeMajor then calls .replace on an invalid value and throws instead of
+ * returning the intended corrupt-artifact failure. Returns the names of
+ * fields that are missing or have the wrong runtime type.
+ * (chatgpt-codex-connector #1688 P2: 'Validate fingerprint field types'.)
+ */
+function invalidFingerprintFields(fp: MachineFingerprint): string[] {
+  const bad: string[] = [];
+  if (typeof fp.arch !== "string") bad.push("arch");
+  if (typeof fp.platform !== "string") bad.push("platform");
+  // nodeVersion feeds nodeMajor's .replace — a non-string throws.
+  if (typeof fp.nodeVersion !== "string") bad.push("nodeVersion");
+  if (typeof fp.cpuCores !== "number" || !Number.isFinite(fp.cpuCores)) bad.push("cpuCores");
+  return bad;
+}
+
 /**
  * Compare a report against a baseline. Returns a gate result that exits
  * non-zero when any metric regresses beyond the tolerance.
@@ -190,18 +210,53 @@ export function checkCodingGraphRegression(
     };
   }
 
-  // Machine-fingerprint presence guard: a corrupt JSON report or baseline
-  // may have a missing/null machine fingerprint. compareMachineFingerprints
-  // dereferences fingerprint fields; without this guard it throws on a null
-  // machine instead of returning a structured gate failure
-  // (chatgpt-codex-connector #1688 P2: 'Validate machine fingerprints').
-  if (report.machine == null || baseline.machine == null) {
+  // Baseline-side metric value guard: the report guard above only
+  // validates report values. A corrupt baseline JSON could carry a
+  // non-numeric metric (e.g. fullIndexLocsPerSecond: "oops") that reaches
+  // the comparison loop where measVal / baseVal yields NaN, and NaN >
+  // tolerance is false so the gate silently passes. The baseline is loaded
+  // from JSON and carries the regression thresholds, so require every
+  // PRESENT baseline metric to be a finite number. A metric that is simply
+  // absent stays additive (skipped below), preserving the "keys present in
+  // BOTH" contract — only a present non-number is corruption
+  // (chatgpt-codex-connector #1688 P2: 'Validate baseline metrics').
+  const badBaselineMetrics = (Object.keys(METRIC_DIRECTION) as RegressionMetricKey[])
+    .filter((key) => {
+      const v = baseline.metrics[key];
+      return v != null && (typeof v !== "number" || !Number.isFinite(v as number));
+    });
+  if (badBaselineMetrics.length > 0) {
     return {
       passed: false,
       regressions: [],
       summary:
-        "Report or baseline is missing the machine fingerprint — the " +
-        "artifact is incomplete or corrupt. Regenerate it (#1688).",
+        "Baseline has a non-numeric required metric field(s): " +
+        badBaselineMetrics.join(", ") +
+        " — the baseline is corrupt. Regenerate it (#1688).",
+    };
+  }
+
+  // Machine-fingerprint presence + field-type guard: a corrupt JSON report
+  // or baseline may carry a null fingerprint OR a fingerprint with wrong-
+  // typed fields (e.g. machine: {} or nodeVersion as a number).
+  // compareMachineFingerprints → nodeMajor calls .replace on nodeVersion; a
+  // non-string throws instead of returning the intended corrupt-artifact
+  // failure. Reject both missing and wrong-typed fingerprints before
+  // comparing (chatgpt-codex-connector #1688 P2: 'Validate fingerprint
+  // field types').
+  const reportFpBad = report.machine == null ? ["<missing>"] : invalidFingerprintFields(report.machine);
+  const baselineFpBad = baseline.machine == null ? ["<missing>"] : invalidFingerprintFields(baseline.machine);
+  if (reportFpBad.length > 0 || baselineFpBad.length > 0) {
+    const which: string[] = [];
+    if (reportFpBad.length > 0) which.push("report (" + reportFpBad.join(", ") + ")");
+    if (baselineFpBad.length > 0) which.push("baseline (" + baselineFpBad.join(", ") + ")");
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        "Report or baseline machine fingerprint is missing or has an invalid " +
+        "field type(s): " + which.join("; ") +
+        " — the artifact is incomplete or corrupt. Regenerate it (#1688).",
     };
   }
   // Guard (#1688 item 2): a timing comparison is only meaningful on the

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -157,6 +157,23 @@ export function checkCodingGraphRegression(
     };
   }
 
+  // Field-presence guard: a corrupt/partial v2 report may carry
+  // schemaVersion 2 yet lack a v2-only field (a hand-edited or truncated
+  // JSON). extractMetrics dereferences these fields; without this guard
+  // it throws an uncaught TypeError instead of a structured gate failure
+  // (cursor #1688 review: 'v2 report crashes regression gate').
+  if (report.incrementalModifiedUpdate == null || report.incrementalUpdate == null) {
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        "Report claims schemaVersion " + report.schemaVersion +
+        " but is missing a required metric field (incrementalUpdate or " +
+        "incrementalModifiedUpdate) — the report is incomplete or corrupt. " +
+        "Regenerate it (#1688).",
+    };
+  }
+
   // Guard (#1688 item 2): a timing comparison is only meaningful on the
   // same machine class. A baseline carries a fingerprint (arch/platform/
   // nodeVersion/cpuModel/cores); a report from a different machine class
@@ -181,23 +198,6 @@ export function checkCodingGraphRegression(
         baseline: baseline.machine,
         differingFields: mismatch.differingFields,
       },
-    };
-  }
-
-  // Field-presence guard: a corrupt/partial v2 report may carry
-  // schemaVersion 2 yet lack a v2-only field (a hand-edited or truncated
-  // JSON). extractMetrics dereferences these fields; without this guard
-  // it throws an uncaught TypeError instead of a structured gate failure
-  // (cursor #1688 review: 'v2 report crashes regression gate').
-  if (report.incrementalModifiedUpdate == null || report.incrementalUpdate == null) {
-    return {
-      passed: false,
-      regressions: [],
-      summary:
-        "Report claims schemaVersion " + report.schemaVersion +
-        " but is missing a required metric field (incrementalUpdate or " +
-        "incrementalModifiedUpdate) — the report is incomplete or corrupt. " +
-        "Regenerate it (#1688).",
     };
   }
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -95,7 +95,18 @@ export function compareMachineFingerprints(
   if (report.arch !== baseline.arch) differing.push("arch");
   if (report.platform !== baseline.platform) differing.push("platform");
   if (nodeMajor(report) !== nodeMajor(baseline)) differing.push("nodeVersion(major)");
-  if (report.cpuModel !== baseline.cpuModel) differing.push("cpuModel");
+  // cpuModel is nullable — null means "unknown / undetected", not "different".
+  // Only count a cpuModel difference when BOTH sides report a concrete model,
+  // so a null cpuModel does not spuriously skip the gate and hide a real
+  // regression on the same machine class (cursor Bugbot: 'Fingerprint skip
+  // omits cpuModel validation').
+  if (
+    report.cpuModel !== null &&
+    baseline.cpuModel !== null &&
+    report.cpuModel !== baseline.cpuModel
+  ) {
+    differing.push("cpuModel");
+  }
   if (report.cpuCores !== baseline.cpuCores) differing.push("cpuCores");
   return { differingFields: differing };
 }
@@ -116,6 +127,11 @@ function invalidFingerprintFields(fp: MachineFingerprint): string[] {
   // nodeVersion feeds nodeMajor's .replace — a non-string throws.
   if (typeof fp.nodeVersion !== "string") bad.push("nodeVersion");
   if (typeof fp.cpuCores !== "number" || !Number.isFinite(fp.cpuCores)) bad.push("cpuCores");
+  // cpuModel is nullable (the harness sets null when no CPUs are detected),
+  // but it must still be a string-or-null — a number/object/undefined (a
+  // missing key) is corruption (cursor Bugbot: 'Fingerprint skip omits
+  // cpuModel validation').
+  if (fp.cpuModel !== null && typeof fp.cpuModel !== "string") bad.push("cpuModel");
   return bad;
 }
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -184,6 +184,23 @@ export function checkCodingGraphRegression(
     };
   }
 
+  // Field-presence guard: a corrupt/partial v2 report may carry
+  // schemaVersion 2 yet lack a v2-only field (a hand-edited or truncated
+  // JSON). extractMetrics dereferences these fields; without this guard
+  // it throws an uncaught TypeError instead of a structured gate failure
+  // (cursor #1688 review: 'v2 report crashes regression gate').
+  if (report.incrementalModifiedUpdate == null || report.incrementalUpdate == null) {
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        "Report claims schemaVersion " + report.schemaVersion +
+        " but is missing a required metric field (incrementalUpdate or " +
+        "incrementalModifiedUpdate) — the report is incomplete or corrupt. " +
+        "Regenerate it (#1688).",
+    };
+  }
+
   const measured = extractMetrics(report);
   const baselineMetrics = baseline.metrics;
   const regressions: RegressionMetricDetail[] = [];

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -173,6 +173,10 @@ export function checkCodingGraphRegression(
   if (report.incrementalModifiedUpdate?.p95 == null) missingFields.push("incrementalModifiedUpdate.p95");
   if (report.tracePath?.p95 == null) missingFields.push("tracePath.p95");
   if (report.searchGraph?.p95 == null) missingFields.push("searchGraph.p95");
+  if (report.fullIndexMs?.ms == null) missingFields.push("fullIndexMs.ms");
+  if (report.fullIndexLocsPerSecond == null) missingFields.push("fullIndexLocsPerSecond");
+  if (report.deadCodeMs?.ms == null) missingFields.push("deadCodeMs.ms");
+  if (report.dbBytesPerKloc == null) missingFields.push("dbBytesPerKloc");
   if (missingFields.length > 0) {
     return {
       passed: false,

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -190,6 +190,20 @@ export function checkCodingGraphRegression(
     };
   }
 
+  // Machine-fingerprint presence guard: a corrupt JSON report or baseline
+  // may have a missing/null machine fingerprint. compareMachineFingerprints
+  // dereferences fingerprint fields; without this guard it throws on a null
+  // machine instead of returning a structured gate failure
+  // (chatgpt-codex-connector #1688 P2: 'Validate machine fingerprints').
+  if (report.machine == null || baseline.machine == null) {
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        "Report or baseline is missing the machine fingerprint — the " +
+        "artifact is incomplete or corrupt. Regenerate it (#1688).",
+    };
+  }
   // Guard (#1688 item 2): a timing comparison is only meaningful on the
   // same machine class. A baseline carries a fingerprint (arch/platform/
   // nodeVersion/cpuModel/cores); a report from a different machine class

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -16,6 +16,7 @@ import type {
   CodingGraphBaseline,
   RegressionGateResult,
   RegressionMetricDetail,
+  MachineFingerprint,
 } from "./types.js";
 import { DEFAULT_TOLERANCE_PERCENT } from "./types.js";
 
@@ -31,6 +32,8 @@ const METRIC_DIRECTION = {
   fullIndexLocsPerSecond: "higher-is-better" as const,
   incrementalUpdateP95Ms: "lower-is-better" as const,
   incrementalUpdateP50Ms: "lower-is-better" as const,
+  incrementalModifiedUpdateP95Ms: "lower-is-better" as const,
+  incrementalModifiedUpdateP50Ms: "lower-is-better" as const,
   tracePathP95Ms: "lower-is-better" as const,
   searchGraphP95Ms: "lower-is-better" as const,
   deadCodeMs: "lower-is-better" as const,
@@ -48,6 +51,8 @@ export function extractMetrics(report: CodingGraphBenchReport): Record<string, n
     fullIndexLocsPerSecond: report.fullIndexLocsPerSecond,
     incrementalUpdateP50Ms: report.incrementalUpdate.p50,
     incrementalUpdateP95Ms: report.incrementalUpdate.p95,
+    incrementalModifiedUpdateP50Ms: report.incrementalModifiedUpdate.p50,
+    incrementalModifiedUpdateP95Ms: report.incrementalModifiedUpdate.p95,
     tracePathP95Ms: report.tracePath.p95,
     searchGraphP95Ms: report.searchGraph.p95,
     deadCodeMs: report.deadCodeMs.ms,
@@ -55,6 +60,45 @@ export function extractMetrics(report: CodingGraphBenchReport): Record<string, n
   };
 }
 
+
+// ---------------------------------------------------------------------------
+// Machine-fingerprint comparison (#1688 item 2).
+//
+// Compares the load-bearing fields that drive timing variance. nodeVersion
+// is compared on its MAJOR version only (v22.20.0 vs v22.5.0 race identically
+// for our purposes; v22 vs v23 do not). cpuCores counts; totalMemoryMb does
+// not (a memory difference alone rarely moves sub-ms SQLite ops and would
+// over-trigger the skip).
+// ---------------------------------------------------------------------------
+
+const NODE_MAJOR_CACHE = new WeakMap<MachineFingerprint, string>();
+
+function nodeMajor(fp: MachineFingerprint): string {
+  const cached = NODE_MAJOR_CACHE.get(fp);
+  if (cached !== undefined) return cached;
+  // process.version shape: "v22.20.0" → major "22".
+  const major = fp.nodeVersion.replace(/^v/, "").split(".")[0] ?? fp.nodeVersion;
+  NODE_MAJOR_CACHE.set(fp, major);
+  return major;
+}
+
+/**
+ * Compare two machine fingerprints on the fields that matter for timing.
+ * Returns the list of fields that differ. An empty list means the
+ * fingerprints are comparable.
+ */
+export function compareMachineFingerprints(
+  report: MachineFingerprint,
+  baseline: MachineFingerprint,
+): { readonly differingFields: readonly string[] } {
+  const differing: string[] = [];
+  if (report.arch !== baseline.arch) differing.push("arch");
+  if (report.platform !== baseline.platform) differing.push("platform");
+  if (nodeMajor(report) !== nodeMajor(baseline)) differing.push("nodeVersion(major)");
+  if (report.cpuModel !== baseline.cpuModel) differing.push("cpuModel");
+  if (report.cpuCores !== baseline.cpuCores) differing.push("cpuCores");
+  return { differingFields: differing };
+}
 /**
  * Compare a report against a baseline. Returns a gate result that exits
  * non-zero when any metric regresses beyond the tolerance.
@@ -72,6 +116,33 @@ export function checkCodingGraphRegression(
   const measured = extractMetrics(report);
   const baselineMetrics = baseline.metrics;
   const regressions: RegressionMetricDetail[] = [];
+
+  // Guard (#1688 item 2): a timing comparison is only meaningful on the
+  // same machine class. A baseline carries a fingerprint (arch/platform/
+  // nodeVersion/cpuModel/cores); a report from a different machine class
+  // can fail the gate on legitimate hardware variance rather than a real
+  // regression. When the fingerprints differ on a load-bearing field, SKIP
+  // the comparison (passed: true + skipped: true) and surface the mismatch
+  // so a human decides whether cross-machine numbers are comparable.
+  const mismatch = compareMachineFingerprints(report.machine, baseline.machine);
+  if (mismatch.differingFields.length > 0) {
+    return {
+      passed: true,
+      skipped: true,
+      regressions: [],
+      summary:
+        "Machine-fingerprint mismatch — comparison skipped to avoid a " +
+        "false-positive hardware-variance failure. Differing fields: " +
+        mismatch.differingFields.join(", ") +
+        ". Regenerate the baseline on this machine for a real comparison " +
+        "(#1688).",
+      machineMismatch: {
+        report: report.machine,
+        baseline: baseline.machine,
+        differingFields: mismatch.differingFields,
+      },
+    };
+  }
 
   // Guard: a regression comparison is only meaningful when the report's
   // fixture matches the baseline's fixture on EVERY knob. A different seed

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -157,26 +157,28 @@ export function checkCodingGraphRegression(
     };
   }
 
-  // Field-presence guard: a corrupt/partial v2 report may carry
-  // schemaVersion 2 yet lack a required metric field OR a nested sub-field
-  // (a hand-edited or truncated JSON). extractMetrics dereferences both the
-  // top-level field and its nested p50/p95; without this guard a missing
-  // nested field produces undefined in the metric map, and the comparison
-  // loop silently skips it (passed: true) — letting corrupt artifacts pass
-  // (chatgpt-codex-connector #1688 P2: 'Validate nested metric fields').
-  const missingFields: string[] = [];
-  if (report.incrementalUpdate == null) missingFields.push("incrementalUpdate");
-  if (report.incrementalModifiedUpdate == null) missingFields.push("incrementalModifiedUpdate");
-  if (report.incrementalUpdate?.p50 == null) missingFields.push("incrementalUpdate.p50");
-  if (report.incrementalUpdate?.p95 == null) missingFields.push("incrementalUpdate.p95");
-  if (report.incrementalModifiedUpdate?.p50 == null) missingFields.push("incrementalModifiedUpdate.p50");
-  if (report.incrementalModifiedUpdate?.p95 == null) missingFields.push("incrementalModifiedUpdate.p95");
-  if (report.tracePath?.p95 == null) missingFields.push("tracePath.p95");
-  if (report.searchGraph?.p95 == null) missingFields.push("searchGraph.p95");
-  if (report.fullIndexMs?.ms == null) missingFields.push("fullIndexMs.ms");
-  if (report.fullIndexLocsPerSecond == null) missingFields.push("fullIndexLocsPerSecond");
-  if (report.deadCodeMs?.ms == null) missingFields.push("deadCodeMs.ms");
-  if (report.dbBytesPerKloc == null) missingFields.push("dbBytesPerKloc");
+  // Field-presence + finite-number guard: a corrupt/partial v2 report
+  // may carry schemaVersion 2 yet lack a required metric field, have a
+  // nested sub-field missing, or carry a non-numeric value from a malformed
+  // JSON (e.g. fullIndexLocsPerSecond: "oops"). extractMetrics feeds these
+  // values into ratio math; a NaN result silently passes the gate. Validate
+  // every metric as a finite number before comparing or skipping
+  // (chatgpt-codex-connector #1688 P2: 'Validate metric values as finite').
+  const metricChecks: ReadonlyArray<readonly [string, unknown]> = [
+    ["incrementalUpdate.p50", report.incrementalUpdate?.p50],
+    ["incrementalUpdate.p95", report.incrementalUpdate?.p95],
+    ["incrementalModifiedUpdate.p50", report.incrementalModifiedUpdate?.p50],
+    ["incrementalModifiedUpdate.p95", report.incrementalModifiedUpdate?.p95],
+    ["tracePath.p95", report.tracePath?.p95],
+    ["searchGraph.p95", report.searchGraph?.p95],
+    ["fullIndexMs.ms", report.fullIndexMs?.ms],
+    ["fullIndexLocsPerSecond", report.fullIndexLocsPerSecond],
+    ["deadCodeMs.ms", report.deadCodeMs?.ms],
+    ["dbBytesPerKloc", report.dbBytesPerKloc],
+  ];
+  const missingFields = metricChecks
+    .filter(([, v]) => typeof v !== "number" || !Number.isFinite(v as number))
+    .map(([k]) => k);
   if (missingFields.length > 0) {
     return {
       passed: false,

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -162,15 +162,28 @@ export function checkCodingGraphRegression(
   // JSON). extractMetrics dereferences these fields; without this guard
   // it throws an uncaught TypeError instead of a structured gate failure
   // (cursor #1688 review: 'v2 report crashes regression gate').
-  if (report.incrementalModifiedUpdate == null || report.incrementalUpdate == null) {
+  // Field-presence guard: a corrupt/partial v2 report may carry
+  // schemaVersion 2 yet lack a required metric field OR a nested sub-field
+  // (a hand-edited or truncated JSON). extractMetrics dereferences both the
+  // top-level field and its nested p50/p95; without this guard a missing
+  // nested field produces undefined in the metric map, and the comparison
+  // loop silently skips it (passed: true) — letting corrupt artifacts pass
+  // (chatgpt-codex-connector #1688 P2: 'Validate nested metric fields').
+  const missingFields: string[] = [];
+  if (report.incrementalUpdate == null) missingFields.push("incrementalUpdate");
+  if (report.incrementalModifiedUpdate == null) missingFields.push("incrementalModifiedUpdate");
+  if (report.incrementalUpdate?.p95 == null) missingFields.push("incrementalUpdate.p95");
+  if (report.incrementalModifiedUpdate?.p95 == null) missingFields.push("incrementalModifiedUpdate.p95");
+  if (report.tracePath?.p95 == null) missingFields.push("tracePath.p95");
+  if (report.searchGraph?.p95 == null) missingFields.push("searchGraph.p95");
+  if (missingFields.length > 0) {
     return {
       passed: false,
       regressions: [],
       summary:
         "Report claims schemaVersion " + report.schemaVersion +
-        " but is missing a required metric field (incrementalUpdate or " +
-        "incrementalModifiedUpdate) — the report is incomplete or corrupt. " +
-        "Regenerate it (#1688).",
+        " but is missing required metric field(s): " + missingFields.join(", ") +
+        " — the report is incomplete or corrupt. Regenerate it (#1688).",
     };
   }
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -113,9 +113,49 @@ export function checkCodingGraphRegression(
   baseline: CodingGraphBaseline,
   tolerancePercent: number = DEFAULT_TOLERANCE_PERCENT,
 ): RegressionGateResult {
-  const measured = extractMetrics(report);
-  const baselineMetrics = baseline.metrics;
-  const regressions: RegressionMetricDetail[] = [];
+
+  // Guard: a regression comparison is only meaningful when the report's
+  // fixture matches the baseline's fixture on EVERY knob. A different seed
+  // or language produces a structurally different synthetic repo, so timing
+  // deltas across mismatched fixtures are meaningless. Compare all keys
+  // present in the baseline config so new knobs are covered automatically.
+  const reportFixture = report.fixture.config;
+  const baselineFixture = baseline.fixtureConfig;
+  const mismatchedKeys = (Object.keys(baselineFixture) as Array<
+    keyof typeof baselineFixture
+  >).filter((key) => reportFixture[key] !== baselineFixture[key]);
+  if (mismatchedKeys.length > 0) {
+    const diffs = mismatchedKeys
+      .map(
+        (key) =>
+          `${key}: report=${reportFixture[key]} baseline=${baselineFixture[key]}`,
+      )
+      .join(", ");
+    return {
+      passed: false,
+      regressions: [],
+      summary: `Fixture mismatch (${diffs}). Metrics are not comparable across different fixtures.`,
+    };
+  }
+
+  // Guard: schema-version compatibility. extractMetrics below
+  // unconditionally dereferences v2-only fields (e.g.
+  // incrementalModifiedUpdate); a pre-v2 report lacks them and would
+  // throw a TypeError before any skip could run — defeating the
+  // cross-environment robustness the machine guard targets
+  // (kilo-code-bot review of #1688). A schema mismatch is a structural
+  // incompatibility: fail with an actionable message instead of
+  // crashing or silently skipping.
+  if (report.schemaVersion !== baseline.schemaVersion) {
+    return {
+      passed: false,
+      regressions: [],
+      summary:
+        `Schema-version mismatch: report=${report.schemaVersion} ` +
+        `baseline=${baseline.schemaVersion}. Metrics are not comparable ` +
+        `across schema versions — regenerate the baseline (#1688).`,
+    };
+  }
 
   // Guard (#1688 item 2): a timing comparison is only meaningful on the
   // same machine class. A baseline carries a fingerprint (arch/platform/
@@ -144,29 +184,9 @@ export function checkCodingGraphRegression(
     };
   }
 
-  // Guard: a regression comparison is only meaningful when the report's
-  // fixture matches the baseline's fixture on EVERY knob. A different seed
-  // or language produces a structurally different synthetic repo, so timing
-  // deltas across mismatched fixtures are meaningless. Compare all keys
-  // present in the baseline config so new knobs are covered automatically.
-  const reportFixture = report.fixture.config;
-  const baselineFixture = baseline.fixtureConfig;
-  const mismatchedKeys = (Object.keys(baselineFixture) as Array<
-    keyof typeof baselineFixture
-  >).filter((key) => reportFixture[key] !== baselineFixture[key]);
-  if (mismatchedKeys.length > 0) {
-    const diffs = mismatchedKeys
-      .map(
-        (key) =>
-          `${key}: report=${reportFixture[key]} baseline=${baselineFixture[key]}`,
-      )
-      .join(", ");
-    return {
-      passed: false,
-      regressions: [],
-      summary: `Fixture mismatch (${diffs}). Metrics are not comparable across different fixtures.`,
-    };
-  }
+  const measured = extractMetrics(report);
+  const baselineMetrics = baseline.metrics;
+  const regressions: RegressionMetricDetail[] = [];
 
   for (const key of Object.keys(METRIC_DIRECTION) as RegressionMetricKey[]) {
     const baseVal = baselineMetrics[key];

--- a/packages/bench/src/coding-graph/types.ts
+++ b/packages/bench/src/coding-graph/types.ts
@@ -130,6 +130,8 @@ export type CodingGraphMetricKey =
   | "fullIndexLocsPerSecond"
   | "incrementalUpdateP50Ms"
   | "incrementalUpdateP95Ms"
+  | "incrementalModifiedUpdateP50Ms"
+  | "incrementalModifiedUpdateP95Ms"
   | "tracePathP95Ms"
   | "searchGraphP95Ms"
   | "deadCodeMs"
@@ -155,8 +157,14 @@ export interface CodingGraphBenchReport {
   readonly fullIndexMs: WallMetric;
   /** LOC/s sustained during full index (higher is better). */
   readonly fullIndexLocsPerSecond: number;
-  /** Incremental single-file update latency distribution. */
+  /** Incremental single-file update latency distribution (idempotent
+   *  re-ingest of UNCHANGED content — the common-case no-op path). */
   readonly incrementalUpdate: MicroMetric;
+  /** Incremental MODIFIED-content re-ingest latency distribution. A
+   *  complementary metric to `incrementalUpdate`: measures the change-heavy
+   *  path (edge deletion/creation, symbol re-resolution) rather than the
+   *  cache-hit no-op (#1688 item 1). */
+  readonly incrementalModifiedUpdate: MicroMetric;
   /** trace_path (depth ≤ 5) latency distribution. */
   readonly tracePath: MicroMetric;
   /** search_graph name-pattern latency distribution. */
@@ -212,6 +220,24 @@ export interface RegressionGateResult {
   readonly passed: boolean;
   readonly regressions: readonly RegressionMetricDetail[];
   readonly summary: string;
+  /**
+   * True when the gate SKIPPED the metric comparison because of a
+   * non-fatal precondition (machine-fingerprint mismatch). `passed` is
+   * also true in that case — a hardware variance must not fail CI (#1688
+   * item 2). Callers that want to treat a skip as informational can check
+   * this flag.
+   */
+  readonly skipped?: boolean;
+  /**
+   * Present when `skipped` is true due to a machine-fingerprint mismatch
+   * between the report and the baseline. Lists the fingerprint fields that
+   * differ so a human can decide whether the comparison is still meaningful.
+   */
+  readonly machineMismatch?: {
+    readonly report: MachineFingerprint;
+    readonly baseline: MachineFingerprint;
+    readonly differingFields: readonly string[];
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -261,4 +287,4 @@ export const MIN_ITERATIONS = 20;
 export const DEFAULT_TOLERANCE_PERCENT = 30;
 
 /** Report schema version — bump when the shape changes. */
-export const CODING_GRAPH_BENCH_SCHEMA_VERSION = 1;
+export const CODING_GRAPH_BENCH_SCHEMA_VERSION = 2;

--- a/packages/coding-graph/README.md
+++ b/packages/coding-graph/README.md
@@ -111,6 +111,10 @@ const indexResult = await indexSymbolVectors({ store, provider, repoRoot, config
 // SIMILAR_TO: MinHash/LSH candidates → cosine confirmation.
 // repoRoot (or prebuilt bodies) is required so the pipeline hashes real
 // symbol bodies, not qualified names.
+// Clear existing SIMILAR_TO edges first so the recompute is replace-not-
+// append (upsertEdges does not delete absent rows — without clearing, two
+// symbols that stop being similar would leave a stale edge).
+await store.clearSemanticSimilarToEdges();
 const similar = computeSimilarTo({ store, provider, repoRoot, config });
 if (similar.ok) {
   await store.upsertEdges(similarEdgesToEdgeIR(similar.edges));

--- a/packages/coding-graph/README.md
+++ b/packages/coding-graph/README.md
@@ -111,12 +111,17 @@ const indexResult = await indexSymbolVectors({ store, provider, repoRoot, config
 // SIMILAR_TO: MinHash/LSH candidates → cosine confirmation.
 // repoRoot (or prebuilt bodies) is required so the pipeline hashes real
 // symbol bodies, not qualified names.
-// Clear existing SIMILAR_TO edges first so the recompute is replace-not-
-// append (upsertEdges does not delete absent rows — without clearing, two
-// symbols that stop being similar would leave a stale edge).
-await store.clearSemanticSimilarToEdges();
+// Compute-first-then-swap: computeSimilarTo is pure (it reads nodes +
+// vectors but never mutates edges), so compute the candidate set BEFORE
+// touching the table. Only on success do we clear + upsert — this
+// preserves the existing SIMILAR_TO edges if the recompute fails (e.g. a
+// closed store or a missing repoRoot), instead of leaving the graph with
+// zero semantic edges. The clear is still required because upsertEdges
+// does not delete absent rows — without it, two symbols that stop being
+// similar would keep a stale edge (replace-not-append).
 const similar = computeSimilarTo({ store, provider, repoRoot, config });
 if (similar.ok) {
+  await store.clearSemanticSimilarToEdges();
   await store.upsertEdges(similarEdgesToEdgeIR(similar.edges));
 }
 

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -27,6 +27,7 @@ import {
   kindFromCapture,
   type DefKind,
 } from "./extractors.js";
+import { buildUtf16ToByteOffsetMap, utf16ToByte } from "./utf16-offsets.js";
 
 // ---------------------------------------------------------------------------
 // Content hashing — SHA-256 of the raw bytes (rule 23).
@@ -313,6 +314,7 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
       let handler = "";
       let startByte = 0;
       let endByte = 0;
+      let argsNode: TSNode | null = null;
       for (const cap of match.captures) {
         if (cap.name === "route.verb") {
           verb = cap.node.text.toUpperCase();
@@ -320,14 +322,20 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
         } else if (cap.name === "route.path") {
           pathTemplate = cleanModuleSpecifier(cap.node.text);
         } else if (cap.name === "route.handler") {
-          // Identifier handlers (Python function names, JS named route
-          // handlers like app.get("/x", handler)) carry the name directly.
-          // Function/arrow expression handlers need name extraction.
+          // Python route handlers (function names) and legacy JS patterns.
           handler = cap.node.type === "identifier"
             ? cap.node.text
             : (findHandlerName(cap.node) ?? "anonymous");
           endByte = cap.node.endIndex;
+        } else if (cap.name === "route.args") {
+          argsNode = cap.node;
+          endByte = cap.node.endIndex;
         }
+      }
+      // Extract handler from the last argument when we captured the args
+      // node (JS routes). Handles middleware: handler is the LAST arg (#1659 #5).
+      if (argsNode) {
+        handler = extractHandlerFromArgs(argsNode);
       }
       if (verb && pathTemplate) {
         routes.push({
@@ -344,6 +352,25 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
   } finally {
     query.delete();
   }
+}
+
+/**
+ * Extract the route handler name from the LAST argument of an arguments
+ * node. Handles middleware: app.get("/path", requireAuth, getUsers) →
+ * handler=getUsers (the last arg), not requireAuth (issue #1659 #5).
+ */
+function extractHandlerFromArgs(argsNode: TSNode): string {
+  const count = argsNode.namedChildCount;
+  if (count < 2) return "";
+  const lastArg = argsNode.namedChild(count - 1);
+  if (!lastArg) return "";
+  if (lastArg.type === "identifier") {
+    return lastArg.text;
+  }
+  if (lastArg.type === "function_expression") {
+    return findHandlerName(lastArg) ?? "anonymous";
+  }
+  return "anonymous";
 }
 
 /**
@@ -370,6 +397,13 @@ function findHandlerName(node: TSNode): string | null {
 /**
  * Assemble a FileIR from a parsed tree. All collections are sorted for
  * deterministic output (rule 38).
+ *
+ * `contentStr` is the UTF-8 string that was passed to the parser. It is used
+ * to build a UTF-16→byte offset map so all spans are converted from UTF-16
+ * code-unit offsets (what web-tree-sitter returns) to UTF-8 byte offsets
+ * (what on-disk files use). For ASCII-only content the two are identical;
+ * multibyte content (comments, strings, identifiers) needs the conversion
+ * (issue #1659 item 3).
  */
 export function emitFileIR(
   filePath: string,
@@ -377,20 +411,61 @@ export function emitFileIR(
   content: Uint8Array,
   root: TSNode,
   language: Language,
+  contentStr: string,
 ): FileIR {
   const symbols = extractSymbols(root, language, lang);
   const imports = extractImports(root, language, lang);
   const exports = extractExports(root, language, lang);
   const callSites = extractCallSites(root, language, lang);
   const routes = extractRoutes(root, language, lang);
+
+  // Convert UTF-16 code-unit offsets → UTF-8 byte offsets (issue #1659 #3).
+  // Spans are readonly, so rebuild each object with converted offsets.
+  const offsetMap = buildUtf16ToByteOffsetMap(contentStr);
+  const convSymbols = symbols.map((s) => ({
+    ...s,
+    span: {
+      startByte: utf16ToByte(offsetMap, s.span.startByte),
+      endByte: utf16ToByte(offsetMap, s.span.endByte),
+    },
+  }));
+  const convImports = imports.map((i) => ({
+    ...i,
+    span: {
+      startByte: utf16ToByte(offsetMap, i.span.startByte),
+      endByte: utf16ToByte(offsetMap, i.span.endByte),
+    },
+  }));
+  const convExports = exports.map((e) => ({
+    ...e,
+    span: {
+      startByte: utf16ToByte(offsetMap, e.span.startByte),
+      endByte: utf16ToByte(offsetMap, e.span.endByte),
+    },
+  }));
+  const convCallSites = callSites.map((c) => ({
+    ...c,
+    span: {
+      startByte: utf16ToByte(offsetMap, c.span.startByte),
+      endByte: utf16ToByte(offsetMap, c.span.endByte),
+    },
+  }));
+  const convRoutes = routes.map((r) => ({
+    ...r,
+    span: {
+      startByte: utf16ToByte(offsetMap, r.span.startByte),
+      endByte: utf16ToByte(offsetMap, r.span.endByte),
+    },
+  }));
+
   return {
     path: filePath,
     language: lang,
     contentHash: hashContent(content),
-    symbols,
-    imports,
-    exports,
-    callSites,
-    routes,
+    symbols: convSymbols,
+    imports: convImports,
+    exports: convExports,
+    callSites: convCallSites,
+    routes: convRoutes,
   };
 }

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -369,7 +369,7 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
       if (argsNode) {
         handler = extractHandlerFromArgs(argsNode);
       }
-      if (verb && pathTemplate) {
+      if (verb && pathTemplate && handler) {
         routes.push({
           verb,
           pathTemplate,

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -252,14 +252,46 @@ function extractExports(root: TSNode, language: Language, lang: CodingGraphLangu
   const query = new Query(language, extractor.exportsQuery);
   try {
     const captures = query.captures(root);
+    // Dedup a CommonJS pair overlap (#1659 review): a pair
+    // `{ key: value }` whose value is an identifier is matched by BOTH
+    // the value-identifier pattern (captures the real symbol) AND the
+    // non-identifier fallback (captures the key). The fallback's
+    // #not-match? regex is ASCII-only, so a Unicode identifier value
+    // (e.g. Universität) defeats it and both patterns fire on the same
+    // pair, duplicating the export. web-tree-sitter's query regex
+    // engine does not support \p{L}, so dedup here: if a pair already
+    // exported its value identifier, drop the spurious key capture.
+    const valueExportedPairs = new Set<number>();
+    const pairOf = (node: TSNode): TSNode | null => {
+      let cur: TSNode | null = node;
+      for (let i = 0; i < 5 && cur; i++) {
+        if (cur.type === "pair") return cur;
+        cur = cur.parent;
+      }
+      return null;
+    };
+    for (const cap of captures) {
+      if (cap.name !== "export.name") continue;
+      const pair = pairOf(cap.node);
+      if (pair && cap.node.type === "identifier") {
+        valueExportedPairs.add(pair.id);
+      }
+    }
     const exports: ExportIR[] = [];
     for (const cap of captures) {
-      if (cap.name === "export.name") {
-        exports.push({
-          name: cap.node.text,
-          span: { startByte: cap.node.startIndex, endByte: cap.node.endIndex },
-        });
+      if (cap.name !== "export.name") continue;
+      const pair = pairOf(cap.node);
+      if (
+        pair &&
+        cap.node.type === "property_identifier" &&
+        valueExportedPairs.has(pair.id)
+      ) {
+        continue; // value identifier is the real export; drop the alias key
       }
+      exports.push({
+        name: cap.node.text,
+        span: { startByte: cap.node.startIndex, endByte: cap.node.endIndex },
+      });
     }
     return exports.sort(
       (a, b) => a.span.startByte - b.span.startByte || a.name.localeCompare(b.name),
@@ -360,10 +392,20 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
  * handler=getUsers (the last arg), not requireAuth (issue #1659 #5).
  */
 function extractHandlerFromArgs(argsNode: TSNode): string {
-  const count = argsNode.namedChildCount;
-  if (count < 2) return "";
-  const lastArg = argsNode.namedChild(count - 1);
-  if (!lastArg) return "";
+  // Collect the real (non-comment) named args, skipping trailing inline/
+  // block comments. tree-sitter treats comments as named children, so
+  // `app.get("/users", getUsers /* auth */)` would otherwise select the
+  // comment as the last arg, miss the real handler, and leave it
+  // un-protected by the route-handler exclusion (a false dead-code hit).
+  // (chatgpt-codex-connector #1659 review: 'Skip comments when selecting
+  // route handler'.)
+  const realArgs: TSNode[] = [];
+  for (let i = 0; i < argsNode.namedChildCount; i++) {
+    const child = argsNode.namedChild(i);
+    if (child && child.type !== "comment") realArgs.push(child);
+  }
+  if (realArgs.length < 2) return "";
+  const lastArg = realArgs[realArgs.length - 1]!;
   if (lastArg.type === "identifier") {
     return lastArg.text;
   }

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -365,7 +365,21 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
           const memberExpr = cap.node.parent;
           const objectNode = memberExpr?.childForFieldName("object");
           if (objectNode) {
-            routeObject = objectNode.text;
+            // Normalize nested receivers to their tail property so a call
+            // like this.client.get("/api", opts, cb) is caught by the HTTP-
+            // client exclusion. objectNode.text for `this.client` is
+            // "this.client", which misses the ^client$ pattern; descend to
+            // the rightmost property (chatgpt-codex-connector #1688 P2:
+            // 'Normalize receiver names before client-route filtering').
+            let receiver = objectNode;
+            for (
+              let prop = receiver.childForFieldName("property");
+              prop;
+              prop = receiver.childForFieldName("property")
+            ) {
+              receiver = prop;
+            }
+            routeObject = receiver.text;
           }
         } else if (cap.name === "route.path") {
           pathTemplate = cleanModuleSpecifier(cap.node.text);

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -412,7 +412,13 @@ function extractHandlerFromArgs(argsNode: TSNode): string {
   if (lastArg.type === "function_expression") {
     return findHandlerName(lastArg) ?? "anonymous";
   }
-  return "anonymous";
+  if (lastArg.type === "arrow_function") {
+    return "anonymous";
+  }
+  // Non-handler last arg (object, number, call expression, etc.) —
+  // not a route handler. Return empty so the caller skips the route
+  // (cursor Bugbot: 'Spurious routes from client calls').
+  return "";
 }
 
 /**

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -333,6 +333,15 @@ function extractCallSites(root: TSNode, language: Language, lang: CodingGraphLan
 // Route extraction (Express/Fastify/Flask/etc.).
 // ---------------------------------------------------------------------------
 
+
+// Common HTTP client variable names that should NOT produce routes.
+// These objects have methods named get/post/etc. that match the route
+// verb pattern but are client-side calls, not server route registrations.
+// Without this exclusion, httpClient.get("/api", opts, cb) would produce
+// a spurious route with handler=cb, marking cb as is_route_handler and
+// hiding it from dead-code detection (chatgpt-codex-connector #1688 P2).
+const HTTP_CLIENT_OBJECT_PATTERNS = /^(http|https|client|httpClient|axios|fetch|request|req|res|\$|superagent|got)$/;
+
 function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLanguage): RouteIR[] {
   const extractor = EXTRACTORS[lang];
   if (!extractor.routesQuery) return [];
@@ -347,10 +356,17 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
       let startByte = 0;
       let endByte = 0;
       let argsNode: TSNode | null = null;
+      let routeObject = "";
       for (const cap of match.captures) {
         if (cap.name === "route.verb") {
           verb = cap.node.text.toUpperCase();
           startByte = cap.node.parent?.startIndex ?? cap.node.startIndex;
+          // Extract the receiver object name for the HTTP-client exclusion.
+          const memberExpr = cap.node.parent;
+          const objectNode = memberExpr?.childForFieldName("object");
+          if (objectNode) {
+            routeObject = objectNode.text;
+          }
         } else if (cap.name === "route.path") {
           pathTemplate = cleanModuleSpecifier(cap.node.text);
         } else if (cap.name === "route.handler") {
@@ -369,15 +385,14 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
       if (argsNode) {
         handler = extractHandlerFromArgs(argsNode);
       }
-      // Path-prefix guard: real route paths always start with "/" or "*"
-      // (Express/Fastify/etc.). This filters non-route call expressions
-      // whose "path" is a full URL (httpClient.get("https://...", opts, cb)).
-      // Relative-path client calls (httpClient.get("/api", opts, cb)) are a
-      // semantic ambiguity that needs type inference to fully resolve —
-      // documented here as a known limitation (chatgpt-codex-connector #1688
-      // P2: 'Reject client callbacks as route handlers').
+      // Guards: (1) path-prefix — routes start with "/" or "*";
+      // (2) HTTP-client exclusion — objects named http/client/axios/etc.
+      // are clients, not routers. Together these filter the most common
+      // non-route call expressions that match the verb+string-arg pattern
+      // (chatgpt-codex-connector #1688 P2: 'Reject client callbacks').
       const isRoutePath = pathTemplate.startsWith("/") || pathTemplate.startsWith("*");
-      if (verb && pathTemplate && handler && isRoutePath) {
+      const isHttpClient = HTTP_CLIENT_OBJECT_PATTERNS.test(routeObject);
+      if (verb && pathTemplate && handler && isRoutePath && !isHttpClient) {
         routes.push({
           verb,
           pathTemplate,

--- a/packages/coding-graph/src/engine/emit.ts
+++ b/packages/coding-graph/src/engine/emit.ts
@@ -369,7 +369,15 @@ function extractRoutes(root: TSNode, language: Language, lang: CodingGraphLangua
       if (argsNode) {
         handler = extractHandlerFromArgs(argsNode);
       }
-      if (verb && pathTemplate && handler) {
+      // Path-prefix guard: real route paths always start with "/" or "*"
+      // (Express/Fastify/etc.). This filters non-route call expressions
+      // whose "path" is a full URL (httpClient.get("https://...", opts, cb)).
+      // Relative-path client calls (httpClient.get("/api", opts, cb)) are a
+      // semantic ambiguity that needs type inference to fully resolve —
+      // documented here as a known limitation (chatgpt-codex-connector #1688
+      // P2: 'Reject client callbacks as route handlers').
+      const isRoutePath = pathTemplate.startsWith("/") || pathTemplate.startsWith("*");
+      if (verb && pathTemplate && handler && isRoutePath) {
         routes.push({
           verb,
           pathTemplate,

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1295,6 +1295,32 @@ test("1688-route-2: HTTP client calls with options object do NOT produce spuriou
   assert.equal(clientRoutes.length, 0, "httpClient.get/delete/put must NOT produce spurious routes");
   await engine.dispose();
 });
+test("1688-route-3: full-URL client calls do NOT produce routes (path-prefix guard)", async () => {
+  // Route paths always start with "/" or "*". HTTP client calls with full
+  // URLs (httpClient.get("https://api.example.com", opts, cb)) are filtered
+  // by the path-prefix guard (chatgpt-codex-connector #1688 P2).
+  const engine = createCodingGraphEngine();
+  const code = [
+    'const http = require("http");',
+    'http.get("https://api.example.com/data", (res) => {});',
+    'http.request("http://localhost:3000/api", { method: "POST" }, (res) => {});',
+    "",
+    "function listUsers(req, res) { res.json([]); }",
+    'app.get("/users", listUsers);',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/client2.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  // Real route must still be captured.
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should still capture the real /users route");
+  // Full-URL client calls must NOT produce routes.
+  const urlRoutes = routes.filter((r) => r.pathTemplate.startsWith("http"));
+  assert.equal(urlRoutes.length, 0, "full-URL http.get/request calls must NOT produce routes");
+  await engine.dispose();
+});
+
 
 
 

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1261,6 +1261,41 @@ test("1688-route: cache.get('user') does NOT produce a route (empty-handler skip
   assert.equal(cacheRoutes.length, 0, "cache.get/delete/set must NOT produce routes");
   await engine.dispose();
 });
+test("1688-route-2: HTTP client calls with options object do NOT produce spurious routes", async () => {
+  // The cursor Bugbot thread @14:47: the unified route matcher treats any
+  // call whose method name is an HTTP verb and first arg is a string as a
+  // route when there are >= 2 args. extractHandlerFromArgs previously
+  // returned "anonymous" for non-handler last args (objects, numbers),
+  // producing spurious routes from client calls like httpClient.get(url, opts).
+  // Now non-handler last args return "" so the route is skipped.
+  const engine = createCodingGraphEngine();
+  const code = [
+    'const httpClient = { get: (url, opts) => {} };',
+    'httpClient.get("https://api.example.com", { headers: { auth: "token" } });',
+    'httpClient.delete("https://api.example.com/resource", { method: "DELETE" });',
+    'httpClient.put("https://api.example.com/data", 42);',
+    "",
+    "function getUsers(req, res) { res.json([]); }",
+    'app.get("/users", getUsers);',
+    'app.post("/items", (req, res) => {});',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/client.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  // Real routes must still be captured.
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should still capture the real /users route");
+  const itemsRoute = routes.find((r) => r.pathTemplate === "/items");
+  assert.ok(itemsRoute, "should still capture the real /items route with arrow fn handler");
+  // HTTP client calls must NOT produce routes.
+  const clientRoutes = routes.filter((r) =>
+    r.pathTemplate.startsWith("https://") || r.pathTemplate.includes("api.example.com"),
+  );
+  assert.equal(clientRoutes.length, 0, "httpClient.get/delete/put must NOT produce spurious routes");
+  await engine.dispose();
+});
+
 
 
 test("1659-6: Python relative import from .models captures module", async () => {

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1050,3 +1050,131 @@ test("lifecycle: double dispose is safe", async () => {
   await engine.dispose();
   await engine.dispose(); // should not throw
 });
+
+// ===========================================================================
+// Issue #1659: export-capture edge cases (default exports, CJS alias,
+// UTF-16 offsets, C++ qualified methods, Express middleware, Python relative).
+// ===========================================================================
+
+test("1659-1: export default App (bare identifier) captured as export", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "function App() { return null; }",
+    "export default App;",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/app.tsx", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const exportNames = result.ir.exports.map((e) => e.name);
+  assert.ok(exportNames.includes("App"), `TSX: export default App should be exported, got: ${exportNames.join(", ")}`);
+  await engine.dispose();
+});
+
+test("1659-1b: export default App in JS captured as export", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "const App = () => {}",
+    "export default App;",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/app.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const exportNames = result.ir.exports.map((e) => e.name);
+  assert.ok(exportNames.includes("App"), `JS: export default App should be exported, got: ${exportNames.join(", ")}`);
+  await engine.dispose();
+});
+
+test("1659-2: CJS alias target captures value identifier, not key", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "function createRouter() { return {}; }",
+    "module.exports = { publicName: createRouter };",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/router.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const exportNames = result.ir.exports.map((e) => e.name);
+  assert.ok(
+    exportNames.includes("createRouter"),
+    `CJS: module.exports = { publicName: createRouter } should export createRouter (the value), got: ${exportNames.join(", ")}`,
+  );
+  await engine.dispose();
+});
+
+test("1659-3: UTF-16 offsets produce correct byte spans for multibyte content", async () => {
+  const engine = createCodingGraphEngine();
+  // Leading comment with multibyte chars so UTF-16 and byte offsets diverge.
+  // "café" = 4 UTF-16 code units but 5 UTF-8 bytes (é = 2 bytes).
+  const code = "// café comment\nfunction hello() { return 1; }\n";
+  const buf = Buffer.from(code, "utf-8");
+  const result = await engine.parseFile({ path: "src/multibyte.ts", content: buf });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const fn = result.ir.symbols.find((s) => s.name === "hello");
+  assert.ok(fn, "should find hello function");
+  if (!fn) return;
+  // The function keyword starts after "// café comment\n".
+  // "// " = 3 bytes, "café" = 5 bytes, " comment" = 8 bytes, "\n" = 1 byte = 17 bytes total prefix.
+  // So "function hello..." starts at byte offset 17.
+  assert.equal(
+    fn.span.startByte, 17,
+    `hello startByte should be 17 (byte offset), got ${fn.span.startByte}`,
+  );
+  // Verify we can slice the correct text from the byte buffer.
+  const sliced = buf.subarray(fn.span.startByte, fn.span.endByte).toString("utf-8");
+  assert.ok(sliced.startsWith("function hello"), `byte-offset slice should start with 'function hello', got: ${sliced}`);
+  await engine.dispose();
+});
+
+test("1659-4: C++ out-of-class method A::start captured as method", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "class Engine {",
+    "public:",
+    "  void start();",
+    "};",
+    "void Engine::start() { /* impl */ }",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/engine.cpp", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  // The qualified_identifier pattern captures "Engine::start" as the name.
+  const method = result.ir.symbols.find((s) => s.kind === "method");
+  assert.ok(method, "should find a method symbol for Engine::start");
+  await engine.dispose();
+});
+
+test("1659-5: Express middleware route captures handler, not middleware", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "function requireAuth(req, res, next) { next(); }",
+    "function getUsers(req, res) { res.json([]); }",
+    "app.get(\"/users\", requireAuth, getUsers);",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/server.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should have a /users route");
+  if (!usersRoute) return;
+  assert.equal(
+    usersRoute.handlerQualifiedName, "getUsers",
+    `middleware route handler should be 'getUsers' (the handler), not 'requireAuth' (the middleware), got: ${usersRoute.handlerQualifiedName}`,
+  );
+  await engine.dispose();
+});
+
+test("1659-6: Python relative import from .models captures module", async () => {
+  const engine = createCodingGraphEngine();
+  const code = "from .models import User\n";
+  const result = await engine.parseFile({ path: "src/app.py", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const modules = result.ir.imports.map((i) => i.module);
+  assert.ok(
+    modules.some((m) => m.includes("models")),
+    `Python: from .models import User should capture 'models' module, got: ${modules.join(", ")}`,
+  );
+  await engine.dispose();
+});

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1321,6 +1321,31 @@ test("1688-route-3: full-URL client calls do NOT produce routes (path-prefix gua
   await engine.dispose();
 });
 
+test("1688-route-4: HTTP client objects (http/client/axios) do NOT produce routes", async () => {
+  const engine = createCodingGraphEngine();
+  const code = [
+    "const httpClient = { get: (url, opts, cb) => {} };",
+    'httpClient.get("/api/users", { headers: {} }, cb);',
+    "const client = { post: (url, data, cb) => {} };",
+    'client.post("/api/data", { id: 1 }, handler);',
+    "const axios = { delete: (url) => {} };",
+    'axios.delete("/api/item/1");',
+    "",
+    "function getUsers(req, res) { res.json([]); }",
+    'app.get("/users", getUsers);',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/client3.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should still capture the real app.get /users route");
+  const clientRoutes = routes.filter((r) => r.pathTemplate.startsWith("/api"));
+  assert.equal(clientRoutes.length, 0, "httpClient/client/axios calls must NOT produce routes");
+  await engine.dispose();
+});
+
+
 
 
 

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1345,6 +1345,36 @@ test("1688-route-4: HTTP client objects (http/client/axios) do NOT produce route
   await engine.dispose();
 });
 
+test("1688-route-5: nested HTTP client receivers (this.client) do NOT produce routes", async () => {
+  // A nested receiver keeps its full expression in objectNode.text
+  // ("this.client"), which missed the ^client$ pattern and let
+  // this.client.get("/api", opts, cb) emit a spurious route (marking cb as
+  // a route handler). The receiver is now normalized to its tail property
+  // (chatgpt-codex-connector #1688 P2: 'Normalize receiver names').
+  const engine = createCodingGraphEngine();
+  const code = [
+    'this.client.get("/api/users", { headers: {} }, cb);',
+    'svc.httpClient.post("/api/data", { id: 1 }, handler);',
+    'foo.bar.client.put("/api/item", 42);',
+    "",
+    "function getUsers(req, res) { res.json([]); }",
+    'app.get("/users", getUsers);',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/client-nested.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should still capture the real app.get /users route");
+  const clientRoutes = routes.filter((r) => r.pathTemplate.startsWith("/api"));
+  assert.equal(
+    clientRoutes.length,
+    0,
+    "nested-receiver client calls (this.client / svc.httpClient / foo.bar.client) must NOT produce routes",
+  );
+  await engine.dispose();
+});
+
 
 
 

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1101,6 +1101,33 @@ test("1659-2: CJS alias target captures value identifier, not key", async () => 
   await engine.dispose();
 });
 
+
+test("1659-2b: CJS pair with a Unicode identifier value exports the value once (no alias-key duplicate)", async () => {
+  // The non-identifier fallback's #not-match? regex is ASCII-only, so a
+  // Unicode identifier value (Universität) defeats it and BOTH the
+  // value-identifier pattern and the fallback fire on the same pair.
+  // extractExports dedups by pair so only the real value symbol is kept
+  // (cursor #1659 review: 'CJS export fallback duplicates Unicode').
+  const engine = createCodingGraphEngine();
+  const code = [
+    "function Universität() { return 1; }",
+    "module.exports = { alias: Universität };",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/u.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const exportNames = result.ir.exports.map((e) => e.name);
+  assert.ok(
+    exportNames.includes("Universität"),
+    `CJS Unicode value should export Universität, got: ${exportNames.join(", ")}`,
+  );
+  assert.ok(
+    !exportNames.includes("alias"),
+    `CJS Unicode value must NOT also export the alias key, got: ${exportNames.join(", ")}`,
+  );
+  await engine.dispose();
+});
+
 test("1659-3: UTF-16 offsets produce correct byte spans for multibyte content", async () => {
   const engine = createCodingGraphEngine();
   // Leading comment with multibyte chars so UTF-16 and byte offsets diverge.
@@ -1161,6 +1188,31 @@ test("1659-5: Express middleware route captures handler, not middleware", async 
   assert.equal(
     usersRoute.handlerQualifiedName, "getUsers",
     `middleware route handler should be 'getUsers' (the handler), not 'requireAuth' (the middleware), got: ${usersRoute.handlerQualifiedName}`,
+  );
+  await engine.dispose();
+});
+
+
+test("1659-5b: route handler after a trailing comment is still captured (not 'anonymous')", async () => {
+  // tree-sitter treats the inline comment as a named child of the
+  // arguments node; without skipping it the comment becomes the "last
+  // arg" and the real handler is missed (chatgpt-codex-connector #1659
+  // review: 'Skip comments when selecting route handler').
+  const engine = createCodingGraphEngine();
+  const code = [
+    "function getUsers(req, res) { res.json([]); }",
+    'app.get("/users", getUsers /* auth middleware */);',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/server.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes;
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should have a /users route");
+  if (!usersRoute) return;
+  assert.equal(
+    usersRoute.handlerQualifiedName, "getUsers",
+    `route with trailing comment should still capture 'getUsers', got: ${usersRoute.handlerQualifiedName}`,
   );
   await engine.dispose();
 });

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1232,6 +1232,36 @@ test("1659-5b: route handler after a trailing comment is still captured (not 'an
   );
   await engine.dispose();
 });
+test("1688-route: cache.get('user') does NOT produce a route (empty-handler skip)", async () => {
+  // The unified route matcher captures any call_expression where the method
+  // name matches a verb (get/post/...) and the first arg is a string. Without
+  // the empty-handler skip, ordinary code like cache.get("user") matches and
+  // emits a route with handlerQualifiedName: "", which GraphStore rejects
+  // (chatgpt-codex-connector #1688 review: 'Require a handler before
+  // matching JS routes'). Routes without a real handler are now skipped.
+  const engine = createCodingGraphEngine();
+  const code = [
+    "const cache = new Map();",
+    'cache.get("user");',
+    'cache.delete("session");',
+    'cache.set("key", "value");',
+    "",
+    "function getUsers(req, res) { res.json([]); }",
+    'app.get("/users", getUsers);',
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/app.js", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const routes = result.ir.routes ?? [];
+  // The real route must still be captured.
+  const usersRoute = routes.find((r) => r.pathTemplate === "/users");
+  assert.ok(usersRoute, "should still capture the real /users route");
+  // Non-route calls must NOT produce routes.
+  const cacheRoutes = routes.filter((r) => r.pathTemplate === "user" || r.pathTemplate === "session" || r.pathTemplate === "key");
+  assert.equal(cacheRoutes.length, 0, "cache.get/delete/set must NOT produce routes");
+  await engine.dispose();
+});
+
 
 test("1659-6: Python relative import from .models captures module", async () => {
   const engine = createCodingGraphEngine();

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -18,6 +18,7 @@ import { FIXTURES } from "./fixtures.js";
 import { hashContent } from "./emit.js";
 import { hashContent as hashContentFromReindex } from "../reindex.js";
 import { sniffLanguage } from "./language-sniff.js";
+import { buildUtf16ToByteOffsetMap } from "./utf16-offsets.js";
 import { WasmTreeSitterBackend } from "./parser-backend.js";
 
 // ---------------------------------------------------------------------------
@@ -1151,6 +1152,21 @@ test("1659-3: UTF-16 offsets produce correct byte spans for multibyte content", 
   const sliced = buf.subarray(fn.span.startByte, fn.span.endByte).toString("utf-8");
   assert.ok(sliced.startsWith("function hello"), `byte-offset slice should start with 'function hello', got: ${sliced}`);
   await engine.dispose();
+});
+
+test("1659-3b: buildUtf16ToByteOffsetMap maps BOTH surrogate code units to the pair's start byte", () => {
+  // "𝕏" (U+1D54F) is one astral code point: 2 UTF-16 code units (a surrogate
+  // pair), 4 UTF-8 bytes. Before the fix the low surrogate's map entry pointed
+  // PAST the pair, so a span starting on the low code unit got an inflated
+  // startByte (cursor #1659 review: 'Surrogate UTF-16 index maps wrong').
+  const content = "a𝕏b"; // idx 0='a', 1=high surrogate, 2=low surrogate, 3='b'
+  const map = buildUtf16ToByteOffsetMap(content);
+  // byte layout: 'a'=1B, '𝕏'=4B, 'b'=1B → 0,1,5,6
+  assert.equal(map[0], 0, "'a' starts at byte 0");
+  assert.equal(map[1], 1, "high surrogate (pair start) at byte 1");
+  assert.equal(map[2], 1, "low surrogate must map to the PAIR start (byte 1), not past it");
+  assert.equal(map[3], 5, "'b' starts at byte 5 (1 + 4 for the pair)");
+  assert.equal(map[content.length], 6, "total byte length is 6");
 });
 
 test("1659-4: C++ out-of-class method A::start captured as method", async () => {

--- a/packages/coding-graph/src/engine/engine.test.ts
+++ b/packages/coding-graph/src/engine/engine.test.ts
@@ -1337,3 +1337,26 @@ test("1659-6: Python relative import from .models captures module", async () => 
   );
   await engine.dispose();
 });
+
+test("1688-import: Python relative imports preserve prefix dots (..parent not parent)", async () => {
+  // tree-sitter-python wraps the module inside a relative_import node.
+  // Capturing only the inner dotted_name drops the prefix dots, collapsing
+  // different relative levels (..parent vs .parent) to the same module name.
+  // Now the relative_import node is captured directly, preserving the dots
+  // (chatgpt-codex-connector #1688 P2: "Preserve dots in Python relative imports").
+  const engine = createCodingGraphEngine();
+  const code = [
+    "from .models import User",
+    "from ..parent import X",
+    "from ...grandparent import Y",
+  ].join("\n");
+  const result = await engine.parseFile({ path: "src/app2.py", content: Buffer.from(code, "utf-8") });
+  assert.ok(result.ok);
+  if (!result.ok) return;
+  const modules = result.ir.imports.map((i) => i.module);
+  assert.ok(modules.includes(".models"), "expected .models in " + JSON.stringify(modules));
+  assert.ok(modules.includes("..parent"), "expected ..parent in " + JSON.stringify(modules));
+  assert.ok(modules.includes("...grandparent"), "expected ...grandparent in " + JSON.stringify(modules));
+  await engine.dispose();
+});
+

--- a/packages/coding-graph/src/engine/engine.ts
+++ b/packages/coding-graph/src/engine/engine.ts
@@ -107,9 +107,11 @@ class CodingGraphEngineImpl implements CodingGraphEngine {
       };
     }
 
-    // Convert raw bytes to UTF-8 string for parsing.
-    const content = Buffer.from(input.content).toString("utf-8");
-    const tree = this.backend.parse(lang, content);
+    // web-tree-sitter parses UTF-16 internally, so node offsets are UTF-16
+    // code-unit offsets. We convert to UTF-8 byte offsets after extraction
+    // (issue #1659 item 3 — multibyte span accuracy).
+    const contentStr = Buffer.from(input.content).toString("utf-8");
+    const tree = this.backend.parse(lang, contentStr);
     if (!tree) {
       return {
         ok: false,
@@ -137,6 +139,7 @@ class CodingGraphEngineImpl implements CodingGraphEngine {
         input.content,
         root,
         language,
+        contentStr,
       );
       return { ok: true, ir };
     } catch (err) {

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -82,6 +82,9 @@ const TS_EXPORTS = `
 (export_statement declaration: (enum_declaration name: (identifier) @export.name))
 (export_statement declaration: (interface_declaration name: (type_identifier) @export.name))
 (export_statement (export_clause (export_specifier name: (identifier) @export.name)))
+
+; export default App; (bare identifier re-export)
+(export_statement (identifier) @export.name)
 `.trim();
 
 // JavaScript exports — class names use identifier (no type_identifier in JS grammar).
@@ -93,16 +96,27 @@ const JS_EXPORTS = `
 (export_statement (lexical_declaration (variable_declarator name: (identifier) @export.name)))
 (export_statement (export_clause (export_specifier name: (identifier) @export.name)))
 
+; export default App; (bare identifier re-export)
+(export_statement (identifier) @export.name)
+
 ; CommonJS: module.exports = { App, createRouter }
 (assignment_expression
   left: (member_expression object: (identifier) @__cjs.mod property: (property_identifier) @__cjs.exp)
   right: (object (shorthand_property_identifier) @export.name)
   (#eq? @__cjs.mod "module") (#eq? @__cjs.exp "exports"))
-; CommonJS: module.exports = { foo: bar }
+; CommonJS: module.exports = { publicName: createRouter }
+; Capture the VALUE identifier (the actual symbol), not the key (public alias).
 (assignment_expression
   left: (member_expression object: (identifier) @__cjs.mod2 property: (property_identifier) @__cjs.exp2)
-  right: (object (pair key: (property_identifier) @export.name))
+  right: (object (pair key: (property_identifier) @__cjs.key2 value: (identifier) @export.name))
   (#eq? @__cjs.mod2 "module") (#eq? @__cjs.exp2 "exports"))
+; Fallback: { foo: <non-identifier-value> } — capture the key as the public name
+; when the value is not a named symbol (arrow fn, literal, etc).
+(assignment_expression
+  left: (member_expression object: (identifier) @__cjs.mod2b property: (property_identifier) @__cjs.exp2b)
+  right: (object (pair key: (property_identifier) @export.name value: (_) @__cjs.nonId))
+  (#eq? @__cjs.mod2b "module") (#eq? @__cjs.exp2b "exports")
+  (#not-match? @__cjs.nonId "^[A-Za-z_$][A-Za-z0-9_$]*$"))
 ; CommonJS: module.exports = App
 (assignment_expression
   left: (member_expression object: (identifier) @__cjs.mod3 property: (property_identifier) @__cjs.exp3)
@@ -120,26 +134,17 @@ const JS_CALLS = `
 `.trim();
 
 const JS_ROUTES = `
-; The HTTP app/router object can be a bare identifier (app.get) or a
-; member expression (this.router.get, app.router.get). Using (_) matches
-; both without restricting to one shape.
+; Unified route pattern: captures verb + path + the arguments node.
+; emit.ts extracts the handler from the LAST argument (identifier,
+; arrow_function, or function_expression), correctly handling middleware:
+;   app.get("/users", requireAuth, getUsers) → handler=getUsers
 (call_expression
   function: (member_expression
     object: (_) @__route.app
     property: (property_identifier) @route.verb)
-  arguments: (arguments . (string (string_fragment) @route.path) . (arrow_function) @route.handler)
-  (#match? @route.verb "^(get|post|put|patch|delete|head|options|all|use)$"))
-(call_expression
-  function: (member_expression
-    object: (_) @__route.app
-    property: (property_identifier) @route.verb)
-  arguments: (arguments . (string (string_fragment) @route.path) . (function_expression) @route.handler)
-  (#match? @route.verb "^(get|post|put|patch|delete|head|options|all|use)$"))
-(call_expression
-  function: (member_expression
-    object: (_) @__route.app
-    property: (property_identifier) @route.verb)
-  arguments: (arguments . (string (string_fragment) @route.path) . (identifier) @route.handler)
+  arguments: (arguments
+    . (string (string_fragment) @route.path)
+  ) @route.args
   (#match? @route.verb "^(get|post|put|patch|delete|head|options|all|use)$"))
 `.trim();
 
@@ -182,6 +187,10 @@ const PYTHON_EXTRACTOR: LanguageExtractor = {
   importsQuery: `
 (import_statement (dotted_name) @import.module) @__import.stmt
 (import_from_statement module_name: (dotted_name) @import.module) @__import.stmt
+; Python relative imports: from .models import User / from ..parent import X
+; tree-sitter-python wraps the module inside a relative_import node, so the
+; module_name field is NOT set. Match the dotted_name inside relative_import.
+(import_from_statement (relative_import (dotted_name) @import.module)) @__import.stmt
 `.trim(),
   exportsQuery: ``,
   callSitesQuery: `
@@ -304,6 +313,9 @@ const CPP_EXTRACTOR: LanguageExtractor = {
   definitionsQuery: `
 (function_definition declarator: (function_declarator declarator: (identifier) @name)) @def.function
 (function_definition declarator: (function_declarator declarator: (field_identifier) @name)) @def.method
+; C++ out-of-class method definitions: void A::start() {}
+; The qualified_identifier (A::start) encodes the full qualified name.
+(function_definition declarator: (function_declarator declarator: (qualified_identifier) @name)) @def.method
 (class_specifier name: (type_identifier) @name) @def.class
 (struct_specifier name: (type_identifier) @name) @def.class
 (enum_specifier name: (type_identifier) @name) @def.enum

--- a/packages/coding-graph/src/engine/extractors.ts
+++ b/packages/coding-graph/src/engine/extractors.ts
@@ -189,8 +189,11 @@ const PYTHON_EXTRACTOR: LanguageExtractor = {
 (import_from_statement module_name: (dotted_name) @import.module) @__import.stmt
 ; Python relative imports: from .models import User / from ..parent import X
 ; tree-sitter-python wraps the module inside a relative_import node, so the
-; module_name field is NOT set. Match the dotted_name inside relative_import.
-(import_from_statement (relative_import (dotted_name) @import.module)) @__import.stmt
+; module_name field is NOT set. Capture the relative_import node itself so
+; the prefix dots are preserved (..parent, not just parent) — different
+; relative levels must not collapse to the same module name
+; (chatgpt-codex-connector #1688 P2: 'Preserve dots in Python relative imports').
+(import_from_statement (relative_import) @import.module) @__import.stmt
 `.trim(),
   exportsQuery: ``,
   callSitesQuery: `

--- a/packages/coding-graph/src/engine/parser-backend.ts
+++ b/packages/coding-graph/src/engine/parser-backend.ts
@@ -34,7 +34,8 @@ export interface ParserBackend {
   /**
    * Parse `content` (a UTF-8 string) using the grammar for `lang`. Returns the
    * tree-sitter Tree on success, or `null` if the grammar is not loaded / the
-   * parser cannot produce a tree.
+   * parser cannot produce a tree. Node offsets are UTF-16 code-unit offsets;
+   * callers must convert to UTF-8 byte offsets for multibyte content (#1659).
    */
   parse(lang: CodingGraphLanguage, content: string): TSTree | null;
   /** Return the loaded Language for `lang`, or null if not loaded. */
@@ -151,7 +152,6 @@ export class WasmTreeSitterBackend implements ParserBackend {
     if (!this.parser) return null;
     const language = this.languages.get(lang);
     if (!language) return null;
-    // setLanguage is cheap (just sets a pointer); safe to call per-parse.
     this.parser.setLanguage(language);
     return this.parser.parse(content);
   }

--- a/packages/coding-graph/src/engine/utf16-offsets.ts
+++ b/packages/coding-graph/src/engine/utf16-offsets.ts
@@ -37,7 +37,13 @@ export function buildUtf16ToByteOffsetMap(content: string): Uint32Array {
       // High surrogate of a surrogate pair. The full code point encodes to
       // 4 UTF-8 bytes; we charge all 4 here and skip the low surrogate.
       byteOffset += 4;
-      map[i + 1] = byteOffset;
+      // Both code units of the pair represent the SAME character, which
+      // starts at map[i] (set at the top of the loop, before the increment).
+      // The low surrogate must map to that SAME start byte — not to
+      // byteOffset (which is now past the pair) — or a span whose start
+      // falls on the low code unit gets an inflated startByte (cursor
+      // #1659 review: 'Surrogate UTF-16 index maps wrong').
+      map[i + 1] = map[i]!;
       i++;
     } else if (code >= 0xdc00 && code <= 0xdfff) {
       // Lone low surrogate (unpaired) — treat as 3-byte UTF-8 replacement.

--- a/packages/coding-graph/src/engine/utf16-offsets.ts
+++ b/packages/coding-graph/src/engine/utf16-offsets.ts
@@ -1,0 +1,62 @@
+/**
+ * UTF-16 code-unit offset → UTF-8 byte offset conversion (issue #1659 item 3).
+ *
+ * web-tree-sitter 0.25 parses strings internally by converting them to UTF-16
+ * (`stringToUTF16` in the WASM glue), so every node's `startIndex`/`endIndex`
+ * is a UTF-16 code-unit offset, NOT a UTF-8 byte offset. For pure-ASCII
+ * content these are identical, but multibyte content (comments, strings, or
+ * identifiers containing non-ASCII characters) produces incorrect spans:
+ * dead-code analysis, navigation, and body extraction all rely on byte
+ * offsets matching the on-disk file.
+ *
+ * This module builds a single lookup array per file (O(n) build, O(1)
+ * lookup) so all offsets in a FileIR can be converted in one pass.
+ */
+
+/**
+ * Build a map from UTF-16 code-unit offset → UTF-8 byte offset for the given
+ * string. `map[i]` is the byte offset of the i-th UTF-16 code unit.
+ * `map[content.length]` is the total byte length.
+ *
+ * Surrogate pairs (U+10000–U+10FFFF) occupy 2 UTF-16 code units but encode to
+ * 4 UTF-8 bytes. The high surrogate's entry points to the start of the pair;
+ * the low surrogate's entry also points there (its byte delta is 0, added by
+ * the high surrogate).
+ */
+export function buildUtf16ToByteOffsetMap(content: string): Uint32Array {
+  const map = new Uint32Array(content.length + 1);
+  let byteOffset = 0;
+  for (let i = 0; i < content.length; i++) {
+    map[i] = byteOffset;
+    const code = content.charCodeAt(i);
+    if (code < 0x80) {
+      byteOffset += 1;
+    } else if (code < 0x800) {
+      byteOffset += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate of a surrogate pair. The full code point encodes to
+      // 4 UTF-8 bytes; we charge all 4 here and skip the low surrogate.
+      byteOffset += 4;
+      map[i + 1] = byteOffset;
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      // Lone low surrogate (unpaired) — treat as 3-byte UTF-8 replacement.
+      // This path is only hit for malformed input.
+      byteOffset += 3;
+    } else {
+      byteOffset += 3;
+    }
+  }
+  map[content.length] = byteOffset;
+  return map;
+}
+
+/**
+ * Convert a single UTF-16 code-unit offset to a UTF-8 byte offset using a
+ * pre-built map. Returns 0 for negative offsets; clamps to the map length.
+ */
+export function utf16ToByte(map: Uint32Array, utf16Offset: number): number {
+  if (utf16Offset <= 0) return 0;
+  if (utf16Offset >= map.length) return map[map.length - 1];
+  return map[utf16Offset];
+}

--- a/packages/coding-graph/src/semantic/config.ts
+++ b/packages/coding-graph/src/semantic/config.ts
@@ -226,6 +226,10 @@ export function resolveSemanticConfig(
     // out-of-range confidence gate.
     similarToThreshold: Math.min(1, Math.max(0, similarToThreshold)),
     maxSymbolsPerRun: Math.max(0, Math.floor(maxSymbolsPerRun)),
-    canonicalBodyLines: Math.max(0, Math.floor(canonicalBodyLines)),
+    // canonicalBodyLines: a negative/zero value must NOT clamp to 0 because
+    // extractBodyText treats <= 0 as unlimited — sending full symbol bodies to
+    // the embedding provider instead of the bounded excerpt (defeats the
+    // privacy/cost cap). Fall back to the default instead (#1680).
+    canonicalBodyLines: canonicalBodyLines >= 1 ? Math.floor(canonicalBodyLines) : DEFAULT_CANONICAL_BODY_LINES,
   };
 }

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -97,12 +97,25 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
 
   // Brute-force cosine over all vectors for this model.
   const modelId = modelIdFor(provider);
-  const rows = store.readAllSymbolVectors(modelId);
+  // Wrap the store read so a transient SQLite error (SQLITE_BUSY / CORRUPT)
+  // maps to a tagged db_error instead of escaping semanticQuery (#1680).
+  let rows: readonly ReturnType<typeof store.readAllSymbolVectors>[number][];
+  try {
+    rows = store.readAllSymbolVectors(modelId);
+  } catch {
+    return { ok: false, code: "db_error" };
+  }
   if (rows.length === 0) {
     return { ok: false, code: "no_vectors" };
   }
 
-  const limit = Math.max(1, input.limit ?? DEFAULT_SEMANTIC_QUERY_LIMIT);
+  // Validate limit: NaN/Infinity/non-numeric must not produce a NaN/Infinity
+  // slice (#1680). NaN → slice(0, NaN) returns no hits; Infinity → every row.
+  // Coerce to a finite positive integer, falling back to the default.
+  const rawLimit = input.limit;
+  const limit = (typeof rawLimit === "number" && Number.isFinite(rawLimit) && rawLimit > 0)
+    ? Math.floor(rawLimit)
+    : DEFAULT_SEMANTIC_QUERY_LIMIT;
   // Only score vectors whose dimensionality matches the query embedding.
   // cosineSimilarity compares over the SHORTER length, so a row from a
   // different model size would otherwise get a misleading partial-overlap

--- a/packages/coding-graph/src/semantic/semantic-query.ts
+++ b/packages/coding-graph/src/semantic/semantic-query.ts
@@ -114,7 +114,7 @@ export async function semanticQuery(input: SemanticQueryInput): Promise<Semantic
   // Coerce to a finite positive integer, falling back to the default.
   const rawLimit = input.limit;
   const limit = (typeof rawLimit === "number" && Number.isFinite(rawLimit) && rawLimit > 0)
-    ? Math.floor(rawLimit)
+    ? Math.max(1, Math.floor(rawLimit))
     : DEFAULT_SEMANTIC_QUERY_LIMIT;
   // Only score vectors whose dimensionality matches the query embedding.
   // cosineSimilarity compares over the SHORTER length, so a row from a

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -33,6 +33,8 @@ import {
   resolveSemanticConfig,
   DEFAULT_SIMILAR_TO_THRESHOLD,
   DEFAULT_MAX_SYMBOLS_PER_RUN,
+  DEFAULT_SEMANTIC_QUERY_LIMIT,
+  DEFAULT_CANONICAL_BODY_LINES,
   type SemanticConfig,
 } from "./index.js";
 
@@ -1071,6 +1073,194 @@ test("SIMILAR_TO: duplicate qualified name across files persists by node id (iss
         t1.hits.some((h) => h.nodeId === idB),
         "SIMILAR_TO edge connects the two distinct same-qname nodes",
       );
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #1680 — deferred review nits on the semantic layer (tagged read failures,
+// limit validation, negative body budget, README recompute example).
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Wrap a real store so one read method throws (simulates SQLITE_BUSY/CORRUPT)
+ * while the rest of the surface (isClosed, etc.) keeps working. Used to prove
+ * the tagged db_error wrapping (#1680) rather than an escaping throw.
+ */
+function throwingReadStore(
+  base: GraphStore,
+  method: "readAllSymbolVectors" | "readNodesForSemantic",
+): GraphStore {
+  return new Proxy(base as object, {
+    get(target, prop, receiver) {
+      if (prop === method) {
+        return () => {
+          throw new Error("stub: SQLITE_BUSY");
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as GraphStore;
+}
+
+// config: a negative/zero canonicalBodyLines must NOT clamp to 0 (which
+// extractBodyText treats as unlimited, sending full symbol bodies to the
+// remote embedder and defeating the cost/privacy cap). It falls back to the
+// documented default instead (#1680).
+test("config: negative/zero canonicalBodyLines falls back to default (not 0/unlimited)", () => {
+  const neg = resolveSemanticConfig({ enabled: true, canonicalBodyLines: -5 });
+  assert.equal(neg.canonicalBodyLines, DEFAULT_CANONICAL_BODY_LINES, "negative → default");
+  const zero = resolveSemanticConfig({ enabled: true, canonicalBodyLines: 0 });
+  assert.equal(zero.canonicalBodyLines, DEFAULT_CANONICAL_BODY_LINES, "zero → default");
+  // A positive value is still honored (not clobbered by the fallback).
+  const ok = resolveSemanticConfig({ enabled: true, canonicalBodyLines: 7 });
+  assert.equal(ok.canonicalBodyLines, 7, "positive value honored");
+  // String coercion path (coerceHostNumber) — a numeric string like "-3"
+  // must also fall back, not clamp to 0.
+  const negStr = resolveSemanticConfig({ enabled: true, canonicalBodyLines: "-3" as never });
+  assert.equal(negStr.canonicalBodyLines, DEFAULT_CANONICAL_BODY_LINES, "numeric-string -3 → default");
+});
+
+// semanticQuery: a transient store read failure (SQLITE_BUSY/CORRUPT) on
+// readAllSymbolVectors maps to a tagged db_error instead of escaping as a
+// throw (#1680).
+test("semanticQuery: transient store read error → db_error (tagged, not thrown)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const throwing = throwingReadStore(store, "readAllSymbolVectors");
+    const provider = countingProvider();
+    const r = await semanticQuery({ store: throwing, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "anything" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "db_error");
+  } finally {
+    await cleanup();
+  }
+});
+
+// indexSymbolVectors: a transient store read failure on readNodesForSemantic
+// maps to a tagged db_error instead of rejecting the promise (#1680).
+test("indexSymbolVectors: transient store read error → db_error (tagged, not thrown)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const throwing = throwingReadStore(store, "readNodesForSemantic");
+    const provider = countingProvider();
+    const r = await indexSymbolVectors({ store: throwing, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "db_error");
+  } finally {
+    await cleanup();
+  }
+});
+
+// semanticQuery: a caller-supplied limit of NaN/Infinity must not produce a
+// NaN/Infinity slice. slice(0, NaN) returns no hits; slice(0, Infinity)
+// returns every scored vector. Both are wrong — coerce to the finite default
+// (#1680).
+test("semanticQuery: NaN/Infinity limit falls back to default (no empty/all slice)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    // Index more symbols than DEFAULT_SEMANTIC_QUERY_LIMIT so the default
+    // cap is observable (default=10; 12 symbols → NaN must NOT return 0 and
+    // Infinity must NOT return 12).
+    const src = Array.from({ length: 12 }, (_, i) => `function f${i}() { return ${i}; }`).join("\n");
+    await writeFile(path.join(dir, "many.ts"), src);
+    const symbols = Array.from({ length: 12 }, (_, i) => ({
+      name: `f${i}`,
+      qname: `mod.f${i}`,
+      kind: "function",
+      start: src.indexOf(`function f${i}`),
+      end: src.length,
+    }));
+    // Fix the end byte for each to the next symbol's start (last = src.length).
+    for (let i = 0; i < symbols.length; i++) {
+      symbols[i]!.end = i + 1 < symbols.length ? symbols[i + 1]!.start : src.length;
+    }
+    await store.upsertFileBatch([makeFileIR("many.ts", symbols, src)]);
+
+    const provider = countingProvider();
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+
+    // NaN limit → default (10), not 0.
+    const nanR = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "function", limit: NaN });
+    assert.equal(nanR.ok, true);
+    if (nanR.ok) {
+      assert.ok(nanR.hits.length > 0, `NaN limit must not return zero hits, got ${nanR.hits.length}`);
+      assert.ok(nanR.hits.length <= DEFAULT_SEMANTIC_QUERY_LIMIT, `NaN limit capped to default, got ${nanR.hits.length}`);
+    }
+    // Infinity limit → default (10), not all 12.
+    const infR = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "function", limit: Infinity });
+    assert.equal(infR.ok, true);
+    if (infR.ok) {
+      assert.ok(infR.hits.length <= DEFAULT_SEMANTIC_QUERY_LIMIT, `Infinity limit capped to default, got ${infR.hits.length}`);
+    }
+    // A finite positive limit is honored.
+    const two = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "function", limit: 2 });
+    assert.equal(two.ok, true);
+    if (two.ok) assert.equal(two.hits.length, 2, "limit=2 returns exactly 2 hits");
+  } finally {
+    await cleanup();
+  }
+});
+
+// SIMILAR_TO recompute is replace-not-append: the README example clears
+// semantic SIMILAR_TO edges before upserting so two symbols that STOP being
+// similar do not leave a stale edge (upsertEdges does not delete absent rows).
+// This test exercises the documented README flow end to end (#1680).
+test("SIMILAR_TO recompute: clearSemanticSimilarToEdges makes recompute replace-not-append (README example)", async () => {
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    // Two near-identical bodies → MinHash candidate → SIMILAR_TO edge.
+    const bodyA = "function twin() { const x = 1; const y = 2; return x + y; }";
+    const bodyB = "function twin() { const x = 1; const y = 2; return x + y; }";
+    await writeFile(path.join(dir, "a.ts"), bodyA);
+    await writeFile(path.join(dir, "b.ts"), bodyB);
+    await store.upsertFileBatch([
+      makeFileIR("a.ts", [{ name: "twin", qname: "mod.a", kind: "function", start: 0, end: bodyA.length }], bodyA),
+      makeFileIR("b.ts", [{ name: "twin", qname: "mod.b", kind: "function", start: 0, end: bodyB.length }], bodyB),
+    ]);
+
+    const provider = countingProvider();
+    // README step 0: index vectors FIRST so cosine confirmation has data.
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    const r1 = computeSimilarTo({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r1.ok, true);
+    if (!r1.ok) throw new Error("expected ok");
+    assert.ok(r1.edges.length >= 1, "first recompute finds the near-clone pair");
+    await store.upsertEdges(similarEdgesToEdgeIR(r1.edges));
+
+    const idA = nodeIdFor({ qualifiedName: "mod.a", filePath: "a.ts", label: "function" });
+    const beforeClear = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.ok(beforeClear.ok, "traverse ok before clear");
+    if (beforeClear.ok) {
+      assert.ok(beforeClear.hits.some((h) => h.qualifiedName === "mod.b"), "mod.b reachable via SIMILAR_TO before clear");
+    }
+
+    // README step 1: clear before recompute (replace-not-append).
+    await store.clearSemanticSimilarToEdges();
+    const afterClear = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.ok(afterClear.ok, "traverse ok after clear");
+    if (afterClear.ok) {
+      assert.ok(!afterClear.hits.some((h) => h.qualifiedName === "mod.b"), "SIMILAR_TO edge to mod.b gone after clear");
+    }
+
+    // README step 2: recompute + upsert. A stale edge that recompute would
+    // NOT re-emit would have survived without the clear; here recompute
+    // re-emits the still-similar pair, so the final set equals the
+    // recomputed set — not doubled.
+    const r2 = computeSimilarTo({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r2.ok, true);
+    if (!r2.ok) throw new Error("expected ok");
+    if (r2.edges.length >= 1) {
+      await store.upsertEdges(similarEdgesToEdgeIR(r2.edges));
+    }
+    const final = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.ok(final.ok, "traverse ok");
+    if (final.ok) {
+      // After clear + recompute + upsert, mod.b is reachable again — the
+      // still-similar pair has its edge (clean replace, not a stale append).
+      assert.ok(final.hits.some((h) => h.qualifiedName === "mod.b"), "mod.b reachable again after recompute (replace worked)");
     }
   } finally {
     await cleanup();

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -1204,6 +1204,39 @@ test("semanticQuery: NaN/Infinity limit falls back to default (no empty/all slic
   }
 });
 
+
+test("semanticQuery: a fractional limit between 0 and 1 returns at least 1 hit (not an empty slice)", async () => {
+  // Math.floor(0.5) === 0; without clamping, slice(0, 0) returns no hits
+  // even when matching vectors exist (#1680 review: 'Clamp sub-one query
+  // limits before slicing').
+  const { store, dir, cleanup } = await tempStore();
+  try {
+    const src = Array.from({ length: 3 }, (_, i) => `function f${i}() { return ${i}; }`).join("\n");
+    await writeFile(path.join(dir, "many.ts"), src);
+    const symbols = Array.from({ length: 3 }, (_, i) => ({
+      name: `f${i}`,
+      qname: `mod.f${i}`,
+      kind: "function",
+      start: src.indexOf(`function f${i}`),
+      end: src.length,
+    }));
+    for (let i = 0; i < symbols.length; i++) {
+      symbols[i]!.end = i + 1 < symbols.length ? symbols[i + 1]!.start : src.length;
+    }
+    await store.upsertFileBatch([makeFileIR("many.ts", symbols, src)]);
+    const provider = countingProvider();
+    await indexSymbolVectors({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+
+    const r = await semanticQuery({ store, provider, repoRoot: dir, config: ENABLED_CONFIG, query: "function", limit: 0.5 });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.ok(r.hits.length >= 1, `fractional limit 0.5 must return at least 1 hit (clamped to 1), got ${r.hits.length}`);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
 // SIMILAR_TO recompute is replace-not-append: the README example clears
 // semantic SIMILAR_TO edges before upserting so two symbols that STOP being
 // similar do not leave a stale edge (upsertEdges does not delete absent rows).

--- a/packages/coding-graph/src/semantic/semantic.test.ts
+++ b/packages/coding-graph/src/semantic/semantic.test.ts
@@ -1270,21 +1270,24 @@ test("SIMILAR_TO recompute: clearSemanticSimilarToEdges makes recompute replace-
       assert.ok(beforeClear.hits.some((h) => h.qualifiedName === "mod.b"), "mod.b reachable via SIMILAR_TO before clear");
     }
 
-    // README step 1: clear before recompute (replace-not-append).
+    // README flow: compute-first-then-swap. computeSimilarTo is pure (no
+    // edge mutation), so compute candidates BEFORE clearing — if the
+    // recompute fails, existing SIMILAR_TO edges are preserved instead of
+    // leaving the graph empty (chatgpt-codex-connector P2: "Preserve
+    // existing edges until recompute succeeds").
+    const r2 = computeSimilarTo({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
+    assert.equal(r2.ok, true);
+    if (!r2.ok) throw new Error("expected ok");
+
+    // Compute succeeded → safe to swap. Clear makes it replace-not-append
+    // (upsertEdges does not delete absent rows); without it, a stale edge
+    // recompute would NOT re-emit would survive.
     await store.clearSemanticSimilarToEdges();
     const afterClear = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
     assert.ok(afterClear.ok, "traverse ok after clear");
     if (afterClear.ok) {
       assert.ok(!afterClear.hits.some((h) => h.qualifiedName === "mod.b"), "SIMILAR_TO edge to mod.b gone after clear");
     }
-
-    // README step 2: recompute + upsert. A stale edge that recompute would
-    // NOT re-emit would have survived without the clear; here recompute
-    // re-emits the still-similar pair, so the final set equals the
-    // recomputed set — not doubled.
-    const r2 = computeSimilarTo({ store, provider, repoRoot: dir, config: ENABLED_CONFIG });
-    assert.equal(r2.ok, true);
-    if (!r2.ok) throw new Error("expected ok");
     if (r2.edges.length >= 1) {
       await store.upsertEdges(similarEdgesToEdgeIR(r2.edges));
     }
@@ -1294,6 +1297,17 @@ test("SIMILAR_TO recompute: clearSemanticSimilarToEdges makes recompute replace-
       // After clear + recompute + upsert, mod.b is reachable again — the
       // still-similar pair has its edge (clean replace, not a stale append).
       assert.ok(final.hits.some((h) => h.qualifiedName === "mod.b"), "mod.b reachable again after recompute (replace worked)");
+    }
+
+    // Preserve-on-failure: a recompute that returns { ok: false } must NOT
+    // clear — the existing edge survives. semantic_disabled short-circuits
+    // before any table work, so no clear runs and mod.b stays reachable.
+    const failing = computeSimilarTo({ store, provider, repoRoot: dir, config: DISABLED_CONFIG });
+    assert.equal(failing.ok, false);
+    const preserved = store.traverse({ start: idA, edgeTypes: ["SIMILAR_TO"], maxDepth: 1 });
+    assert.ok(preserved.ok, "traverse ok");
+    if (preserved.ok) {
+      assert.ok(preserved.hits.some((h) => h.qualifiedName === "mod.b"), "existing SIMILAR_TO edge preserved when recompute fails");
     }
   } finally {
     await cleanup();

--- a/packages/coding-graph/src/semantic/vectors.ts
+++ b/packages/coding-graph/src/semantic/vectors.ts
@@ -100,7 +100,14 @@ export async function indexSymbolVectors(
   }
 
   const modelId = modelIdFor(provider);
-  const nodes = store.readNodesForSemantic();
+  // Wrap the store read so a transient SQLite error (SQLITE_BUSY / CORRUPT)
+  // maps to a tagged db_error instead of escaping indexSymbolVectors (#1680).
+  let nodes: readonly ReturnType<typeof store.readNodesForSemantic>[number][];
+  try {
+    nodes = store.readNodesForSemantic();
+  } catch {
+    return { ok: false, code: "db_error" };
+  }
   // Budget applies to EMBED WORK, not the candidate list. Slicing the
   // full node list (ordered by qualified_name) BEFORE the cache check
   // meant a bounded run kept re-visiting the cached alphabetical prefix


### PR DESCRIPTION
Closes #1659, Closes #1680, Closes #1688

Three follow-up issues on the optional `@remnic/coding-graph` + `@remnic/bench` packages (non-core). All deferred P2 review nits batched here to converge their parent PRs.

## #1659 — export-capture edge cases (6 items)

All six marginal export/span/import edge cases from PR #1652 review:
- **Default exports**: `export default App` now captured as an export (TS+JS).
- **CJS alias targets**: `module.exports = { publicName: createRouter }` captures the value identifier (`createRouter`), not just the key.
- **UTF-16 → byte offsets**: spans converted from web-tree-sitter's UTF-16 code-unit offsets to UTF-8 byte offsets via a per-file lookup map (new `utf16-offsets.ts`). Fixes multibyte-content spans across all languages.
- **C++ out-of-class methods**: `void A::start() {}` matched via `qualified_identifier`.
- **Express middleware routes**: `app.get('/users', requireAuth, getUsers)` captures the last identifier (`getUsers`) as the handler, not the first (middleware).
- **Python relative imports**: `from .models import User` captures `models` via the `relative_import` node (tree-sitter-python does not set `module_name` for relative imports).

7 new tests; coding-graph suite green.

## #1680 — semantic-layer deferred review nits (4 items)

- **Tagged-failure read contract**: `semantic-query.ts` (`readAllSymbolVectors`) and `vectors.ts` (`readNodesForSemantic`) now wrap their store reads and map transient SQLite errors (SQLITE_BUSY/CORRUPT) to tagged `{ok:false, code:"db_error"}` results instead of escaping/rejecting — consistent with the rest of the semantic surface.
- **Query-limit validation**: a caller-supplied `limit` of `NaN`/`Infinity`/non-numeric no longer produces a NaN/Infinity slice (`slice(0,NaN)`=empty, `slice(0,Infinity)`=all). Coerced to `DEFAULT_SEMANTIC_QUERY_LIMIT`.
- **Negative canonical-body budget**: a malformed negative `canonicalBodyLines` no longer clamps to 0 (which `extractBodyText` treats as unlimited, sending full symbol bodies to the remote embedder and defeating the cost/privacy cap). Falls back to the documented default.
- **README recompute example**: the SIMILAR_TO recompute example now calls `clearSemanticSimilarToEdges()` before the upsert so recompute is replace-not-append (`upsertEdges` does not delete absent rows).

5 new tests (throwing-Proxy store for the db_error paths; 12-symbol fixture for the limit paths; end-to-end recompute for the README flow).

## #1688 — bench(coding-graph) follow-ups from #1557 review (3 items)

1. **Modified-content incremental metric**: new `incrementalModifiedUpdate` p50/p95 metric measuring the change-heavy re-ingest path (edge deletion/creation, symbol re-resolution) — complementary to the existing idempotent no-op `incrementalUpdate`. Runs AFTER the steady-state DB-size measurement (churn upserts move pages to the SQLite free-list without shrinking the file; a pre-DB-size churn would inflate `dbBytesPerKloc` with residue). Report schema bumped 1 → 2.
2. **Machine-fingerprint guard**: `compareMachineFingerprints()` compares arch/platform/Node-major/cpuModel/cores; on mismatch the regression gate SKIPS (`passed:true` + `skipped:true` + `machineMismatch` detail) instead of failing CI on legitimate hardware variance. `totalMemoryMb` deliberately excluded (over-triggers the skip).
3. **README**: usage example now uses the baseline fixture (was 1000×10/0.2 which trips the fixture-mismatch guard against the 20×10/0.3 baseline) + notes custom fixtures need their own baseline; measured-numbers table refreshed from the regenerated schema-v2 baseline (fixes stale ~2 KB/KLOC DB-size → ~270 KB/KLOC).

Baseline regenerated with the new metric on the baseline machine class (Apple M2 Max, Node v22). Natural-variance gate test hardened: sub-ms p95 metrics (incremental/modified/trace/search) are outlier-dominated and excluded from the relative-variance assertion via a ≥2ms baseline floor; stable metrics show 0% worst-case under 4× concurrent contention.

## Verification

- `pnpm --filter @remnic/coding-graph test` — 422 pass / 0 fail
- `tsx --test packages/bench/src/coding-graph/harness.test.ts` — 19 pass / 0 fail (10/10 stable full-suite runs)
- `pnpm --filter @remnic/bench run check-types` — clean
- `npm run preflight:quick` — `[preflight] OK (quick)`

## Chokepoints used / not applicable

Not applicable — this PR touches only the optional `@remnic/coding-graph` and `@remnic/bench` packages (no `packages/remnic-core` edits, no god files, no PluginConfig, no new MCP/HTTP/CLI surfaces). No catalog/caps/validation/serialization chokepoints apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large test surface and regression-gate behavior changes (skip vs fail) affect CI interpretation; extraction/route heuristics can shift graph edges and dead-code signals without touching remnic-core.
> 
> **Overview**
> Optional **`@remnic/coding-graph`** and **`@remnic/bench`** follow-ups for #1659, #1680, and #1688 — no core CLI/plugin surfaces.
> 
> **Symbol extraction (#1659)** improves export capture (default exports, CJS value vs alias key with Unicode dedup), converts tree-sitter **UTF-16 spans to UTF-8 bytes** via `utf16-offsets.ts`, tightens **route** detection (middleware last-arg, HTTP-client/path guards), and extends queries for C++ qualified methods and **Python relative import** dots.
> 
> **Semantic layer (#1680)** maps SQLite read failures to **`db_error`**, validates **`semanticQuery` limits** and negative **`canonicalBodyLines`**, and documents **compute-then-clear-then-upsert** for SIMILAR_TO recompute.
> 
> **Coding-graph bench (#1688)** adds **`incrementalModifiedUpdate`** (change-heavy path with full-fixture restore), bumps report/baseline **schema to v2**, introduces **`compareMachineFingerprints`** skip on hardware mismatch, and layers **ordered guards** (fixture/schema/metric/fingerprint validation before compare) plus extensive harness tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 840cc9610dacffe8790584aade55303c3a49d58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->