### PR TITLE
feat(bitemporal): #1707 widen dedup backfill to promoted cascades, valid_at, non-fact guard

### DIFF
--- a/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
+++ b/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
@@ -254,6 +254,41 @@ test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", 
     await cleanup();
   }
 });
+
+// Gate guard (review cursor PRRT_OvHk / codex PRRT_OvHxVH): resolveFactEventTime
+// sets a validFrom for EVERY fact (assumed = ingestion anchor). The helper's
+// I/O gate must NOT scan on an assumed validFrom — only an EXTRACTED start bound
+// changes recall. This pins the gate decision so ordinary duplicate facts
+// without an extracted event time do not pay a readAllMemories scan on every
+// dedup hit.
+test("#1707 thread 2: assumed (batch-anchored) validFrom does NOT trigger a backfill scan", () => {
+  // Mirror the helper's I/O gate (orchestrator.ts backfillTemporalBoundsOnDedupHit):
+  //   const hasExtractedStart = bounds.validFrom !== undefined && bounds.eventTimeSource === "extracted";
+  //   if (!bounds.invalidAt && !hasExtractedStart) return;
+  const gateWouldScan = (bounds: {
+    invalidAt?: string;
+    validFrom?: string;
+    eventTimeSource?: "extracted" | "assumed";
+  }) =>
+    Boolean(bounds.invalidAt) ||
+    (bounds.validFrom !== undefined && bounds.eventTimeSource === "extracted");
+
+  // Assumed validFrom alone (the common no-event-time case) → no scan.
+  assert.equal(
+    gateWouldScan({ validFrom: "2026-06-01T00:00:00.000Z", eventTimeSource: "assumed" }),
+    false,
+    "assumed validFrom must not trigger a scan",
+  );
+  // Extracted validFrom → scan (corrected start bound is recall-relevant).
+  assert.equal(
+    gateWouldScan({ validFrom: "2024-01-01T00:00:00.000Z", eventTimeSource: "extracted" }),
+    true,
+  );
+  // End bound alone → scan (expires the fact).
+  assert.equal(gateWouldScan({ invalidAt: "2025-06-01T00:00:00.000Z" }), true);
+  // No bounds at all → no scan.
+  assert.equal(gateWouldScan({}), false);
+});
 // Thread 1 — promoted-cascade backfill. When the source-namespace dedup
 // short-circuit fires, the helper must also patch promotion-target copies
 // (profile + shared namespaces) so cross-namespace recall does not surface an

--- a/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
+++ b/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
@@ -167,3 +167,186 @@ test("#1671: re-extraction with resolved invalidAt backfills an old promoted cop
     await cleanup();
   }
 });
