### PR TITLE
refactor(caps): #1523 batch 3 — lifecycle/temporal/extraction/embedding flags

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5,6 +5,7 @@ import { readdirSync, unlinkSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
+import { resolveMemoryLifecycleCapabilities } from "./capabilities.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
@@ -8187,7 +8188,7 @@ export class EngramAccessService {
 
   get embeddingLookupFactoryRef(): (storage: import("./storage.js").StorageManager) => SemanticDedupLookup | undefined {
     return (storage) => {
-      if (!this.orchestrator.config.embeddingFallbackEnabled) return undefined;
+      if (!resolveMemoryLifecycleCapabilities(this.orchestrator.config).embeddingFallback) return undefined;
       return async (content: string, limit: number) => {
         try {
           return await this.orchestrator.semanticDedupLookup(content, limit, storage);

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -153,6 +153,12 @@ import {
   type GraphConstructionCapabilitySet,
 } from "./capabilities.js";
 
+import {
+  resolveMemoryLifecycleCapabilities,
+  type MemoryLifecycleCapabilitySet,
+} from "./capabilities.js";
+
+
 const GRAPH_FIELD_TO_FLAG: Record<keyof GraphConstructionCapabilitySet, string> = {
   entityGraph: "entityGraphEnabled",
   timeGraph: "timeGraphEnabled",
@@ -304,5 +310,149 @@ test("resolveGraphConstructionCapabilities matches pre-migration config reads (p
       config.graphWriteSessionAdjacencyEnabled !== false,
       `[${label}] graphWriteSessionAdjacency parity (must match !== false)`,
     );
+  }
+});
+
+
+// ---------------------------------------------------------------------------
+// MemoryLifecycleCapabilitySet — gate-parity tests (issue #1523 batch 3).
+//
+// Same invariant as the sets above: every caps field must project from its
+// `<field>Enabled` config flag, so a future edit that maps a field to the wrong
+// flag fails loudly here. All ten flags are required booleans on PluginConfig
+// (defaults resolved at the parse boundary), so the projection is a pure
+// passthrough — no optional-default variants needed.
+//
+// Parity contract: a caps-resolved run and a config-derived run MUST produce
+// identical boolean values for every gate — on AND off.
+// ---------------------------------------------------------------------------
+
+const LIFECYCLE_FIELD_TO_FLAG: Record<keyof MemoryLifecycleCapabilitySet, string> = {
+  temporalSupersession: "temporalSupersessionEnabled",
+  temporalMemoryTree: "temporalMemoryTreeEnabled",
+  lifecyclePolicy: "lifecyclePolicyEnabled",
+  lifecycleFilterStale: "lifecycleFilterStaleEnabled",
+  lifecycleMetrics: "lifecycleMetricsEnabled",
+  extractionScopeClassification: "extractionScopeClassificationEnabled",
+  extractionJudge: "extractionJudgeEnabled",
+  extractionDedupe: "extractionDedupeEnabled",
+  extractionTelemetryPrefilter: "extractionTelemetryPrefilterEnabled",
+  extractionJudgeTelemetry: "extractionJudgeTelemetryEnabled",
+};
+
+const LIFECYCLE_FIELDS = Object.keys(LIFECYCLE_FIELD_TO_FLAG) as Array<
+  keyof MemoryLifecycleCapabilitySet
+>;
+
+test("resolveMemoryLifecycleCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(LIFECYCLE_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveMemoryLifecycleCapabilities(config);
+
+  for (const field of LIFECYCLE_FIELDS) {
+    const flag = LIFECYCLE_FIELD_TO_FLAG[field];
+    assert.equal(
+      caps[field],
+      (config as unknown as Record<string, boolean>)[flag],
+      `caps.${field} must equal config.${flag} (true variant)`,
+    );
+    assert.equal(caps[field], true, `caps.${field} should be true here`);
+  }
+});
+
+test("resolveMemoryLifecycleCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(LIFECYCLE_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveMemoryLifecycleCapabilities(config);
+
+  for (const field of LIFECYCLE_FIELDS) {
+    const flag = LIFECYCLE_FIELD_TO_FLAG[field];
+    assert.equal(
+      caps[field],
+      (config as unknown as Record<string, boolean>)[flag],
+      `caps.${field} must equal config.${flag} (false variant)`,
+    );
+    assert.equal(caps[field], false, `caps.${field} should be false here`);
+  }
+});
+
+test("resolveMemoryLifecycleCapabilities returns a frozen object", () => {
+  const config = parseConfig({});
+  const caps = resolveMemoryLifecycleCapabilities(config);
+  assert.equal(Object.isFrozen(caps), true);
+});
+
+test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (parity contract)", () => {
+  // For representative on/off combinations, the caps-resolved values MUST be
+  // identical to what the old scattered `this.config.<flag>Enabled` reads
+  // produced. All ten flags used bare reads (no `!== false`/`=== true` at the
+  // call site that would change the value — the two sites that wrote
+  // `=== true` were redundant coercion on an already-boolean config field),
+  // so parity is a direct equality against the resolved config boolean.
+  const cases: Record<string, Record<string, boolean>> = {
+    "all-off": {
+      temporalSupersessionEnabled: false,
+      temporalMemoryTreeEnabled: false,
+      lifecyclePolicyEnabled: false,
+      lifecycleFilterStaleEnabled: false,
+      lifecycleMetricsEnabled: false,
+      extractionScopeClassificationEnabled: false,
+      extractionJudgeEnabled: false,
+      extractionDedupeEnabled: false,
+      extractionTelemetryPrefilterEnabled: false,
+      extractionJudgeTelemetryEnabled: false,
+    },
+    "all-on": {
+      temporalSupersessionEnabled: true,
+      temporalMemoryTreeEnabled: true,
+      lifecyclePolicyEnabled: true,
+      lifecycleFilterStaleEnabled: true,
+      lifecycleMetricsEnabled: true,
+      extractionScopeClassificationEnabled: true,
+      extractionJudgeEnabled: true,
+      extractionDedupeEnabled: true,
+      extractionTelemetryPrefilterEnabled: true,
+      extractionJudgeTelemetryEnabled: true,
+    },
+    "temporal-on-rest-off": {
+      temporalSupersessionEnabled: true,
+      temporalMemoryTreeEnabled: true,
+      lifecyclePolicyEnabled: false,
+      lifecycleFilterStaleEnabled: false,
+      lifecycleMetricsEnabled: false,
+      extractionScopeClassificationEnabled: false,
+      extractionJudgeEnabled: false,
+      extractionDedupeEnabled: false,
+      extractionTelemetryPrefilterEnabled: false,
+      extractionJudgeTelemetryEnabled: false,
+    },
+    "extraction-on-rest-off": {
+      temporalSupersessionEnabled: false,
+      temporalMemoryTreeEnabled: false,
+      lifecyclePolicyEnabled: false,
+      lifecycleFilterStaleEnabled: false,
+      lifecycleMetricsEnabled: false,
+      extractionScopeClassificationEnabled: true,
+      extractionJudgeEnabled: true,
+      extractionDedupeEnabled: true,
+      extractionTelemetryPrefilterEnabled: true,
+      extractionJudgeTelemetryEnabled: true,
+    },
+  };
+
+  for (const [label, overrides] of Object.entries(cases)) {
+    const config = parseConfig(overrides);
+    const caps = resolveMemoryLifecycleCapabilities(config);
+
+    for (const field of LIFECYCLE_FIELDS) {
+      const flag = LIFECYCLE_FIELD_TO_FLAG[field];
+      assert.equal(
+        caps[field],
+        (config as unknown as Record<string, boolean>)[flag],
+        `[${label}] caps.${field} must equal config.${flag}`,
+      );
+    }
   }
 });

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -338,6 +338,7 @@ const LIFECYCLE_FIELD_TO_FLAG: Record<keyof MemoryLifecycleCapabilitySet, string
   extractionDedupe: "extractionDedupeEnabled",
   extractionTelemetryPrefilter: "extractionTelemetryPrefilterEnabled",
   extractionJudgeTelemetry: "extractionJudgeTelemetryEnabled",
