### PR TITLE
feat(bench): add claude-cli provider (claude -p / Opus) for Tier-F runs

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -114,6 +114,7 @@ export type {
 } from "./memory-evals.js";
 export type {
   AnthropicProviderConfig,
+  ClaudeCliProviderConfig,
   CodexCliProviderConfig,
   CompletionOpts,
   CompletionResult,
@@ -166,6 +167,7 @@ export type {
   WriteBenchmarkArtifactResult,
 } from "./published-artifact.js";
 export { createAnthropicProvider } from "./providers/anthropic.js";
+export { createClaudeCliProvider } from "./providers/claude-cli.js";
 export { createCodexCliProvider } from "./providers/codex-cli.js";
 export { getRemnicVersion } from "./reporter.js";
 export {

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -689,3 +689,57 @@ test("claude-cli benchmark prompt keeps system and user input in separate JSON f
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+test("claude-cli parseClaudeCliJsonResult treats non-object JSON as an error blob (no TypeError)", () => {
+  const { parseClaudeCliJsonResult } = __claudeCliProviderTestHooks;
+  for (const stdout of ["null", "42", "\"a string\"", "[1,2,3]"]) {
+    const parsed = parseClaudeCliJsonResult(stdout);
+    assert.equal(parsed.is_error, true, `expected non-object JSON ${stdout} to become an error blob`);
+  }
+  const ok = parseClaudeCliJsonResult(JSON.stringify({ is_error: false, result: "hi" }));
+  assert.equal(ok.is_error, false);
+  assert.equal(ok.result, "hi");
+});
+
+test("claude-cli provider backs off on a zero-exit empty result whose quota text is only on stderr", async () => {
+  let attempts = 0;
+  const sleepCalls: number[] = [];
+  const originalSetTimeout = global.setTimeout;
+  // @ts-expect-error -- test-only monkeypatch of the provider's sleep timer.
+  global.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
+    sleepCalls.push(ms ?? 0);
+    return originalSetTimeout(fn, 0);
+  }) as typeof setTimeout;
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus", retryOptions: { maxAttempts: 1, max429WaitMs: 5 * 60_000 } },
+      {
+        async runClaudeCli() {
+          attempts += 1;
+          if (attempts === 1) {
+            // zero exit, is_error unset, empty result — quota only on stderr.
+            return {
+              status: 0,
+              signal: null,
+              stdout: JSON.stringify({ is_error: false, result: "" }),
+              stderr: "Claude AI usage limit reached, resets at 5pm",
+            };
+          }
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "recovered after empty usage-limit" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+    const result = await provider.complete("hello");
+    assert.equal(result.text, "recovered after empty usage-limit");
+    assert.equal(attempts, 2);
+    assert.equal(sleepCalls.length, 1);
+    assert.ok(sleepCalls[0] >= 60_000, `expected a usage-limit backoff, got ${sleepCalls[0]}ms`);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -65,6 +65,7 @@ test("claude-cli provider invokes claude -p in an isolated benchmark mode", asyn
     "--strict-mcp-config",
     "--tools",
     "",
+    "--no-session-persistence",
     "--append-system-prompt",
     "Answer using only benchmark context.",
   ]);
@@ -730,7 +731,68 @@ test("claude-cli buildClaudeCliArgs passes systemPrompt via --append-system-prom
     "--strict-mcp-config",
     "--tools",
     "",
+    "--no-session-persistence",
   ]);
+});
+
+test("claude-cli buildClaudeCliArgs always includes --no-session-persistence (verified real flag, claude -p --help v2.1.202)", () => {
+  const { buildClaudeCliArgs } = __claudeCliProviderTestHooks;
+
+  assert.ok(buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }).includes("--no-session-persistence"));
+});
+
+test("claude-cli buildIsolatedClaudeEnv forwards opts.maxTokens as CLAUDE_CODE_MAX_OUTPUT_TOKENS", () => {
+  const { buildIsolatedClaudeEnv } = __claudeCliProviderTestHooks;
+
+  const withMaxTokens = buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }, 50);
+  assert.equal(withMaxTokens.CLAUDE_CODE_MAX_OUTPUT_TOKENS, "50");
+
+  // Fractional values are floored to an integer token count.
+  const withFractionalMaxTokens = buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }, 50.9);
+  assert.equal(withFractionalMaxTokens.CLAUDE_CODE_MAX_OUTPUT_TOKENS, "50");
+});
+
+test("claude-cli buildIsolatedClaudeEnv omits CLAUDE_CODE_MAX_OUTPUT_TOKENS when maxTokens is absent or invalid", () => {
+  const { buildIsolatedClaudeEnv } = __claudeCliProviderTestHooks;
+
+  assert.equal(
+    buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }).CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+    undefined,
+  );
+  assert.equal(
+    buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }, 0).CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+    undefined,
+  );
+  assert.equal(
+    buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }, -5).CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+    undefined,
+  );
+  assert.equal(
+    buildIsolatedClaudeEnv({ provider: "claude-cli", model: "opus" }, Number.NaN).CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+    undefined,
+  );
+});
+
+test("claude-cli provider forwards opts.maxTokens through to the child process env end to end", async () => {
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli(request) {
+        capturedEnv = request.env;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello", { maxTokens: 128 });
+
+  assert.equal(capturedEnv?.CLAUDE_CODE_MAX_OUTPUT_TOKENS, "128");
 });
 
 function escapeRegExp(value: string): string {

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -1041,3 +1041,46 @@ test("claude-cli provider forwards CLAUDE_CODE_OAUTH_TOKEN but still drops ANTHR
     }
   }
 });
+
+test("claude-cli provider does not throw on a non-string JSON result (coerces to empty)", async () => {
+  for (const badResult of [42, true, {}, [1, 2]]) {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus", retryOptions: { maxAttempts: 1 } },
+      {
+        async runClaudeCli() {
+          return {
+            status: 0,
+            signal: null,
+            // is_error not strictly true; result is a non-string.
+            stdout: JSON.stringify({ is_error: false, result: badResult }),
+            stderr: "",
+          };
+        },
+      },
+    );
+    // Coerced to empty -> falls into the controlled "no result text" path,
+    // a plain Error, NOT a TypeError from calling .trim() on a non-string.
+    await assert.rejects(provider.complete("hello"), (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(!(err instanceof TypeError), `non-string result ${JSON.stringify(badResult)} threw a TypeError`);
+      return true;
+    });
+  }
+});
+
+test("claude-cli provider fails fast when opts.signal is already aborted (no claude -p spawn)", async () => {
+  let spawned = 0;
+  const controller = new AbortController();
+  controller.abort(new Error("phase timeout already elapsed while queued"));
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        spawned += 1;
+        return { status: 0, signal: null, stdout: JSON.stringify({ is_error: false, result: "ok" }), stderr: "" };
+      },
+    },
+  );
+  await assert.rejects(provider.complete("hello", { signal: controller.signal }));
+  assert.equal(spawned, 0, "must not spawn claude -p for an already-aborted call");
+});

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -852,3 +852,35 @@ test("claude-cli provider backs off on a zero-exit empty result whose quota text
     global.setTimeout = originalSetTimeout;
   }
 });
+
+test("claude-cli provider forwards CLAUDE_CODE_OAUTH_TOKEN but still drops ANTHROPIC_API_KEY", async () => {
+  const seededEnv: Record<string, string> = {
+    CLAUDE_CODE_OAUTH_TOKEN: "oauth-token-should-forward",
+    ANTHROPIC_API_KEY: "ambient-secret-should-not-leak",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(seededEnv)) {
+    previousEnv.set(k, process.env[k]);
+    process.env[k] = v;
+  }
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus" },
+      {
+        async runClaudeCli(request) {
+          capturedEnv = request.env;
+          return { status: 0, signal: null, stdout: JSON.stringify({ is_error: false, result: "ok" }), stderr: "" };
+        },
+      },
+    );
+    await provider.complete("hello");
+    assert.equal(capturedEnv?.CLAUDE_CODE_OAUTH_TOKEN, "oauth-token-should-forward");
+    assert.equal(capturedEnv?.ANTHROPIC_API_KEY, undefined);
+  } finally {
+    for (const [k, v] of previousEnv) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -66,7 +66,7 @@ test("claude-cli provider invokes claude -p in an isolated benchmark mode", asyn
     "--tools",
     "",
     "--no-session-persistence",
-    "--append-system-prompt",
+    "--system-prompt",
     "Answer using only benchmark context.",
   ]);
   assert.ok(captured.input?.includes("BENCHMARK_REQUEST_JSON:"));
@@ -77,7 +77,7 @@ test("claude-cli provider invokes claude -p in an isolated benchmark mode", asyn
   assert.notEqual(captured.cwd, process.cwd());
 });
 
