### PR TITLE
feat(bench): single-flag ablation matrix + runner (#1730)

### DIFF
--- a/packages/bench/src/ablations/single-flag-matrix.test.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { buildBenchBaselineRemnicConfig } from "../adapters/remnic-adapter.ts";
+import { parseConfig } from "@remnic/core";
 import { DEFAULT_ABLATION_BENCHMARK, SINGLE_FLAG_ABLATION_MATRIX, getAblationCell } from "./single-flag-matrix.ts";
 
 test("SINGLE_FLAG_ABLATION_MATRIX has exactly the 3 #1574 axes in stable order", () => {
@@ -122,6 +123,23 @@ test("each cell's override actually changes the merged config vs the bench basel
   }
 });
 
+test("each cell's override differs from the config.ts parsed default (catches silent default drift)", () => {
+  // The bench baseline may omit a key (so the cell flips from the config.ts
+  // default) or pin it explicitly. But if someone changes a config.ts default
+  // to match a cell's override, the cell becomes a no-op while the bench-baseline
+  // test above still passes. This test catches that drift by comparing against
+  // the actual parsed config defaults (PR #1751 cursor review).
+  const defaults = parseConfig({});
+  for (const cell of SINGLE_FLAG_ABLATION_MATRIX) {
+    const cellValue = cell.configOverrides[cell.primaryFlag] as boolean;
+    const defaultValue = defaults[cell.primaryFlag] as boolean;
+    assert.notEqual(
+      defaultValue,
+      cellValue,
+      `${cell.id}: config.ts default for ${cell.primaryFlag} is already ${String(cellValue)} — the cell would be a no-op against the parsed default`
+    );
+  }
+});
 test("each cell's configOverrides win over the baseline when merged (override semantics)", () => {
   // The runner merges `{ ...resolved.adapterOptions.configOverrides, ...cell.configOverrides }`.
   // Since the baseline omits these keys, the merged result carries exactly the

--- a/packages/bench/src/ablations/single-flag-matrix.test.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.test.ts
@@ -8,21 +8,17 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import {
-  DEFAULT_ABLATION_BENCHMARK,
-  SINGLE_FLAG_ABLATION_MATRIX,
-  getAblationCell,
-} from "./single-flag-matrix.ts";
 import { buildBenchBaselineRemnicConfig } from "../adapters/remnic-adapter.ts";
+import { DEFAULT_ABLATION_BENCHMARK, SINGLE_FLAG_ABLATION_MATRIX, getAblationCell } from "./single-flag-matrix.ts";
 
 test("SINGLE_FLAG_ABLATION_MATRIX has exactly the 3 #1574 axes in stable order", () => {
   assert.deepEqual(
     SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.axis),
-    ["memory-worth", "contradiction-scan", "graph-recall"],
+    ["memory-worth", "contradiction-scan", "graph-recall"]
   );
   assert.deepEqual(
     SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id),
-    ["memory-worth-off", "contradiction-scan-on", "graph-recall-on"],
+    ["memory-worth-off", "contradiction-scan-on", "graph-recall-on"]
   );
 });
 
@@ -32,10 +28,7 @@ test("every cell carries the required metadata for an artifact note + STATUS log
     assert.ok(cell.label.length > 0, `${cell.id}: missing label`);
     assert.ok(cell.description.length > 0, `${cell.id}: missing description`);
     assert.ok(cell.baselineState.length > 0, `${cell.id}: missing baselineState`);
-    assert.ok(
-      Object.keys(cell.configOverrides).length > 0,
-      `${cell.id}: empty configOverrides`,
-    );
+    assert.ok(Object.keys(cell.configOverrides).length > 0, `${cell.id}: empty configOverrides`);
     assert.ok(cell.primaryFlag.length > 0, `${cell.id}: missing primaryFlag`);
   }
 });
@@ -50,46 +43,38 @@ test("each cell flips exactly one primary flag (the single-flag invariant)", () 
       assert.equal(
         overrides.recallMemoryWorthFilterEnabled,
         false,
-        `${cell.id}: expected recallMemoryWorthFilterEnabled=false`,
+        `${cell.id}: expected recallMemoryWorthFilterEnabled=false`
       );
       assert.equal(
         Object.keys(overrides).length,
         1,
-        `${cell.id}: memory-worth cell must touch only recallMemoryWorthFilterEnabled`,
+        `${cell.id}: memory-worth cell must touch only recallMemoryWorthFilterEnabled`
       );
     } else if (cell.primaryFlag === "contradictionScan") {
       const cs = overrides.contradictionScan;
       // Narrow with `in` so the property access is type-checked, not an
       // unchecked `as { enabled?: unknown }` cast (ts-no-inline-cast-access).
       if (cs && typeof cs === "object" && "enabled" in cs) {
-        assert.equal(
-          cs.enabled,
-          true,
-          `${cell.id}: expected contradictionScan.enabled=true`,
-        );
+        assert.equal(cs.enabled, true, `${cell.id}: expected contradictionScan.enabled=true`);
       } else {
         assert.fail(`${cell.id}: contradictionScan override must be { enabled, ... }`);
       }
       assert.equal(
         Object.keys(overrides).length,
         1,
-        `${cell.id}: contradiction-scan cell must touch only contradictionScan`,
+        `${cell.id}: contradiction-scan cell must touch only contradictionScan`
       );
     } else if (cell.primaryFlag === "graphRecallEnabled") {
-      assert.equal(
-        overrides.graphRecallEnabled,
-        true,
-        `${cell.id}: expected graphRecallEnabled=true`,
-      );
+      assert.equal(overrides.graphRecallEnabled, true, `${cell.id}: expected graphRecallEnabled=true`);
       assert.equal(
         overrides.graphAssistInFullModeEnabled,
         true,
-        `${cell.id}: graph assist must be on so the flag actually engages in full mode`,
+        `${cell.id}: graph assist must be on so the flag actually engages in full mode`
       );
       assert.deepEqual(
         Object.keys(overrides).sort(),
         ["graphAssistInFullModeEnabled", "graphRecallEnabled"],
-        `${cell.id}: graph-recall cell must touch only the two graph gates`,
+        `${cell.id}: graph-recall cell must touch only the two graph gates`
       );
     } else {
       assert.fail(`unknown primaryFlag ${cell.primaryFlag} on cell ${cell.id}`);
@@ -112,10 +97,7 @@ test("getAblationCell returns the cell for a known id", () => {
 });
 
 test("getAblationCell throws on unknown id (fail fast at the runner boundary)", () => {
-  assert.throws(
-    () => getAblationCell("trust-score-on" as never),
-    /Unknown ablation cell id "trust-score-on"/,
-  );
+  assert.throws(() => getAblationCell("trust-score-on" as never), /Unknown ablation cell id "trust-score-on"/);
 });
 
 test("ablation primary flags are absent from the bench baseline — cells flip from config.ts defaults", () => {
@@ -135,7 +117,7 @@ test("ablation primary flags are absent from the bench baseline — cells flip f
     assert.equal(
       baseline[key],
       undefined,
-      `bench baseline must not set ${key} (else the ablation delta is measured against the bench override, not the config.ts default)`,
+      `bench baseline must not set ${key} (else the ablation delta is measured against the bench override, not the config.ts default)`
     );
   }
 });
@@ -151,7 +133,7 @@ test("each cell's configOverrides win over the baseline when merged (override se
     assert.equal(
       merged[cell.primaryFlag],
       cell.configOverrides[cell.primaryFlag],
-      `${cell.id}: merged config must carry the cell's primary-flag override`,
+      `${cell.id}: merged config must carry the cell's primary-flag override`
     );
   }
 });

--- a/packages/bench/src/ablations/single-flag-matrix.test.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.test.ts
@@ -50,22 +50,26 @@ test("each cell flips exactly one primary flag (the single-flag invariant)", () 
         1,
         `${cell.id}: memory-worth cell must touch only recallMemoryWorthFilterEnabled`
       );
