### PR TITLE
docs(coding): #1548 Track A PR6 — coding-knowledge + coding-graph single-source docs

### DIFF
--- a/docs/coding-agent.md
+++ b/docs/coding-agent.md
@@ -22,6 +22,11 @@ This document covers the surfaces that ship today:
 6. Per-connector behavior (Claude Code, Codex CLI, Cursor / MCP).
 7. How to opt out.
 
+Beyond namespace scoping, two companion features build on coding mode:
+[coding knowledge](coding-knowledge.md) (Track A — decision records,
+architecture card, session delta) and the [coding graph](coding-graph.md)
+engine (Track B — `@remnic/coding-graph`, structural queries, blast radius).
+
 ## Overview
 
 Session-scoped overlay. When a session attaches a `CodingContext`
@@ -417,6 +422,8 @@ Two paths:
 
 ## Related reading
 
+- [Coding knowledge (Track A)](coding-knowledge.md) — decision records, architecture card, session delta, structural provider.
+- [Coding graph (Track B)](coding-graph.md) — the `@remnic/coding-graph` engine: install, config, the 14 parity tools, Cypher subset, performance.
 - [`docs/namespaces.md`](./namespaces.md) — the underlying namespace
   system coding mode overlays on top of.
 - [`packages/remnic-core/src/coding/git-context.ts`](../packages/remnic-core/src/coding/git-context.ts) — `resolveGitContext` and origin URL normalization.

