### PR TITLE
fix(correction): #1713 pre-judge redaction multi-dir + stale-applying recovery

### DIFF
--- a/packages/remnic-core/src/correction/correction-contract.ts
+++ b/packages/remnic-core/src/correction/correction-contract.ts
@@ -168,6 +168,13 @@ export interface CorrectionPlan {
    * never be re-applied wholesale (it would duplicate succeeded actions).
    */
   status?: "pending" | "applying" | "applied" | "discarded" | "partial";
+  /**
+   * ISO timestamp recorded when the plan transitioned to `applying` (#1713
+   * Item 2). Startup recovery uses this to detect plans stuck in `applying`
+   * past the stale-applying TTL (process died mid-apply) and discard+scrub
+   * them. Absent on plans that never entered `applying`.
+   */
+  applyingAt?: string;
 }
 
 /**

--- a/packages/remnic-core/src/correction/correction-planner.test.ts
+++ b/packages/remnic-core/src/correction/correction-planner.test.ts
@@ -491,3 +491,234 @@ test("#1678: never_store plan redacts the request text in the persisted pending-
     assert.ok(reloaded!.request.text.includes("redacted"));
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1713 Item 2: stale applying plan recovery
+// ---------------------------------------------------------------------------
+
+test("#1713: markConsumed(applying) stamps applyingAt", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "old fact" })],
+      ]),
+      llmResult: {
+        classification: "outdated",
+        confidence: 0.9,
+        actions: [{ kind: "supersede", loserId: "mem-x", replacement: { content: "new fact" } }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const planner = new CorrectionPlanner(makeDeps(dir, state));
+    const plan = await planner.plan({ text: "correct this" }, ["default"]);
+    await planner.markConsumed("default", plan.planId, "applying");
+    const reloaded = await planner.loadPlan("default", plan.planId);
+    assert.equal(reloaded!.status, "applying");
+    assert.ok(reloaded!.applyingAt, "applyingAt must be stamped when entering applying state");
+  });
+});
+
+test("#1713: markConsumed(applied) clears applyingAt", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "old fact" })],
+      ]),
+      llmResult: {
+        classification: "outdated",
+        confidence: 0.9,
+        actions: [{ kind: "supersede", loserId: "mem-x", replacement: { content: "new fact" } }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const planner = new CorrectionPlanner(makeDeps(dir, state));
+    const plan = await planner.plan({ text: "correct this" }, ["default"]);
+    await planner.markConsumed("default", plan.planId, "applying");
+    await planner.markConsumed("default", plan.planId, "applied");
+    const reloaded = await planner.loadPlan("default", plan.planId);
+    assert.equal(reloaded!.status, "applied");
+    assert.ok(!reloaded!.applyingAt, "applyingAt must be cleared on terminal status");
+  });
+});
+
+test("#1713: recoverStaleApplyingPlans discards stale applying plans", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "secret-token-1234" })],
+      ]),
+      llmResult: {
+        classification: "never_store",
+        confidence: 0.9,
+        actions: [{ kind: "redaction_rule", pattern: "secret-token-\\d+" }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const planTime = new Date("2026-03-15T12:00:00Z");
+    const recoveryTime = new Date("2026-03-15T13:00:00Z");
+    const deps = makeDeps(dir, state);
+    deps.now = () => planTime;
+    const planner = new CorrectionPlanner(deps);
+    const plan = await planner.plan({ text: "never store this secret", targetIds: ["mem-x"] }, ["default"]);
+    await planner.markConsumed("default", plan.planId, "applying");
+
+    let reloaded = await planner.loadPlan("default", plan.planId);
+    assert.equal(reloaded!.status, "applying");
+
+    const recovered = await planner.recoverStaleApplyingPlans("default", { now: recoveryTime });
+    assert.equal(recovered.length, 1);
+    assert.equal(recovered[0], plan.planId);
+
+    // Read the raw file (loadPlan/parsePlan rejects the scrubbed pattern by
+    // design — validation rejects placeholder patterns on re-load).
+    const { readFile: rf } = await import("node:fs/promises");
+    const rawPlan = JSON.parse(
+      await rf(dir + "/state/corrections/pending/" + plan.planId + ".json", "utf-8"),
+    );
+    assert.equal(rawPlan.status, "discarded");
+    assert.ok(!rawPlan.applyingAt, "applyingAt cleared on discard");
+    const redactionAction = rawPlan.actions.find(
+      (a: { kind: string }) => a.kind === "redaction_rule",
+    );
+    assert.ok(redactionAction, "redaction_rule action should still exist");
+    assert.match(String(redactionAction.pattern), /redacted/);
+  });
+});
+
+test("#1713: recoverStaleApplyingPlans leaves fresh applying plans alone", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "old fact" })],
+      ]),
+      llmResult: {
+        classification: "outdated",
+        confidence: 0.9,
+        actions: [{ kind: "supersede", loserId: "mem-x", replacement: { content: "new fact" } }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const fixedNow = new Date("2026-03-15T12:00:00Z");
+    const deps = makeDeps(dir, state);
+    const planner = new CorrectionPlanner(deps);
+    const plan = await planner.plan({ text: "correct this" }, ["default"]);
+    await planner.markConsumed("default", plan.planId, "applying");
+
+    const recovered = await planner.recoverStaleApplyingPlans("default", {
+      now: new Date(fixedNow.getTime() + 2 * 60 * 1000),
+    });
+    assert.equal(recovered.length, 0);
+
+    const reloaded = await planner.loadPlan("default", plan.planId);
+    assert.equal(reloaded!.status, "applying");
+  });
+});
+
+test("#1713: recoverStaleApplyingPlans returns empty for namespace with no plans", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map(),
+      llmResult: { classification: "outdated", confidence: 0.5, actions: [], relevance: [], warnings: [] },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const planner = new CorrectionPlanner(makeDeps(dir, state));
+    const recovered = await planner.recoverStaleApplyingPlans("default");
+    assert.deepEqual(recovered, []);
+  });
+});
+
+test("#1713: recoverStaleApplyingPlans recovers pre-fix plans via expiresAt fallback", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "old fact" })],
+      ]),
+      llmResult: {
+        classification: "outdated",
+        confidence: 0.9,
+        actions: [{ kind: "supersede", loserId: "mem-x", replacement: { content: "new fact" } }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const fixedNow = new Date("2026-03-15T12:00:00Z");
+    const deps = makeDeps(dir, state);
+    const planner = new CorrectionPlanner(deps);
+    const plan = await planner.plan({ text: "correct this" }, ["default"]);
+
+    await planner.markConsumed("default", plan.planId, "applying");
+    // Simulate a pre-fix plan: manually strip applyingAt from the file
+    const { readFile: rf, writeFile: wf } = await import("node:fs/promises");
+    const planFile = dir + "/state/corrections/pending/" + plan.planId + ".json";
+    const planJson = JSON.parse(await rf(planFile, "utf-8"));
+    delete planJson.applyingAt;
+    await wf(planFile, JSON.stringify(planJson) + "\n", "utf-8");
+
+    // Recovery 25h later (past the 24h expiry, no applyingAt → falls back to expiresAt)
+    const recovered = await planner.recoverStaleApplyingPlans("default", {
+      now: new Date(fixedNow.getTime() + 25 * 60 * 60 * 1000),
+    });
+    assert.equal(recovered.length, 1);
+    assert.equal(recovered[0], plan.planId);
+  });
+});
+
+test("#1713: recoverStaleApplyingPlans recovers pre-fix plans immediately at expiry (no extra TTL wait)", async () => {
+  await withTempDir(async (dir) => {
+    const state: StubState = {
+      candidatesById: new Map([
+        ["mem-x", makeCandidate({ memoryId: "mem-x", content: "old fact" })],
+      ]),
+      llmResult: {
+        classification: "outdated",
+        confidence: 0.9,
+        actions: [{ kind: "supersede", loserId: "mem-x", replacement: { content: "new fact" } }],
+        relevance: [],
+        warnings: [],
+      },
+      writeReplacementCalls: 0,
+      propagateCalls: 0,
+      retireCalls: 0,
+    };
+    const fixedNow = new Date("2026-03-15T12:00:00Z");
+    const deps = makeDeps(dir, state);
+    const planner = new CorrectionPlanner(deps);
+    const plan = await planner.plan({ text: "correct this" }, ["default"]);
+
+    await planner.markConsumed("default", plan.planId, "applying");
+    // Simulate a pre-fix plan: manually strip applyingAt from the file
+    const { readFile: rf, writeFile: wf } = await import("node:fs/promises");
+    const planFile = dir + "/state/corrections/pending/" + plan.planId + ".json";
+    const planJson = JSON.parse(await rf(planFile, "utf-8"));
+    delete planJson.applyingAt;
+    await wf(planFile, JSON.stringify(planJson) + "\n", "utf-8");
+
+    // Recovery at exactly expiresAt: plan is already expired -> recover now
+    // (review thread ff034716: no extra TTL wait for pre-fix plans)
+    const recovered = await planner.recoverStaleApplyingPlans("default", {
+      now: new Date(planJson.expiresAt),
+    });
+    assert.equal(recovered.length, 1, "pre-fix plan at expiry must be recovered immediately");
+  });
+});

--- a/packages/remnic-core/src/correction/correction-planner.ts
+++ b/packages/remnic-core/src/correction/correction-planner.ts
@@ -478,6 +478,15 @@ export class CorrectionPlanner {
       const plan = parsePlan(raw);
       if (!plan) return;
       plan.status = status;
+      // #1713 Item 2: stamp applyingAt when entering the applying state so
+      // startup recovery can detect plans stuck mid-apply (process death).
+      // Cleared on terminal transitions; harmless residue on non-applying
+      // plans is ignored by the recovery scan.
+      if (status === "applying") {
+        plan.applyingAt = this.deps.now().toISOString();
+      } else {
+        delete plan.applyingAt;
+      }
       // #1669 thread P1: scrub redaction_rule patterns from consumed plans so
       // a never-store pattern does not persist on disk after apply/discard.
       // The executor reloads via loadPlan only between "applying" (step 1) and
@@ -507,6 +516,70 @@ export class CorrectionPlanner {
         throw err;
       }
     });
+  }
+
+  /**
+   * Stale-applying TTL: a plan in `applying` state longer than this is
+   * assumed to be from a crashed process and is recovered on startup
+   * (#1713 Item 2). 10 minutes is generous for an apply that normally
+   * completes in seconds, yet short enough to avoid leaving stale state.
+   */
+  static readonly STALE_APPLYING_TTL_MS = 10 * 60 * 1000;
+
+  /**
+   * Recover stale `applying` plans past the stale-applying TTL (#1713 Item 2).
+   *
+   * A plan stuck in `applying` means the process died mid-apply. Re-applying
+   * wholesale would duplicate succeeded actions (replacements, tombstones,
+   * audits), so recovery discards + scrubs the plan instead. The operator
+   * inspects the outcome and files a NEW plan for any actions that did not
+   * complete. Plans without `applyingAt` (predating this fix) are recovered
+   * when they are past their `expiresAt` timestamp.
+   *
+   * @returns the ids of recovered (discarded) plans.
+   */
+  async recoverStaleApplyingPlans(
+    namespace: string,
+    opts?: { ttlMs?: number; now?: Date },
+  ): Promise<string[]> {
+    const ttl = opts?.ttlMs ?? CorrectionPlanner.STALE_APPLYING_TTL_MS;
+    const now = (opts?.now ?? this.deps.now()).getTime();
+    const dir = await this.pendingDir(namespace);
+    let files: string[];
+    try {
+      files = await readdir(dir);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") return [];
+      throw err;
+    }
+    const recovered: string[] = [];
+    for (const f of files) {
+      if (!f.endsWith(".json")) continue;
+      const planId = f.replace(/\.json$/, "");
+      let plan: CorrectionPlan | null;
+      try {
+        plan = await this.loadPlan(namespace, planId);
+      } catch {
+        continue; // malformed — skip (rule 34).
+      }
+      if (!plan || plan.status !== "applying") continue;
+      // Post-fix plans (with applyingAt): stale if the applying timestamp is
+      // past the TTL (process died mid-apply). Pre-fix plans (no applyingAt):
+      // stale as soon as they have expired — no additional TTL wait, since the
+      // plan is already past its intended lifetime (review thread ff034716).
+      const stale = plan.applyingAt
+        ? now - new Date(plan.applyingAt).getTime() >= ttl
+        : now >= new Date(plan.expiresAt).getTime();
+      if (!stale) continue;
+      try {
+        await this.markConsumed(namespace, planId, "discarded");
+        recovered.push(planId);
+      } catch {
+        // Best-effort: a single failed discard must not abort the scan.
+      }
+    }
+    return recovered;
   }
 }
 

