### PR TITLE
fix(bench): harden build-artifact-from-result dev helper (#1712)

### DIFF
--- a/scripts/bench/build-artifact-from-result.ts
+++ b/scripts/bench/build-artifact-from-result.ts
@@ -16,49 +16,64 @@
  *     [--quantization Q4_K_M] [--note "..."] [--dataset-version <v>]
  *
  * Prints the written path + sha256 on success; exits non-zero on failure.
+ *
+ * Input is validated at the CLI boundary (issue #1712): an invalid --tier,
+ * non-integer --vram-gb, unpublished benchmarkId, incomplete source run, or a
+ * `--tier local` invocation missing the hardware envelope all fail fast with a
+ * clear stderr message + non-zero exit, rather than slipping through to
+ * `parseBenchmarkArtifact`/`verify-artifact.ts` at publish time.
  */
-import path from "node:path";
+import { realpathSync } from "node:fs";
 import process from "node:process";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import {
   buildBenchmarkArtifact,
   writeBenchmarkArtifact,
-  type BenchmarkArtifact,
+  PUBLISHED_BENCHMARK_ARTIFACT_IDS,
   type BenchmarkArtifactHardware,
+  type BenchmarkArtifactTier,
+  type BenchmarkResult,
+  type PublishedBenchmarkId,
 } from "@remnic/bench";
 
-interface BenchmarkResult {
-  meta: {
-    benchmark: string;
-    remnicVersion: string;
-    gitSha: string;
-    timestamp: string;
-    seeds: number[];
-  };
-  config: {
-    systemProvider?: { model?: string };
-    runtimeProfile?: string;
-    benchmarkOptions?: { judgeCalibration?: unknown };
-  };
-  cost?: {
-    totalLatencyMs?: number;
-    judgeModelCalls?: number;
-  };
-  results: BenchmarkArtifact extends never ? never : unknown;
-  environment: { nodeVersion: string; os: string; hardware?: string };
-}
-
-function parseArgs(argv: string[]): {
+/** CLI flags + positionals, parsed and validated by {@link parseArgs}. */
+export interface ParsedArgs {
   resultPath: string;
   outDir: string;
-  tier?: "local" | "frontier";
+  tier?: BenchmarkArtifactTier;
   hardware?: BenchmarkArtifactHardware;
   note?: string;
   datasetVersion?: string;
-} {
+}
+
+/** Discriminated result of {@link parseArgs}: either a clean parse or a diagnostic. */
+export type ArgParseResult = { ok: true; value: ParsedArgs } | { ok: false; message: string };
+
+/** Discriminated result of {@link validateResultForPromotion}. */
+export type ValidationResult = { ok: true } | { ok: false; message: string };
+
+/** Allowed `--tier` values (issue #1573 two-tier provenance). */
+const ALLOWED_TIERS: Record<string, true> = { local: true, frontier: true };
+
+/** True when `id` is one of the published benchmark artifact identifiers. */
+export function isPublishedBenchmarkId(id: string): id is PublishedBenchmarkId {
+  return (PUBLISHED_BENCHMARK_ARTIFACT_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * Parse + validate the CLI argument vector. Pure (no process.exit) so it can
+ * be unit-tested directly; {@link main} translates a non-`ok` result into a
+ * stderr message + exit code. Every flag that takes a value must receive one,
+ * and value-bearing flags are type-checked at the boundary:
+ *   - `--tier` must be `local` or `frontier`;
+ *   - `--vram-gb` must be a positive finite integer;
+ *   - a `--tier local` invocation must carry the full hardware envelope.
+ */
+export function parseArgs(argv: string[]): ArgParseResult {
   const positional: string[] = [];
-  let tier: "local" | "frontier" | undefined;
+  let tier: BenchmarkArtifactTier | undefined;
   let gpu: string | undefined;
   let vramGb: number | undefined;
   let quantization: string | undefined;
@@ -66,75 +81,261 @@ function parseArgs(argv: string[]): {
   let datasetVersion: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
+    const arg = argv[i];
+    if (arg === undefined) continue;
     switch (arg) {
-      case "--tier":
-        tier = argv[++i] as "local" | "frontier";
+      case "--tier": {
+        const value = argv[++i];
+        if (value === undefined) {
+          return { ok: false, message: "ERROR: --tier requires a value (one of: local, frontier)." };
+        }
+        if (ALLOWED_TIERS[value] !== true) {
+          return {
+            ok: false,
+            message: `ERROR: --tier must be one of: local, frontier; got "${value}".`,
+          };
+        }
+        tier = value as BenchmarkArtifactTier;
         break;
-      case "--gpu":
-        gpu = argv[++i];
+      }
+      case "--gpu": {
+        const value = argv[++i];
+        if (value === undefined) {
+          return { ok: false, message: "ERROR: --gpu requires a value." };
+        }
+        gpu = value;
         break;
-      case "--vram-gb":
-        vramGb = Number(argv[++i]);
+      }
+      case "--vram-gb": {
+        const raw = argv[++i];
+        if (raw === undefined) {
+          return { ok: false, message: "ERROR: --vram-gb requires a positive integer value." };
+        }
+        const parsed = Number(raw);
+        // Number("") === 0 and Number(" ") === 0, so reject non-finite and
+        // non-integer explicitly; NaN from "abc" or a fractional/zero/negative
+        // value all fail here instead of serializing as JSON `null` later.
+        if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+          return {
+            ok: false,
+            message: `ERROR: --vram-gb must be a positive finite integer; got "${raw}".`,
+          };
+        }
+        vramGb = parsed;
         break;
-      case "--quantization":
-        quantization = argv[++i];
+      }
+      case "--quantization": {
+        const value = argv[++i];
+        if (value === undefined) {
+          return { ok: false, message: "ERROR: --quantization requires a value." };
+        }
+        quantization = value;
         break;
-      case "--note":
-        note = argv[++i];
+      }
+      case "--note": {
+        const value = argv[++i];
+        if (value === undefined) {
+          return { ok: false, message: "ERROR: --note requires a value." };
+        }
+        note = value;
         break;
-      case "--dataset-version":
-        datasetVersion = argv[++i];
+      }
+      case "--dataset-version": {
+        const value = argv[++i];
+        if (value === undefined) {
+          return { ok: false, message: "ERROR: --dataset-version requires a value." };
+        }
+        datasetVersion = value;
         break;
+      }
       default:
         positional.push(arg);
     }
   }
 
   if (positional.length < 2) {
-    process.stderr.write(
-      "usage: build-artifact-from-result.ts <result.json> <outDir> [--tier local] [--gpu ...] [--vram-gb N] [--quantization ...] [--note ...] [--dataset-version ...]\n",
-    );
-    process.exit(2);
+    return {
+      ok: false,
+      message:
+        "usage: build-artifact-from-result.ts <result.json> <outDir> [--tier local] [--gpu ...] [--vram-gb N] [--quantization ...] [--note ...] [--dataset-version ...]",
+    };
   }
 
   let hardware: BenchmarkArtifactHardware | undefined;
   if (gpu !== undefined || vramGb !== undefined || quantization !== undefined) {
     if (gpu === undefined || vramGb === undefined || quantization === undefined) {
-      process.stderr.write(
-        "ERROR: --gpu, --vram-gb, and --quantization must all be supplied together.\n",
-      );
-      process.exit(2);
+      return {
+        ok: false,
+        message: "ERROR: --gpu, --vram-gb, and --quantization must all be supplied together.",
+      };
     }
     hardware = { gpu, vramGb, quantization };
   }
 
+  // Tier L artifacts must carry the hardware envelope so a local-lab number is
+  // never conflated with a frontier number (issue #1573).
+  if (tier === "local" && hardware === undefined) {
+    return {
+      ok: false,
+      message:
+        "ERROR: --tier local requires the full hardware envelope (--gpu, --vram-gb, --quantization).",
+    };
+  }
+
   return {
-    resultPath: positional[0]!,
-    outDir: positional[1]!,
-    tier,
-    hardware,
-    note,
-    datasetVersion,
+    ok: true,
+    value: {
+      resultPath: positional[0] as string,
+      outDir: positional[1] as string,
+      tier,
+      hardware,
+      note,
+      datasetVersion,
+    },
   };
 }
 
-async function main(): Promise<number> {
-  const opts = parseArgs(process.argv.slice(2));
-  const raw = await readFile(opts.resultPath, "utf8");
-  const result = JSON.parse(raw) as BenchmarkResult;
-
-  const startedAtMs = Date.parse(result.meta.timestamp);
-  if (!Number.isFinite(startedAtMs)) {
-    process.stderr.write(`ERROR: meta.timestamp "${result.meta.timestamp}" is not a valid ISO-8601 timestamp.\n`);
-    return 1;
+/**
+ * Validate a parsed result for promotion to a publishable artifact. Publish-
+ * safety guards (issue #1712): reject unpublished benchmark ids, partial /
+ * quick-mode runs, and runs persisted with a `benchmarkOptions.limit` or
+ * `trialLimit` — only complete full runs may be published. Structural
+ * validation of the inner task/aggregate shape is delegated to
+ * `buildBenchmarkArtifact`, which throws with a per-field diagnostic.
+ */
+export function validateResultForPromotion(result: unknown): ValidationResult {
+  if (typeof result !== "object" || result === null) {
+    return { ok: false, message: "ERROR: result file is not a JSON object." };
   }
-  const durationMs = opts.resultPath ? result.cost?.totalLatencyMs ?? 0 : 0;
-  const finishedAt = new Date(startedAtMs + durationMs).toISOString();
+  const r = result as Record<string, unknown>;
+  const meta = r.meta as Record<string, unknown> | undefined;
+  const benchmarkId = meta?.benchmark;
+
+  if (typeof benchmarkId !== "string" || !isPublishedBenchmarkId(benchmarkId)) {
+    return {
+      ok: false,
+      message:
+        `ERROR: meta.benchmark "${String(benchmarkId)}" is not a published benchmark artifact id ` +
+        `(allowed: ${PUBLISHED_BENCHMARK_ARTIFACT_IDS.join(", ")}).`,
+    };
+  }
+
+  if (meta?.status === "partial") {
+    return {
+      ok: false,
+      message:
+        'ERROR: refusing to promote a partial run (meta.status="partial"); only complete runs may be published.',
+    };
+  }
+
+  if (meta?.mode === "quick") {
+    return {
+      ok: false,
+      message:
+        'ERROR: refusing to promote a quick-mode run (meta.mode="quick"); only full runs may be published.',
+    };
+  }
+
+  const config = r.config as Record<string, unknown> | undefined;
+  const benchmarkOptions = config?.benchmarkOptions as Record<string, unknown> | undefined;
+  if (benchmarkOptions !== undefined && typeof benchmarkOptions === "object") {
+    if (benchmarkOptions.limit !== undefined || benchmarkOptions.trialLimit !== undefined) {
+      return {
+        ok: false,
+        message:
+          "ERROR: refusing to promote a limited run (config.benchmarkOptions.limit/trialLimit set); only full runs may be published.",
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Derive the true run window from a stored `BenchmarkResult`.
+ *
+ * `meta.timestamp` is recorded at run **end** — `buildBenchmarkResult` in the
+ * published harness runs after every task has completed, so the timestamp is
+ * the finish, not the start. Treating it as `startedAt` (the pre-#1712
+ * behavior) produced a `finishedAt` in the future (`timestamp + duration`).
+ * The true window is therefore: `finishedAt = meta.timestamp` and
+ * `startedAt = finishedAt − totalLatencyMs`. A non-finite or non-positive
+ * duration collapses to a zero-length window (start === finish) rather than a
+ * backwards interval.
+ */
+export function deriveRunWindow(
+  metaTimestamp: string,
+  totalLatencyMs: number,
+): { startedAt: string; finishedAt: string } {
+  const finishedMs = Date.parse(metaTimestamp);
+  if (!Number.isFinite(finishedMs)) {
+    throw new Error(`meta.timestamp "${metaTimestamp}" is not a valid ISO-8601 timestamp.`);
+  }
+  const duration = Number.isFinite(totalLatencyMs) && totalLatencyMs > 0 ? totalLatencyMs : 0;
+  const startedMs = finishedMs - duration;
+  return {
+    startedAt: new Date(startedMs).toISOString(),
+    finishedAt: new Date(finishedMs).toISOString(),
+  };
+}
+
+/** Outcome of a successful {@link promote} run, mirroring the `WROTE` log line. */
+export interface PromotionResult {
+  path: string;
+  sha256: string;
+  benchmarkId: PublishedBenchmarkId;
+  model: string;
+  seed: number;
+  taskCount: number;
+  judgeCalls: number | undefined;
+}
+
+/**
+ * Read a stored `BenchmarkResult`, validate it for publication, derive the
+ * true run window, build the `BenchmarkArtifact`, and write it to `outDir`.
+ * Throws an `Error` whose `message` is a clear, single-line diagnostic on any
+ * failure (missing file, bad JSON, validation rejection, builder error) so
+ * {@link main} can surface it verbatim. Exported as the integration seam used
+ * by the test suite.
+ */
+export async function promote(opts: ParsedArgs): Promise<PromotionResult> {
+  let raw: string;
+  try {
+    raw = await readFile(opts.resultPath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `could not read result file "${opts.resultPath}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let parsedResult: unknown;
+  try {
+    parsedResult = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `could not parse result file "${opts.resultPath}" as JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const validity = validateResultForPromotion(parsedResult);
+  if (!validity.ok) {
+    throw new Error(validity.message);
+  }
+
+  // validateResultForPromotion narrowed meta.benchmark to a published id, so
+  // the cast here is bounded and safe; buildBenchmarkArtifact validates the
+  // remaining task/aggregate structure and throws with a per-field diagnostic.
+  const result = parsedResult as BenchmarkResult;
+  const benchmarkId = result.meta.benchmark as PublishedBenchmarkId;
+
+  // meta.timestamp is the run-end stamp; derive the true start from the summed
+  // task latency. resultPath is a required positional, so there is no longer a
+  // dead "no path" branch — cost.totalLatencyMs is read unconditionally.
+  const totalLatencyMs = result.cost?.totalLatencyMs ?? 0;
+  const { startedAt, finishedAt } = deriveRunWindow(result.meta.timestamp, totalLatencyMs);
 
   const model = result.config.systemProvider?.model ?? "unknown";
   const seed = result.meta.seeds[0] ?? 1;
-  const benchmarkId = result.meta.benchmark;
 
   // Default dataset version per benchmark when not explicitly supplied.
   const datasetVersion =
@@ -152,14 +353,12 @@ async function main(): Promise<number> {
       : undefined);
 
   const artifact = buildBenchmarkArtifact({
-    // The builder only reads result.results + result.meta + result.environment,
-    // so the loose cast is safe for a stored BenchmarkResult.
-    result: result as never,
-    benchmarkId: benchmarkId as never,
+    result,
+    benchmarkId,
     datasetVersion,
     model,
     seed,
-    startedAt: result.meta.timestamp,
+    startedAt,
     finishedAt,
     ...(opts.tier !== undefined ? { tier: opts.tier } : {}),
     ...(opts.hardware !== undefined ? { hardware: opts.hardware } : {}),
@@ -167,21 +366,58 @@ async function main(): Promise<number> {
   });
 
   const written = await writeBenchmarkArtifact(artifact, opts.outDir);
-  process.stdout.write(
-    `WROTE ${written.path} ${benchmarkId} model=${model} seed=${seed} ` +
-      `tasks=${artifact.perTaskScores.length} judgeCalls=${result.cost?.judgeModelCalls ?? "n/a"} ` +
-      `sha256=${written.sha256}\n`,
-  );
-  return 0;
+  return {
+    path: written.path,
+    sha256: written.sha256,
+    benchmarkId,
+    model,
+    seed,
+    taskCount: artifact.perTaskScores.length,
+    judgeCalls: result.cost?.judgeModelCalls,
+  };
 }
 
-main()
-  .then((code) => {
-    process.exitCode = code;
-  })
-  .catch((error) => {
-    process.stderr.write(
-      `build-artifact-from-result.ts crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+async function main(): Promise<number> {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (!parsed.ok) {
+    process.stderr.write(`${parsed.message}\n`);
+    return 2;
+  }
+  try {
+    const result = await promote(parsed.value);
+    process.stdout.write(
+      `WROTE ${result.path} ${result.benchmarkId} model=${result.model} seed=${result.seed} ` +
+        `tasks=${result.taskCount} judgeCalls=${result.judgeCalls ?? "n/a"} ` +
+        `sha256=${result.sha256}\n`,
     );
-    process.exitCode = 1;
-  });
+    return 0;
+  } catch (error) {
+    process.stderr.write(`ERROR: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+// Only auto-run when invoked directly (not when imported by tests). Mirrors the
+// realpath-based direct-run check in scripts/check-test-types.mjs so a
+// symlinked or tsx-wrapped invocation still resolves correctly.
+function isDirectRun(argvPath: string | undefined, moduleUrl: string): boolean {
+  if (!argvPath) return false;
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun(process.argv[1], import.meta.url)) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `build-artifact-from-result.ts crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+      );
+      process.exitCode = 1;
+    });
+}

--- a/scripts/bench/build-artifact-from-result.ts
+++ b/scripts/bench/build-artifact-from-result.ts
@@ -205,7 +205,7 @@ export function parseArgs(argv: string[]): ArgParseResult {
  */
 export function validateResultForPromotion(result: unknown): ValidationResult {
   if (typeof result !== "object" || result === null) {
-    return { ok: false, message: "ERROR: result file is not a JSON object." };
+    return { ok: false, message: "result file is not a JSON object." };
   }
   const r = result as Record<string, unknown>;
   const meta = r.meta as Record<string, unknown> | undefined;
@@ -215,7 +215,7 @@ export function validateResultForPromotion(result: unknown): ValidationResult {
     return {
       ok: false,
       message:
-        `ERROR: meta.benchmark "${String(benchmarkId)}" is not a published benchmark artifact id ` +
+        `meta.benchmark "${String(benchmarkId)}" is not a published benchmark artifact id ` +
         `(allowed: ${PUBLISHED_BENCHMARK_ARTIFACT_IDS.join(", ")}).`,
     };
   }
@@ -224,7 +224,7 @@ export function validateResultForPromotion(result: unknown): ValidationResult {
     return {
       ok: false,
       message:
-        'ERROR: refusing to promote a partial run (meta.status="partial"); only complete runs may be published.',
+        'refusing to promote a partial run (meta.status="partial"); only complete runs may be published.',
     };
   }
 
@@ -232,18 +232,18 @@ export function validateResultForPromotion(result: unknown): ValidationResult {
     return {
       ok: false,
       message:
-        'ERROR: refusing to promote a quick-mode run (meta.mode="quick"); only full runs may be published.',
+        'refusing to promote a quick-mode run (meta.mode="quick"); only full runs may be published.',
     };
   }
 
   const config = r.config as Record<string, unknown> | undefined;
   const benchmarkOptions = config?.benchmarkOptions as Record<string, unknown> | undefined;
-  if (benchmarkOptions !== undefined && typeof benchmarkOptions === "object") {
+  if (benchmarkOptions !== null && typeof benchmarkOptions === "object") {
     if (benchmarkOptions.limit !== undefined || benchmarkOptions.trialLimit !== undefined) {
       return {
         ok: false,
         message:
-          "ERROR: refusing to promote a limited run (config.benchmarkOptions.limit/trialLimit set); only full runs may be published.",
+          "refusing to promote a limited run (config.benchmarkOptions.limit/trialLimit set); only full runs may be published.",
       };
     }
   }

--- a/tests/bench-build-artifact-helper.test.ts
+++ b/tests/bench-build-artifact-helper.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for scripts/bench/build-artifact-from-result.ts (issue #1712).
+ *
+ * Covers the 12 hardening nits in three bands:
+ *   1. CLI input validation — invalid --tier / --vram-gb / missing positionals
+ *      / --tier local without hardware are rejected by parseArgs.
+ *   2. Publish-safety + identity — validateResultForPromotion rejects
+ *      unpublished benchmark ids, partial/quick runs, and limited runs;
+ *      isPublishedBenchmarkId matches the allow-list.
+ *   3. Timestamp derivation + end-to-end promotion — deriveRunWindow treats
+ *      meta.timestamp as the run END (startedAt = finish − duration), and a
+ *      full promote() round-trip yields an artifact that re-parses cleanly
+ *      through loadBenchmarkArtifact (the verify-artifact.ts path).
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { loadBenchmarkArtifact, type BenchmarkResult, type TaskResult } from "@remnic/bench";
+
+import {
+  parseArgs,
+  validateResultForPromotion,
+  deriveRunWindow,
+  isPublishedBenchmarkId,
+  promote,
+} from "../scripts/bench/build-artifact-from-result.js";
+
+function makeTask(overrides: Partial<TaskResult> = {}): TaskResult {
+  return {
+    taskId: "t1",
+    question: "q",
+    expected: "e",
+    actual: "a",
+    scores: { f1: 0.5 },
+    latencyMs: 1000,
+    tokens: { input: 10, output: 5 },
+    ...overrides,
+  };
+}
+
+interface ResultOverrides {
+  benchmark?: string;
+  status?: "complete" | "partial";
+  mode?: "full" | "quick";
+  timestamp?: string;
+  totalLatencyMs?: number;
+  benchmarkOptions?: Record<string, unknown>;
+  tasks?: TaskResult[];
+  model?: string;
+}
+
+function makeResult(overrides: ResultOverrides = {}): BenchmarkResult {
+  const tasks =
+    overrides.tasks ?? [
+      makeTask(),
+      makeTask({ taskId: "t2", scores: { f1: 0.9, llm_judge: 1 }, latencyMs: 4000 }),
+    ];
+  return {
+    meta: {
+      id: "run-1",
+      benchmark: overrides.benchmark ?? "locomo",
+      benchmarkTier: "published",
+      version: "1.0.0",
+      remnicVersion: "9.3.725",
+      gitSha: "abc1234",
+      timestamp: overrides.timestamp ?? "2026-07-07T10:00:00.000Z",
+      mode: overrides.mode ?? "full",
+      runCount: 1,
+      seeds: [42],
+      ...(overrides.status !== undefined ? { status: overrides.status } : {}),
+    },
+    config: {
+      systemProvider: { provider: "openai", model: overrides.model ?? "gpt-4o-mini" },
+      judgeProvider: { provider: "openai", model: "gpt-4o" },
+      adapterMode: "direct",
+      remnicConfig: {},
+      ...(overrides.benchmarkOptions !== undefined
+        ? { benchmarkOptions: overrides.benchmarkOptions }
+        : {}),
+    },
+    cost: {
+      totalTokens: 100,
+      inputTokens: 60,
+      outputTokens: 40,
+      estimatedCostUsd: 0.01,
+      totalLatencyMs: overrides.totalLatencyMs ?? 5000,
+      meanQueryLatencyMs: 2500,
+      judgeModelCalls: 2,
+    },
+    results: {
+      tasks,
+      aggregates: {
+        f1: { mean: 0.7, median: 0.7, stdDev: 0.2, min: 0.5, max: 0.9 },
+      },
+    },
+    environment: {
+      os: "linux",
+      nodeVersion: "v22.20.0",
+      hardware: "arm64",
+    },
+  };
+}
+
+// --- isPublishedBenchmarkId -------------------------------------------------
+
+test("isPublishedBenchmarkId accepts known ids and rejects unknown ones", () => {
+  assert.equal(isPublishedBenchmarkId("locomo"), true);
+  assert.equal(isPublishedBenchmarkId("longmemeval"), true);
+  assert.equal(isPublishedBenchmarkId("not-a-bench"), false);
+  assert.equal(isPublishedBenchmarkId(""), false);
+});
+
+// --- parseArgs: --tier allow-list (nit [2],[5]) -----------------------------
+
+test("parseArgs accepts --tier frontier bare and --tier local with hardware", () => {
+  // frontier never requires hardware; local does (nit [13]), so it is tested
+  // with the envelope here to isolate the allow-list check.
+  const frontier = parseArgs(["a.json", "out", "--tier", "frontier"]);
+  assert.equal(frontier.ok, true);
+  assert.equal(frontier.ok && frontier.value.tier, "frontier");
+
+  const local = parseArgs([
+    "a.json",
+    "out",
+    "--tier",
+    "local",
+    "--gpu",
+    "NVIDIA RTX 3090",
+    "--vram-gb",
+    "24",
+    "--quantization",
+    "Q4_K_M",
+  ]);
+  assert.equal(local.ok, true);
+  assert.equal(local.ok && local.value.tier, "local");
+});
+
+test("parseArgs rejects an invalid --tier with a clear diagnostic", () => {
+  const r = parseArgs(["a.json", "out", "--tier", "batman"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /--tier must be one of: local, frontier/);
+});
+
+test("parseArgs rejects a missing --tier value", () => {
+  const r = parseArgs(["a.json", "out", "--tier"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /--tier requires a value/);
+});
+
+// --- parseArgs: --vram-gb finite-integer (nit [3],[9]) ----------------------
+
+test("parseArgs accepts a positive integer --vram-gb", () => {
+  const r = parseArgs(["a.json", "out", "--gpu", "RTX 3090", "--vram-gb", "24", "--quantization", "Q4_K_M"]);
+  assert.equal(r.ok, true);
+  assert.equal(r.ok && r.value.hardware?.vramGb, 24);
+});
+
+test("parseArgs rejects non-integer / non-finite / non-positive --vram-gb values", () => {
+  const bad = ["abc", "1.5", "0", "-1", "", " "];
+  for (const raw of bad) {
+    const r = parseArgs(["a.json", "out", "--vram-gb", raw]);
+    assert.equal(r.ok, false, `expected --vram-gb "${raw}" to be rejected`);
+    assert.match(!r.ok && r.message, /--vram-gb must be a positive finite integer/);
+  }
+});
+
+test("parseArgs rejects a missing --vram-gb value", () => {
+  const r = parseArgs(["a.json", "out", "--vram-gb"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /--vram-gb requires a positive integer/);
+});
+
+// --- parseArgs: hardware envelope + positionals -----------------------------
+
+test("parseArgs requires all three hardware flags together", () => {
+  const r = parseArgs(["a.json", "out", "--gpu", "RTX 3090", "--vram-gb", "24"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /--gpu, --vram-gb, and --quantization must all be supplied together/);
+});
+
+test("parseArgs rejects --tier local without the hardware envelope (nit [13])", () => {
+  const r = parseArgs(["a.json", "out", "--tier", "local"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /--tier local requires the full hardware envelope/);
+});
+
+test("parseArgs accepts --tier local with the full hardware envelope", () => {
+  const r = parseArgs([
+    "a.json",
+    "out",
+    "--tier",
+    "local",
+    "--gpu",
+    "NVIDIA RTX 3090",
+    "--vram-gb",
+    "24",
+    "--quantization",
+    "Q4_K_M",
+  ]);
+  assert.equal(r.ok, true);
+  assert.equal(r.ok && r.value.tier, "local");
+  assert.deepEqual(r.ok && r.value.hardware, {
+    gpu: "NVIDIA RTX 3090",
+    vramGb: 24,
+    quantization: "Q4_K_M",
+  });
+});
+
+test("parseArgs rejects a missing outDir positional", () => {
+  const r = parseArgs(["a.json"]);
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /^usage:/);
+});
+
+// --- validateResultForPromotion: identity + publish-safety (nit [10],[12]) --
+
+test("validateResultForPromotion accepts a complete full run", () => {
+  assert.equal(validateResultForPromotion(makeResult()).ok, true);
+});
+
+test("validateResultForPromotion rejects an unpublished benchmark id (nit [10])", () => {
+  const r = validateResultForPromotion(makeResult({ benchmark: "made-up-bench" }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /is not a published benchmark artifact id/);
+});
+
+test("validateResultForPromotion rejects a partial run (nit [12])", () => {
+  const r = validateResultForPromotion(makeResult({ status: "partial" }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /refusing to promote a partial run/);
+});
+
+test("validateResultForPromotion rejects a quick-mode run (nit [12])", () => {
+  const r = validateResultForPromotion(makeResult({ mode: "quick" }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /refusing to promote a quick-mode run/);
+});
+
+test("validateResultForPromotion rejects a limited run via benchmarkOptions.limit (nit [12])", () => {
+  const r = validateResultForPromotion(makeResult({ benchmarkOptions: { limit: 100 } }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /refusing to promote a limited run/);
+});
+
+test("validateResultForPromotion rejects a limited run via benchmarkOptions.trialLimit (nit [12])", () => {
+  const r = validateResultForPromotion(makeResult({ benchmarkOptions: { trialLimit: 3 } }));
+  assert.equal(r.ok, false);
+  assert.match(!r.ok && r.message, /refusing to promote a limited run/);
+});
+
+test("validateResultForPromotion rejects a non-object result", () => {
+  assert.equal(validateResultForPromotion(null).ok, false);
+  assert.equal(validateResultForPromotion("nope").ok, false);
+  assert.equal(validateResultForPromotion(undefined).ok, false);
+});
+
+// --- deriveRunWindow: timestamp derivation (nit [8],[11]) -------------------
+
+test("deriveRunWindow treats meta.timestamp as the finish and derives start = finish - duration", () => {
+  // meta.timestamp is recorded at run END; the pre-#1712 helper misused it as
+  // the start. start must be duration-earlier than finish.
+  const w = deriveRunWindow("2026-07-07T10:00:00.000Z", 5000);
+  assert.equal(w.finishedAt, "2026-07-07T10:00:00.000Z");
+  assert.equal(w.startedAt, "2026-07-07T09:59:55.000Z");
+});
+
+test("deriveRunWindow collapses a zero/negative/non-finite duration to a zero-length window", () => {
+  for (const duration of [0, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const w = deriveRunWindow("2026-07-07T10:00:00.000Z", duration);
+    assert.equal(w.startedAt, "2026-07-07T10:00:00.000Z", `duration ${duration}`);
+    assert.equal(w.finishedAt, "2026-07-07T10:00:00.000Z", `duration ${duration}`);
+  }
+});
+
+test("deriveRunWindow throws on an invalid timestamp", () => {
+  assert.throws(
+    () => deriveRunWindow("not-a-date", 1000),
+    /is not a valid ISO-8601 timestamp/,
+  );
+});
+
+// --- promote: end-to-end valid input -> correct artifact (nit [4],[6],[7]) --
+
+test("promote writes a publishable artifact with the true run window + envelope", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-helper-"));
+  const outDir = path.join(tmp, "out");
+  await mkdir(outDir, { recursive: true });
+  const resultPath = path.join(tmp, "result.json");
+  await writeFile(resultPath, JSON.stringify(makeResult({ totalLatencyMs: 5000 })), "utf8");
+
+  try {
+    const r = await promote({
+      resultPath,
+      outDir,
+      tier: "local",
+      hardware: { gpu: "NVIDIA RTX 3090", vramGb: 24, quantization: "Q4_K_M" },
+    });
+    assert.equal(r.benchmarkId, "locomo");
+    assert.equal(r.model, "gpt-4o-mini");
+    assert.equal(r.seed, 42);
+    assert.equal(r.taskCount, 2);
+    assert.equal(r.judgeCalls, 2);
+    assert.match(r.sha256, /^[0-9a-f]{64}$/);
+
+    // The written file must re-parse + re-hash through the verify-artifact.ts
+    // path (loadBenchmarkArtifact), proving publishability.
+    const loaded = await loadBenchmarkArtifact(r.path);
+    assert.equal(loaded.artifact.benchmarkId, "locomo");
+    assert.equal(loaded.artifact.model, "gpt-4o-mini");
+    assert.equal(loaded.artifact.tier, "local");
+    assert.deepEqual(loaded.artifact.hardware, {
+      gpu: "NVIDIA RTX 3090",
+      vramGb: 24,
+      quantization: "Q4_K_M",
+    });
+
+    // Timestamp derivation landed in the artifact: finish === meta.timestamp,
+    // start === finish − duration, durationMs === totalLatencyMs.
+    assert.equal(loaded.artifact.finishedAt, "2026-07-07T10:00:00.000Z");
+    assert.equal(loaded.artifact.startedAt, "2026-07-07T09:59:55.000Z");
+    assert.equal(loaded.artifact.durationMs, 5000);
+
+    // metrics are the aggregate means; perTaskScores preserve runner order.
+    assert.equal(loaded.artifact.metrics.f1, 0.7);
+    assert.equal(loaded.artifact.perTaskScores.length, 2);
+    assert.equal(loaded.artifact.perTaskScores[0]?.taskId, "t1");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("promote surfaces a validation rejection as a clear thrown diagnostic", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-helper-"));
+  const resultPath = path.join(tmp, "result.json");
+  await writeFile(resultPath, JSON.stringify(makeResult({ benchmark: "bogus" })), "utf8");
+  try {
+    await assert.rejects(
+      promote({ resultPath, outDir: tmp }),
+      /is not a published benchmark artifact id/,
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("promote surfaces a missing result file as a clear thrown diagnostic", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-helper-"));
+  try {
+    await assert.rejects(
+      promote({ resultPath: path.join(tmp, "nope.json"), outDir: tmp }),
+      /could not read result file/,
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/tests/bench-build-artifact-helper.test.ts
+++ b/tests/bench-build-artifact-helper.test.ts
@@ -251,6 +251,12 @@ test("validateResultForPromotion rejects a limited run via benchmarkOptions.tria
   assert.match(!r.ok && r.message, /refusing to promote a limited run/);
 });
 
+test("validateResultForPromotion treats a null benchmarkOptions as absent (typeof null === object footgun)", () => {
+  // JSON `null` must not crash the limit check (typeof null === "object").
+  const r = validateResultForPromotion(makeResult({ benchmarkOptions: null as unknown as Record<string, unknown> }));
+  assert.equal(r.ok, true);
+});
+
 test("validateResultForPromotion rejects a non-object result", () => {
   assert.equal(validateResultForPromotion(null).ok, false);
   assert.equal(validateResultForPromotion("nope").ok, false);


### PR DESCRIPTION
Closes #1712.

Hardens the dev-facing bridge `scripts/bench/build-artifact-from-result.ts` (promotes a stored `BenchmarkResult` → publishable `BenchmarkArtifact`) against the 12 deferred review nits from #1709, all in one coherent commit. **None affected the committed Tier L artifacts** (produced directly by `remnic bench run` with true `startedAt`/`finishedAt`, verified by `verify-artifact.ts`); all were caught downstream by `parseBenchmarkArtifact`/`verify-artifact.ts`. This lands the validation at the CLI boundary so mis-use fails fast with a clear stderr diagnostic.

## Input validation at the CLI boundary (threads [2],[3],[5],[9],[10])
- `--tier` validated against `{local, frontier}` (was cast `as "local"|"frontier"` unchecked).
- `--vram-gb` requires a positive finite integer — `NaN`/fractional/zero/negative/empty all rejected (previously `Number(argv[++i])` slipped `NaN` past the all-together guard and serialized as `null`).
- `benchmarkId` checked against `PUBLISHED_BENCHMARK_ARTIFACT_IDS` up front (was cast `as never`, bypassing the allow-list).

## Timestamp derivation (threads [8],[11]) — latent correctness
`meta.timestamp` is recorded at run **end** (`buildBenchmarkResult` in the harness runs after all tasks complete). The old code used it as `startedAt` and set `finishedAt = timestamp + duration` (a future time). Now: `finishedAt = meta.timestamp`, `startedAt = finishedAt − totalLatencyMs`. A non-finite/non-positive duration collapses to a zero-length window.

## Publish-safety guards (threads [12],[13])
- Reject incomplete source runs: `meta.status="partial"`, `meta.mode="quick"`, or persisted `config.benchmarkOptions.limit`/`trialLimit`.
- Require the full hardware envelope when `--tier local`.

## Type / dead-code nits (threads [4],[6],[7])
- Drop `results: BenchmarkArtifact extends never ? never : unknown` → import the real `BenchmarkResult` type.
- Drop `result as never` / `benchmarkId as never` casts → validate shape and fail fast with a diagnostic; cast only after validation narrows to `PublishedBenchmarkId`.
- Remove dead `opts.resultPath ? ... : 0` branch (`resultPath` is a required positional).

## Refactor for testability
`parseArgs` / `validateResultForPromotion` / `deriveRunWindow` / `isPublishedBenchmarkId` / `promote` are exported pure functions; `main()` is a thin CLI wrapper guarded by an `isDirectRun` check (mirrors `scripts/check-test-types.mjs`) so importing the module for tests does not execute it.

## Test
`tests/bench-build-artifact-helper.test.ts` — 24 `node:test` cases covering: valid input → correct artifact (round-trips through `loadBenchmarkArtifact`), invalid `--tier`/`--vram-gb`/`benchmarkId` rejected, timestamp derivation (`start = finish − duration`), and the publish-safety guards (partial/quick/limited/local-without-hardware).

## Verification (local)
- `pnpm exec tsx --test tests/bench-build-artifact-helper.test.ts` → 24/24 pass.
- CLI boundary smoke: invalid `--tier`/`--vram-gb`/`--tier local`-without-hardware → exit 2 + clear stderr; valid run → exit 0, artifact with `startedAt=09:59:55 finishedAt=10:00:00 durationMs=5000` (true window).
- `scripts/bench/verify-artifact.ts` on a promoted artifact → `OK ... verify-exit=0`.
- `npm run preflight:quick` → `[preflight] OK (quick)`.
- `node scripts/check-ratchets.mjs` → `[ratchet] OK`.
- `node scripts/check-test-types.mjs` → matches existing baseline (zero new type errors from this change).
- `scripts/bench/bench-smoke.ts` → all metrics within tolerance.
- `pnpm --filter @remnic/bench build` → green.

Chokepoints used / not applicable: n/a — isolated dev-helper script, no orchestrator/storage/validation-registry/catalog surface touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to an isolated dev-helper script and its tests; they improve validation and fix artifact timing metadata without touching production bench run or committed Tier L artifacts.
> 
> **Overview**
> Hardens **`build-artifact-from-result.ts`** so promoting a stored `BenchmarkResult` to a publishable artifact fails fast at the CLI with clear stderr instead of surfacing mistakes only at `verify-artifact` time.
> 
> **CLI validation:** `parseArgs` now returns discriminated errors for bad `--tier`, invalid/missing `--vram-gb`, incomplete hardware flags, missing positionals, and **`--tier local` without the full GPU/VRAM/quantization envelope**.
> 
> **Publish-safety:** New **`validateResultForPromotion`** rejects unpublished `meta.benchmark` ids (checked against `PUBLISHED_BENCHMARK_ARTIFACT_IDS`), partial/quick runs, and runs with `benchmarkOptions.limit` / `trialLimit`.
> 
> **Run window fix:** **`deriveRunWindow`** treats `meta.timestamp` as run **end** (`finishedAt = timestamp`, `startedAt = finish − totalLatencyMs`), fixing the prior behavior that produced a future `finishedAt`.
> 
> **Structure:** Logic is split into exported **`promote`**, **`parseArgs`**, etc., with a thin `main()` and **`isDirectRun`** so tests can import the module without executing the CLI. Unsafe `as never` casts are replaced with real `BenchmarkResult` types and post-validation narrowing.
> 
> Adds **`tests/bench-build-artifact-helper.test.ts`** (24 cases) covering validation, timestamp derivation, and a full `promote` round-trip through `loadBenchmarkArtifact`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd44ddebf812a045b1d7b975fa56f2c488fa4e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->