### PR TITLE
fix(bench): full-payload dataset hash + count unconsidered skill FN (#1708 follow-up)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/bounded-memory-contracts/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/bounded-memory-contracts/fixture.ts
@@ -586,19 +586,10 @@ export const BOUNDED_MEMORY_SMOKE_FIXTURE: BoundedMemoryTask[] = [
  * the datasets apart. Defaults to the full fixture when no slice is passed.
  */
 export function fixtureHash(tasks?: readonly BoundedMemoryTask[]): string {
-  // Simple, stable hash over task ids + expected answers + item ids. Kept
-  // deterministic and dependency-free (no crypto of user data).
+  // Hash the FULL served payload — prompt text, memory content, answer tokens,
+  // keywords, token costs, skill steps — so any edit that changes what the
+  // benchmark actually serves invalidates the digest. (review thread 8t09)
   const source = tasks ?? BOUNDED_MEMORY_FIXTURE;
-  const payload = source.map((t) =>
-    [
-      t.id,
-      t.family,
-      t.expectedAnswer,
-      t.scope,
-      t.shouldAsk === undefined ? "-" : String(t.shouldAsk),
-      t.memoryItems.map((m) => `${m.id}:${m.status}:${m.scope}`).join(","),
-      t.skills.map((s) => s.id).join(","),
-    ].join("|"),
-  ).join("\n");
+  const payload = JSON.stringify(source);
   return createHash("sha256").update(payload, "utf8").digest("hex");
 }

--- a/packages/bench/src/benchmarks/remnic/bounded-memory-contracts/scoring.ts
+++ b/packages/bench/src/benchmarks/remnic/bounded-memory-contracts/scoring.ts
@@ -200,7 +200,9 @@ export function aggregateCondition(
   const tp = injected.filter((e) => e.outcome === "helped").length;
   const fp = injected.filter((e) => e.outcome === "harmed").length;
   const notInjected = considered.filter((e) => !e.injected);
-  const fn = notInjected.filter((e) => e.outcome === "harmed").length;
+  // False negatives: any skill that should have helped but was never injected —
+  // INCLUDING ones the trigger classifier never considered (review 8t0-).
+  const fn = skillLog.filter((e) => !e.injected && e.outcome === "harmed").length;
   const tn = notInjected.filter((e) => e.outcome === "irrelevant").length;
 
   return {


### PR DESCRIPTION
## Summary

Fast-follow to #1722 addressing two P2 review threads from the ai-reviewer pass that landed just after the squash merge.

### Changes

**fixture.ts — hash the full served fixture payload [thread 8t09]**
fixtureHash now JSON-stringifies the entire task array (prompt, memory content, answerToken, keywords, token costs, skill steps) instead of serializing only id:status:scope for memory items and skill ids. Any edit to what the benchmark actually serves now invalidates the digest.

**scoring.ts — count unconsidered expected skills as false negatives [thread 8t0-]**
The aggregate previously filtered the skill log to e.considered before computing fn, so a skill-positive task whose expected skill had no trigger overlap (considered=false, injected=false, outcome=harmed) was silently dropped from recall / false-negative rate. fn now spans ALL skill-log entries.

### Verification
- 16/16 bounded-memory-contracts tests green
- Both changes are benchmark-local; no production code touched

Chokepoints used: N/A (bench-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only scoring and hashing; no production paths. Existing runs may show different dataset hashes and slightly different C3 skill-trigger aggregates.
> 
> **Overview**
> **Reproducibility digest:** `fixtureHash` now hashes the full served task slice via `JSON.stringify` instead of a reduced id/status/skill-id fingerprint, so changes to prompts, memory text, tokens, or skill steps change the manifest `datasetHash`.
> 
> **C3 skill metrics:** False negatives (`fn`) now include every log entry that was not injected but had `outcome === "harmed"`, including skills the trigger never marked `considered`. Previously only `considered && !injected` harmed cases counted, which understated recall and false-negative rate when overlap failed entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a65dc74427e7f6378d65a2801c5e94f5da378a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->