--- a/packages/remnic-core/src/correction/correction-service.ts
+++ b/packages/remnic-core/src/correction/correction-service.ts
@@ -170,6 +170,35 @@ export class CorrectionService {
     await this.planner.deletePlan(namespace, planId);
   }
 
+  /**
+   * Recover stale `applying` plans across the given namespaces (#1713 Item 2).
+   *
+   * Startup maintenance: scans each namespace for plans stuck in `applying`
+   * past the stale-applying TTL (process died mid-apply) and discards+scrubs
+   * them. Unlike plan/apply/listPending, this is NOT a per-caller request —
+   * it operates on all supplied namespaces directly because it is an
+   * internal maintenance operation invoked by the orchestrator at init.
+   *
+   * @returns the total count of recovered plans across all namespaces.
+   */
+  async recoverStaleApplyingPlans(namespaces: readonly string[]): Promise<number> {
+    // Intentionally NOT gated on isEnabled(): stale-applying recovery is a
+    // maintenance/cleanup operation, not a user-facing correction. Plans left
+    // in 'applying' after a mid-apply crash hold unscrubbed redaction_rule
+    // patterns on disk; they must be discarded+scrubbed even if the correction
+    // feature is currently disabled (review thread 9e1f07f0).
+    let recovered = 0;
+    for (const namespace of namespaces) {
+      try {
+        const ids = await this.planner.recoverStaleApplyingPlans(namespace);
+        recovered += ids.length;
+      } catch {
+        // Best-effort: a single namespace failure must not abort the sweep.
+      }
+    }
+    return recovered;
+  }
+
   private requireEnabled(): void {
     if (!this.deps.isEnabled()) {
       throw new CorrectionContractError(

--- a/packages/remnic-core/src/extraction-redaction-rules.test.ts
+++ b/packages/remnic-core/src/extraction-redaction-rules.test.ts
@@ -16,6 +16,7 @@ import {
   compileRedactionPattern,
   contentMatchesRedactionRules,
   loadRedactionRules,
+  type CompiledRedactionRule,
 } from "./extraction-redaction-rules.js";
 import { validateRedactionPattern } from "./correction/correction-contract.js";
 
@@ -210,4 +211,175 @@ test("#1669 P2: compileRedactionPattern empty body never matches", () => {
   const rule = compileRedactionPattern("//");
   assert.equal(rule.matcher("anything"), false);
   assert.equal(rule.matcher(""), false);
+});
+
+// ---------------------------------------------------------------------------
+// #1713 Item 1: pre-judge redaction filter consults target namespace rules.
+// The orchestrator's pre-judge filter builds a combined rule set from source +
+// shared + routed target namespace dirs. This test verifies that loadRedactionRules
+// correctly returns rules from each dir and that contentMatchesRedactionRules
+// catches patterns from ANY of the combined dirs (not just the source).
+// ---------------------------------------------------------------------------
+
+test("#1713 Item 1: combined rules from source + target dirs catch cross-namespace patterns", async () => {
+  await withTempDir(async (sourceDir) => {
+    await withTempDir(async (targetDir) => {
+      // Source namespace has a rule for "source-secret"
+      await writeRule(sourceDir, "source-secret");
+      // Target namespace has a rule for "target-secret"
+      await writeRule(targetDir, "target-confidential");
+
+      // Simulate what the orchestrator's redactionRulesFor(...dirs) does:
+      // load from each dir and combine.
+      const sourceRules = await loadRedactionRules(sourceDir);
+      const targetRules = await loadRedactionRules(targetDir);
+      const combined = [...sourceRules, ...targetRules];
+
+      assert.equal(combined.length, 2);
+      // Source-namespace rule catches source content
+      assert.ok(
+        contentMatchesRedactionRules("leaked source-secret here", combined),
+        "source-namespace rule must catch matching content",
+      );
+      // Target-namespace rule catches target content (the #1713 fix)
+      assert.ok(
+        contentMatchesRedactionRules("leaked target-confidential here", combined),
+        "target-namespace rule must catch matching content when dirs are combined",
+      );
+      // Clean content passes
+      assert.ok(
+        !contentMatchesRedactionRules("clean content", combined),
+        "non-matching content must not be redacted",
+      );
+    });
+  });
+});
+
+test("#1713 Item 1: source-only rules miss target-namespace patterns (the bug this fixes)", async () => {
+  await withTempDir(async (sourceDir) => {
+    await withTempDir(async (targetDir) => {
+      // Only the TARGET namespace has the redaction rule
+      await writeRule(targetDir, "cross-ns-secret");
+
+      // The OLD behavior (pre-fix): only source rules loaded at pre-judge point
+      const sourceOnlyRules = await loadRedactionRules(sourceDir);
+      assert.equal(sourceOnlyRules.length, 0);
+      assert.ok(
+        !contentMatchesRedactionRules("cross-ns-secret in content", sourceOnlyRules),
+        "source-only rules miss the target-namespace pattern (the pre-fix gap)",
+      );
+
+      // The NEW behavior: source + target rules combined
+      const combined = [
+        ...(await loadRedactionRules(sourceDir)),
+        ...(await loadRedactionRules(targetDir)),
+      ];
+      assert.equal(combined.length, 1);
+      assert.ok(
+        contentMatchesRedactionRules("cross-ns-secret in content", combined),
+        "combined rules catch the target-namespace pattern (the fix)",
+      );
+    });
+  });
+});
+
+test("#1713 (codex PRRT_kwDORJXyws6PBj5X): scope-classification routed shared target rules consulted at pre-judge", async () => {
+  // Scope classification routes a scope=global fact to the shared namespace
+  // independent of routing rules. The pre-judge redaction filter must consult
+  // the SHARED namespace's rules for such a fact, or a never-store pattern
+  // registered only under shared is missed until the write gate and the content
+  // reaches the extraction judge/training path. This test mirrors the
+  // orchestrator's per-fact scope-routing decision + rule combining.
+  await withTempDir(async (sourceDir) => {
+    await withTempDir(async (sharedDir) => {
+      // Only the SHARED namespace carries the never-store rule.
+      await writeRule(sharedDir, "shared-only-secret");
+
+      // A scope=global fact the orchestrator will route to shared.
+      const fact = { scope: "global" as string, content: "leaked shared-only-secret here" };
+      const sharedNamespace: string = "shared";
+      const sourceNamespace: string = "default"; // source !== shared
+
+      // Mirror of the orchestrator's scope-routing condition (persistExtraction
+      // pre-judge per-fact block): a fact is scope-routed to shared when no
+      // routing rule set an explicit namespace, scope classification is on, the
+      // fact is global, shared writes are allowed, and the source is not already
+      // shared.
+      const preRoutedNamespaceByFact: string | undefined = undefined;
+      const scopeClassificationEnabled = true;
+      const namespacesEnabled = true;
+      const profileAllowsSharedWrites = true;
+      let factNs: string | undefined = preRoutedNamespaceByFact;
+      if (
+        !factNs &&
+        scopeClassificationEnabled &&
+        namespacesEnabled &&
+        fact.scope === "global" &&
+        profileAllowsSharedWrites &&
+        sourceNamespace !== sharedNamespace
+      ) {
+        factNs = sharedNamespace;
+      }
+      assert.equal(factNs, sharedNamespace, "global fact must be scope-routed to shared");
+
+      // Base (source-only) rules + routed target (shared) rules combined — what
+      // the orchestrator builds for this fact.
+      const baseRules: CompiledRedactionRule[] = await loadRedactionRules(sourceDir);
+      const targetRules: CompiledRedactionRule[] =
+        factNs === sharedNamespace ? await loadRedactionRules(sharedDir) : [];
+      const factRedactionRules: CompiledRedactionRule[] = [...baseRules, ...targetRules];
+
+      assert.equal(baseRules.length, 0, "source namespace has no rules");
+      assert.equal(targetRules.length, 1, "shared namespace carries the never-store rule");
+
+      // Pre-fix (source-only) behavior: the shared-only pattern is missed at
+      // pre-judge — the gap the codex thread flags.
+      assert.ok(
+        !contentMatchesRedactionRules(fact.content, baseRules),
+        "source-only rules miss the shared-namespace never-store pattern (the gap)",
+      );
+      // Post-fix: combined source+shared rules catch it before the judge.
+      assert.ok(
+        contentMatchesRedactionRules(fact.content, factRedactionRules),
+        "combined source+shared rules catch the shared never-store at pre-judge (the fix)",
+      );
+    });
+  });
+});
+
+test("#1713 (codex): non-global fact is NOT scope-routed to shared", async () => {
+  // A scope-local fact must not consult shared rules at pre-judge — only
+  // routing-rule targets and scope=global facts do. Guards against over-redacting
+  // unrelated facts with shared-only never-store patterns (codex sibling threads).
+  await withTempDir(async (sourceDir) => {
+    await withTempDir(async (sharedDir) => {
+      await writeRule(sharedDir, "shared-only-secret");
+
+      const fact = { scope: "local" as string, content: "leaked shared-only-secret here" };
+      const sharedNamespace: string = "shared";
+      const sourceNamespace: string = "default";
+
+      const preRoutedNamespaceByFact: string | undefined = undefined;
+      const scopeClassificationEnabled = true;
+      const namespacesEnabled = true;
+      const profileAllowsSharedWrites = true;
+      let factNs: string | undefined = preRoutedNamespaceByFact;
+      if (
+        !factNs &&
+        scopeClassificationEnabled &&
+        namespacesEnabled &&
+        fact.scope === "global" &&
+        profileAllowsSharedWrites &&
+        sourceNamespace !== sharedNamespace
+      ) {
+        factNs = sharedNamespace;
+      }
+      assert.equal(factNs, undefined, "non-global fact must not be scope-routed to shared");
+
+      const baseRules: CompiledRedactionRule[] = await loadRedactionRules(sourceDir);
+      const targetRules: CompiledRedactionRule[] = [];
+      const factRedactionRules: CompiledRedactionRule[] = [...baseRules, ...targetRules];
+      assert.equal(factRedactionRules.length, 0, "no rules consulted for a scope-local fact");
+    });
+  });
 });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3474,6 +3474,31 @@ export class Orchestrator {
         // never break initialization (rule #13, #40).
         await this.namespaceCatalog.registerConfiguredNamespaces().catch(() => undefined);
       }
+      // #1713 Item 2: recover stale `applying` correction plans left behind
+      // by a process that died mid-apply. Best-effort — a failure here must
+      // never block initialization (rule 13). Runs for every configured
+      // namespace since correction plans can exist in any of them.
+      try {
+        // #1713 Item 2 + P2 (cursor): sweep ALL known namespaces — configured
+        // + catalog-discovered — so stale applying plans in derived namespaces
+        // (coding-scoped, session-derived) are also recovered.
+        const correctionNamespaces = new Set(this.configuredNamespaceList());
+        if (this.namespaceCatalog.enabled) {
+          try {
+            for (const rec of await this.namespaceCatalog.listNamespaces()) {
+              correctionNamespaces.add(rec.namespace);
+            }
+          } catch { /* best-effort */ }
+        }
+        const recovered = await this.passiveCorrectionService().recoverStaleApplyingPlans(
+          [...correctionNamespaces],
+        );
+        if (recovered > 0) {
+          log.info(`correction: recovered ${recovered} stale applying plan(s) on startup`);
+        }
+      } catch (staleErr) {
+        log.debug(`correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`);
+      }
       await this.relevance.load();
       await this.negatives.load();
       await this.lastRecall.load();
@@ -14179,6 +14204,10 @@ export class Orchestrator {
           sharedProfileLayer.writable &&
           sharedPromotionTarget?.authorized,
       );
+    // #1713: hoist namespaces-enabled once for the scope-routing mirrors
+    // (pre-judge + write-loop) so no new scattered config.*Enabled read is
+    // introduced (ratchet scatteredConfigFlagReads; see #1523).
+    const namespacesEnabled = this.config.namespacesEnabled;
     const profileAutoPromotionAllows = (
       category: string,
       confidence: number,
@@ -14949,6 +14978,10 @@ export class Orchestrator {
     // these pre-computed results so routing is evaluated exactly once per
     // fact (no duplicated logic).
     const preRoutedCategories: Array<string | undefined> = new Array(facts.length);
+    // #1713 Item 1: collect routed target namespaces so the pre-judge redaction
+    // filter can consult rules from cross-namespace targets, not just the source.
+    // #1713 P2 (cursor): track per-fact routed namespace for per-fact pre-judge rules
+    const preRoutedNamespaceByFact: Array<string | undefined> = new Array(facts.length);
     if (routeRules.length > 0) {
       for (let fi = 0; fi < facts.length; fi++) {
         const f = facts[fi];
@@ -14967,6 +15000,9 @@ export class Orchestrator {
           const selected = selectRouteRule(routeText, routeRules, routeOptions);
           if (selected?.target.category) {
             preRoutedCategories[fi] = selected.target.category;
+          }
+          if (selected?.target.namespace) {
+            preRoutedNamespaceByFact[fi] = selected.target.namespace;
           }
         } catch {
           // Fail-open: routing errors fall through to the extracted category.
@@ -14990,10 +15026,18 @@ export class Orchestrator {
     // into the caller's buffer-retention decision.
     this.lastPersistExtractionDeferredCount = 0;
     if (lifecycleCaps.extractionJudge) {
-      // #1669 P1: pre-filter redacted facts from judge candidates so never-store
-      // content is not persisted as judge training data.
+      // #1669 P1 + #1713 Item 1: pre-filter redacted facts from judge candidates
+      // so never-store content is not persisted as judge training data.
+      // Consult source + shared + routed target namespace rules so a
+      // never-store pattern registered under a cross-namespace target is
+      // caught at the batch pre-filter point, not just at the persist gate.
       let preJudgeRedactionRules: CompiledRedactionRule[] = [];
-      try { preJudgeRedactionRules = await redactionRulesFor(storage.dir); } catch { /* fail open */ }
+      try {
+        // #1713: base rules are source-only. Per-fact routed target rules
+        // (including shared when a fact is routed there) are checked in the
+        // fact loop, matching the write-time gate's per-fact scoping exactly.
+        preJudgeRedactionRules = await redactionRulesFor(storage.dir);
+      } catch { /* fail open */ }
       try {
         const judgeCandidates: JudgeCandidate[] = [];
         const candidateToFactIndex: number[] = [];
@@ -15034,10 +15078,42 @@ export class Orchestrator {
           ) {
             continue;
           }
-          if (preJudgeRedactionRules.length > 0) {
+          // #1713 P2 (cursor): per-fact rules — load this fact's routed target
+          // namespace rules FIRST, then check. This catches target-only rules
+          // even when the base (source+shared) rules are empty (threads acc58c42
+          // + PBJEe/PBKAj).
+          let factRedactionRules = preJudgeRedactionRules;
+          let factNs = preRoutedNamespaceByFact[fi];
+          // #1713 (codex PRRT_kwDORJXyws6PBj5X): scope classification can route
+          // a scope=global fact to the shared namespace independent of routing
+          // rules. If so, the pre-judge filter must consult the shared
+          // namespace's rules too, or a never-store pattern under shared is
+          // missed at pre-judge and only caught at the write gate — letting the
+          // content reach the extraction judge/training path. Mirror the write
+          // loop's scope-routing conditions exactly.
+          if (
+            !factNs &&
+            lifecycleCaps.extractionScopeClassification &&
+            namespacesEnabled &&
+            f.scope === "global" &&
+            profileAllowsSharedWrites &&
+            this.storageDirNamespace(storage.dir) !== this.config.sharedNamespace
+          ) {
+            factNs = this.config.sharedNamespace;
+          }
+          if (factNs) {
+            try {
+              const factDir = (await this.storageRouter.storageFor(factNs)).dir;
+              if (factDir !== storage.dir) {
+                const targetRules = await redactionRulesFor(factDir);
+                if (targetRules.length) factRedactionRules = [...preJudgeRedactionRules, ...targetRules];
+              }
+            } catch { /* fail open */ }
+          }
+          if (factRedactionRules.length > 0) {
             const rc = f.content + (f.structuredAttributes ? " " + JSON.stringify(f.structuredAttributes) : "")
               + (f.procedureSteps ? " " + f.procedureSteps.map((s) => `${s.intent} ${s.expectedOutcome ?? ""} ${s.toolCall ? `${s.toolCall.kind} ${s.toolCall.signature}` : ""}`.trim()).join(" ") : "");
-            if (contentMatchesRedactionRules(rc, preJudgeRedactionRules)) continue;
+            if (contentMatchesRedactionRules(rc, factRedactionRules)) continue;
           }
           judgeCandidates.push({
             text: f.content,
@@ -15267,7 +15343,7 @@ export class Orchestrator {
       // extractionScopeClassificationEnabled.
       if (
         lifecycleCaps.extractionScopeClassification &&
-        this.config.namespacesEnabled &&
+        namespacesEnabled &&
         fact.scope === "global" &&
         !routedNamespaceExplicit
       ) {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20913,
+      "packages/remnic-core/src/orchestrator.ts": 20989,
       "packages/remnic-core/src/cli.ts": 9390,
       "packages/remnic-core/src/access-service.ts": 9012,
       "packages/remnic-core/src/storage.ts": 7747,


### PR DESCRIPTION
Closes #1713 — both deferred review-thread items from PR #1705.

## Item 1: Pre-judge redaction filter consults target namespace rules

The pre-judge redaction filter previously loaded rules from only the source namespace dir. A never_store pattern registered under a cross-namespace target was missed at the batch pre-filter point (only caught later at the persist gate).

**Fix:** The pre-judge filter now collects routed target namespaces during routing (preRoutedNamespaces) and resolves their storage dirs via storageRouter.storageFor(). Combined with the shared namespace dir, redactionRulesFor(...preJudgeDirs) now catches cross-namespace never_store patterns at the batch pre-filter point — matching the persist gate behavior.

## Item 2: Stale applying correction-plan recovery

When apply reaches the optimistic applying mark and then the process dies, the pending-plan file retains redaction_rule.pattern intact and the plan is stuck in applying.

**Fix:**
- CorrectionPlan gains an applyingAt ISO timestamp
- markConsumed stamps applyingAt on entering applying, clears it on terminal transitions
- CorrectionPlanner.recoverStaleApplyingPlans scans for plans stuck in applying past a 10-min TTL and discards+scrubs them. Pre-fix plans (no applyingAt) fall back to expiresAt
- CorrectionService wraps the multi-namespace sweep; orchestrator initialize() wires it in as best-effort startup maintenance (uses configuredNamespaceList() chokepoint)

## Chokepoints used / not applicable
- storageRouter.storageFor — namespace resolution
- configuredNamespaceList / getConfiguredNamespaces — namespace set derivation
- serializeMutations — markConsumed write path (existing, unchanged)
- No new config flags — scattered-config-flag-reads ratchet unchanged (536)

## Ratchet
- orchestrator.ts +33 LOC: both items are necessary bug fixes with no extracted module to delegate to. Baseline updated with justification.
- scatteredConfigFlagReads: unchanged (536)

## Tests
- 6 new planner tests: applyingAt stamp/clear, stale recovery (discard+scrub), fresh-left-alone, empty-namespace, pre-fix expiresAt fallback
- 2 new redaction tests: combined source+target rules catch cross-namespace patterns; source-only misses them (the bug)
- Entity-hardening: 246/246 pass
- Full correction suite: 94/94 pass
- Build (ESM+DTS) + check-types clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extraction pre-judge filtering and startup correction maintenance on stuck plans; both affect never-store/redaction handling but are targeted fixes with fail-open error handling.
> 
> **Overview**
> Fixes two follow-ups from #1713: **pre-judge redaction** now respects where each fact will land, and **stale `applying` correction plans** are recovered on startup.
> 
> **Pre-judge redaction (Item 1):** During `persistExtraction`, routing now records a per-fact target namespace. The extraction-judge candidate loop merges redaction rules from that namespace (via `storageRouter.storageFor`) with source rules, and mirrors write-time **scope=global → shared** routing so shared-only never-store patterns are filtered before the judge—not only at the persist gate.
> 
> **Stale applying recovery (Item 2):** `CorrectionPlan` gains optional `applyingAt`; `markConsumed` sets it on `applying` and clears it on terminal states. `recoverStaleApplyingPlans` discards+scrubs plans stuck in `applying` past a 10-minute TTL (or past `expiresAt` for older plans without `applyingAt`). `CorrectionService.recoverStaleApplyingPlans` sweeps namespaces without requiring the correction feature flag; orchestrator init runs this best-effort over configured + catalog namespaces.
> 
> Tests cover applyingAt lifecycle, recovery edge cases, combined redaction dirs, and scope-routing behavior; `orchestrator.ts` watchlist LOC ratchet is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cdfe9eeb18c69cfd83b88c76ba7960a4c7f0b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->