--- a/docs/coding-graph.md
+++ b/docs/coding-graph.md
@@ -1,0 +1,354 @@
+# Coding graph (Track B)
+
+Issue [#1548](https://github.com/joshuaswarren/remnic/issues/1548) Track B is
+`@remnic/coding-graph`, an optional à-la-carte package that ships a native
+codebase-graph engine: web-tree-sitter (WASM) parsing, a SQLite knowledge
+graph, structural queries, blast-radius analysis, dead-code detection, an
+openCypher read subset, optional LSP-upgraded type resolution, and an optional
+semantic layer. This document is the single source of truth for the engine.
+
+> One-source rule (#1527): the four durable coding-knowledge *features*
+> (decision records, architecture card, session delta, structural provider)
+> are documented in [Coding knowledge (Track A)](coding-knowledge.md) and are
+> not repeated here. Namespace scoping is in
+> [Coding agent mode](coding-agent.md). Track B's `manage_adr` and
+> `get_architecture` tools *compose* Track A's records and card with live
+> graph stats — one implementation each (rule 22).
+
+## Install
+
+`@remnic/coding-graph` is an optional peer dependency. `@remnic/core` never
+imports it directly; it uses a computed-specifier dynamic import so the base
+install compiles and runs without it:
+
+```bash
+npm install @remnic/coding-graph
+```
+
+When the package is absent, the loader returns a user-facing install hint
+(never `MODULE_NOT_FOUND`); when present but shape-mismatched, it throws a
+tagged `module_load_failed` error telling the operator the install is broken.
+The loader lives in
+[`coding/optional-coding-graph.ts`](../packages/remnic-core/src/coding/optional-coding-graph.ts).
+
+## Why an optional package
+
+The engine is heavy (web-tree-sitter runtime + grammar `.wasm` assets + LSP
+client) and most Remnic users never index code. Core hosts only: types-only
+engine interface declarations, the computed-specifier loader, and the surface
+wiring. Optional peer dep with `peerDependenciesMeta.*.optional = true`;
+never in base `dependencies` or any tsup `noExternal`. This is the à-la-carte
+rule (CLAUDE.md rule 57).
+
+The parser is **web-tree-sitter (WASM), not native bindings**. Native
+`node-tree-sitter` + per-grammar native modules would repeat the
+better-sqlite3 binding pain this repo already paid for (#1538) and the
+Windows/cross-platform hook failures (#1518). WASM grammars are prebuilt,
+platform-independent files loaded at runtime — no `node-gyp` anywhere. Cost:
+~2–3× slower parsing than native; accepted, and measured by the benchmark
+harness rather than argued about (see [Performance](#performance)).
+
+## Config and gating
+
+There is no `codingGraph` plugin config block. Track B is gated entirely
+through the existing `codingKnowledge` config (see
+[Coding knowledge (Track A)](coding-knowledge.md#config-surface) for the full
+table). The two relevant keys:
+
+| Key | Default | Behavior |
+|-----|---------|----------|
+| `codingKnowledge.codegraphTools` | `false` | Gate for the 14 parity tools. Off = `tools/list`, HTTP route registration, and CLI help are byte-identical to pre-feature. **Also requires `@remnic/coding-graph` to be installed.** |
+| `codingKnowledge.codegraphDbDir` | `""` | Root for per-project graph SQLite DBs. Empty = derive from `memoryDir`. |
+
+The visibility gate is one predicate —
+[`codegraphSurfaceVisible(config)`](../packages/remnic-core/src/coding/codegraph-runtime.ts)
+— which returns `true` iff `codingKnowledge.enabled && codegraphTools`. Call
+sites that are about to *open* a graph store tighten it with the loader probe
+via `codegraphRuntimeAvailable(config)` (config alone is insufficient; the
+package may be missing). The probe outcome is memoized.
+
+Database location (rule 11 — no path assembly at call sites):
+
+```text
+<codegraphDbDir>/<principalSafe>/<projectIdSafe>.sqlite        (explicit root)
+<memoryDir>/codegraph/<principalSafe>/<projectIdSafe>.sqlite   (default)
+```
+
+Both `principalSafe` and `projectIdSafe` are sanitized to filesystem-safe
+tokens so a hostile project id cannot escape the codegraph root.
+
+## The 14 parity tools
+
+Mirrors the external codebase-memory-mcp tool surface. All 14 are registered
+as MCP tools with `engram.*` canonical names and `remnic.*` aliases; they
+dispatch through the `codegraph_*` boundary operations to one shared handler
+([`coding/codegraph-surfaces.ts`](../packages/remnic-core/src/coding/codegraph-surfaces.ts)).
+The runtime bridge is
+[`coding/codegraph-runtime.ts`](../packages/remnic-core/src/coding/codegraph-runtime.ts).
+
+| Tool | Operation | Notes |
+|------|-----------|-------|
+| `engram.codegraph_index` | `codegraph_index` | Index a repository (full or incremental). Mutating. |
+| `engram.codegraph_list_projects` | `codegraph_list_projects` | List indexed projects. |
+| `engram.codegraph_delete_project` | `codegraph_delete_project` | Delete a project's graph. Mutating. |
+| `engram.codegraph_index_status` | `codegraph_index_status` | Index freshness + degradation state. |
+| `engram.codegraph_search_graph` | `codegraph_search_graph` | Structured label/name search. |
+| `engram.codegraph_trace_path` | `codegraph_trace_path` | Traverse from a symbol over typed edges. |
+| `engram.codegraph_detect_changes` | `codegraph_detect_changes` | Diff → affected symbols + [blast radius](#detect_changes--blast-radius). |
+| `engram.codegraph_query_graph` | `codegraph_query_graph` | [openCypher read subset](#opencypher-read-subset). |
+| `engram.codegraph_get_schema` | `codegraph_get_schema` | Node/edge label histogram. |
+| `engram.codegraph_get_snippet` | `codegraph_get_snippet` | Source snippet for a symbol (read from disk). |
+| `engram.codegraph_get_architecture` | `codegraph_get_architecture` | Composes Track A's architecture card with live graph stats. |
+| `engram.codegraph_search_code` | `codegraph_search_code` | FTS5 full-text search over symbol text. |
+| `engram.codegraph_manage_adr` | `codegraph_manage_adr` | Delegates to Track A's decision records (rule 22). |
+| `engram.codegraph_ingest_traces` | `codegraph_ingest_traces` | Ingest external trace data as edges. Mutating. |
+
+Reuse, not fork: `manage_adr` reuses
+[`coding/decision-records.ts`](../packages/remnic-core/src/coding/decision-records.ts);
+`get_architecture` composes the Track A architecture card with live graph
+stats. Zero duplicated ADR or architecture-card logic.
+
+Example MCP tool call (`query_graph` with a structured query — raw Cypher
+strings are rejected by the boundary, see below):
+
+```json
+{
+  "tool": "engram.codegraph_query_graph",
+  "sessionKey": "string",
+  "structuredQuery": { "label": "Function", "limit": 20 }
+}
+```
+
+Example (`detect_changes` against the current diff):
+
+```json
+{
+  "tool": "engram.codegraph_detect_changes",
+  "sessionKey": "string",
+  "head": "HEAD"
+}
+```
+
+## Graph schema
+
+One SQLite DB per coding namespace via the existing `better-sqlite3`
+dependency. Schema is versioned (`CODING_GRAPH_SCHEMA_VERSION = 1`, meta-table
+version, WAL, `busy_timeout`) following the `lcm/schema.ts` precedent. File
+*contents* are never stored in the DB — spans + content hashes only;
+`get_snippet` reads source from disk.
+
+**Node labels** (13 — the documented schema universe). The ingest pipeline
+emits the lowercase symbol `kind` for these; `Project`, `Package`, `Folder`,
+`File`, `Route`, `Resource` are accepted by queries but not yet emitted by
+ingest, so they return zero rows:
+
+```text
+Project  Package  Folder  File  Module  Class  Function  Method
+Interface  Enum  Type  Route  Resource
+```
+
+**Edge provenance** — a CHECK-constrained whitelist so a buggy resolver
+cannot write an unknown value:
+
+```text
+heuristic   lsp   trace   semantic
+```
+
+Every edge carries a `confidence ∈ [0.0, 1.0]` and a provenance tag.
+Additional tables: `node_attributes` (per-symbol `is_exported` /
+`is_route_handler` flags consumed by dead-code detection), `co_changes`
+(file-level co-change edges mined from git history), and `symbol_vectors`
+(symbol embedding vectors for the semantic layer).
+
+## detect_changes + blast radius
+
+[`detect-changes.ts`](../packages/coding-graph/src/detect-changes.ts) maps the
+current diff (staged + unstaged + committed-since-last-index) hunks to symbols
+whose spans overlap the changed line ranges — against a **fresh parse** of the
+changed files, never stale stored spans. Half-open interval semantics (rule
+35): a hunk range `[startLine, endLine)` overlaps a symbol span
+`[symStartLine, symEndLine)` iff `startLine < symEndLine && symStartLine < endLine`.
+
+Blast radius is reverse BFS from affected symbols over inbound `CALLS` /
+`IMPORTS` / `USES_TYPE` edges (`BLAST_RADIUS_EDGE_TYPES`) with a depth cap.
+Risk classification is a **deterministic rubric** (no LLM):
+
+| Risk | Criterion |
+|------|-----------|
+| `direct` | The symbol itself is in a changed hunk (depth 0). |
+| `near` | 1 hop away from a directly-changed symbol. |
+| `transitive` | 2+ hops away. |
+
+Fan-in escalation: when an affected symbol has ≥ `FAN_IN_ESCALATION_THRESHOLD`
+inbound edges, its risk is escalated one level (`near → direct`,
+`transitive → near`) because high-fan-in symbols concentrate blast radius. A
+backend/store failure during traversal is surfaced as
+`{ ok: false, code: "store_error" }` rather than masked as an empty result.
+
+## Dead-code detection
+
+[`GraphStore.deadCode()`](../packages/coding-graph/src/graph-store.ts) finds
+symbols with zero inbound `CALLS` / `USES_TYPE` edges, excluding the
+`DEAD_CODE_EXCLUSION` set. Two flags keep genuinely-reachable symbols off the
+list:
+
+- `is_exported` — the symbol's name matches a file's `exports` list. Exported
+  symbols form the package's public surface and may be called by external
+  consumers the graph cannot see.
+- `is_route_handler` — the symbol's qualified name matches a route's
+  `handlerQualifiedName`. Route handlers are reachable from HTTP requests
+  regardless of internal call edges.
+
+## openCypher read subset
+
+[`cypher/query-parser.ts`](../packages/coding-graph/src/cypher/query-parser.ts)
+is a hand-written recursive-descent parser + executor compiling a strict
+read-only subset of openCypher to the structured store API (`searchGraph` /
+`traverse` / `traversePaths`). There is **no SQL string assembly from user
+input** anywhere; the structured API already parameterises every bind
+(rule 51).
+
+Supported grammar:
+
+```text
+query        := MATCH pattern [WHERE where_clause] RETURN return_list [LIMIT int]
+pattern      := node_pattern (rel_pattern node_pattern)*
+node_pattern := '(' [var] [':' label] ['{' prop_map '}'] ')'
+rel_pattern  := dashes+brackets+dashes with optional arrows (direction)
+bracket      := '[' [':' type ('|' ':' type)*] ['*' range] ']'
+range        := int ('..' int)? | '..' int
+where_clause := comparison ((AND | OR) comparison)*
+```
+
+- **Direction** resolved from the dashes/arrows: `-[...]->` outgoing,
+  `<-[...]-` incoming, `-[...]-` both.
+- **Variable-length hops**: `-[:CALLS*1..3]->` (1–3 hops), `-[:CALLS*2]->`
+  (exactly 2). Unbounded `*` is **rejected** (must specify a range). Exact
+  `*N` honours concrete length-N paths via the path-enumerating primitive
+  `traversePaths` (#1650); results are deduped by node id and carry
+  `truncated: true` if the store's maxPaths cap is hit.
+- **Read-only by construction**: every mutation clause token (`CREATE`,
+  `MERGE`, `SET`, `DELETE`, `DETACH`, `REMOVE`, `DROP`, …) is rejected with a
+  clear error naming the supported grammar. The module has no code path that
+  writes to the store.
+- Unknown labels and unsupported clauses each have a dedicated rejection test.
+
+## Incremental reindex and co-change
+
+[`reindex.ts`](../packages/coding-graph/src/reindex.ts) computes an incremental
+plan from `last-indexed-head` + per-file content hashes: only changed files
+are re-parsed, deleted files' nodes are pruned, and the new head + hashes are
+persisted as meta. [`co-change.ts`](../packages/coding-graph/src/co-change.ts)
+mines `FILE_CHANGES_WITH`-style file-to-file co-change edges from bounded
+`git log` history with support/confidence thresholds (`DEFAULT_CO_CHANGE_CONFIG`).
+
+## Type resolution (phased)
+
+- **Phase A — heuristic** (shipped with the store): resolution from the syntax
+  graph — import/export matching, scope, qualified names, arity. Edges carry
+  `provenance: "heuristic"`.
+- **Phase B — LSP client layer** ([`lsp/`](../packages/coding-graph/src/lsp/)):
+  a minimal JSON-RPC-over-stdio client driving **already-installed** language
+  servers (typescript-language-server, pyright, gopls, rust-analyzer, …) as
+  subprocesses to upgrade unresolved/low-confidence edges. This is the
+  pragmatic non-C answer to a "Hybrid LSP": Remnic does not reimplement type
+  checkers, it orchestrates the real ones, with budgets and tagged
+  degradation.
+
+LSP config is an engine-internal object with least-privileged defaults
+([`lsp/config.ts`](../packages/coding-graph/src/lsp/config.ts)):
+
+| Field | Default | Behavior |
+|-------|---------|----------|
+| `enabled` | `false` | Master switch. Off = index identical to Phase A. |
+| `servers` | `{}` | Per-language `{ command, args }` overrides (argv arrays — rule 10). Unknown language keys are rejected listing supported languages. |
+| `timeoutMs` | `3000` | Handshake + per-request timeout. |
+| `maxRequestsPerRun` | `500` | Max definition requests per index run. |
+
+Enabling LSP with zero servers installed produces a working Phase-A index plus
+**visible degradations** — a degraded index never masquerades as an empty one
+(rule 34). Env override: `REMNIC_CODING_GRAPH_LSP_ENABLED` with `ENGRAM_`
+fallback.
+
+## Semantic layer
+
+[`semantic/`](../packages/coding-graph/src/semantic/) adds symbol embeddings,
+`SIMILAR_TO` near-clone edges, and `semantic_query` (natural-language
+retrieval over the symbol graph). It builds on `@remnic/core`'s host embedding
+provider + fallback — no new embedding stack.
+
+**Privacy posture — default sends nothing anywhere.** The semantic layer is
+off by default. When off, zero embedding provider calls are made and zero rows
+are written to the `symbol_vectors` table (the gate-off test asserts this end
+to end). When on:
+
+- **No embedding provider configured**: degrades gracefully. `SIMILAR_TO`
+  edges are still produced via local, deterministic MinHash/LSH (pure
+  TypeScript, no network). `semantic_query` returns a tagged
+  `{ ok: false, code: "provider_unavailable" }` — never an empty result
+  masquerading as "no matches".
+- **Remote embedding provider configured**: symbol text (canonical form:
+  kind + qualified name + signature + body excerpt) leaves the machine to be
+  embedded — the same path `@remnic/core`'s `EmbeddingFallback` uses for
+  conversation embeddings, no new network stack.
+
+The canonical text that is embedded is the canonical text that is hashed for
+the cache (rule 23); cached vectors are reused on re-index when the content
+hash is unchanged (rule 37). See the
+[`@remnic/coding-graph` README](../packages/coding-graph/README.md#semantic-layer-1556)
+for the API surface (`resolveSemanticConfig`, `indexSymbolVectors`,
+`computeSimilarTo`, `semanticQuery`).
+
+## Team-shareable artifacts
+
+`@remnic/coding-graph` exports the store, schema, reindex, detect-changes,
+co-change, Cypher, LSP, and semantic layers from its package root so consumers
+can `import { GraphStore, executeCypher, … } from "@remnic/coding-graph"`. The
+subpath exports `./graph-schema`, `./graph-store`, and `./cypher` remain for
+callers that want only one layer. Schema and IR types live in
+[`coding/coding-graph-types.ts`](../packages/remnic-core/src/coding/coding-graph-types.ts)
+(owned by core so the base install compiles without the optional package).
+
+## Performance
+
+Every number below is traced to the committed baseline artifact
+[`packages/bench/baselines/coding-graph-baseline.json`](../packages/bench/baselines/coding-graph-baseline.json).
+The harness
+([`packages/bench/src/coding-graph/`](../packages/bench/src/coding-graph/))
+runs a deterministic synthetic repo generator + the real `GraphStore` over
+≥20 iterations; there are **no invented numbers** and no README claim without a
+measurement behind it (rule 55).
+
+**Baseline fixture** (`DEFAULT_SMOKE_FIXTURE`, seed 42): 20 TypeScript files,
+10 symbols per file, call density 0.3. **Machine**: Apple M2 Max, darwin
+arm64, Node v22.20.0. Measured (regenerated 2026-07-07):
+
+| Metric | Value |
+|--------|-------|
+| Full index | 15.5 ms (≈131 000 LOC/s) |
+| Incremental single-file update (p50 / p95) | 0.17 ms / 0.24 ms |
+| Incremental *modified* update (p50 / p95) | 0.60 ms / 0.96 ms |
+| `trace_path` (p95) | 0.13 ms |
+| `search_graph` (p95) | 0.18 ms |
+| `dead_code` | 0.53 ms |
+| DB size | ≈270 KB / KLOC |
+
+These are micro-benchmarks on a small synthetic fixture, not scale claims. A
+larger fixture (`DEFAULT_10K_FIXTURE`: ~1000 files × 10 symbols, ~10 000 nodes)
+is available for scale runs. Regression is gated by
+`checkCodingGraphRegression` against this baseline with a generous 30 %
+tolerance; the report includes a machine fingerprint so baselines are only
+comparable on the same machine. Working scale *targets* (not measurements) —
+tier-1 1M LOC indexing, incremental file < 250 ms p95, `trace_path` < 50 ms p95
+at 200k nodes — are owned and adjusted by this harness as real hardware runs
+land; they are not cited as achieved results.
+
+## Related reading
+
+- [Coding knowledge (Track A)](coding-knowledge.md) — the four durable
+  features; `manage_adr` and `get_architecture` compose them with graph stats.
+- [Coding agent mode](coding-agent.md) — namespace scoping Track B inherits.
+- [`packages/coding-graph/`](../packages/coding-graph/) — engine, store,
+  Cypher, LSP, and semantic source.
+- [`packages/bench/baselines/coding-graph-baseline.json`](../packages/bench/baselines/coding-graph-baseline.json)
+  — the performance baseline cited above.

--- a/docs/coding-graph.md
+++ b/docs/coding-graph.md
@@ -95,7 +95,7 @@ The runtime bridge is
 | `engram.codegraph_search_graph` | `codegraph_search_graph` | Structured label/name search. |
 | `engram.codegraph_trace_path` | `codegraph_trace_path` | Traverse from a symbol over typed edges. |
 | `engram.codegraph_detect_changes` | `codegraph_detect_changes` | Diff → affected symbols + [blast radius](#detect_changes--blast-radius). |
-| `engram.codegraph_query_graph` | `codegraph_query_graph` | [openCypher read subset](#opencypher-read-subset). |
+| `engram.codegraph_query_graph` | `codegraph_query_graph` | Structured label/name search (raw Cypher text rejected — see [openCypher read subset](#opencypher-read-subset)). |
 | `engram.codegraph_get_schema` | `codegraph_get_schema` | Node/edge label histogram. |
 | `engram.codegraph_get_snippet` | `codegraph_get_snippet` | Source snippet for a symbol (read from disk). |
 | `engram.codegraph_get_architecture` | `codegraph_get_architecture` | Composes Track A's architecture card with live graph stats. |
@@ -162,6 +162,16 @@ Additional tables: `node_attributes` (per-symbol `is_exported` /
 
 ## detect_changes + blast radius
 
+**Wiring status (honest).** The `engram.codegraph_detect_changes` MCP tool is
+registered and dispatches to a runtime delegate, but that delegate does **not**
+yet gather the diff or fresh-parse changed files — it calls `computeBlastRadius`
+with an empty affected set, so the tool returns an empty `affected` list today.
+The diff-gathering + fresh-parse pipeline (the library functions below) lands in a
+follow-up; until then the result is an honest empty set, never a stub claiming
+affected symbols. The library functions (`computeBlastRadius`,
+`findDirectlyAffectedSymbols`, `classifyRisk`) are implemented and work when called
+directly from `@remnic/coding-graph`.
+
 [`detect-changes.ts`](../packages/coding-graph/src/detect-changes.ts) maps the
 current diff (staged + unstaged + committed-since-last-index) hunks to symbols
 whose spans overlap the changed line ranges — against a **fresh parse** of the
@@ -187,6 +197,8 @@ backend/store failure during traversal is surfaced as
 
 ## Dead-code detection
 
+**Library primitive, not an MCP tool.** `deadCode()` is a `GraphStore` method — it is not one of the 14 `codegraph_*` parity tools, but the store primitive they and library consumers build on.
+
 [`GraphStore.deadCode()`](../packages/coding-graph/src/graph-store.ts) finds
 symbols with zero inbound `CALLS` / `USES_TYPE` edges, excluding the
 `DEAD_CODE_EXCLUSION` set. Two flags keep genuinely-reachable symbols off the
@@ -200,6 +212,9 @@ list:
   regardless of internal call edges.
 
 ## openCypher read subset
+
+**Two surfaces, one engine.** The MCP `engram.codegraph_query_graph` tool accepts a **structured** query object (`structuredQuery`) and **rejects raw Cypher text** — Cypher strings are not passed through the tool boundary. The openCypher parser + executor below (`executeCypher`) is a `@remnic/coding-graph` library capability for direct consumers; the MCP tool compiles the structured query to the same `searchGraph` / `traverse` primitives.
+
 
 [`cypher/query-parser.ts`](../packages/coding-graph/src/cypher/query-parser.ts)
 is a hand-written recursive-descent parser + executor compiling a strict

--- a/docs/coding-graph.md
+++ b/docs/coding-graph.md
@@ -115,7 +115,7 @@ strings are rejected by the boundary, see below):
 {
   "tool": "engram.codegraph_query_graph",
   "sessionKey": "string",
-  "structuredQuery": { "label": "Function", "limit": 20 }
+  "structuredQuery": { "label": "function", "limit": 20 }
 }
 ```
 

--- a/docs/coding-knowledge.md
+++ b/docs/coding-knowledge.md
@@ -48,9 +48,9 @@ deep-equal characterization test so the schema and the docs cannot drift.
 | Key | Default | Behavior |
 |-----|---------|----------|
 | `codingKnowledge.enabled` | `false` | Master gate. Off = pre-feature behaviour on every path. |
-| `codingKnowledge.decisionRecords` | `true` | Decision-record MCP tool + briefing titles (under the master gate). |
-| `codingKnowledge.architectureCard` | `true` | Architecture-card build/refresh + briefing injection. |
-| `codingKnowledge.sessionDelta` | `true` | Last-seen-head persistence + delta briefing line. |
+| `codingKnowledge.decisionRecords` | `true` | Advertises the `engram.coding_decision` MCP tool + HTTP route (under the master gate). |
+| `codingKnowledge.architectureCard` | `true` | Advertises the `engram.coding_architecture` MCP tool + HTTP route. |
+| `codingKnowledge.sessionDelta` | `true` | Advertises the `engram.coding_delta` MCP tool + HTTP route. |
 | `codingKnowledge.architectureCardLlmSummary` | `false` | Opt-in LLM summary pass on the architecture card (costs tokens). |
 | `codingKnowledge.structuralProvider` | `"none"` | `"none" \| "subprocess" \| "native"`. See [Structural provider (reserved)](#structural-provider-reserved). |
 | `codingKnowledge.structuralProviderCommand` | `""` | Absolute path to the subprocess provider binary (used only when `structuralProvider = "subprocess"`). |
@@ -60,8 +60,10 @@ deep-equal characterization test so the schema and the docs cannot drift.
 Boolean values are coerced at the parse boundary (so `--config
 codingKnowledge.enabled=false` arrives as `false`, not a truthy string). An
 unknown `structuralProvider` value is rejected listing the valid options
-(rule 51 — silent defaulting is a contract lie). Env overrides follow the
-`REMNIC_*` + `ENGRAM_*` fallback already used elsewhere in `config.ts`.
+(rule 51 — silent defaulting is a contract lie). Configuration is set via the
+plugin config object (`openclaw.json`); per-key `REMNIC_*` / `ENGRAM_*` environment
+overrides are **not** wired for `codingKnowledge` today — set the keys in the plugin
+config, not via env vars.
 
 The type lives in
 [`packages/remnic-core/src/types.ts`](../packages/remnic-core/src/types.ts)

--- a/docs/coding-knowledge.md
+++ b/docs/coding-knowledge.md
@@ -1,0 +1,313 @@
+# Coding knowledge (Track A)
+
+Issue [#1548](https://github.com/joshuaswarren/remnic/issues/1548) Track A
+ships durable, project-scoped coding knowledge inside `@remnic/core` with no
+new dependencies. Four memory-shaped features live under the `coding/`
+directory; this document is the single source of truth for what is
+implemented today.
+
+> One-source rule (#1527): namespace scoping, `resolveGitContext`, and the
+> file-path **review-context** recall tier are documented in
+> [Coding agent mode](coding-agent.md) and are not repeated here. Track A
+> composes with those surfaces; it does not redefine them.
+
+The features, all gated by the `codingKnowledge` config block:
+
+1. [Decision records](#decision-records) — standing architectural decisions
+   with a status lifecycle.
+2. [Architecture card](#architecture-card) — a deterministic, versioned
+   per-project overview.
+3. [Session delta](#session-delta) — "since you last worked here: N commits,
+   these files."
+4. [Structural provider (reserved)](#structural-provider-reserved) — the
+   config knob for symbol-anchored review-intent recall; the provider modules
+   ship in a follow-up PR.
+
+## Gate contract
+
+Every Track A surface obeys one rule: with the master gate off, behaviour is
+byte-for-byte identical to the pre-feature codebase on MCP `tools/list`, HTTP
+route registration, the briefing, recall, and the state directory (nothing is
+created). The per-feature switches are effective **only** under the master
+gate.
+
+Each feature has a single gate predicate, checked identically on every
+transport. The MCP `tools/list` visibility check evaluates the config-level
+conditions (master gate + feature switch) at construction time; the call-time
+gate re-checks those conditions **plus** a coding context (decision records,
+the architecture card, and the session delta all live *in* the coding
+namespace — [rule 42](coding-agent.md#overview)).
+
+## Config surface
+
+`codingKnowledge` is a nested object in the plugin config, parsed by
+[`coding/coding-knowledge-config.ts`](../packages/remnic-core/src/coding/coding-knowledge-config.ts).
+Defaults are declared in `CODING_KNOWLEDGE_DEFAULTS` and exercised by a
+deep-equal characterization test so the schema and the docs cannot drift.
+
+| Key | Default | Behavior |
+|-----|---------|----------|
+| `codingKnowledge.enabled` | `false` | Master gate. Off = pre-feature behaviour on every path. |
+| `codingKnowledge.decisionRecords` | `true` | Decision-record MCP tool + briefing titles (under the master gate). |
+| `codingKnowledge.architectureCard` | `true` | Architecture-card build/refresh + briefing injection. |
+| `codingKnowledge.sessionDelta` | `true` | Last-seen-head persistence + delta briefing line. |
+| `codingKnowledge.architectureCardLlmSummary` | `false` | Opt-in LLM summary pass on the architecture card (costs tokens). |
+| `codingKnowledge.structuralProvider` | `"none"` | `"none" \| "subprocess" \| "native"`. See [Structural provider (reserved)](#structural-provider-reserved). |
+| `codingKnowledge.structuralProviderCommand` | `""` | Absolute path to the subprocess provider binary (used only when `structuralProvider = "subprocess"`). |
+| `codingKnowledge.codegraphTools` | `false` | Gate for the 14 codegraph parity tools. See [Coding graph (Track B)](coding-graph.md). |
+| `codingKnowledge.codegraphDbDir` | `""` | Root for per-project graph SQLite DBs. Empty = derive from `memoryDir`. |
+
+Boolean values are coerced at the parse boundary (so `--config
+codingKnowledge.enabled=false` arrives as `false`, not a truthy string). An
+unknown `structuralProvider` value is rejected listing the valid options
+(rule 51 — silent defaulting is a contract lie). Env overrides follow the
+`REMNIC_*` + `ENGRAM_*` fallback already used elsewhere in `config.ts`.
+
+The type lives in
+[`packages/remnic-core/src/types.ts`](../packages/remnic-core/src/types.ts)
+(`CodingKnowledgeConfig`).
+
+## Decision records
+
+Standing architectural decisions stored as markdown + YAML frontmatter under
+the coding namespace, so QMD hybrid search finds them for free and the normal
+persist pipeline fires catalog recording, reindex, and dedup (no direct `fs`
+writes of memory content).
+
+Pure contract: [`coding/decision-records.ts`](../packages/remnic-core/src/coding/decision-records.ts).
+Surfaces: [`coding/decision-surfaces.ts`](../packages/remnic-core/src/coding/decision-surfaces.ts).
+
+### Record shape
+
+```text
+id            stable identifier (typically ADR-XXXX); must be unique
+title         one-line summary surfaced in briefings and `list` output
+status        "proposed" | "accepted" | "superseded" | "rejected"
+context       the problem / context the decision addresses
+decision      the decision itself
+consequences  trade-offs, follow-ups (optional, free-form)
+entityRefs    entity ids / doc anchors / code paths (may be empty)
+supersedes    the record this one replaces (set by `supersede`, never by hand)
+```
+
+Status lifecycle:
+
+- `ACTIVE_DECISION_STATUSES = { "proposed", "accepted" }` — the statuses
+  surfaced in standing-decisions lists and briefing titles. `superseded` and
+  `rejected` are intentionally excluded; the `supersedes` edge tells callers
+  what to fall back to.
+- A record whose frontmatter omits `status` defaults to `"proposed"`, never
+  `"accepted"` (rule 48 — accepting a decision is a deliberate action).
+- `supersede(a → b)` writes `b` to disk **before** flipping `a.status` to
+  `"superseded"` (rule 25 — a crash between the two writes leaves the new
+  decision discoverable, not nothing).
+
+### Surfaces
+
+All three transports dispatch through the `coding_decision` boundary
+operation, which calls one shared handler. Invalid subcommands throw listing
+the valid options; an unknown decision id returns an explicit not-found, never
+an empty success.
+
+| Transport | Surface |
+|-----------|---------|
+| MCP tool | `engram.coding_decision` (alias `remnic.coding_decision`) |
+| HTTP route | `POST /engram/v1/coding/decisions` |
+| MCP `tools/list` visibility | advertised only when `enabled && decisionRecords` |
+
+Subcommands: `list`, `get`, `record`, `supersede`.
+
+MCP tool call (option 1 — `record` a new decision):
+
+```json
+{
+  "tool": "engram.coding_decision",
+  "subcommand": "record",
+  "sessionKey": "string",
+  "id": "ADR-0007",
+  "title": "Use web-tree-sitter, not native bindings",
+  "status": "accepted",
+  "context": "Native node-tree-sitter repeats the better-sqlite3 binding pain.",
+  "decision": "Adopt web-tree-sitter (WASM) grammars.",
+  "consequences": "~2-3x slower parsing; measured by the bench harness.",
+  "entityRefs": ["packages/coding-graph"]
+}
+```
+
+MCP tool call (option 2 — `supersede`):
+
+```json
+{
+  "tool": "engram.coding_decision",
+  "subcommand": "supersede",
+  "sessionKey": "string",
+  "id": "ADR-0008",
+  "title": "Use native bindings after all",
+  "status": "accepted",
+  "context": "Benchmarks showed parsing was the bottleneck.",
+  "decision": "Switch to native node-tree-sitter.",
+  "supersedesId": "ADR-0007"
+}
+```
+
+HTTP equivalent:
+
+```bash
+curl -s -X POST http://127.0.0.1:4318/engram/v1/coding/decisions \
+  -H "Authorization: Bearer $REMNIC_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"subcommand":"list","sessionKey":"string"}'
+```
+
+## Architecture card
+
+A compact, byte-stable markdown overview of a repository: known manifests,
+top-level directories, a language histogram by extension, and entry points
+derived from manifests. The deterministic card is useful on its own; an
+optional LLM summary pass (gated by `architectureCardLlmSummary`) can prepend
+a human-readable overview using the existing extraction engine — on LLM
+failure the deterministic card ships unchanged (rule 13).
+
+Pure builder: [`coding/architecture-card.ts`](../packages/remnic-core/src/coding/architecture-card.ts).
+Surfaces: [`coding/architecture-surfaces.ts`](../packages/remnic-core/src/coding/architecture-surfaces.ts).
+
+### Properties
+
+- **Byte-stable** — every multi-value field is sorted before serialising, so
+  two runs over the same fixture produce byte-identical output (rule 38).
+- **Size-capped** — `ARCHITECTURE_CARD_MAX_BYTES = 4096`. When the card
+  exceeds the cap it is truncated with a visible marker
+  (`ARCHITECTURE_CARD_TRUNCATION_MARKER`) so consumers know information was
+  elided (rule 34 — never silently incomplete).
+- **LLM summary capped** — the summary prefix is clamped to
+  `ARCHITECTURE_CARD_MAX_SUMMARY_BYTES = 1024` so a misbehaving summariser
+  cannot crowd out the deterministic sections.
+- **Privacy + speed** — file *contents* are never read except for manifest
+  files.
+- **Versioned** — each refresh snapshots the prior content via
+  `page-versioning.ts` before overwriting (rule 25), giving snapshot/diff/
+  revert for free.
+
+Known manifest files the scanner parses for project metadata and entry
+points: `package.json`, `Cargo.toml`, `go.mod`, `pyproject.toml`, `setup.py`,
+`pom.xml`, `build.gradle`, `build.gradle.kts`, `Gemfile`, `composer.json`,
+`mix.exs`, `deno.json`. Directories skipped by the scanner (`node_modules`,
+`.git`, `vendor`, `dist`, `build`, `__pycache__`, venvs, …) are declared in
+`SCAN_IGNORE_DIRS`.
+
+### Surfaces
+
+| Transport | Surface |
+|-----------|---------|
+| MCP tool | `engram.coding_architecture` (alias `remnic.coding_architecture`) |
+| HTTP route | `POST /engram/v1/coding/architecture` |
+| MCP `tools/list` visibility | advertised only when `enabled && architectureCard` |
+
+Subcommands: `get` (return the current card or not-found), `refresh` (build a
+fresh card from the repo, snapshot the prior version, persist it).
+
+MCP tool call:
+
+```json
+{
+  "tool": "engram.coding_architecture",
+  "subcommand": "refresh",
+  "sessionKey": "string"
+}
+```
+
+## Session delta
+
+Tells a returning agent what changed since the last session in the same coding
+namespace: commits, touched files, and a one-line summary. The differ is a
+pure function over a `GitLogSlice`; the caller supplies the slice from a real
+git invoker (reusing the 2-second-per-call timeout discipline from
+`coding/git-context.ts`).
+
+Pure differ: [`coding/session-delta.ts`](../packages/remnic-core/src/coding/session-delta.ts).
+Surfaces: [`coding/session-delta-surfaces.ts`](../packages/remnic-core/src/coding/session-delta-surfaces.ts).
+
+### Behaviour
+
+- The `get` subcommand computes the delta against the persisted last-seen head
+  **and** updates the marker in the same call, so the *next* session sees this
+  one as the baseline.
+- A first session (no prior state) produces no delta section **and** initialises
+  the state — it never claims "0 changes".
+- An unchanged repo (prior head == current head) suppresses the "no changes"
+  line rather than rendering it.
+- A prior head missing from the repo (force-push/rebase) is surfaced as a
+  tagged `{ ok: false, code: "unreachable_head" }` outcome handled as "delta
+  unavailable", never a crash.
+- Results are capped (`MAX_DELTA_COMMITS`, `MAX_DELTA_FILES`; the `slice(-n)`
+  caps guard against `n === 0` — rule 27). The uncapped commit total is also
+  reported so summaries never under-report on large repos.
+- State writes are temp-file-then-rename (rule 54) and the new last-seen-head
+  is persisted **after** the delta is computed from the old one (rule 25).
+- State location: `<memoryDir>/state/coding-knowledge/<sanitized-namespace>.json`
+  (the namespace is already sanitized by the coding-namespace router;
+  `sanitizeFragment` is reused defensively).
+
+### Surfaces
+
+| Transport | Surface |
+|-----------|---------|
+| MCP tool | `engram.coding_delta` (alias `remnic.coding_delta`) |
+| HTTP route | `POST /engram/v1/coding/delta` |
+| MCP `tools/list` visibility | advertised only when `enabled && sessionDelta` |
+
+Subcommand: `get` (read-only semantically; it mutates only the operator-side
+state file, which is uncounted bookkeeping — the same way `calibration.ts`
+writes are uncounted).
+
+MCP tool call:
+
+```json
+{
+  "tool": "engram.coding_delta",
+  "subcommand": "get",
+  "sessionKey": "string"
+}
+```
+
+## Structural provider (reserved)
+
+The `structuralProvider` knob selects how review-intent recall expands a diff
+to affected *symbols* (not just file paths). It is the architectural boundary
+between Track A and the native [coding-graph engine](coding-graph.md) (Track
+B): the native engine (`"native"`) and an external binary (`"subprocess"`)
+are both providers of the same port.
+
+| Value | Behavior |
+|-------|----------|
+| `"none"` (default) | No provider consulted. Review-intent recall runs **file-path-only** boosting, identical to the [review-context tier](coding-agent.md#review-context-recall-tier) shipped in #569. |
+| `"subprocess"` | Reserved: shell out to `structuralProviderCommand` via `execFile` (argv array, never a shell string). |
+| `"native"` | Reserved: adapt the `@remnic/coding-graph` engine to the port. |
+
+The config field is parsed and validated today; the provider modules
+themselves (the port interface, the subprocess provider, the native adapter)
+ship in a follow-up PR. **Until then, review-intent recall is file-path-only
+regardless of this setting** — setting `structuralProvider` to `"subprocess"`
+or `"native"` is accepted by the parser but has no effect on recall. This is
+documented honestly rather than implied.
+
+## Diagnostics
+
+`remnic doctor` renders the effective coding scope (see
+[Coding agent mode](coding-agent.md#remnic-doctor-output)). The three Track A
+features are accessed through their [MCP tools and HTTP routes](#gate-contract)
+today; automatic injection of the architecture card, session-delta line, and
+decision titles into the daily briefing is reserved for a follow-up PR (the
+design calls for a single `buildCodingKnowledgeBriefingSection` injection
+helper so future additions have one chokepoint). With the master gate off,
+behaviour is byte-identical to pre-feature on every path.
+
+## Related reading
+
+- [Coding agent mode](coding-agent.md) — namespace scoping, `resolveGitContext`,
+  and the file-path review-context recall tier Track A composes with.
+- [Coding graph (Track B)](coding-graph.md) — the native codebase-graph engine;
+  `manage_adr` and `get_architecture` compose Track A's records and card with
+  live graph stats.
+- [`packages/remnic-core/src/coding/`](../packages/remnic-core/src/coding/) —
+  the pure modules and their contract tests.

--- a/docs/coding-knowledge.md
+++ b/docs/coding-knowledge.md
@@ -119,14 +119,15 @@ an empty success.
 
 Subcommands: `list`, `get`, `record`, `supersede`.
 
-MCP tool call (option 1 — `record` a new decision):
+MCP tool call (option 1 — `record` a new decision). The handler ignores any
+caller-supplied `id` and generates its own canonical id; the response returns
+`{ memoryId, status }`, and that `memoryId` is what `get`/`supersede` use later:
 
 ```json
 {
   "tool": "engram.coding_decision",
   "subcommand": "record",
   "sessionKey": "string",
-  "id": "ADR-0007",
   "title": "Use web-tree-sitter, not native bindings",
   "status": "accepted",
   "context": "Native node-tree-sitter repeats the better-sqlite3 binding pain.",
@@ -136,19 +137,20 @@ MCP tool call (option 1 — `record` a new decision):
 }
 ```
 
-MCP tool call (option 2 — `supersede`):
+MCP tool call (option 2 — `supersede`). `id` (or its alias `supersedesId`)
+names the **existing** record being retired; the replacement is built from
+`title`/`decision`/`context`. The response returns
+`{ supersededMemoryId, replacementMemoryId }`:
 
 ```json
 {
   "tool": "engram.coding_decision",
   "subcommand": "supersede",
   "sessionKey": "string",
-  "id": "ADR-0008",
+  "id": "decision-a1b2c3",
   "title": "Use native bindings after all",
-  "status": "accepted",
   "context": "Benchmarks showed parsing was the bottleneck.",
-  "decision": "Switch to native node-tree-sitter.",
-  "supersedesId": "ADR-0007"
+  "decision": "Switch to native node-tree-sitter."
 }
 ```
 


### PR DESCRIPTION
Part of #1548 (Track A PR 6 — Documentation section). Closes the missing documentation deliverable.

## What

Two new single-source-of-truth docs, each covering what is **actually implemented** today (grepped from `packages/remnic-core/src/coding/` + the merged Track A/B PRs), linked from `docs/coding-agent.md`.

### `docs/coding-knowledge.md` — the four Track A features
- **Decision records** — `DecisionRecord` shape, status lifecycle (`proposed → accepted → superseded → rejected`), `ACTIVE_DECISION_STATUSES`, supersede ordering (rule 25), `engram.coding_decision` (`list|get|record|supersede`) + `POST /engram/v1/coding/decisions`.
- **Architecture card** — deterministic builder, 4096-byte cap, 12 known manifests, `architectureCardLlmSummary` opt-in, page-versioned refresh, `engram.coding_architecture` (`get|refresh`) + HTTP route.
- **Session delta** — pure differ, tagged outcomes (`unreachable_head`, `git_error`), temp-file-then-rename state, caps, `engram.coding_delta` (`get`) + HTTP route.
- **Structural provider** — config knob parsed/validated (`none|subprocess|native`); provider modules **reserved for a follow-up PR** (Track A PR5 not merged) — documented honestly, not implied.
- Config table traced to `CODING_KNOWLEDGE_DEFAULTS`; MCP tools + HTTP routes traced to `access-surface-catalog.ts`.

### `docs/coding-graph.md` — the `@remnic/coding-graph` engine (Track B)
- Install + computed-specifier loader + WASM (not native) rationale.
- Gating via `codingKnowledge.codegraphTools` (there is **no** `codingGraph` plugin config block — documented accurately).
- The **14 `codegraph_*` parity tools** (`manage_adr`/`get_architecture` compose Track A — rule 22).
- Graph schema (13 node labels, 4 provenance tags), `detect_changes` blast radius + risk rubric, dead-code detection, openCypher read subset (grammar, variable-length paths, read-only).
- LSP + semantic layers (engine-API config, default off, privacy posture).
- **Performance numbers traced ONLY to `packages/bench/baselines/coding-graph-baseline.json`** (Apple M2 Max, 20-file fixture, seed 42) — every metric cited verbatim from the artifact, no invented numbers; scale *targets* clearly labelled as unmeasured.

### `docs/coding-agent.md`
One-line intro pointer + two `Related reading` links. No document paraphrases another (#1527 one-source rule).

## Accuracy notes
- The coding features are surfaced via **MCP tools + HTTP routes**, not CLI subcommands — so no `remnic <coding-cmd>` appears in any fenced block (docs-parity-safe by construction).
- Track A PR5 (structural-context provider port + subprocess provider) is **not merged** — only the `structuralProvider` config field exists; the doc says so explicitly.
- Briefing injection of coding-knowledge content is **not wired** (`buildCodingKnowledgeBriefingSection` does not exist; `briefing.ts` has no coding refs) — the doc states this is reserved for a follow-up.

## Gates
- `node scripts/check-docs-parity.mjs` → **OK** (40 documented commands resolve; 1 no-op tracked; 2 stub publishers honest).
- Docs-only change: no source touched, ratchets unaffected, no god-file edits.

Chokepoints used / not applicable: n/a (documentation only; no code paths). Standards: #1520, #1527 (one-source rule).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no source or config behavior modified; main risk is doc inaccuracy, which the PR description claims is parity-checked.
> 
> **Overview**
> Closes the #1548 documentation gap with **two new single-source docs** and small **cross-links** in `docs/coding-agent.md`, following the one-source rule (#1527).
> 
> **`docs/coding-knowledge.md` (Track A)** documents the `codingKnowledge` config gate, decision records (`engram.coding_decision` + HTTP), the deterministic architecture card, session delta behavior/state, and the **reserved** `structuralProvider` knob (no provider modules yet). It also states that briefing injection is **not wired** today.
> 
> **`docs/coding-graph.md` (Track B)** documents optional `@remnic/coding-graph` install/loader, gating via `codingKnowledge.codegraphTools` (no separate `codingGraph` config block), the **14** `engram.codegraph_*` parity tools, schema/query/LSP/semantic layers, and performance numbers **only** from `packages/bench/baselines/coding-graph-baseline.json`. It explicitly notes **`codegraph_detect_changes` currently returns an empty affected set** until diff + fresh-parse wiring lands.
> 
> **`docs/coding-agent.md`** gains a short intro pointer to Track A/B and two **Related reading** links; existing namespace/review-context content is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a337ddb14ea334453035cca52baea9abe9c5e4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->