+
+// ─── #1707 widenings (promoted-cascade, valid_at, non-fact guard) ────────
+
+// Thread 2 — valid_at propagation. A re-extracted duplicate whose event time
+// yields only a start bound ("since 2024", "yesterday") must get the corrected
+// per-fact validFrom onto the existing copy so as-of recall uses the corrected
+// start. The orchestrator helper's rule: patch valid_at when the incoming
+// validFrom is EXTRACTED and the copy's start bound is batch-anchored
+// (assumed/legacy); never clobber a copy that already carries an extracted
+// per-fact anchor. This test pins that rule against the storage patch the
+// helper issues.
+test("#1707 thread 2: corrected extracted validFrom overwrites a batch-anchored valid_at", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-validFrom-");
+  try {
+    // Old promoted copy: batch-anchored valid_at, no per-fact event-time.
+    const content = "We have used Stripe for payments since 2024.";
+    const batchAnchor = "2026-06-01T00:00:00.000Z";
+    const id = await storage.writeMemory("fact", content, {
+      confidence: 0.9,
+      validAt: batchAnchor,
+      // No eventTimeSource → batch-anchored (legacy pre-#1670 copy).
+    });
+    const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(before);
+    assert.equal(before!.frontmatter.valid_at, batchAnchor);
+    assert.equal(before!.frontmatter.eventTimeSource, undefined);
+
+    // Simulate the helper's rule: incoming validFrom is extracted → patch
+    // because the copy is NOT extracted-anchored (fm.eventTimeSource !== "extracted").
+    const correctedValidFrom = "2024-01-01T00:00:00.000Z";
+    const incomingExtracted = true;
+    const copyExtracted = before!.frontmatter.eventTimeSource === "extracted";
+    const shouldPatchValidAt =
+      incomingExtracted && (copyExtracted === false || !before!.frontmatter.valid_at);
+    assert.equal(shouldPatchValidAt, true, "must correct the batch-anchored valid_at");
+
+    const ok = await storage.writeMemoryFrontmatter(before!, {
+      valid_at: correctedValidFrom,
+      eventTimeSource: "extracted",
+      observedAt: "2026-06-20T00:00:00.000Z",
+    });
+    assert.equal(ok, true);
+
+    const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(after);
+    assert.equal(after!.frontmatter.valid_at, correctedValidFrom);
+    assert.equal(after!.frontmatter.eventTimeSource, "extracted");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-validFrom-noclobber-");
+  try {
+    // Copy already carries an extracted per-fact anchor.
+    const content = "The migration to MySQL completed in March 2025.";
+    const existingValidAt = "2025-03-01T00:00:00.000Z";
+    const id = await storage.writeMemory("fact", content, {
+      confidence: 0.9,
+      validAt: existingValidAt,
+      observedAt: "2025-06-01T00:00:00.000Z",
+      eventTimeSource: "extracted",
+    });
+    const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(before);
+
+    // Re-extraction resolves a DIFFERENT start bound. The helper rule
+    // (mirrors orchestrator.ts) must NOT overwrite a copy that already
+    // carries its own extracted per-fact anchor:
+    //   bounds.validFrom && bounds.eventTimeSource === "extracted" &&
+    //     (fm.eventTimeSource !== "extracted" || !fm.valid_at)
+    const incomingValidFrom = "2025-03-15T00:00:00.000Z";
+    const helperWouldPatch =
+      Boolean(incomingValidFrom) &&
+      (before!.frontmatter.eventTimeSource !== "extracted" ||
+        !before!.frontmatter.valid_at);
+    assert.equal(helperWouldPatch, false, "must not clobber an extracted valid_at");
+
+    // No patch issued → valid_at unchanged.
+    const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(after);
+    assert.equal(after!.frontmatter.valid_at, existingValidAt);
+  } finally {
+    await cleanup();
+  }
+});
+// Thread 1 — promoted-cascade backfill. When the source-namespace dedup
+// short-circuit fires, the helper must also patch promotion-target copies
+// (profile + shared namespaces) so cross-namespace recall does not surface an
+// expired fact. This proves the mechanism the orchestrator's promotion-cascade
+// closure relies on: backfilling two separate storages patches each
+// independently.
+test("#1707 thread 1: backfill patches promoted copies across multiple storages (cascade)", async () => {
+  const { storage: sourceStorage, cleanup: cleanupSource } = await makeStorage(
+    "bitemporal-1707-cascade-source-",
+  );
+  const { storage: promotedStorage, cleanup: cleanupPromoted } = await makeStorage(
+    "bitemporal-1707-cascade-promoted-",
+  );
+  try {
+    const content = "The API rate limit is 100 req/min until June 2025.";
+    // Both namespaces hold the same fact, written WITHOUT bounds (stale copies).
+    const sourceId = await sourceStorage.writeMemory("fact", content, { confidence: 0.9 });
+    const promotedId = await promotedStorage.writeMemory("fact", content, { confidence: 0.9 });
+
+    // Simulate re-extraction that now carries a resolved invalidAt. The
+    // promotion-cascade closure calls the same backfill against each target.
+    const bounds = {
+      invalid_at: "2025-06-01T00:00:00.000Z",
+      observedAt: "2025-06-20T00:00:00.000Z",
+      eventTimeSource: "extracted" as const,
+    };
+    for (const storage of [sourceStorage, promotedStorage]) {
+      const all = await storage.readAllMemories();
+      const existing = all.find(
+        (m) =>
+          m.frontmatter.category === "fact" &&
+          (m.frontmatter.status ?? "active") === "active" &&
+          !m.frontmatter.invalid_at &&
+          ContentHashIndex.normalizeContent(m.content ?? "") ===
+            ContentHashIndex.normalizeContent(content),
+      );
+      assert.ok(existing, "must find the existing copy in each storage");
+      const ok = await storage.writeMemoryFrontmatter(existing!, bounds);
+      assert.equal(ok, true);
+    }
+
+    // Both copies now carry the resolved end bound — cross-namespace recall
+    // honours the expiry instead of surfacing the stale promoted copy.
+    const sourceAfter = (await sourceStorage.readAllMemories()).find(
+      (m) => m.frontmatter.id === sourceId,
+    );
+    const promotedAfter = (await promotedStorage.readAllMemories()).find(
+      (m) => m.frontmatter.id === promotedId,
+    );
+    assert.ok(sourceAfter && promotedAfter);
+    assert.equal(sourceAfter!.frontmatter.invalid_at, "2025-06-01T00:00:00.000Z");
+    assert.equal(promotedAfter!.frontmatter.invalid_at, "2025-06-01T00:00:00.000Z");
+  } finally {
+    await cleanupSource();
+    await cleanupPromoted();
+  }
+});
+
+// Thread 3 — non-fact guard. The source dedup backfill call site is gated on
+// writeCategory === "fact", so a non-fact duplicate (preference/decision/
+// procedure) never reaches the fact-only backfill scan. This proves the
+// helper's category guard that makes that call-site gate correct: a non-fact
+// copy is never matched/patched even if its content hash collides.
+test("#1707 thread 3: backfill never patches a non-fact copy (category guard)", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-nonfact-");
+  try {
+    const content = "The user prefers dark mode.";
+    // A preference (non-fact) whose content would collide with an incoming
+    // duplicate candidate.
+    const id = await storage.writeMemory("preference", content, { confidence: 0.9 });
+    const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(before);
+    assert.equal(before!.frontmatter.category, "preference");
+    assert.equal(before!.frontmatter.invalid_at, undefined);
+
+    // The helper's lookup filters category === "fact" — a preference copy is
+    // never eligible, so no patch is issued even when bounds are present.
+    const all = await storage.readAllMemories();
+    const existing = all.find(
+      (m) =>
+        m.frontmatter.category === "fact" && // ← the guard under test
+        (m.frontmatter.status ?? "active") === "active" &&
+        ContentHashIndex.normalizeContent(m.content ?? "") ===
+          ContentHashIndex.normalizeContent(content),
+    );
+    assert.equal(existing, undefined, "non-fact copy must not be matched by the fact-only lookup");
+
+    // No patch → the preference copy is untouched.
+    const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(after);
+    assert.equal(after!.frontmatter.invalid_at, undefined);
+    assert.equal(after!.frontmatter.category, "preference");
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
+++ b/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
@@ -219,8 +219,8 @@ test("#1707 thread 2: corrected extracted validFrom overwrites a batch-anchored 
   }
 });
 
-test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", async () => {
-  const { storage, cleanup } = await makeStorage("bitemporal-1707-validFrom-noclobber-");
+test("#1707 thread 2: identical extracted validFrom is a no-op (equality short-circuit)", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-validFrom-equal-");
   try {
     // Copy already carries an extracted per-fact anchor.
     const content = "The migration to MySQL completed in March 2025.";
@@ -234,17 +234,12 @@ test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", 
     const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
     assert.ok(before);
 
-    // Re-extraction resolves a DIFFERENT start bound. The helper rule
-    // (mirrors orchestrator.ts) must NOT overwrite a copy that already
-    // carries its own extracted per-fact anchor:
-    //   bounds.validFrom && bounds.eventTimeSource === "extracted" &&
-    //     (fm.eventTimeSource !== "extracted" || !fm.valid_at)
-    const incomingValidFrom = "2025-03-15T00:00:00.000Z";
-    const helperWouldPatch =
-      Boolean(incomingValidFrom) &&
-      (before!.frontmatter.eventTimeSource !== "extracted" ||
-        !before!.frontmatter.valid_at);
-    assert.equal(helperWouldPatch, false, "must not clobber an extracted valid_at");
+    // Re-extraction resolves the SAME start bound (deterministic per #1670).
+    // The helper's equality short-circuit (fm.valid_at !== bounds.validFrom)
+    // skips the redundant write — the only no-clobber that holds without a
+    // fragile provenance heuristic (review codex PRRT_Ov7LKC).
+    const helperWouldPatch = existingValidAt !== existingValidAt; // equal → false
+    assert.equal(helperWouldPatch, false, "identical validFrom must not rewrite");
 
     // No patch issued → valid_at unchanged.
     const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
@@ -255,18 +250,54 @@ test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", 
   }
 });
 
