### PR TITLE
fix(chat): raise transcript seq from on-disk max on session load (#1718)

### DIFF
--- a/packages/remnic-core/src/chat/chat-engine.test.ts
+++ b/packages/remnic-core/src/chat/chat-engine.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdir, rm, readFile, utimes, unlink } from "node:fs/promises";
+import { mkdir, rm, readFile, utimes, unlink, appendFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
@@ -22,6 +22,7 @@ import {
   sessionBelongsToPrincipal,
   chatSessionFile,
   cleanupExpiredChatSessions,
+  __resetTranscriptSeqForTest,
 } from "./chat-session.js";
 import type { ChatSessionState } from "./chat-types.js";
 import type { ChatToolExecutor } from "./chat-engine.js";
@@ -333,5 +334,42 @@ test("appendTranscriptEntry refuses to recreate a swept session (chat_session_ex
   await assert.rejects(
     appendTranscriptEntry(dir, session.id, { role: "user", content: "x" }),
     /chat_session_expired/,
+  );
+});
+
+
+test("loadChatSession raises the seq counter above the on-disk max on backward clock skew (issue #1718)", async () => {
+  const dir = await makeTempDir();
+  const session = await createChatSession(dir, { principal: "skew" });
+  // Simulate a previous process that ran with a forward-skewed clock: append a
+  // transcript line whose seq is far in the future relative to the current
+  // Date.now(). A later restart with a normal (or backward-stepped) clock must
+  // still issue seqs strictly greater than this persisted line.
+  const futureSeq = Date.now() + 10_000_000;
+  await appendFile(
+    chatSessionFile(dir, session.id),
+    JSON.stringify({
+      seq: futureSeq,
+      ts: new Date().toISOString(),
+      role: "user",
+      content: "future-dated line from a forward-skewed prior process",
+    }) + "\n",
+    "utf8",
+  );
+  // Simulate a process restart whose module-level counter starts below the
+  // persisted on-disk seq (the backward-clock-skew window).
+  __resetTranscriptSeqForTest();
+  // Resume the session: loadChatSession must raise the counter above the
+  // on-disk max so the next append is strictly greater, regardless of the
+  // current Date.now().
+  const loaded = await loadChatSession(dir, session.id);
+  assert.ok(loaded, "session must load");
+  const next = await appendTranscriptEntry(dir, session.id, {
+    role: "assistant",
+    content: "resumed after backward clock skew",
+  });
+  assert.ok(
+    next.seq > futureSeq,
+    `seq ${next.seq} must exceed the on-disk max ${futureSeq} after a backward clock skew (issue #1718)`,
   );
 });

