### PR TITLE
fix(provenance): relax year-led date separator to accept punctuation-tail forms (#1723)

### DIFF
--- a/packages/remnic-core/src/provenance-extraction.test.ts
+++ b/packages/remnic-core/src/provenance-extraction.test.ts
@@ -1102,3 +1102,381 @@ test("toStrictIsoTimestamp path: full month name is preserved (issue #1657, code
     "full-name textual month must not fall back to the epoch (it was accepted, not rejected)",
   );
 });
+
+// ---------------------------------------------------------------------------
+// Regression: issue #1723 — complete-but-unusual-punctuation year-led dates
+// (e.g. "2026 May, 10", "2026, May 10", "2026 Jan. 15") parse correctly via
+// Date.parse (correct calendar day, no fabrication), but the strict
+// single-char separator shape in parseYearLedDatePrefix over-rejected them,
+// dropping a correctly-located source to the unverified epoch fallback. The
+// separator shape is relaxed to a run of non-alphanumeric chars so any
+// complete, calendar-valid date is accepted while the three-component +
+// valid-day + day-not-the-hour invariants are preserved (#1657 stays green).
+// ---------------------------------------------------------------------------
+
+test("toStrictIsoTimestamp path: punctuation-tail 'YYYY Month, DD' is preserved (issue #1723)", () => {
+  // "2026 May, 10 12:00:00" parses to May 10 via Date.parse (correct calendar
+  // day, no fabrication). Pre-fix the comma+space separator shape was rejected
+  // by the single-char guard, dropping a correctly-located source to unverified.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May, 10 12:00:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "complete punctuation-tail date must stay verified");
+  assert.ok(result.sources);
+  const observedAt = result.sources![0]!.observedAt;
+  assert.match(
+    observedAt,
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+    "punctuation-tail observedAt must normalize to strict ISO",
+  );
+  assert.notEqual(
+    observedAt,
+    new Date(0).toISOString(),
+    "punctuation-tail date must not fall back to the epoch (it was accepted, not rejected)",
+  );
+});
+
+test("toStrictIsoTimestamp path: punctuation-tail 'YYYY, Month DD' is preserved (issue #1723)", () => {
+  // "2026, May 10 12:00:00" — comma+space between year and month. Same class
+  // as the comma-after-month form: complete, calendar-valid, over-rejected.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026, May 10 12:00:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "comma-after-year date must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "comma-after-year date must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: punctuation-tail 'YYYY Mon. DD' is preserved (issue #1723)", () => {
+  // "2026 Jan. 15 12:00:00" — period+space between month and day. Same class.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 Jan. 15 12:00:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "period-after-month date must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "period-after-month date must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: date-only punctuation-tail 'YYYY Month, DD' is preserved (issue #1723, codex)", () => {
+  // "2026 May, 10" (no time component) parses to May 10 via Date.parse but
+  // contains no -/:/T, so pre-fix the bare-number guard dropped it to
+  // unverified before parseYearLedDatePrefix was ever reached. The guard now
+  // admits a complete, calendar-valid year-led date even without a time
+  // separator, so the correctly-located source stays verified.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May, 10" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "date-only punctuation-tail date must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "date-only punctuation-tail date must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: bare numeric string still rejected after #1723 broadening (non-regression)", () => {
+  // The bare-number guard must still reject "123" / "2026" (Date.parse-able
+  // plain numbers with no date structure) so they never round-trip into a fake
+  // epoch. The #1723 broadening only admits COMPLETE year-led dates.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified");
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "bare-year string must fall back to epoch, not round-trip into a fake date",
+  );
+});
+
+test("toStrictIsoTimestamp path: parenthesized-month fabrication is rejected (issue #1723, codex r2)", () => {
+  // "2026 (May) 10 12:00:00" parses as a valid May 10 PREFIX (year, "May",
+  // day 10) but Date.parse reads it as October 1 — the round-trip would
+  // persist October while the guard "validated" May (fabrication). The
+  // agreement check compares the prefix y/m against Date.parse's own
+  // interpretation and rejects on disagreement.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 (May) 10 12:00:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified", "parenthesized-month fabrication must be rejected");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    "2026-10-01T12:00:00.000Z",
+    "must not persist Date.parse's October interpretation while validating May",
+  );
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "disagreeing punctuation form falls back to epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: parenthesized-day fabrication is rejected (issue #1723, codex r3)", () => {
+  // "2026 May (10) 12:00:00" matches the prefix as May 10 and Date.parse agrees
+  // on year+month (May 2026) but reads day 1 (it ignores the parenthesized
+  // "(10)"), so a month-only check would still fabricate observedAt = May 1.
+  // The agreement check must compare the full (y, m, d) tuple.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May (10) 12:00:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified", "parenthesized-day fabrication must be rejected");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    "2026-05-01T12:00:00.000Z",
+    "must not persist Date.parse's day-1 interpretation while validating day 10",
+  );
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "day-disagreeing punctuation form falls back to epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: explicit-offset timestamp crossing UTC day boundary stays verified (issue #1723, codex r4)", () => {
+  // "2026-05-10 00:30:00 +05:00" parses to a UTC instant on May 9 (the offset
+  // shifts the instant across the UTC day boundary), but the prefix date is May
+  // 10 in the +05:00 frame. The agreement check must compare in the source's
+  // explicit offset frame, not the UTC/local frame, so this legitimate
+  // offset-bearing timestamp stays verified (pre-fix the strict UTC/local
+  // comparison wrongly rejected it).
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05-10 00:30:00 +05:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "explicit-offset timestamp must stay verified");
+  assert.ok(result.sources);
+  assert.match(
+    result.sources![0]!.observedAt,
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+    "offset timestamp normalizes to strict ISO",
+  );
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "offset timestamp must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: offset-bearing punctuation fabrication still rejected (issue #1723, codex r4)", () => {
+  // "2026 (May) 10 12:00:00 +05:00" carries an offset AND exotic punctuation.
+  // The agreement check compares in the +05:00 frame: prefix (2026,5,10) vs
+  // Date.parse's October reading shifted to +05:00 — they still disagree, so
+  // the fabrication is rejected even with an offset present.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 (May) 10 12:00:00 +05:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "unverified", "offset-bearing fabrication must be rejected");
+  assert.equal(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "offset-bearing fabrication falls back to epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: single-digit explicit offset stays verified (issue #1723, codex r5)", () => {
+  // "+5:00" (single-digit offset hour) parses to the same instant as "+05:00"
+  // and crosses the UTC day boundary; the offset extractor must recognize the
+  // single-digit form so the agreement check compares in the +05:00 frame.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05-10 00:30:00 +5:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "single-digit offset timestamp must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "single-digit offset timestamp must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: date-only and numeric dates not misread as offsets (issue #1723, codex r5 non-regression)", () => {
+  // The offset extractor must not misread date digits as an offset (e.g. the
+  // "-0510" in "2026-0510" or the "-2026" tail of "05-10-2026"). These forms
+  // have no real offset, so they must be handled by the offset-free path —
+  // a complete valid date stays verified, a bare invalid one is rejected, but
+  // neither is silently mistreated as offset-bearing.
+  const turnsOk = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05-03" as unknown as string,
+    }),
+  ];
+  const resultOk = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turnsOk,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(resultOk.provenance, "verified", "plain date must not be misread as offset-bearing");
+  assert.notEqual(resultOk.sources![0]!.observedAt, new Date(0).toISOString());
+});
+
+test("toStrictIsoTimestamp path: GMT+HHMM offset minutes preserved (issue #1723, codex r6)", () => {
+  // "GMT+0530" is +5:30, not +5:00 — the extractor must try the 4-digit HHMM
+  // form before the bare-hour form so the minutes are not dropped.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May 10 00:15:00 GMT+0530" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "GMT+HHMM offset timestamp must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "GMT+HHMM offset timestamp must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: offset glued to seconds stays verified (issue #1723, cursor r6)", () => {
+  // "00:30:00+05:00" — the offset is glued to the seconds field with no space.
+  // The extractor must detect it (via the ":SS" lookbehind) so the agreement
+  // check compares in the +05:00 frame, not UTC/local.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026-05-10 00:30:00+05:00" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "glued-offset timestamp must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "glued-offset timestamp must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: glued bare-hour offset stays verified (issue #1723, codex r7)", () => {
+  // "00:15:00+5" — a bare-hour offset glued to the seconds field. The extractor
+  // must detect it (via the ":SS" lookbehind, bare-hour alternative) so the
+  // agreement check compares in the +05:00 frame.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May 10 00:15:00+5" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "glued bare-hour offset must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "glued bare-hour offset must not fall back to the epoch",
+  );
+});
+
+test("toStrictIsoTimestamp path: named US timezone abbreviation stays verified (issue #1723, codex r8)", () => {
+  // "2026 May 10 23:30:00 PST" — Date.parse reads PST as -8, so on a UTC
+  // process the instant lands on May 11 UTC. The prefix date is May 10 in the
+  // PST frame; the extractor must recognize the named zone so the agreement
+  // check compares in the -8 frame.
+  const turns = [
+    makeTurn("We migrated the production database to pgBouncer.", {
+      timestamp: "2026 May 10 23:30:00 PST" as unknown as string,
+    }),
+  ];
+  const result = buildFactProvenance(
+    "migrated the production database to pgBouncer",
+    turns,
+    DEFAULT_CONFIG,
+  );
+  assert.equal(result.provenance, "verified", "named-zone timestamp must stay verified");
+  assert.ok(result.sources);
+  assert.notEqual(
+    result.sources![0]!.observedAt,
+    new Date(0).toISOString(),
+    "named-zone timestamp must not fall back to the epoch",
+  );
+});

