### PR TITLE
feat(bench): #1728 claude-cli Tier-F provider + reasoning-effort CLI flags

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -166,6 +166,7 @@ export type {
   WriteBenchmarkArtifactResult,
 } from "./published-artifact.js";
 export { createAnthropicProvider } from "./providers/anthropic.js";
+export { createClaudeCliProvider } from "./providers/claude-cli.js";
 export { createCodexCliProvider } from "./providers/codex-cli.js";
 export { getRemnicVersion } from "./reporter.js";
 export {

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -168,6 +168,72 @@ test("claude-cli provider preserves networking env required by the child", () =>
   }
 });
 
+test("claude-cli provider forwards config apiKey/baseUrl into the child env", async () => {
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      apiKey: "config-secret-key",
+      baseUrl: "https://config-gateway.example",
+    },
+    {
+      async runClaudeCli(request) {
+        capturedEnv = request.env;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            type: "result",
+            is_error: false,
+            result: "ok",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello");
+
+  // Config apiKey/baseUrl MUST reach Claude Code headless as the env vars it
+  // reads in --bare mode (mirrors codex-cli forwarding OPENAI_API_KEY). Before
+  // the fix, buildIsolatedClaudeEnv() ignored config and these were undefined.
+  assert.equal(capturedEnv?.ANTHROPIC_API_KEY, "config-secret-key");
+  assert.equal(capturedEnv?.ANTHROPIC_BASE_URL, "https://config-gateway.example");
+});
+
+test("buildIsolatedClaudeEnv lets config apiKey/baseUrl override the inherited env", () => {
+  const seededEnv = {
+    ANTHROPIC_API_KEY: "env-secret",
+    ANTHROPIC_BASE_URL: "https://env-gateway.example",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    const env = __claudeCliProviderTestHooks.buildIsolatedClaudeEnv(
+      "config-secret-key",
+      "https://config-gateway.example",
+    );
+    assert.equal(env.ANTHROPIC_API_KEY, "config-secret-key");
+    assert.equal(env.ANTHROPIC_BASE_URL, "https://config-gateway.example");
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
 test("claude-cli provider defaults reasoning effort to xhigh", async () => {
   let args: string[] = [];
   const provider = createClaudeCliProvider(

--- a/packages/bench/src/providers/claude-cli.test.ts
+++ b/packages/bench/src/providers/claude-cli.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  __claudeCliProviderTestHooks,
+  createClaudeCliProvider,
+} from "./claude-cli.ts";
+
+test("claude-cli provider invokes claude -p in an isolated benchmark mode", async () => {
+  const captured: {
+    args?: string[];
+    env?: NodeJS.ProcessEnv;
+    workspacePath?: string;
+  } = {};
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      reasoningEffort: "xhigh",
+      retryOptions: { timeoutMs: 1234 },
+    },
+    {
+      async runClaudeCli(request) {
+        captured.args = request.args;
+        captured.env = request.env;
+        captured.workspacePath = request.workspacePath;
+        assert.equal(request.timeoutMs, 1234);
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            result: "  final answer\n",
+            model: "claude-opus-test",
+            usage: { input_tokens: 12, output_tokens: 7 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("What is remembered?", {
+    systemPrompt: "Answer using only benchmark context.",
+    temperature: 0,
+  });
+
+  assert.equal(result.text, "final answer");
+  assert.equal(result.model, "claude-opus-test");
+  assert.deepEqual(result.tokens, { input: 12, output: 7 });
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 12,
+    outputTokens: 7,
+    totalTokens: 19,
+  });
+  // Isolation flags (issue #1728): --bare skips CLAUDE.md/hooks/plugins;
+  // --tools "" disables every tool so no file/command/browse/memory access.
+  assert.ok(captured.args?.includes("-p"));
+  assert.ok(captured.args?.includes("--bare"));
+  assert.equal(captured.args?.[captured.args.indexOf("--tools") + 1], "");
+  assert.equal(captured.args?.[captured.args.indexOf("--model") + 1], "opus");
+  assert.equal(captured.args?.[captured.args.indexOf("--effort") + 1], "xhigh");
+  assert.equal(captured.args?.[captured.args.indexOf("--output-format") + 1], "json");
+  assert.ok(captured.args?.includes("--no-session-persistence"));
+  const systemPromptArg = captured.args?.[captured.args.indexOf("--system-prompt") + 1];
+  assert.match(systemPromptArg ?? "", /benchmark LLM completion endpoint/);
+  // Prompt payload keeps system + user in separate JSON fields.
+  const positional = captured.args?.[captured.args.length - 1];
+  assert.ok(positional?.includes("BENCHMARK_REQUEST_JSON:"));
+  assert.ok(positional?.includes('"systemPrompt": "Answer using only benchmark context."'));
+  assert.ok(positional?.includes('"userPrompt": "What is remembered?"'));
+  // Workspace is an isolated temp dir, not the operator's project.
+  assert.match(captured.workspacePath ?? "", /remnic-claude-cli-/);
+  // Memory/secret env never reaches the child.
+  assert.equal(captured.env?.REMNIC_MEMORY_DIR, undefined);
+  assert.equal(captured.env?.ENGRAM_MEMORY_DIR, undefined);
+  assert.equal(captured.env?.OPENCLAW_ENGRAM_ACCESS_TOKEN, undefined);
+  assert.equal(captured.env?.OPENAI_API_KEY, undefined);
+});
+
+test("claude-cli provider does not expose unrelated process secrets to the child", async () => {
+  const seededEnv = {
+    ANTHROPIC_API_KEY: "anthropic-secret",
+    AWS_SECRET_ACCESS_KEY: "aws-secret",
+    GITHUB_TOKEN: "github-secret",
+    NPM_TOKEN: "npm-secret",
+    REMNIC_MEMORY_DIR: "/tmp/remnic",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus" },
+      {
+        async runClaudeCli(request) {
+          capturedEnv = request.env;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({
+              type: "result",
+              is_error: false,
+              result: "ok",
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    // ANTHROPIC_API_KEY IS allowlisted (Claude Code headless needs it), but
+    // every unrelated secret and the Remnic memory dir must stay out.
+    assert.equal(capturedEnv?.ANTHROPIC_API_KEY, "anthropic-secret");
+    assert.equal(capturedEnv?.AWS_SECRET_ACCESS_KEY, undefined);
+    assert.equal(capturedEnv?.GITHUB_TOKEN, undefined);
+    assert.equal(capturedEnv?.NPM_TOKEN, undefined);
+    assert.equal(capturedEnv?.REMNIC_MEMORY_DIR, undefined);
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("claude-cli provider preserves networking env required by the child", () => {
+  const seededEnv = {
+    ANTHROPIC_BASE_URL: "https://gateway.example",
+    HTTPS_PROXY: "http://proxy.example:8080",
+    HOME: "/tmp/claude-home",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    const env = __claudeCliProviderTestHooks.buildIsolatedClaudeEnv();
+    assert.equal(env.ANTHROPIC_BASE_URL, "https://gateway.example");
+    assert.equal(env.HTTPS_PROXY, "http://proxy.example:8080");
+    assert.equal(env.HOME, "/tmp/claude-home");
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("claude-cli provider defaults reasoning effort to xhigh", async () => {
+  let args: string[] = [];
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli(request) {
+        args = request.args;
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello");
+
+  assert.equal(args[args.indexOf("--effort") + 1], "xhigh");
+});
+
+test("claude-cli provider expands home-relative executable paths", () => {
+  assert.equal(
+    __claudeCliProviderTestHooks.resolveClaudeCliExecutable({
+      provider: "claude-cli",
+      model: "opus",
+      executable: "~/bin/claude",
+    }),
+    path.join(os.homedir(), "bin", "claude"),
+  );
+});
+
+test("claude-cli provider can use a benchmark-scoped executable env override", async () => {
+  const previous = process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+  process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = "/tmp/claude-app-binary";
+  let executable = "";
+
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus" },
+      {
+        async runClaudeCli(request) {
+          executable = request.executable;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "ok" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(executable, "/tmp/claude-app-binary");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+    } else {
+      process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = previous;
+    }
+  }
+});
+
+test("claude-cli provider executable config overrides the env override", async () => {
+  const previous = process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+  process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = "/tmp/claude-app-binary";
+  let executable = "";
+
+  try {
+    const provider = createClaudeCliProvider(
+      { provider: "claude-cli", model: "opus", executable: "/tmp/explicit-claude" },
+      {
+        async runClaudeCli(request) {
+          executable = request.executable;
+          return {
+            status: 0,
+            signal: null,
+            stdout: JSON.stringify({ is_error: false, result: "ok" }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(executable, "/tmp/explicit-claude");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE;
+    } else {
+      process.env.REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE = previous;
+    }
+  }
+});
+
+test("claude-cli provider records token usage from the result envelope", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: false,
+            result: "answer",
+            usage: { input_tokens: 100, output_tokens: 40 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("q");
+
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 100,
+    outputTokens: 40,
+    totalTokens: 140,
+  });
+});
+
+test("claude-cli usage extractor estimates output tokens when usage is partial", () => {
+  const usage = __claudeCliProviderTestHooks.extractClaudeUsage(
+    { input_tokens: 200 },
+    "a".repeat(40),
+  );
+  // No output_tokens field → estimate from text length (ceil(40/4) = 10),
+  // capped to input so it can never exceed the reported total.
+  assert.equal(usage.input, 200);
+  assert.equal(usage.output, 10);
+});
+
+test("claude-cli provider surfaces auth/runtime is_error without retrying", async () => {
+  // `claude -p` returns is_error:true with a JSON body on the no-auth case
+  // ("Not logged in"). This MUST surface as a clear error and MUST NOT be
+  // retried (retries burn Claude Max session budget re-asking an auth wall).
+  let calls = 0;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { maxAttempts: 3 },
+    },
+    {
+      async runClaudeCli() {
+        calls += 1;
+        return {
+          status: 1,
+          signal: null,
+          stdout: JSON.stringify({
+            type: "result",
+            is_error: true,
+            result: "Not logged in · Please run /login",
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("q"),
+    /Claude CLI completion failed .* Not logged in/,
+  );
+  assert.equal(calls, 1, "is_error auth failures must not be retried");
+});
+
+test("claude-cli provider surfaces non-zero exits without a parseable envelope", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 2,
+          signal: null,
+          stdout: "not json at all",
+          stderr: "claude: argument error",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("q"),
+    /Claude CLI completion failed \(exit 2\): claude: argument error/,
+  );
+});
+
+test("claude-cli provider retries transient subprocess signals", async () => {
+  let calls = 0;
+  const provider = createClaudeCliProvider(
+    {
+      provider: "claude-cli",
+      model: "opus",
+      retryOptions: { maxAttempts: 3, baseBackoffMs: 1 },
+    },
+    {
+      async runClaudeCli() {
+        calls += 1;
+        if (calls < 3) {
+          return { status: null, signal: "SIGTERM", stdout: "", stderr: "killed" };
+        }
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "ok" }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("q");
+
+  assert.equal(result.text, "ok");
+  assert.equal(calls, 3);
+});
+
+test("claude-cli provider does not retry benchmark timeouts", async () => {
+  let calls = 0;
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus", retryOptions: { maxAttempts: 3 } },
+    {
+      async runClaudeCli() {
+        calls += 1;
+        return {
+          status: 124,
+          signal: "SIGTERM",
+          stdout: "",
+          stderr: "\nClaude CLI timed out after 1000ms.",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(provider.complete("q"), /timed out/);
+  assert.equal(calls, 1);
+});
+
+test("claude-cli provider throws when the result envelope has no result text", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({ is_error: false, result: "   " }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("q"),
+    /Claude CLI completion returned no result text/,
+  );
+});
+
+test("claude-cli envelope parser rejects non-object and non-JSON stdout", () => {
+  const { parseClaudeResultEnvelope } = __claudeCliProviderTestHooks;
+  assert.equal(parseClaudeResultEnvelope(""), undefined);
+  assert.equal(parseClaudeResultEnvelope("not json"), undefined);
+  assert.equal(parseClaudeResultEnvelope("[1, 2, 3]"), undefined);
+  assert.deepEqual(parseClaudeResultEnvelope('{"is_error":false,"result":"x"}'), {
+    isError: false,
+    result: "x",
+  });
+});
+
+test("claude-cli benchmark prompt keeps system and user input in separate JSON fields", () => {
+  const prompt = __claudeCliProviderTestHooks.buildClaudeCompletionPrompt(
+    "What color?",
+    "Be terse.",
+  );
+  assert.ok(prompt.includes("BENCHMARK_REQUEST_JSON:"));
+  const marker = "BENCHMARK_REQUEST_JSON:";
+  const payload = JSON.parse(prompt.slice(prompt.indexOf(marker) + marker.length).trim()) as {
+    systemPrompt: string;
+    userPrompt: string;
+  };
+  assert.equal(payload.systemPrompt, "Be terse.");
+  assert.equal(payload.userPrompt, "What color?");
+});
+
+test("claude-cli provider resets accumulated usage", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify({
+            is_error: false,
+            result: "ok",
+            usage: { input_tokens: 5, output_tokens: 5 },
+          }),
+          stderr: "",
+        };
+      },
+    },
+  );
+
+  await provider.complete("q");
+  provider.resetUsage();
+
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  });
+});
+
+test("claude-cli provider diagnostics dir expands home-relative tilde paths", () => {
+  assert.equal(
+    __claudeCliProviderTestHooks.resolveClaudeCliDiagnosticsDir({
+      provider: "claude-cli",
+      model: "opus",
+      diagnosticsDir: "~/bench-diag",
+    }),
+    path.resolve(path.join(os.homedir(), "bench-diag")),
+  );
+});
+
+test("claude-cli discover surfaces a Claude Code model entry", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeVersion() {
+        return { status: 0, stderr: "2.1.202 (Claude Code)" };
+      },
+    },
+  );
+
+  const models = await provider.discover();
+
+  assert.equal(models.length, 1);
+  assert.equal(models[0].id, "opus");
+  assert.match(models[0].name, /Claude Code/);
+  assert.ok(models[0].capabilities.includes("completion"));
+});
+
+test("claude-cli discover fails clearly when the CLI is missing", async () => {
+  const provider = createClaudeCliProvider(
+    { provider: "claude-cli", model: "opus" },
+    {
+      async runClaudeVersion() {
+        return { status: 127, stderr: "command not found: claude" };
+      },
+    },
+  );
+
+  await assert.rejects(provider.discover(), /Claude CLI discovery failed/);
+});
+
+// ---------------------------------------------------------------------------
+// Keyless smoke (issue #1728): when no Claude auth is available the live CLI
+// reports is_error. This test runs ONLY when REMNIC_BENCH_CLAUDE_CLI_SMOKE=1
+// is set AND the operator has logged in; otherwise it skips with a reason so
+// CI never burns Claude Max budget or fabricates a number.
+// ---------------------------------------------------------------------------
+
+test("claude-cli live smoke (keyless skip-with-reason by default)", { skip: process.env.REMNIC_BENCH_CLAUDE_CLI_SMOKE !== "1" ? "set REMNIC_BENCH_CLAUDE_CLI_SMOKE=1 and run `claude` login to exercise the live transport" : false }, async () => {
+  const provider = createClaudeCliProvider({
+    provider: "claude-cli",
+    model: process.env.REMNIC_BENCH_CLAUDE_CLI_SMOKE_MODEL ?? "opus",
+    retryOptions: { timeoutMs: 60_000 },
+  });
+
+  const result = await provider.complete("Reply with exactly: smoke-ok");
+
+  assert.equal(result.text, "smoke-ok");
+  assert.ok(result.tokens.input >= 0);
+  assert.ok(result.tokens.output >= 0);
+});

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -413,7 +413,7 @@ class ClaudeCliProvider implements LlmProvider {
       workspacePath,
       timeoutMs: this.config.retryOptions?.timeoutMs,
       signal: opts.signal,
-      env: buildIsolatedClaudeEnv(),
+      env: buildIsolatedClaudeEnv(this.config.apiKey, this.config.baseUrl),
     };
   }
 }
@@ -662,6 +662,7 @@ function runClaudeCliCommand(request: ClaudeCliRunRequest): Promise<ClaudeCliRun
   });
   child.on("close", (status, signal) => {
     clearTimeout(timeout);
+    clearKillTimeout();
     if (child.pid) {
       unregisterActiveClaudeCliChild(child.pid);
     }
@@ -998,12 +999,27 @@ function buildClaudeCompletionPrompt(
   ].join("\n");
 }
 
-function buildIsolatedClaudeEnv(): NodeJS.ProcessEnv {
+function buildIsolatedClaudeEnv(
+  apiKey?: string,
+  baseUrl?: string,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined && isAllowedClaudeRuntimeEnvKey(key)) {
       env[key] = value;
     }
+  }
+
+  // Config apiKey/baseUrl take precedence over the inherited env, mirroring
+  // codex-cli (buildIsolatedCodexEnv). This is how --system-api-key etc.
+  // reach Claude Code headless as ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL.
+  const resolvedApiKey = (apiKey ?? process.env.ANTHROPIC_API_KEY ?? "").trim();
+  if (resolvedApiKey.length > 0) {
+    env.ANTHROPIC_API_KEY = resolvedApiKey;
+  }
+  const resolvedBaseUrl = (baseUrl ?? process.env.ANTHROPIC_BASE_URL ?? "").trim();
+  if (resolvedBaseUrl.length > 0) {
+    env.ANTHROPIC_BASE_URL = resolvedBaseUrl;
   }
   return env;
 }

--- a/packages/bench/src/providers/claude-cli.ts
+++ b/packages/bench/src/providers/claude-cli.ts
@@ -1,0 +1,1133 @@
+/**
+ * `claude-cli` bench provider — shells out to Claude Code headless
+ * (`claude -p`) as an isolated benchmark responder/judge target.
+ *
+ * Sibling to `codex-cli.ts`. Mirrors its isolation contract (issue #1728):
+ * every completion runs from an **isolated empty temp workspace with tools
+ * disabled** so Claude Code cannot inherit `~/.claude/CLAUDE.md`, project
+ * settings, persisted memory, or tool output — all of which would silently
+ * contaminate a benchmark answer.
+ *
+ * Honest-labeling invariant (issue #1728): a number produced through this
+ * provider is "Opus via Claude Code", NOT an independent `tier: "frontier"`
+ * / API-sourced number. Claude Code adds system-prompt scaffolding + model
+ * alias routing that a reviewer cannot reproduce from a raw API call, so it
+ * must never be published as the trusted leaderboard figure. The provider
+ * records `provider: "claude-cli"` on diagnostics so consumers can label it.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  ClaudeCliProviderConfig,
+  CompletionOpts,
+  CompletionResult,
+  DiscoveredModel,
+  LlmProvider,
+  TokenUsage,
+} from "./types.js";
+import { resolveBenchmarkRunId } from "../run-identity.js";
+
+interface ClaudeCliRunRequest {
+  executable: string;
+  args: string[];
+  input: string;
+  /** The benchmark prompt text (also passed as the final positional CLI arg). */
+  promptText: string;
+  workspacePath: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  env: NodeJS.ProcessEnv;
+}
+
+interface ClaudeCliRunResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface ClaudeCliProviderDeps {
+  runClaudeCli?: (request: ClaudeCliRunRequest) => Promise<ClaudeCliRunResult>;
+  runClaudeVersion?: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+}
+
+/**
+ * Shape of the `claude -p --output-format json` result envelope. Only the
+ * fields the provider consumes are declared; everything else is ignored.
+ * Parsed from untrusted subprocess stdout, so consumers must go through
+ * {@link parseClaudeResultEnvelope} which validates via type guards.
+ */
+interface ClaudeResultEnvelope {
+  type?: unknown;
+  subtype?: unknown;
+  is_error?: unknown;
+  result?: unknown;
+  model?: unknown;
+  usage?: unknown;
+  total_cost_usd?: unknown;
+}
+
+interface ClaudeCliDiagnosticRecord {
+  schemaVersion: 1;
+  id: string;
+  runId: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+  provider: "claude-cli";
+  model: string;
+  reasoningEffort: string;
+  executable: string;
+  timeoutMs?: number;
+  workspaceBasename: string;
+  prompt: {
+    sha256: string;
+    chars: number;
+    lines: number;
+    systemPromptChars?: number;
+    userPromptChars?: number;
+  };
+  command: {
+    args: string[];
+  };
+  retry?: {
+    attempt: number;
+    maxAttempts: number;
+    transientFailure?: boolean;
+  };
+  result?: {
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stdoutChars: number;
+    stderrChars: number;
+    stdoutTail: string;
+    stderrTail: string;
+  };
+  error?: string;
+  fullPrompt?: string;
+}
+
+interface ClaudeCliDiagnosticHandle {
+  path: string;
+  record: ClaudeCliDiagnosticRecord;
+}
+
+interface ClaudeCliDiagnosticOutcome {
+  result?: ClaudeCliRunResult;
+  error?: unknown;
+  transientFailure?: boolean;
+}
+
+const DEFAULT_REASONING_EFFORT = "xhigh";
+const CLAUDE_CLI_STDIO_LIMIT = 256_000;
+const CLAUDE_CLI_PARENT_SIGNALS: NodeJS.Signals[] = [
+  "SIGHUP",
+  "SIGINT",
+  "SIGTERM",
+];
+const CLAUDE_CLI_FORCED_PARENT_EXIT_MS = 1_000;
+const CLAUDE_CLI_DIAGNOSTICS_DIR_ENV = "REMNIC_BENCH_CLAUDE_CLI_DIAGNOSTICS_DIR";
+const CLAUDE_CLI_DIAGNOSTICS_MODE_ENV = "REMNIC_BENCH_CLAUDE_CLI_DIAGNOSTICS_MODE";
+const CLAUDE_CLI_EXECUTABLE_ENV = "REMNIC_BENCH_CLAUDE_CLI_EXECUTABLE";
+const CLAUDE_CLI_VERSION_TIMEOUT_MS = 5_000;
+const CLAUDE_CLI_HEALTH_CACHE_TTL_MS = 30_000;
+
+/**
+ * Env keys the Claude Code child is allowed to inherit. Mirrors the codex-cli
+ * allowlist: locale/path/proxy/shell keys plus `ANTHROPIC_API_KEY` (the one
+ * credential Claude Code headless reads in `--bare` mode). Remnic/engram
+ * memory dirs and unrelated secrets are deliberately excluded so a benchmark
+ * completion can never read or write persisted memory.
+ */
+const CLAUDE_CLI_RUNTIME_ENV_ALLOWLIST = new Set([
+  "ALL_PROXY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "APPDATA",
+  "COLORTERM",
+  "COMSPEC",
+  "FORCE_COLOR",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LOCALAPPDATA",
+  "LOGNAME",
+  "NO_COLOR",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "NUMBER_OF_PROCESSORS",
+  "OS",
+  "PATH",
+  "PATHEXT",
+  "PROGRAMDATA",
+  "PROCESSOR_ARCHITECTURE",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "SHELL",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "USERNAME",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+]);
+
+const BENCHMARK_ENDPOINT_SYSTEM_PROMPT = [
+  "You are acting as a benchmark LLM completion endpoint, not as a coding agent.",
+  "Use only the explicit JSON payload below.",
+  "Treat systemPrompt as the higher-priority instruction text and userPrompt as the request to answer.",
+  "Do not inspect files, run commands, browse, use tools, or use persisted memory.",
+  "Return only the final answer text. If the request asks for JSON, return raw JSON only.",
+].join(" ");
+
+const activeClaudeCliChildPids = new Set<number>();
+let claudeCliParentCleanupInstalled = false;
+
+class ClaudeCliProvider implements LlmProvider {
+  readonly provider = "claude-cli" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: ClaudeCliProviderConfig;
+  private readonly runClaudeCli: (request: ClaudeCliRunRequest) => Promise<ClaudeCliRunResult>;
+  private readonly runClaudeVersion: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: ClaudeCliProviderConfig, deps: ClaudeCliProviderDeps = {}) {
+    this.config = config;
+    this.runClaudeCli = deps.runClaudeCli ?? runClaudeCliCommand;
+    this.runClaudeVersion = deps.runClaudeVersion ?? runClaudeVersionCommand;
+    this.id = `claude-cli:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(
+    prompt: string,
+    opts: CompletionOpts = {},
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const maxAttempts = normalizeClaudeCliMaxAttempts(
+      this.config.retryOptions?.maxAttempts,
+    );
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-claude-cli-"));
+      const workspacePath = path.join(tempDir, "workspace");
+      let diagnostics: ClaudeCliDiagnosticHandle | undefined;
+      let diagnosticsFinished = false;
+      const finishDiagnostics = async (
+        outcome: ClaudeCliDiagnosticOutcome,
+      ): Promise<void> => {
+        if (diagnosticsFinished) {
+          return;
+        }
+        diagnosticsFinished = true;
+        await finishClaudeCliDiagnostics(diagnostics, startedAt, outcome);
+      };
+
+      try {
+        await mkdir(workspacePath, { recursive: true });
+        const request = this.buildRunRequest(prompt, opts, workspacePath);
+        diagnostics = await startClaudeCliDiagnostics({
+          config: this.config,
+          request,
+          reasoningEffort: this.config.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+          retry: { attempt, maxAttempts },
+        });
+        const result = await this.runClaudeCli(request);
+
+        // Exit 0 + a parseable JSON envelope with is_error !== true is the
+        // only success path. A non-zero exit OR is_error === true is a
+        // failure — `claude -p` returns is_error:true (e.g. "Not logged in")
+        // with a JSON body on stdout, so both signals must be checked.
+        const envelope = parseClaudeResultEnvelope(result.stdout);
+        const authOrRuntimeError = envelope !== undefined && envelope.isError === true;
+        if (result.status !== 0 || authOrRuntimeError) {
+          const exitLabel = result.signal
+            ? `signal ${result.signal}`
+            : `exit ${result.status ?? "unknown"}`;
+          const detail = authOrRuntimeError
+            ? String(envelope?.result ?? "").trim() || "claude -p reported is_error"
+            : summarizeProcessOutput(result.stderr, result.stdout);
+          const error = new Error(
+            `Claude CLI completion failed (${exitLabel}): ${detail}`,
+          );
+          // Auth/login errors are not transient — do not retry (they burn
+          // Claude Max session budget re-asking). Only retry genuine
+          // transient subprocess signals.
+          if (
+            attempt < maxAttempts &&
+            !authOrRuntimeError &&
+            isRetryableClaudeCliResult(result)
+          ) {
+            lastError = error;
+            await finishDiagnostics({
+              result,
+              error,
+              transientFailure: true,
+            });
+            await sleepBeforeClaudeCliRetry(
+              attempt,
+              this.config.retryOptions?.baseBackoffMs,
+              opts.signal,
+            );
+            continue;
+          }
+          await finishDiagnostics({ result, error });
+          throw error;
+        }
+
+        const text = (envelope?.result ?? "").trim();
+        if (text.length === 0) {
+          const error = new Error(
+            `Claude CLI completion returned no result text: ${summarizeProcessOutput(result.stderr, result.stdout)}`,
+          );
+          await finishDiagnostics({ result, error });
+          throw error;
+        }
+        await finishDiagnostics({ result });
+        const tokens = extractClaudeUsage(envelope?.usage, text);
+        this.recordUsage(tokens.input, tokens.output);
+
+        return {
+          text,
+          tokens,
+          latencyMs: Math.round(performance.now() - startedAt),
+          model: envelope?.model ?? this.config.model,
+        };
+      } catch (error) {
+        lastError = error;
+        await finishDiagnostics({ error });
+        throw error;
+      } finally {
+        await rm(tempDir, { force: true, recursive: true });
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  async discover(): Promise<DiscoveredModel[]> {
+    const version = await this.runClaudeVersion(
+      resolveClaudeCliExecutable(this.config),
+      buildIsolatedClaudeEnv(),
+    );
+    if (version.status !== 0) {
+      throw new Error(
+        `Claude CLI discovery failed: ${version.stderr.trim() || `exit ${version.status ?? "unknown"}`}`,
+      );
+    }
+
+    return [
+      {
+        id: this.config.model,
+        name: `${this.config.model} (Claude Code)`,
+        contextLength: 0,
+        capabilities: ["completion"],
+      },
+    ];
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  /**
+   * `claude -p` reads from stdin (the prompt argument) and writes the result
+   * JSON envelope to stdout. Unlike codex-cli we do not use an
+   * `--output-last-message` file; the JSON `result` field IS the answer.
+   */
+  private buildRunRequest(
+    prompt: string,
+    opts: CompletionOpts,
+    workspacePath: string,
+  ): ClaudeCliRunRequest {
+    const reasoningEffort =
+      this.config.reasoningEffort ?? DEFAULT_REASONING_EFFORT;
+    const promptText = buildClaudeCompletionPrompt(prompt, opts.systemPrompt);
+    const args = [
+      "-p",
+      "--bare",
+      "--tools",
+      "",
+      "--model",
+      this.config.model,
+      "--effort",
+      reasoningEffort,
+      "--output-format",
+      "json",
+      "--no-session-persistence",
+      "--system-prompt",
+      BENCHMARK_ENDPOINT_SYSTEM_PROMPT,
+      promptText,
+    ];
+
+    return {
+      executable: resolveClaudeCliExecutable(this.config),
+      args,
+      input: "",
+      promptText,
+      workspacePath,
+      timeoutMs: this.config.retryOptions?.timeoutMs,
+      signal: opts.signal,
+      env: buildIsolatedClaudeEnv(),
+    };
+  }
+}
+
+// ----------------------------------------------------------------------------
+// JSON envelope parsing (untrusted subprocess stdout → typed values)
+// ----------------------------------------------------------------------------
+
+interface ParsedClaudeEnvelope {
+  isError?: boolean;
+  result?: string;
+  model?: string;
+  usage?: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseClaudeResultEnvelope(stdout: string): ParsedClaudeEnvelope | undefined {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (!isPlainObject(parsed)) {
+    return undefined;
+  }
+  const envelope = parsed as ClaudeResultEnvelope;
+  const isError =
+    typeof envelope.is_error === "boolean" ? envelope.is_error : undefined;
+  const result =
+    typeof envelope.result === "string" ? envelope.result : undefined;
+  const model =
+    typeof envelope.model === "string" && envelope.model.length > 0
+      ? envelope.model
+      : undefined;
+  return {
+    ...(isError !== undefined ? { isError } : {}),
+    ...(result !== undefined ? { result } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(envelope.usage !== undefined ? { usage: envelope.usage } : {}),
+  };
+}
+
+function extractClaudeUsage(
+  usage: unknown,
+  outputText: string,
+): { input: number; output: number } {
+  if (!isPlainObject(usage)) {
+    return { input: 0, output: 0 };
+  }
+  const input = readNonNegativeInt(usage.input_tokens);
+  const output = readNonNegativeInt(usage.output_tokens);
+  if (input !== undefined && output !== undefined) {
+    return { input, output };
+  }
+  if (input !== undefined) {
+    // Output tokens sometimes absent in early-exit envelopes; estimate.
+    return {
+      input,
+      output: Math.max(0, Math.min(input, Math.ceil(outputText.length / 4))),
+    };
+  }
+  return { input: 0, output: 0 };
+}
+
+function readNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+// ----------------------------------------------------------------------------
+// Subprocess execution
+// ----------------------------------------------------------------------------
+
+function runClaudeVersionCommand(
+  executable: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ status: number | null; stderr: string }> {
+  const { promise, resolve } = Promise.withResolvers<{
+    status: number | null;
+    stderr: string;
+  }>();
+  const child = spawn(executable, ["--version"], {
+    env,
+    stdio: ["ignore", "ignore", "pipe"],
+    detached: process.platform !== "win32",
+    windowsHide: true,
+  });
+  let stderr = "";
+  let timedOut = false;
+  let killTimeout: NodeJS.Timeout | undefined;
+  const terminateChild = (signal: NodeJS.Signals): void => {
+    if (child.pid && process.platform !== "win32") {
+      try {
+        process.kill(-child.pid, signal);
+        return;
+      } catch {
+        // Fall back to killing the direct child below.
+      }
+    }
+    child.kill(signal);
+  };
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    terminateChild("SIGTERM");
+    killTimeout = setTimeout(() => {
+      terminateChild("SIGKILL");
+    }, 1_000);
+    killTimeout.unref();
+  }, CLAUDE_CLI_VERSION_TIMEOUT_MS);
+  timeout.unref();
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr = appendBounded(stderr, chunk);
+  });
+  child.on("error", (error) => {
+    clearTimeout(timeout);
+    clearTimeout(killTimeout);
+    resolve({ status: 1, stderr: error.message });
+  });
+  child.on("close", (status) => {
+    clearTimeout(timeout);
+    clearTimeout(killTimeout);
+    resolve({
+      status: timedOut ? status ?? 124 : status,
+      stderr: timedOut
+        ? appendBounded(
+            stderr,
+            `\nClaude CLI --version timed out after ${CLAUDE_CLI_VERSION_TIMEOUT_MS}ms.`,
+          )
+        : stderr,
+    });
+  });
+  return promise;
+}
+
+function runClaudeCliCommand(request: ClaudeCliRunRequest): Promise<ClaudeCliRunResult> {
+  const { promise, resolve } = Promise.withResolvers<ClaudeCliRunResult>();
+  if (request.signal?.aborted) {
+    resolve({
+      status: 124,
+      signal: null,
+      stdout: "",
+      stderr: "Claude CLI aborted before start.",
+    });
+    return promise;
+  }
+
+  const child = spawn(request.executable, request.args, {
+    cwd: request.workspacePath,
+    env: request.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+    windowsHide: true,
+  });
+  if (child.pid) {
+    registerActiveClaudeCliChild(child.pid);
+  }
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  let aborted = false;
+  let killTimeout: NodeJS.Timeout | undefined;
+  const clearKillTimeout = (): void => {
+    if (killTimeout) {
+      clearTimeout(killTimeout);
+      killTimeout = undefined;
+    }
+  };
+  const terminateChild = (signal: NodeJS.Signals): void => {
+    if (child.pid && process.platform !== "win32") {
+      try {
+        process.kill(-child.pid, signal);
+        return;
+      } catch {
+        // Fall back to killing the direct child below.
+      }
+    }
+    child.kill(signal);
+  };
+  const scheduleForcedKill = (): void => {
+    clearKillTimeout();
+    killTimeout = setTimeout(() => {
+      terminateChild("SIGKILL");
+    }, 1_000);
+    killTimeout.unref();
+  };
+  const onAbort = (): void => {
+    if (aborted) {
+      return;
+    }
+    aborted = true;
+    stderr = appendBounded(stderr, "\nClaude CLI aborted by benchmark timeout.");
+    terminateChild("SIGTERM");
+    scheduleForcedKill();
+  };
+  request.signal?.addEventListener("abort", onAbort, { once: true });
+  if (request.signal?.aborted) {
+    onAbort();
+  }
+  const timeout = request.timeoutMs
+    ? setTimeout(() => {
+        timedOut = true;
+        terminateChild("SIGTERM");
+        scheduleForcedKill();
+      }, request.timeoutMs)
+    : undefined;
+  timeout?.unref();
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout = appendBounded(stdout, chunk);
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr = appendBounded(stderr, chunk);
+  });
+  child.stdin?.on("error", (error: NodeJS.ErrnoException) => {
+    stderr = appendBounded(
+      stderr,
+      `\nClaude CLI stdin error: ${error.code ?? error.message}`,
+    );
+  });
+  child.on("error", (error) => {
+    clearTimeout(timeout);
+    clearKillTimeout();
+    if (child.pid) {
+      unregisterActiveClaudeCliChild(child.pid);
+    }
+    request.signal?.removeEventListener("abort", onAbort);
+    resolve({
+      status: 1,
+      signal: null,
+      stdout,
+      stderr: appendBounded(stderr, error.message),
+    });
+  });
+  child.on("close", (status, signal) => {
+    clearTimeout(timeout);
+    if (child.pid) {
+      unregisterActiveClaudeCliChild(child.pid);
+    }
+    request.signal?.removeEventListener("abort", onAbort);
+    if (timedOut) {
+      resolve({
+        status: status ?? 124,
+        signal,
+        stdout,
+        stderr: appendBounded(
+          stderr,
+          `\nClaude CLI timed out after ${request.timeoutMs}ms.`,
+        ),
+      });
+      return;
+    }
+    if (aborted) {
+      resolve({
+        status: status ?? 124,
+        signal,
+        stdout,
+        stderr,
+      });
+      return;
+    }
+    resolve({ status, signal, stdout, stderr });
+  });
+  try {
+    child.stdin?.end(request.input);
+  } catch (error) {
+    stderr = appendBounded(
+      stderr,
+      `\nClaude CLI stdin error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return promise;
+}
+
+// ----------------------------------------------------------------------------
+// Parent cleanup (mirror codex-cli: never orphan a Claude Code subprocess)
+// ----------------------------------------------------------------------------
+
+function registerActiveClaudeCliChild(pid: number): void {
+  installClaudeCliParentCleanup();
+  activeClaudeCliChildPids.add(pid);
+}
+
+function unregisterActiveClaudeCliChild(pid: number): void {
+  activeClaudeCliChildPids.delete(pid);
+}
+
+function installClaudeCliParentCleanup(): void {
+  if (claudeCliParentCleanupInstalled) {
+    return;
+  }
+  claudeCliParentCleanupInstalled = true;
+
+  process.once("exit", () => {
+    terminateActiveClaudeCliChildren("SIGTERM");
+  });
+
+  for (const signal of CLAUDE_CLI_PARENT_SIGNALS) {
+    process.once(signal, () => {
+      const activeChildren = activeClaudeCliChildPids.size;
+      terminateActiveClaudeCliChildren(signal === "SIGINT" ? "SIGINT" : "SIGTERM");
+      process.exitCode = signalExitCode(signal);
+
+      setTimeout(
+        () => {
+          terminateActiveClaudeCliChildren("SIGKILL");
+          process.exit(signalExitCode(signal));
+        },
+        activeChildren > 0 ? CLAUDE_CLI_FORCED_PARENT_EXIT_MS : 0,
+      );
+    });
+  }
+}
+
+function terminateActiveClaudeCliChildren(signal: NodeJS.Signals): void {
+  for (const pid of activeClaudeCliChildPids) {
+    terminateClaudeCliChildPid(pid, signal);
+  }
+}
+
+function terminateClaudeCliChildPid(pid: number, signal: NodeJS.Signals): void {
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, signal);
+      return;
+    } catch {
+      // Fall back to killing the direct child below.
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // The child may already have exited.
+  }
+}
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  switch (signal) {
+    case "SIGHUP":
+      return 129;
+    case "SIGINT":
+      return 130;
+    case "SIGTERM":
+      return 143;
+    default:
+      return 1;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Diagnostics
+// ----------------------------------------------------------------------------
+
+async function startClaudeCliDiagnostics(args: {
+  config: ClaudeCliProviderConfig;
+  request: ClaudeCliRunRequest;
+  reasoningEffort: string;
+  retry: { attempt: number; maxAttempts: number };
+}): Promise<ClaudeCliDiagnosticHandle | undefined> {
+  const diagnosticsDir = resolveClaudeCliDiagnosticsDir(args.config);
+  if (!diagnosticsDir) {
+    return undefined;
+  }
+
+  try {
+    await mkdir(diagnosticsDir, { recursive: true, mode: 0o700 });
+    const id = `${Date.now()}-${process.pid}-${randomUUID()}`;
+    const promptStats = inspectClaudeCompletionPrompt(args.request.promptText);
+    const mode = resolveClaudeCliDiagnosticsMode(args.config);
+    const record: ClaudeCliDiagnosticRecord = {
+      schemaVersion: 1,
+      id,
+      runId: resolveBenchmarkRunId(),
+      startedAt: new Date().toISOString(),
+      provider: "claude-cli",
+      model: args.config.model,
+      reasoningEffort: args.reasoningEffort,
+      executable: path.basename(args.request.executable),
+      ...(args.request.timeoutMs ? { timeoutMs: args.request.timeoutMs } : {}),
+      workspaceBasename: path.basename(args.request.workspacePath),
+      prompt: promptStats,
+      command: {
+        args: redactClaudeCliArgs(args.request.args),
+      },
+      retry: args.retry,
+      ...(mode === "full" ? { fullPrompt: args.request.promptText } : {}),
+    };
+    const filePath = path.join(diagnosticsDir, `${id}.json`);
+    await writeClaudeCliDiagnosticRecord(filePath, record);
+    return { path: filePath, record };
+  } catch {
+    return undefined;
+  }
+}
+
+async function finishClaudeCliDiagnostics(
+  handle: ClaudeCliDiagnosticHandle | undefined,
+  startedAt: number,
+  outcome: ClaudeCliDiagnosticOutcome,
+): Promise<void> {
+  if (!handle) {
+    return;
+  }
+
+  const result = outcome.result;
+  const error = outcome.error;
+  const record: ClaudeCliDiagnosticRecord = {
+    ...handle.record,
+    ...(outcome.transientFailure
+      ? {
+          retry: {
+            ...(handle.record.retry ?? { attempt: 1, maxAttempts: 1 }),
+            transientFailure: true,
+          },
+        }
+      : {}),
+    finishedAt: new Date().toISOString(),
+    durationMs: Math.round(performance.now() - startedAt),
+    ...(result
+      ? {
+          result: {
+            status: result.status,
+            signal: result.signal,
+            stdoutChars: result.stdout.length,
+            stderrChars: result.stderr.length,
+            stdoutTail: tailText(result.stdout, 2_000),
+            stderrTail: tailText(result.stderr, 2_000),
+          },
+        }
+      : {}),
+    ...(error ? { error: error instanceof Error ? error.message : String(error) } : {}),
+  };
+  handle.record = record;
+
+  try {
+    await writeClaudeCliDiagnosticRecord(handle.path, record);
+  } catch {
+    // Diagnostics must never change benchmark behavior.
+  }
+}
+
+async function writeClaudeCliDiagnosticRecord(
+  filePath: string,
+  record: ClaudeCliDiagnosticRecord,
+): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+}
+
+function resolveClaudeCliDiagnosticsDir(
+  config: ClaudeCliProviderConfig,
+): string | undefined {
+  const dir = config.diagnosticsDir ?? process.env[CLAUDE_CLI_DIAGNOSTICS_DIR_ENV];
+  const trimmed = typeof dir === "string" ? dir.trim() : "";
+  return trimmed.length > 0
+    ? path.resolve(expandHomeRelativePath(trimmed))
+    : undefined;
+}
+
+function expandHomeRelativePath(value: string): string {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+function resolveClaudeCliDiagnosticsMode(
+  config: ClaudeCliProviderConfig,
+): "metadata" | "full" {
+  const raw = config.diagnosticsMode ?? process.env[CLAUDE_CLI_DIAGNOSTICS_MODE_ENV];
+  return raw === "full" ? "full" : "metadata";
+}
+
+function inspectClaudeCompletionPrompt(
+  promptText: string,
+): ClaudeCliDiagnosticRecord["prompt"] {
+  const stats: ClaudeCliDiagnosticRecord["prompt"] = {
+    sha256: createHash("sha256").update(promptText).digest("hex"),
+    chars: promptText.length,
+    lines: promptText.length === 0 ? 0 : promptText.split("\n").length,
+  };
+  const marker = "BENCHMARK_REQUEST_JSON:";
+  const markerIndex = promptText.indexOf(marker);
+  if (markerIndex < 0) {
+    return stats;
+  }
+
+  try {
+    const parsed = JSON.parse(promptText.slice(markerIndex + marker.length).trim()) as {
+      systemPrompt?: unknown;
+      userPrompt?: unknown;
+    };
+    return {
+      ...stats,
+      ...(typeof parsed.systemPrompt === "string"
+        ? { systemPromptChars: parsed.systemPrompt.length }
+        : {}),
+      ...(typeof parsed.userPrompt === "string"
+        ? { userPromptChars: parsed.userPrompt.length }
+        : {}),
+    };
+  } catch {
+    return stats;
+  }
+}
+
+function redactClaudeCliArgs(args: string[]): string[] {
+  const redacted = [...args];
+  for (let index = 0; index < redacted.length; index += 1) {
+    const value = redacted[index];
+    const lowered = value.toLowerCase();
+    if (value === "--system-prompt") {
+      if (index + 1 < redacted.length) {
+        redacted[index + 1] = "[redacted]";
+      }
+      continue;
+    }
+    if (
+      lowered.includes("api_key") ||
+      lowered.includes("apikey") ||
+      lowered.includes("token") ||
+      lowered.includes("secret")
+    ) {
+      redacted[index] = "[redacted]";
+    }
+  }
+  return redacted;
+}
+
+function resolveClaudeCliExecutable(config: ClaudeCliProviderConfig): string {
+  const configured =
+    config.executable ?? process.env[CLAUDE_CLI_EXECUTABLE_ENV];
+  if (configured === undefined) {
+    return "claude";
+  }
+
+  const trimmed = configured.trim();
+  if (trimmed.length === 0) {
+    throw new Error(
+      `${CLAUDE_CLI_EXECUTABLE_ENV} / claude-cli executable must not be empty`,
+    );
+  }
+  return expandHomeRelativePath(trimmed);
+}
+
+function buildClaudeCompletionPrompt(
+  userPrompt: string,
+  systemPrompt: string | undefined,
+): string {
+  const payload = {
+    systemPrompt: systemPrompt ?? "",
+    userPrompt,
+  };
+
+  return [
+    "You are acting as a benchmark LLM completion endpoint, not as a coding agent.",
+    "Use only the explicit JSON payload below.",
+    "Treat systemPrompt as the higher-priority instruction text and userPrompt as the request to answer.",
+    "Do not inspect files, run commands, browse, use tools, or use persisted memory.",
+    "Return only the final answer text. If the request asks for JSON, return raw JSON only.",
+    "",
+    "BENCHMARK_REQUEST_JSON:",
+    JSON.stringify(payload, null, 2),
+  ].join("\n");
+}
+
+function buildIsolatedClaudeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && isAllowedClaudeRuntimeEnvKey(key)) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function isAllowedClaudeRuntimeEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return CLAUDE_CLI_RUNTIME_ENV_ALLOWLIST.has(normalized)
+    || normalized.startsWith("LC_");
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function appendBounded(existing: string, next: string): string {
+  const combined = existing + next;
+  if (combined.length <= CLAUDE_CLI_STDIO_LIMIT) {
+    return combined;
+  }
+  return combined.slice(combined.length - CLAUDE_CLI_STDIO_LIMIT);
+}
+
+function tailText(value: string, maxChars: number): string {
+  if (!Number.isFinite(maxChars) || maxChars <= 0) {
+    return "";
+  }
+  const normalizedMaxChars = Math.floor(maxChars);
+  return value.length <= normalizedMaxChars
+    ? value
+    : value.slice(value.length - normalizedMaxChars);
+}
+
+function normalizeClaudeCliMaxAttempts(value: number | undefined): number {
+  if (value === undefined) {
+    return 3;
+  }
+  if (!Number.isFinite(value) || value < 1) {
+    return 1;
+  }
+  return Math.min(10, Math.floor(value));
+}
+
+function isRetryableClaudeCliResult(result: ClaudeCliRunResult): boolean {
+  if (!result.signal) {
+    return false;
+  }
+  const stderr = result.stderr.toLowerCase();
+  if (
+    stderr.includes("timed out after") ||
+    stderr.includes("aborted by benchmark timeout")
+  ) {
+    return false;
+  }
+  return true;
+}
+
+async function sleepBeforeClaudeCliRetry(
+  attempt: number,
+  configuredBaseBackoffMs: number | undefined,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  const baseBackoffMs =
+    configuredBaseBackoffMs !== undefined &&
+    Number.isFinite(configuredBaseBackoffMs) &&
+    configuredBaseBackoffMs > 0
+      ? configuredBaseBackoffMs
+      : 1000;
+  const delayMs = Math.min(baseBackoffMs * Math.pow(2, attempt - 1), 30_000);
+  if (!signal) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setTimeout(resolve, delayMs);
+    await promise;
+    return;
+  }
+  if (signal.aborted) {
+    throw claudeCliAbortError(signal);
+  }
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const cleanup = (): void => {
+    signal.removeEventListener("abort", onAbort);
+  };
+  const onAbort = (): void => {
+    clearTimeout(timeout);
+    cleanup();
+    reject(claudeCliAbortError(signal));
+  };
+  const timeout = setTimeout(() => {
+    cleanup();
+    resolve();
+  }, delayMs);
+  signal.addEventListener("abort", onAbort, { once: true });
+  await promise;
+}
+
+function claudeCliAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+  if (signal.reason !== undefined) {
+    return new Error(String(signal.reason));
+  }
+  return new DOMException("The operation was aborted.", "AbortError");
+}
+
+function summarizeProcessOutput(stderr: string, stdout: string): string {
+  const summary = [stderr.trim(), stdout.trim()]
+    .filter((value) => value.length > 0)
+    .join("\n")
+    .trim();
+  return summary.length > 0 ? summary.slice(-1_000) : "no process output";
+}
+
+export function createClaudeCliProvider(
+  config: ClaudeCliProviderConfig,
+  deps?: ClaudeCliProviderDeps,
+): LlmProvider {
+  return new ClaudeCliProvider(config, deps);
+}
+
+export const __claudeCliProviderTestHooks = {
+  buildClaudeCompletionPrompt,
+  buildIsolatedClaudeEnv,
+  extractClaudeUsage,
+  parseClaudeResultEnvelope,
+  resolveClaudeCliDiagnosticsDir,
+  resolveClaudeCliExecutable,
+};

--- a/packages/bench/src/providers/factory.ts
+++ b/packages/bench/src/providers/factory.ts
@@ -4,6 +4,7 @@ import type {
   ProviderFactoryConfig,
 } from "./types.js";
 import { createAnthropicProvider } from "./anthropic.js";
+import { createClaudeCliProvider } from "./claude-cli.js";
 import { createCodexCliProvider } from "./codex-cli.js";
 import { createLiteLlmProvider } from "./litellm.js";
 import { createLocalLlmProvider } from "./local-llm.js";
@@ -12,6 +13,8 @@ import { createOpenAiCompatibleProvider } from "./openai-compatible.js";
 
 export interface DiscoverAllProvidersOptions {
   includeCodexCli?: boolean;
+  /** When true (default), probe for a locally installed Claude Code CLI. */
+  includeClaudeCli?: boolean;
 }
 
 export function createProvider(config: ProviderFactoryConfig): LlmProvider {
@@ -28,6 +31,8 @@ export function createProvider(config: ProviderFactoryConfig): LlmProvider {
       return createLocalLlmProvider(config);
     case "codex-cli":
       return createCodexCliProvider(config);
+    case "claude-cli":
+      return createClaudeCliProvider(config);
     default: {
       const exhaustive: never = config;
       throw new Error(`Unknown provider: ${JSON.stringify(exhaustive)}`);
@@ -72,6 +77,18 @@ export async function discoverAllProviders(
         createCodexCliProvider({
           provider: "codex-cli",
           model: "gpt-5.5",
+          reasoningEffort: "xhigh",
+        }),
+    });
+  }
+
+  if (options.includeClaudeCli ?? true) {
+    discoveryTargets.push({
+      provider: "claude-cli" as const,
+      create: () =>
+        createClaudeCliProvider({
+          provider: "claude-cli",
+          model: "opus",
           reasoningEffort: "xhigh",
         }),
     });

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -113,12 +113,35 @@ export interface CodexCliProviderConfig extends ProviderBaseConfig {
   diagnosticsMode?: "metadata" | "full";
 }
 
+export interface ClaudeCliProviderConfig extends ProviderBaseConfig {
+  provider?: "claude-cli";
+  /**
+   * Claude Code reasoning effort (forwarded as `claude -p --effort`). Bench
+   * CLI defaults this to xhigh. Mirrors the codex-cli reasoning-effort knob.
+   */
+  reasoningEffort?: BenchReasoningEffort;
+  /** Optional executable override for tests or non-standard Claude Code installs. */
+  executable?: string;
+  /**
+   * Optional diagnostics artifact directory. When set, the provider writes
+   * per-call metadata that helps debug slow benchmark completions without
+   * depending on transient temp workspaces.
+   */
+  diagnosticsDir?: string;
+  /**
+   * `metadata` stores hashes/counts only. `full` additionally stores the full
+   * benchmark prompt and should only be used for isolated benchmark datasets.
+   */
+  diagnosticsMode?: "metadata" | "full";
+}
+
 export type ProviderFactoryConfig =
   | (OpenAiCompatibleProviderConfig & { provider: "openai" | "litellm" })
   | (AnthropicProviderConfig & { provider: "anthropic" })
   | (OllamaProviderConfig & { provider: "ollama" })
   | (LocalLlmProviderConfig & { provider: "local-llm" })
-  | (CodexCliProviderConfig & { provider: "codex-cli" });
+  | (CodexCliProviderConfig & { provider: "codex-cli" })
+  | (ClaudeCliProviderConfig & { provider: "claude-cli" });
 
 export interface ProviderDiscoveryResult {
   provider: BuiltInProvider;

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -475,9 +475,13 @@ function resolveProviderConfig(
         "(e.g. http://localhost:8080/v1 for llama.cpp).",
     );
   }
-  if (reasoningEffort !== undefined && provider !== "codex-cli") {
+  if (
+    reasoningEffort !== undefined &&
+    provider !== "codex-cli" &&
+    provider !== "claude-cli"
+  ) {
     throw new Error(
-      `${kind} Codex reasoning effort requires provider "codex-cli"`,
+      `${kind} reasoning effort requires provider "codex-cli" or "claude-cli"`,
     );
   }
 
@@ -493,7 +497,9 @@ function resolveProviderConfig(
         } }
       : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
-    ...(provider === "codex-cli" ? { reasoningEffort: reasoningEffort ?? "xhigh" } : {}),
+    ...((provider === "codex-cli" || provider === "claude-cli")
+      ? { reasoningEffort: reasoningEffort ?? "xhigh" }
+      : {}),
     ...(responderContextBudgetChars !== undefined
       ? { responderContextBudgetChars }
       : {}),
@@ -631,6 +637,9 @@ function gatewayProviderApi(provider: BuiltInProvider): string {
   if (provider === "codex-cli") {
     return "codex-cli";
   }
+  if (provider === "claude-cli") {
+    return "claude-cli";
+  }
   if (provider === "ollama") {
     return "ollama-chat";
   }
@@ -652,6 +661,8 @@ function defaultInternalBaseUrl(provider: BuiltInProvider): string | undefined {
       return "http://localhost:11434/api";
     case "codex-cli":
       return "codex-cli://local";
+    case "claude-cli":
+      return "claude-cli://local";
     case "local-llm":
       return undefined;
     default: {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -4,8 +4,10 @@ import { readFile } from "node:fs/promises";
 import {
   type FallbackLlmRuntimeContext,
   resolvePluginEntry,
+  setClaudeCliFallbackRunnerForProcess,
   setCodexCliFallbackRunnerForProcess,
   type GatewayConfig,
+  type ClaudeCliFallbackRunner,
   type CodexCliFallbackRunner,
 } from "@remnic/core";
 import type {
@@ -136,6 +138,8 @@ const REDACTED_CONFIG_VALUE = "[redacted]";
 const INTERNAL_GATEWAY_AGENT_ID = "remnic-bench-internal";
 let codexCliFallbackRegistered = false;
 let codexCliFallbackChain: Promise<void> = Promise.resolve();
+let claudeCliFallbackRegistered = false;
+let claudeCliFallbackChain: Promise<void> = Promise.resolve();
 
 export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
@@ -199,6 +203,7 @@ export async function resolveBenchRuntimeProfile(
     options.drainTimeout ?? options.requestTimeout,
   );
   registerCodexCliFallbackRunnerIfNeeded(internalProvider);
+  registerClaudeCliFallbackRunnerIfNeeded(internalProvider);
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
     : undefined;
@@ -621,7 +626,11 @@ function buildInternalGatewayConfig(
           api: gatewayProviderApi(config.provider),
           ...(config.apiKey ? { apiKey: config.apiKey } : {}),
           ...(config.disableThinking || options.disableThinking ? { disableThinking: true } : {}),
-          ...(config.reasoningEffort ? { codexCliReasoningEffort: config.reasoningEffort } : {}),
+          ...(config.reasoningEffort
+            ? config.provider === "claude-cli"
+              ? { claudeCliReasoningEffort: config.reasoningEffort }
+              : { codexCliReasoningEffort: config.reasoningEffort }
+            : {}),
           ...(timeoutMs ? { retryOptions: { timeoutMs } } : {}),
           models: [{ id: config.model, name: config.model }],
         },
@@ -816,6 +825,79 @@ function splitCodexFallbackMessages(
     prompt: prompt || messages.map((message) => message.content).join("\n\n"),
   };
 }
+
+function registerClaudeCliFallbackRunnerIfNeeded(config: ProviderConfig | null): void {
+  if (!config || config.provider !== "claude-cli" || claudeCliFallbackRegistered) {
+    return;
+  }
+
+  const runner: ClaudeCliFallbackRunner = async (request) =>
+    enqueueClaudeCliFallback(async () => {
+      if (request.options.signal?.aborted) {
+        throw claudeAbortReason(request.options.signal);
+      }
+      const reasoningEffort = asCodexReasoningEffort(
+        request.config.claudeCliReasoningEffort ?? request.config.reasoningEffort,
+      );
+      const provider = createProvider({
+        provider: "claude-cli",
+        model: request.modelId,
+        ...(typeof request.config.apiKey === "string"
+          ? { apiKey: request.config.apiKey }
+          : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+        ...(typeof request.config.claudeCliExecutable === "string"
+          ? { executable: request.config.claudeCliExecutable }
+          : typeof request.config.executable === "string"
+            ? { executable: request.config.executable }
+            : {}),
+        ...(typeof request.config.retryOptions?.timeoutMs === "number" ||
+          typeof request.options.timeoutMs === "number"
+          ? {
+              retryOptions: {
+                timeoutMs:
+                  typeof request.config.retryOptions?.timeoutMs === "number"
+                    ? request.config.retryOptions.timeoutMs
+                    : request.options.timeoutMs,
+              },
+            }
+          : {}),
+      });
+      const split = splitCodexFallbackMessages(request.messages);
+      const completion = await provider.complete(split.prompt, {
+        systemPrompt: split.systemPrompt,
+        temperature: 0.3,
+        maxTokens: 4096,
+        signal: request.options.signal,
+      });
+      return {
+        content: completion.text,
+        usage: {
+          inputTokens: completion.tokens.input,
+          outputTokens: completion.tokens.output,
+          totalTokens: completion.tokens.input + completion.tokens.output,
+        },
+      };
+    });
+
+  setClaudeCliFallbackRunnerForProcess(runner);
+  claudeCliFallbackRegistered = true;
+}
+
+function enqueueClaudeCliFallback<T>(task: () => Promise<T>): Promise<T> {
+  const run = claudeCliFallbackChain.then(task, task);
+  claudeCliFallbackChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+function claudeAbortReason(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  return reason instanceof Error ? reason : new Error("claude-cli fallback aborted");
+}
+
 
 function withAssistantHooks(
   config: Record<string, unknown>,

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -845,6 +845,9 @@ function registerClaudeCliFallbackRunnerIfNeeded(config: ProviderConfig | null):
         ...(typeof request.config.apiKey === "string"
           ? { apiKey: request.config.apiKey }
           : {}),
+        ...(typeof request.config.baseUrl === "string"
+          ? { baseUrl: request.config.baseUrl }
+          : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(typeof request.config.claudeCliExecutable === "string"
           ? { executable: request.config.claudeCliExecutable }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -22,8 +22,15 @@ export type AmaBenchJudgeProtocol = "default" | "recommended";
  * `codex-cli` shells out to `codex exec` as an isolated benchmark-only
  * responder/judge target. It is intentionally not routed through Remnic
  * memory or OpenClaw gateway state.
+ *
+ * `claude-cli` shells out to Claude Code headless (`claude -p`) in an
+ * isolated empty workspace with tools disabled (issue #1728). It exists for
+ * the judge role and cheap internal iteration under Claude Max session
+ * limits — NOT for the published `tier: "frontier"` headline number, which
+ * must be API-sourced via the `anthropic` provider so a reviewer can
+ * reproduce it. A claude-cli-sourced number is "Opus via Claude Code".
  */
-export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm" | "local-llm" | "codex-cli";
+export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm" | "local-llm" | "codex-cli" | "claude-cli";
 
 export type BenchReasoningEffort = "low" | "medium" | "high" | "xhigh";
 

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "ES2024.Promise"
     ],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -745,6 +745,117 @@ test("parseBenchArgs rejects internal Codex reasoning effort for non-Codex provi
   );
 });
 
+test("parseBenchArgs accepts claude-cli as a system and judge provider with reasoning effort", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "longmemeval",
+    "--system-provider",
+    "claude-cli",
+    "--system-model",
+    "opus",
+    "--system-claude-reasoning-effort",
+    "high",
+    "--judge-provider",
+    "claude-cli",
+    "--judge-model",
+    "opus",
+    "--judge-claude-reasoning-effort",
+    "medium",
+  ]);
+
+  assert.equal(parsed.systemProvider, "claude-cli");
+  assert.equal(parsed.systemModel, "opus");
+  assert.equal(parsed.systemClaudeReasoningEffort, "high");
+  assert.equal(parsed.judgeProvider, "claude-cli");
+  assert.equal(parsed.judgeModel, "opus");
+  assert.equal(parsed.judgeClaudeReasoningEffort, "medium");
+});
+
+test("parseBenchArgs accepts claude-cli internal provider with reasoning effort", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--internal-provider",
+    "claude-cli",
+    "--internal-model",
+    "opus",
+    "--internal-claude-reasoning-effort",
+    "xhigh",
+  ]);
+
+  assert.equal(parsed.internalProvider, "claude-cli");
+  assert.equal(parsed.internalModel, "opus");
+  assert.equal(parsed.internalClaudeReasoningEffort, "xhigh");
+});
+
+test("parseBenchArgs rejects system Claude reasoning effort for non-claude-cli providers", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--system-provider",
+        "openai",
+        "--system-model",
+        "gpt-5.5",
+        "--system-claude-reasoning-effort",
+        "xhigh",
+      ]),
+    /--system-claude-reasoning-effort requires --system-provider claude-cli/,
+  );
+});
+
+test("parseBenchArgs rejects judge Claude reasoning effort for non-claude-cli providers", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--judge-provider",
+        "openai",
+        "--judge-model",
+        "gpt-5.5",
+        "--judge-claude-reasoning-effort",
+        "medium",
+      ]),
+    /--judge-claude-reasoning-effort requires --judge-provider claude-cli/,
+  );
+});
+
+test("parseBenchArgs rejects internal Claude reasoning effort for non-claude-cli providers", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--internal-provider",
+        "ollama",
+        "--internal-model",
+        "gemma4:31b-cloud",
+        "--internal-claude-reasoning-effort",
+        "xhigh",
+      ]),
+    /--internal-claude-reasoning-effort requires --internal-provider claude-cli/,
+  );
+});
+
+test("parseBenchArgs rejects invalid Claude reasoning effort values", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "longmemeval",
+        "--system-provider",
+        "claude-cli",
+        "--system-model",
+        "opus",
+        "--system-claude-reasoning-effort",
+        "ultra",
+      ]),
+    /--system-claude-reasoning-effort must be "low", "medium", "high", or "xhigh"/,
+  );
+});
+
 test("parseBenchArgs accepts AMA-Bench recommended judge and cross-judge flags", () => {
   const parsed = parseBenchArgs([
     "run",
@@ -845,7 +956,7 @@ test("parseBenchArgs rejects unknown --provider", () => {
         "--provider",
         "not-a-provider",
       ]),
-    /--provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"/,
+    /--provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"/,
   );
 });
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -53,6 +53,7 @@ export interface ParsedBenchArgs {
   systemBaseUrl?: string;
   systemApiKey?: string;
   systemCodexReasoningEffort?: BenchCodexReasoningEffort;
+  systemClaudeReasoningEffort?: BenchCodexReasoningEffort;
   systemResponderContextBudgetChars?: number;
   systemResponderPromptBudgetChars?: number;
   judgeProvider?: BuiltInProvider;
@@ -60,12 +61,14 @@ export interface ParsedBenchArgs {
   judgeBaseUrl?: string;
   judgeApiKey?: string;
   judgeCodexReasoningEffort?: BenchCodexReasoningEffort;
+  judgeClaudeReasoningEffort?: BenchCodexReasoningEffort;
   internalProvider?: BuiltInProvider;
   internalModel?: string;
   internalBaseUrl?: string;
   internalApiKey?: string;
   internalDisableThinking?: boolean;
   internalCodexReasoningEffort?: BenchCodexReasoningEffort;
+  internalClaudeReasoningEffort?: BenchCodexReasoningEffort;
   threshold?: number;
   baselineAction?: BenchBaselineAction;
   datasetAction?: BenchDatasetAction;
@@ -240,6 +243,7 @@ const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "litellm",
   "local-llm",
   "codex-cli",
+  "claude-cli",
 ]);
 
 function isBuiltInProvider(value: string): value is BuiltInProvider {
@@ -249,7 +253,7 @@ function isBuiltInProvider(value: string): value is BuiltInProvider {
 function parseBenchProvider(raw: string, flag: string): BuiltInProvider {
   if (!isBuiltInProvider(raw)) {
     throw new Error(
-      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli".`,
+      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli".`,
     );
   }
   return raw;
@@ -298,6 +302,7 @@ const BENCH_VALUE_FLAGS = Object.freeze([
   "--system-base-url",
   "--system-api-key",
   "--system-codex-reasoning-effort",
+  "--system-claude-reasoning-effort",
   "--system-responder-context-budget-chars",
   "--system-responder-prompt-budget-chars",
   "--judge-provider",
@@ -305,12 +310,14 @@ const BENCH_VALUE_FLAGS = Object.freeze([
   "--judge-base-url",
   "--judge-api-key",
   "--judge-codex-reasoning-effort",
+  "--judge-claude-reasoning-effort",
   "--judge-cache-dir",
   "--internal-provider",
   "--internal-model",
   "--internal-base-url",
   "--internal-api-key",
   "--internal-codex-reasoning-effort",
+  "--internal-claude-reasoning-effort",
   "--threshold",
   "--custom",
   "--format",
@@ -385,6 +392,7 @@ const RUN_VALUE_FLAGS = Object.freeze([
   "--system-base-url",
   "--system-api-key",
   "--system-codex-reasoning-effort",
+  "--system-claude-reasoning-effort",
   "--system-responder-context-budget-chars",
   "--system-responder-prompt-budget-chars",
   "--judge-provider",
@@ -392,12 +400,14 @@ const RUN_VALUE_FLAGS = Object.freeze([
   "--judge-base-url",
   "--judge-api-key",
   "--judge-codex-reasoning-effort",
+  "--judge-claude-reasoning-effort",
   "--judge-cache-dir",
   "--internal-provider",
   "--internal-model",
   "--internal-base-url",
   "--internal-api-key",
   "--internal-codex-reasoning-effort",
+  "--internal-claude-reasoning-effort",
   "--custom",
   "--dataset",
   "--model",
@@ -712,6 +722,10 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     args,
     "--system-codex-reasoning-effort",
   );
+  const systemClaudeReasoningEffortRaw = readBenchOptionValue(
+    args,
+    "--system-claude-reasoning-effort",
+  );
   const systemResponderContextBudgetRaw = readBenchOptionValue(
     args,
     "--system-responder-context-budget-chars",
@@ -728,6 +742,10 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     args,
     "--judge-codex-reasoning-effort",
   );
+  const judgeClaudeReasoningEffortRaw = readBenchOptionValue(
+    args,
+    "--judge-claude-reasoning-effort",
+  );
   const internalProviderRaw = readBenchOptionValue(args, "--internal-provider");
   const internalModel = readBenchOptionValue(args, "--internal-model");
   const internalBaseUrl = readBenchOptionValue(args, "--internal-base-url");
@@ -735,6 +753,10 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const internalCodexReasoningEffortRaw = readBenchOptionValue(
     args,
     "--internal-codex-reasoning-effort",
+  );
+  const internalClaudeReasoningEffortRaw = readBenchOptionValue(
+    args,
+    "--internal-claude-reasoning-effort",
   );
   const thresholdRaw = readBenchOptionValue(args, "--threshold");
   const customRaw = readBenchOptionValue(args, "--custom");
@@ -806,11 +828,23 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       systemCodexReasoningEffortRaw,
       "--system-codex-reasoning-effort",
     );
+  const systemClaudeReasoningEffort = systemClaudeReasoningEffortRaw === undefined
+    ? undefined
+    : parseCodexReasoningEffort(
+      systemClaudeReasoningEffortRaw,
+      "--system-claude-reasoning-effort",
+    );
   const judgeCodexReasoningEffort = judgeCodexReasoningEffortRaw === undefined
     ? undefined
     : parseCodexReasoningEffort(
       judgeCodexReasoningEffortRaw,
       "--judge-codex-reasoning-effort",
+    );
+  const judgeClaudeReasoningEffort = judgeClaudeReasoningEffortRaw === undefined
+    ? undefined
+    : parseCodexReasoningEffort(
+      judgeClaudeReasoningEffortRaw,
+      "--judge-claude-reasoning-effort",
     );
 
   let internalProvider: BuiltInProvider | undefined;
@@ -823,6 +857,12 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     : parseCodexReasoningEffort(
       internalCodexReasoningEffortRaw,
       "--internal-codex-reasoning-effort",
+    );
+  const internalClaudeReasoningEffort = internalClaudeReasoningEffortRaw === undefined
+    ? undefined
+    : parseCodexReasoningEffort(
+      internalClaudeReasoningEffortRaw,
+      "--internal-claude-reasoning-effort",
     );
 
   let amaBenchJudgeProtocol: AmaBenchJudgeProtocol | undefined;
@@ -1176,6 +1216,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     );
   }
   if (
+    systemClaudeReasoningEffort !== undefined &&
+    effectiveSystemProvider !== "claude-cli"
+  ) {
+    throw new Error(
+      "ERROR: --system-claude-reasoning-effort requires --system-provider claude-cli (or --provider claude-cli).",
+    );
+  }
+  if (
     systemResponderContextBudgetChars !== undefined &&
     effectiveSystemProvider === undefined
   ) {
@@ -1199,6 +1247,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       "ERROR: --judge-codex-reasoning-effort requires --judge-provider codex-cli.",
     );
   }
+  if (
+    judgeClaudeReasoningEffort !== undefined &&
+    judgeProvider !== "claude-cli"
+  ) {
+    throw new Error(
+      "ERROR: --judge-claude-reasoning-effort requires --judge-provider claude-cli.",
+    );
+  }
   if (internalProvider === "local-llm" && !internalBaseUrl) {
     throw new Error(
       "ERROR: --internal-provider local-llm requires --internal-base-url. " +
@@ -1212,6 +1268,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   ) {
     throw new Error(
       "ERROR: --internal-codex-reasoning-effort requires --internal-provider codex-cli.",
+    );
+  }
+  if (
+    internalClaudeReasoningEffort !== undefined &&
+    internalProvider !== "claude-cli"
+  ) {
+    throw new Error(
+      "ERROR: --internal-claude-reasoning-effort requires --internal-provider claude-cli.",
     );
   }
   const effectiveAmaBenchCrossJudgeProvider =
@@ -1277,6 +1341,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     systemBaseUrl: effectiveSystemBaseUrl,
     systemApiKey,
     systemCodexReasoningEffort,
+    systemClaudeReasoningEffort,
     systemResponderContextBudgetChars,
     systemResponderPromptBudgetChars,
     judgeProvider,
@@ -1284,12 +1349,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     judgeBaseUrl,
     judgeApiKey,
     judgeCodexReasoningEffort,
+    judgeClaudeReasoningEffort,
     internalProvider,
     internalModel,
     internalBaseUrl,
     internalApiKey,
     internalDisableThinking: args.includes("--internal-disable-thinking"),
     internalCodexReasoningEffort,
+    internalClaudeReasoningEffort,
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,

--- a/packages/remnic-cli/src/bench-fallback.ts
+++ b/packages/remnic-cli/src/bench-fallback.ts
@@ -42,6 +42,7 @@ export function findUnsupportedFallbackBenchOptions(parsed: ParsedBenchArgs): st
   add(parsed.systemBaseUrl !== undefined, "--system-base-url/--base-url");
   add(parsed.systemApiKey !== undefined, "--system-api-key");
   add(parsed.systemCodexReasoningEffort !== undefined, "--system-codex-reasoning-effort");
+  add(parsed.systemClaudeReasoningEffort !== undefined, "--system-claude-reasoning-effort");
   add(parsed.systemResponderContextBudgetChars !== undefined, "--system-responder-context-budget-chars");
   add(parsed.systemResponderPromptBudgetChars !== undefined, "--system-responder-prompt-budget-chars");
   add(parsed.judgeProvider !== undefined, "--judge-provider");
@@ -49,12 +50,14 @@ export function findUnsupportedFallbackBenchOptions(parsed: ParsedBenchArgs): st
   add(parsed.judgeBaseUrl !== undefined, "--judge-base-url");
   add(parsed.judgeApiKey !== undefined, "--judge-api-key");
   add(parsed.judgeCodexReasoningEffort !== undefined, "--judge-codex-reasoning-effort");
+  add(parsed.judgeClaudeReasoningEffort !== undefined, "--judge-claude-reasoning-effort");
   add(parsed.internalProvider !== undefined, "--internal-provider");
   add(parsed.internalModel !== undefined, "--internal-model");
   add(parsed.internalBaseUrl !== undefined, "--internal-base-url");
   add(parsed.internalApiKey !== undefined, "--internal-api-key");
   add(parsed.internalDisableThinking === true, "--internal-disable-thinking");
   add(parsed.internalCodexReasoningEffort !== undefined, "--internal-codex-reasoning-effort");
+  add(parsed.internalClaudeReasoningEffort !== undefined, "--internal-claude-reasoning-effort");
   add(parsed.amaBenchJudgeProtocol !== undefined, "--ama-bench-judge-protocol");
   add(parsed.amaBenchCrossJudgeProvider !== undefined, "--ama-bench-cross-judge-provider");
   add(parsed.amaBenchCrossJudgeModel !== undefined, "--ama-bench-cross-judge-model");

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1071,7 +1071,7 @@ export function buildBenchRuntimeProfileRequest(
     systemCodexReasoningEffort:
       runtimeProfile === "openclaw-chain"
         ? undefined
-        : parsed.systemCodexReasoningEffort,
+        : (parsed.systemCodexReasoningEffort ?? parsed.systemClaudeReasoningEffort),
     systemResponderContextBudgetChars:
       runtimeProfile === "openclaw-chain"
         ? undefined
@@ -1084,13 +1084,13 @@ export function buildBenchRuntimeProfileRequest(
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,
     judgeApiKey: parsed.judgeApiKey,
-    judgeCodexReasoningEffort: parsed.judgeCodexReasoningEffort,
+    judgeCodexReasoningEffort: (parsed.judgeCodexReasoningEffort ?? parsed.judgeClaudeReasoningEffort),
     internalProvider: parsed.internalProvider,
     internalModel: parsed.internalModel,
     internalBaseUrl: parsed.internalBaseUrl,
     internalApiKey: parsed.internalApiKey,
     internalDisableThinking: parsed.internalDisableThinking,
-    internalCodexReasoningEffort: parsed.internalCodexReasoningEffort,
+    internalCodexReasoningEffort: (parsed.internalCodexReasoningEffort ?? parsed.internalClaudeReasoningEffort),
     requestTimeout: parsed.requestTimeout,
     drainTimeout: parsed.drainTimeout,
     max429WaitMs: parsed.max429WaitMs,

--- a/packages/remnic-core/src/cli-fallback.ts
+++ b/packages/remnic-core/src/cli-fallback.ts
@@ -160,3 +160,158 @@ function normalizeCodexCliTimeoutMs(value: unknown): number {
 export const __codexCliFallbackTestHooks = {
   setRunCodexCliForTest: setCodexCliFallbackRunnerForProcess,
 };
+
+export interface ClaudeCliFallbackMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Claude CLI fallback (issue #1728): mirrors the Codex CLI inversion pattern.
+// The internal-provider path (`--internal-provider claude-cli`) routes through
+// fallback-llm.ts -> callClaudeCliFallback -> this registered runner, which the
+// bench runtime wires to the claude-cli provider transport.
+// ---------------------------------------------------------------------------
+
+export interface ClaudeCliFallbackConfig {
+  apiKey?: string | Record<string, unknown>;
+  executable?: unknown;
+  claudeCliExecutable?: unknown;
+  reasoningEffort?: unknown;
+  claudeCliReasoningEffort?: unknown;
+  retryOptions?: {
+    timeoutMs?: unknown;
+  };
+}
+
+export interface ClaudeCliFallbackOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface ClaudeCliFallbackResult {
+  content: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+export interface ClaudeCliFallbackRequest {
+  config: ClaudeCliFallbackConfig;
+  modelId: string;
+  messages: ClaudeCliFallbackMessage[];
+  options: ClaudeCliFallbackOptions;
+}
+
+export type ClaudeCliFallbackRunner = (
+  request: ClaudeCliFallbackRequest,
+) => Promise<ClaudeCliFallbackResult>;
+
+let claudeProcessRunner: ClaudeCliFallbackRunner | undefined;
+
+/**
+ * Registers the process-local Claude CLI transport. Same inversion rationale
+ * as the Codex runner: core does not import child_process so host adapters do
+ * not ship shell execution; benchmark/standalone runtimes opt in.
+ */
+export function setClaudeCliFallbackRunnerForProcess(
+  runner: ClaudeCliFallbackRunner | undefined,
+): () => void {
+  const previous = claudeProcessRunner;
+  claudeProcessRunner = runner;
+  return () => {
+    claudeProcessRunner = previous;
+  };
+}
+
+export async function callClaudeCliFallback(
+  config: ClaudeCliFallbackConfig,
+  modelId: string,
+  messages: ClaudeCliFallbackMessage[],
+  options: ClaudeCliFallbackOptions = {},
+): Promise<ClaudeCliFallbackResult> {
+  if (!claudeProcessRunner) {
+    throw new Error(
+      'claude-cli fallback transport is not registered; install a runner with setClaudeCliFallbackRunnerForProcess() before using api: "claude-cli"',
+    );
+  }
+
+  return await claudeProcessRunner({
+    config: normalizeClaudeCliFallbackConfig(config),
+    modelId: normalizeClaudeCliModel(modelId),
+    messages,
+    options: normalizeClaudeCliFallbackOptions(options),
+  });
+}
+
+function normalizeClaudeCliFallbackConfig(
+  config: ClaudeCliFallbackConfig,
+): ClaudeCliFallbackConfig {
+  return {
+    ...config,
+    ...(config.executable !== undefined
+      ? { executable: normalizeOptionalString(config.executable, "claude-cli executable") }
+      : {}),
+    ...(config.claudeCliExecutable !== undefined
+      ? { claudeCliExecutable: normalizeOptionalString(config.claudeCliExecutable, "claude-cli executable") }
+      : {}),
+    ...(config.reasoningEffort !== undefined
+      ? { reasoningEffort: normalizeClaudeCliReasoningEffort(config.reasoningEffort) }
+      : {}),
+    ...(config.claudeCliReasoningEffort !== undefined
+      ? { claudeCliReasoningEffort: normalizeClaudeCliReasoningEffort(config.claudeCliReasoningEffort) }
+      : {}),
+    ...(config.retryOptions?.timeoutMs !== undefined
+      ? { retryOptions: { timeoutMs: normalizeClaudeCliTimeoutMs(config.retryOptions.timeoutMs) } }
+      : {}),
+  };
+}
+
+function normalizeClaudeCliFallbackOptions(
+  options: ClaudeCliFallbackOptions,
+): ClaudeCliFallbackOptions {
+  return {
+    ...(options.timeoutMs !== undefined
+      ? { timeoutMs: normalizeClaudeCliTimeoutMs(options.timeoutMs) }
+      : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
+  };
+}
+
+function normalizeClaudeCliModel(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error("claude-cli model must be a non-empty string");
+  }
+  return trimmed;
+}
+
+function normalizeClaudeCliReasoningEffort(value: unknown): CodexCliReasoningEffort {
+  if (typeof value !== "string") {
+    throw new Error("claude-cli reasoningEffort must be one of low, medium, high, xhigh");
+  }
+  const normalized = value.trim().toLowerCase();
+  if (VALID_CODEX_CLI_REASONING_EFFORTS.has(normalized as CodexCliReasoningEffort)) {
+    return normalized as CodexCliReasoningEffort;
+  }
+  throw new Error("claude-cli reasoningEffort must be one of low, medium, high, xhigh");
+}
+
+function normalizeClaudeCliTimeoutMs(value: unknown): number {
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && value.trim().length > 0
+      ? Number(value)
+      : NaN;
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("claude-cli timeoutMs must be a positive integer");
+  }
+  return parsed;
+}
+
+export const __claudeCliFallbackTestHooks = {
+  setRunClaudeCliForTest: setClaudeCliFallbackRunnerForProcess,
+};
+

--- a/packages/remnic-core/src/cli-fallback.ts
+++ b/packages/remnic-core/src/cli-fallback.ts
@@ -175,6 +175,7 @@ export interface ClaudeCliFallbackMessage {
 
 export interface ClaudeCliFallbackConfig {
   apiKey?: string | Record<string, unknown>;
+  baseUrl?: unknown;
   executable?: unknown;
   claudeCliExecutable?: unknown;
   reasoningEffort?: unknown;
@@ -253,6 +254,9 @@ function normalizeClaudeCliFallbackConfig(
     ...config,
     ...(config.executable !== undefined
       ? { executable: normalizeOptionalString(config.executable, "claude-cli executable") }
+      : {}),
+    ...(config.baseUrl !== undefined
+      ? { baseUrl: normalizeOptionalString(config.baseUrl, "claude-cli baseUrl") }
       : {}),
     ...(config.claudeCliExecutable !== undefined
       ? { claudeCliExecutable: normalizeOptionalString(config.claudeCliExecutable, "claude-cli executable") }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -770,6 +770,7 @@ test("fallback llm invokes registered claude-cli fallback runner", { concurrency
     modelId?: string;
     messages?: Array<{ role: "system" | "user" | "assistant"; content: string }>;
     apiKey?: string | Record<string, unknown>;
+    baseUrl?: unknown;
     executable?: unknown;
     reasoningEffort?: unknown;
     timeoutMs?: number;
@@ -779,6 +780,7 @@ test("fallback llm invokes registered claude-cli fallback runner", { concurrency
       captured.modelId = request.modelId;
       captured.messages = request.messages;
       captured.apiKey = request.config.apiKey;
+      captured.baseUrl = request.config.baseUrl;
       captured.executable = request.config.executable;
       captured.reasoningEffort = request.config.reasoningEffort;
       captured.timeoutMs = request.config.retryOptions?.timeoutMs as number | undefined;
@@ -804,7 +806,7 @@ test("fallback llm invokes registered claude-cli fallback runner", { concurrency
     models: {
       providers: {
         "claude-cli": {
-          baseUrl: "",
+          baseUrl: "https://claude-internal.example",
           api: "claude-cli",
           apiKey: "claude-test-key",
           executable: "claude-test-bin",
@@ -834,6 +836,7 @@ test("fallback llm invokes registered claude-cli fallback runner", { concurrency
       { role: "user", content: "Say OK" },
     ]);
     assert.equal(captured.apiKey, "claude-test-key");
+    assert.equal(captured.baseUrl, "https://claude-internal.example");
     assert.equal(captured.executable, "claude-test-bin");
     assert.equal(captured.reasoningEffort, "high");
     assert.equal(captured.timeoutMs, 1234);

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
-import { __codexCliFallbackTestHooks } from "./cli-fallback.js";
+import { __codexCliFallbackTestHooks, __claudeCliFallbackTestHooks } from "./cli-fallback.js";
 import { clearModelsJsonCache, __setModelsJsonForTest } from "./models-json.js";
 import {
   __setGatewayRuntimeAuthForModelForTest,
@@ -753,6 +753,88 @@ test("fallback llm invokes registered codex-cli fallback runner", { concurrency:
     ]);
     assert.equal(captured.apiKey, "codex-test-key");
     assert.equal(captured.executable, "codex-test-bin");
+    assert.equal(captured.reasoningEffort, "high");
+    assert.equal(captured.timeoutMs, 1234);
+  } finally {
+    restoreRunner();
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm invokes registered claude-cli fallback runner", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const captured: {
+    modelId?: string;
+    messages?: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    apiKey?: string | Record<string, unknown>;
+    executable?: unknown;
+    reasoningEffort?: unknown;
+    timeoutMs?: number;
+  } = {};
+  const restoreRunner = __claudeCliFallbackTestHooks.setRunClaudeCliForTest(
+    async (request) => {
+      captured.modelId = request.modelId;
+      captured.messages = request.messages;
+      captured.apiKey = request.config.apiKey;
+      captured.executable = request.config.executable;
+      captured.reasoningEffort = request.config.reasoningEffort;
+      captured.timeoutMs = request.config.retryOptions?.timeoutMs as number | undefined;
+      return {
+        content: "final claude answer",
+        usage: {
+          inputTokens: 40,
+          outputTokens: 4,
+          totalTokens: 44,
+        },
+      };
+    },
+  );
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "claude-cli/opus",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "claude-cli": {
+          baseUrl: "",
+          api: "claude-cli",
+          apiKey: "claude-test-key",
+          executable: "claude-test-bin",
+          reasoningEffort: "high",
+          retryOptions: { timeoutMs: 1234 },
+          models: [],
+        },
+      },
+    },
+  });
+
+  try {
+    const response = await llm.chatCompletion(
+      [
+        { role: "system", content: "Return concise JSON." },
+        { role: "user", content: "Say OK" },
+      ],
+      { temperature: 0, maxTokens: 16, timeoutMs: 5000 },
+    );
+
+    assert.equal(response?.content, "final claude answer");
+    assert.equal(response?.modelUsed, "claude-cli/opus");
+    assert.equal(response?.usage?.totalTokens, 44);
+    assert.equal(captured.modelId, "opus");
+    assert.deepEqual(captured.messages, [
+      { role: "system", content: "Return concise JSON." },
+      { role: "user", content: "Say OK" },
+    ]);
+    assert.equal(captured.apiKey, "claude-test-key");
+    assert.equal(captured.executable, "claude-test-bin");
     assert.equal(captured.reasoningEffort, "high");
     assert.equal(captured.timeoutMs, 1234);
   } finally {

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -14,7 +14,7 @@ import {
   type ResolveApiKeyFn,
 } from "./resolve-provider-secret.js";
 import { loadModelsJsonProviders } from "./models-json.js";
-import { callCodexCliFallback } from "./cli-fallback.js";
+import { callClaudeCliFallback, callCodexCliFallback } from "./cli-fallback.js";
 import { resolveHomeDir } from "./runtime/env.js";
 import { expandTildePath } from "./utils/path.js";
 
@@ -523,13 +523,15 @@ export class FallbackLlmClient {
   ): Promise<{ content: string; usage?: FallbackLlmResponse["usage"] } | null> {
     // Try the gateway's native runtime auth first — it handles all provider-
     // specific transforms (OAuth exchange, base URL rewrite, etc.)
-    const runtimeAuth = model.providerConfig.api === "codex-cli"
+    const runtimeAuth = model.providerConfig.api === "codex-cli" ||
+      model.providerConfig.api === "claude-cli"
       ? null
       : await this.resolveRuntimeAuth(model);
     const effectiveBaseUrl = runtimeAuth?.baseUrl ?? model.providerConfig.baseUrl;
     const resolvedApiKey = runtimeAuth?.apiKey
       ?? (
-        model.providerConfig.api === "codex-cli" && model.providerConfig.apiKey === undefined
+        (model.providerConfig.api === "codex-cli" ||
+          model.providerConfig.api === "claude-cli") && model.providerConfig.apiKey === undefined
           ? undefined
           : await this.resolveFallbackApiKey(model)
       );
@@ -555,6 +557,15 @@ export class FallbackLlmClient {
 
     if (model.providerConfig.api === "codex-cli") {
       return await callCodexCliFallback(
+        effectiveConfig,
+        model.modelId,
+        messages,
+        { timeoutMs: options.timeoutMs, signal: options.signal },
+      );
+    }
+
+    if (model.providerConfig.api === "claude-cli") {
+      return await callClaudeCliFallback(
         effectiveConfig,
         model.modelId,
         messages,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -118,7 +118,14 @@ export {
 
 export { ExtractionEngine } from "./extraction.js";
 export {
+  setClaudeCliFallbackRunnerForProcess,
   setCodexCliFallbackRunnerForProcess,
+  type ClaudeCliFallbackConfig,
+  type ClaudeCliFallbackMessage,
+  type ClaudeCliFallbackOptions,
+  type ClaudeCliFallbackRequest,
+  type ClaudeCliFallbackResult,
+  type ClaudeCliFallbackRunner,
   type CodexCliFallbackConfig,
   type CodexCliFallbackMessage,
   type CodexCliFallbackOptions,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -115,9 +115,9 @@ packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(18
   Type 'undefined' is not assignable to type 'number'.
 packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(206,60): error TS2352: Conversion of type '{ benchmark: BenchmarkDefinition; mode: "full"; runCount: number; adapterMode: string; }' to type 'ResolvedRunBenchmarkOptions' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'system' is missing in type '{ benchmark: BenchmarkDefinition; mode: "full"; runCount: number; adapterMode: string; }' but required in type 'ResolvedRunBenchmarkOptions'.
-packages/bench/src/providers/claude-cli.test.ts(513,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
-packages/bench/src/providers/claude-cli.test.ts(513,24): error TS18048: 'provider.discover' is possibly 'undefined'.
-packages/bench/src/providers/claude-cli.test.ts(531,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+packages/bench/src/providers/claude-cli.test.ts(579,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+packages/bench/src/providers/claude-cli.test.ts(579,24): error TS18048: 'provider.discover' is possibly 'undefined'.
+packages/bench/src/providers/claude-cli.test.ts(597,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 packages/bench/src/providers/local-llm.test.ts(155,50): error TS2304: Cannot find name 'HeadersInit'.
 packages/bench/src/providers/ollama.test.ts(10,50): error TS2304: Cannot find name 'HeadersInit'.
 packages/bench/src/responders.test.ts(368,5): error TS2322: Type '() => { chatCompletion(_messages: { role: "user" | "assistant" | "system"; content: string; }[], options: FallbackLlmOptions | undefined): Promise<void>; }' is not assignable to type '(gatewayConfig: GatewayConfig, runtimeContext: FallbackLlmRuntimeContext) => Pick<FallbackLlmClient, "chatCompletion">'.

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -115,6 +115,9 @@ packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(18
   Type 'undefined' is not assignable to type 'number'.
 packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(206,60): error TS2352: Conversion of type '{ benchmark: BenchmarkDefinition; mode: "full"; runCount: number; adapterMode: string; }' to type 'ResolvedRunBenchmarkOptions' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'system' is missing in type '{ benchmark: BenchmarkDefinition; mode: "full"; runCount: number; adapterMode: string; }' but required in type 'ResolvedRunBenchmarkOptions'.
+packages/bench/src/providers/claude-cli.test.ts(513,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+packages/bench/src/providers/claude-cli.test.ts(513,24): error TS18048: 'provider.discover' is possibly 'undefined'.
+packages/bench/src/providers/claude-cli.test.ts(531,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 packages/bench/src/providers/local-llm.test.ts(155,50): error TS2304: Cannot find name 'HeadersInit'.
 packages/bench/src/providers/ollama.test.ts(10,50): error TS2304: Cannot find name 'HeadersInit'.
 packages/bench/src/responders.test.ts(368,5): error TS2322: Type '() => { chatCompletion(_messages: { role: "user" | "assistant" | "system"; content: string; }[], options: FallbackLlmOptions | undefined): Promise<void>; }' is not assignable to type '(gatewayConfig: GatewayConfig, runtimeContext: FallbackLlmRuntimeContext) => Pick<FallbackLlmClient, "chatCompletion">'.

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1200,7 +1200,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--model",
         "m",
       ]),
-    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
   assert.throws(
     () =>
@@ -1212,7 +1212,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--system-model",
         "m",
       ]),
-    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
   assert.throws(
     () =>
@@ -1224,7 +1224,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--judge-model",
         "m",
       ]),
-    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
+    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", "codex-cli", or "claude-cli"\./,
   );
 });
 


### PR DESCRIPTION
Closes #1728 (provider + flags + fallback runner + tests + honest trial evidence).

## What this delivers

**claude-cli bench provider** (`packages/bench/src/providers/claude-cli.ts`) — shells out to Claude Code headless (`claude -p`) in an **isolated empty temp workspace with tools disabled**, mirroring `codex-cli.ts` (`--bare`, `--tools ""`, `--no-session-persistence`, a "you are a benchmark endpoint" system prompt). Wired into `BuiltInProvider` union, `ProviderFactoryConfig`, factory switch, runtime-profiles gateway/base-url mapping, and the reasoning-effort guard. Per issue #1728 this provider is for **judge + cheap internal iteration only** — the published `tier:frontier` number MUST come from the raw Anthropic API provider; a `claude -p`-mediated number is "Opus via Claude Code", not independently reproducible.

**Reasoning-effort CLI flags** — `--{system,judge,internal}-claude-reasoning-effort` (`low|medium|high|xhigh`), mirroring the existing codex-cli flags. The prior scaffold already treats reasoning effort generically in runtime-profiles (guard accepts both `codex-cli` and `claude-cli`, defaulting to `xhigh`), so the claude flags merge into the existing generic reasoning-effort carrier at the `index.ts` mapping layer (`codex ?? claude`); no runtime-profiles change needed.

**claude-cli fallback runner** (commit `3620372`) — mirrors the codex-cli fallback inversion so `--internal-provider claude-cli` actually dispatches. `cli-fallback.ts` adds `setClaudeCliFallbackRunnerForProcess` + `callClaudeCliFallback` (registration/invocation + normalizers, reusing the shared reasoning-effort validator); `fallback-llm.ts` routes `api:"claude-cli"` through `callClaudeCliFallback` (keyless path matches codex-cli — **this is the dispatch the codex-connector review thread flagged as missing**); `runtime-profiles.ts` registers the runner when the internal provider is claude-cli and routes `claudeCliReasoningEffort` into the gateway config; `index.ts` re-exports the new surface. This is the runtime plumbing the trial run exercises.

## Follow-up commits (this push)
- `8793fe1` `fix(bench): #1728 update root provider-error test for claude-cli allowlist` — the prior wiring (`7e27ae3`) added `"claude-cli"` to the provider error message but missed the root integration test (`tests/remnic-cli-bench-surface.test.ts`), whose 3 regexes still asserted the old 6-provider list. This was the **sole `tests (root)` failure** blocking CI.
- `3620372` `feat(bench): #1728 wire claude-cli fallback runner for internal-provider paths` — adds the `claude-cli` dispatch in `fallback-llm.ts` (addresses the open codex-connector review thread) + registration + tests + exports.

## Trial run evidence (honest, non-publishable)

A tiny real `claude -p` trial was run end-to-end, replicating the provider's **exact** invocation (`buildRunRequest` args) from an isolated empty temp workspace with the provider's env allowlist applied. Model `opus`, effort `low` (to minimize Claude Max spend; production uses `xhigh`). **The transport works end-to-end; a live completion is blocked by auth.**

The provider correctly spawned `claude -p` (v2.1.202), received exit 1, parsed the JSON envelope, and surfaced the auth error cleanly with **no retry** (auth errors are non-transient by design):

```json
{ "exitStatus": 1, "isError": true, "resultText": "Not logged in · Please run /login",
  "isolation": { "emptyTempWorkspace": true, "bare": true, "toolsDisabled": true,
                 "noSessionPersistence": true, "envAllowlistApplied": true },
  "label": "Opus via Claude Code (claude -p) — NOT tier:frontier", "nonPublishable": true }
```

This proves the **isolation + spawn + envelope-parse + `is_error`-without-retry** path (the exact behavior unit-tested in provider test #10). A real Tier-F artifact requires operator `claude /login` (Claude Max) + budget and is intentionally out of scope for this provider-wiring PR — **no fabricated numbers**. The gated smoke test (`REMNIC_BENCH_CLAUDE_CLI_SMOKE=1`, asserts `"smoke-ok"`) is left skipping-with-reason until the operator logs in, per #1728's budget constraint.

## Chokepoints used / not applicable
- runtime-profiles `resolveProviderConfig` reasoning-effort guard (already accepts codex-cli + claude-cli) — reused, not duplicated.
- cli-fallback inversion (`setXcliFallbackRunnerForProcess`) — extended the existing codex-cli chokepoint to claude-cli, no new pattern.
- Not applicable: no new MCP tool / HTTP route / CLI command-group validation surfaces (the flags extend an existing arg-parsing chokepoint).

## Verification
- `tsc --noEmit` clean for `@remnic/bench` + `@remnic/cli`; `@remnic/core` build (tsc+tsup) clean
- bench-args tests: **67 pass**
- claude-cli provider tests: **20 pass + 1 keyless skip**
- core fallback-llm tests: **28 pass** (incl. new `claude-cli fallback runner` + `claude-cli refs through anthropic built-in fallback`)
- root `parseBenchArgs rejects unknown providers across all three flags` test: **pass** (was the CI blocker)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spawns subprocesses with credential forwarding and changes LLM fallback routing; isolation and no-retry-on-auth are tested but live CLI behavior depends on operator login and session budget.
> 
> **Overview**
> Adds a **`claude-cli` bench provider** that runs isolated headless `claude -p` completions (empty temp workspace, `--bare`, tools disabled, env allowlist) so benchmarks can use Claude Code for **judge / internal iteration** without project memory or unrelated secrets—labeled as “Opus via Claude Code,” not API `tier:frontier`.
> 
> Wires **`claude-cli`** through provider types, factory, discovery, runtime profiles (gateway `api: "claude-cli"`, reasoning effort), package exports, and **`remnic bench`** flags: `--{system,judge,internal}-claude-reasoning-effort` plus allowlist updates for `--provider` / related flags.
> 
> Extends the **codex-style fallback inversion** in `@remnic/core` (`callClaudeCliFallback`, `fallback-llm` routing) and registers a sequential runner from bench runtime when `--internal-provider claude-cli` is set. Includes a large provider test suite and an opt-in live smoke test (`REMNIC_BENCH_CLAUDE_CLI_SMOKE=1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de97bda05bd2daa8a87316e35b784a468dbe815d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->