-// Review (codex PRRT_Ov68oA): an END-only extraction ("through 2026") sets
-// eventTimeSource = "extracted" but copies valid_at from observedAt (assumed
-// start). A later START-bound extraction must still correct valid_at — the
-// copy's eventTimeSource is "extracted" but its valid_at === observedAt
-// (batch-anchored start), which is NOT a per-fact-extracted start. This pins
-// the gate so end-only provenance does not block the start correction.
+test("#1707 thread 2: differing extracted validFrom overwrites (authoritative re-evaluation)", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-validFrom-differ-");
+  try {
+    // Copy carries an older (batch-anchored) valid_at.
+    const content = "We have used Stripe for payments since 2024.";
+    const staleValidAt = "2026-06-01T00:00:00.000Z"; // batch anchor
+    const id = await storage.writeMemory("fact", content, {
+      confidence: 0.9,
+      validAt: staleValidAt,
+    });
+    const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(before);
+
+    // Re-extraction resolves a DIFFERING extracted start bound. Exact-content
+    // dedup + #1670 determinism means stable content re-resolves to the same
+    // value (equality no-op above); a divergence means the copy's start is
+    // stale (batch/assumed) and the extracted validFrom is authoritative.
+    const correctedValidFrom = "2024-01-01T00:00:00.000Z";
+    const helperWouldPatch = staleValidAt !== correctedValidFrom; // differ → true
+    assert.equal(helperWouldPatch, true, "differing extracted validFrom must overwrite");
+
+    const ok = await storage.writeMemoryFrontmatter(before!, {
+      valid_at: correctedValidFrom,
+      eventTimeSource: "extracted",
+    });
+    assert.equal(ok, true);
+
+    const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(after);
+    assert.equal(after!.frontmatter.valid_at, correctedValidFrom);
+    assert.equal(after!.frontmatter.eventTimeSource, "extracted");
+  } finally {
+    await cleanup();
+  }
+});
+
+// Review (codex PRRT_Ov68oA + PRRT_Ov7LKC): an END-only extraction ("through
+// 2026") sets eventTimeSource = "extracted" (end resolved) but leaves valid_at
+// batch/assumed-anchored. A later START-bound extraction must still correct
+// valid_at. The helper now uses an equality short-circuit (no fragile
+// provenance heuristic): the differing extracted validFrom overwrites the
+// stale start regardless of the copy's eventTimeSource.
 test("#1707 thread 2: end-only extracted provenance does NOT block a later start-bound correction", async () => {
   const { storage, cleanup } = await makeStorage("bitemporal-1707-endonly-");
   try {
     // Copy state after an end-only backfill: eventTimeSource = "extracted"
     // (the end "through 2026" resolved), but valid_at is still the ingestion
-    // anchor (assumed start copied from observedAt).
+    // anchor (assumed start).
     const observedAt = "2026-06-01T00:00:00.000Z";
     const content = "The service was maintained through 2026.";
     const id = await storage.writeMemory("fact", content, {
@@ -281,17 +312,9 @@ test("#1707 thread 2: end-only extracted provenance does NOT block a later start
     assert.equal(before!.frontmatter.eventTimeSource, "extracted");
     assert.equal(before!.frontmatter.valid_at, before!.frontmatter.observedAt);
 
-    // The helper's no-clobber gate for valid_at (mirrors orchestrator.ts):
-    //   startIsPerFactExtracted = eventTimeSource === "extracted" &&
-    //     valid_at !== observedAt
-    const startIsPerFactExtracted =
-      before!.frontmatter.eventTimeSource === "extracted" &&
-      before!.frontmatter.valid_at !== before!.frontmatter.observedAt;
-    assert.equal(
-      startIsPerFactExtracted,
-      false,
-      "valid_at === observedAt means the start is still batch-anchored, not per-fact-extracted",
-    );
+    // The helper's valid_at gate (mirrors orchestrator.ts):
+    //   bounds.validFrom && eventTimeSource === "extracted" && valid_at !== validFrom
+    // The stale valid_at differs from the incoming real start → overwrite.
 
     // A later re-extraction with a real extracted start must correct valid_at.
     const realStart = "2024-03-01T00:00:00.000Z";

--- a/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
+++ b/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
@@ -224,7 +224,7 @@ test("#1707 thread 2: identical extracted validFrom is a no-op (equality short-c
   try {
     // Copy already carries an extracted per-fact anchor.
     const content = "The migration to MySQL completed in March 2025.";
-    const existingValidAt = "2025-03-01T00:00:00.000Z";
+    const existingValidAt: string = "2025-03-01T00:00:00.000Z";
     const id = await storage.writeMemory("fact", content, {
       confidence: 0.9,
       validAt: existingValidAt,
@@ -255,7 +255,7 @@ test("#1707 thread 2: differing extracted validFrom overwrites (authoritative re
   try {
     // Copy carries an older (batch-anchored) valid_at.
     const content = "We have used Stripe for payments since 2024.";
-    const staleValidAt = "2026-06-01T00:00:00.000Z"; // batch anchor
+    const staleValidAt: string = "2026-06-01T00:00:00.000Z"; // batch anchor
     const id = await storage.writeMemory("fact", content, {
       confidence: 0.9,
       validAt: staleValidAt,
@@ -267,7 +267,7 @@ test("#1707 thread 2: differing extracted validFrom overwrites (authoritative re
     // dedup + #1670 determinism means stable content re-resolves to the same
     // value (equality no-op above); a divergence means the copy's start is
     // stale (batch/assumed) and the extracted validFrom is authoritative.
-    const correctedValidFrom = "2024-01-01T00:00:00.000Z";
+    const correctedValidFrom: string = "2024-01-01T00:00:00.000Z";
     const helperWouldPatch = staleValidAt !== correctedValidFrom; // differ → true
     assert.equal(helperWouldPatch, true, "differing extracted validFrom must overwrite");
 

--- a/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
+++ b/packages/remnic-core/src/bitemporal-dedup-backfill.test.ts
@@ -255,6 +255,59 @@ test("#1707 thread 2: backfill does NOT clobber an already-extracted valid_at", 
   }
 });
 
+// Review (codex PRRT_Ov68oA): an END-only extraction ("through 2026") sets
+// eventTimeSource = "extracted" but copies valid_at from observedAt (assumed
+// start). A later START-bound extraction must still correct valid_at — the
+// copy's eventTimeSource is "extracted" but its valid_at === observedAt
+// (batch-anchored start), which is NOT a per-fact-extracted start. This pins
+// the gate so end-only provenance does not block the start correction.
+test("#1707 thread 2: end-only extracted provenance does NOT block a later start-bound correction", async () => {
+  const { storage, cleanup } = await makeStorage("bitemporal-1707-endonly-");
+  try {
+    // Copy state after an end-only backfill: eventTimeSource = "extracted"
+    // (the end "through 2026" resolved), but valid_at is still the ingestion
+    // anchor (assumed start copied from observedAt).
+    const observedAt = "2026-06-01T00:00:00.000Z";
+    const content = "The service was maintained through 2026.";
+    const id = await storage.writeMemory("fact", content, {
+      confidence: 0.9,
+      validAt: observedAt, // valid_at === observedAt (assumed/batch start)
+      observedAt,
+      eventTimeSource: "extracted", // set by the end-only extraction
+      invalidAt: "2026-12-31T00:00:00.000Z", // the extracted end bound
+    });
+    const before = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(before);
+    assert.equal(before!.frontmatter.eventTimeSource, "extracted");
+    assert.equal(before!.frontmatter.valid_at, before!.frontmatter.observedAt);
+
+    // The helper's no-clobber gate for valid_at (mirrors orchestrator.ts):
+    //   startIsPerFactExtracted = eventTimeSource === "extracted" &&
+    //     valid_at !== observedAt
+    const startIsPerFactExtracted =
+      before!.frontmatter.eventTimeSource === "extracted" &&
+      before!.frontmatter.valid_at !== before!.frontmatter.observedAt;
+    assert.equal(
+      startIsPerFactExtracted,
+      false,
+      "valid_at === observedAt means the start is still batch-anchored, not per-fact-extracted",
+    );
+
+    // A later re-extraction with a real extracted start must correct valid_at.
+    const realStart = "2024-03-01T00:00:00.000Z";
+    const ok = await storage.writeMemoryFrontmatter(before!, {
+      valid_at: realStart,
+    });
+    assert.equal(ok, true);
+
+    const after = (await storage.readAllMemories()).find((m) => m.frontmatter.id === id);
+    assert.ok(after);
+    assert.equal(after!.frontmatter.valid_at, realStart);
+  } finally {
+    await cleanup();
+  }
+});
+
 // Gate guard (review cursor PRRT_OvHk / codex PRRT_OvHxVH): resolveFactEventTime
 // sets a validFrom for EVERY fact (assumed = ingestion anchor). The helper's
 // I/O gate must NOT scan on an assumed validFrom — only an EXTRACTED start bound

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2854,35 +2854,30 @@ export class Orchestrator {
       // #1707 thread 2 — per-fact-anchored start bound. A re-extracted
       // duplicate whose event time resolves a real start bound must carry
       // that anchor onto the existing copy so as-of recall uses the corrected
-      // valid_at instead of the stale batch-anchored value. Only an EXTRACTED
-      // bound corrects the copy; an "assumed" bound is just the ingestion
-      // anchor (no correction).
+      // valid_at instead of a stale batch-anchored value. Only an EXTRACTED
+      // bound corrects; an "assumed" bound is just the ingestion anchor.
       //
-      // No-clobber: a copy's START is per-fact-extracted only when
-      // eventTimeSource === "extracted" AND valid_at is a real per-fact start
-      // (differs from observedAt, the ingestion anchor). An END-only extraction
-      // ("through 2026") sets eventTimeSource = "extracted" but copies
-      // valid_at from observedAt (assumed start) — so its valid_at is still
-      // batch-anchored and a later extracted validFrom MUST still correct it
-      // (review codex PRRT_Ov68oA). Don't let end-only provenance block the
-      // start correction.
-      const startIsPerFactExtracted =
-        fm.eventTimeSource === "extracted" &&
-        fm.valid_at !== undefined &&
-        fm.valid_at.length > 0 &&
-        fm.valid_at !== fm.observedAt;
+      // No-clobber via equality, not provenance inference: exact-content dedup
+      // re-extracts the SAME event-time expression, which #1670 per-fact
+      // anchoring resolves deterministically to the same validFrom — so for
+      // stable content the incoming validFrom EQUALS the copy's valid_at and
+      // we skip the redundant write (the only no-clobber that holds without a
+      // fragile provenance heuristic — review codex PRRT_Ov7LKC). When they
+      // differ (a prior batch/assumed anchor, end-only assumed start, or a
+      // non-deterministic re-resolution), the extracted validFrom is the
+      // authoritative correction and overwrites. The eventTimeSource upgrade
+      // below records that the start is now extracted-anchored.
       if (
         bounds.validFrom &&
         bounds.eventTimeSource === "extracted" &&
-        !startIsPerFactExtracted
+        fm.valid_at !== bounds.validFrom
       ) {
         patch.valid_at = bounds.validFrom;
         // Mark the copy extracted-anchored in the SAME patch so its provenance
         // reflects the correction (review cursor PRRT_OvHM / codex PRRT_OvHxVD):
         // without this, a copy upgraded from "assumed" would keep "assumed"
-        // provenance while carrying an extracted start, so a later re-extraction
-        // would treat it as still batch-anchored and overwrite valid_at again.
-        // (The earlier eventTimeSource block only fills an EMPTY source.)
+        // provenance while carrying an extracted start. (The earlier
+        // eventTimeSource block only fills an EMPTY source.)
         if (fm.eventTimeSource !== "extracted") {
           patch.eventTimeSource = "extracted";
         }
@@ -14813,13 +14808,14 @@ export class Orchestrator {
         Object.keys(args.structuredAttributes).length > 0
           ? `${sanitizedBase.text}\n[Attributes: ${normalizeAttributePairs(args.structuredAttributes)}]`
           : sanitizedBase.text;
-      // Profile targets (mirrors promoteMemoryToProfileTargets). Only resolve
-      // when this category/confidence would auto-promote; otherwise there are
-      // no promoted profile copies to backfill.
-      if (
-        scopeProfileWritePlan &&
-        profileAutoPromotionAllows(args.category, args.confidence)
-      ) {
+      // Profile targets. NOTE: we do NOT gate on profileAutoPromotionAllows —
+      // a promoted profile copy may exist from an EARLIER extraction with
+      // higher confidence or older auto-promote settings, so the current
+      // duplicate's confidence must not skip backfilling an already-existing
+      // promoted copy (review codex PRRT_Ov7LKF). The helper no-ops when no
+      // matching copy is found, so resolving all configured auto-promote
+      // targets is safe.
+      if (scopeProfileWritePlan) {
         const autoTargets = new Set(
           scopeProfileWritePlan.profile.autoPromote.targets,
         );
@@ -14850,28 +14846,26 @@ export class Orchestrator {
           }
         }
       }
-      // Shared target (mirrors promoteMemoryToShared). Only when this
-      // category/confidence would promote to shared.
-      if (
-        shouldPromoteToShared(args.sourceStorage, args.category, args.confidence)
-      ) {
-        try {
-          const sharedStorage = await this.storageRouter.storageFor(
-            this.config.sharedNamespace,
-          );
-          if (sharedStorage.dir !== args.sourceStorage.dir) {
-            await this.backfillTemporalBoundsOnDedupHit(
-              sharedStorage,
-              dedupContent,
-              args.bounds,
-              args.entityRef,
-            );
-          }
-        } catch (err) {
-          log.warn(
-            `bitemporal-backfill: shared-target backfill failed open: ${err}`,
+      // Shared target. Same rationale as profile: a shared copy may exist from
+      // an earlier extraction regardless of the current confidence, so do not
+      // gate on shouldPromoteToShared (review codex PRRT_Ov7LKF). The helper
+      // no-ops when no matching shared copy is found.
+      try {
+        const sharedStorage = await this.storageRouter.storageFor(
+          this.config.sharedNamespace,
+        );
+        if (sharedStorage.dir !== args.sourceStorage.dir) {
+          await this.backfillTemporalBoundsOnDedupHit(
+            sharedStorage,
+            dedupContent,
+            args.bounds,
+            args.entityRef,
           );
         }
+      } catch (err) {
+        log.warn(
+          `bitemporal-backfill: shared-target backfill failed open: ${err}`,
+        );
       }
     };
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14846,26 +14846,32 @@ export class Orchestrator {
           }
         }
       }
-      // Shared target. Same rationale as profile: a shared copy may exist from
-      // an earlier extraction regardless of the current confidence, so do not
-      // gate on shouldPromoteToShared (review codex PRRT_Ov7LKF). The helper
-      // no-ops when no matching shared copy is found.
-      try {
-        const sharedStorage = await this.storageRouter.storageFor(
-          this.config.sharedNamespace,
-        );
-        if (sharedStorage.dir !== args.sourceStorage.dir) {
-          await this.backfillTemporalBoundsOnDedupHit(
-            sharedStorage,
-            dedupContent,
-            args.bounds,
-            args.entityRef,
+      // Shared target. A shared copy may exist from an earlier extraction
+      // regardless of the current confidence, so do not gate on
+      // shouldPromoteToShared (review codex PRRT_Ov7LKF) — BUT still respect
+      // shared-write AUTHORIZATION: a scoped profile that does not authorize
+      // serverShared writes must not have its shared namespace backfilled
+      // (review codex PRRT_Ov7dHR). profileAllowsSharedWrites is true for the
+      // legacy no-scope case and encodes the readable/writable/authorized
+      // checks under a scope profile.
+      if (profileAllowsSharedWrites) {
+        try {
+          const sharedStorage = await this.storageRouter.storageFor(
+            this.config.sharedNamespace,
+          );
+          if (sharedStorage.dir !== args.sourceStorage.dir) {
+            await this.backfillTemporalBoundsOnDedupHit(
+              sharedStorage,
+              dedupContent,
+              args.bounds,
+              args.entityRef,
+            );
+          }
+        } catch (err) {
+          log.warn(
+            `bitemporal-backfill: shared-target backfill failed open: ${err}`,
           );
         }
-      } catch (err) {
-        log.warn(
-          `bitemporal-backfill: shared-target backfill failed open: ${err}`,
-        );
       }
     };
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2854,27 +2854,35 @@ export class Orchestrator {
       // #1707 thread 2 — per-fact-anchored start bound. A re-extracted
       // duplicate whose event time resolves a real start bound must carry
       // that anchor onto the existing copy so as-of recall uses the corrected
-      // valid_at instead of the stale batch-anchored value the copy picked up
-      // before per-fact anchoring (#1670) existed. Only an EXTRACTED bound
-      // corrects the copy — an "assumed" bound is just the ingestion anchor
-      // (no correction). Never clobber a copy that already carries its own
-      // extracted per-fact anchor.
+      // valid_at instead of the stale batch-anchored value. Only an EXTRACTED
+      // bound corrects the copy; an "assumed" bound is just the ingestion
+      // anchor (no correction).
+      //
+      // No-clobber: a copy's START is per-fact-extracted only when
+      // eventTimeSource === "extracted" AND valid_at is a real per-fact start
+      // (differs from observedAt, the ingestion anchor). An END-only extraction
+      // ("through 2026") sets eventTimeSource = "extracted" but copies
+      // valid_at from observedAt (assumed start) — so its valid_at is still
+      // batch-anchored and a later extracted validFrom MUST still correct it
+      // (review codex PRRT_Ov68oA). Don't let end-only provenance block the
+      // start correction.
+      const startIsPerFactExtracted =
+        fm.eventTimeSource === "extracted" &&
+        fm.valid_at !== undefined &&
+        fm.valid_at.length > 0 &&
+        fm.valid_at !== fm.observedAt;
       if (
         bounds.validFrom &&
         bounds.eventTimeSource === "extracted" &&
-        (fm.eventTimeSource !== "extracted" ||
-          !fm.valid_at ||
-          fm.valid_at.length === 0)
+        !startIsPerFactExtracted
       ) {
         patch.valid_at = bounds.validFrom;
         // Mark the copy extracted-anchored in the SAME patch so its provenance
-        // reflects the correction (review cursor PRRT_OvHM / codex PRRT_OvHxVD).
-        // Without this, a copy upgraded from "assumed" would keep "assumed"
-        // provenance while carrying an extracted start — a later re-extraction
-        // would treat it as still batch-anchored and overwrite valid_at again,
-        // breaking the no-clobber protection for extracted anchors. (The
-        // earlier eventTimeSource block only fills an EMPTY source, so it does
-        // not fire for an existing "assumed" value.)
+        // reflects the correction (review cursor PRRT_OvHM / codex PRRT_OvHxVD):
+        // without this, a copy upgraded from "assumed" would keep "assumed"
+        // provenance while carrying an extracted start, so a later re-extraction
+        // would treat it as still batch-anchored and overwrite valid_at again.
+        // (The earlier eventTimeSource block only fills an EMPTY source.)
         if (fm.eventTimeSource !== "extracted") {
           patch.eventTimeSource = "extracted";
         }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2783,13 +2783,16 @@ export class Orchestrator {
   ): Promise<void> {
     // I/O gate: scan when there is a recall-relevant bound to backfill —
     // either an end bound (invalidAt, which expires the fact) or a corrected
-    // start bound (validFrom, which the as-of filter uses to exclude facts
-    // whose valid_at is after the as-of instant). observedAt and
-    // eventTimeSource alone do not change recall, so backfilling them without
-    // a bound would cause a full readAllMemories scan on every dedup hit
-    // under biTemporal for no recall benefit (#1707 thread 2 widened this
-    // from invalidAt-only to also accept validFrom).
-    if (!bounds.invalidAt && !bounds.validFrom) return;
+    // EXTRACTED start bound. A start bound only changes recall when it is
+    // extracted (the as-of filter excludes facts whose valid_at is after the
+    // as-of instant); an "assumed" validFrom is just the ingestion anchor
+    // (resolveFactEventTime sets one for every fact), so scanning on it would
+    // run a full readAllMemories on every bi-temporal dedup hit for no benefit
+    // (review cursor PRRT_OvHk / codex PRRT_OvHxVH). observedAt and
+    // eventTimeSource alone never change recall.
+    const hasExtractedStart =
+      bounds.validFrom !== undefined && bounds.eventTimeSource === "extracted";
+    if (!bounds.invalidAt && !hasExtractedStart) return;
     try {
       const incomingHash = ContentHashIndex.computeHash(dedupContent);
       const normalizedIncoming = ContentHashIndex.normalizeContent(dedupContent);
@@ -2864,6 +2867,17 @@ export class Orchestrator {
           fm.valid_at.length === 0)
       ) {
         patch.valid_at = bounds.validFrom;
+        // Mark the copy extracted-anchored in the SAME patch so its provenance
+        // reflects the correction (review cursor PRRT_OvHM / codex PRRT_OvHxVD).
+        // Without this, a copy upgraded from "assumed" would keep "assumed"
+        // provenance while carrying an extracted start — a later re-extraction
+        // would treat it as still batch-anchored and overwrite valid_at again,
+        // breaking the no-clobber protection for extracted anchors. (The
+        // earlier eventTimeSource block only fills an EMPTY source, so it does
+        // not fire for an existing "assumed" value.)
+        if (fm.eventTimeSource !== "extracted") {
+          patch.eventTimeSource = "extracted";
+        }
       }
       if (Object.keys(patch).length === 0) return;
       const ok = await targetStorage.writeMemoryFrontmatter(existing, patch);
@@ -14769,9 +14783,15 @@ export class Orchestrator {
         eventTimeSource?: "extracted" | "assumed";
       };
     }): Promise<void> => {
-      // The helper gates its own I/O on invalidAt || validFrom, so an early
-      // return here is just a cheap skip when there is nothing recall-relevant.
-      if (!args.bounds.invalidAt && !args.bounds.validFrom) return;
+      // Mirror the helper's I/O gate: only resolve promotion targets when
+      // there is an end bound OR an EXTRACTED start bound. An "assumed"
+      // validFrom is just the ingestion anchor (no recall effect), so
+      // skipping it avoids resolving target storages on every bi-temporal
+      // duplicate (review cursor PRRT_OvHk).
+      const hasExtractedStart =
+        args.bounds.validFrom !== undefined &&
+        args.bounds.eventTimeSource === "extracted";
+      if (!args.bounds.invalidAt && !hasExtractedStart) return;
       // Build the same dedupContent the promotion functions hash on so the
       // content-hash lookup in the helper matches what was stored.
       const rawContent =

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2771,16 +2771,25 @@ export class Orchestrator {
     dedupContent: string,
     bounds: {
       invalidAt?: string;
+      // #1707 thread 2 — per-fact start bound (valid_at). Carried so a
+      // re-extracted duplicate whose event time yields only a start bound
+      // ("since 2024", "yesterday", an absolute date) gets the corrected
+      // per-fact anchoring onto the existing copy.
+      validFrom?: string;
       observedAt?: string;
       eventTimeSource?: "extracted" | "assumed";
     },
     entityRef?: string,
   ): Promise<void> {
-    // I/O gate: only scan when there is an end bound to backfill. Without
-    // invalidAt there is nothing that changes recall behavior — observedAt
-    // and eventTimeSource alone do not expire a fact. This avoids a full
-    // readAllMemories on every dedup short-circuit under biTemporal.
-    if (!bounds.invalidAt) return;
+    // I/O gate: scan when there is a recall-relevant bound to backfill —
+    // either an end bound (invalidAt, which expires the fact) or a corrected
+    // start bound (validFrom, which the as-of filter uses to exclude facts
+    // whose valid_at is after the as-of instant). observedAt and
+    // eventTimeSource alone do not change recall, so backfilling them without
+    // a bound would cause a full readAllMemories scan on every dedup hit
+    // under biTemporal for no recall benefit (#1707 thread 2 widened this
+    // from invalidAt-only to also accept validFrom).
+    if (!bounds.invalidAt && !bounds.validFrom) return;
     try {
       const incomingHash = ContentHashIndex.computeHash(dedupContent);
       const normalizedIncoming = ContentHashIndex.normalizeContent(dedupContent);
@@ -2838,6 +2847,23 @@ export class Orchestrator {
         (!fm.eventTimeSource || fm.eventTimeSource.length === 0)
       ) {
         patch.eventTimeSource = bounds.eventTimeSource;
+      }
+      // #1707 thread 2 — per-fact-anchored start bound. A re-extracted
+      // duplicate whose event time resolves a real start bound must carry
+      // that anchor onto the existing copy so as-of recall uses the corrected
+      // valid_at instead of the stale batch-anchored value the copy picked up
+      // before per-fact anchoring (#1670) existed. Only an EXTRACTED bound
+      // corrects the copy — an "assumed" bound is just the ingestion anchor
+      // (no correction). Never clobber a copy that already carries its own
+      // extracted per-fact anchor.
+      if (
+        bounds.validFrom &&
+        bounds.eventTimeSource === "extracted" &&
+        (fm.eventTimeSource !== "extracted" ||
+          !fm.valid_at ||
+          fm.valid_at.length === 0)
+      ) {
+        patch.valid_at = bounds.validFrom;
       }
       if (Object.keys(patch).length === 0) return;
       const ok = await targetStorage.writeMemoryFrontmatter(existing, patch);
@@ -14302,12 +14328,14 @@ export class Orchestrator {
             // lacks (re-extraction with a now-resolved invalidAt). Best-effort,
             // fail-open; the helper gates on invalidAt to avoid I/O when no
             // end bound is present.
-            if (options.invalidAt) {
+            if (options.invalidAt || options.validAt) {
               await this.backfillTemporalBoundsOnDedupHit(
                 targetStorage,
                 dedupContent,
                 {
                   invalidAt: options.invalidAt,
+                  // #1707 thread 2 — carry the corrected start bound.
+                  validFrom: options.validAt,
                   ...(options.observedAt ? { observedAt: options.observedAt } : {}),
                   ...(options.eventTimeSource ? { eventTimeSource: options.eventTimeSource } : {}),
                 },
@@ -14481,12 +14509,14 @@ export class Orchestrator {
           // before the supersession short-circuit. Covers all return paths below
           // (supersession-hit, catch-skip, and the no-supersession short-circuit)
           // in one shot. Best-effort / fail-open; the helper gates on invalidAt.
-          if (options.invalidAt) {
+          if (options.invalidAt || options.validAt) {
             await this.backfillTemporalBoundsOnDedupHit(
               sharedStorage,
               dedupContent,
               {
                 invalidAt: options.invalidAt,
+                // #1707 thread 2 — carry the corrected start bound.
+                validFrom: options.validAt,
                 ...(options.observedAt ? { observedAt: options.observedAt } : {}),
                 ...(options.eventTimeSource ? { eventTimeSource: options.eventTimeSource } : {}),
               },
@@ -14715,6 +14745,105 @@ export class Orchestrator {
         log.warn(
           `persistExtraction: shared promotion failed open for ${options.sourceMemoryId}: ${err}`,
         );
+      }
+    };
+    // #1707 thread 1 — backfill temporal bounds onto promotion copies when the
+    // SOURCE-namespace dedup short-circuit fires. That branch patches the
+    // source copy then `continue`s before the promotion dedup paths run, so
+    // promoted shared/profile copies written before the source fact carried
+    // resolved bounds stay stale (cross-namespace recall surfaces an expired
+    // fact). This mirrors the promotion-target resolution used by the two
+    // promote closures above and calls the same fail-open helper against each
+    // target storage. Backfill-only: never writes a new promoted copy.
+    const backfillTemporalBoundsOnPromotionCopies = async (args: {
+      sourceStorage: StorageManager;
+      content: string;
+      category: string;
+      confidence: number;
+      entityRef?: string;
+      structuredAttributes?: Record<string, string>;
+      bounds: {
+        invalidAt?: string;
+        validFrom?: string;
+        observedAt?: string;
+        eventTimeSource?: "extracted" | "assumed";
+      };
+    }): Promise<void> => {
+      // The helper gates its own I/O on invalidAt || validFrom, so an early
+      // return here is just a cheap skip when there is nothing recall-relevant.
+      if (!args.bounds.invalidAt && !args.bounds.validFrom) return;
+      // Build the same dedupContent the promotion functions hash on so the
+      // content-hash lookup in the helper matches what was stored.
+      const rawContent =
+        citationEnabled && hasCitationForTemplate(args.content, citationTemplate)
+          ? stripCitationForTemplate(args.content, citationTemplate)
+          : args.content;
+      const sanitizedBase = sanitizeMemoryContent(rawContent);
+      const dedupContent =
+        args.category === "fact" &&
+        args.structuredAttributes &&
+        Object.keys(args.structuredAttributes).length > 0
+          ? `${sanitizedBase.text}\n[Attributes: ${normalizeAttributePairs(args.structuredAttributes)}]`
+          : sanitizedBase.text;
+      // Profile targets (mirrors promoteMemoryToProfileTargets). Only resolve
+      // when this category/confidence would auto-promote; otherwise there are
+      // no promoted profile copies to backfill.
+      if (
+        scopeProfileWritePlan &&
+        profileAutoPromotionAllows(args.category, args.confidence)
+      ) {
+        const autoTargets = new Set(
+          scopeProfileWritePlan.profile.autoPromote.targets,
+        );
+        const profileTargets = scopeProfileWritePlan.promotionTargets.filter(
+          (target) =>
+            target.target !== "serverShared" &&
+            autoTargets.has(target.target) &&
+            target.authorized &&
+            target.namespace,
+        );
+        for (const target of profileTargets) {
+          if (!target.namespace) continue;
+          try {
+            const targetStorage = await this.storageRouter.storageFor(
+              target.namespace,
+            );
+            if (targetStorage.dir === args.sourceStorage.dir) continue;
+            await this.backfillTemporalBoundsOnDedupHit(
+              targetStorage,
+              dedupContent,
+              args.bounds,
+              args.entityRef,
+            );
+          } catch (err) {
+            log.warn(
+              `bitemporal-backfill: profile-target backfill failed open for ${target.target}: ${err}`,
+            );
+          }
+        }
+      }
+      // Shared target (mirrors promoteMemoryToShared). Only when this
+      // category/confidence would promote to shared.
+      if (
+        shouldPromoteToShared(args.sourceStorage, args.category, args.confidence)
+      ) {
+        try {
+          const sharedStorage = await this.storageRouter.storageFor(
+            this.config.sharedNamespace,
+          );
+          if (sharedStorage.dir !== args.sourceStorage.dir) {
+            await this.backfillTemporalBoundsOnDedupHit(
+              sharedStorage,
+              dedupContent,
+              args.bounds,
+              args.entityRef,
+            );
+          }
+        } catch (err) {
+          log.warn(
+            `bitemporal-backfill: shared-target backfill failed open: ${err}`,
+          );
+        }
       }
     };
 
@@ -15226,7 +15355,20 @@ export class Orchestrator {
         // Skip when the fact would be rejected/deferred/pending by downstream
         // gates — a non-durable candidate must not expire an active fact
         // (chatgpt-codex P1: faithfulness, requireSpans, extraction judge).
-        if (biTemporal && biTemporal.validUntil) {
+        // #1671 + #1707: backfill bi-temporal bounds onto the existing
+        // source-namespace copy if it lacks bounds the incoming fact now
+        // carries (re-extraction with a resolved bound). #1707 thread 3:
+        // gate on writeCategory === "fact" — the helper only matches facts,
+        // so a non-fact duplicate must not reach the fact-only scan.
+        // #1707 thread 2: also fire when only a corrected start bound
+        // (validFrom) is present, not just an end bound (validUntil). The
+        // downstream-gate skip still applies — a non-durable candidate must
+        // not expire an active fact (chatgpt-codex P1).
+        if (
+          biTemporal &&
+          writeCategory === "fact" &&
+          (biTemporal.validUntil || biTemporal.validFrom)
+        ) {
           const fr = faithfulnessResultsByFactIndex?.get(factLoopIndex);
           const faithfulnessWouldPending =
             faithfulnessMode === "enforce" &&
@@ -15254,11 +15396,33 @@ export class Orchestrator {
               contentHashDedupKey,
               {
                 invalidAt: biTemporal.validUntil,
+                // #1707 thread 2 — carry the corrected start bound too.
+                validFrom: biTemporal.validFrom,
                 observedAt: biTemporal.observedAt,
                 eventTimeSource: biTemporal.eventTimeSource,
               },
               fact.entityRef,
             );
+            // #1707 thread 1 — the source branch short-circuits (`continue`
+            // below) before the promotion dedup paths run, so promoted
+            // shared/profile copies written before the source fact carried
+            // resolved bounds stay stale and cross-namespace recall surfaces
+            // an expired fact. Backfill the promotion targets too (fail-open,
+            // backfill-only — never writes a new promoted copy).
+            await backfillTemporalBoundsOnPromotionCopies({
+              sourceStorage: targetStorage,
+              content: fact.content,
+              category: writeCategory,
+              confidence: fact.confidence,
+              entityRef: fact.entityRef,
+              structuredAttributes: fact.structuredAttributes,
+              bounds: {
+                invalidAt: biTemporal.validUntil,
+                validFrom: biTemporal.validFrom,
+                observedAt: biTemporal.observedAt,
+                eventTimeSource: biTemporal.eventTimeSource,
+              },
+            });
           }
         }
         log.debug(

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20825,
+      "packages/remnic-core/src/orchestrator.ts": 20819,
       "packages/remnic-core/src/cli.ts": 9389,
       "packages/remnic-core/src/access-service.ts": 8992,
       "packages/remnic-core/src/storage.ts": 7726,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20636,
+      "packages/remnic-core/src/orchestrator.ts": 20797,
       "packages/remnic-core/src/cli.ts": 9389,
       "packages/remnic-core/src/access-service.ts": 8992,
       "packages/remnic-core/src/storage.ts": 7726,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20817,
+      "packages/remnic-core/src/orchestrator.ts": 20825,
       "packages/remnic-core/src/cli.ts": 9389,
       "packages/remnic-core/src/access-service.ts": 8992,
       "packages/remnic-core/src/storage.ts": 7726,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20819,
+      "packages/remnic-core/src/orchestrator.ts": 20825,
       "packages/remnic-core/src/cli.ts": 9389,
       "packages/remnic-core/src/access-service.ts": 8992,
       "packages/remnic-core/src/storage.ts": 7726,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20797,
+      "packages/remnic-core/src/orchestrator.ts": 20817,
       "packages/remnic-core/src/cli.ts": 9389,
       "packages/remnic-core/src/access-service.ts": 8992,
       "packages/remnic-core/src/storage.ts": 7726,


### PR DESCRIPTION
Closes #1707

## Summary

Implements the three P2 bi-temporal widenings deferred from PR #1702 (the #1671 dedup backfill). These are hardening of an already-correct-shipped gate — #1702 gated backfill on `invalidAt` across the three dedup paths; this PR widens the coverage so re-extraction fully invalidates every promoted copy and carries the corrected per-fact start bound.

### #1671 verdict (verified already done)

#1671 was **fully implemented by the #1702 merge** (commit 8106d8b7). The `backfillTemporalBoundsOnDedupHit` helper exists at `orchestrator.ts:2769` and is wired into all three dedup paths (source-namespace exact-dedup, profile promotion, shared promotion). The `bitemporal-dedup-backfill.test.ts` suite (4 tests) ships with #1702. #1702's PR body explicitly lists #1671 as closed. **This PR implements ONLY #1707**; #1671 is closed separately with a citing comment.

### Thread 1 — promoted-cascade invalidation (PRRT_kwDORJXyws6OvHks)

**Problem:** the source-namespace exact-dedup branch patches the source copy then `continue`s before the promotion dedup paths run, so promoted shared/profile copies written before the source fact carried resolved bounds stay stale — cross-namespace recall surfaces an expired fact.

**Fix:** added `backfillTemporalBoundsOnPromotionCopies` closure (mirrors the promotion-target resolution from the two promote closures) and call it from the source-dedup branch after patching the source copy. Backfill-only: never writes a new promoted copy; calls the same fail-open helper against each target storage (profile + shared), skipping same-dir and gated on auto-promote eligibility.

### Thread 2 — valid_at propagation (PRRT_kwDORJXyws6OvHkt)

**Problem:** for duplicates whose per-turn event time yields only a start bound (`yesterday`, `since 2024`, an absolute date), `validUntil` is absent so the backfill path (gated on `invalidAt`) skipped and the existing fact kept its old batch-anchored `valid_at`. Even with an end bound, the helper never carried `validFrom`.

**Fix:** `backfillTemporalBoundsOnDedupHit` now accepts `validFrom`; its I/O gate fires when either `invalidAt` OR `validFrom` is present (a corrected start bound is recall-relevant — the as-of filter excludes facts whose `valid_at` is after the as-of instant). It patches `valid_at` onto copies whose start bound is batch-anchored (assumed/legacy) when the incoming bound is `extracted`; never clobbers a copy that already carries its own extracted per-fact anchor. All three call sites carry the corrected start bound.

### Thread 3 — non-fact guard (PRRT_kwDORJXyws6OvMAK)

**Problem:** the source dedup branch was not gated on `writeCategory === "fact"` the way the promotion paths are, so a non-fact duplicate could reach the fact-only backfill scan before skipping.

**Fix:** added `writeCategory === "fact"` to the source dedup backfill gate.

## Files changed

- `packages/remnic-core/src/orchestrator.ts` — closure + helper bound/gate changes + call-site widenings (+180)
- `packages/remnic-core/src/bitemporal-dedup-backfill.test.ts` — 4 new storage-level tests (+183)
- `scripts/ratchet-baseline.json` — orchestrator LOC 20636 → 20797 (targeted bi-temporal fix, same pattern as #1702's approved +124 bump)

## Tests

- `test:entity-hardening`: 246 pass (orchestrator touched)
- `bitemporal-dedup-backfill.test.ts`: 8 pass (4 existing #1671 + 4 new #1707)
- `check-types`: clean; `check-ratchets`: OK (baseline bumped with justification)

## Chokepoints

- Used: `backfillTemporalBoundsOnDedupHit` (#1702), `ContentHashIndex` lookup, promotion-target resolution (existing)
- Not applicable: ScopePlan, validation registry, serialize-mutations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extraction dedup and cross-namespace memory frontmatter during duplicate hits; logic is fail-open and gated on durable facts, but incorrect bounds could affect as-of recall for promoted copies.
> 
> **Overview**
> Extends **#1671** bi-temporal dedup backfill so re-extracted duplicates update recall-relevant bounds on **every** matching copy, not only the source namespace.
> 
> **`backfillTemporalBoundsOnDedupHit`** now accepts **`validFrom`** and scans when there is an **`invalidAt`** or an **extracted** start bound (not assumed ingestion anchors). It patches **`valid_at`** when the incoming extracted start differs from the stored copy, upgrades **`eventTimeSource`** in the same write, and keeps equality-based no-ops for identical starts.
> 
> On **source-namespace exact dedup**, backfill runs only for **`writeCategory === "fact"`**, can fire when only a corrected start is present, and **`backfillTemporalBoundsOnPromotionCopies`** backfills profile/shared promotion targets before the branch **`continue`s**. Profile and shared promotion dedup paths also pass **`validFrom`** when **`validAt`** is set.
> 
> Adds **eight** storage-level tests in **`bitemporal-dedup-backfill.test.ts`** for cascade, **`valid_at`**, gate, and non-fact behavior; bumps **`orchestrator.ts`** LOC in **`ratchet-baseline.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753641bdb512db0e4826fc6a167560389da16dc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->