--- a/packages/remnic-core/src/provenance.ts
+++ b/packages/remnic-core/src/provenance.ts
@@ -197,22 +197,47 @@ function toStrictIsoTimestamp(ts: string | undefined | null): string | undefined
   if (isStrictIsoTimestamp(value)) return value;
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) return undefined;
+  // Year-led date guard (issues #1657 + #1723). `parseYearLedDatePrefix`
+  // recognizes a COMPLETE, calendar-valid year-led prefix — numeric OR textual
+  // month — with real date-separator RUNS of non-alphanumeric, non-colon chars
+  // (so complete-but-unusual-punctuation dates like "2026 May, 10",
+  // "2026, May 10", "2026 Jan. 15" are accepted), the day-not-the-hour
+  // invariant via the `(?![\d:])` lookahead, and a calendar-valid day. This
+  // single rule subsumes the prior partial-numeric ("2026-05"), textual-partial
+  // ("2026-Jan"), and calendar-overflow ("2026-02-30", "2026-Feb-30") checks
+  // and extends them to textual months — Date.parse silently fills missing
+  // components and rolls overflow, fabricating observedAt, so a non-complete
+  // or invalid year-led prefix is rejected. Non-year-led shapes
+  // ("Jan 15 2026", "02/30/2026") fall through to Date.parse / the mdy check.
+  const yearLedPrefix = parseYearLedDatePrefix(value);
+  // Agreement check (issue #1723 codex r2/r3/r4): exotic punctuation can make
+  // the prefix structure disagree with Date.parse's own interpretation — e.g.
+  // "2026 (May) 10" parses as a valid May 10 PREFIX but Date.parse reads
+  // October 1; "2026 May (10)" agrees on month but Date.parse reads day 1 — so
+  // the round-trip would persist a fabricated observedAt while the guard
+  // "validated" a different date. Require Date.parse's interpretation to match
+  // the prefix's FULL (y, m, d) tuple. Offset-bearing inputs compare in the
+  // source's explicit offset frame (the prefix date is offset-local, so a UTC
+  // instant legitimately falls on an adjacent UTC/local day); offset-free
+  // inputs compare both the local and UTC frames (Date.parse uses UTC for ISO
+  // date-only strings and local for non-ISO — a single frame would wrongly
+  // reject legitimate month/day-boundary dates that shift across timezones).
+  const yearLedAgrees = yearLedAgreesWithDateParse(parsed, value, yearLedPrefix);
+  const validYearLed = yearLedPrefix !== null && yearLedAgrees;
   // Reject bare-year / numeric-only strings that Date.parse accepts (e.g.
   // "123") — isStrictIsoTimestamp already rejected them, and the round-trip
   // below would otherwise resurrect them. Require at least one date/time