-test("claude-cli provider omits --append-system-prompt when no systemPrompt is given", async () => {
+test("claude-cli provider omits --system-prompt when no systemPrompt is given", async () => {
   const captured: { args?: string[] } = {};
   const provider = createClaudeCliProvider(
     { provider: "claude-cli", model: "opus" },
@@ -96,7 +96,7 @@ test("claude-cli provider omits --append-system-prompt when no systemPrompt is g
 
   await provider.complete("hello");
 
-  assert.ok(!captured.args?.includes("--append-system-prompt"));
+  assert.ok(!captured.args?.includes("--system-prompt"));
 });
 
 test("claude-cli provider runs from a freshly created empty temp directory", async () => {
@@ -211,6 +211,54 @@ test("claude-cli provider is_error JSON response throws with a useful message", 
     provider.complete("hello"),
     /Claude CLI reported is_error: invalid model requested/,
   );
+});
+
+test("claude-cli provider treats a truthy non-boolean is_error (e.g. the string \"false\") as success, not an error", async () => {
+  // PR #1735 review, finding 2: `payload.is_error` was read with a plain
+  // truthy check, so any non-empty string — including the string "false" —
+  // would be misread as an error. The JSON payload is untrusted CLI output
+  // parsed with an `as` cast, so this is a real reachable shape, not just a
+  // type-system nicety. Only a real boolean `true` should count as an error.
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: "false",
+            result: "answer despite stringly-typed is_error",
+            usage: { input_tokens: 2, output_tokens: 3 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("hello");
+
+  assert.equal(result.text, "answer despite stringly-typed is_error");
+  assert.deepEqual(result.tokens, { input: 2, output: 3 });
+});
+
+test("claude-cli provider still treats a real boolean is_error: true as an error", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: true, result: "boom" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(provider.complete("hello"), /Claude CLI reported is_error: boom/);
 });
 
 test("claude-cli provider surfaces non-zero CLI exits", async () => {
@@ -380,6 +428,33 @@ test("claude-cli usage-limit signal detector recognizes common phrasing", () => 
   assert.equal(isClaudeUsageLimitSignal("HTTP 429 Too Many Requests"), true);
   assert.equal(isClaudeUsageLimitSignal("invalid model requested"), false);
   assert.equal(isClaudeUsageLimitSignal(""), false);
+  // Real CLI-observed phrasing (verified via `strings` on the installed
+  // claude binary, v2.1.202): "You've hit your session limit" / "...weekly
+  // limit" / "...Opus limit" / "...Sonnet limit".
+  assert.equal(isClaudeUsageLimitSignal("You've hit your session limit · resets in 2h"), true);
+  assert.equal(isClaudeUsageLimitSignal("You've hit your weekly limit"), true);
+  assert.equal(isClaudeUsageLimitSignal("You've hit your Opus limit"), true);
+});
+
+test("claude-cli usage-limit signal detector does NOT misclassify a generic non-quota retry error (PR #1735 review, finding 1)", () => {
+  // Before this fix, the regex also matched bare "please try again later"
+  // and a standalone "resets at ... hour" pattern — generic transient-error
+  // phrasing that has nothing to do with quota. A genuine non-quota failure
+  // whose text happens to contain that phrasing must fail fast, not trigger
+  // the multi-minute usage-limit backoff.
+  const { isClaudeUsageLimitSignal } = __claudeCliProviderTestHooks;
+  assert.equal(
+    isClaudeUsageLimitSignal("Network error: connection reset, please try again later"),
+    false,
+  );
+  assert.equal(
+    isClaudeUsageLimitSignal("Transient upstream failure, please try again in a moment"),
+    false,
+  );
+  assert.equal(
+    isClaudeUsageLimitSignal("Scheduled maintenance window resets at midnight, expect an hour of downtime"),
+    false,
+  );
 });
 
 test("claude-cli provider backs off much longer on a detected usage-limit than a normal retry", async () => {
@@ -772,7 +847,7 @@ test("claude-cli parent cleanup terminates active subprocesses", async () => {
   }
 });
 
-test("claude-cli benchmark prompt carries only the user payload (system prompt goes via --append-system-prompt)", () => {
+test("claude-cli benchmark prompt carries only the user payload (system prompt goes via --system-prompt)", () => {
   const prompt = __claudeCliProviderTestHooks.buildClaudeCompletionPrompt("USER_CONTEXT: answer this");
 
   const json = prompt.slice(prompt.indexOf("{"));
@@ -782,17 +857,25 @@ test("claude-cli benchmark prompt carries only the user payload (system prompt g
   });
 });
 
-test("claude-cli buildClaudeCliArgs passes systemPrompt via --append-system-prompt, trimmed", () => {
+test("claude-cli buildClaudeCliArgs passes systemPrompt via --system-prompt (full replace, not append), trimmed", () => {
+  // PR #1735 review, finding 3: `--append-system-prompt` keeps Claude Code's
+  // default coding-agent system prompt underneath the benchmark instructions.
+  // `--system-prompt` fully replaces it instead — verified live against the
+  // installed CLI (v2.1.202): a `--system-prompt` call reported
+  // `usage.cache_read_input_tokens: 0`, while the same call with
+  // `--append-system-prompt` reported `usage.cache_read_input_tokens: 1599`
+  // (the cached default system prompt still underneath).
   const { buildClaudeCliArgs } = __claudeCliProviderTestHooks;
 
   const withPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, "  judge this carefully  ");
-  assert.deepEqual(withPrompt.slice(-2), ["--append-system-prompt", "judge this carefully"]);
+  assert.deepEqual(withPrompt.slice(-2), ["--system-prompt", "judge this carefully"]);
+  assert.ok(!withPrompt.includes("--append-system-prompt"));
 
   const withoutPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, undefined);
-  assert.ok(!withoutPrompt.includes("--append-system-prompt"));
+  assert.ok(!withoutPrompt.includes("--system-prompt"));
 
   const withBlankPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, "   ");
-  assert.ok(!withBlankPrompt.includes("--append-system-prompt"));
+  assert.ok(!withBlankPrompt.includes("--system-prompt"));
 
   assert.deepEqual(withPrompt.slice(0, -2), [
     "--print",

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -1084,3 +1084,40 @@ test("claude-cli provider fails fast when opts.signal is already aborted (no cla
   await assert.rejects(provider.complete("hello", { signal: controller.signal }));
   assert.equal(spawned, 0, "must not spawn claude -p for an already-aborted call");
 });
+
+test("claude-cli usage-limit retries do NOT consume the transient maxAttempts budget", async () => {
+  // maxAttempts=2 means at most ONE transient retry. But several usage-limit
+  // backoffs must NOT eat that budget: after N usage-limit cycles, a later
+  // transient failure should still get its one transient retry.
+  let call = 0;
+  const originalSetTimeout = global.setTimeout;
+  // @ts-expect-error -- test-only: short-circuit the backoff sleep.
+  global.setTimeout = ((fn) => originalSetTimeout(fn, 0));
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus", retryOptions: { maxAttempts: 2, baseBackoffMs: 1, max429WaitMs: 10 * 60_000 } },
+      {
+        async runClaudeCli() {
+          call += 1;
+          if (call <= 2) {
+            // two usage-limit failures first (budget-bounded, must not count against maxAttempts)
+            return { status: 1, signal: null, stdout: "", stderr: "Claude AI usage limit reached, resets at 5pm" };
+          }
+          if (call === 3) {
+            // now a transient signal failure — the ONE allowed transient retry must still be available
+            return { status: null, signal: "SIGTERM", stdout: "", stderr: "killed" };
+          }
+          return { status: 0, signal: null, stdout: JSON.stringify({ is_error: false, result: "recovered" }), stderr: "" };
+        },
+      },
+    );
+    const result = await provider.complete("hello");
+    assert.equal(result.text, "recovered");
+    // 2 usage-limit + 1 transient-fail + 1 transient-retry-success = 4 calls.
+    // If the counters were shared, the transient retry at call 3 would have been
+    // denied (attempt already >= maxAttempts) and it would have thrown.
+    assert.equal(call, 4);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -472,6 +472,7 @@ test("claude-cli provider gives up once the usage-limit backoff budget is exhaus
 });
 
 test("claude-cli provider defaults concurrency to 1 and serializes calls", async () => {
+  __claudeCliProviderTestHooks.resetSharedClaudeCliGateForTests();
   let active = 0;
   let maxActive = 0;
   const order: string[] = [];
@@ -501,7 +502,48 @@ test("claude-cli provider defaults concurrency to 1 and serializes calls", async
   assert.deepEqual(order, ["start", "end", "start", "end", "start", "end"]);
 });
 
+test("claude-cli provider serializes claude -p calls across SEPARATE provider instances (shared global gate)", async () => {
+  // Regression test for PR #1735 review: a benchmark run uses distinct
+  // ClaudeCliProvider instances for the responder and the judge. Before this
+  // fix, each instance owned its own ClaudeCliConcurrencyGate, so a
+  // responder call and a judge call could run `claude -p` concurrently
+  // against the operator's single shared Claude Max quota. The gate must now
+  // be shared process-wide so two independently-constructed instances still
+  // serialize against each other.
+  __claudeCliProviderTestHooks.resetSharedClaudeCliGateForTests();
+  let active = 0;
+  let maxActive = 0;
+  const order: string[] = [];
+  const makeBlockingDeps = (label: string) => ({
+    async runClaudeCli() {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      order.push(`${label}-start`);
+      // Blocks on a shared latch (the timer) so both instances would overlap
+      // here if they were not serialized by a shared gate.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      order.push(`${label}-end`);
+      active -= 1;
+      return {
+        status: 0,
+        signal: null,
+        stdout: JSON.stringify({ is_error: false, result: "ok" }),
+        stderr: "",
+      };
+    },
+  });
+
+  const responder = createClaudeCliProvider({ provider: "claude-cli", model: "opus" }, makeBlockingDeps("responder"));
+  const judge = createClaudeCliProvider({ provider: "claude-cli", model: "opus" }, makeBlockingDeps("judge"));
+
+  await Promise.all([responder.complete("respond to this"), judge.complete("judge this")]);
+
+  assert.equal(maxActive, 1);
+  assert.deepEqual(order, ["responder-start", "responder-end", "judge-start", "judge-end"]);
+});
+
 test("claude-cli provider concurrency can be raised explicitly above the default of 1", async () => {
+  __claudeCliProviderTestHooks.resetSharedClaudeCliGateForTests();
   let active = 0;
   let maxActive = 0;
   const provider = createClaudeCliProvider(
@@ -523,6 +565,39 @@ test("claude-cli provider concurrency can be raised explicitly above the default
   );
 
   await Promise.all([provider.complete("one"), provider.complete("two"), provider.complete("three")]);
+
+  assert.equal(maxActive, 2);
+});
+
+test("claude-cli provider raising concurrency on one instance raises the shared limit for a second instance too", async () => {
+  // Documents/verifies the "max across all instances, never shrinks" policy
+  // from getSharedClaudeCliGate: once ANY constructed instance raises the
+  // limit, every instance sharing the process-wide gate gets that higher
+  // budget too — this is the intended, documented behavior for the
+  // local-testing opt-out, not an isolation bug.
+  __claudeCliProviderTestHooks.resetSharedClaudeCliGateForTests();
+  let active = 0;
+  let maxActive = 0;
+
+  const makeDeps = () => ({
+    async runClaudeCli() {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return {
+        status: 0,
+        signal: null,
+        stdout: JSON.stringify({ is_error: false, result: "ok" }),
+        stderr: "",
+      };
+    },
+  });
+
+  const raised = createClaudeCliProvider({ provider: "claude-cli", model: "opus", concurrency: 2 }, makeDeps());
+  const defaulted = createClaudeCliProvider({ provider: "claude-cli", model: "opus" }, makeDeps());
+
+  await Promise.all([raised.complete("one"), defaulted.complete("two")]);
 
   assert.equal(maxActive, 2);
 });

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -463,9 +463,8 @@ test("claude-cli provider backs off much longer on a detected usage-limit than a
   const originalSetTimeout = global.setTimeout;
   // Short-circuit real waiting: record the requested delay and resolve
   // immediately, so the backoff *decision* is exercised without the test
-  // actually sleeping for minutes.
-  // @ts-expect-error -- test-only monkeypatch of the timer used by the
-  // provider's abort-aware sleep helper.
+  // actually sleeping for minutes. Test-only monkeypatch of the timer
+  // used by the provider's abort-aware sleep helper.
   global.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
     sleepCalls.push(ms ?? 0);
     return originalSetTimeout(fn, 0);
@@ -514,7 +513,7 @@ test("claude-cli provider backs off much longer on a detected usage-limit than a
 test("claude-cli provider gives up once the usage-limit backoff budget is exhausted", async () => {
   let attempts = 0;
   const originalSetTimeout = global.setTimeout;
-  // @ts-expect-error -- test-only monkeypatch, see above.
+  // Test-only monkeypatch, see above.
   global.setTimeout = ((fn: (...args: unknown[]) => void) => originalSetTimeout(fn, 0)) as typeof setTimeout;
 
   try {
@@ -972,7 +971,7 @@ test("claude-cli provider backs off on a zero-exit empty result whose quota text
   let attempts = 0;
   const sleepCalls: number[] = [];
   const originalSetTimeout = global.setTimeout;
-  // @ts-expect-error -- test-only monkeypatch of the provider's sleep timer.
+  // Test-only monkeypatch of the provider's sleep timer.
   global.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
     sleepCalls.push(ms ?? 0);
     return originalSetTimeout(fn, 0);

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -63,15 +63,39 @@ test("claude-cli provider invokes claude -p in an isolated benchmark mode", asyn
     "text",
     "--safe-mode",
     "--strict-mcp-config",
-    "--allowedTools",
+    "--tools",
     "",
+    "--append-system-prompt",
+    "Answer using only benchmark context.",
   ]);
   assert.ok(captured.input?.includes("BENCHMARK_REQUEST_JSON:"));
-  assert.ok(captured.input?.includes('"systemPrompt": "Answer using only benchmark context."'));
+  assert.ok(!captured.input?.includes("systemPrompt"));
   assert.ok(captured.input?.includes('"userPrompt": "What is remembered?"'));
   assert.match(captured.input ?? "", /Do not use tools, do not read or write files, do not browse/);
   assert.match(captured.cwd ?? "", /remnic-claude-cli-/);
   assert.notEqual(captured.cwd, process.cwd());
+});
+
+test("claude-cli provider omits --append-system-prompt when no systemPrompt is given", async () => {
+  const captured: { args?: string[] } = {};
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli(request) {
+        captured.args = request.args;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello");
+
+  assert.ok(!captured.args?.includes("--append-system-prompt"));
 });
 
 test("claude-cli provider runs from a freshly created empty temp directory", async () => {
@@ -672,18 +696,41 @@ test("claude-cli parent cleanup terminates active subprocesses", async () => {
   }
 });
 
-test("claude-cli benchmark prompt keeps system and user input in separate JSON fields", () => {
-  const prompt = __claudeCliProviderTestHooks.buildClaudeCompletionPrompt(
-    "USER_CONTEXT: answer this",
-    "SYSTEM_CONTEXT: judge this",
-  );
+test("claude-cli benchmark prompt carries only the user payload (system prompt goes via --append-system-prompt)", () => {
+  const prompt = __claudeCliProviderTestHooks.buildClaudeCompletionPrompt("USER_CONTEXT: answer this");
 
   const json = prompt.slice(prompt.indexOf("{"));
   const parsed = JSON.parse(json);
   assert.deepEqual(parsed, {
-    systemPrompt: "SYSTEM_CONTEXT: judge this",
     userPrompt: "USER_CONTEXT: answer this",
   });
+});
+
+test("claude-cli buildClaudeCliArgs passes systemPrompt via --append-system-prompt, trimmed", () => {
+  const { buildClaudeCliArgs } = __claudeCliProviderTestHooks;
+
+  const withPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, "  judge this carefully  ");
+  assert.deepEqual(withPrompt.slice(-2), ["--append-system-prompt", "judge this carefully"]);
+
+  const withoutPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, undefined);
+  assert.ok(!withoutPrompt.includes("--append-system-prompt"));
+
+  const withBlankPrompt = buildClaudeCliArgs({ provider: "claude-cli", model: "opus" }, "   ");
+  assert.ok(!withBlankPrompt.includes("--append-system-prompt"));
+
+  assert.deepEqual(withPrompt.slice(0, -2), [
+    "--print",
+    "--model",
+    "opus",
+    "--output-format",
+    "json",
+    "--input-format",
+    "text",
+    "--safe-mode",
+    "--strict-mcp-config",
+    "--tools",
+    "",
+  ]);
 });
 
 function escapeRegExp(value: string): string {

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -1,0 +1,691 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { __claudeCliProviderTestHooks, createClaudeCliProvider } from "./claude-cli.ts";
+
+test("claude-cli provider invokes claude -p in an isolated benchmark mode", async () => {
+  const captured: {
+    args?: string[];
+    input?: string;
+    env?: NodeJS.ProcessEnv;
+    cwd?: string;
+  } = {};
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { timeoutMs: 1234 },
+    },
+    {
+      async runClaudeCli(request) {
+        captured.args = request.args;
+        captured.input = request.input;
+        captured.env = request.env;
+        captured.cwd = request.cwd;
+        assert.equal(request.executable, "claude");
+        assert.equal(request.timeoutMs, 1234);
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: false,
+            result: "final answer",
+            usage: { input_tokens: 10, output_tokens: 4 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("What is remembered?", {
+    systemPrompt: "Answer using only benchmark context.",
+    temperature: 0,
+  });
+
+  assert.equal(result.text, "final answer");
+  assert.equal(result.model, "opus");
+  assert.deepEqual(result.tokens, { input: 10, output: 4 });
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 10,
+    outputTokens: 4,
+    totalTokens: 14,
+  });
+  assert.deepEqual(captured.args, [
+    "--print",
+    "--model",
+    "opus",
+    "--output-format",
+    "json",
+    "--input-format",
+    "text",
+    "--safe-mode",
+    "--strict-mcp-config",
+    "--allowedTools",
+    "",
+  ]);
+  assert.ok(captured.input?.includes("BENCHMARK_REQUEST_JSON:"));
+  assert.ok(captured.input?.includes('"systemPrompt": "Answer using only benchmark context."'));
+  assert.ok(captured.input?.includes('"userPrompt": "What is remembered?"'));
+  assert.match(captured.input ?? "", /Do not use tools, do not read or write files, do not browse/);
+  assert.match(captured.cwd ?? "", /remnic-claude-cli-/);
+  assert.notEqual(captured.cwd, process.cwd());
+});
+
+test("claude-cli provider runs from a freshly created empty temp directory", async () => {
+  const seenCwds: string[] = [];
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli(request) {
+        seenCwds.push(request.cwd);
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello");
+  await provider.complete("hello again");
+
+  assert.equal(seenCwds.length, 2);
+  for (const cwd of seenCwds) {
+    assert.match(cwd, new RegExp(`^${escapeRegExp(os.tmpdir())}`));
+    assert.match(path.basename(cwd), /^remnic-claude-cli-/);
+  }
+  // Each call gets its own fresh directory, not a shared/reused one.
+  assert.notEqual(seenCwds[0], seenCwds[1]);
+});
+
+test("claude-cli provider does not forward an ambient ANTHROPIC_API_KEY by default", async () => {
+  const seededEnv = {
+    ANTHROPIC_API_KEY: "ambient-secret-should-not-leak",
+    OPENAI_API_KEY: "unrelated-secret",
+    AWS_SECRET_ACCESS_KEY: "aws-secret",
+    GITHUB_TOKEN: "github-secret",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus" },
+      {
+        async runClaudeCli(request) {
+          capturedEnv = request.env;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "ok" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(capturedEnv?.ANTHROPIC_API_KEY, undefined);
+    assert.equal(capturedEnv?.OPENAI_API_KEY, undefined);
+    assert.equal(capturedEnv?.AWS_SECRET_ACCESS_KEY, undefined);
+    assert.equal(capturedEnv?.GITHUB_TOKEN, undefined);
+    assert.equal(capturedEnv?.HOME, os.homedir());
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("claude-cli provider forwards an explicitly configured apiKey/baseUrl (opt-in only)", () => {
+  const env = __claudeCliProviderTestHooks.buildIsolatedClaudeEnv({
+    provider: "claude-cli",
+    model: "opus",
+    apiKey: "explicit-key",
+    baseUrl: "https://gateway.example/v1",
+  });
+
+  assert.equal(env.ANTHROPIC_API_KEY, "explicit-key");
+  assert.equal(env.ANTHROPIC_BASE_URL, "https://gateway.example/v1");
+});
+
+test("claude-cli provider is_error JSON response throws with a useful message", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: true,
+            result: "invalid model requested",
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("hello"),
+    /Claude CLI reported is_error: invalid model requested/,
+  );
+});
+
+test("claude-cli provider surfaces non-zero CLI exits", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 2,
+          signal: null,
+          stdout: "",
+          stderr: "invalid model",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("hello"),
+    /Claude CLI completion failed \(exit 2\): invalid model/,
+  );
+});
+
+test("claude-cli provider throws when stdout is not valid JSON", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: "not json at all",
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(provider.complete("hello"), /Claude CLI reported is_error/);
+});
+
+test("claude-cli provider throws when the JSON result has empty text", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "   " }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(provider.complete("hello"), /Claude CLI completion returned no result text/);
+});
+
+test("claude-cli provider retries transient subprocess signals", async () => {
+  let attempts = 0;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { maxAttempts: 2, baseBackoffMs: 1 },
+    },
+    {
+      async runClaudeCli() {
+        attempts += 1;
+        if (attempts === 1) {
+          return {
+            status: null,
+            signal: "SIGTERM",
+            stdout: "",
+            stderr: "parent process interrupted child",
+          };
+        }
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: false,
+            result: "recovered answer",
+            usage: { input_tokens: 3, output_tokens: 5 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("hello");
+
+  assert.equal(attempts, 2);
+  assert.equal(result.text, "recovered answer");
+  assert.deepEqual(result.tokens, { input: 3, output: 5 });
+});
+
+test("claude-cli provider does not retry benchmark timeouts", async () => {
+  let attempts = 0;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { maxAttempts: 2, baseBackoffMs: 1 },
+    },
+    {
+      async runClaudeCli() {
+        attempts += 1;
+        return {
+          status: 124,
+          signal: "SIGTERM",
+          stdout: "",
+          stderr: "Claude CLI timed out after 1000ms.",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("hello"),
+    /Claude CLI completion failed \(signal SIGTERM\): Claude CLI timed out after 1000ms\./,
+  );
+  assert.equal(attempts, 1);
+});
+
+test("claude-cli provider stops retry backoff when the completion is aborted", async () => {
+  const controller = new AbortController();
+  let attempts = 0;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { maxAttempts: 2, baseBackoffMs: 10_000 },
+    },
+    {
+      async runClaudeCli() {
+        attempts += 1;
+        setTimeout(() => {
+          controller.abort(new Error("benchmark cancelled"));
+        }, 10);
+        return {
+          status: null,
+          signal: "SIGTERM",
+          stdout: "",
+          stderr: "parent process interrupted child",
+        };
+      },
+    },
+  );
+
+  const startedAt = performance.now();
+  await assert.rejects(
+    provider.complete("hello", { signal: controller.signal }),
+    /benchmark cancelled/,
+  );
+
+  assert.equal(attempts, 1);
+  assert.ok(performance.now() - startedAt < 1_000);
+});
+
+test("claude-cli usage-limit signal detector recognizes common phrasing", () => {
+  const { isClaudeUsageLimitSignal } = __claudeCliProviderTestHooks;
+  assert.equal(isClaudeUsageLimitSignal("Error: usage limit reached, resets in 3 hours"), true);
+  assert.equal(isClaudeUsageLimitSignal("You are being rate limited, please try again later"), true);
+  assert.equal(isClaudeUsageLimitSignal("HTTP 429 Too Many Requests"), true);
+  assert.equal(isClaudeUsageLimitSignal("invalid model requested"), false);
+  assert.equal(isClaudeUsageLimitSignal(""), false);
+});
+
+test("claude-cli provider backs off much longer on a detected usage-limit than a normal retry", async () => {
+  let attempts = 0;
+  const sleepCalls: number[] = [];
+  const originalSetTimeout = global.setTimeout;
+  // Short-circuit real waiting: record the requested delay and resolve
+  // immediately, so the backoff *decision* is exercised without the test
+  // actually sleeping for minutes.
+  // @ts-expect-error -- test-only monkeypatch of the timer used by the
+  // provider's abort-aware sleep helper.
+  global.setTimeout = ((fn: (...args: unknown[]) => void, ms?: number) => {
+    sleepCalls.push(ms ?? 0);
+    return originalSetTimeout(fn, 0);
+  }) as typeof setTimeout;
+
+  try {
+    const provider = createClaudeCliProvider(
+      {
+        provider: "claude-cli",
+        model: "opus",
+        retryOptions: { maxAttempts: 1, max429WaitMs: 5 * 60_000 },
+      },
+      {
+        async runClaudeCli() {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              status: 0,
+              signal: null,
+              stdout: "",
+              stderr: "Claude AI usage limit reached, resets at 5pm",
+            };
+          }
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "recovered after usage limit" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    const result = await provider.complete("hello");
+    assert.equal(result.text, "recovered after usage limit");
+    assert.equal(attempts, 2);
+    assert.equal(sleepCalls.length, 1);
+    // The usage-limit backoff step must be seconds-to-minutes, not the
+    // millisecond-scale backoff used for ordinary transient failures.
+    assert.ok(sleepCalls[0] >= 60_000, `expected a >=60s usage-limit backoff, got ${sleepCalls[0]}ms`);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("claude-cli provider gives up once the usage-limit backoff budget is exhausted", async () => {
+  let attempts = 0;
+  const originalSetTimeout = global.setTimeout;
+  // @ts-expect-error -- test-only monkeypatch, see above.
+  global.setTimeout = ((fn: (...args: unknown[]) => void) => originalSetTimeout(fn, 0)) as typeof setTimeout;
+
+  try {
+    const provider = createClaudeCliProvider(
+      {
+        provider: "claude-cli",
+        model: "opus",
+        // A budget smaller than the usage-limit base backoff step (60s)
+        // forces the very first detection to exhaust the budget.
+        retryOptions: { maxAttempts: 5, max429WaitMs: 10 },
+      },
+      {
+        async runClaudeCli() {
+          attempts += 1;
+          return {
+            status: 0,
+            signal: null,
+            stdout: "",
+            stderr: "usage limit exceeded",
+          };
+        },
+      },
+    );
+
+    await assert.rejects(provider.complete("hello"), /usage-limit backoff budget \(10ms\) exhausted/);
+    assert.equal(attempts, 1);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("claude-cli provider defaults concurrency to 1 and serializes calls", async () => {
+  let active = 0;
+  let maxActive = 0;
+  const order: string[] = [];
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        order.push("start");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push("end");
+        active -= 1;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await Promise.all([provider.complete("one"), provider.complete("two"), provider.complete("three")]);
+
+  assert.equal(maxActive, 1);
+  assert.deepEqual(order, ["start", "end", "start", "end", "start", "end"]);
+});
+
+test("claude-cli provider concurrency can be raised explicitly above the default of 1", async () => {
+  let active = 0;
+  let maxActive = 0;
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus", concurrency: 2 },
+    {
+      async runClaudeCli() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        active -= 1;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await Promise.all([provider.complete("one"), provider.complete("two"), provider.complete("three")]);
+
+  assert.equal(maxActive, 2);
+});
+
+test("claude-cli provider can use a benchmark-scoped executable env override", async () => {
+  const previous = process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+  process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = "/tmp/claude-app-binary";
+  let executable = "";
+
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus" },
+      {
+        async runClaudeCli(request) {
+          executable = request.executable;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "ok" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(executable, "/tmp/claude-app-binary");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+    } else {
+      process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = previous;
+    }
+  }
+});
+
+test("claude-cli provider executable config overrides the env override", async () => {
+  const previous = process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+  process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = "/tmp/claude-app-binary";
+  let executable = "";
+
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus", executable: "/tmp/explicit-claude" },
+      {
+        async runClaudeCli(request) {
+          executable = request.executable;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "ok" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(executable, "/tmp/explicit-claude");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+    } else {
+      process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = previous;
+    }
+  }
+});
+
+test("claude-cli provider expands home-relative executable paths", () => {
+  assert.equal(
+    __claudeCliProviderTestHooks.resolveClaudeCliExecutable({
+      provider: "claude-cli",
+      model: "opus",
+      executable: "~/bin/claude",
+    }),
+    path.join(os.homedir(), "bin", "claude"),
+  );
+});
+
+test("claude-cli provider discovery reports the configured model", async () => {
+  let versionChecked = false;
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeVersion() {
+        versionChecked = true;
+        return { status: 0, stderr: "" };
+      },
+    },
+  );
+
+  const models = await provider.discover?.();
+
+  assert.equal(versionChecked, true);
+  assert.deepEqual(models, [
+    {
+      id: "opus",
+      name: "opus (Claude CLI)",
+      contextLength: 0,
+      capabilities: ["completion"],
+    },
+  ]);
+});
+
+test("claude-cli provider discovery fails loudly when the CLI is missing", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeVersion() {
+        return { status: 127, stderr: "command not found" };
+      },
+    },
+  );
+
+  await assert.rejects(provider.discover?.() as Promise<unknown>, /Claude CLI discovery failed/);
+});
+
+test("claude-cli command terminates subprocess when aborted", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-claude-cli-test-"));
+  const controller = new AbortController();
+
+  try {
+    const run = __claudeCliProviderTestHooks.runClaudeCliCommand({
+      executable: process.execPath,
+      args: ["-e", "process.stdin.resume(); setInterval(() => {}, 1000);"],
+      input: "hello",
+      cwd: tempDir,
+      timeoutMs: 60_000,
+      signal: controller.signal,
+      env: process.env,
+    });
+
+    setTimeout(() => controller.abort(), 20);
+    const result = await run;
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Claude CLI aborted by benchmark timeout/);
+    assert.equal(__claudeCliProviderTestHooks.getActiveClaudeCliChildCount(), 0);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("claude-cli parent cleanup terminates active subprocesses", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-claude-cli-test-"));
+
+  try {
+    const run = __claudeCliProviderTestHooks.runClaudeCliCommand({
+      executable: process.execPath,
+      args: ["-e", "process.stdin.resume(); setInterval(() => {}, 1000);"],
+      input: "hello",
+      cwd: tempDir,
+      timeoutMs: 60_000,
+      env: process.env,
+    });
+
+    assert.equal(__claudeCliProviderTestHooks.getActiveClaudeCliChildCount(), 1);
+    __claudeCliProviderTestHooks.terminateActiveClaudeCliChildren("SIGTERM");
+
+    const result = await run;
+
+    assert.equal(result.status, null);
+    assert.equal(result.signal, "SIGTERM");
+    assert.equal(__claudeCliProviderTestHooks.getActiveClaudeCliChildCount(), 0);
+  } finally {
+    __claudeCliProviderTestHooks.terminateActiveClaudeCliChildren("SIGKILL");
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("claude-cli benchmark prompt keeps system and user input in separate JSON fields", () => {
+  const prompt = __claudeCliProviderTestHooks.buildClaudeCompletionPrompt(
+    "USER_CONTEXT: answer this",
+    "SYSTEM_CONTEXT: judge this",
+  );
+
+  const json = prompt.slice(prompt.indexOf("{"));
+  const parsed = JSON.parse(json);
+  assert.deepEqual(parsed, {
+    systemPrompt: "SYSTEM_CONTEXT: judge this",
+    userPrompt: "USER_CONTEXT: answer this",
+  });
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -151,14 +151,22 @@ let claudeCliParentCleanupInstalled = false;
 /** Serializes `.complete()` calls so the harness never fires concurrent
  * `claude -p` invocations against the operator's shared Claude Max quota.
  * Defaults to 1 (fully serialized); `config.concurrency` can raise this for
- * local testing but should stay at 1 for real benchmark runs. */
+ * local testing but should stay at 1 for real benchmark runs.
+ *
+ * IMPORTANT: this gate must be shared process-wide (see
+ * `getSharedClaudeCliGate` below), not one-per-`ClaudeCliProvider`. A
+ * benchmark run constructs separate `claude-cli` provider instances for the
+ * responder and the judge; if each held its own gate, a responder call and a
+ * judge call could still run `claude -p` concurrently against the same
+ * Claude Max session, defeating the whole point of serializing (PR #1735
+ * review). */
 class ClaudeCliConcurrencyGate {
   private active = 0;
-  private readonly limit: number;
+  private limit: number;
   private readonly waiters: Array<() => void> = [];
 
   constructor(limit: number) {
-    this.limit = Number.isFinite(limit) && limit >= 1 ? Math.floor(limit) : 1;
+    this.limit = normalizeGateLimit(limit);
   }
 
   async run<T>(fn: () => Promise<T>): Promise<T> {
@@ -167,6 +175,25 @@ class ClaudeCliConcurrencyGate {
       return await fn();
     } finally {
       this.release();
+    }
+  }
+
+  /** Raises the gate's limit if `limit` is higher than the current one;
+   * never lowers it. Immediately wakes any queued waiters that fit under
+   * the new, higher limit — see `getSharedClaudeCliGate` for the policy
+   * this implements (shared max across all constructed instances). */
+  raiseLimit(limit: number): void {
+    const normalized = normalizeGateLimit(limit);
+    if (normalized <= this.limit) {
+      return;
+    }
+    this.limit = normalized;
+    while (this.active < this.limit) {
+      const next = this.waiters.shift();
+      if (!next) {
+        break;
+      }
+      next();
     }
   }
 
@@ -192,6 +219,39 @@ class ClaudeCliConcurrencyGate {
   }
 }
 
+function normalizeGateLimit(limit: number): number {
+  return Number.isFinite(limit) && limit >= 1 ? Math.floor(limit) : 1;
+}
+
+/** Process-wide `claude -p` concurrency gate, shared by every
+ * `ClaudeCliProvider` instance in this process (see `ClaudeCliConcurrencyGate`
+ * doc for why a per-instance gate is unsafe). Lazily created on first use
+ * with limit 1.
+ *
+ * Concurrency-sharing policy when instances disagree: the gate is a true
+ * singleton, and its limit only ever goes UP, never down — each
+ * `ClaudeCliProvider` constructor call passes its own `config.concurrency`
+ * (default 1) here, and the shared gate's limit becomes the MAX of every
+ * value seen so far. This is deliberate: 1 is the only limit that is safe
+ * for a real benchmark run sharing the operator's Claude Max session, so any
+ * single instance opting into a higher number is assumed to be an explicit,
+ * deliberate local-testing choice — and per the finding this fixes, that
+ * higher shared budget is intentionally what every other `claude-cli`
+ * instance in the same process (e.g. both the responder and the judge) gets
+ * too, since they all draw on the same underlying quota regardless of which
+ * instance raised the limit. Do not reach for a per-instance override here:
+ * that would silently reintroduce the concurrent-subprocess bug this fixes. */
+let sharedClaudeCliGate: ClaudeCliConcurrencyGate | undefined;
+
+function getSharedClaudeCliGate(requestedLimit: number): ClaudeCliConcurrencyGate {
+  if (!sharedClaudeCliGate) {
+    sharedClaudeCliGate = new ClaudeCliConcurrencyGate(requestedLimit);
+    return sharedClaudeCliGate;
+  }
+  sharedClaudeCliGate.raiseLimit(requestedLimit);
+  return sharedClaudeCliGate;
+}
+
 class ClaudeCliProvider implements LlmProvider {
   readonly provider = "claude-cli" as const;
   readonly id: string;
@@ -214,7 +274,7 @@ class ClaudeCliProvider implements LlmProvider {
     this.config = config;
     this.runClaudeCli = deps.runClaudeCli ?? runClaudeCliCommand;
     this.runClaudeVersion = deps.runClaudeVersion ?? runClaudeVersionCommand;
-    this.gate = new ClaudeCliConcurrencyGate(config.concurrency ?? 1);
+    this.gate = getSharedClaudeCliGate(config.concurrency ?? 1);
     this.id = `claude-cli:${config.model}`;
     this.name = config.model;
   }
@@ -990,4 +1050,12 @@ export const __claudeCliProviderTestHooks = {
   resolveClaudeCliExecutable,
   runClaudeCliCommand,
   terminateActiveClaudeCliChildren,
+  /** Test-only: drops the process-wide shared `claude -p` concurrency gate
+   * so each concurrency test starts from a fresh limit instead of inheriting
+   * one raised by an earlier test in the same process (the gate's limit only
+   * ever grows — see `getSharedClaudeCliGate`). Must never be called from
+   * non-test code. */
+  resetSharedClaudeCliGateForTests: () => {
+    sharedClaudeCliGate = undefined;
+  },
 };

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -303,7 +303,14 @@ class ClaudeCliProvider implements LlmProvider {
     const usageLimitBudgetMs = normalizeUsageLimitMaxWaitMs(this.config.retryOptions?.max429WaitMs);
     const loopStartedAt = performance.now();
 
-    for (let attempt = 1; ; attempt += 1) {
+    // These two retry mechanisms are INDEPENDENT and must not share a counter:
+    // usage-limit backoff is budget-bounded (deliberately bypasses maxAttempts),
+    // while transient-failure retries are count-bounded by maxAttempts. A single
+    // shared counter let usage-limit cycles prematurely exhaust the transient
+    // budget (and inflated each mechanism's backoff exponent). (#1735 review)
+    let transientAttempt = 1;
+    let usageLimitAttempt = 1;
+    while (true) {
       const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-claude-cli-"));
 
       try {
@@ -317,26 +324,28 @@ class ClaudeCliProvider implements LlmProvider {
           // or "429" must never trigger backoff.
           if (isClaudeUsageLimitSignal(`${result.stderr}\n${result.stdout}`)) {
             await sleepBeforeUsageLimitRetry({
-              attempt,
+              attempt: usageLimitAttempt,
               loopStartedAt,
               budgetMs: usageLimitBudgetMs,
               failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
               signal: opts.signal,
             });
+            usageLimitAttempt += 1;
             continue;
           }
           const exitLabel = result.signal ? `signal ${result.signal}` : `exit ${result.status ?? "unknown"}`;
           const error = new Error(
             `Claude CLI completion failed (${exitLabel}): ${summarizeProcessOutput(result.stderr, result.stdout)}`,
           );
-          if (attempt < maxAttempts && isRetryableClaudeCliResult(result)) {
+          if (transientAttempt < maxAttempts && isRetryableClaudeCliResult(result)) {
             await sleepBeforeClaudeCliRetry({
-              attempt,
+              attempt: transientAttempt,
               baseBackoffMs: this.config.retryOptions?.baseBackoffMs,
               maxStepMs: 30_000,
               capMs: Number.POSITIVE_INFINITY,
               signal: opts.signal,
             });
+            transientAttempt += 1;
             continue;
           }
           throw error;
@@ -352,12 +361,13 @@ class ClaudeCliProvider implements LlmProvider {
             )
           ) {
             await sleepBeforeUsageLimitRetry({
-              attempt,
+              attempt: usageLimitAttempt,
               loopStartedAt,
               budgetMs: usageLimitBudgetMs,
               failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
               signal: opts.signal,
             });
+            usageLimitAttempt += 1;
             continue;
           }
           throw new Error(
@@ -379,12 +389,13 @@ class ClaudeCliProvider implements LlmProvider {
           // failure shapes instead of throwing a terminal "no result text".
           if (isClaudeUsageLimitSignal(`${result.stderr}\n${payload.error ?? ""}`)) {
             await sleepBeforeUsageLimitRetry({
-              attempt,
+              attempt: usageLimitAttempt,
               loopStartedAt,
               budgetMs: usageLimitBudgetMs,
               failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
               signal: opts.signal,
             });
+            usageLimitAttempt += 1;
             continue;
           }
           throw new Error(

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -86,11 +86,15 @@ export const DEFAULT_CLAUDE_CLI_MODEL_ALIAS = "opus";
  * pointed at the real user home (not redirected) so the CLI can still find
  * its OAuth session — isolation from CLAUDE.md / project settings is
  * achieved via `--safe-mode` plus a freshly created empty cwd instead, see
- * `buildClaudeCliArgs`.
+ * `buildClaudeCliArgs`. CLAUDE_CODE_OAUTH_TOKEN IS forwarded: it is the
+ * subscription OAuth token (free under the Max plan) used to authenticate
+ * headless/CI runs that have no interactive keychain login — unlike
+ * ANTHROPIC_API_KEY it does not switch the child to metered API billing.
  */
 const CLAUDE_CLI_RUNTIME_ENV_ALLOWLIST = new Set([
   "ALL_PROXY",
   "APPDATA",
+  "CLAUDE_CODE_OAUTH_TOKEN",
   "COLORTERM",
   "COMSPEC",
   "FORCE_COLOR",

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -294,6 +294,19 @@ class ClaudeCliProvider implements LlmProvider {
 
         const text = (payload.result ?? "").trim();
         if (text.length === 0) {
+          // A zero-exit, empty-result payload whose quota text lives only on
+          // stderr is still a usage-limit failure — back off like the other
+          // failure shapes instead of throwing a terminal "no result text".
+          if (isClaudeUsageLimitSignal(`${result.stderr}\n${payload.error ?? ""}`)) {
+            await sleepBeforeUsageLimitRetry({
+              attempt,
+              loopStartedAt,
+              budgetMs: usageLimitBudgetMs,
+              failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
+              signal: opts.signal,
+            });
+            continue;
+          }
           throw new Error(
             `Claude CLI completion returned no result text: ${summarizeProcessOutput(result.stderr, result.stdout)}`,
           );
@@ -481,8 +494,14 @@ function parseClaudeCliJsonResult(stdout: string): ClaudeCliJsonResult {
   }
 
   try {
-    const parsed = JSON.parse(trimmed) as ClaudeCliJsonResult;
-    return parsed;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      // `--output-format json` yielding a non-object (null / number / string /
+      // array) is itself an anomaly; treat it as an error blob so a later
+      // `payload.is_error` read can't throw a TypeError.
+      return { is_error: true, error: trimmed.slice(-1_000) };
+    }
+    return parsed as ClaudeCliJsonResult;
   } catch {
     // Fall back to treating raw stdout as an error blob — a non-JSON
     // response from `--output-format json` is itself an anomaly.

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -287,6 +287,17 @@ class ClaudeCliProvider implements LlmProvider {
     prompt: string,
     opts: CompletionOpts,
   ): Promise<CompletionResult> {
+    // Runs AFTER the shared concurrency gate has been acquired (see
+    // `complete()` -> `gate.run`), so the per-attempt timeout armed inside
+    // `runClaudeCliCommand` only starts counting once this call is actually
+    // active, never while it was queued. A caller-provided `opts.signal`
+    // (e.g. a harness phase/trial timeout) is owned by the caller and does
+    // keep counting while queued; the provider can't extend it, but it MUST
+    // NOT spawn a doomed `claude -p` for a call whose signal already fired
+    // while it waited in the gate — fail fast here instead.
+    if (opts.signal?.aborted) {
+      throw claudeCliAbortError(opts.signal);
+    }
     const startedAt = performance.now();
     const maxAttempts = normalizeClaudeCliMaxAttempts(this.config.retryOptions?.maxAttempts);
     const usageLimitBudgetMs = normalizeUsageLimitMaxWaitMs(this.config.retryOptions?.max429WaitMs);
@@ -356,7 +367,12 @@ class ClaudeCliProvider implements LlmProvider {
           );
         }
 
-        const text = (payload.result ?? "").trim();
+        // `result` is `as`-cast from untrusted CLI JSON, so it may be a
+        // non-string (number/boolean/object/array). Coerce anything that
+        // isn't a string to empty so `.trim()` can't throw a TypeError — a
+        // non-string result falls into the same controlled "no result text" /
+        // usage-limit path below as an empty answer.
+        const text = typeof payload.result === "string" ? payload.result.trim() : "";
         if (text.length === 0) {
           // A zero-exit, empty-result payload whose quota text lives only on
           // stderr is still a usage-limit failure — back off like the other

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -1,0 +1,913 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  ClaudeCliProviderConfig,
+  CompletionOpts,
+  CompletionResult,
+  DiscoveredModel,
+  LlmProvider,
+  TokenUsage,
+} from "./types.js";
+
+interface ClaudeCliRunRequest {
+  executable: string;
+  args: string[];
+  input: string;
+  cwd: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  env: NodeJS.ProcessEnv;
+}
+
+interface ClaudeCliRunResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface ClaudeCliProviderDeps {
+  runClaudeCli?: (request: ClaudeCliRunRequest) => Promise<ClaudeCliRunResult>;
+  runClaudeVersion?: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+}
+
+/**
+ * Subset of `claude -p --output-format json` stdout we rely on. The CLI's
+ * JSON result schema is not versioned/published, so this only reads the
+ * fields that have been stable across `claude --help` output: `result`
+ * (answer text, or the error text when `is_error` is true), `is_error`,
+ * and `usage` token counts. Anything else (session_id, duration_ms,
+ * total_cost_usd, num_turns, ...) is intentionally ignored because
+ * `CompletionResult` has no field for it.
+ */
+interface ClaudeCliJsonResult {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  error?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+const CLAUDE_CLI_STDIO_LIMIT = 64_000;
+const CLAUDE_CLI_PARENT_SIGNALS: NodeJS.Signals[] = ["SIGHUP", "SIGINT", "SIGTERM"];
+const CLAUDE_CLI_FORCED_PARENT_EXIT_MS = 1_000;
+const CLAUDE_CLI_EXECUTABLE_ENV = "REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE";
+const CLAUDE_CLI_VERSION_TIMEOUT_MS = 5_000;
+
+/** Default model alias when a config does not pin an explicit model.
+ * There is no repo-wide "current Opus model id" constant for the `claude`
+ * CLI (unlike e.g. a pinned OpenAI model string) — the CLI itself exposes
+ * stable rolling aliases (`--model opus|sonnet|fable`) specifically so
+ * callers do not have to hardcode a dated model id that goes stale. Bench
+ * CLI wiring / callers still set `config.model` explicitly per run; this
+ * constant only documents the recommended default for a Tier-F "Opus as
+ * judge" invocation. */
+export const DEFAULT_CLAUDE_CLI_MODEL_ALIAS = "opus";
+
+/**
+ * Runtime env keys forwarded to the `claude` child process. Deliberately
+ * does NOT include ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL by default: this
+ * provider exists specifically to run `claude -p` against the operator's
+ * Claude Max subscription (OAuth/keychain auth), which is free under the
+ * plan's usage caps. Leaking an ambient ANTHROPIC_API_KEY into the child
+ * would silently switch it to metered API billing instead. HOME is kept
+ * pointed at the real user home (not redirected) so the CLI can still find
+ * its OAuth session — isolation from CLAUDE.md / project settings is
+ * achieved via `--safe-mode` plus a freshly created empty cwd instead, see
+ * `buildClaudeCliArgs`.
+ */
+const CLAUDE_CLI_RUNTIME_ENV_ALLOWLIST = new Set([
+  "ALL_PROXY",
+  "APPDATA",
+  "COLORTERM",
+  "COMSPEC",
+  "FORCE_COLOR",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LOCALAPPDATA",
+  "LOGNAME",
+  "NO_COLOR",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "NUMBER_OF_PROCESSORS",
+  "OS",
+  "PATH",
+  "PATHEXT",
+  "PROGRAMDATA",
+  "PROCESSOR_ARCHITECTURE",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "SHELL",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "USERNAME",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+]);
+
+/** Default wall-clock budget (ms) to keep backing off on detected Claude
+ * usage/session-limit responses before giving up. This is deliberately far
+ * longer than a normal transient-failure retry: a Claude Max 5-hour/weekly
+ * cap does not clear in seconds. Overridable via `retryOptions.max429WaitMs`
+ * (the same field `retryFetch` uses for provider-side quota waits). */
+const DEFAULT_USAGE_LIMIT_MAX_WAIT_MS = 30 * 60 * 1000;
+/** Base backoff (ms) for the first usage-limit retry; doubles each attempt. */
+const USAGE_LIMIT_BASE_BACKOFF_MS = 60_000;
+/** Backoff ceiling (ms) for any single usage-limit retry step. */
+const USAGE_LIMIT_MAX_STEP_MS = 10 * 60 * 1000;
+
+const activeClaudeCliChildPids = new Set<number>();
+let claudeCliParentCleanupInstalled = false;
+
+/** Serializes `.complete()` calls so the harness never fires concurrent
+ * `claude -p` invocations against the operator's shared Claude Max quota.
+ * Defaults to 1 (fully serialized); `config.concurrency` can raise this for
+ * local testing but should stay at 1 for real benchmark runs. */
+class ClaudeCliConcurrencyGate {
+  private active = 0;
+  private readonly limit: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(limit: number) {
+    this.limit = Number.isFinite(limit) && limit >= 1 ? Math.floor(limit) : 1;
+  }
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.limit) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(() => {
+        this.active += 1;
+        resolve();
+      });
+    });
+  }
+
+  private release(): void {
+    this.active = Math.max(0, this.active - 1);
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    }
+  }
+}
+
+class ClaudeCliProvider implements LlmProvider {
+  readonly provider = "claude-cli" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: ClaudeCliProviderConfig;
+  private readonly runClaudeCli: (request: ClaudeCliRunRequest) => Promise<ClaudeCliRunResult>;
+  private readonly runClaudeVersion: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+  private readonly gate: ClaudeCliConcurrencyGate;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: ClaudeCliProviderConfig, deps: ClaudeCliProviderDeps = {}) {
+    this.config = config;
+    this.runClaudeCli = deps.runClaudeCli ?? runClaudeCliCommand;
+    this.runClaudeVersion = deps.runClaudeVersion ?? runClaudeVersionCommand;
+    this.gate = new ClaudeCliConcurrencyGate(config.concurrency ?? 1);
+    this.id = `claude-cli:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(prompt: string, opts: CompletionOpts = {}): Promise<CompletionResult> {
+    return this.gate.run(() => this.completeSerialized(prompt, opts));
+  }
+
+  private async completeSerialized(
+    prompt: string,
+    opts: CompletionOpts,
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const maxAttempts = normalizeClaudeCliMaxAttempts(this.config.retryOptions?.maxAttempts);
+    const usageLimitBudgetMs = normalizeUsageLimitMaxWaitMs(this.config.retryOptions?.max429WaitMs);
+    const loopStartedAt = performance.now();
+
+    for (let attempt = 1; ; attempt += 1) {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-claude-cli-"));
+
+      try {
+        const request = this.buildRunRequest(prompt, opts, tempDir);
+        const result = await this.runClaudeCli(request);
+
+        if (result.status !== 0) {
+          // Usage-limit detection is deliberately restricted to FAILURE
+          // paths (non-zero exits here, is_error payloads below). A
+          // successful benchmark answer that merely mentions "rate limit"
+          // or "429" must never trigger backoff.
+          if (isClaudeUsageLimitSignal(`${result.stderr}\n${result.stdout}`)) {
+            await sleepBeforeUsageLimitRetry({
+              attempt,
+              loopStartedAt,
+              budgetMs: usageLimitBudgetMs,
+              failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
+              signal: opts.signal,
+            });
+            continue;
+          }
+          const exitLabel = result.signal ? `signal ${result.signal}` : `exit ${result.status ?? "unknown"}`;
+          const error = new Error(
+            `Claude CLI completion failed (${exitLabel}): ${summarizeProcessOutput(result.stderr, result.stdout)}`,
+          );
+          if (attempt < maxAttempts && isRetryableClaudeCliResult(result)) {
+            await sleepBeforeClaudeCliRetry({
+              attempt,
+              baseBackoffMs: this.config.retryOptions?.baseBackoffMs,
+              maxStepMs: 30_000,
+              capMs: Number.POSITIVE_INFINITY,
+              signal: opts.signal,
+            });
+            continue;
+          }
+          throw error;
+        }
+
+        const payload = parseClaudeCliJsonResult(result.stdout);
+        if (payload.is_error) {
+          // Usage-limit responses can surface as a zero-exit is_error JSON
+          // payload, or as bare stderr with empty stdout — both land here.
+          if (
+            isClaudeUsageLimitSignal(
+              `${result.stderr}\n${payload.error ?? ""}\n${payload.result ?? ""}`,
+            )
+          ) {
+            await sleepBeforeUsageLimitRetry({
+              attempt,
+              loopStartedAt,
+              budgetMs: usageLimitBudgetMs,
+              failureSummary: summarizeProcessOutput(result.stderr, result.stdout),
+              signal: opts.signal,
+            });
+            continue;
+          }
+          throw new Error(
+            `Claude CLI reported is_error: ${
+              payload.error?.trim() || payload.result?.trim() || summarizeProcessOutput(result.stderr, result.stdout)
+            }`,
+          );
+        }
+
+        const text = (payload.result ?? "").trim();
+        if (text.length === 0) {
+          throw new Error(
+            `Claude CLI completion returned no result text: ${summarizeProcessOutput(result.stderr, result.stdout)}`,
+          );
+        }
+
+        const inputTokens = nonNegativeInt(payload.usage?.input_tokens);
+        const outputTokens = nonNegativeInt(payload.usage?.output_tokens);
+        this.recordUsage(inputTokens, outputTokens);
+
+        return {
+          text,
+          tokens: { input: inputTokens, output: outputTokens },
+          latencyMs: Math.round(performance.now() - startedAt),
+          model: this.config.model,
+        };
+      } finally {
+        await rm(tempDir, { force: true, recursive: true });
+      }
+    }
+  }
+
+  async discover(): Promise<DiscoveredModel[]> {
+    const version = await this.runClaudeVersion(
+      resolveClaudeCliExecutable(this.config),
+      buildIsolatedClaudeEnv(this.config),
+    );
+    if (version.status !== 0) {
+      throw new Error(
+        `Claude CLI discovery failed: ${version.stderr.trim() || `exit ${version.status ?? "unknown"}`}`,
+      );
+    }
+
+    return [
+      {
+        id: this.config.model,
+        name: `${this.config.model} (Claude CLI)`,
+        contextLength: 0,
+        capabilities: ["completion"],
+      },
+    ];
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  private buildRunRequest(prompt: string, opts: CompletionOpts, cwd: string): ClaudeCliRunRequest {
+    return {
+      executable: resolveClaudeCliExecutable(this.config),
+      args: buildClaudeCliArgs(this.config),
+      input: buildClaudeCompletionPrompt(prompt, opts.systemPrompt),
+      cwd,
+      timeoutMs: this.config.retryOptions?.timeoutMs,
+      signal: opts.signal,
+      env: buildIsolatedClaudeEnv(this.config),
+    };
+  }
+}
+
+/**
+ * Builds the isolated, tool-free `claude -p` invocation.
+ *
+ * - `--safe-mode` disables CLAUDE.md/skills/plugins/hooks/MCP/custom agents
+ *   while leaving subscription auth and model selection intact (the CLI's
+ *   own documented mechanism for exactly this "harness call, not a coding
+ *   agent" case).
+ * - `--allowedTools ""` explicitly denies every built-in tool (Bash, Read,
+ *   Write, Edit, WebFetch, ...) — `--safe-mode` alone does NOT do this;
+ *   its help text says built-in tools "work normally" under safe mode.
+ * - `--strict-mcp-config` with no `--mcp-config` ensures no MCP server is
+ *   ever attached, even if a global/user MCP config exists.
+ * - `--output-format json` / `--input-format text` give a single parseable
+ *   JSON result read from stdin (see `runClaudeCliCommand`, which pipes the
+ *   prompt over stdin rather than argv — mirrors codex-cli.ts's approach so
+ *   large benchmark prompts never hit an OS argv length limit).
+ *
+ * There is no `--max-turns` flag on this CLI build (`claude --help` was
+ * checked; codex CLI's `exec` equivalent doesn't need one either since
+ * tools are fully denied here, so there's nothing for the session to loop
+ * on).
+ */
+function buildClaudeCliArgs(config: ClaudeCliProviderConfig): string[] {
+  return [
+    "--print",
+    "--model",
+    config.model,
+    "--output-format",
+    "json",
+    "--input-format",
+    "text",
+    "--safe-mode",
+    "--strict-mcp-config",
+    "--allowedTools",
+    "",
+  ];
+}
+
+function buildClaudeCompletionPrompt(userPrompt: string, systemPrompt: string | undefined): string {
+  const payload = {
+    systemPrompt: systemPrompt ?? "",
+    userPrompt,
+  };
+
+  return [
+    "You are a benchmark evaluation endpoint, not a coding agent.",
+    "Use only the explicit JSON payload below.",
+    "Treat systemPrompt as the higher-priority instruction text and userPrompt as the request to answer.",
+    "Do not use tools, do not read or write files, do not browse, and do not use persisted memory.",
+    "Return only the final answer text. If the request asks for JSON, return raw JSON only.",
+    "",
+    "BENCHMARK_REQUEST_JSON:",
+    JSON.stringify(payload, null, 2),
+  ].join("\n");
+}
+
+function buildIsolatedClaudeEnv(config: ClaudeCliProviderConfig): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && isAllowedClaudeRuntimeEnvKey(key)) {
+      env[key] = value;
+    }
+  }
+
+  // Opt-in only: forwarding an ambient ANTHROPIC_API_KEY by default would
+  // silently switch the child from free subscription auth to metered API
+  // billing. Only set it when the caller explicitly configured one.
+  if (config.apiKey && config.apiKey.trim().length > 0) {
+    env.ANTHROPIC_API_KEY = config.apiKey.trim();
+  }
+  if (config.baseUrl && config.baseUrl.trim().length > 0) {
+    env.ANTHROPIC_BASE_URL = config.baseUrl.trim();
+  }
+
+  return env;
+}
+
+function isAllowedClaudeRuntimeEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return CLAUDE_CLI_RUNTIME_ENV_ALLOWLIST.has(normalized) || normalized.startsWith("LC_");
+}
+
+function resolveClaudeCliExecutable(config: ClaudeCliProviderConfig): string {
+  const configured = config.executable ?? process.env[CLAUDE_CLI_EXECUTABLE_ENV];
+  if (configured === undefined) {
+    return "claude";
+  }
+
+  const trimmed = configured.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${CLAUDE_CLI_EXECUTABLE_ENV} / claude-cli executable must not be empty`);
+  }
+  return expandHomeRelativePath(trimmed);
+}
+
+function expandHomeRelativePath(value: string): string {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+function parseClaudeCliJsonResult(stdout: string): ClaudeCliJsonResult {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) {
+    return { is_error: true, error: "Claude CLI produced no stdout." };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as ClaudeCliJsonResult;
+    return parsed;
+  } catch {
+    // Fall back to treating raw stdout as an error blob — a non-JSON
+    // response from `--output-format json` is itself an anomaly.
+    return { is_error: true, error: trimmed.slice(-1_000) };
+  }
+}
+
+function nonNegativeInt(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+const USAGE_LIMIT_SIGNAL_REGEX =
+  /\b(usage limit|rate limit|rate-limited|rate limited|too many requests|quota exceeded|429|please try again (?:later|in)|resets? (?:at|in)\b.*\b(?:hour|minute|day))\b/i;
+
+function isClaudeUsageLimitSignal(combinedOutput: string): boolean {
+  return USAGE_LIMIT_SIGNAL_REGEX.test(combinedOutput);
+}
+
+function isRetryableClaudeCliResult(result: ClaudeCliRunResult): boolean {
+  if (!result.signal) {
+    return false;
+  }
+  const stderr = result.stderr.toLowerCase();
+  if (stderr.includes("timed out after") || stderr.includes("aborted by benchmark timeout")) {
+    return false;
+  }
+  return true;
+}
+
+function normalizeClaudeCliMaxAttempts(value: number | undefined): number {
+  if (value === undefined) {
+    return 3;
+  }
+  if (!Number.isFinite(value) || value < 1) {
+    return 1;
+  }
+  return Math.min(10, Math.floor(value));
+}
+
+function normalizeUsageLimitMaxWaitMs(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_USAGE_LIMIT_MAX_WAIT_MS;
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_USAGE_LIMIT_MAX_WAIT_MS;
+  }
+  return value;
+}
+
+/**
+ * Backoff for detected usage-limit/rate-limit failures. Gives up (throws)
+ * when the NEXT required backoff step no longer fits in the remaining
+ * wall-clock budget — sleeping a truncated sliver and immediately hammering
+ * a capped Claude Max session again would only burn quota.
+ */
+async function sleepBeforeUsageLimitRetry(options: {
+  attempt: number;
+  loopStartedAt: number;
+  budgetMs: number;
+  failureSummary: string;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const delayMs = Math.min(
+    USAGE_LIMIT_BASE_BACKOFF_MS * Math.pow(2, options.attempt - 1),
+    USAGE_LIMIT_MAX_STEP_MS,
+  );
+  const remainingBudgetMs = options.budgetMs - (performance.now() - options.loopStartedAt);
+  if (delayMs > remainingBudgetMs) {
+    throw new Error(
+      `Claude CLI usage-limit backoff budget (${options.budgetMs}ms) exhausted: ${options.failureSummary}`,
+    );
+  }
+  await sleepBeforeClaudeCliRetry({
+    attempt: options.attempt,
+    baseBackoffMs: USAGE_LIMIT_BASE_BACKOFF_MS,
+    maxStepMs: USAGE_LIMIT_MAX_STEP_MS,
+    capMs: remainingBudgetMs,
+    signal: options.signal,
+  });
+}
+
+async function sleepBeforeClaudeCliRetry(options: {
+  attempt: number;
+  baseBackoffMs: number | undefined;
+  maxStepMs: number;
+  capMs: number;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const baseBackoffMs =
+    options.baseBackoffMs !== undefined && Number.isFinite(options.baseBackoffMs) && options.baseBackoffMs > 0
+      ? options.baseBackoffMs
+      : 1000;
+  const uncappedDelayMs = baseBackoffMs * Math.pow(2, options.attempt - 1);
+  const delayMs = Math.max(0, Math.min(uncappedDelayMs, options.maxStepMs, options.capMs));
+
+  const signal = options.signal;
+  if (!signal) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
+    return;
+  }
+  if (signal.aborted) {
+    throw claudeCliAbortError(signal);
+  }
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      clearTimeout(timeout);
+      cleanup();
+      reject(claudeCliAbortError(signal));
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function claudeCliAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+  if (signal.reason !== undefined) {
+    return new Error(String(signal.reason));
+  }
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function summarizeProcessOutput(stderr: string, stdout: string): string {
+  const summary = [stderr.trim(), stdout.trim()].filter((value) => value.length > 0).join("\n").trim();
+  return summary.length > 0 ? summary.slice(-1_000) : "no process output";
+}
+
+function runClaudeVersionCommand(
+  executable: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ status: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, ["--version"], {
+      env,
+      stdio: ["ignore", "ignore", "pipe"],
+      detached: process.platform !== "win32",
+      windowsHide: true,
+    });
+    let stderr = "";
+    let timedOut = false;
+    let killTimeout: NodeJS.Timeout | undefined;
+    const terminateChild = (signal: NodeJS.Signals): void => {
+      if (child.pid && process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      child.kill(signal);
+    };
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      terminateChild("SIGTERM");
+      killTimeout = setTimeout(() => {
+        terminateChild("SIGKILL");
+      }, 1_000);
+      killTimeout.unref();
+    }, CLAUDE_CLI_VERSION_TIMEOUT_MS);
+    timeout.unref();
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr = appendBounded(stderr, chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+      }
+      reject(error);
+    });
+    child.on("close", (status) => {
+      clearTimeout(timeout);
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+      }
+      resolve({
+        status: timedOut ? (status ?? 124) : status,
+        stderr: timedOut
+          ? appendBounded(stderr, `\nClaude CLI --version timed out after ${CLAUDE_CLI_VERSION_TIMEOUT_MS}ms.`)
+          : stderr,
+      });
+    });
+  });
+}
+
+function runClaudeCliCommand(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+  return new Promise((resolve, reject) => {
+    if (request.signal?.aborted) {
+      resolve({
+        status: 124,
+        signal: null,
+        stdout: "",
+        stderr: "Claude CLI aborted before start.",
+      });
+      return;
+    }
+
+    const child = spawn(request.executable, request.args, {
+      cwd: request.cwd,
+      env: request.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      windowsHide: true,
+    });
+    if (child.pid) {
+      registerActiveClaudeCliChild(child.pid);
+    }
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let aborted = false;
+    let killTimeout: NodeJS.Timeout | undefined;
+    const clearKillTimeout = (): void => {
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+        killTimeout = undefined;
+      }
+    };
+    const terminateChild = (signal: NodeJS.Signals): void => {
+      if (child.pid && process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      child.kill(signal);
+    };
+    const scheduleForcedKill = (): void => {
+      clearKillTimeout();
+      killTimeout = setTimeout(() => {
+        terminateChild("SIGKILL");
+      }, 1_000);
+      killTimeout.unref();
+    };
+    const onAbort = (): void => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      stderr = appendBounded(stderr, "\nClaude CLI aborted by benchmark timeout.");
+      terminateChild("SIGTERM");
+      scheduleForcedKill();
+    };
+    request.signal?.addEventListener("abort", onAbort, { once: true });
+    if (request.signal?.aborted) {
+      onAbort();
+    }
+    const timeout = request.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          terminateChild("SIGTERM");
+          scheduleForcedKill();
+        }, request.timeoutMs)
+      : undefined;
+    timeout?.unref();
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout = appendBounded(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr = appendBounded(stderr, chunk);
+    });
+    child.stdin?.on("error", (error: NodeJS.ErrnoException) => {
+      stderr = appendBounded(stderr, `\nClaude CLI stdin error: ${error.code ?? error.message}`);
+    });
+    child.on("error", (error) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      clearKillTimeout();
+      if (child.pid) {
+        unregisterActiveClaudeCliChild(child.pid);
+      }
+      request.signal?.removeEventListener("abort", onAbort);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      clearKillTimeout();
+      if (child.pid) {
+        unregisterActiveClaudeCliChild(child.pid);
+      }
+      request.signal?.removeEventListener("abort", onAbort);
+      if (timedOut) {
+        resolve({
+          status: status ?? 124,
+          signal,
+          stdout,
+          stderr: appendBounded(stderr, `\nClaude CLI timed out after ${request.timeoutMs}ms.`),
+        });
+        return;
+      }
+      if (aborted) {
+        resolve({
+          status: status ?? 124,
+          signal,
+          stdout,
+          stderr,
+        });
+        return;
+      }
+
+      resolve({ status, signal, stdout, stderr });
+    });
+    try {
+      child.stdin?.end(request.input);
+    } catch (error) {
+      stderr = appendBounded(stderr, `\nClaude CLI stdin error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  });
+}
+
+function registerActiveClaudeCliChild(pid: number): void {
+  installClaudeCliParentCleanup();
+  activeClaudeCliChildPids.add(pid);
+}
+
+function unregisterActiveClaudeCliChild(pid: number): void {
+  activeClaudeCliChildPids.delete(pid);
+}
+
+function installClaudeCliParentCleanup(): void {
+  if (claudeCliParentCleanupInstalled) {
+    return;
+  }
+  claudeCliParentCleanupInstalled = true;
+
+  process.once("exit", () => {
+    terminateActiveClaudeCliChildren("SIGTERM");
+  });
+
+  for (const signal of CLAUDE_CLI_PARENT_SIGNALS) {
+    process.once(signal, () => {
+      const activeChildren = activeClaudeCliChildPids.size;
+      terminateActiveClaudeCliChildren(signal === "SIGINT" ? "SIGINT" : "SIGTERM");
+      process.exitCode = signalExitCode(signal);
+
+      setTimeout(
+        () => {
+          terminateActiveClaudeCliChildren("SIGKILL");
+          process.exit(signalExitCode(signal));
+        },
+        activeChildren > 0 ? CLAUDE_CLI_FORCED_PARENT_EXIT_MS : 0,
+      );
+    });
+  }
+}
+
+function terminateActiveClaudeCliChildren(signal: NodeJS.Signals): void {
+  for (const pid of activeClaudeCliChildPids) {
+    terminateClaudeCliChildPid(pid, signal);
+  }
+}
+
+function terminateClaudeCliChildPid(pid: number, signal: NodeJS.Signals): void {
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, signal);
+      return;
+    } catch {
+      // Fall back to killing the direct child below.
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // The child may already have exited.
+  }
+}
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  switch (signal) {
+    case "SIGHUP":
+      return 129;
+    case "SIGINT":
+      return 130;
+    case "SIGTERM":
+      return 143;
+    default:
+      return 1;
+  }
+}
+
+function appendBounded(existing: string, next: string): string {
+  const combined = existing + next;
+  if (combined.length <= CLAUDE_CLI_STDIO_LIMIT) {
+    return combined;
+  }
+  return combined.slice(combined.length - CLAUDE_CLI_STDIO_LIMIT);
+}
+
+export function createClaudeCliProvider(
+  config: ClaudeCliProviderConfig,
+  deps?: ClaudeCliProviderDeps,
+): LlmProvider {
+  return new ClaudeCliProvider(config, deps);
+}
+
+export const __claudeCliProviderTestHooks = {
+  buildClaudeCliArgs,
+  buildClaudeCompletionPrompt,
+  buildIsolatedClaudeEnv,
+  getActiveClaudeCliChildCount: () => activeClaudeCliChildPids.size,
+  isClaudeUsageLimitSignal,
+  parseClaudeCliJsonResult,
+  resolveClaudeCliExecutable,
+  runClaudeCliCommand,
+  terminateActiveClaudeCliChildren,
+};

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -372,8 +372,8 @@ class ClaudeCliProvider implements LlmProvider {
   private buildRunRequest(prompt: string, opts: CompletionOpts, cwd: string): ClaudeCliRunRequest {
     return {
       executable: resolveClaudeCliExecutable(this.config),
-      args: buildClaudeCliArgs(this.config),
-      input: buildClaudeCompletionPrompt(prompt, opts.systemPrompt),
+      args: buildClaudeCliArgs(this.config, opts.systemPrompt),
+      input: buildClaudeCompletionPrompt(prompt),
       cwd,
       timeoutMs: this.config.retryOptions?.timeoutMs,
       signal: opts.signal,
@@ -389,11 +389,30 @@ class ClaudeCliProvider implements LlmProvider {
  *   while leaving subscription auth and model selection intact (the CLI's
  *   own documented mechanism for exactly this "harness call, not a coding
  *   agent" case).
- * - `--allowedTools ""` explicitly denies every built-in tool (Bash, Read,
- *   Write, Edit, WebFetch, ...) — `--safe-mode` alone does NOT do this;
- *   its help text says built-in tools "work normally" under safe mode.
+ * - `--tools ""` (verified against `claude --help` / `claude -p --help` on
+ *   the installed CLI, v2.1.202) makes every built-in tool (Bash, Read,
+ *   Write, Edit, WebFetch, ...) genuinely UNAVAILABLE to the model, not
+ *   merely un-auto-approved. This replaces a prior `--allowedTools ""`,
+ *   which per the CLI's own help text only controls which tools skip
+ *   permission prompts — it does not remove tools from the model's tool
+ *   list. Live verification (PR #1735 review): with `--allowedTools ""`
+ *   and `--permission-mode bypassPermissions`, a `claude -p` child process
+ *   was still able to invoke the Write tool and create a file on disk.
+ *   With `--tools ""`, the same prompt produced only a hallucinated
+ *   "I wrote the file" response in the *text* output — no tool actually
+ *   ran and no file was created. `--tools ""` is the CLI's own documented
+ *   mechanism for "no tools available at all" and does not depend on
+ *   permission-mode defaults or the operator's global `settings.json`
+ *   allow-list, both of which `--allowedTools` is exposed to.
  * - `--strict-mcp-config` with no `--mcp-config` ensures no MCP server is
  *   ever attached, even if a global/user MCP config exists.
+ * - `--append-system-prompt` carries the caller's scoring/format protocol
+ *   (`opts.systemPrompt`) through the CLI's own system-prompt channel
+ *   instead of embedding it in the stdin user payload (PR #1735 review).
+ *   Verified live: a `claude -p --append-system-prompt "<marker>"` call
+ *   correctly echoed the marker back when asked to quote its system-level
+ *   instructions, confirming the flag is real and wired through on this
+ *   CLI build.
  * - `--output-format json` / `--input-format text` give a single parseable
  *   JSON result read from stdin (see `runClaudeCliCommand`, which pipes the
  *   prompt over stdin rather than argv — mirrors codex-cli.ts's approach so
@@ -404,8 +423,8 @@ class ClaudeCliProvider implements LlmProvider {
  * tools are fully denied here, so there's nothing for the session to loop
  * on).
  */
-function buildClaudeCliArgs(config: ClaudeCliProviderConfig): string[] {
-  return [
+function buildClaudeCliArgs(config: ClaudeCliProviderConfig, systemPrompt?: string): string[] {
+  const args = [
     "--print",
     "--model",
     config.model,
@@ -415,21 +434,26 @@ function buildClaudeCliArgs(config: ClaudeCliProviderConfig): string[] {
     "text",
     "--safe-mode",
     "--strict-mcp-config",
-    "--allowedTools",
+    "--tools",
     "",
   ];
+
+  const trimmedSystemPrompt = systemPrompt?.trim();
+  if (trimmedSystemPrompt) {
+    args.push("--append-system-prompt", trimmedSystemPrompt);
+  }
+
+  return args;
 }
 
-function buildClaudeCompletionPrompt(userPrompt: string, systemPrompt: string | undefined): string {
-  const payload = {
-    systemPrompt: systemPrompt ?? "",
-    userPrompt,
-  };
+function buildClaudeCompletionPrompt(userPrompt: string): string {
+  const payload = { userPrompt };
 
   return [
     "You are a benchmark evaluation endpoint, not a coding agent.",
     "Use only the explicit JSON payload below.",
-    "Treat systemPrompt as the higher-priority instruction text and userPrompt as the request to answer.",
+    "Any additional scoring/format protocol instructions are provided via the",
+    "system prompt, which takes priority over this user payload.",
     "Do not use tools, do not read or write files, do not browse, and do not use persisted memory.",
     "Return only the final answer text. If the request asks for JSON, return raw JSON only.",
     "",

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -332,7 +332,7 @@ class ClaudeCliProvider implements LlmProvider {
         }
 
         const payload = parseClaudeCliJsonResult(result.stdout);
-        if (payload.is_error) {
+        if (isClaudeCliErrorFlagSet(payload.is_error)) {
           // Usage-limit responses can surface as a zero-exit is_error JSON
           // payload, or as bare stderr with empty stdout — both land here.
           if (
@@ -470,13 +470,25 @@ class ClaudeCliProvider implements LlmProvider {
  *   allow-list, both of which `--allowedTools` is exposed to.
  * - `--strict-mcp-config` with no `--mcp-config` ensures no MCP server is
  *   ever attached, even if a global/user MCP config exists.
- * - `--append-system-prompt` carries the caller's scoring/format protocol
- *   (`opts.systemPrompt`) through the CLI's own system-prompt channel
- *   instead of embedding it in the stdin user payload (PR #1735 review).
- *   Verified live: a `claude -p --append-system-prompt "<marker>"` call
- *   correctly echoed the marker back when asked to quote its system-level
- *   instructions, confirming the flag is real and wired through on this
- *   CLI build.
+ * - `--system-prompt` (full REPLACE, not append — verified against
+ *   `claude --help` on the installed CLI, v2.1.202: "System prompt to use
+ *   for the session", distinct from `--append-system-prompt` "Append a
+ *   system prompt to the default system prompt") carries the caller's
+ *   scoring/format protocol (`opts.systemPrompt`) through the CLI's own
+ *   system-prompt channel instead of embedding it in the stdin user payload
+ *   (PR #1735 review). Using the replace flag instead of append matters here:
+ *   `--append-system-prompt` keeps Claude Code's full default coding-agent
+ *   system prompt underneath the benchmark instructions, so the model still
+ *   carries that framing into benchmark answers. Live verification (PR #1735
+ *   review, finding 3): `claude -p --system-prompt "<marker>"` asked to
+ *   reply with a fixed literal answered with EXACTLY that literal and
+ *   `usage.cache_read_input_tokens: 0` (no default system prompt was even
+ *   sent). The same call with `--append-system-prompt` produced the same
+ *   correct answer but with `usage.cache_read_input_tokens: 1599` — the
+ *   cached default Claude Code system prompt was still present underneath.
+ *   `--system-prompt` removes that framing entirely, so the child runs as a
+ *   clean benchmark endpoint rather than a coding agent that happens to obey
+ *   an appended instruction.
  * - `--output-format json` / `--input-format text` give a single parseable
  *   JSON result read from stdin (see `runClaudeCliCommand`, which pipes the
  *   prompt over stdin rather than argv — mirrors codex-cli.ts's approach so
@@ -515,7 +527,7 @@ function buildClaudeCliArgs(config: ClaudeCliProviderConfig, systemPrompt?: stri
 
   const trimmedSystemPrompt = systemPrompt?.trim();
   if (trimmedSystemPrompt) {
-    args.push("--append-system-prompt", trimmedSystemPrompt);
+    args.push("--system-prompt", trimmedSystemPrompt);
   }
 
   return args;
@@ -634,8 +646,53 @@ function nonNegativeInt(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
 }
 
+/**
+ * Strict boolean check for the CLI's `is_error` flag (PR #1735 review,
+ * finding 2). `parseClaudeCliJsonResult` casts parsed JSON straight to
+ * `ClaudeCliJsonResult` with `as`, so the declared `is_error?: boolean` type
+ * is not actually enforced at runtime — a malformed or unexpected payload
+ * could carry `is_error: "false"` (a non-empty, therefore truthy, string) or
+ * any other truthy non-boolean value. A plain `if (payload.is_error)` would
+ * treat that as an error. Only a real boolean `true` counts.
+ */
+function isClaudeCliErrorFlagSet(value: unknown): boolean {
+  return value === true;
+}
+
+/**
+ * Quota/usage-limit signal anchors (PR #1735 review, finding 1). Deliberately
+ * narrower than earlier drafts, which also matched bare `please try again
+ * later` and a standalone `resets at ... hour` pattern — both of those are
+ * generic transient-failure phrasing that can appear in a genuine
+ * non-quota error (timeouts, connection resets, ordinary retry copy), which
+ * would misclassify it as a usage limit and trigger the multi-minute
+ * usage-limit backoff instead of failing fast. Only true quota-specific
+ * anchors are matched now:
+ *
+ * - `usage limit` / `session limit` / `weekly limit` / `opus limit` /
+ *   `sonnet limit` — verified against the installed `claude` CLI binary
+ *   (v2.1.202) via `strings`: the CLI's own rate-limit-banner code builds
+ *   user-facing text as `` `You've hit your ${label}` `` where `label` is
+ *   `"session limit"` (5-hour cap), `"weekly limit"` (7-day cap), `"Opus
+ *   limit"`, or `"Sonnet limit"` depending on `rateLimitType`. Separately,
+ *   the CLI's own help/error-classification text also lists the literal
+ *   phrase `"usage limit reached"` as a recognized Anthropic API error
+ *   signal. verify: the exact wording "Claude AI usage limit reached" cited
+ *   in the review was not found verbatim in this CLI build's strings, but
+ *   `usage limit` as a substring covers it.
+ * - `rate limit` / `rate-limit` / `rate limited` / `rate-limited` —
+ *   verified: the CLI's own API-error-signal list includes the literal
+ *   string `"rate limited"`.
+ * - `429` — verified: the CLI's own retry/error-handling code checks
+ *   `status===429` and renders `"Request rejected (429)"` /
+ *   `"429 Rate Limited"`.
+ * - `too many requests` / `quota exceeded` — standard HTTP 429 / quota
+ *   terminology; verify: not found verbatim in this CLI build's strings,
+ *   kept as anchors per review guidance since they are unambiguous
+ *   quota-specific phrases unlikely to appear in ordinary error text.
+ */
 const USAGE_LIMIT_SIGNAL_REGEX =
-  /\b(usage limit|rate limit|rate-limited|rate limited|too many requests|quota exceeded|429|please try again (?:later|in)|resets? (?:at|in)\b.*\b(?:hour|minute|day))\b/i;
+  /\b(?:usage limit|session limit|weekly limit|opus limit|sonnet limit|rate[- ]limit(?:ed)?|too many requests|quota exceeded|429)\b/i;
 
 function isClaudeUsageLimitSignal(combinedOutput: string): boolean {
   return USAGE_LIMIT_SIGNAL_REGEX.test(combinedOutput);

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -377,7 +377,7 @@ class ClaudeCliProvider implements LlmProvider {
       cwd,
       timeoutMs: this.config.retryOptions?.timeoutMs,
       signal: opts.signal,
-      env: buildIsolatedClaudeEnv(this.config),
+      env: buildIsolatedClaudeEnv(this.config, opts.maxTokens),
     };
   }
 }
@@ -417,6 +417,16 @@ class ClaudeCliProvider implements LlmProvider {
  *   JSON result read from stdin (see `runClaudeCliCommand`, which pipes the
  *   prompt over stdin rather than argv — mirrors codex-cli.ts's approach so
  *   large benchmark prompts never hit an OS argv length limit).
+ * - `--no-session-persistence` (verified against `claude -p --help` on the
+ *   installed CLI, v2.1.202: "Disable session persistence - sessions will
+ *   not be saved to disk and cannot be resumed (only works with --print)")
+ *   stops the CLI from writing this call's transcript/session state to disk
+ *   at all, so recalled-memory context and expected answers fed into a
+ *   responder/judge call can't leak into or be resumed by a later `claude
+ *   -p` call (PR #1735 review, finding 1). This is in addition to, not a
+ *   replacement for, the isolated per-call temp `cwd`: the flag addresses
+ *   session-transcript persistence, while the fresh cwd addresses
+ *   CLAUDE.md/project-file discovery.
  *
  * There is no `--max-turns` flag on this CLI build (`claude --help` was
  * checked; codex CLI's `exec` equivalent doesn't need one either since
@@ -436,6 +446,7 @@ function buildClaudeCliArgs(config: ClaudeCliProviderConfig, systemPrompt?: stri
     "--strict-mcp-config",
     "--tools",
     "",
+    "--no-session-persistence",
   ];
 
   const trimmedSystemPrompt = systemPrompt?.trim();
@@ -462,7 +473,26 @@ function buildClaudeCompletionPrompt(userPrompt: string): string {
   ].join("\n");
 }
 
-function buildIsolatedClaudeEnv(config: ClaudeCliProviderConfig): NodeJS.ProcessEnv {
+/**
+ * `claude -p --help` has no `--max-tokens` / `--max-output-tokens` flag (v2.1.202
+ * checked; see `buildClaudeCliArgs` for the flags that do exist). The CLI does,
+ * however, honor an undocumented-in---help env var, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`:
+ * it appears in the installed binary's own strings alongside the runtime message
+ * "Claude's response exceeded the ... output token maximum. To configure this
+ * behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.", and was
+ * confirmed live (PR #1735 review, finding 2) — a `claude -p` call asked to count
+ * to 200 produced 434 output tokens uncapped, and only 117 output tokens (8 lines)
+ * with `CLAUDE_CODE_MAX_OUTPUT_TOKENS=50` set, with `is_error: false` (a silent
+ * truncation, not a hard error). This is the CLI's real, if unofficial, mechanism
+ * for `opts.maxTokens`, so it's forwarded here rather than left unhonored. Because
+ * truncation is silent, this is a soft cap: the judge/responder prompts themselves
+ * ("answer yes/no only", "return a single number", ...) still do the primary work
+ * of keeping the answer shape small; this env var is a backstop, not a hard
+ * contract enforced by the API itself the way an SDK's `max_tokens` param is.
+ */
+const CLAUDE_CLI_MAX_OUTPUT_TOKENS_ENV = "CLAUDE_CODE_MAX_OUTPUT_TOKENS";
+
+function buildIsolatedClaudeEnv(config: ClaudeCliProviderConfig, maxTokens?: number): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined && isAllowedClaudeRuntimeEnvKey(key)) {
@@ -478,6 +508,9 @@ function buildIsolatedClaudeEnv(config: ClaudeCliProviderConfig): NodeJS.Process
   }
   if (config.baseUrl && config.baseUrl.trim().length > 0) {
     env.ANTHROPIC_BASE_URL = config.baseUrl.trim();
+  }
+  if (typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0) {
+    env[CLAUDE_CLI_MAX_OUTPUT_TOKENS_ENV] = String(Math.floor(maxTokens));
   }
 
   return env;

--- a/packages/bench/src/providers/factory.ts
+++ b/packages/bench/src/providers/factory.ts
@@ -4,6 +4,7 @@ import type {
   ProviderFactoryConfig,
 } from "./types.js";
 import { createAnthropicProvider } from "./anthropic.js";
+import { createClaudeCliProvider } from "./claude-cli.js";
 import { createCodexCliProvider } from "./codex-cli.js";
 import { createLiteLlmProvider } from "./litellm.js";
 import { createLocalLlmProvider } from "./local-llm.js";
@@ -28,6 +29,8 @@ export function createProvider(config: ProviderFactoryConfig): LlmProvider {
       return createLocalLlmProvider(config);
     case "codex-cli":
       return createCodexCliProvider(config);
+    case "claude-cli":
+      return createClaudeCliProvider(config);
     default: {
       const exhaustive: never = config;
       throw new Error(`Unknown provider: ${JSON.stringify(exhaustive)}`);

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -113,12 +113,27 @@ export interface CodexCliProviderConfig extends ProviderBaseConfig {
   diagnosticsMode?: "metadata" | "full";
 }
 
+export interface ClaudeCliProviderConfig extends ProviderBaseConfig {
+  provider?: "claude-cli";
+  /** Optional executable override for tests or non-standard Claude Code installs. */
+  executable?: string;
+  /**
+   * Max concurrent `claude -p` invocations. Defaults to 1 (fully
+   * serialized) — the operator's Claude Max plan enforces shared 5-hour
+   * and weekly usage caps, so the bench harness must not fire concurrent
+   * CLI invocations against it even when the harness's own trial
+   * concurrency setting is higher.
+   */
+  concurrency?: number;
+}
+
 export type ProviderFactoryConfig =
   | (OpenAiCompatibleProviderConfig & { provider: "openai" | "litellm" })
   | (AnthropicProviderConfig & { provider: "anthropic" })
   | (OllamaProviderConfig & { provider: "ollama" })
   | (LocalLlmProviderConfig & { provider: "local-llm" })
-  | (CodexCliProviderConfig & { provider: "codex-cli" });
+  | (CodexCliProviderConfig & { provider: "codex-cli" })
+  | (ClaudeCliProviderConfig & { provider: "claude-cli" });
 
 export interface ProviderDiscoveryResult {
   provider: BuiltInProvider;

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -460,6 +460,18 @@ test("runtime profile can route Remnic internal LLM calls through codex-cli", as
   );
 });
 
+test("runtime profile rejects claude-cli as an internal provider (PR #1735 review: no @remnic/core gateway wiring)", async () => {
+  await assert.rejects(
+    () =>
+      resolveBenchRuntimeProfile({
+        runtimeProfile: "baseline",
+        internalProvider: "claude-cli",
+        internalModel: "opus",
+      }),
+    /claude-cli.*not supported/,
+  );
+});
+
 test("runtime profile can decouple provider request timeout from drain timeout", async () => {
   const resolved = await resolveBenchRuntimeProfile({
     runtimeProfile: "baseline",

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -631,6 +631,9 @@ function gatewayProviderApi(provider: BuiltInProvider): string {
   if (provider === "codex-cli") {
     return "codex-cli";
   }
+  if (provider === "claude-cli") {
+    return "claude-cli";
+  }
   if (provider === "ollama") {
     return "ollama-chat";
   }
@@ -652,6 +655,8 @@ function defaultInternalBaseUrl(provider: BuiltInProvider): string | undefined {
       return "http://localhost:11434/api";
     case "codex-cli":
       return "codex-cli://local";
+    case "claude-cli":
+      return "claude-cli://local";
     case "local-llm":
       return undefined;
     default: {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -475,6 +475,21 @@ function resolveProviderConfig(
         "(e.g. http://localhost:8080/v1 for llama.cpp).",
     );
   }
+  // PR #1735 review: defense in depth for programmatic callers that bypass
+  // the CLI's `--internal-provider` allow-list (see bench-args.ts). Unlike
+  // "codex-cli" / "anthropic", `@remnic/core`'s gateway has no `claude-cli`
+  // api wiring — routing the internal Remnic-runtime LLM through it would
+  // silently fall through to the generic/OpenAI-compatible gateway path
+  // instead of actually invoking `claude -p`. `claude-cli` is only wired
+  // for the bench responder/judge factory path (--provider / --system-
+  // provider / --judge-provider), not this internal-LLM path.
+  if (kind === "internal" && provider === "claude-cli") {
+    throw new Error(
+      `${kind} provider "claude-cli" is not supported: it has no @remnic/core ` +
+        "gateway wiring and is only available via --provider, --system-provider, " +
+        "or --judge-provider.",
+    );
+  }
   if (reasoningEffort !== undefined && provider !== "codex-cli") {
     throw new Error(
       `${kind} Codex reasoning effort requires provider "codex-cli"`,
@@ -632,7 +647,17 @@ function gatewayProviderApi(provider: BuiltInProvider): string {
     return "codex-cli";
   }
   if (provider === "claude-cli") {
-    return "claude-cli";
+    // PR #1735 review: `@remnic/core` only special-cases `api ===
+    // "codex-cli"` and `api === "anthropic-messages"` — there is no
+    // `claude-cli` gateway integration, so this must never be reached.
+    // `resolveProviderConfig` (kind === "internal") already rejects
+    // `claude-cli` before a config gets here; this is a second guard so a
+    // future caller of this function directly can't silently regress to
+    // the old "falls through to openai-completions" behavior.
+    throw new Error(
+      "claude-cli has no @remnic/core gateway api mapping; it is only supported as a " +
+        "--provider / --system-provider / --judge-provider, not an internal provider.",
+    );
   }
   if (provider === "ollama") {
     return "ollama-chat";
@@ -656,7 +681,12 @@ function defaultInternalBaseUrl(provider: BuiltInProvider): string | undefined {
     case "codex-cli":
       return "codex-cli://local";
     case "claude-cli":
-      return "claude-cli://local";
+      // PR #1735 review: no internal gateway wiring for claude-cli (see
+      // gatewayProviderApi above) — never hand back a fake base URL for it.
+      throw new Error(
+        "claude-cli has no internal-provider base URL; it is only supported as a " +
+          "--provider / --system-provider / --judge-provider, not an internal provider.",
+      );
     case "local-llm":
       return undefined;
     default: {

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -22,8 +22,21 @@ export type AmaBenchJudgeProtocol = "default" | "recommended";
  * `codex-cli` shells out to `codex exec` as an isolated benchmark-only
  * responder/judge target. It is intentionally not routed through Remnic
  * memory or OpenClaw gateway state.
+ *
+ * `claude-cli` shells out to `claude -p` (Claude Code headless) as an
+ * isolated benchmark-only responder/judge target, running against the
+ * operator's Claude subscription rather than a metered API key. Like
+ * `codex-cli`, it is intentionally not routed through Remnic memory or
+ * OpenClaw gateway state.
  */
-export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm" | "local-llm" | "codex-cli";
+export type BuiltInProvider =
+  | "openai"
+  | "anthropic"
+  | "ollama"
+  | "litellm"
+  | "local-llm"
+  | "codex-cli"
+  | "claude-cli";
 
 export type BenchReasoningEffort = "low" | "medium" | "high" | "xhigh";
 

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -845,7 +845,7 @@ test("parseBenchArgs rejects unknown --provider", () => {
         "--provider",
         "not-a-provider",
       ]),
-    /--provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"/,
+    /--provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"/,
   );
 });
 

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -728,6 +728,39 @@ test("parseBenchArgs accepts internal Remnic LLM provider flags", () => {
   assert.equal(parsed.internalCodexReasoningEffort, "xhigh");
 });
 
+test("parseBenchArgs rejects --internal-provider claude-cli (no @remnic/core gateway wiring, PR #1735 review)", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--internal-provider",
+        "claude-cli",
+        "--internal-model",
+        "opus",
+      ]),
+    /--internal-provider does not support "claude-cli"/,
+  );
+});
+
+test("parseBenchArgs still accepts claude-cli for --judge-provider and --system-provider (responder/judge path only)", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--system-provider",
+    "claude-cli",
+    "--system-model",
+    "opus",
+    "--judge-provider",
+    "claude-cli",
+    "--judge-model",
+    "opus",
+  ]);
+
+  assert.equal(parsed.systemProvider, "claude-cli");
+  assert.equal(parsed.judgeProvider, "claude-cli");
+});
+
 test("parseBenchArgs rejects internal Codex reasoning effort for non-Codex providers", () => {
   assert.throws(
     () =>

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -243,14 +243,49 @@ const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "claude-cli",
 ]);
 
+/**
+ * `--internal-provider` allow-list. Deliberately narrower than
+ * `BENCH_PROVIDER_ALLOWED`: it excludes "claude-cli". The internal
+ * provider feeds Remnic's own gateway (`@remnic/core`), which only
+ * special-cases `api === "codex-cli"` and `api === "anthropic-messages"` —
+ * there is no `claude-cli` gateway integration, so selecting it here would
+ * silently fall through to the generic/OpenAI-compatible gateway path
+ * instead of actually invoking `claude -p`. `claude-cli` is only wired for
+ * the bench responder/judge factory path (`--provider` / `--system-
+ * provider` / `--judge-provider`), see providers/factory.ts. (PR #1735
+ * review)
+ */
+const BENCH_INTERNAL_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze(
+  BENCH_PROVIDER_ALLOWED.filter((provider) => provider !== "claude-cli"),
+);
+
 function isBuiltInProvider(value: string): value is BuiltInProvider {
   return (BENCH_PROVIDER_ALLOWED as readonly string[]).includes(value);
+}
+
+function isBuiltInInternalProvider(value: string): value is BuiltInProvider {
+  return (BENCH_INTERNAL_PROVIDER_ALLOWED as readonly string[]).includes(value);
 }
 
 function parseBenchProvider(raw: string, flag: string): BuiltInProvider {
   if (!isBuiltInProvider(raw)) {
     throw new Error(
       `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli".`,
+    );
+  }
+  return raw;
+}
+
+function parseBenchInternalProvider(raw: string, flag: string): BuiltInProvider {
+  if (!isBuiltInInternalProvider(raw)) {
+    if (raw === "claude-cli") {
+      throw new Error(
+        `ERROR: ${flag} does not support "claude-cli" (no @remnic/core gateway wiring); ` +
+          "use --provider, --system-provider, or --judge-provider instead.",
+      );
+    }
+    throw new Error(
+      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli".`,
     );
   }
   return raw;
@@ -816,7 +851,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
 
   let internalProvider: BuiltInProvider | undefined;
   if (internalProviderRaw !== undefined) {
-    internalProvider = parseBenchProvider(internalProviderRaw, "--internal-provider");
+    internalProvider = parseBenchInternalProvider(internalProviderRaw, "--internal-provider");
   }
 
   const internalCodexReasoningEffort = internalCodexReasoningEffortRaw === undefined

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -230,8 +230,8 @@ function parseBenchRuntimeProfile(
  * `--judge-provider`. Keeping these in lockstep is a CLAUDE.md rule 52
  * concern: if one flag accepts "local-llm" but another rejects it,
  * behavior becomes path-dependent. Issue #566 slice 5 added
- * "local-llm"; Codex CLI provider wiring added "codex-cli". The
- * single source of truth is here.
+ * "local-llm"; Codex CLI provider wiring added "codex-cli"; Claude CLI
+ * provider wiring added "claude-cli". The single source of truth is here.
  */
 const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "openai",
@@ -240,6 +240,7 @@ const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "litellm",
   "local-llm",
   "codex-cli",
+  "claude-cli",
 ]);
 
 function isBuiltInProvider(value: string): value is BuiltInProvider {
@@ -249,7 +250,7 @@ function isBuiltInProvider(value: string): value is BuiltInProvider {
 function parseBenchProvider(raw: string, flag: string): BuiltInProvider {
   if (!isBuiltInProvider(raw)) {
     throw new Error(
-      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli".`,
+      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli".`,
     );
   }
   return raw;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -952,7 +952,7 @@ Options:
   --gateway-agent-id <id>  OpenClaw agent persona id for gateway model routing
   --fast-gateway-agent-id <id>
                            OpenClaw fast-tier agent persona id for gateway model routing
-  --system-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
+  --system-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli|claude-cli>
                            Use a direct provider-backed answering path
   --system-model <model>   Model name for the direct answering provider
   --system-base-url <url>  Base URL for the direct answering provider
@@ -962,13 +962,13 @@ Options:
                            Compact recalled memory context before sending it to the direct answerer
   --system-responder-prompt-budget-chars <n>
                            Compact repeated benchmark prompt instructions before sending them to the direct answerer
-  --judge-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
+  --judge-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli|claude-cli>
                            Use a direct provider-backed judge
   --judge-model <model>    Model name for the judge provider
   --judge-base-url <url>   Base URL for the judge provider
   --judge-codex-reasoning-effort <low|medium|high|xhigh>
                            Codex CLI reasoning effort for the judge
-  --internal-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
+  --internal-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli|claude-cli>
                            Provider for Remnic's internal extraction/summarization LLM
   --internal-model <model> Model name for Remnic's internal LLM provider
   --internal-base-url <url>

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -968,8 +968,9 @@ Options:
   --judge-base-url <url>   Base URL for the judge provider
   --judge-codex-reasoning-effort <low|medium|high|xhigh>
                            Codex CLI reasoning effort for the judge
-  --internal-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli|claude-cli>
+  --internal-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
                            Provider for Remnic's internal extraction/summarization LLM
+                           (claude-cli is not supported here — use --provider/--judge-provider)
   --internal-model <model> Model name for Remnic's internal LLM provider
   --internal-base-url <url>
                            Base URL for Remnic's internal LLM provider

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -213,9 +213,9 @@ test("bench CLI exposes runtime profile and provider-backed run surfaces", async
   assert.match(source, /--model-source <plugin\|gateway>/);
   assert.match(source, /--gateway-agent-id <id>/);
   assert.match(source, /--fast-gateway-agent-id <id>/);
-  assert.match(source, /--system-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli>/);
+  assert.match(source, /--system-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli\|claude-cli>/);
   assert.match(source, /--system-model <model>/);
-  assert.match(source, /--judge-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli>/);
+  assert.match(source, /--judge-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli\|claude-cli>/);
   assert.match(source, /--judge-model <model>/);
   assert.match(source, /remnic bench run --quick longmemeval --runtime-profile baseline/);
   assert.match(source, /remnic bench run longmemeval --runtime-profile real --remnic-config/);
@@ -1200,7 +1200,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--model",
         "m",
       ]),
-    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
   assert.throws(
     () =>
@@ -1212,7 +1212,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--system-model",
         "m",
       ]),
-    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
   assert.throws(
     () =>
@@ -1224,7 +1224,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--judge-model",
         "m",
       ]),
-    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
 });
 


### PR DESCRIPTION
Adds a `claude-cli` benchmark provider that runs Opus 4.8 via Claude Code headless (`claude -p`), modeled on `codex-cli.ts`. Enables Tier-F LoCoMo/LongMemEval runs without an Anthropic API budget.

- Isolated empty temp workspace per call (no ~/.claude/CLAUDE.md contamination); tools disabled; ambient ANTHROPIC_API_KEY dropped.
- `--output-format json` parsing; default concurrency 1 with usage-limit backoff (Claude Max session limits).
- Fixed a real bug found in review: usage-limit detection was running on *successful* results, looping backoff until budget exhaustion — now scoped to failure paths only. Budget give-up logic added.
- 110 tests pass across touched surfaces; bench + remnic-cli typechecks clean.

Part of Evidence Sprint epic #1725; unblocks the Tier-F run #1728.

Caveat: unit tests inject a fake CLI; no end-to-end run against a real `claude` binary yet (that's the #1728 smoke test).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New subprocess provider with env isolation and retry/backoff logic affects benchmark scoring paths; misconfiguration could still hit shared Claude Max quota or metered billing if API keys are opted in.
> 
> **Overview**
> Adds a **`claude-cli`** bench LLM provider that runs headless **`claude -p`** for responder/judge paths (Claude Max subscription), parallel to **`codex-cli`**. It is wired through the provider factory, types, and package exports, and is selectable via **`--provider`**, **`--system-provider`**, and **`--judge-provider`** — but **not** **`--internal-provider`** (no `@remnic/core` gateway mapping).
> 
> Each completion uses a fresh empty temp **`cwd`**, **`--safe-mode`**, **`--tools ""`**, **`--no-session-persistence`**, and **`--system-prompt`** (full replace). Ambient **`ANTHROPIC_API_KEY`** is dropped by default; **`CLAUDE_CODE_OAUTH_TOKEN`** is forwarded. JSON stdout is parsed with strict **`is_error === true`** handling, separate usage-limit vs transient retry budgets, a process-wide concurrency gate (default 1), subprocess abort/cleanup, and quota-specific usage-limit detection.
> 
> Includes a large **`claude-cli.test.ts`** suite and CLI/runtime guards so **`claude-cli`** cannot be misrouted as an internal Remnic LLM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1570d7c9a98cf716cd3da8fcdde75f61de742738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->