+  embeddingFallback: "embeddingFallbackEnabled",
 };
 
 const LIFECYCLE_FIELDS = Object.keys(LIFECYCLE_FIELD_TO_FLAG) as Array<
@@ -403,6 +404,7 @@ test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (par
       extractionDedupeEnabled: false,
       extractionTelemetryPrefilterEnabled: false,
       extractionJudgeTelemetryEnabled: false,
+      embeddingFallbackEnabled: false,
     },
     "all-on": {
       temporalSupersessionEnabled: true,
@@ -415,6 +417,7 @@ test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (par
       extractionDedupeEnabled: true,
       extractionTelemetryPrefilterEnabled: true,
       extractionJudgeTelemetryEnabled: true,
+      embeddingFallbackEnabled: true,
     },
     "temporal-on-rest-off": {
       temporalSupersessionEnabled: true,
@@ -427,6 +430,7 @@ test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (par
       extractionDedupeEnabled: false,
       extractionTelemetryPrefilterEnabled: false,
       extractionJudgeTelemetryEnabled: false,
+      embeddingFallbackEnabled: false,
     },
     "extraction-on-rest-off": {
       temporalSupersessionEnabled: false,
@@ -439,6 +443,7 @@ test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (par
       extractionDedupeEnabled: true,
       extractionTelemetryPrefilterEnabled: true,
       extractionJudgeTelemetryEnabled: true,
+      embeddingFallbackEnabled: true,
     },
   };
 

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -248,6 +248,8 @@ export interface MemoryLifecycleCapabilitySet {
   readonly extractionTelemetryPrefilter: boolean;
   /** `extractionJudgeTelemetryEnabled` — collect judge verdict telemetry. */
   readonly extractionJudgeTelemetry: boolean;
+  /** `embeddingFallbackEnabled` — semantic-dedup / archive-search embedding fallback. */
+  readonly embeddingFallback: boolean;
 }
 
 /**
@@ -265,6 +267,7 @@ export type MemoryLifecycleConfigProjection = Pick<
   | "extractionDedupeEnabled"
   | "extractionTelemetryPrefilterEnabled"
   | "extractionJudgeTelemetryEnabled"
+  | "embeddingFallbackEnabled"
 >;
 
 /**
@@ -288,5 +291,6 @@ export function resolveMemoryLifecycleCapabilities(
     extractionDedupe: config.extractionDedupeEnabled,
     extractionTelemetryPrefilter: config.extractionTelemetryPrefilterEnabled,
     extractionJudgeTelemetry: config.extractionJudgeTelemetryEnabled,
+    embeddingFallback: config.embeddingFallbackEnabled,
   });
 }

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -203,3 +203,90 @@ export function resolveAccessSetupCapabilities(
     recallAuditAnomalyDetection: config.recallAuditAnomalyDetectionEnabled === true,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Memory-lifecycle capability set (issue #1523 batch 3).
+//
+// The flags below gate memory WRITE/EXTRACTION (extraction judge, scope
+// classification, dedupe, telemetry prefilter), temporal supersession of
+// stored facts, and the lifecycle policy pass (promotion / decay / stale
+// filtering). They are read on the persistExtraction write path, the recall
+// candidate-filter path, and the maintenance / lifecycle-pass path — so, like
+// the graph-construction set above, they get their own projection resolved
+// ONCE at each operation entry that reads them (never re-derived from raw
+// config mid-operation — the gate-divergence defect class #1523 targets).
+//
+// Every field projects from an already-resolved PluginConfig boolean (defaults
+// are applied at the config-parse boundary, rule 36), so the resolver is a
+// pure projection — no `!== false` / `=== true` re-coercion here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of memory-lifecycle feature gates (issue #1523 batch 3).
+ *
+ * Resolved once per write / recall-filter / maintenance operation and threaded
+ * down. Composition lives ONLY in {@link resolveMemoryLifecycleCapabilities}.
+ */
+export interface MemoryLifecycleCapabilitySet {
+  /** `temporalSupersessionEnabled` — supersede stale structured facts on write, filter on recall. */
+  readonly temporalSupersession: boolean;
+  /** `temporalMemoryTreeEnabled` — temporal-memory-tree build + recall tier. */
+  readonly temporalMemoryTree: boolean;
+  /** `lifecyclePolicyEnabled` — lifecycle promotion / decay metadata pass. */
+  readonly lifecyclePolicy: boolean;
+  /** `lifecycleFilterStaleEnabled` — filter stale-lifecycle memories from recall. */
+  readonly lifecycleFilterStale: boolean;
+  /** `lifecycleMetricsEnabled` — emit lifecycle-pass metrics. */
+  readonly lifecycleMetrics: boolean;
+  /** `extractionScopeClassificationEnabled` — LLM classifies each fact's scope. */
+  readonly extractionScopeClassification: boolean;
+  /** `extractionJudgeEnabled` — LLM-as-judge fact-worthiness gate. */
+  readonly extractionJudge: boolean;
+  /** `extractionDedupeEnabled` — dedupe against recent extractions. */
+  readonly extractionDedupe: boolean;
+  /** `extractionTelemetryPrefilterEnabled` — skip mechanical-telemetry transcripts. */
+  readonly extractionTelemetryPrefilter: boolean;
+  /** `extractionJudgeTelemetryEnabled` — collect judge verdict telemetry. */
+  readonly extractionJudgeTelemetry: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveMemoryLifecycleCapabilities}.
+ */
+export type MemoryLifecycleConfigProjection = Pick<
+  PluginConfig,
+  | "temporalSupersessionEnabled"
+  | "temporalMemoryTreeEnabled"
+  | "lifecyclePolicyEnabled"
+  | "lifecycleFilterStaleEnabled"
+  | "lifecycleMetricsEnabled"
+  | "extractionScopeClassificationEnabled"
+  | "extractionJudgeEnabled"
+  | "extractionDedupeEnabled"
+  | "extractionTelemetryPrefilterEnabled"
+  | "extractionJudgeTelemetryEnabled"
+>;
+
+/**
+ * Resolve the {@link MemoryLifecycleCapabilitySet} from parsed config.
+ *
+ * Call this ONCE per write / recall-filter / maintenance operation entry and
+ * thread the result down — exactly the pattern {@link resolveCapabilities}
+ * established for recall.
+ */
+export function resolveMemoryLifecycleCapabilities(
+  config: MemoryLifecycleConfigProjection,
+): MemoryLifecycleCapabilitySet {
+  return Object.freeze({
+    temporalSupersession: config.temporalSupersessionEnabled,
+    temporalMemoryTree: config.temporalMemoryTreeEnabled,
+    lifecyclePolicy: config.lifecyclePolicyEnabled,
+    lifecycleFilterStale: config.lifecycleFilterStaleEnabled,
+    lifecycleMetrics: config.lifecycleMetricsEnabled,
+    extractionScopeClassification: config.extractionScopeClassificationEnabled,
+    extractionJudge: config.extractionJudgeEnabled,
+    extractionDedupe: config.extractionDedupeEnabled,
+    extractionTelemetryPrefilter: config.extractionTelemetryPrefilterEnabled,
+    extractionJudgeTelemetry: config.extractionJudgeTelemetryEnabled,
+  });
+}

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4,6 +4,7 @@ import { access, lstat, readFile, readdir, realpath, unlink } from "node:fs/prom
 import { createHash } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 import type { Orchestrator } from "./orchestrator.js";
+import { resolveMemoryLifecycleCapabilities } from "./capabilities.js";
 import { ThreadingManager } from "./threading.js";
 import { utcDayRange } from "./transcript.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
@@ -3728,7 +3729,7 @@ export function registerCli(
           console.log("=== Extraction Judge Verdict Stats ===\n");
           console.log(`Total verdicts: ${stats.total}`);
           if (stats.total === 0) {
-            if (!orchestrator.config.extractionJudgeTelemetryEnabled) {
+            if (!resolveMemoryLifecycleCapabilities(orchestrator.config).extractionJudgeTelemetry) {
               console.log(
                 "\nNote: extractionJudgeTelemetryEnabled is OFF. Enable it in plugin config to collect verdict telemetry.",
               );
@@ -8541,7 +8542,7 @@ export function registerCli(
             config: orchestrator.config,
             memoryDir: orchestrator.config.memoryDir,
             embeddingLookupFactory: (storage) => {
-              if (!orchestrator.config.embeddingFallbackEnabled) return undefined;
+              if (!resolveMemoryLifecycleCapabilities(orchestrator.config).embeddingFallback) return undefined;
               return async (content: string, limit: number) => {
                 try {
                   return await orchestrator.semanticDedupLookup(content, limit, storage);

--- a/packages/remnic-core/src/embedding-fallback.ts
+++ b/packages/remnic-core/src/embedding-fallback.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { log } from "./logger.js";
+import { resolveMemoryLifecycleCapabilities } from "./capabilities.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { PluginConfig } from "./types.js";
 import {
@@ -397,7 +398,7 @@ export class EmbeddingFallback {
   private async resolveProvider(
     options: { includeHost?: boolean } = {},
   ): Promise<ProviderConfig | null> {
-    if (!this.config.embeddingFallbackEnabled) return null;
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) return null;
 
     if (
       options.includeHost !== false &&

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -38,6 +38,7 @@ import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
 import { looksLikeMechanicalTelemetryTranscript } from "./telemetry-transcript.js";
 import { buildFactProvenance, type ProvenanceTurnInput } from "./provenance.js";
+import { resolveMemoryLifecycleCapabilities } from "./capabilities.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
@@ -1055,6 +1056,7 @@ export class ExtractionEngine {
   }
 
   async extract(turns: BufferTurn[], existingEntities?: string[]): Promise<ExtractionResult> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
 
     // Guard: skip if buffer is empty or all turns are whitespace-only
     const substantiveTurns = turns.filter((t) => t.content.trim().length > 0);
@@ -1083,7 +1085,7 @@ export class ExtractionEngine {
       return { facts: [], profileUpdates: [], entities: [], questions: [] };
     }
     if (
-      this.config.extractionTelemetryPrefilterEnabled &&
+      lifecycleCaps.extractionTelemetryPrefilter &&
       looksLikeMechanicalTelemetryTranscript(conversation)
     ) {
       log.debug("extraction skipped — mechanical action/state telemetry without durable-memory cues");
@@ -1331,6 +1333,7 @@ export class ExtractionEngine {
    * Uses a minimal prompt to fit within local model context limits (typically 4k-8k).
    */
   private async extractWithLocalLlm(conversation: string, existingEntities?: string[]): Promise<ExtractionResult | null> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     log.debug(
       `extractWithLocalLlm: starting extraction, localLlmEnabled=${this.shouldUseLocalLlm}, model=${this.config.localLlmModel}`,
     );
@@ -1406,7 +1409,7 @@ These are durable insights - capture them:
 - CRITICAL: Use canonical hyphenated entity names (e.g., "jane-doe" not "janedoe")
 - CRITICAL: NEVER extract the same fact twice - check for duplicates before adding to facts array
 - CRITICAL: NEVER extract cron job schedules, automation configurations, or system monitoring details (these are operational noise)
-- If uncertain about relevance, prefer NOT extracting${this.config.extractionScopeClassificationEnabled ? `
+- If uncertain about relevance, prefer NOT extracting${lifecycleCaps.extractionScopeClassification ? `
 - For each fact, set "scope" to "global" (cross-project knowledge: framework bugs, library behavior, user preferences, tool configs, general patterns) or "project" (codebase-specific: file paths, env configs, deployment details, project workarounds). When in doubt, prefer "project".` : ""}
 
 === Structured Attributes ===
@@ -1645,6 +1648,7 @@ Omit "eventTime" when the fact has no explicit temporal anchor — do NOT guess 
    * Build extraction instructions shared between local and cloud LLM.
    */
   private buildExtractionInstructions(existingEntities?: string[]): string {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     return `You are a memory extraction system. Analyze the following conversation and extract durable, reusable memories.
 
 Memory categories:
@@ -1681,7 +1685,7 @@ Rules:
   * Inferred (0.40-0.69): Pattern recognition — reasonable guess from limited evidence
   * Speculative (0.00-0.39): Tentative hypothesis — weak signal, needs future confirmation. Speculative memories auto-expire after 30 days if not confirmed.${this.config.provenance?.enabled ? `
 - Source quotes: For each fact, include a "quote" field containing the EXACT verbatim words from the conversation that support the fact. Copy a contiguous span from a single speaker turn (not a paraphrase, not a summary). Cap at ~300 characters. This grounds every memory in the literal utterance that created it.` : ""}
-- For commitments: include any deadline or timeframe mentioned${this.config.extractionScopeClassificationEnabled ? `
+- For commitments: include any deadline or timeframe mentioned${lifecycleCaps.extractionScopeClassification ? `
 
 Scope classification:
 For each fact, set "scope" to one of:

--- a/packages/remnic-core/src/maintenance/first-start-migration.ts
+++ b/packages/remnic-core/src/maintenance/first-start-migration.ts
@@ -18,6 +18,7 @@
 
 import path from "node:path";
 import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { resolveMemoryLifecycleCapabilities } from "../capabilities.js";
 import type { StorageManager } from "../storage.js";
 import type { PluginConfig } from "../types.js";
 import {
@@ -179,6 +180,7 @@ export async function runFirstStartMigration(
     signal,
   } = options;
   const now = (options.now ?? (() => new Date()))();
+  const lifecycleCaps = resolveMemoryLifecycleCapabilities(config);
   const abortedResult = (candidateCount = 0, demotedCount = 0, failureCount = 0): FirstStartMigrationResult => ({
     skipped: candidateCount === 0 && demotedCount === 0 && failureCount === 0,
     skipReason: candidateCount === 0 && demotedCount === 0 && failureCount === 0 ? "aborted" : undefined,
@@ -193,7 +195,7 @@ export async function runFirstStartMigration(
     return abortedResult();
   }
 
-  if (!config.lifecyclePolicyEnabled) {
+  if (!lifecycleCaps.lifecyclePolicy) {
     return {
       skipped: true,
       skipReason: "lifecyclePolicyEnabled is false",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -269,8 +269,10 @@ import { tryDirectAnswer, type DirectAnswerSources } from "./direct-answer-wirin
 import {
   resolveCapabilities,
   resolveGraphConstructionCapabilities,
+  resolveMemoryLifecycleCapabilities,
   type CapabilitySet,
   type GraphConstructionCapabilitySet,
+  type MemoryLifecycleCapabilitySet,
 } from "./capabilities.js";
 import { DEFAULT_TAXONOMY } from "./taxonomy/index.js";
 import {
@@ -3094,9 +3096,10 @@ export class Orchestrator {
     );
     // BoxBuilders are created per-namespace on first use in runExtraction().
 
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(config);
     // Temporal Memory Tree (v8.2) — lazy build during consolidation
     this.tmtBuilder = new TmtBuilder(config.memoryDir, {
-      temporalMemoryTreeEnabled: config.temporalMemoryTreeEnabled,
+      temporalMemoryTreeEnabled: lifecycleCaps.temporalMemoryTree,
       tmtHourlyMinMemories: config.tmtHourlyMinMemories,
       tmtSummaryMaxTokens: config.tmtSummaryMaxTokens,
     });
@@ -3654,6 +3657,7 @@ export class Orchestrator {
   }
 
   private async deferredInitialize(signal: AbortSignal): Promise<void> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
 
     // Sync QMD index with current disk state so recall finds recently-written
     // facts. Without this, the index stays stale from the last extraction-
@@ -3707,7 +3711,7 @@ export class Orchestrator {
           }),
       );
     }
-    if (this.config.embeddingFallbackEnabled) {
+    if (resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) {
       warmupPromises.push(
         this.embeddingFallback
           .isAvailable()
@@ -3792,7 +3796,7 @@ export class Orchestrator {
     // sweep (capped at 50 demotions) so the hot tier isn't flooded on the
     // first real cron pass. Non-fatal — a failure here must not break init.
     if (signal.aborted) return;
-    if (this.config.lifecyclePolicyEnabled && this.config.qmdTierMigrationEnabled) {
+    if (lifecycleCaps.lifecyclePolicy && this.config.qmdTierMigrationEnabled) {
       try {
         const { runFirstStartMigration } = await import(
           "./maintenance/first-start-migration.js"
@@ -4117,6 +4121,7 @@ export class Orchestrator {
    * default storage.
    */
   async runLifecyclePolicyFanout(): Promise<NamespaceMaintenanceSummary> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     return this.runNamespaceMaintenanceFanoutForJob(
       "lifecycle",
       async (ctx) => {
@@ -4125,7 +4130,7 @@ export class Orchestrator {
         const assessed = await this.runLifecyclePolicyPass(corpus, storage);
         return { itemCount: assessed };
       },
-      { enabled: this.config.lifecyclePolicyEnabled },
+      { enabled: lifecycleCaps.lifecyclePolicy },
     );
   }
 
@@ -7438,6 +7443,7 @@ export class Orchestrator {
     options: RecallInvocationOptions = {},
     caps: CapabilitySet = resolveCapabilities(this.config),
     graphCaps: GraphConstructionCapabilitySet = resolveGraphConstructionCapabilities(this.config),
+    lifecycleCaps: MemoryLifecycleCapabilitySet = resolveMemoryLifecycleCapabilities(this.config),
   ): Promise<string> {
     const recallStart = Date.now();
     // Backend degradations observed by this recall's QMD searches (#1536):
@@ -10845,9 +10851,9 @@ export class Orchestrator {
     if (
       this.isRecallSectionEnabled(
         "temporal-memory-tree",
-        this.config.temporalMemoryTreeEnabled === true,
+        lifecycleCaps.temporalMemoryTree,
       ) &&
-      this.config.temporalMemoryTreeEnabled &&
+      lifecycleCaps.temporalMemoryTree &&
       recallMode !== "minimal" &&
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
@@ -11707,7 +11713,7 @@ export class Orchestrator {
           // Using the shared gate fixes both Finding 2 and Finding 3 from
           // PR #402 (round 6).
           const supersessionOptions = {
-            enabled: this.config.temporalSupersessionEnabled,
+            enabled: lifecycleCaps.temporalSupersession,
             includeInRecall: this.config.temporalSupersessionIncludeInRecall,
           };
           // Cursor Medium on PR #713: when `as_of` is active, the
@@ -13231,7 +13237,8 @@ export class Orchestrator {
     turns: BufferTurn[],
     options: { commit?: boolean; bufferKey?: string } = {},
   ): boolean {
-    if (!this.config.extractionDedupeEnabled) return true;
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
+    if (!lifecycleCaps.extractionDedupe) return true;
     if (!Array.isArray(turns) || turns.length === 0) return false;
 
     const bufferKey = options.bufferKey ?? turns[0]?.sessionKey ?? "default";
@@ -14090,6 +14097,7 @@ export class Orchestrator {
     /** Verbatim source turn text the facts were extracted from (faithfulness gate #1576). */
     sourceText?: string,
     graphCaps: GraphConstructionCapabilitySet = resolveGraphConstructionCapabilities(this.config),
+    lifecycleCaps: MemoryLifecycleCapabilitySet = resolveMemoryLifecycleCapabilities(this.config),
   ): Promise<string[]> {
     // Inline source attribution (issue #369). When enabled, every extracted
     // fact is rewritten to carry a compact provenance tag inside its body so
@@ -14388,7 +14396,7 @@ export class Orchestrator {
             },
           );
           if (
-            this.config.temporalSupersessionEnabled &&
+            lifecycleCaps.temporalSupersession &&
             options.category === "fact" &&
             options.entityRef &&
             options.structuredAttributes &&
@@ -14552,7 +14560,7 @@ export class Orchestrator {
           // would have run post-writeMemory.  This is a best-effort / fail-open
           // step — if the lookup fails we skip silently (same as the normal path).
           if (
-            this.config.temporalSupersessionEnabled &&
+            lifecycleCaps.temporalSupersession &&
             options.entityRef &&
             options.structuredAttributes &&
             Object.keys(options.structuredAttributes).length > 0
@@ -14714,7 +14722,7 @@ export class Orchestrator {
         // shared recall continues returning the stale state.  Reuses the same
         // applyTemporalSupersession helper — no logic duplication.
         if (
-          this.config.temporalSupersessionEnabled &&
+          lifecycleCaps.temporalSupersession &&
           options.entityRef &&
           options.structuredAttributes &&
           Object.keys(options.structuredAttributes).length > 0
@@ -15024,7 +15032,7 @@ export class Orchestrator {
     // persistExtraction call so stale state from a prior call cannot leak
     // into the caller's buffer-retention decision.
     this.lastPersistExtractionDeferredCount = 0;
-    if (this.config.extractionJudgeEnabled) {
+    if (lifecycleCaps.extractionJudge) {
       // #1669 P1: pre-filter redacted facts from judge candidates so never-store
       // content is not persisted as judge training data.
       let preJudgeRedactionRules: CompiledRedactionRule[] = [];
@@ -15090,7 +15098,7 @@ export class Orchestrator {
         // off; the combined callback itself is undefined when both are
         // disabled so there is zero overhead in the default configuration.
         const judgeTelemetryOpts = {
-          enabled: this.config.extractionJudgeTelemetryEnabled === true,
+          enabled: lifecycleCaps.extractionJudgeTelemetry,
           memoryDir: this.config.memoryDir,
         };
         const judgeTrainingOpts = {
@@ -15301,7 +15309,7 @@ export class Orchestrator {
       // do not block scope routing). Rule 30: gated by
       // extractionScopeClassificationEnabled.
       if (
-        this.config.extractionScopeClassificationEnabled &&
+        lifecycleCaps.extractionScopeClassification &&
         this.config.namespacesEnabled &&
         fact.scope === "global" &&
         !routedNamespaceExplicit
@@ -15954,7 +15962,7 @@ export class Orchestrator {
                 // #1578 r3: an extracted end-only bound (validFrom absent) is
                 // historical, not a new authoritative state — never let it
                 // supersede a later active fact (codex P1 on :15534).
-                enabled: this.config.temporalSupersessionEnabled &&
+                enabled: lifecycleCaps.temporalSupersession &&
                   !(biTemporal && !biTemporal.validFrom),
               });
             } catch (err) {
@@ -16190,7 +16198,7 @@ export class Orchestrator {
             entityRef: supersessionEntityRef,
             structuredAttributes: fact.structuredAttributes,
             createdAt: supersessionOrderingAt(biTemporal?.validFrom ?? sourceContext?.validAt),
-            enabled: this.config.temporalSupersessionEnabled &&
+            enabled: lifecycleCaps.temporalSupersession &&
               !(biTemporal && !biTemporal.validFrom),
           });
         } catch (err) {
@@ -16557,7 +16565,7 @@ export class Orchestrator {
     storage: StorageManager,
     memoryId: string,
   ): Promise<void> {
-    if (!this.config.embeddingFallbackEnabled) return;
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) return;
     if (!(await this.embeddingFallback.isAvailable())) return;
     const memory = await storage.getMemoryById(memoryId);
     if (!memory) return;
@@ -16749,6 +16757,7 @@ export class Orchestrator {
     merged: number;
     invalidated: number;
   }> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     log.info("running consolidation pass");
     let merged = 0;
     let invalidated = 0;
@@ -16985,7 +16994,7 @@ export class Orchestrator {
     }
 
     // v8.3 Lifecycle policy pass — deterministic promotion/decay metadata
-    if (this.config.lifecyclePolicyEnabled) {
+    if (lifecycleCaps.lifecyclePolicy) {
       try {
         const lightSleepStartedAt = new Date().toISOString();
         const lifecycleCorpus = await this.storage.readAllMemories();
@@ -17173,7 +17182,7 @@ export class Orchestrator {
     await this.storage.saveMeta(meta);
 
     // Temporal Memory Tree (v8.2) — rebuild nodes from all memories, fail-open
-    if (this.config.temporalMemoryTreeEnabled) {
+    if (lifecycleCaps.temporalMemoryTree) {
       try {
         const tmtEntries = allMemories
           .filter(
@@ -17715,6 +17724,7 @@ export class Orchestrator {
     let updatedCount = 0;
     let disputedCount = 0;
     let evaluatedCount = 0;
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
 
     const thresholds = this.effectiveLifecycleThresholds();
     const policy = {
@@ -17780,7 +17790,7 @@ export class Orchestrator {
 
     // Report how many memories had frontmatter rewritten so callers can record a
     // catalog write touch for lifecycle-only passes (codex NR-tS).
-    if (!this.config.lifecycleMetricsEnabled) return updatedCount;
+    if (!lifecycleCaps.lifecycleMetrics) return updatedCount;
 
     const total = evaluatedCount;
     const metrics = {
@@ -19226,7 +19236,7 @@ export class Orchestrator {
     //   • search() throws                 → re-throw (network/provider error).
     //   • search() returns []             → return [] (empty index, not a
     //     backend failure; decideSemanticDedup reports no_candidates).
-    if (!this.config.embeddingFallbackEnabled) {
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) {
       throw new Error("semantic dedup: embedding backend not configured");
     }
     if (!(await this.embeddingFallback.isAvailable())) {
@@ -19300,7 +19310,7 @@ export class Orchestrator {
     query: string,
     limit: number,
   ): Promise<QmdSearchResult[]> {
-    if (!this.config.embeddingFallbackEnabled) return [];
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) return [];
     if (!(await this.embeddingFallback.isAvailable())) return [];
     const hits = await this.embeddingFallback.search(query, limit);
     if (hits.length === 0) return [];
@@ -20010,6 +20020,7 @@ export class Orchestrator {
       blockedPaths?: Set<string>;
     },
   ): QmdSearchResult[] {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     let lifecycleFilteredCount = 0;
     let temporalSupersededFilteredCount = 0;
     let biTemporalExpiredFilteredCount = 0;
@@ -20043,9 +20054,9 @@ export class Orchestrator {
         if (
           options?.allowLifecycleFiltered !== true &&
           shouldFilterLifecycleRecallCandidate(memory.frontmatter, {
-            lifecyclePolicyEnabled: this.config.lifecyclePolicyEnabled,
+            lifecyclePolicyEnabled: lifecycleCaps.lifecyclePolicy,
             lifecycleFilterStaleEnabled:
-              this.config.lifecycleFilterStaleEnabled,
+              lifecycleCaps.lifecycleFilterStale,
           })
         ) {
           lifecycleFilteredCount += 1;
@@ -20079,7 +20090,7 @@ export class Orchestrator {
           // half-open `[valid_at, invalid_at)` evaluation in isValidAsOf
           // is the authoritative gate for historical recall.
           shouldFilterSupersededFromRecall(memory.frontmatter, {
-            enabled: this.config.temporalSupersessionEnabled,
+            enabled: lifecycleCaps.temporalSupersession,
             includeInRecall: this.config.temporalSupersessionIncludeInRecall,
           })
         ) {
@@ -20223,6 +20234,7 @@ export class Orchestrator {
       asOfMs?: number;
     },
   ): Promise<QmdSearchResult[]> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
     if (results.length === 0) return results;
 
     const safety = await this.filterSearchResultsForRecall(
@@ -20397,7 +20409,7 @@ export class Orchestrator {
         const lifecycleDelta = lifecycleRecallScoreAdjustment(
           memory.frontmatter,
           {
-            lifecyclePolicyEnabled: this.config.lifecyclePolicyEnabled,
+            lifecyclePolicyEnabled: lifecycleCaps.lifecyclePolicy,
           },
         );
         score += applyUtilityRankingRuntimeDelta(

--- a/packages/remnic-core/src/search/embed-helper.ts
+++ b/packages/remnic-core/src/search/embed-helper.ts
@@ -1,4 +1,5 @@
 import { log } from "../logger.js";
+import { resolveMemoryLifecycleCapabilities } from "../capabilities.js";
 import type { PluginConfig } from "../types.js";
 import { isAbortError } from "../abort-error.js";
 import { withTimeoutSignal } from "./abort.js";
@@ -209,7 +210,7 @@ export class EmbedHelper {
   }
 
   private resolveProvider(options: { includeHost?: boolean } = {}): ProviderConfig | null {
-    if (!this.config.embeddingFallbackEnabled) return null;
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) return null;
 
     if (
       options.includeHost !== false &&
@@ -244,7 +245,7 @@ export class EmbedHelper {
   }
 
   private resolveFallbackProviderForIdentity(identity: EmbedProviderIdentity): ProviderConfig | null {
-    if (!this.config.embeddingFallbackEnabled) return null;
+    if (!resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) return null;
     const separator = identity.indexOf(":");
     if (separator <= 0 || separator === identity.length - 1) return null;
     const type = identity.slice(0, separator);

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20825,
-      "packages/remnic-core/src/cli.ts": 9389,
-      "packages/remnic-core/src/access-service.ts": 8992,
+      "packages/remnic-core/src/orchestrator.ts": 20837,
+      "packages/remnic-core/src/cli.ts": 9390,
+      "packages/remnic-core/src/access-service.ts": 8993,
       "packages/remnic-core/src/storage.ts": 7726,
       "packages/remnic-core/src/config.ts": 4689
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 536,
+    "scatteredConfigFlagReads": 511,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 0,
     "directStorageImports": 38


### PR DESCRIPTION
## Summary

Part of #1523 (CapabilitySet — resolve feature gates once per operation). Batch 3 migrates the **lifecycle / temporal / extraction / embedding-fallback** subsystems onto the `MemoryLifecycleCapabilitySet`, the fourth capability-set projection (after recall, graph-construction, and access-setup).

**scatteredConfigFlagReads ratchet: 536 → 511 (−25).**

## Flag inventory (current, post-migration)

```
114 config.namespacesEnabled
 20 config.qmdEnabled
 15 config.queryAwareIndexingEnabled
 14 config.conversationIndexEnabled
 13 config.identityContinuityEnabled
 12 config.creationMemoryEnabled
 11 config.localLlmEnabled
  8 config.trustZonesEnabled
  …  (each migrated flag below now shows exactly 1 read — the resolver)
```

## What migrated (11 flags, 36 call sites → 1 resolver read each)

| Flag | Call sites | Files touched |
|---|---|---|
| `temporalSupersessionEnabled` | 7 | orchestrator |
| `temporalMemoryTreeEnabled` | 4 | orchestrator |
| `lifecyclePolicyEnabled` | 6 | orchestrator, first-start-migration |
| `lifecycleFilterStaleEnabled` | 1 | orchestrator |
| `lifecycleMetricsEnabled` | 1 | orchestrator |
| `extractionScopeClassificationEnabled` | 3 | orchestrator, extraction |
| `extractionJudgeEnabled` | 1 | orchestrator |
| `extractionDedupeEnabled` | 1 | orchestrator |
| `extractionTelemetryPrefilterEnabled` | 1 | extraction |
| `extractionJudgeTelemetryEnabled` | 2 | orchestrator, cli |
| `embeddingFallbackEnabled` | 9 | orchestrator, embedding-fallback, embed-helper, access-service, cli |

## Design

`MemoryLifecycleCapabilitySet` is a frozen projection resolved once per operation entry and threaded down — exactly the pattern batches 1–2 established for recall / graph / access flags:

- `recallInternal` / `persistExtraction` gain a `lifecycleCaps` default-param (alongside the existing `caps` / `graphCaps`).
- Leaf operation methods (lifecycle pass, consolidation, recall-filter, dedupe, embedding-fallback) resolve the set once at entry.
- Every migrated call site reads a **capability**, never a raw `config.*Enabled` flag — so the gate-divergence defect class (#1523 root cause) is eliminated for these flags.

Parity tests (`capabilities.test.ts`) follow the established `FIELD_TO_FLAG` map pattern and assert `caps.field === config.<field>Enabled` across on/off combinations — the executable proof that the migration is behavior-preserving.

## Chokepoints used / not applicable

- **CapabilitySet gate** (#1523/#1566): all 11 flags now route through `resolveMemoryLifecycleCapabilities` — no new `config.*Enabled` reads at call sites.
- serialize-mutations / catalog chokepoint / validation boundary: not applicable (no mutation, catalog, or handler changes).

## Ratchet baseline

`scatteredConfigFlagReads` 536 → 511 (−25). Watchlist LOC grows by thin-wiring delegation lines threading the capability set (orchestrator +12, cli/access-service +1 each) — same registration/delegation pattern as recall/graph caps in batches 1–2 (ground rule 4). Baseline updated with `--update`.

## Verification

- `pnpm --filter @remnic/core build` ✅
- `capabilities.test.ts` — 14/14 pass (4 new lifecycle parity tests) ✅
- entity-hardening (8 suites incl. orchestrator-characterization, recall-no-recall, path-filter) — 131/131 pass ✅
- `node scripts/check-ratchets.mjs` — OK ✅

Refs #1523.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall filtering, extraction persistence, and embedding paths in the orchestrator, but the change is a mechanical gate centralization with parity tests and no new semantics.
> 
> **Overview**
> Adds **`MemoryLifecycleCapabilitySet`** and **`resolveMemoryLifecycleCapabilities`** in `capabilities.ts`, then routes eleven lifecycle-related config flags through that frozen projection instead of scattered `config.*Enabled` reads (issue **#1523** batch 3).
> 
> **Orchestrator** resolves `lifecycleCaps` once on paths like `recallInternal`, `persistExtraction`, consolidation, lifecycle fanout, recall safety filtering, extraction dedupe, and embedding index/search — threading the same booleans for temporal supersession/TMT, lifecycle policy/metrics/stale filtering, extraction judge/scope/dedupe/telemetry, and embedding fallback. **`extraction.ts`**, **`embedding-fallback.ts`**, **`embed-helper.ts`**, **`cli.ts`**, **`access-service.ts`**, and **`first-start-migration.ts`** switch their gates to the resolver at operation entry.
> 
> **`capabilities.test.ts`** gains parity tests (field-to-flag map, on/off, frozen object, pre-migration contract). **`scripts/ratchet-baseline.json`** updates **`scatteredConfigFlagReads`** 536 → 511.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2845afa62170b922be613cd05cdb1fc6a5fcb72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->