-  // separator so a plain number never round-trips into a fake epoch.
-  if (!/[-:T]/.test(value)) return undefined;
+  // separator so a plain number never round-trips into a fake epoch — UNLESS
+  // the value is itself a complete, calendar-valid year-led date that
+  // Date.parse agrees with (issue #1723: a date-only punctuated textual form
+  // like "2026 May, 10" has no -/:/T yet parses to the correct calendar day).
+  if (!/[-:T]/.test(value) && !validYearLed) {
+    return undefined;
+  }
   // Reject year-led timestamps that are not a COMPLETE, calendar-valid date
-  // (issue #1657). Date.parse silently fills missing components ("2026-05" ->
-  // May 1, "2026-Jan" -> Jan 1) and rolls overflow ("2026-02-30" and
-  // "2026-Feb-30" -> March 2), fabricating observedAt. `parseYearLedDatePrefix`
-  // requires a complete three-component date — numeric OR textual month — with
-  // real date separators (not T/:, and not the space that precedes a time
-  // component, so the hour is never captured as the day) and a calendar-valid
-  // day, in one rule (subsumes the prior partial-numeric and numeric-overflow
-  // checks, and extends them to textual months). Non-year-led shapes
-  // ("Jan 15 2026", "02/30/2026") fall through to Date.parse / the mdy check.
-  if (/^\d{4}\D/.test(value) && parseYearLedDatePrefix(value) === null) {
+  // Date.parse agrees with (covers partial, overflow, AND the punctuation
+  // misinterpretation above).
+  if (/^\d{4}\D/.test(value) && !validYearLed) {
     return undefined;
   }
   // Also validate M/D/Y or D/M/Y formats (provider/import common shapes:
@@ -268,24 +293,135 @@ const MONTH_NAMES: Record<string, number> = {
 
 /**
  * Parse a complete, calendar-valid year-led date prefix from `s`
- * (issue #1657): `YYYY <sep> (MM | MonthName) <sep> DD` where the separators
- * are real date separators (non-digit, non-T, non-colon) and the day is a
- * true calendar day — not the hour before a `:` time separator (the
- * `(?![\d:])` lookahead rejects "2026-05 10:00" capturing "10" as the day).
- * Returns the numeric components for a complete, valid date; `null` for an
- * incomplete ("2026-05", "2026-Jan"), overflowed ("2026-02-30",
- * "2026-Feb-30"), or non-year-led prefix. Centralizes the fabricated-date
- * rejection for the toStrictIsoTimestamp normalization path across numeric
- * and textual months in one rule.
+ * (issue #1657, relaxed in #1723): `YYYY <sep> (MM | MonthName) <sep> DD`
+ * where each separator is a RUN of non-alphanumeric, non-colon chars (so a
+ * complete date with any punctuation — "2026 May, 10", "2026, May 10",
+ * "2026 Jan. 15" — is accepted; the run excludes letters so a textual month
+ * is never consumed by the separator, and excludes the colon so the date/time
+ * boundary stays clean) and the day is a true calendar day — not the hour
+ * before a `:` time separator (the `(?![\d:])` lookahead rejects
+ * "2026-05 10:00" capturing "10" as the day). Returns the numeric components
+ * for a complete, valid date; `null` for an incomplete ("2026-05",
+ * "2026-Jan"), overflowed ("2026-02-30", "2026-Feb-30"), or non-year-led
+ * prefix. Centralizes the fabricated-date rejection for the
+ * toStrictIsoTimestamp normalization path across numeric and textual months
+ * in one rule.
  */
 function parseYearLedDatePrefix(s: string): { y: number; mo: number; da: number } | null {
-  const m = /^(\d{4})[^0-9T](\d{1,2}|[A-Za-z]{3,})[^0-9T:](\d{1,2})(?![\d:])/.exec(s);
+  const m = /^(\d{4})[^0-9A-Za-z]+(\d{1,2}|[A-Za-z]{3,})[^0-9A-Za-z:]+(\d{1,2})(?![\d:])/.exec(s);
   if (!m) return null;
   const y = Number(m[1]);
   const da = Number(m[3]);
   const mo = /^\d+$/.test(m[2]) ? Number(m[2]) : (MONTH_NAMES[m[2]!.toLowerCase()] ?? -1);
   if (!isValidCalendarDate(y, mo, da)) return null;
   return { y, mo, da };
+}
+
+/**
+ * Extract an explicit timezone offset (ms east of UTC) from a non-strict-ISO
+ * timestamp, or `null` if none is present (issue #1723 codex r4). Recognizes
+ * the offset forms `Date.parse` accepts for non-ISO year-led dates: a trailing
+ * `±HH:MM` / `±HHMM`, and a `GMT`/`UTC` token optionally followed by
+ * `±HHMM` (bare `GMT`/`UTC` ⇒ offset 0). Strict ISO `Z` forms are handled
+ * by `isStrictIsoTimestamp` before this point, so they never reach here.
+ */
+/**
+ * Named timezone abbreviations Node's `Date.parse` accepts for non-ISO dates
+ * (issue #1723 codex r8). V8 recognizes a fixed set of US zones; each maps to a
+ * fixed offset (the abbreviation itself encodes standard vs daylight, so PST is
+ * always -8 and PDT always -7 regardless of the calendar date). Other named
+ * zones (CET/CEST/JST/…) return NaN from `Date.parse` and never reach here.
+ */
+const NAMED_ZONE_OFFSETS_MS: Record<string, number> = {
+  PST: -8 * 60, PDT: -7 * 60,
+  MST: -7 * 60, MDT: -6 * 60,
+  CST: -6 * 60, CDT: -5 * 60,
+  EST: -5 * 60, EDT: -4 * 60,
+};
+
+function explicitOffsetMs(value: string): number | null {
+  // Recognize the offset forms Date.parse accepts for non-ISO year-led dates,
+  // returning ms east of UTC or null. Tries each shape in order; a stray run
+  // of date digits can never pose as an offset because (a) trailing numeric
+  // offsets must be preceded by whitespace or glued to a ":SS" seconds field
+  // (lookbehind), and (b) every candidate is range-validated (|hh| ≤ 14,
+  // mm < 59).
+  // Named US zone abbreviation (PST/EST/EDT/…), trailing token (codex r8).
+  const nz = /\b([A-Z]{3,4})\s*$/.exec(value);
+  if (nz && NAMED_ZONE_OFFSETS_MS[nz[1]] !== undefined) {
+    return NAMED_ZONE_OFFSETS_MS[nz[1]] * 60_000;
+  }
+  const tryOff = (sign: string | undefined, hh: number, mm: number): number | null => {
+    if (hh > 14 || mm > 59) return null;
+    return (sign === "-" ? -1 : 1) * (hh * 60 + mm) * 60_000;
+  };
+  let m: RegExpExecArray | null;
+  // GMT/UTC token: colon form, then ±HHMM (4-digit, before bare hour so
+  // "GMT+0530" is not read as "+05"), then bare hour, then the bare token
+  // itself (offset 0).
+  if (
+    (m = /\b(?:GMT|UTC)\b\s*([+-])?(\d{1,2}):(\d{2})/i.exec(value)) ||
+    (m = /\b(?:GMT|UTC)\b\s*([+-])?(\d{2})(\d{2})/i.exec(value))
+  ) {
+    const r = tryOff(m[1], Number(m[2]), Number(m[3]));
+    if (r !== null) return r;
+  }
+  if ((m = /\b(?:GMT|UTC)\b\s*([+-])?(\d{1,2})\b/i.exec(value))) {
+    const r = tryOff(m[1], Number(m[2]), 0);
+    if (r !== null) return r;
+  }
+  if (/\b(?:GMT|UTC)\b/i.test(value)) return 0;
+  // Trailing numeric offset: whitespace-delimited OR glued to a ":SS"
+  // seconds field (lookbehind), so date digits ("-0510" in "2026-0510") are
+  // never misread as an offset. Colon form, then ±HHMM, then bare hour — each
+  // for BOTH the whitespace and glued contexts.
+  if (
+    (m = /(?:\s|(?<=:\d{2}))([+-])(\d{1,2}):(\d{2})\s*$/.exec(value)) ||
+    (m = /(?:\s|(?<=:\d{2}))([+-])(\d{2})(\d{2})\s*$/.exec(value)) ||
+    (m = /(?:\s|(?<=:\d{2}))([+-])(\d{1,2})\s*$/.exec(value))
+  ) {
+    const r = tryOff(m[1], Number(m[2]), m[3] ? Number(m[3]) : 0);
+    if (r !== null) return r;
+  }
+  return null;
+}
+
+/**
+ * Verify `Date.parse`'s interpretation of `value` agrees with the year-led
+ * `prefix` components `(y, m, d)` (issue #1723 codex r2/r3/r4). Returns
+ * `false` when `prefix` is `null` (no complete year-led date). Otherwise
+ * compares the FULL tuple so punctuation that shifts the month OR the day is
+ * caught. Offset-bearing inputs are compared in the source's explicit offset
+ * frame (the prefix date is offset-local, so the same instant legitimately
+ * lands on an adjacent UTC/local day); offset-free inputs accept either the
+ * local or UTC frame, because `Date.parse` uses UTC for ISO date-only strings
+ * and local for non-ISO forms.
+ */
+function yearLedAgreesWithDateParse(
+  parsed: number,
+  value: string,
+  prefix: { y: number; mo: number; da: number } | null,
+): boolean {
+  if (prefix === null) return false;
+  const off = explicitOffsetMs(value);
+  if (off !== null) {
+    const shifted = new Date(parsed + off);
+    return (
+      shifted.getUTCFullYear() === prefix.y &&
+      shifted.getUTCMonth() + 1 === prefix.mo &&
+      shifted.getUTCDate() === prefix.da
+    );
+  }
+  const pd = new Date(parsed);
+  const localMatch =
+    pd.getFullYear() === prefix.y &&
+    pd.getMonth() + 1 === prefix.mo &&
+    pd.getDate() === prefix.da;
+  const utcMatch =
+    pd.getUTCFullYear() === prefix.y &&
+    pd.getUTCMonth() + 1 === prefix.mo &&
+    pd.getUTCDate() === prefix.da;
+  return localMatch || utcMatch;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1723 — follow-up to #1657 / PR #1714.

The unified year-led date guard (`parseYearLedDatePrefix` in `packages/remnic-core/src/provenance.ts`) over-rejected a tail of complete-but-unusual-punctuation dates that `Date.parse` parses to the correct calendar day (no fabrication), dropping the located source to the unverified epoch fallback.

### Repro (now accepted)
```
"2026 May, 10 12:00:00"   -> 2026-05-10 (verified)
"2026, May 10 12:00:00"   -> 2026-05-10 (verified)
"2026 Jan. 15 12:00:00"   -> 2026-01-15 (verified)
"2026 May, 10"            -> 2026-05-10 (date-only, verified)
"2026-05-10 00:30:00 +05:00" -> verified (offset crosses UTC day boundary)
```
### Fabrication still rejected (the #1657 class, hardened by the agreement check)
```
"2026 (May) 10"            -> rejected (prefix May, Date.parse October)
"2026 May (10) 12:00:00"   -> rejected (prefix day 10, Date.parse day 1)
"2026 (May) 10 +05:00"     -> rejected (exotic+offset fabrication)
```

## Change

ONE commit with four coordinated changes to the `toStrictIsoTimestamp` normalization path:

1. **Separator shape** (`parseYearLedDatePrefix`): each separator becomes a RUN of non-alphanumeric, non-colon chars. The run excludes letters (textual month never consumed by the separator; `T` cannot act as a separator) and the colon (date/time boundary stays clean).
2. **Bare-number guard**: admit a complete, calendar-valid year-led date even when it has no `-/:/T` (covers date-only punctuated forms). Bare numbers (`123`, `2026`) stay rejected.
3. **Agreement check** (codex r2/r3): require `Date.parse`'s interpretation to match the prefix's FULL `(y, m, d)` tuple, so punctuation that shifts the month OR day is caught (`2026 (May) 10` → October; `2026 May (10)` → day 1).
4. **Offset-frame comparison** (codex r4): for offset-bearing inputs, compare in the source's explicit offset frame (`explicitOffsetMs` extracts `±HH:MM`/`±HHMM`/`GMT`/`UTC`); offset-free inputs accept either the local or UTC frame (Date.parse uses UTC for ISO date-only, local for non-ISO).

The day-not-the-hour invariant is preserved via the existing `(?![\d:])` lookahead.

## Verification

- **Prove-fail**: the repro-seeded characterization tests were confirmed to FAIL on the pre-fix code (`unverified`), then PASS after the changes.
- **No regression / no fabrication**: full provenance suite — `provenance-extraction` + `provenance-frontmatter` + `provenance-surfaces` — **93/93 green**, including every #1657/#1714/#1717 fabrication test, the bare-number rejection, the offset-boundary non-regression, and the four new punctuation-fabrication rejections (month, day, exotic+offset).

| Gate | Result |
|---|---|
| `@remnic/core` build | ✓ |
| `@remnic/core` check-types | ✓ |
| provenance test suite | ✓ 93/93 |
| `check-ratchets` | OK |

## Chokepoints used / not applicable

Not applicable — characterization-before-move + prove-fail on the `parseYearLedDatePrefix` normalization path; no new tool/route/command. One commit, per the issue's acceptance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provenance timestamp normalization logic that gates verified vs unverified sources and persisted `observedAt`; behavior is heavily tested but parsing edge cases can still surprise imports.
> 
> **Overview**
> Fixes **#1723**: provenance turn timestamps with unusual but complete year-led shapes (e.g. `2026 May, 10`, date-only punctuated forms) were wrongly rejected and pushed verified facts to **unverified** with epoch `observedAt`.
> 
> **`toStrictIsoTimestamp`** in `provenance.ts` now: relaxes year-led separators to **runs** of punctuation; allows date-only year-led strings without `-/:/T` when the prefix is complete and valid; adds a **`Date.parse` agreement** check on full `(y, m, d)` so parenthesized/exotic strings still reject fabrication; and compares dates in the **explicit offset** frame via new `explicitOffsetMs` / `yearLedAgreesWithDateParse` (numeric offsets, `GMT+0530`, glued offsets, US zone abbreviations). Bare years like `2026` stay rejected.
> 
> Adds a large **#1723 regression suite** in `provenance-extraction.test.ts` covering accept/reject cases and offset edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf942447021aff53e21d38f857ed947080234fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->