--- a/packages/remnic-core/src/chat/chat-session.ts
+++ b/packages/remnic-core/src/chat/chat-session.ts
@@ -50,8 +50,10 @@ export function chatSessionFile(memoryDir: string, chatSessionId: string): strin
  * incremented when two appends land in the same millisecond, so `seq` is
  * strictly increasing within a process (review thread: `Date.now()` alone is
  * not monotonic — same-ms entries would share a seq and break the SSE
- * reconnect dedup-by-seq contract). Across process restarts `Date.now()` is
- * already forward-moving, so no collision occurs in practice.
+ * reconnect dedup-by-seq contract). Across process restarts the counter is
+ * raised above the on-disk max by `loadChatSession` (issue #1718), so a
+ * backward clock step (NTP, VM migration, manual change) cannot re-seed it
+ * below lines already persisted for a resumed session.
  */
 let lastTranscriptSeq = 0;
 
@@ -59,6 +61,14 @@ function nextTranscriptSeq(): number {
   const now = Date.now();
   lastTranscriptSeq = now > lastTranscriptSeq ? now : lastTranscriptSeq + 1;
   return lastTranscriptSeq;
+}
+
+/**
+ * Test-only: reset the module-level transcript seq counter so a regression
+ * test can deterministically simulate a fresh process restart (issue #1718).
+ */
+export function __resetTranscriptSeqForTest(): void {
+  lastTranscriptSeq = 0;
 }
 
 /**
@@ -173,6 +183,19 @@ export async function loadChatSession(
     } catch {
       // Skip malformed lines (rule 54 — atomic appends; partial lines are
       // tolerated, never crash the engine).
+    }
+  }
+  // Issue #1718 — backward-clock-skew robustness: raise the module-level seq
+  // counter so the next append is strictly greater than any line already on
+  // disk for this session, regardless of clock direction across restarts
+  // (NTP step, VM migration, manual change). Without this, a backward clock
+  // skew would re-seed the counter below the on-disk max and the SSE
+  // reconnect dedup-by-seq contract could drop freshly-appended entries as
+  // duplicates. The transcript is already fully parsed above, so this is a
+  // single pass over the in-memory array.
+  for (const e of transcript) {
+    if (typeof e.seq === "number" && e.seq + 1 > lastTranscriptSeq) {
+      lastTranscriptSeq = e.seq + 1;
     }
   }
   return {


### PR DESCRIPTION
## Summary

Closes #1718 (follow-up from #1711 review thread — cursor Medium).

`nextTranscriptSeq` (`packages/remnic-core/src/chat/chat-session.ts`) issues transcript \`seq\` from a module-level counter seeded from \`Date.now()\` on first use. The existing comment assumed \`Date.now()\` is forward-moving across restarts, so the SSE reconnect dedup-by-\`seq\` contract held.

**The edge case:** if the system clock moves *backward* across a restart (NTP step, VM migration, manual change), the re-seeded counter can produce a \`seq\` ≤ lines already in an old session's JSONL. Resuming that session would append entries a reconnecting SSE client (which dedups by \`seq\`) could drop as duplicates — breaking the per-session monotonic contract.

## Change

When \`loadChatSession\` finishes parsing a transcript, it raises the module-level \`lastTranscriptSeq\` to \`max(on-disk seq) + 1\` so the next append is strictly greater than anything already persisted for that session, regardless of clock direction. The transcript is already fully parsed by \`loadChatSession\`, so this is a single pass over the in-memory array.

No change to the in-process strict-increment behavior (already correct). This only closes the backward-clock-skew window.

## Test

Added a regression test in \`chat-engine.test.ts\`: persist a session with a future-dated \`seq\`, reset the module counter (\`__resetTranscriptSeqForTest\`), resume via \`loadChatSession\`, and assert the new entry's \`seq\` exceeds the on-disk max.

**Proven to fail on a seeded violation** (ground rule 6): with the fix disabled, the new seq lands ~10M below the on-disk max (\`AssertionError: seq … must exceed the on-disk max …\`). With the fix, the new seq strictly exceeds it.

## Gates

- \`pnpm --filter @remnic/core check-types\` (tsc --noEmit) — clean
- \`node scripts/check-test-types.mjs\` — OK
- \`node scripts/check-ratchets.mjs\` — OK
- \`npm run lint\` (biome) — clean
- \`npm run check-config-contract\` / \`check-docs-parity\` / \`plugin:inspect\` — OK / OK / PASS
- chat test suite (\`chat-engine\`, \`chat-http\`, \`chat-security\`, \`chat-mcp\`, \`chat-cli\`) — 58 tests, 0 failures (incl. the new #1718 regression and the existing #1687 monotonic-seq test)
- entity-hardening: not triggered (changed files are not in its trigger set: orchestrator/storage/intent/memory-cache/entity-retrieval/config)

## Chokepoints used

Not applicable — no new MCP tool, HTTP route, CLI command, catalog write, or feature gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to seq initialization on session load; improves correctness of chat SSE reconnect dedup without touching auth or persistence formats.
> 
> **Overview**
> Fixes **#1718**: after a restart, transcript `seq` values could fall at or below lines already on disk when the system clock steps backward (NTP, VM migration, etc.). SSE clients dedupe reconnect replays by `seq`, so those new lines could be treated as duplicates and never shown.
> 
> **`loadChatSession`** now bumps the module-level `lastTranscriptSeq` to **max persisted `seq` + 1** after parsing the JSONL, so the next append stays strictly greater than anything already stored for that session. In-process monotonic behavior via `nextTranscriptSeq()` is unchanged.
> 
> Adds **`__resetTranscriptSeqForTest`** and a regression test that simulates a high on-disk `seq`, resets the counter like a fresh process, reloads the session, and asserts the next append exceeds the on-disk max.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e7d7013635feb1927e265ed1a01aef39f19bba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->