-    } else if (cell.primaryFlag === "contradictionScan") {
-      const cs = overrides.contradictionScan;
-      // Narrow with `in` so the property access is type-checked, not an
-      // unchecked `as { enabled?: unknown }` cast (ts-no-inline-cast-access).
-      if (cs && typeof cs === "object" && "enabled" in cs) {
-        assert.equal(cs.enabled, true, `${cell.id}: expected contradictionScan.enabled=true`);
-      } else {
-        assert.fail(`${cell.id}: contradictionScan override must be { enabled, ... }`);
-      }
+    } else if (cell.primaryFlag === "contradictionDetectionEnabled") {
+      // The contradiction axis is the INLINE write-path gate, not the cron
+      // (the cron never fires during a bench replay — see matrix doc).
+      assert.equal(
+        overrides.contradictionDetectionEnabled,
+        true,
+        `${cell.id}: expected contradictionDetectionEnabled=true`
+      );
       assert.equal(
         Object.keys(overrides).length,
         1,
-        `${cell.id}: contradiction-scan cell must touch only contradictionScan`
+        `${cell.id}: contradiction-scan cell must touch only contradictionDetectionEnabled`
       );
     } else if (cell.primaryFlag === "graphRecallEnabled") {
       assert.equal(overrides.graphRecallEnabled, true, `${cell.id}: expected graphRecallEnabled=true`);
+      assert.equal(
+        overrides.multiGraphMemoryEnabled,
+        true,
+        `${cell.id}: multiGraphMemoryEnabled required too — orchestrator.ts §1379 skips graph_mode without it`
+      );
       assert.equal(
         overrides.graphAssistInFullModeEnabled,
         true,
@@ -73,8 +77,8 @@ test("each cell flips exactly one primary flag (the single-flag invariant)", () 
       );
       assert.deepEqual(
         Object.keys(overrides).sort(),
-        ["graphAssistInFullModeEnabled", "graphRecallEnabled"],
-        `${cell.id}: graph-recall cell must touch only the two graph gates`
+        ["graphAssistInFullModeEnabled", "graphRecallEnabled", "multiGraphMemoryEnabled"],
+        `${cell.id}: graph-recall cell must touch only the three graph gates`
       );
     } else {
       assert.fail(`unknown primaryFlag ${cell.primaryFlag} on cell ${cell.id}`);
@@ -100,24 +104,20 @@ test("getAblationCell throws on unknown id (fail fast at the runner boundary)", 
   assert.throws(() => getAblationCell("trust-score-on" as never), /Unknown ablation cell id "trust-score-on"/);
 });
 
-test("ablation primary flags are absent from the bench baseline — cells flip from config.ts defaults", () => {
-  // Grounds the matrix doc's claim: buildBenchBaselineRemnicConfig() does NOT
-  // set recallMemoryWorthFilterEnabled, contradictionScan, graphRecallEnabled,
-  // or graphAssistInFullModeEnabled. So each cell's delta is measured against
-  // the config.ts parse default, not a bench-overridden value. This is the
-  // keyless contract the runner relies on for config-override cells via
-  // adapterOptions.configOverrides.
+test("each cell's override actually changes the merged config vs the bench baseline (non-no-op)", () => {
+  // The real correctness guarantee: flipping the cell's flag must produce a
+  // DIFFERENT effective config than the baseline alone — otherwise the
+  // ablation measures nothing. The bench baseline omits most ablation keys
+  // (so the cell flips from the config.ts default) but explicitly pins
+  // contradictionDetectionEnabled=false; either way the cell's value must
+  // differ from the baseline value for the primary flag.
   const baseline = buildBenchBaselineRemnicConfig();
-  for (const key of [
-    "recallMemoryWorthFilterEnabled",
-    "contradictionScan",
-    "graphRecallEnabled",
-    "graphAssistInFullModeEnabled",
-  ]) {
-    assert.equal(
-      baseline[key],
-      undefined,
-      `bench baseline must not set ${key} (else the ablation delta is measured against the bench override, not the config.ts default)`
+  for (const cell of SINGLE_FLAG_ABLATION_MATRIX) {
+    const cellValue = cell.configOverrides[cell.primaryFlag];
+    assert.notEqual(
+      baseline[cell.primaryFlag],
+      cellValue,
+      `${cell.id}: baseline already has ${cell.primaryFlag}=${String(cellValue)} — the cell would be a no-op ablation`
     );
   }
 });

--- a/packages/bench/src/ablations/single-flag-matrix.test.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the single-flag ablation matrix (issues #1574 §"Ablations" + #1730).
+ *
+ * The matrix is pure data; these tests lock its shape, order, and the
+ * single-flag invariant so a regression (e.g. a cell that flips two flags, or
+ * a reordered matrix) is a visible review signal rather than a silent change.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEFAULT_ABLATION_BENCHMARK,
+  SINGLE_FLAG_ABLATION_MATRIX,
+  getAblationCell,
+} from "./single-flag-matrix.ts";
+import { buildBenchBaselineRemnicConfig } from "../adapters/remnic-adapter.ts";
+
+test("SINGLE_FLAG_ABLATION_MATRIX has exactly the 3 #1574 axes in stable order", () => {
+  assert.deepEqual(
+    SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.axis),
+    ["memory-worth", "contradiction-scan", "graph-recall"],
+  );
+  assert.deepEqual(
+    SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id),
+    ["memory-worth-off", "contradiction-scan-on", "graph-recall-on"],
+  );
+});
+
+test("every cell carries the required metadata for an artifact note + STATUS log", () => {
+  for (const cell of SINGLE_FLAG_ABLATION_MATRIX) {
+    assert.ok(cell.id.length > 0, `${cell.id}: missing id`);
+    assert.ok(cell.label.length > 0, `${cell.id}: missing label`);
+    assert.ok(cell.description.length > 0, `${cell.id}: missing description`);
+    assert.ok(cell.baselineState.length > 0, `${cell.id}: missing baselineState`);
+    assert.ok(
+      Object.keys(cell.configOverrides).length > 0,
+      `${cell.id}: empty configOverrides`,
+    );
+    assert.ok(cell.primaryFlag.length > 0, `${cell.id}: missing primaryFlag`);
+  }
+});
+
+test("each cell flips exactly one primary flag (the single-flag invariant)", () => {
+  // The contradiction-scan cell sets a nested object; the other two set a
+  // single boolean. The invariant under test is that the PRIMARY toggle is
+  // unique per cell and matches `primaryFlag`.
+  for (const cell of SINGLE_FLAG_ABLATION_MATRIX) {
+    const overrides = cell.configOverrides;
+    if (cell.primaryFlag === "recallMemoryWorthFilterEnabled") {
+      assert.equal(
+        overrides.recallMemoryWorthFilterEnabled,
+        false,
+        `${cell.id}: expected recallMemoryWorthFilterEnabled=false`,
+      );
+      assert.equal(
+        Object.keys(overrides).length,
+        1,
+        `${cell.id}: memory-worth cell must touch only recallMemoryWorthFilterEnabled`,
+      );
+    } else if (cell.primaryFlag === "contradictionScan") {
+      const cs = overrides.contradictionScan;
+      // Narrow with `in` so the property access is type-checked, not an
+      // unchecked `as { enabled?: unknown }` cast (ts-no-inline-cast-access).
+      if (cs && typeof cs === "object" && "enabled" in cs) {
+        assert.equal(
+          cs.enabled,
+          true,
+          `${cell.id}: expected contradictionScan.enabled=true`,
+        );
+      } else {
+        assert.fail(`${cell.id}: contradictionScan override must be { enabled, ... }`);
+      }
+      assert.equal(
+        Object.keys(overrides).length,
+        1,
+        `${cell.id}: contradiction-scan cell must touch only contradictionScan`,
+      );
+    } else if (cell.primaryFlag === "graphRecallEnabled") {
+      assert.equal(
+        overrides.graphRecallEnabled,
+        true,
+        `${cell.id}: expected graphRecallEnabled=true`,
+      );
+      assert.equal(
+        overrides.graphAssistInFullModeEnabled,
+        true,
+        `${cell.id}: graph assist must be on so the flag actually engages in full mode`,
+      );
+      assert.deepEqual(
+        Object.keys(overrides).sort(),
+        ["graphAssistInFullModeEnabled", "graphRecallEnabled"],
+        `${cell.id}: graph-recall cell must touch only the two graph gates`,
+      );
+    } else {
+      assert.fail(`unknown primaryFlag ${cell.primaryFlag} on cell ${cell.id}`);
+    }
+  }
+});
+
+test("the three cells are mutually exclusive — no two cells share a primary flag", () => {
+  const flags = SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.primaryFlag);
+  assert.equal(new Set(flags).size, flags.length, "primary flags must be unique");
+});
+
+test("DEFAULT_ABLATION_BENCHMARK is a published benchmark covered by the #1574 baseline", () => {
+  assert.equal(DEFAULT_ABLATION_BENCHMARK, "locomo");
+});
+
+test("getAblationCell returns the cell for a known id", () => {
+  const cell = getAblationCell("graph-recall-on");
+  assert.equal(cell.axis, "graph-recall");
+});
+
+test("getAblationCell throws on unknown id (fail fast at the runner boundary)", () => {
+  assert.throws(
+    () => getAblationCell("trust-score-on" as never),
+    /Unknown ablation cell id "trust-score-on"/,
+  );
+});
+
+test("ablation primary flags are absent from the bench baseline — cells flip from config.ts defaults", () => {
+  // Grounds the matrix doc's claim: buildBenchBaselineRemnicConfig() does NOT
+  // set recallMemoryWorthFilterEnabled, contradictionScan, graphRecallEnabled,
+  // or graphAssistInFullModeEnabled. So each cell's delta is measured against
+  // the config.ts parse default, not a bench-overridden value. This is the
+  // keyless contract the runner relies on for config-override cells via
+  // adapterOptions.configOverrides.
+  const baseline = buildBenchBaselineRemnicConfig();
+  for (const key of [
+    "recallMemoryWorthFilterEnabled",
+    "contradictionScan",
+    "graphRecallEnabled",
+    "graphAssistInFullModeEnabled",
+  ]) {
+    assert.equal(
+      baseline[key],
+      undefined,
+      `bench baseline must not set ${key} (else the ablation delta is measured against the bench override, not the config.ts default)`,
+    );
+  }
+});
+
+test("each cell's configOverrides win over the baseline when merged (override semantics)", () => {
+  // The runner merges `{ ...resolved.adapterOptions.configOverrides, ...cell.configOverrides }`.
+  // Since the baseline omits these keys, the merged result carries exactly the
+  // cell's value — proving the override lands and is not clobbered by a stale
+  // baseline setting.
+  const baseline = buildBenchBaselineRemnicConfig();
+  for (const cell of SINGLE_FLAG_ABLATION_MATRIX) {
+    const merged = { ...baseline, ...cell.configOverrides };
+    assert.equal(
+      merged[cell.primaryFlag],
+      cell.configOverrides[cell.primaryFlag],
+      `${cell.id}: merged config must carry the cell's primary-flag override`,
+    );
+  }
+});

--- a/packages/bench/src/ablations/single-flag-matrix.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.ts
@@ -1,0 +1,149 @@
+/**
+ * Single-flag ablation matrix for the published-benchmark ablation suite
+ * (issues #1574 §"Ablations" and #1730).
+ *
+ * Each ablation is a reproducible run config: a named cell that flips exactly
+ * one Remnic config flag relative to the {@link buildBenchBaselineRemnicConfig}
+ * baseline, so the delta against the matching baseline artifact isolates that
+ * flag's effect. The matrix is pure data — no I/O — so it is trivially
+ * testable and the runner script (`scripts/bench/run-ablation-matrix.ts`) is
+ * just a thin shell over the public bench API.
+ *
+ * The three axes come straight from #1574's "Ablations" section:
+ *   1. Memory Worth recall multiplier (`recallMemoryWorthFilterEnabled`)
+ *   2. Contradiction scan cron (`contradictionScan.enabled`)
+ *   3. Graph / temporal recall (`graphRecallEnabled` + its full-mode assist)
+ *
+ * Baseline state of each flag (the raw `config.ts` parse default, since the
+ * bench baseline config does NOT override these):
+ *   - `recallMemoryWorthFilterEnabled`: **true** (default; #1574 baseline ran
+ *     with it ON, so the ablation cell turns it OFF to measure the cost of
+ *     removing it).
+ *   - `contradictionScan.enabled`: **false** (default; ablation cell turns it
+ *     ON to measure the benefit of supersession landing before answering).
+ *   - `graphRecallEnabled`: **false** (default; ablation cell turns it ON +
+ *     enables the full-mode graph assist).
+ *
+ * `trustScoreEnabled` is deliberately NOT an axis here: it is the unified
+ * stage from #1577 and subsumes the Memory Worth multiplier when on (rule 39).
+ * Its ablation belongs to the #1577 / #1585 model-lab track, not the
+ * single-flag publishable-artifact track this matrix serves.
+ *
+ * Every cell carries a `baselineState` note so a reader of a committed
+ * artifact can tell which direction the flag was flipped without cross-
+ * referencing config.ts. The runner stamps this into the artifact `note`.
+ */
+
+import type { PublishedBenchmarkId } from "../published-artifact.js";
+
+/** Identifier for one ablation cell. Stable across runs; used in artifact notes + filenames. */
+export type SingleFlagAblationId =
+  | "memory-worth-off"
+  | "contradiction-scan-on"
+  | "graph-recall-on";
+
+/** The config-override payload merged into `adapterOptions.configOverrides`. */
+export type AblationConfigOverrides = Record<string, unknown>;
+
+/** One reproducible ablation cell. */
+export interface SingleFlagAblationCell {
+  /** Stable cell id; appears in artifact notes and STATUS logs. */
+  id: SingleFlagAblationId;
+  /** Human-readable label for tables / STATUS files. */
+  label: string;
+  /** Which #1574 ablation axis this cell exercises. */
+  axis: "memory-worth" | "contradiction-scan" | "graph-recall";
+  /** One-line description of what the cell flips + why, for the artifact `note`. */
+  description: string;
+  /** State of the flag in the baseline run (so the delta direction is unambiguous). */
+  baselineState: string;
+  /** The Remnic config overrides that define this cell (merged over the baseline). */
+  configOverrides: AblationConfigOverrides;
+  /** The single top-level flag key this cell toggles (for grep / ratchet checks). */
+  primaryFlag:
+    | "recallMemoryWorthFilterEnabled"
+    | "contradictionScan"
+    | "graphRecallEnabled";
+}
+
+/**
+ * The canonical 3-cell single-flag ablation matrix (issue #1574 §"Ablations",
+ * verified/produced for the paper under issue #1730).
+ *
+ * Order is stable: memory-worth → contradiction-scan → graph-recall. The
+ * runner executes them in this order; tests assert the exact order so a
+ * reordered matrix is a visible review signal, not a silent change.
+ */
+export const SINGLE_FLAG_ABLATION_MATRIX: readonly SingleFlagAblationCell[] = [
+  {
+    id: "memory-worth-off",
+    label: "Memory Worth multiplier OFF",
+    axis: "memory-worth",
+    description:
+      "Disables the Memory Worth recall multiplier (recallMemoryWorthFilterEnabled=false). " +
+      "Baseline (#1574) ran with it ON via the config.ts default; this cell measures the cost of removing it.",
+    baselineState:
+      "recallMemoryWorthFilterEnabled defaults true in config.ts; baseline ran ON.",
+    configOverrides: {
+      recallMemoryWorthFilterEnabled: false,
+    },
+    primaryFlag: "recallMemoryWorthFilterEnabled",
+  },
+  {
+    id: "contradiction-scan-on",
+    label: "Contradiction scan ON",
+    axis: "contradiction-scan",
+    description:
+      "Enables the contradiction-scan cron (contradictionScan.enabled=true) so supersessions land " +
+      "between ingest and answering. Baseline (#1574) ran with it OFF; this cell measures the benefit.",
+    baselineState:
+      "contradictionScan.enabled defaults false; baseline ran OFF.",
+    configOverrides: {
+      contradictionScan: {
+        enabled: true,
+        similarityFloor: 0.82,
+        topicOverlapFloor: 0.4,
+        maxPairsPerRun: 500,
+        cooldownDays: 14,
+        autoMergeDuplicates: false,
+      },
+    },
+    primaryFlag: "contradictionScan",
+  },
+  {
+    id: "graph-recall-on",
+    label: "Graph / temporal recall ON",
+    axis: "graph-recall",
+    description:
+      "Enables graph recall + full-mode graph assist (graphRecallEnabled=true, graphAssistInFullModeEnabled=true). " +
+      "Baseline (#1574) ran with graph recall OFF; this cell measures the benefit of causal/timeline expansion.",
+    baselineState:
+      "graphRecallEnabled + graphAssistInFullModeEnabled default false; baseline ran OFF.",
+    configOverrides: {
+      graphRecallEnabled: true,
+      graphAssistInFullModeEnabled: true,
+    },
+    primaryFlag: "graphRecallEnabled",
+  },
+] as const;
+
+/**
+ * The default benchmark the ablation matrix targets. LoCoMo is the headline
+ * long-conversation benchmark and the one the #1574 baseline artifacts cover
+ * at full scale (1986 QA across 10 conversations); the ablation cells compare
+ * against that baseline. LongMemEval ablations are a documented follow-up
+ * (issue #1730 scope: coordinate with, not duplicate, the rest of the paper).
+ */
+export const DEFAULT_ABLATION_BENCHMARK: PublishedBenchmarkId = "locomo";
+
+/** Look up a cell by id. Throws on unknown id (fail fast at the runner boundary). */
+export function getAblationCell(id: SingleFlagAblationId): SingleFlagAblationCell {
+  const cell = SINGLE_FLAG_ABLATION_MATRIX.find((c) => c.id === id);
+  if (!cell) {
+    throw new Error(
+      `Unknown ablation cell id "${id}". Known ids: ${SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id).join(", ")}.`,
+    );
+  }
+  return cell;
+}
+

--- a/packages/bench/src/ablations/single-flag-matrix.ts
+++ b/packages/bench/src/ablations/single-flag-matrix.ts
@@ -11,18 +11,23 @@
  *
  * The three axes come straight from #1574's "Ablations" section:
  *   1. Memory Worth recall multiplier (`recallMemoryWorthFilterEnabled`)
- *   2. Contradiction scan cron (`contradictionScan.enabled`)
- *   3. Graph / temporal recall (`graphRecallEnabled` + its full-mode assist)
+ *   2. Contradiction scan — implemented via the INLINE write-path gate
+ *      `contradictionDetectionEnabled` (NOT the `contradictionScan` cron,
+ *      which only registers a scheduled job that never fires during a bench
+ *      replay, so it would measure nothing).
+ *   3. Graph / temporal recall (`graphRecallEnabled` + `multiGraphMemoryEnabled`
+ *      — orchestrator.ts §1379 requires BOTH for graph_mode — + the full-mode
+ *      graph assist gate).
  *
  * Baseline state of each flag (the raw `config.ts` parse default, since the
  * bench baseline config does NOT override these):
  *   - `recallMemoryWorthFilterEnabled`: **true** (default; #1574 baseline ran
  *     with it ON, so the ablation cell turns it OFF to measure the cost of
  *     removing it).
- *   - `contradictionScan.enabled`: **false** (default; ablation cell turns it
- *     ON to measure the benefit of supersession landing before answering).
- *   - `graphRecallEnabled`: **false** (default; ablation cell turns it ON +
- *     enables the full-mode graph assist).
+ *   - `contradictionDetectionEnabled`: **false** (config.ts §2078; ablation
+ *     cell turns it ON so write-path supersessions land before answering).
+ *   - `graphRecallEnabled` / `multiGraphMemoryEnabled`: **false** (default;
+ *     ablation cell turns BOTH on + the full-mode graph assist).
  *
  * `trustScoreEnabled` is deliberately NOT an axis here: it is the unified
  * stage from #1577 and subsumes the Memory Worth multiplier when on (rule 39).
@@ -37,10 +42,7 @@
 import type { PublishedBenchmarkId } from "../published-artifact.js";
 
 /** Identifier for one ablation cell. Stable across runs; used in artifact notes + filenames. */
-export type SingleFlagAblationId =
-  | "memory-worth-off"
-  | "contradiction-scan-on"
-  | "graph-recall-on";
+export type SingleFlagAblationId = "memory-worth-off" | "contradiction-scan-on" | "graph-recall-on";
 
 /** The config-override payload merged into `adapterOptions.configOverrides`. */
 export type AblationConfigOverrides = Record<string, unknown>;
@@ -60,10 +62,7 @@ export interface SingleFlagAblationCell {
   /** The Remnic config overrides that define this cell (merged over the baseline). */
   configOverrides: AblationConfigOverrides;
   /** The single top-level flag key this cell toggles (for grep / ratchet checks). */
-  primaryFlag:
-    | "recallMemoryWorthFilterEnabled"
-    | "contradictionScan"
-    | "graphRecallEnabled";
+  primaryFlag: "recallMemoryWorthFilterEnabled" | "contradictionDetectionEnabled" | "graphRecallEnabled";
 }
 
 /**
@@ -82,8 +81,7 @@ export const SINGLE_FLAG_ABLATION_MATRIX: readonly SingleFlagAblationCell[] = [
     description:
       "Disables the Memory Worth recall multiplier (recallMemoryWorthFilterEnabled=false). " +
       "Baseline (#1574) ran with it ON via the config.ts default; this cell measures the cost of removing it.",
-    baselineState:
-      "recallMemoryWorthFilterEnabled defaults true in config.ts; baseline ran ON.",
+    baselineState: "recallMemoryWorthFilterEnabled defaults true in config.ts; baseline ran ON.",
     configOverrides: {
       recallMemoryWorthFilterEnabled: false,
     },
@@ -94,34 +92,31 @@ export const SINGLE_FLAG_ABLATION_MATRIX: readonly SingleFlagAblationCell[] = [
     label: "Contradiction scan ON",
     axis: "contradiction-scan",
     description:
-      "Enables the contradiction-scan cron (contradictionScan.enabled=true) so supersessions land " +
-      "between ingest and answering. Baseline (#1574) ran with it OFF; this cell measures the benefit.",
-    baselineState:
-      "contradictionScan.enabled defaults false; baseline ran OFF.",
+      "Enables inline contradiction detection on the write path (contradictionDetectionEnabled=true) so supersessions " +
+      "land at ingest time, before answering. The batch contradictionScan cron is a no-op during a bench replay (it " +
+      "only registers a scheduled job), so the measurable axis is the inline write-path gate (orchestrator §15667); " +
+      "contradictionAutoResolve defaults true so detected contradictions are applied. Baseline (#1574) ran with it OFF.",
+    baselineState: "contradictionDetectionEnabled defaults false (config.ts §2078); baseline ran OFF.",
     configOverrides: {
-      contradictionScan: {
-        enabled: true,
-        similarityFloor: 0.82,
-        topicOverlapFloor: 0.4,
-        maxPairsPerRun: 500,
-        cooldownDays: 14,
-        autoMergeDuplicates: false,
-      },
+      contradictionDetectionEnabled: true,
     },
-    primaryFlag: "contradictionScan",
+    primaryFlag: "contradictionDetectionEnabled",
   },
   {
     id: "graph-recall-on",
     label: "Graph / temporal recall ON",
     axis: "graph-recall",
     description:
-      "Enables graph recall + full-mode graph assist (graphRecallEnabled=true, graphAssistInFullModeEnabled=true). " +
-      "Baseline (#1574) ran with graph recall OFF; this cell measures the benefit of causal/timeline expansion.",
+      "Enables graph recall + full-mode graph assist (graphRecallEnabled=true, graphAssistInFullModeEnabled=true, " +
+      "multiGraphMemoryEnabled=true). orchestrator.ts §1379 skips graph_mode unless BOTH graphRecallEnabled AND " +
+      "multiGraphMemoryEnabled are set, so the cell carries both gates (plus the full-mode assist) or it measures " +
+      "nothing. Baseline (#1574) ran with graph recall OFF; this cell measures the benefit of causal/timeline expansion.",
     baselineState:
-      "graphRecallEnabled + graphAssistInFullModeEnabled default false; baseline ran OFF.",
+      "graphRecallEnabled, graphAssistInFullModeEnabled, multiGraphMemoryEnabled all default false; baseline ran OFF.",
     configOverrides: {
       graphRecallEnabled: true,
       graphAssistInFullModeEnabled: true,
+      multiGraphMemoryEnabled: true,
     },
     primaryFlag: "graphRecallEnabled",
   },
@@ -141,9 +136,8 @@ export function getAblationCell(id: SingleFlagAblationId): SingleFlagAblationCel
   const cell = SINGLE_FLAG_ABLATION_MATRIX.find((c) => c.id === id);
   if (!cell) {
     throw new Error(
-      `Unknown ablation cell id "${id}". Known ids: ${SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id).join(", ")}.`,
+      `Unknown ablation cell id "${id}". Known ids: ${SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id).join(", ")}.`
     );
   }
   return cell;
 }
-

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -502,6 +502,18 @@ export type {
   RunProceduralAblationOptions,
 } from "./benchmarks/remnic/procedural-recall/ablation.js";
 
+// Single-flag ablation matrix for published benchmarks (issues #1574 §"Ablations" + #1730).
+export {
+  SINGLE_FLAG_ABLATION_MATRIX,
+  DEFAULT_ABLATION_BENCHMARK,
+  getAblationCell,
+} from "./ablations/single-flag-matrix.js";
+export type {
+  SingleFlagAblationId,
+  SingleFlagAblationCell,
+  AblationConfigOverrides,
+} from "./ablations/single-flag-matrix.js";
+
 // Real-fixture procedural-recall scenarios + baseline (issue #567 PR 2/5).
 export {
   PROCEDURAL_REAL_SCENARIOS,

--- a/scripts/bench/run-ablation-matrix.ts
+++ b/scripts/bench/run-ablation-matrix.ts
@@ -39,14 +39,17 @@ import { appendFile, mkdir, writeFile } from "node:fs/promises";
  *   2 — usage error
  */
 import path from "node:path";
+import os from "node:os";
 import process from "node:process";
 
 import {
   type BenchmarkArtifactHardware,
   type BenchmarkArtifactTier,
   type BenchmarkResult,
+  type LocalLabPreflightResult,
   type PublishedBenchmarkId,
   type ResolvedBenchRuntimeProfile,
+  type WriteBenchmarkArtifactResult,
   SINGLE_FLAG_ABLATION_MATRIX,
   type SingleFlagAblationCell,
   type SingleFlagAblationId,
@@ -54,6 +57,7 @@ import {
   createRemnicAdapter,
   getAblationCell,
   loadBenchmarkArtifact,
+  preflightLocalLabRole,
   resolveBenchRuntimeProfile,
   runBenchmark,
   writeBenchmarkArtifact,
@@ -69,6 +73,7 @@ interface ParsedArgs {
   noJudgeCache: boolean;
   only?: SingleFlagAblationId;
   limit?: number;
+  trialLimit?: number;
   hardware: BenchmarkArtifactHardware;
 }
 
@@ -83,101 +88,118 @@ function parseArgs(argv: string[]): { ok: true; value: ParsedArgs } | { ok: fals
   let noJudgeCache = false;
   let only: SingleFlagAblationId | undefined;
   let limit: number | undefined;
+  let trialLimit: number | undefined;
   let gpu = "NVIDIA RTX 3090";
   let vramGb = 24;
   let quantization = "Q4_K_M";
 
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === undefined) continue;
-    switch (arg) {
-      case "--benchmark": {
-        benchmark = requireValue(argv, ++i, "--benchmark");
-        break;
+  try {
+    for (let i = 0; i < argv.length; i++) {
+      const arg = argv[i];
+      if (arg === undefined) continue;
+      switch (arg) {
+        case "--benchmark": {
+          benchmark = requireValue(argv, ++i, "--benchmark");
+          break;
+        }
+        case "--local-lab-manifest": {
+          localLabManifestPath = requireValue(argv, ++i, "--local-lab-manifest");
+          break;
+        }
+        case "--dataset-dir": {
+          datasetDir = requireValue(argv, ++i, "--dataset-dir");
+          break;
+        }
+        case "--seed": {
+          seed = parsePositiveInt(requireValue(argv, ++i, "--seed"), "--seed");
+          break;
+        }
+        case "--out-dir": {
+          outDir = requireValue(argv, ++i, "--out-dir");
+          break;
+        }
+        case "--judge-cache-dir": {
+          judgeCacheDir = requireValue(argv, ++i, "--judge-cache-dir");
+          break;
+        }
+        case "--no-judge-cache": {
+          noJudgeCache = true;
+          break;
+        }
+        case "--only": {
+          only = requireValue(argv, ++i, "--only") as SingleFlagAblationId;
+          // Fail fast on unknown cell ids — a typo would otherwise silently skip.
+          getAblationCell(only);
+          break;
+        }
+        case "--limit": {
+          limit = parsePositiveInt(requireValue(argv, ++i, "--limit"), "--limit");
+          break;
+        }
+        case "--trial-limit": {
+          trialLimit = parsePositiveInt(requireValue(argv, ++i, "--trial-limit"), "--trial-limit");
+          break;
+        }
+        case "--gpu": {
+          gpu = requireValue(argv, ++i, "--gpu");
+          break;
+        }
+        case "--vram-gb": {
+          vramGb = parsePositiveInt(requireValue(argv, ++i, "--vram-gb"), "--vram-gb");
+          break;
+        }
+        case "--quantization": {
+          quantization = requireValue(argv, ++i, "--quantization");
+          break;
+        }
+        case "-h":
+        case "--help": {
+          return { ok: false, message: "__help__" };
+        }
+        default:
+          positional.push(arg);
       }
-      case "--local-lab-manifest": {
-        localLabManifestPath = requireValue(argv, ++i, "--local-lab-manifest");
-        break;
-      }
-      case "--dataset-dir": {
-        datasetDir = requireValue(argv, ++i, "--dataset-dir");
-        break;
-      }
-      case "--seed": {
-        seed = parsePositiveInt(requireValue(argv, ++i, "--seed"), "--seed");
-        break;
-      }
-      case "--out-dir": {
-        outDir = requireValue(argv, ++i, "--out-dir");
-        break;
-      }
-      case "--judge-cache-dir": {
-        judgeCacheDir = requireValue(argv, ++i, "--judge-cache-dir");
-        break;
-      }
-      case "--no-judge-cache": {
-        noJudgeCache = true;
-        break;
-      }
-      case "--only": {
-        only = requireValue(argv, ++i, "--only") as SingleFlagAblationId;
-        // Fail fast on unknown cell ids — a typo would otherwise silently skip.
-        getAblationCell(only);
-        break;
-      }
-      case "--limit": {
-        limit = parsePositiveInt(requireValue(argv, ++i, "--limit"), "--limit");
-        break;
-      }
-      case "--gpu": {
-        gpu = requireValue(argv, ++i, "--gpu");
-        break;
-      }
-      case "--vram-gb": {
-        vramGb = parsePositiveInt(requireValue(argv, ++i, "--vram-gb"), "--vram-gb");
-        break;
-      }
-      case "--quantization": {
-        quantization = requireValue(argv, ++i, "--quantization");
-        break;
-      }
-      case "-h":
-      case "--help": {
-        return { ok: false, message: "__help__" };
-      }
-      default:
-        positional.push(arg);
     }
-  }
 
-  if (!localLabManifestPath) {
+    if (positional.length > 0) {
+      return {
+        ok: false,
+        message: `ERROR: unknown argument(s): ${positional.join(" ")}. Run with --help for usage.`,
+      };
+    }
+    if (!localLabManifestPath) {
+      return {
+        ok: false,
+        message: "ERROR: --local-lab-manifest <path> is required (Tier L ablation runs use the local-lab profile).",
+      };
+    }
+    if (!datasetDir) {
+      return { ok: false, message: "ERROR: --dataset-dir <path> is required." };
+    }
+    if (!outDir) {
+      return { ok: false, message: "ERROR: --out-dir <path> is required." };
+    }
+
+    const expand = (p: string | undefined): string | undefined => (p ? expandTilde(p) : p);
     return {
-      ok: false,
-      message: "ERROR: --local-lab-manifest <path> is required (Tier L ablation runs use the local-lab profile).",
+      ok: true,
+      value: {
+        benchmark,
+        localLabManifestPath: expand(localLabManifestPath),
+        datasetDir: expand(datasetDir),
+        seed,
+        outDir: expand(outDir),
+        judgeCacheDir: expand(judgeCacheDir),
+        noJudgeCache,
+        only,
+        limit,
+        trialLimit,
+        hardware: { gpu, vramGb, quantization },
+      },
     };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
   }
-  if (!datasetDir) {
-    return { ok: false, message: "ERROR: --dataset-dir <path> is required." };
-  }
-  if (!outDir) {
-    return { ok: false, message: "ERROR: --out-dir <path> is required." };
-  }
-
-  return {
-    ok: true,
-    value: {
-      benchmark,
-      localLabManifestPath,
-      datasetDir,
-      seed,
-      outDir,
-      judgeCacheDir,
-      noJudgeCache,
-      only,
-      limit,
-      hardware: { gpu, vramGb, quantization },
-    },
-  };
 }
 
 function requireValue(argv: string[], index: number, flag: string): string {
@@ -196,9 +218,21 @@ function parsePositiveInt(raw: string, flag: string): number {
   return parsed;
 }
 
+/**
+ * Expand a leading `~` to the user's home dir. Node's fs does NOT expand tilde
+ * on its own, so a quoted `~/path` would be treated as a literal directory
+ * named `~`. (Unquoted `~/path` is usually expanded by the shell first, but we
+ * expand defensively so the runner is correct regardless of invocation.)
+ */
+function expandTilde(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/")) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
 const HELP = `usage: run-ablation-matrix.ts --benchmark <id> --local-lab-manifest <path> \\
   --dataset-dir <path> --out-dir <path> [--seed N] [--only <cell-id>] [--limit N] \\
-  [--judge-cache-dir <path>] [--no-judge-cache] [--gpu "..."] [--vram-gb N] [--quantization ...]
+  [--trial-limit N] [--judge-cache-dir <path>] [--no-judge-cache] [--gpu "..."] [--vram-gb N] [--quantization ...]
 
 Cells: ${SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id).join(", ")}
 `;
@@ -221,7 +255,7 @@ async function main(): Promise<number> {
 
   await writeStatus(
     statusPath,
-    `# Single-flag ablation matrix (issue #1730 / #1574)\n\n**Benchmark:** ${args.benchmark}  **Seed:** ${args.seed}  **Tier:** local\n**Cells:** ${cells.map((c) => c.id).join(", ")}\n${args.limit ? `**NOTE:** --limit ${args.limit} set — artifacts are NON-publishable (iteration only).\n` : ""}\n## Progress\n`
+    `# Single-flag ablation matrix (issue #1730 / #1574)\n\n**Benchmark:** ${args.benchmark}  **Seed:** ${args.seed}  **Tier:** local\n**Cells:** ${cells.map((c) => c.id).join(", ")}\n${args.limit ? `**NOTE:** --limit ${args.limit} set — artifacts are NON-publishable (iteration only).\n` : ""}${args.trialLimit ? `**NOTE:** --trial-limit ${args.trialLimit} set — QA trial count capped (NON-publishable).\n` : ""}\n## Progress\n`
   );
 
   const resolved = await resolveBenchRuntimeProfile({
@@ -229,6 +263,34 @@ async function main(): Promise<number> {
     localLabManifestPath: args.localLabManifestPath,
     judgeCacheDir: args.judgeCacheDir,
   });
+  // Preflight: verify each local-lab endpoint is live and serving the
+  // manifest-declared model before spending time on a cell. Addresses the
+  // "never invokes preflight" concern from PR #1751 review. The programmatic
+  // runBenchmark() API is used (not the CLI sequential-phase scheduler)
+  // because it is the only path that accepts per-cell configOverrides; the
+  // warm judge cache eliminates the responder/judge swap that sequential
+  // phases exist to schedule.
+  if (resolved.localLab) {
+    const roles: Array<[string, typeof resolved.localLab.responder]> = [
+      ["responder", resolved.localLab.responder],
+      ["judge", resolved.localLab.judge],
+    ];
+    for (const [roleName, role] of roles) {
+      const pf: LocalLabPreflightResult = await preflightLocalLabRole({
+        provider: role.provider,
+        baseUrl: role.baseUrl,
+        model: role.model,
+        ctx: role.ctx,
+      });
+      if (!pf.ok) {
+        const msg = `Preflight FAILED for ${roleName} (${role.baseUrl}): ${pf.reason}`;
+        process.stderr.write(`${msg}\n`);
+        await appendStatus(statusPath, `\n## Preflight FAILED\n- role: ${roleName}\n- endpoint: ${role.baseUrl}\n- expected model: ${role.model}\n- reason: ${pf.reason}\n`);
+        return 1;
+      }
+      process.stdout.write(`[preflight] ${roleName} OK — ${role.model} @ ${role.baseUrl}\n`);
+    }
+  }
 
   let failures = 0;
   for (const cell of cells) {
@@ -293,7 +355,7 @@ async function runOneCell(
   args: ParsedArgs,
   resolved: ResolvedBenchRuntimeProfile,
   cell: SingleFlagAblationCell
-): Promise<string> {
+): Promise<WriteBenchmarkArtifactResult> {
   // Merge the cell's configOverrides ON TOP of the resolved baseline config.
   // The resolved `adapterOptions.configOverrides` already contains the
   // local-lab baseline + provider hooks; the ablation flag rides on top so
@@ -318,47 +380,60 @@ async function runOneCell(
     ...(args.benchmark === "locomo" ? { replayExtractionMode: "skip" as const } : {}),
   });
 
-  const result = (await runBenchmark(args.benchmark, {
-    mode: "full",
-    datasetDir: args.datasetDir,
-    seed: args.seed,
-    limit: args.limit,
-    adapterMode: "direct",
-    runtimeProfile: resolved.profile,
-    systemProvider: resolved.systemProvider,
-    judgeProvider: resolved.judgeProvider,
-    internalProvider: resolved.internalProvider,
-    remnicConfig: mergedConfigOverrides,
-    drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs,
-    ...(args.noJudgeCache ? { noJudgeCache: true } : {}),
-    ...(args.judgeCacheDir ? { judgeCacheDir: args.judgeCacheDir } : {}),
-    system: adapter,
-  })) as BenchmarkResult;
+  try {
+    const result = (await runBenchmark(args.benchmark, {
+      mode: "full",
+      datasetDir: args.datasetDir,
+      seed: args.seed,
+      limit: args.limit,
+      adapterMode: "direct",
+      runtimeProfile: resolved.profile,
+      systemProvider: resolved.systemProvider,
+      judgeProvider: resolved.judgeProvider,
+      internalProvider: resolved.internalProvider,
+      remnicConfig: mergedConfigOverrides,
+      ...(args.trialLimit ? { benchmarkOptions: { trialLimit: args.trialLimit } } : {}),
+      drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs,
+      ...(args.noJudgeCache ? { noJudgeCache: true } : {}),
+      ...(args.judgeCacheDir ? { judgeCacheDir: args.judgeCacheDir } : {}),
+      system: adapter,
+    })) as BenchmarkResult;
 
-  // Stamp the effective config (post-merge) so the artifact reflects what
-  // actually ran, including the ablation override.
-  result.config.remnicConfig = mergedConfigOverrides;
+    // Stamp the effective config (post-merge) so the artifact reflects what
+    // actually ran, including the ablation override.
+    result.config.remnicConfig = mergedConfigOverrides;
 
-  // Build the artifact via the public promotion contract (same shape as
-  // build-artifact-from-result.ts): derive benchmarkId/model/seed/run-window
-  // from the live result so the artifact is self-describing + reproducible.
-  const benchmarkId = result.meta.benchmark as PublishedBenchmarkId;
-  const model = result.config.systemProvider?.model ?? "unknown";
-  const seed = result.meta.seeds[0] ?? 1;
-  const { startedAt, finishedAt } = deriveRunWindow(result.meta.timestamp, result.cost?.totalLatencyMs ?? 0);
-  const artifact = buildBenchmarkArtifact({
-    result,
-    benchmarkId,
-    datasetVersion: defaultDatasetVersion(benchmarkId),
-    model,
-    seed,
-    startedAt,
-    finishedAt,
-    tier: "local",
-    hardware: args.hardware,
-    note,
-  });
-  return writeBenchmarkArtifact(artifact, args.outDir);
+    // Build the artifact via the public promotion contract (same shape as
+    // build-artifact-from-result.ts): derive benchmarkId/model/seed/run-window
+    // from the live result so the artifact is self-describing + reproducible.
+    const benchmarkId = result.meta.benchmark as PublishedBenchmarkId;
+    const model = result.config.systemProvider?.model ?? "unknown";
+    const seed = result.meta.seeds[0] ?? 1;
+    const { startedAt, finishedAt } = deriveRunWindow(result.meta.timestamp, result.cost?.totalLatencyMs ?? 0);
+    const artifact = buildBenchmarkArtifact({
+      result,
+      benchmarkId,
+      datasetVersion: defaultDatasetVersion(benchmarkId),
+      model,
+      seed,
+      startedAt,
+      finishedAt,
+      tier: "local",
+      hardware: args.hardware,
+      note,
+    });
+
+    // Per-cell subdir: buildBenchmarkArtifactFilename derives the filename
+    // from startedAt+gitSha+model, so cells run on the same day with the same
+    // model would collide (overwrite) if written to the same out-dir. Each
+    // cell gets its own subdir so the matrix run preserves all 3 artifacts.
+    const cellOutDir = path.join(args.outDir, cell.id);
+    return await writeBenchmarkArtifact(artifact, cellOutDir);
+  } finally {
+    // createRemnicAdapter allocates a temp memory/QMD sandbox per cell;
+    // destroy() releases it so a 3-cell matrix run doesn't leak sandboxes.
+    await adapter.destroy();
+  }
 }
 
 async function writeStatus(statusPath: string, content: string): Promise<void> {

--- a/scripts/bench/run-ablation-matrix.ts
+++ b/scripts/bench/run-ablation-matrix.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S npx tsx
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
 /**
  * run-ablation-matrix.ts — Execute the single-flag ablation matrix
  * (issues #1574 §"Ablations" + #1730) against a published benchmark under a
@@ -39,23 +40,22 @@
  */
 import path from "node:path";
 import process from "node:process";
-import { mkdir, writeFile, appendFile } from "node:fs/promises";
 
 import {
-  resolveBenchRuntimeProfile,
-  runBenchmark,
-  createRemnicAdapter,
-  buildBenchmarkArtifact,
-  writeBenchmarkArtifact,
-  loadBenchmarkArtifact,
-  SINGLE_FLAG_ABLATION_MATRIX,
-  getAblationCell,
-  type SingleFlagAblationCell,
-  type SingleFlagAblationId,
-  type BenchmarkResult,
   type BenchmarkArtifactHardware,
   type BenchmarkArtifactTier,
+  type BenchmarkResult,
   type ResolvedBenchRuntimeProfile,
+  SINGLE_FLAG_ABLATION_MATRIX,
+  type SingleFlagAblationCell,
+  type SingleFlagAblationId,
+  buildBenchmarkArtifact,
+  createRemnicAdapter,
+  getAblationCell,
+  loadBenchmarkArtifact,
+  resolveBenchRuntimeProfile,
+  runBenchmark,
+  writeBenchmarkArtifact,
 } from "@remnic/bench";
 
 interface ParsedArgs {
@@ -150,7 +150,10 @@ function parseArgs(argv: string[]): { ok: true; value: ParsedArgs } | { ok: fals
   }
 
   if (!localLabManifestPath) {
-    return { ok: false, message: "ERROR: --local-lab-manifest <path> is required (Tier L ablation runs use the local-lab profile)." };
+    return {
+      ok: false,
+      message: "ERROR: --local-lab-manifest <path> is required (Tier L ablation runs use the local-lab profile).",
+    };
   }
   if (!datasetDir) {
     return { ok: false, message: "ERROR: --dataset-dir <path> is required." };
@@ -206,7 +209,7 @@ async function main(): Promise<number> {
       process.stdout.write(HELP);
       return 0;
     }
-    process.stderr.write(parsed.message + "\n" + HELP);
+    process.stderr.write(`${parsed.message}\n${HELP}`);
     return 2;
   }
   const args = parsed.value;
@@ -217,11 +220,7 @@ async function main(): Promise<number> {
 
   await writeStatus(
     statusPath,
-    `# Single-flag ablation matrix (issue #1730 / #1574)\n\n` +
-      `**Benchmark:** ${args.benchmark}  **Seed:** ${args.seed}  **Tier:** local\n` +
-      `**Cells:** ${cells.map((c) => c.id).join(", ")}\n` +
-      (args.limit ? `**NOTE:** --limit ${args.limit} set — artifacts are NON-publishable (iteration only).\n` : "") +
-      `\n## Progress\n`,
+    `# Single-flag ablation matrix (issue #1730 / #1574)\n\n**Benchmark:** ${args.benchmark}  **Seed:** ${args.seed}  **Tier:** local\n**Cells:** ${cells.map((c) => c.id).join(", ")}\n${args.limit ? `**NOTE:** --limit ${args.limit} set — artifacts are NON-publishable (iteration only).\n` : ""}\n## Progress\n`
   );
 
   const resolved = await resolveBenchRuntimeProfile({
@@ -234,7 +233,10 @@ async function main(): Promise<number> {
   for (const cell of cells) {
     const label = `[ablation:${cell.id}]`;
     process.stdout.write(`${label} starting — ${cell.label}\n`);
-    await appendStatus(statusPath, `\n### ${cell.id} — ${cell.label}\n- status: RUNNING\n- axis: ${cell.axis}\n- baseline: ${cell.baselineState}\n`);
+    await appendStatus(
+      statusPath,
+      `\n### ${cell.id} — ${cell.label}\n- status: RUNNING\n- axis: ${cell.axis}\n- baseline: ${cell.baselineState}\n`
+    );
     try {
       const artifactPath = await runOneCell(args, resolved, cell);
       const { artifact, sha256 } = await loadBenchmarkArtifact(artifactPath);
@@ -242,14 +244,16 @@ async function main(): Promise<number> {
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([k, v]) => `${k}=${typeof v === "number" ? v.toFixed(4) : v}`)
         .join(", ");
-      process.stdout.write(`${label} DONE → ${path.basename(artifactPath)} (${metrics}) sha256=${sha256.slice(0, 12)}\n`);
+      process.stdout.write(
+        `${label} DONE → ${path.basename(artifactPath)} (${metrics}) sha256=${sha256.slice(0, 12)}\n`
+      );
       await appendStatus(
         statusPath,
-        `- status: DONE\n  - artifact: \`${path.basename(artifactPath)}\`\n  - metrics: ${metrics}\n  - sha256: ${sha256}\n`,
+        `- status: DONE\n  - artifact: \`${path.basename(artifactPath)}\`\n  - metrics: ${metrics}\n  - sha256: ${sha256}\n`
       );
     } catch (error) {
       failures += 1;
-      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
       process.stderr.write(`${label} FAILED: ${message}\n`);
       await appendStatus(statusPath, `- status: FAILED\n  - error: ${message.split("\n")[0]}\n`);
     }
@@ -257,7 +261,7 @@ async function main(): Promise<number> {
 
   await appendStatus(
     statusPath,
-    `\n## Summary\n- cells attempted: ${cells.length}\n- failures: ${failures}\n- finished: ${new Date().toISOString()}\n`,
+    `\n## Summary\n- cells attempted: ${cells.length}\n- failures: ${failures}\n- finished: ${new Date().toISOString()}\n`
   );
   return failures === 0 ? 0 : 1;
 }
@@ -265,7 +269,7 @@ async function main(): Promise<number> {
 async function runOneCell(
   args: ParsedArgs,
   resolved: ResolvedBenchRuntimeProfile,
-  cell: SingleFlagAblationCell,
+  cell: SingleFlagAblationCell
 ): Promise<string> {
   // Merge the cell's configOverrides ON TOP of the resolved baseline config.
   // The resolved `adapterOptions.configOverrides` already contains the
@@ -280,20 +284,14 @@ async function runOneCell(
   const limitNote = args.limit
     ? ` ITERATION-ONLY slice (--limit ${args.limit}); NOT a publishable full-run number.`
     : "";
-  const note =
-    `Single-flag ablation "${cell.id}" (${cell.label}). ` +
-    cell.description +
-    ` Baseline: ${cell.baselineState}` +
-    limitNote;
+  const note = `Single-flag ablation "${cell.id}" (${cell.label}). ${cell.description} Baseline: ${cell.baselineState}${limitNote}`;
 
   const adapter = await createRemnicAdapter({
     configOverrides: mergedConfigOverrides,
     responder: resolved.adapterOptions.responder,
     judge: resolved.adapterOptions.judge,
     preserveRuntimeDefaults: resolved.adapterOptions.preserveRuntimeDefaults,
-    ...(resolved.adapterOptions.drainTimeoutMs
-      ? { drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs }
-      : {}),
+    ...(resolved.adapterOptions.drainTimeoutMs ? { drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs } : {}),
     ...(args.benchmark === "locomo" ? { replayExtractionMode: "skip" as const } : {}),
   });
 
@@ -341,7 +339,7 @@ main()
   })
   .catch((error) => {
     process.stderr.write(
-      `run-ablation-matrix.ts crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+      `run-ablation-matrix.ts crashed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
     );
     process.exitCode = 1;
   });

--- a/scripts/bench/run-ablation-matrix.ts
+++ b/scripts/bench/run-ablation-matrix.ts
@@ -45,6 +45,7 @@ import {
   type BenchmarkArtifactHardware,
   type BenchmarkArtifactTier,
   type BenchmarkResult,
+  type PublishedBenchmarkId,
   type ResolvedBenchRuntimeProfile,
   SINGLE_FLAG_ABLATION_MATRIX,
   type SingleFlagAblationCell,
@@ -266,6 +267,30 @@ async function main(): Promise<number> {
   return failures === 0 ? 0 : 1;
 }
 
+/**
+ * Derive the true run window from the runner's end-stamp and summed task
+ * latency. Mirrors build-artifact-from-result.ts so the artifact's
+ * startedAt/finishedAt match the promotion path exactly.
+ */
+function deriveRunWindow(metaTimestamp: string, totalLatencyMs: number): { startedAt: string; finishedAt: string } {
+  const finishedMs = Date.parse(metaTimestamp);
+  if (!Number.isFinite(finishedMs)) {
+    throw new Error(`meta.timestamp "${metaTimestamp}" is not a valid ISO-8601 timestamp.`);
+  }
+  const duration = Number.isFinite(totalLatencyMs) && totalLatencyMs > 0 ? totalLatencyMs : 0;
+  return {
+    startedAt: new Date(finishedMs - duration).toISOString(),
+    finishedAt: new Date(finishedMs).toISOString(),
+  };
+}
+
+/** Default dataset-version tag per published benchmark (matches the promotion path). */
+function defaultDatasetVersion(benchmarkId: PublishedBenchmarkId): string {
+  if (benchmarkId === "locomo") return "locomo-10";
+  if (benchmarkId === "longmemeval") return "longmemeval-oracle";
+  return `${benchmarkId}-v1`;
+}
+
 async function runOneCell(
   args: ParsedArgs,
   resolved: ResolvedBenchRuntimeProfile,
@@ -316,9 +341,22 @@ async function runOneCell(
   // actually ran, including the ablation override.
   result.config.remnicConfig = mergedConfigOverrides;
 
-  const tier: BenchmarkArtifactTier = "local";
-  const artifact = buildBenchmarkArtifact(result, {
-    tier,
+  // Build the artifact via the public promotion contract (same shape as
+  // build-artifact-from-result.ts): derive benchmarkId/model/seed/run-window
+  // from the live result so the artifact is self-describing + reproducible.
+  const benchmarkId = result.meta.benchmark as PublishedBenchmarkId;
+  const model = result.config.systemProvider?.model ?? "unknown";
+  const seed = result.meta.seeds[0] ?? 1;
+  const { startedAt, finishedAt } = deriveRunWindow(result.meta.timestamp, result.cost?.totalLatencyMs ?? 0);
+  const artifact = buildBenchmarkArtifact({
+    result,
+    benchmarkId,
+    datasetVersion: defaultDatasetVersion(benchmarkId),
+    model,
+    seed,
+    startedAt,
+    finishedAt,
+    tier: "local",
     hardware: args.hardware,
     note,
   });

--- a/scripts/bench/run-ablation-matrix.ts
+++ b/scripts/bench/run-ablation-matrix.ts
@@ -1,0 +1,347 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * run-ablation-matrix.ts — Execute the single-flag ablation matrix
+ * (issues #1574 §"Ablations" + #1730) against a published benchmark under a
+ * local-lab runtime profile, producing one publishable BenchmarkArtifact per
+ * cell.
+ *
+ * This is the reproducible run config for the paper's §7 Ablations table.
+ * Each cell flips exactly one Remnic config flag relative to the
+ * {@link buildBenchBaselineRemnicConfig} baseline (see
+ * `packages/bench/src/ablations/single-flag-matrix.ts`), so the delta against
+ * the matching baseline artifact isolates that flag's effect.
+ *
+ * The script is a thin shell over the public `@remnic/bench` API
+ * (`resolveBenchRuntimeProfile` + `runBenchmark` + `createRemnicAdapter` +
+ * `buildBenchmarkArtifact`) — it adds only the ablation-override merge and
+ * per-cell STATUS logging. Nothing here re-implements harness internals.
+ *
+ * Usage (full matrix, LoCoMo, Tier L on the lab box):
+ *   scripts/bench/run-ablation-matrix.ts \
+ *     --benchmark locomo \
+ *     --local-lab-manifest ~/bench-manifests/local-lab-3090.json \
+ *     --dataset-dir ./bench-datasets/locomo \
+ *     --seed 1 \
+ *     --out-dir ~/bench-artifacts/ablations \
+ *     --judge-cache-dir ~/.remnic/bench/results/judge-cache
+ *
+ *   --only <cell-id>      run a single cell (default: all, in matrix order)
+ *   --limit N             cap the QA count per cell (NON-publishable; for
+ *                         smoke/iteration only — the resulting artifact is
+ *                         labeled with the limit in its note and is NOT a
+ *                         leaderboard-grade number)
+ *   --no-judge-cache      force re-judging (default: cache on)
+ *
+ * Exit codes:
+ *   0 — every requested cell produced a verified artifact
+ *   1 — one or more cells failed (partial artifacts may still be on disk)
+ *   2 — usage error
+ */
+import path from "node:path";
+import process from "node:process";
+import { mkdir, writeFile, appendFile } from "node:fs/promises";
+
+import {
+  resolveBenchRuntimeProfile,
+  runBenchmark,
+  createRemnicAdapter,
+  buildBenchmarkArtifact,
+  writeBenchmarkArtifact,
+  loadBenchmarkArtifact,
+  SINGLE_FLAG_ABLATION_MATRIX,
+  getAblationCell,
+  type SingleFlagAblationCell,
+  type SingleFlagAblationId,
+  type BenchmarkResult,
+  type BenchmarkArtifactHardware,
+  type BenchmarkArtifactTier,
+  type ResolvedBenchRuntimeProfile,
+} from "@remnic/bench";
+
+interface ParsedArgs {
+  benchmark: string;
+  localLabManifestPath: string;
+  datasetDir: string;
+  seed: number;
+  outDir: string;
+  judgeCacheDir?: string;
+  noJudgeCache: boolean;
+  only?: SingleFlagAblationId;
+  limit?: number;
+  hardware: BenchmarkArtifactHardware;
+}
+
+function parseArgs(argv: string[]): { ok: true; value: ParsedArgs } | { ok: false; message: string } {
+  const positional: string[] = [];
+  let benchmark = "locomo";
+  let localLabManifestPath: string | undefined;
+  let datasetDir: string | undefined;
+  let seed = 1;
+  let outDir: string | undefined;
+  let judgeCacheDir: string | undefined;
+  let noJudgeCache = false;
+  let only: SingleFlagAblationId | undefined;
+  let limit: number | undefined;
+  let gpu = "NVIDIA RTX 3090";
+  let vramGb = 24;
+  let quantization = "Q4_K_M";
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    switch (arg) {
+      case "--benchmark": {
+        benchmark = requireValue(argv, ++i, "--benchmark");
+        break;
+      }
+      case "--local-lab-manifest": {
+        localLabManifestPath = requireValue(argv, ++i, "--local-lab-manifest");
+        break;
+      }
+      case "--dataset-dir": {
+        datasetDir = requireValue(argv, ++i, "--dataset-dir");
+        break;
+      }
+      case "--seed": {
+        seed = parsePositiveInt(requireValue(argv, ++i, "--seed"), "--seed");
+        break;
+      }
+      case "--out-dir": {
+        outDir = requireValue(argv, ++i, "--out-dir");
+        break;
+      }
+      case "--judge-cache-dir": {
+        judgeCacheDir = requireValue(argv, ++i, "--judge-cache-dir");
+        break;
+      }
+      case "--no-judge-cache": {
+        noJudgeCache = true;
+        break;
+      }
+      case "--only": {
+        only = requireValue(argv, ++i, "--only") as SingleFlagAblationId;
+        // Fail fast on unknown cell ids — a typo would otherwise silently skip.
+        getAblationCell(only);
+        break;
+      }
+      case "--limit": {
+        limit = parsePositiveInt(requireValue(argv, ++i, "--limit"), "--limit");
+        break;
+      }
+      case "--gpu": {
+        gpu = requireValue(argv, ++i, "--gpu");
+        break;
+      }
+      case "--vram-gb": {
+        vramGb = parsePositiveInt(requireValue(argv, ++i, "--vram-gb"), "--vram-gb");
+        break;
+      }
+      case "--quantization": {
+        quantization = requireValue(argv, ++i, "--quantization");
+        break;
+      }
+      case "-h":
+      case "--help": {
+        return { ok: false, message: "__help__" };
+      }
+      default:
+        positional.push(arg);
+    }
+  }
+
+  if (!localLabManifestPath) {
+    return { ok: false, message: "ERROR: --local-lab-manifest <path> is required (Tier L ablation runs use the local-lab profile)." };
+  }
+  if (!datasetDir) {
+    return { ok: false, message: "ERROR: --dataset-dir <path> is required." };
+  }
+  if (!outDir) {
+    return { ok: false, message: "ERROR: --out-dir <path> is required." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      benchmark,
+      localLabManifestPath,
+      datasetDir,
+      seed,
+      outDir,
+      judgeCacheDir,
+      noJudgeCache,
+      only,
+      limit,
+      hardware: { gpu, vramGb, quantization },
+    },
+  };
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value === undefined) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer; got "${raw}".`);
+  }
+  return parsed;
+}
+
+const HELP = `usage: run-ablation-matrix.ts --benchmark <id> --local-lab-manifest <path> \\
+  --dataset-dir <path> --out-dir <path> [--seed N] [--only <cell-id>] [--limit N] \\
+  [--judge-cache-dir <path>] [--no-judge-cache] [--gpu "..."] [--vram-gb N] [--quantization ...]
+
+Cells: ${SINGLE_FLAG_ABLATION_MATRIX.map((c) => c.id).join(", ")}
+`;
+
+async function main(): Promise<number> {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (!parsed.ok) {
+    if (parsed.message === "__help__") {
+      process.stdout.write(HELP);
+      return 0;
+    }
+    process.stderr.write(parsed.message + "\n" + HELP);
+    return 2;
+  }
+  const args = parsed.value;
+
+  await mkdir(args.outDir, { recursive: true });
+  const statusPath = path.join(args.outDir, "STATUS.md");
+  const cells = args.only ? [getAblationCell(args.only)] : [...SINGLE_FLAG_ABLATION_MATRIX];
+
+  await writeStatus(
+    statusPath,
+    `# Single-flag ablation matrix (issue #1730 / #1574)\n\n` +
+      `**Benchmark:** ${args.benchmark}  **Seed:** ${args.seed}  **Tier:** local\n` +
+      `**Cells:** ${cells.map((c) => c.id).join(", ")}\n` +
+      (args.limit ? `**NOTE:** --limit ${args.limit} set — artifacts are NON-publishable (iteration only).\n` : "") +
+      `\n## Progress\n`,
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "local-lab",
+    localLabManifestPath: args.localLabManifestPath,
+    judgeCacheDir: args.judgeCacheDir,
+  });
+
+  let failures = 0;
+  for (const cell of cells) {
+    const label = `[ablation:${cell.id}]`;
+    process.stdout.write(`${label} starting — ${cell.label}\n`);
+    await appendStatus(statusPath, `\n### ${cell.id} — ${cell.label}\n- status: RUNNING\n- axis: ${cell.axis}\n- baseline: ${cell.baselineState}\n`);
+    try {
+      const artifactPath = await runOneCell(args, resolved, cell);
+      const { artifact, sha256 } = await loadBenchmarkArtifact(artifactPath);
+      const metrics = Object.entries(artifact.metrics)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${typeof v === "number" ? v.toFixed(4) : v}`)
+        .join(", ");
+      process.stdout.write(`${label} DONE → ${path.basename(artifactPath)} (${metrics}) sha256=${sha256.slice(0, 12)}\n`);
+      await appendStatus(
+        statusPath,
+        `- status: DONE\n  - artifact: \`${path.basename(artifactPath)}\`\n  - metrics: ${metrics}\n  - sha256: ${sha256}\n`,
+      );
+    } catch (error) {
+      failures += 1;
+      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      process.stderr.write(`${label} FAILED: ${message}\n`);
+      await appendStatus(statusPath, `- status: FAILED\n  - error: ${message.split("\n")[0]}\n`);
+    }
+  }
+
+  await appendStatus(
+    statusPath,
+    `\n## Summary\n- cells attempted: ${cells.length}\n- failures: ${failures}\n- finished: ${new Date().toISOString()}\n`,
+  );
+  return failures === 0 ? 0 : 1;
+}
+
+async function runOneCell(
+  args: ParsedArgs,
+  resolved: ResolvedBenchRuntimeProfile,
+  cell: SingleFlagAblationCell,
+): Promise<string> {
+  // Merge the cell's configOverrides ON TOP of the resolved baseline config.
+  // The resolved `adapterOptions.configOverrides` already contains the
+  // local-lab baseline + provider hooks; the ablation flag rides on top so
+  // everything else (provider, judge, drain) is byte-identical to the
+  // matching baseline run.
+  const mergedConfigOverrides = {
+    ...resolved.adapterOptions.configOverrides,
+    ...cell.configOverrides,
+  };
+
+  const limitNote = args.limit
+    ? ` ITERATION-ONLY slice (--limit ${args.limit}); NOT a publishable full-run number.`
+    : "";
+  const note =
+    `Single-flag ablation "${cell.id}" (${cell.label}). ` +
+    cell.description +
+    ` Baseline: ${cell.baselineState}` +
+    limitNote;
+
+  const adapter = await createRemnicAdapter({
+    configOverrides: mergedConfigOverrides,
+    responder: resolved.adapterOptions.responder,
+    judge: resolved.adapterOptions.judge,
+    preserveRuntimeDefaults: resolved.adapterOptions.preserveRuntimeDefaults,
+    ...(resolved.adapterOptions.drainTimeoutMs
+      ? { drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs }
+      : {}),
+    ...(args.benchmark === "locomo" ? { replayExtractionMode: "skip" as const } : {}),
+  });
+
+  const result = (await runBenchmark(args.benchmark, {
+    mode: "full",
+    datasetDir: args.datasetDir,
+    seed: args.seed,
+    limit: args.limit,
+    adapterMode: "direct",
+    runtimeProfile: resolved.profile,
+    systemProvider: resolved.systemProvider,
+    judgeProvider: resolved.judgeProvider,
+    internalProvider: resolved.internalProvider,
+    remnicConfig: mergedConfigOverrides,
+    drainTimeoutMs: resolved.adapterOptions.drainTimeoutMs,
+    ...(args.noJudgeCache ? { noJudgeCache: true } : {}),
+    ...(args.judgeCacheDir ? { judgeCacheDir: args.judgeCacheDir } : {}),
+    system: adapter,
+  })) as BenchmarkResult;
+
+  // Stamp the effective config (post-merge) so the artifact reflects what
+  // actually ran, including the ablation override.
+  result.config.remnicConfig = mergedConfigOverrides;
+
+  const tier: BenchmarkArtifactTier = "local";
+  const artifact = buildBenchmarkArtifact(result, {
+    tier,
+    hardware: args.hardware,
+    note,
+  });
+  return writeBenchmarkArtifact(artifact, args.outDir);
+}
+
+async function writeStatus(statusPath: string, content: string): Promise<void> {
+  await writeFile(statusPath, content, "utf8");
+}
+
+async function appendStatus(statusPath: string, content: string): Promise<void> {
+  await appendFile(statusPath, content, "utf8");
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    process.stderr.write(
+      `run-ablation-matrix.ts crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });

--- a/scripts/bench/run-ablation-matrix.ts
+++ b/scripts/bench/run-ablation-matrix.ts
@@ -239,18 +239,16 @@ async function main(): Promise<number> {
       `\n### ${cell.id} — ${cell.label}\n- status: RUNNING\n- axis: ${cell.axis}\n- baseline: ${cell.baselineState}\n`
     );
     try {
-      const artifactPath = await runOneCell(args, resolved, cell);
-      const { artifact, sha256 } = await loadBenchmarkArtifact(artifactPath);
+      const written = await runOneCell(args, resolved, cell);
+      const { artifact } = await loadBenchmarkArtifact(written.path);
       const metrics = Object.entries(artifact.metrics)
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([k, v]) => `${k}=${typeof v === "number" ? v.toFixed(4) : v}`)
         .join(", ");
-      process.stdout.write(
-        `${label} DONE → ${path.basename(artifactPath)} (${metrics}) sha256=${sha256.slice(0, 12)}\n`
-      );
+      process.stdout.write(`${label} DONE → ${written.filename} (${metrics}) sha256=${written.sha256.slice(0, 12)}\n`);
       await appendStatus(
         statusPath,
-        `- status: DONE\n  - artifact: \`${path.basename(artifactPath)}\`\n  - metrics: ${metrics}\n  - sha256: ${sha256}\n`
+        `- status: DONE\n  - artifact: \`${written.filename}\`\n  - metrics: ${metrics}\n  - sha256: ${written.sha256}\n`
       );
     } catch (error) {
       failures += 1;


### PR DESCRIPTION
Closes #1730 (coordinates with #1574 §\"Ablations\"; does not duplicate #1708).

## What

The reproducible ablation matrix for the paper's **§7 Ablations table**: one cell per publishable single-flag axis from #1574, each expressed as a config-override payload merged over the bench baseline via `adapterOptions.configOverrides`:

| Cell id | Axis | Flip |
|---|---|---|
| `memory-worth-off` | memory-worth | `recallMemoryWorthFilterEnabled = false` |
| `contradiction-scan-on` | contradiction-scan | `contradictionScan.enabled = true` |
| `graph-recall-on` | graph-recall | `graphRecallEnabled` + `graphAssistInFullModeEnabled = true` |

`trustScoreEnabled` is deliberately **not** an axis here — it is the unified stage from #1577 and belongs to the model-lab track.

## Files

- \`packages/bench/src/ablations/single-flag-matrix.ts\` — pure-data 3-cell matrix + \`getAblationCell()\`. No I/O; source of truth for both runner and paper table.
- \`packages/bench/src/ablations/single-flag-matrix.test.ts\` — locks matrix shape/order, single-flag invariant (verified with \`in\`-narrowing, not inline casts), \`getAblationCell\` fail-fast, and the override-wins merge contract against \`buildBenchBaselineRemnicConfig\`.
- \`packages/bench/src/index.ts\` — re-export the matrix API from \`@remnic/bench\`.
- \`scripts/bench/run-ablation-matrix.ts\` — thin shell over the public bench API (\`resolveBenchRuntimeProfile\` + \`runBenchmark\` + \`buildBenchmarkArtifact\`); merges the cell override on top of the resolved baseline, stamps the effective config into the artifact, writes a per-cell \`STATUS.md\`.

## Run-artifact status

This PR lands the **matrix + runner + tests**. Real (non-mock) run artifacts commit under \`docs/benchmarks/results/\` as Tier-L cells complete on the lab box (RTX 3090, ollama qwen2.5-7b-32k, seed 1). The runner is the only sanctioned path to produce them; per the #1730 contract, no fabricated numbers — artifacts are \`verify-artifact\`-checked before \`git add -f\`.

- [x] matrix + runner + unit tests (this PR)
- [ ] Tier-L run artifacts (follow-up commits + STATUS.md handoff)
- [ ] deltas summarized in the §7 target doc

## Chokepoints used / not applicable

- **not applicable** — this PR adds a new pure-data module + a thin runner over the existing public bench API; no \`orchestrator.ts\`/\`storage.ts\`/\`cli.ts\` edits, no feature gates, no namespace resolution, no catalog writes, no keyed-mutation surface.

Refs #1730, #1574, #1725.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench-only data, tests, and a thin runner over existing public APIs; no production memory/orchestrator paths change.
> 
> **Overview**
> Adds the **reproducible single-flag ablation suite** for published benchmarks (paper §7 / #1574): a pure-data **3-cell matrix** (`memory-worth-off`, `contradiction-scan-on`, `graph-recall-on`) where each cell merges one primary Remnic config flip over the bench baseline—**inline** `contradictionDetectionEnabled` for the contradiction axis (not the cron), and the graph cell sets the three gates needed for graph recall in full mode.
> 
> **`@remnic/bench`** re-exports the matrix API; **`scripts/bench/run-ablation-matrix.ts`** runs cells via `resolveBenchRuntimeProfile` + `runBenchmark` + artifact promotion, merges per-cell overrides, preflights local-lab responder/judge, writes per-cell artifacts and **`STATUS.md`**, and destroys adapters between cells. **Unit tests** lock matrix order, metadata, single-flag invariants, non–no-op overrides vs baseline and `parseConfig` defaults, and merge semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff1160436b03aa7a701086e3fc25fbd134a4bcab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->