### PR TITLE
feat(coding): structural-context provider port + symbol-aware review-intent recall (#1548 Track A PR 5)

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5872,6 +5872,47 @@ async function cmdDoctor(): Promise<void> {
     // Never fail doctor for detection errors.
   }
 
+  // ── Structural-context provider (issue #1548 Track A PR 5) ────────────────
+  // Renders the configured provider mode plus a live probe so operators see
+  // "configured / probed / last error code" — a degraded/absent provider is
+  // never silent (rule 34). Pure config read when no config file is present.
+  try {
+    const core = (await import("@remnic/core")) as unknown as {
+      probeStructuralProviderForDoctor?: (config: unknown) => Promise<{
+        active: boolean;
+        mode: string;
+        command?: string;
+        providerId?: string;
+        probed?: { available: boolean; detail?: string };
+      }>;
+      renderStructuralProviderStatusLine?: (status: unknown) => string;
+    };
+    if (typeof core.probeStructuralProviderForDoctor === "function") {
+      const status = standaloneConfig
+        ? await core.probeStructuralProviderForDoctor(standaloneConfig)
+        : { active: false, mode: "none" };
+      const fullLine = typeof core.renderStructuralProviderStatusLine === "function"
+        ? core.renderStructuralProviderStatusLine(status)
+        : `structural-context provider: ${status.mode}`;
+      // Strip the redundant "structural-context provider: " prefix — the check
+      // name already carries it.
+      const detail = fullLine.replace(/^structural-context provider: /, "");
+      const probeUnavailable = status.active === true &&
+        status.probed !== undefined && status.probed.available === false;
+      checks.push({
+        name: "Structural-context provider",
+        ok: true,
+        warn: probeUnavailable ? true : undefined,
+        detail,
+        remediation: probeUnavailable
+          ? "review-context falls back to file-path-only boosting; check the configured binary path or provider install"
+          : undefined,
+      });
+    }
+  } catch {
+    // Never fail doctor for provider detection errors.
+  }
+
   for (const check of checks) {
     const icon = check.ok
       ? check.warn ? "⚠" : "✓"

--- a/packages/remnic-core/src/coding/review-context-structural.test.ts
+++ b/packages/remnic-core/src/coding/review-context-structural.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the structural-context-aware review-context path
+ * (issue #1548 Track A PR 5).
+ *
+ * This file is the prove-fail-before characterization for PR 5:
+ *   1. GATE-OFF PARITY — with no provider consulted (the pure
+ *      {@link packReviewContext} path), output is byte-identical to
+ *      pre-feature behaviour on every input. Captured FIRST, before any
+ *      assertion about the wired path.
+ *   2. PROVIDER-FAILURE FALLBACK — when the provider fails (any code),
+ *      {@link packReviewContextStructural} ranking falls back to
+ *      FILE-PATH-ONLY boosting, IDENTICAL to the pure packer, AND surfaces
+ *      a distinct `structuralDegradation` so the failure is never silent
+ *      (rule 34).
+ *   3. PROVIDER-SUCCESS EXPANSION — when the provider returns symbols,
+ *      memories mentioning a symbol name float up via the same bounded
+ *      additive boost.
+ *
+ * The provider is a fake implementing the port contract; no subprocess.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  packReviewContext,
+  packReviewContextStructural,
+  rankReviewCandidates,
+  type ReviewCandidate,
+} from "./review-context.js";
+import type {
+  StructuralContextProvider,
+  SymbolsForDiffResult,
+} from "./structural-context.js";
+
+function c(id: string, score: number, entityRefs?: string[]): ReviewCandidate {
+  return { id, score, entityRefs };
+}
+
+/** Fake provider whose symbolsForDiff returns a fixed result. */
+function providerReturning(result: SymbolsForDiffResult): StructuralContextProvider {
+  return {
+    id: "fake",
+    async probe() {
+      return { available: true };
+    },
+    async symbolsForDiff() {
+      return result;
+    },
+  };
+}
+
+const DIFF_TOUCHING_AUTH = [
+  "diff --git a/src/auth.ts b/src/auth.ts",
+  "--- a/src/auth.ts",
+  "+++ b/src/auth.ts",
+  "@@ -1,3 +1,4 @@",
+  "+ export function login() {}",
+].join("\n");
+
+// ──────────────────────────────────────────────────────────────────────────
+// 1. GATE-OFF PARITY — pure packReviewContext is byte-identical to today
+//    (prove-fail-before: this must pass BEFORE the structural path exists,
+//     and must keep passing unchanged after).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("gate-off parity: pure packReviewContext boosts only on touched file paths", () => {
+  const candidates = [
+    c("auth-history", 0.2, ["src/auth.ts"]),
+    c("unrelated", 0.9, ["src/other.ts"]),
+    c("weak-match", 0.1, ["auth.ts"]),
+  ];
+  const result = packReviewContext({ diff: DIFF_TOUCHING_AUTH, candidates });
+  assert.equal(result.touchedFiles.length, 1);
+  assert.equal(result.touchedFiles[0], "src/auth.ts");
+  // structuralDegradation is NOT set on the pure path.
+  assert.equal(result.structuralDegradation, undefined);
+  // strongest unrelated wins; auth-history floats above weak-match via boost.
+  const ids = result.rankedRecall.map((r) => r.id);
+  assert.deepEqual(ids, ["unrelated", "auth-history", "weak-match"]);
+});
+
+test("gate-off parity: pure packReviewContext has no structuralDegradation field effect", () => {
+  const result = packReviewContext({ diff: "", candidates: [c("x", 0.5)] });
+  assert.equal(result.structuralDegradation, undefined);
+  assert.equal(result.rankedRecall[0]!.boost, 0);
+});
+
+test("gate-off parity: deterministic ordering matches rankReviewCandidates directly", () => {
+  const candidates = [c("b", 0.3, ["a.ts"]), c("a", 0.8), c("c", 0.3, ["a.ts"])];
+  const packed = packReviewContext({ diff: "diff --git a/a.ts b/a.ts", candidates });
+  const direct = rankReviewCandidates(candidates, ["a.ts"]);
+  assert.deepEqual(
+    packed.rankedRecall.map((r) => ({ id: r.id, boost: r.boost })),
+    direct.map((r) => ({ id: r.id, boost: r.boost })),
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 2. PROVIDER-FAILURE FALLBACK — ranking identical to pure packer +
+//    structuralDegradation populated (rule 34 — never silent)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("structural fallback (a) provider_unavailable: ranking == pure packer, degradation set", async () => {
+  const candidates = [
+    c("auth-history", 0.2, ["src/auth.ts"]),
+    c("unrelated", 0.9, ["src/other.ts"]),
+  ];
+  const provider = providerReturning({
+    ok: false,
+    code: "provider_unavailable",
+    detail: "binary not found",
+  });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  // Ranking must be IDENTICAL to the pure packer (file-path-only).
+  const pure = packReviewContext({ diff: DIFF_TOUCHING_AUTH, candidates });
+  assert.deepEqual(
+    result.rankedRecall.map((r) => ({ id: r.id, boost: r.boost })),
+    pure.rankedRecall.map((r) => ({ id: r.id, boost: r.boost })),
+  );
+  // Degradation surfaced.
+  assert.equal(result.structuralDegradation?.backend, "structural-context");
+  assert.equal(result.structuralDegradation?.code, "provider_unavailable");
+  assert.equal(result.structuralDegradation?.detail, "binary not found");
+});
+
+test("structural fallback (c) provider_timeout: ranking == pure packer, degradation code distinct", async () => {
+  const candidates = [c("auth-history", 0.2, ["src/auth.ts"])];
+  const provider = providerReturning({ ok: false, code: "provider_timeout" });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  const pure = packReviewContext({ diff: DIFF_TOUCHING_AUTH, candidates });
+  assert.deepEqual(
+    result.rankedRecall.map((r) => r.id),
+    pure.rankedRecall.map((r) => r.id),
+  );
+  assert.equal(result.structuralDegradation?.code, "provider_timeout");
+});
+
+test("structural fallback (d) provider_malformed: ranking == pure packer, degradation code distinct", async () => {
+  const candidates = [c("auth-history", 0.2, ["src/auth.ts"])];
+  const provider = providerReturning({ ok: false, code: "provider_malformed" });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  assert.equal(result.structuralDegradation?.code, "provider_malformed");
+  // No symbol expansion happened — touched files unchanged.
+  assert.deepEqual(result.touchedFiles, ["src/auth.ts"]);
+});
+
+test("structural fallback: provider_error code surfaces", async () => {
+  const provider = providerReturning({
+    ok: false,
+    code: "provider_error",
+    detail: "exit 2",
+  });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates: [c("x", 0.5)],
+    provider,
+  });
+  assert.equal(result.structuralDegradation?.code, "provider_error");
+});
+
+test("structural fallback: empty diff + failing provider → no boosts, degradation still set", async () => {
+  const provider = providerReturning({ ok: false, code: "provider_unavailable" });
+  const result = await packReviewContextStructural({
+    diff: "",
+    candidates: [c("x", 0.5, ["src/auth.ts"])],
+    provider,
+  });
+  assert.equal(result.rankedRecall[0]!.boost, 0);
+  assert.equal(result.structuralDegradation?.code, "provider_unavailable");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// 3. PROVIDER-SUCCESS EXPANSION — symbols widen the match set
+// ──────────────────────────────────────────────────────────────────────────
+
+test("structural success: symbol match floats a memory that shares NO file path", async () => {
+  // Candidate mentions the SYMBOL but not the touched file path.
+  const candidates = [
+    c("symbol-memory", 0.1, ["AuthService.login"]),
+    c("file-memory", 0.1, ["src/auth.ts"]),
+    c("unrelated", 0.9, ["src/other.ts"]),
+  ];
+  const provider = providerReturning({
+    ok: true,
+    symbols: [{ symbol: "AuthService.login", path: "src/auth.ts" }],
+  });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  // No degradation on success.
+  assert.equal(result.structuralDegradation, undefined);
+  // Both symbol- and file-matched memories get the boost; unrelated still wins.
+  const symbolMem = result.rankedRecall.find((r) => r.id === "symbol-memory")!;
+  const fileMem = result.rankedRecall.find((r) => r.id === "file-memory")!;
+  assert.equal(symbolMem.boost, 0.5, "symbol name match yields the same boost as a file match");
+  assert.equal(fileMem.boost, 0.5);
+  assert.equal(result.rankedRecall[0]!.id, "unrelated");
+});
+
+test("structural success: only-file-matched baseline does NOT get a symbol boost", async () => {
+  const candidates = [c("only-file", 0.1, ["src/auth.ts"])];
+  const provider = providerReturning({
+    ok: true,
+    symbols: [{ symbol: "CompletelyUnrelated.symbol" }],
+  });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  // The file match still boosts; the unrelated symbol adds nothing for this memory.
+  assert.equal(result.rankedRecall[0]!.boost, 0.5);
+});
+
+test("structural success: empty symbol list behaves like pure packer (no degradation)", async () => {
+  const candidates = [c("auth-history", 0.2, ["src/auth.ts"])];
+  const provider = providerReturning({ ok: true, symbols: [] });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  assert.equal(result.structuralDegradation, undefined);
+  const pure = packReviewContext({ diff: DIFF_TOUCHING_AUTH, candidates });
+  assert.deepEqual(
+    result.rankedRecall.map((r) => ({ id: r.id, boost: r.boost })),
+    pure.rankedRecall.map((r) => ({ id: r.id, boost: r.boost })),
+  );
+});
+
+test("structural success: multiple symbols each contribute to the boost cap", async () => {
+  const candidate = c("multi", 0, ["login", "logout", "validateToken", "session"]);
+  const provider = providerReturning({
+    ok: true,
+    symbols: [
+      { symbol: "login" },
+      { symbol: "logout" },
+      { symbol: "validateToken" },
+      { symbol: "session" },
+    ],
+  });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates: [candidate],
+    provider,
+  });
+  // Boost caps at MAX_BOOST (1.0) regardless of how many symbols match.
+  assert.equal(result.rankedRecall[0]!.boost, 1.0);
+});
+
+test("structural success: ranking is deterministic (stable id tie-break preserved)", async () => {
+  const candidates = [c("zeta", 0.5, ["x"]), c("alpha", 0.5, ["x"])];
+  const provider = providerReturning({ ok: true, symbols: [{ symbol: "x" }] });
+  const result = await packReviewContextStructural({
+    diff: DIFF_TOUCHING_AUTH,
+    candidates,
+    provider,
+  });
+  assert.deepEqual(
+    result.rankedRecall.map((r) => r.id),
+    ["alpha", "zeta"],
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// AbortSignal is forwarded to the provider (rule 40)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("structural: abort signal is forwarded to symbolsForDiff", async () => {
+  let observed: AbortSignal | undefined;
+  const provider: StructuralContextProvider = {
+    id: "fake",
+    async probe() {
+      return { available: true };
+    },
+    async symbolsForDiff(_diff, opts) {
+      observed = opts?.signal;
+      return { ok: true, symbols: [] };
+    },
+  };
+  const ac = new AbortController();
+  await packReviewContextStructural({
+    diff: "",
+    candidates: [],
+    provider,
+    signal: ac.signal,
+  });
+  assert.equal(observed, ac.signal);
+});

--- a/packages/remnic-core/src/coding/review-context.ts
+++ b/packages/remnic-core/src/coding/review-context.ts
@@ -20,6 +20,11 @@
  * surface is what PRs 5/6/7 will call).
  */
 
+import type {
+  StructuralContextDegradation,
+  StructuralContextProvider,
+} from "./structural-context.js";
+
 // ──────────────────────────────────────────────────────────────────────────
 // Public types
 // ──────────────────────────────────────────────────────────────────────────
@@ -61,6 +66,15 @@ export interface ReviewContext {
    * boost is recorded on each entry as `boost` for observability.
    */
   rankedRecall: Array<ReviewCandidate & { boost: number }>;
+  /**
+   * Structural-context provider degradation observed while expanding the
+   * diff to touched symbols (issue #1548 Track A PR 5, #1536 pattern).
+   * Present only when a provider was consulted AND it failed — a silent
+   * provider failure must never look like "no structural matches"
+   * (CLAUDE.md rule 34). Undefined when no provider was consulted (the
+   * pure {@link packReviewContext} path) or when the provider succeeded.
+   */
+  structuralDegradation?: StructuralContextDegradation;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -422,4 +436,69 @@ export function packReviewContext(input: PackReviewContextInput): ReviewContext 
   const touchedFiles = parseTouchedFiles(input.diff);
   const rankedRecall = rankReviewCandidates(input.candidates, touchedFiles);
   return { touchedFiles, rankedRecall };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Structural-context enhancement (issue #1548 Track A PR 5)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Input for the structural-context-aware review-context packer. The pure
+ * {@link packReviewContext} stays unchanged (gate-off parity); this async
+ * variant consults a {@link StructuralContextProvider} to expand the diff's
+ * touched FILE paths into touched SYMBOL names, widening the match set so
+ * memories that mention a changed symbol — not just the file path — float
+ * up. The gate (`structuralProvider !== "none"`) is checked ONCE by the
+ * caller, never inside this function (rule 39).
+ */
+export interface PackReviewContextStructuralInput extends PackReviewContextInput {
+  /** A probed structural-context provider. Never undefined here. */
+  provider: StructuralContextProvider;
+  /** Cancellation forwarded to the provider subprocess (rule 40). */
+  signal?: AbortSignal;
+}
+
+/**
+ * Structural-context-aware packer.
+ *
+ * Contract (issue #1548 Track A PR 5, prove-fail-before characterization):
+ *   - Provider returns symbols (`ok: true`) → symbol names are ADDED to the
+ *     match set alongside touched files; memories mentioning a symbol get the
+ *     same bounded additive boost as a file-path match.
+ *   - Provider fails (`ok: false`, any code) → ranking falls back to
+ *     FILE-PATH-ONLY boosting, BYTE-IDENTICAL to {@link packReviewContext}
+ *     (the match set is exactly the touched files), AND `structuralDegradation`
+ *     is populated so xray/doctor can surface the failure (rule 34).
+ *
+ * The underlying ranker ({@link rankReviewCandidates}) is reused unchanged,
+ * so the deterministic ordering, boost cap, and tie-break are identical to
+ * the pure path.
+ */
+export async function packReviewContextStructural(
+  input: PackReviewContextStructuralInput,
+): Promise<ReviewContext> {
+  const touchedFiles = parseTouchedFiles(input.diff);
+  const diffString = typeof input.diff === "string" ? input.diff : "";
+  const result = await input.provider.symbolsForDiff(diffString, {
+    signal: input.signal,
+  });
+
+  let matchTerms: string[] = touchedFiles;
+  let structuralDegradation: StructuralContextDegradation | undefined;
+
+  if (result.ok) {
+    const symbolNames = result.symbols.map((sym) => sym.symbol);
+    matchTerms = symbolNames.length > 0 ? [...touchedFiles, ...symbolNames] : touchedFiles;
+  } else {
+    // Fallback: file-path-only ranking, identical to the pure packer. The
+    // degradation is surfaced so the failure is never silent (rule 34).
+    structuralDegradation = {
+      backend: "structural-context",
+      code: result.code,
+      detail: result.detail,
+    };
+  }
+
+  const rankedRecall = rankReviewCandidates(input.candidates, matchTerms);
+  return { touchedFiles, rankedRecall, structuralDegradation };
 }

--- a/packages/remnic-core/src/coding/structural-context.test.ts
+++ b/packages/remnic-core/src/coding/structural-context.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the structural-context provider PORT (issue #1548 Track A PR 5).
+ *
+ * Pure module under test — registry, gate predicate, and the config-only
+ * doctor status summariser. The subprocess adapter and the review-context
+ * wiring have their own test files. No filesystem, no subprocess.
+ *
+ * Standards: #1520. Rule 34 (degraded ≠ empty) is the load-bearing invariant
+ * for every tagged outcome here.
+ */
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import type { PluginConfig } from "../types.js";
+import {
+  clearStructuralContextProvidersForTest,
+  describeStructuralProviderStatus,
+  getStructuralContextProvider,
+  registerStructuralContextProvider,
+  renderStructuralProviderStatusLine,
+  structuralProviderActive,
+  toStructuralContextDegradation,
+  type StructuralContextProvider,
+  type SymbolsForDiffResult,
+} from "./structural-context.js";
+
+function configWith(
+  codingKnowledge: Partial<PluginConfig["codingKnowledge"]>,
+): PluginConfig {
+  return {
+    codingKnowledge: {
+      enabled: false,
+      decisionRecords: true,
+      architectureCard: true,
+      sessionDelta: true,
+      architectureCardLlmSummary: false,
+      structuralProvider: "none",
+      structuralProviderCommand: "",
+      codegraphTools: false,
+      codegraphDbDir: "",
+      ...codingKnowledge,
+    },
+  } as unknown as PluginConfig;
+}
+
+function fakeProvider(
+  id: string,
+  symbolsResult: SymbolsForDiffResult,
+): StructuralContextProvider {
+  return {
+    id,
+    async probe() {
+      return { available: true };
+    },
+    async symbolsForDiff() {
+      return symbolsResult;
+    },
+  };
+}
+
+afterEach(() => {
+  clearStructuralContextProvidersForTest();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Gate predicate (rule 39 — one predicate, identical on every path)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("structuralProviderActive: false when master gate off (default)", () => {
+  assert.equal(structuralProviderActive(configWith({})), false);
+});
+
+test("structuralProviderActive: false when enabled but provider is 'none'", () => {
+  assert.equal(
+    structuralProviderActive(configWith({ enabled: true, structuralProvider: "none" })),
+    false,
+  );
+});
+
+test("structuralProviderActive: true only when enabled AND provider !== 'none'", () => {
+  assert.equal(
+    structuralProviderActive(configWith({ enabled: true, structuralProvider: "subprocess" })),
+    true,
+  );
+  assert.equal(
+    structuralProviderActive(configWith({ enabled: true, structuralProvider: "native" })),
+    true,
+  );
+});
+
+test("structuralProviderActive: provider set but master gate off → false", () => {
+  assert.equal(
+    structuralProviderActive(configWith({ enabled: false, structuralProvider: "subprocess" })),
+    false,
+  );
+});
+
+test("structuralProviderActive: missing/null codingKnowledge → false (defensive)", () => {
+  assert.equal(
+    structuralProviderActive({ codingKnowledge: undefined } as unknown as PluginConfig),
+    false,
+  );
+  assert.equal(
+    structuralProviderActive({ codingKnowledge: null } as unknown as PluginConfig),
+    false,
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Registry (rule 11 — instance-scoped via Symbol; mirrors host-embedding)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("registry: register + lookup by scope", () => {
+  const provider = fakeProvider("test", { ok: true, symbols: [] });
+  const unregister = registerStructuralContextProvider("svc-1", provider);
+  assert.equal(getStructuralContextProvider("svc-1"), provider);
+  unregister();
+  assert.equal(getStructuralContextProvider("svc-1"), undefined);
+});
+
+test("registry: empty/whitespace scope normalises to 'default'", () => {
+  const provider = fakeProvider("test", { ok: true, symbols: [] });
+  registerStructuralContextProvider("   ", provider);
+  assert.equal(getStructuralContextProvider(""), provider);
+  assert.equal(getStructuralContextProvider("default"), provider);
+});
+
+test("registry: re-registering a scope closes the previous provider", async () => {
+  let closed = 0;
+  const first: StructuralContextProvider = {
+    id: "first",
+    async probe() {
+      return { available: true };
+    },
+    async symbolsForDiff() {
+      return { ok: true, symbols: [] };
+    },
+    close() {
+      closed += 1;
+    },
+  };
+  const second = fakeProvider("second", { ok: true, symbols: [] });
+  registerStructuralContextProvider("svc", first);
+  registerStructuralContextProvider("svc", second);
+  assert.equal(getStructuralContextProvider("svc"), second);
+  // Allow the microtask queue to drain the close() call.
+  await Promise.resolve();
+  assert.equal(closed, 1, "previous provider must be closed on overwrite");
+});
+
+test("registry: unregister is idempotent and only closes its own provider", () => {
+  const a = fakeProvider("a", { ok: true, symbols: [] });
+  const unregister = registerStructuralContextProvider("svc", a);
+  unregister();
+  unregister();
+  assert.equal(getStructuralContextProvider("svc"), undefined);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// toStructuralContextDegradation — single chokepoint for the backend tag
+// ──────────────────────────────────────────────────────────────────────────
+
+test("toStructuralContextDegradation: carries code + detail with the backend tag", () => {
+  const degradation = toStructuralContextDegradation({
+    ok: false,
+    code: "provider_timeout",
+    detail: "exceeded 5000ms",
+  });
+  assert.deepEqual(degradation, {
+    backend: "structural-context",
+    code: "provider_timeout",
+    detail: "exceeded 5000ms",
+  });
+});
+
+test("toStructuralContextDegradation: detail omitted when absent", () => {
+  const degradation = toStructuralContextDegradation({ ok: false, code: "provider_malformed" });
+  assert.equal(degradation.detail, undefined);
+  assert.equal(degradation.backend, "structural-context");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Doctor status summariser (pure, config-only)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("describeStructuralProviderStatus: inactive when gate off", () => {
+  const status = describeStructuralProviderStatus(configWith({}));
+  assert.equal(status.active, false);
+  assert.equal(status.mode, "none");
+  assert.equal(status.command, undefined);
+  assert.equal(status.probed, undefined);
+});
+
+test("describeStructuralProviderStatus: subprocess mode surfaces configured command", () => {
+  const status = describeStructuralProviderStatus(
+    configWith({ enabled: true, structuralProvider: "subprocess", structuralProviderCommand: "/usr/local/bin/cbm" }),
+  );
+  assert.equal(status.active, true);
+  assert.equal(status.mode, "subprocess");
+  assert.equal(status.command, "/usr/local/bin/cbm");
+});
+
+test("describeStructuralProviderStatus: subprocess mode without command → no command field", () => {
+  const status = describeStructuralProviderStatus(
+    configWith({ enabled: true, structuralProvider: "subprocess", structuralProviderCommand: "" }),
+  );
+  assert.equal(status.active, true);
+  assert.equal(status.command, undefined);
+});
+
+test("describeStructuralProviderStatus: registered provider id surfaces when scope given", () => {
+  const provider = fakeProvider("my-adapter", { ok: true, symbols: [] });
+  registerStructuralContextProvider("svc-7", provider);
+  const status = describeStructuralProviderStatus(
+    configWith({ enabled: true, structuralProvider: "native" }),
+    "svc-7",
+  );
+  assert.equal(status.providerId, "my-adapter");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Status line renderer (pure)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("renderStructuralProviderStatusLine: inactive line is deterministic", () => {
+  const line = renderStructuralProviderStatusLine(
+    describeStructuralProviderStatus(configWith({})),
+  );
+  assert.equal(
+    line,
+    "structural-context provider: none (inactive — review-context stays file-path-only)",
+  );
+});
+
+test("renderStructuralProviderStatusLine: subprocess + command + probed available", () => {
+  const line = renderStructuralProviderStatusLine({
+    active: true,
+    mode: "subprocess",
+    command: "/usr/local/bin/cbm",
+    probed: { available: true },
+  });
+  assert.equal(
+    line,
+    "structural-context provider: subprocess, command=/usr/local/bin/cbm, probed=available",
+  );
+});
+
+test("renderStructuralProviderStatusLine: probed unavailable carries detail", () => {
+  const line = renderStructuralProviderStatusLine({
+    active: true,
+    mode: "subprocess",
+    command: "/usr/local/bin/cbm",
+    probed: { available: false, detail: "binary not found: /usr/local/bin/cbm" },
+  });
+  assert.equal(
+    line,
+    "structural-context provider: subprocess, command=/usr/local/bin/cbm, probed=unavailable (binary not found: /usr/local/bin/cbm)",
+  );
+});

--- a/packages/remnic-core/src/coding/structural-context.ts
+++ b/packages/remnic-core/src/coding/structural-context.ts
@@ -1,0 +1,315 @@
+/**
+ * Structural-context provider port (issue #1548 Track A PR 5).
+ *
+ * The architectural boundary between Track A (durable coding-memory
+ * features) and Track B (the native @remnic/coding-graph engine). A
+ * structural-context provider expands a unified diff into the SYMBOLS it
+ * touches (and optionally yields architecture hints), so review-intent
+ * recall can boost memories that mention those symbols — not just the
+ * bare file paths that `review-context.ts` already boosts on.
+ *
+ * Three providers satisfy this port, selected by
+ * `codingKnowledge.structuralProvider`:
+ *
+ *   - `"none"`      — no provider consulted (default; review-context stays
+ *                     file-path-only, byte-identical to pre-feature — rule 39).
+ *   - `"subprocess"` — an external binary shelled out via `execFile` with an
+ *                     argv ARRAY (never a shell string — rule 10). The
+ *                     built-in adapter lives in `structural-subprocess-provider.ts`;
+ *                     codebase-memory-mcp's CLI mode is the canonical target,
+ *                     but the provider is command-agnostic.
+ *   - `"native"`    — the in-family @remnic/coding-graph engine, adapted to
+ *                     this port by a future PR (#1551/#1554). Only the enum
+ *                     value and this doc note land in this PR — no engine
+ *                     code. codebase-memory-mcp remains a supported
+ *                     subprocess provider through this same port regardless.
+ *
+ * Every result is a tagged outcome shaped like #1536's `SearchDegradation`
+ * (CLAUDE.md rule 34 — a degraded/absent provider must NEVER masquerade as
+ * "no structural matches"):
+ *   - `{ ok: true,  symbols }` on success
+ *   - `{ ok: false, code }`    on every failure (distinct codes per mode)
+ *
+ * No module-level mutable state (rule 11): the registry is keyed per
+ * orchestrator/service instance via a `Symbol.for(...)` slot on
+ * `globalThis`, mirroring `host-embedding-provider.ts`.
+ */
+import type { CodingKnowledgeConfig, PluginConfig } from "../types.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tagged-outcome types (rule 34 — #1536 pattern; rule 18 — object-not-null)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Distinct failure codes for the structural-context port. Every code is
+ * load-bearing: callers (review-context, `remnic doctor`, xray) switch on
+ * `code` to distinguish "binary not installed" from "timed out" from
+ * "protocol violation" so a silent provider failure can never look like an
+ * empty-but-healthy result.
+ */
+export type StructuralContextErrorCode =
+  /** Probe failed: binary missing / not executable, or native package absent. */
+  | "provider_unavailable"
+  /** The provider exceeded its deadline. */
+  | "provider_timeout"
+  /** Output was present but not a valid JSON object/array (rule 18). */
+  | "provider_malformed"
+  /** Provider ran but returned an explicit error or threw. */
+  | "provider_error";
+
+/**
+ * A single symbol touched by a diff. The `symbol` name is the load-bearing
+ * field — it is what review-context adds to its match set. `path`/`kind`
+ * are informational and surface in xray when present.
+ */
+export interface StructuralSymbol {
+  /** Qualified or bare symbol name, e.g. `"AuthService.login"` or `"login"`. */
+  readonly symbol: string;
+  /** Source file the symbol lives in (forward-slashed, repo-relative when possible). */
+  readonly path?: string;
+  /** Coarse kind if the provider knows it (`function`/`method`/`class`/...). */
+  readonly kind?: string;
+}
+
+export interface SymbolsForDiffOk {
+  readonly ok: true;
+  readonly symbols: StructuralSymbol[];
+  /** Provider-reported latency in ms, when available. */
+  readonly latencyMs?: number;
+}
+
+export interface SymbolsForDiffErr {
+  readonly ok: false;
+  readonly code: StructuralContextErrorCode;
+  readonly detail?: string;
+}
+
+export type SymbolsForDiffResult = SymbolsForDiffOk | SymbolsForDiffErr;
+
+export interface ArchitectureHintsOk {
+  readonly ok: true;
+  readonly hints: string[];
+}
+export interface ArchitectureHintsErr {
+  readonly ok: false;
+  readonly code: StructuralContextErrorCode;
+  readonly detail?: string;
+}
+export type ArchitectureHintsResult = ArchitectureHintsOk | ArchitectureHintsErr;
+
+/**
+ * The port contract. Both the built-in subprocess adapter
+ * (`structural-subprocess-provider.ts`) and the future native engine
+ * adapter (#1551) implement this. Registry callers retrieve an instance by
+ * scope; never construct one inline at a call site.
+ */
+export interface StructuralContextProvider {
+  /** Stable identifier for registry logging / `remnic doctor`. */
+  readonly id: string;
+  /**
+   * Probe availability. Resolves to a tagged result so a missing binary
+   * (subprocess) or absent package (native) is surfaced, never thrown
+   * (rule 34). Implementations SHOULD cache the outcome per instance
+   * (rule 11).
+   */
+  probe(): Promise<{ available: boolean; detail?: string }>;
+  /**
+   * Expand a unified diff to the symbols it touches. NEVER throws — every
+   * failure path returns a tagged `{ ok: false, code }`. The optional
+   * `signal` lets the caller cancel an in-flight subprocess (rule 40).
+   */
+  symbolsForDiff(
+    diff: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<SymbolsForDiffResult>;
+  /**
+   * Optional architecture hints for a repo root. Used by the architecture
+   * card composition (#1548 Track A PR 3 + #1554). Implementations MAY omit
+   * this; callers MUST handle its absence.
+   */
+  architectureHints?(
+    root: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ArchitectureHintsResult>;
+  /** Release any resources the provider holds (subprocess handles, etc.). */
+  close?(): Promise<void> | void;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Degradation (shaped like SearchDegradation from search/port.ts — #1536)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Backend tag is a literal so consumers can switch on it programmatically
+ * alongside `SearchDegradation` (`backend: "qmd"`). `detail` is optional
+ * and never load-bearing — `code` is the signal.
+ */
+export interface StructuralContextDegradation {
+  readonly backend: "structural-context";
+  readonly code: StructuralContextErrorCode;
+  readonly detail?: string;
+}
+
+/**
+ * Coerce a {@link SymbolsForDiffErr} into the degradation record consumers
+ * attach to recall snapshots / xray. Centralised so the `{ backend: ... }`
+ * tag is set in one place (rule 22 spirit).
+ */
+export function toStructuralContextDegradation(
+  err: SymbolsForDiffErr,
+): StructuralContextDegradation {
+  return { backend: "structural-context", code: err.code, detail: err.detail };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Registry — instance-scoped via Symbol (rule 11; mirrors host-embedding)
+// ──────────────────────────────────────────────────────────────────────────
+
+const STRUCTURAL_PROVIDERS_KEY = Symbol.for(
+  "remnic.structuralContextProviders",
+);
+
+function providerMap(): Map<string, StructuralContextProvider> {
+  const store = globalThis as Record<PropertyKey, unknown>;
+  const existing = store[STRUCTURAL_PROVIDERS_KEY];
+  if (existing instanceof Map) {
+    return existing as Map<string, StructuralContextProvider>;
+  }
+  const created = new Map<string, StructuralContextProvider>();
+  store[STRUCTURAL_PROVIDERS_KEY] = created;
+  return created;
+}
+
+function normalizeScope(scope: string): string {
+  const normalized = typeof scope === "string" ? scope.trim() : "";
+  return normalized || "default";
+}
+
+/**
+ * Register a provider for a scope (typically an orchestrator `serviceId`).
+ * Overwriting a previous registration closes the old provider. Returns an
+ * unregister function — callers SHOULD invoke it on service teardown so a
+ * hot-reloaded host does not leak subprocess handles.
+ */
+export function registerStructuralContextProvider(
+  scope: string,
+  provider: StructuralContextProvider,
+): () => void {
+  const key = normalizeScope(scope);
+  const providers = providerMap();
+  const previous = providers.get(key);
+  if (previous && previous !== provider) {
+    void previous.close?.();
+  }
+  providers.set(key, provider);
+  return () => {
+    const current = providerMap();
+    if (current.get(key) === provider) {
+      current.delete(key);
+      void provider.close?.();
+    }
+  };
+}
+
+/** Look up the provider registered for a scope, if any. */
+export function getStructuralContextProvider(
+  scope: string,
+): StructuralContextProvider | undefined {
+  return providerMap().get(normalizeScope(scope));
+}
+
+/** Test-only: clear every registered provider. */
+export function clearStructuralContextProvidersForTest(): void {
+  providerMap().clear();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Gate predicate — rule 39: ONE predicate, checked identically on every path
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * The single gate every review-context consumer consults before consulting a
+ * provider. Returns `true` iff the master `codingKnowledge.enabled` switch is
+ * on AND `structuralProvider` is not `"none"`. When this returns `false`,
+ * review-context runs its pure file-path-only ranker — byte-identical to
+ * pre-feature behaviour on every path.
+ */
+export function structuralProviderActive(config: PluginConfig): boolean {
+  const ck = config.codingKnowledge;
+  if (ck === undefined || ck === null) return false;
+  return ck.enabled === true && ck.structuralProvider !== "none";
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Doctor / xray status — pure config-only summariser + renderer
+// (the live PROBE lives in structural-subprocess-provider.ts so this module
+//  stays free of subprocess / optional-package imports)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Config-only structural provider status. `remnic doctor` and xray render
+ * this; an async sibling in `structural-subprocess-provider.ts` augments it
+ * with a live `probed` field.
+ */
+export interface StructuralProviderStatus {
+  readonly active: boolean;
+  readonly mode: CodingKnowledgeConfig["structuralProvider"];
+  /** Command path when mode is `"subprocess"` and a command is configured. */
+  readonly command?: string;
+  /** Provider id when one is registered for the scope. */
+  readonly providerId?: string;
+  /** Live probe outcome — set only by the async doctor probe. */
+  probed?: { available: boolean; detail?: string };
+}
+
+/**
+ * Summarise the structural provider status from config ALONE (no probe, no
+ * I/O). Pure — safe to call from any context, including the recall hot path
+ * for xray labels.
+ */
+export function describeStructuralProviderStatus(
+  config: PluginConfig,
+  scope?: string,
+): StructuralProviderStatus {
+  const ck = config.codingKnowledge;
+  const mode: CodingKnowledgeConfig["structuralProvider"] =
+    ck?.structuralProvider ?? "none";
+  const active = structuralProviderActive(config);
+  const provider =
+    scope !== undefined ? getStructuralContextProvider(scope) : undefined;
+  return {
+    active,
+    mode,
+    command:
+      mode === "subprocess" && ck?.structuralProviderCommand
+        ? ck.structuralProviderCommand
+        : undefined,
+    providerId: provider?.id,
+  };
+}
+
+/**
+ * Render a single human-readable line for `remnic doctor`. Pure.
+ *
+ *   `structural-context provider: none (inactive — review-context stays file-path-only)`
+ *   `structural-context provider: subprocess, command=/usr/local/bin/cbm, probed=available`
+ *   `structural-context provider: subprocess, command=/usr/local/bin/cbm, probed=unavailable (binary not found)`
+ */
+export function renderStructuralProviderStatusLine(
+  status: StructuralProviderStatus,
+): string {
+  if (!status.active) {
+    return `structural-context provider: ${status.mode} (inactive — review-context stays file-path-only)`;
+  }
+  const parts = [`structural-context provider: ${status.mode}`];
+  if (status.command) parts.push(`command=${status.command}`);
+  if (status.providerId) parts.push(`registered=${status.providerId}`);
+  if (status.probed) {
+    parts.push(
+      status.probed.available
+        ? "probed=available"
+        : `probed=unavailable${status.probed.detail ? ` (${status.probed.detail})` : ""}`,
+    );
+  }
+  return parts.join(", ");
+}

--- a/packages/remnic-core/src/coding/structural-subprocess-provider.test.ts
+++ b/packages/remnic-core/src/coding/structural-subprocess-provider.test.ts
@@ -17,7 +17,9 @@
  */
 import assert from "node:assert/strict";
 import path from "node:path";
-import { test } from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { after, before, test } from "node:test";
 
 import {
   createSubprocessStructuralProvider,
@@ -26,9 +28,36 @@ import {
 } from "./structural-subprocess-provider.js";
 import type { PluginConfig } from "../types.js";
 
-const REPO_ROOT = "/Users/joshuawarren/src/remnic-wt-1548prov";
-const EXISTING_FILE = path.join(REPO_ROOT, "package.json");
-const MISSING_FILE = path.join(REPO_ROOT, "definitely-not-a-binary-xyz");
+// Machine-independent fixture paths: a temp dir is created in `before`
+// with a real (executable) dummy binary and a path that never exists. This
+// keeps the probe tests CI-portable (no hard-coded checkout path) and follows
+// the synthetic-test-data-only policy.
+let REPO_ROOT = "";
+let EXISTING_FILE = "";
+let MISSING_FILE = "";
+let NON_EXECUTABLE_FILE = "";
+let tempDir = "";
+
+before(() => {
+  tempDir = mkdtempSync(path.join(tmpdir(), "structural-provider-"));
+  REPO_ROOT = tempDir;
+  EXISTING_FILE = path.join(tempDir, "existing-bin");
+  // Mode 0o755 so the POSIX executable-access probe reports available.
+  writeFileSync(EXISTING_FILE, "#!/bin/sh\necho ok\n", { mode: 0o755 });
+  MISSING_FILE = path.join(tempDir, "definitely-missing-bin");
+  // A regular file WITHOUT the executable bit — used to assert the probe
+  // rejects non-executable files on POSIX (P2 hardening).
+  NON_EXECUTABLE_FILE = path.join(tempDir, "non-executable-bin");
+  writeFileSync(NON_EXECUTABLE_FILE, "not executable", { mode: 0o644 });
+});
+
+after(() => {
+  try {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
 
 function configWith(
   codingKnowledge: Partial<PluginConfig["codingKnowledge"]>,
@@ -96,6 +125,29 @@ test("probe: statSync failure is swallowed (never throws)", async () => {
   const provider = createSubprocessStructuralProvider({ command: "/proc/this/does/not/exist/ anywhere" });
   const probe = await provider.probe();
   assert.equal(probe.available, false);
+});
+
+// Skip the executable-bit assertion on Windows (Node X_OK is always true there).
+const execCheckTest = process.platform === "win32" ? test.skip : test;
+execCheckTest("probe: non-executable regular file → unavailable (P2 hardening, POSIX only)", async () => {
+  const provider = createSubprocessStructuralProvider({ command: NON_EXECUTABLE_FILE });
+  const probe = await provider.probe();
+  assert.equal(probe.available, false);
+  assert.match(probe.detail ?? "", /not executable/);
+});
+
+test("probe: tilde-prefixed command is expanded (rule 17)", async () => {
+  // A tilde path pointing at the existing fixture must resolve after
+  // expansion. We point HOME at the temp dir so ~/existing-bin resolves.
+  const previousHome = process.env.HOME;
+  process.env.HOME = tempDir;
+  try {
+    const provider = createSubprocessStructuralProvider({ command: "~/existing-bin" });
+    const probe = await provider.probe();
+    assert.equal(probe.available, true, "tilde must expand so the probe finds the binary");
+  } finally {
+    process.env.HOME = previousHome;
+  }
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/structural-subprocess-provider.test.ts
+++ b/packages/remnic-core/src/coding/structural-subprocess-provider.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the subprocess structural-context provider (issue #1548 Track A
+ * PR 5).
+ *
+ * Exercises the full 4-state failure matrix mandated by the issue's PR 5
+ * acceptance:
+ *   (a) provider unavailable → {ok:false, code:"provider_unavailable"}
+ *   (b) provider returns symbols → {ok:true, symbols:[...]}
+ *   (c) provider times out     → {ok:false, code:"provider_timeout"}
+ *   (d) provider returns malformed JSON → {ok:false, code:"provider_malformed"}
+ *
+ * The spawn boundary is injected (rule 33 — mock matches production
+ * signature) so no real subprocess is ever launched. No filesystem touched
+ * for real binaries; `statSync` is bypassed by pointing the command at a
+ * path that exists (the repo's package.json) when an "available" probe is
+ * needed, or a nonexistent path when "unavailable" is needed.
+ */
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  createSubprocessStructuralProvider,
+  probeStructuralProviderForDoctor,
+  type StructuralSpawnFn,
+} from "./structural-subprocess-provider.js";
+import type { PluginConfig } from "../types.js";
+
+const REPO_ROOT = "/Users/joshuawarren/src/remnic-wt-1548prov";
+const EXISTING_FILE = path.join(REPO_ROOT, "package.json");
+const MISSING_FILE = path.join(REPO_ROOT, "definitely-not-a-binary-xyz");
+
+function configWith(
+  codingKnowledge: Partial<PluginConfig["codingKnowledge"]>,
+): PluginConfig {
+  return {
+    codingKnowledge: {
+      enabled: false,
+      decisionRecords: true,
+      architectureCard: true,
+      sessionDelta: true,
+      architectureCardLlmSummary: false,
+      structuralProvider: "none",
+      structuralProviderCommand: "",
+      codegraphTools: false,
+      codegraphDbDir: "",
+      ...codingKnowledge,
+    },
+  } as unknown as PluginConfig;
+}
+
+/** Build a fake spawn that responds based on the argv[0] subcommand map. */
+function fakeSpawn(
+  responses: Record<string, () => { stdout: string; stderr: string }>,
+): StructuralSpawnFn & { calls: Array<{ argv: readonly string[] }> } {
+  const calls: Array<{ argv: readonly string[] }> = [];
+  const fn: StructuralSpawnFn = async (_cmd, argv, _opts) => {
+    calls.push({ argv });
+    const sub = argv[0] ?? "";
+    const responder = responses[sub];
+    if (!responder) {
+      throw new Error(`spawn: unknown subcommand ${sub}`);
+    }
+    return responder();
+  };
+  return Object.assign(fn, { calls });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Probe — cached once per instance (rule 11)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("probe: missing binary → unavailable, detail names the path", async () => {
+  const provider = createSubprocessStructuralProvider({ command: MISSING_FILE });
+  const probe = await provider.probe();
+  assert.equal(probe.available, false);
+  assert.match(probe.detail ?? "", /binary not found/);
+});
+
+test("probe: existing file → available", async () => {
+  const provider = createSubprocessStructuralProvider({ command: EXISTING_FILE });
+  const probe = await provider.probe();
+  assert.equal(probe.available, true);
+});
+
+test("probe: empty command → unavailable, cached", async () => {
+  const provider = createSubprocessStructuralProvider({ command: "" });
+  const first = await provider.probe();
+  const second = await provider.probe();
+  assert.equal(first.available, false);
+  assert.match(first.detail ?? "", /empty/);
+  assert.equal(second, first, "probe result must be cached (same object reference)");
+});
+
+test("probe: statSync failure is swallowed (never throws)", async () => {
+  const provider = createSubprocessStructuralProvider({ command: "/proc/this/does/not/exist/ anywhere" });
+  const probe = await provider.probe();
+  assert.equal(probe.available, false);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// symbolsForDiff — 4-state matrix (issue PR 5 acceptance)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("symbolsForDiff (a): unavailable binary → provider_unavailable, never throws", async () => {
+  const spawn = fakeSpawn({});
+  const provider = createSubprocessStructuralProvider({
+    command: MISSING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff --git a/f b/f");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "provider_unavailable");
+    assert.match(result.detail ?? "", /binary not found/);
+  }
+  assert.equal(spawn.calls.length, 0, "spawn must not be called when probe fails");
+});
+
+test("symbolsForDiff (b): provider returns symbols → ok with parsed symbols", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({
+      stdout: JSON.stringify({
+        symbols: [
+          { symbol: "AuthService.login", path: "src/auth.ts", kind: "method" },
+          { symbol: "validateToken", path: "src/auth.ts" },
+        ],
+      }),
+      stderr: "",
+    }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff --git a/src/auth.ts b/src/auth.ts");
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.symbols.length, 2);
+    assert.equal(result.symbols[0]!.symbol, "AuthService.login");
+    assert.equal(result.symbols[0]!.kind, "method");
+    assert.equal(result.symbols[1]!.path, "src/auth.ts");
+  }
+});
+
+test("symbolsForDiff (c): provider times out → provider_timeout", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => {
+      throw new Error("Command timed out after 5000ms (ETIMEDOUT)");
+    },
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff --git a/f b/f");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "provider_timeout");
+  }
+});
+
+test("symbolsForDiff (d): malformed JSON → provider_malformed", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({ stdout: "not json {{{", stderr: "" }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff --git a/f b/f");
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "provider_malformed");
+  }
+});
+
+test("symbolsForDiff: object-but-no-symbols-array → provider_malformed", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({ stdout: JSON.stringify({ oops: 1 }), stderr: "" }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff");
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "provider_malformed");
+});
+
+test("symbolsForDiff: null/array/primitive output → provider_malformed (rule 18)", async () => {
+  for (const bad of ["null", "[]", "42", '"a-string"']) {
+    const spawn = fakeSpawn({
+      "symbols-for-diff": () => ({ stdout: bad, stderr: "" }),
+    });
+    const provider = createSubprocessStructuralProvider({
+      command: EXISTING_FILE,
+      spawn,
+    });
+    const result = await provider.symbolsForDiff("diff");
+    assert.equal(result.ok, false, `expected malformed for ${bad}`);
+    if (!result.ok) assert.equal(result.code, "provider_malformed");
+  }
+});
+
+test("symbolsForDiff: symbols with missing/empty symbol name are skipped, not fatal", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({
+      stdout: JSON.stringify({
+        symbols: [
+          { symbol: "  " },
+          { path: "x.ts" },
+          { symbol: "Good", kind: "function" },
+          null,
+          "not-an-object",
+        ],
+      }),
+      stderr: "",
+    }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff");
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.symbols.length, 1);
+    assert.equal(result.symbols[0]!.symbol, "Good");
+  }
+});
+
+test("symbolsForDiff: non-timeout spawn error → provider_error", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => {
+      throw new Error("non-zero exit code 2");
+    },
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.symbolsForDiff("diff");
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "provider_error");
+});
+
+test("symbolsForDiff: argv is an array with subcommand + json payload (rule 10)", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({
+      stdout: JSON.stringify({ symbols: [] }),
+      stderr: "",
+    }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  await provider.symbolsForDiff("diff --git a/x b/x");
+  assert.equal(spawn.calls.length, 1);
+  const argv = spawn.calls[0]!.argv;
+  assert.equal(argv[0], "symbols-for-diff");
+  const payload = JSON.parse(argv[1]!);
+  assert.equal(payload.diff, "diff --git a/x b/x");
+});
+
+test("symbolsForDiff: extra args are appended after the payload", async () => {
+  const spawn = fakeSpawn({
+    "symbols-for-diff": () => ({
+      stdout: JSON.stringify({ symbols: [] }),
+      stderr: "",
+    }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    args: ["--format", "json"],
+    spawn,
+  });
+  await provider.symbolsForDiff("diff");
+  const argv = spawn.calls[0]!.argv;
+  assert.deepEqual([...argv].slice(2), ["--format", "json"]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// architectureHints (optional) — same matrix, lighter
+// ──────────────────────────────────────────────────────────────────────────
+
+test("architectureHints: returns hints array on success", async () => {
+  const spawn = fakeSpawn({
+    "architecture-hints": () => ({
+      stdout: JSON.stringify(["layered architecture", "sqlite-first"]),
+      stderr: "",
+    }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.architectureHints?.(REPO_ROOT);
+  assert.ok(result);
+  assert.equal(result!.ok, true);
+  if (result!.ok) assert.equal(result!.hints.length, 2);
+});
+
+test("architectureHints: malformed (non-array) → provider_malformed", async () => {
+  const spawn = fakeSpawn({
+    "architecture-hints": () => ({ stdout: JSON.stringify({ not: "array" }), stderr: "" }),
+  });
+  const provider = createSubprocessStructuralProvider({
+    command: EXISTING_FILE,
+    spawn,
+  });
+  const result = await provider.architectureHints?.(REPO_ROOT);
+  assert.ok(result);
+  assert.equal(result!.ok, false);
+  if (!result!.ok) assert.equal(result!.code, "provider_malformed");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// close() resets the probe cache
+// ──────────────────────────────────────────────────────────────────────────
+
+test("close: resets probe cache so the next probe re-checks", async () => {
+  const provider = createSubprocessStructuralProvider({ command: EXISTING_FILE });
+  const first = await provider.probe();
+  assert.equal(first.available, true);
+  provider.close?.();
+  const second = await provider.probe();
+  assert.notEqual(second, first, "close() must invalidate the cached probe");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// probeStructuralProviderForDoctor (config → live probe)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("doctor probe: inactive config returns inactive status, no probe", async () => {
+  const status = await probeStructuralProviderForDoctor(configWith({}));
+  assert.equal(status.active, false);
+  assert.equal(status.probed, undefined);
+});
+
+test("doctor probe: subprocess with missing binary → probed unavailable", async () => {
+  const status = await probeStructuralProviderForDoctor(
+    configWith({
+      enabled: true,
+      structuralProvider: "subprocess",
+      structuralProviderCommand: MISSING_FILE,
+    }),
+  );
+  assert.equal(status.active, true);
+  assert.equal(status.mode, "subprocess");
+  assert.equal(status.probed?.available, false);
+  assert.match(status.probed?.detail ?? "", /binary not found/);
+});
+
+test("doctor probe: subprocess with empty command → probed unavailable (empty)", async () => {
+  const status = await probeStructuralProviderForDoctor(
+    configWith({
+      enabled: true,
+      structuralProvider: "subprocess",
+      structuralProviderCommand: "",
+    }),
+  );
+  assert.equal(status.probed?.available, false);
+  assert.match(status.probed?.detail ?? "", /empty/);
+});
+
+test("doctor probe: subprocess with existing file → probed available", async () => {
+  const status = await probeStructuralProviderForDoctor(
+    configWith({
+      enabled: true,
+      structuralProvider: "subprocess",
+      structuralProviderCommand: EXISTING_FILE,
+    }),
+  );
+  assert.equal(status.probed?.available, true);
+});
+

--- a/packages/remnic-core/src/coding/structural-subprocess-provider.ts
+++ b/packages/remnic-core/src/coding/structural-subprocess-provider.ts
@@ -18,9 +18,10 @@
  */
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { statSync } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 
 import type { PluginConfig } from "../types.js";
+import { expandTildePath } from "../utils/path.js";
 import { isCodingGraphInstalled } from "./optional-coding-graph.js";
 import {
   describeStructuralProviderStatus,
@@ -77,7 +78,10 @@ const DEFAULT_SYMBOLS_SUBCOMMAND = "symbols-for-diff";
 export function createSubprocessStructuralProvider(
   options: SubprocessProviderOptions,
 ): StructuralContextProvider {
-  const command = options.command.trim();
+  // Rule 17 — expand a leading ~ so a home-relative binary path
+  // (e.g. ~/bin/cbm) resolves instead of degrading to unavailable.
+  // Mirrors the codegraph-runtime.ts precedent for operator paths.
+  const command = expandTildePath(options.command.trim());
   const extraArgs = options.args ?? [];
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const symbolsSubcommand = options.symbolsSubcommand ?? DEFAULT_SYMBOLS_SUBCOMMAND;
@@ -96,14 +100,29 @@ export function createSubprocessStructuralProvider(
     // a missing/renamed binary gets a DISTINCT `provider_unavailable` code,
     // never a silent empty result.
     let statOk = false;
+    let notExecutable = false;
     try {
       statOk = statSync(command).isFile();
     } catch {
       statOk = false;
     }
-    probeState = statOk
-      ? { available: true }
-      : { available: false, detail: `binary not found: ${command}` };
+    // P2 hardening: a non-executable regular file would report available
+    // here but fail later with EACCES/provider_error. On POSIX, enforce
+    // executable access so `remnic doctor` surfaces the real state. Windows
+    // has no reliable exec bit (Node X_OK is always true there), so the
+    // check is POSIX-only.
+    if (statOk && process.platform !== "win32") {
+      try {
+        accessSync(command, constants.X_OK);
+      } catch {
+        notExecutable = true;
+      }
+    }
+    probeState = !statOk
+      ? { available: false, detail: `binary not found: ${command}` }
+      : notExecutable
+        ? { available: false, detail: `binary not executable: ${command}` }
+        : { available: true };
     return probeState;
   }
 

--- a/packages/remnic-core/src/coding/structural-subprocess-provider.ts
+++ b/packages/remnic-core/src/coding/structural-subprocess-provider.ts
@@ -1,0 +1,336 @@
+/**
+ * Built-in subprocess structural-context provider + doctor probe
+ * (issue #1548 Track A PR 5).
+ *
+ * Shells out to a configured external binary via `execFile` with an argv
+ * ARRAY (never a shell string — rule 10). codebase-memory-mcp's CLI mode is
+ * the canonical target, but the provider is command-agnostic: any binary
+ * that accepts `<symbols-subcommand> <json-arg>` and emits a JSON object
+ * `{ symbols: [{ symbol, path?, kind? }] }` satisfies it.
+ *
+ * Probe is cached once per instance (rule 11). Every failure path is a
+ * tagged outcome — `provider_unavailable` / `provider_timeout` /
+ * `provider_malformed` / `provider_error` — never a throw (rule 34).
+ *
+ * The async {@link probeStructuralProviderForDoctor} constructs a one-shot
+ * provider from config so `remnic doctor` can render
+ * "configured / probed / last error code" without a registered instance.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { statSync } from "node:fs";
+
+import type { PluginConfig } from "../types.js";
+import { isCodingGraphInstalled } from "./optional-coding-graph.js";
+import {
+  describeStructuralProviderStatus,
+  type ArchitectureHintsResult,
+  type StructuralContextProvider,
+  type StructuralProviderStatus,
+  type StructuralContextErrorCode,
+  type StructuralSymbol,
+  type SymbolsForDiffResult,
+} from "./structural-context.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Injectable spawn shape so tests substitute a stub (rule 33). */
+export type StructuralSpawnFn = (
+  command: string,
+  argv: readonly string[],
+  options: { timeout: number; signal?: AbortSignal },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface SubprocessProviderOptions {
+  /** Absolute path to the binary (rule 24 — statSync at probe time). */
+  readonly command: string;
+  /**
+   * Extra argv appended after the symbols-for-diff subcommand
+   * (rule 10 — array, never a shell string).
+   */
+  readonly args?: readonly string[];
+  /** Per-call deadline in ms. Default 5000. */
+  readonly timeoutMs?: number;
+  /**
+   * Subcommand the provider invokes for symbol expansion.
+   * Default `"symbols-for-diff"`.
+   */
+  readonly symbolsSubcommand?: string;
+  /** Test seam — defaults to promisified `execFile`. */
+  readonly spawn?: StructuralSpawnFn;
+}
+
+interface ProbeState {
+  readonly available: boolean;
+  readonly detail?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_SYMBOLS_SUBCOMMAND = "symbols-for-diff";
+
+/**
+ * Construct a structural-context provider backed by an external subprocess.
+ * The instance is self-contained: callers register it via
+ * `registerStructuralContextProvider(scope, provider)` and dispose via the
+ * returned unregister handle.
+ */
+export function createSubprocessStructuralProvider(
+  options: SubprocessProviderOptions,
+): StructuralContextProvider {
+  const command = options.command.trim();
+  const extraArgs = options.args ?? [];
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const symbolsSubcommand = options.symbolsSubcommand ?? DEFAULT_SYMBOLS_SUBCOMMAND;
+  const spawn: StructuralSpawnFn = options.spawn ?? defaultSpawn;
+
+  let probeState: ProbeState | null = null;
+  const id = `subprocess(${command})`;
+
+  async function ensureProbe(): Promise<ProbeState> {
+    if (probeState !== null) return probeState;
+    if (!command) {
+      probeState = { available: false, detail: "structuralProviderCommand is empty" };
+      return probeState;
+    }
+    // Rule 24 — file existence check at probe time. An operator pointing at
+    // a missing/renamed binary gets a DISTINCT `provider_unavailable` code,
+    // never a silent empty result.
+    let statOk = false;
+    try {
+      statOk = statSync(command).isFile();
+    } catch {
+      statOk = false;
+    }
+    probeState = statOk
+      ? { available: true }
+      : { available: false, detail: `binary not found: ${command}` };
+    return probeState;
+  }
+
+  return {
+    id,
+    async probe() {
+      return ensureProbe();
+    },
+    async symbolsForDiff(
+      diff: string,
+      callOpts,
+    ): Promise<SymbolsForDiffResult> {
+      const probe = await ensureProbe();
+      if (!probe.available) {
+        return { ok: false, code: "provider_unavailable", detail: probe.detail };
+      }
+      // Rule 10 — argv array; the diff is carried as a JSON argument so the
+      // binary never sees a shell and never re-interpolates paths.
+      const payload = JSON.stringify({ diff });
+      const argv = [symbolsSubcommand, payload, ...extraArgs];
+      try {
+        const { stdout } = await spawn(command, argv, {
+          timeout: timeoutMs,
+          signal: callOpts?.signal,
+        });
+        return parseSymbolJson(stdout);
+      } catch (err) {
+        return classifySpawnError(err);
+      }
+    },
+    async architectureHints(
+      root: string,
+      callOpts,
+    ): Promise<ArchitectureHintsResult> {
+      const probe = await ensureProbe();
+      if (!probe.available) {
+        return { ok: false, code: "provider_unavailable", detail: probe.detail };
+      }
+      const argv = ["architecture-hints", root, ...extraArgs];
+      try {
+        const { stdout } = await spawn(command, argv, {
+          timeout: timeoutMs,
+          signal: callOpts?.signal,
+        });
+        return parseHintsJson(stdout);
+      } catch (err) {
+        return classifySpawnError(err);
+      }
+    },
+    close() {
+      probeState = null;
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// JSON validation — rule 18 (object-not-null), rule 51 (shape), rule 34
+// ──────────────────────────────────────────────────────────────────────────
+
+function parseSymbolJson(stdout: string): SymbolsForDiffResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    return {
+      ok: false,
+      code: "provider_malformed",
+      detail: "stdout was not valid JSON",
+    };
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return {
+      ok: false,
+      code: "provider_malformed",
+      detail: "provider output was not a JSON object",
+    };
+  }
+  const obj = value as Record<string, unknown>;
+  const symbolsRaw = obj.symbols;
+  if (!Array.isArray(symbolsRaw)) {
+    return {
+      ok: false,
+      code: "provider_malformed",
+      detail: "provider output .symbols is not an array",
+    };
+  }
+  const symbols: StructuralSymbol[] = [];
+  for (const entry of symbolsRaw) {
+    const item = readStructuralSymbol(entry);
+    if (item !== null) symbols.push(item);
+  }
+  return { ok: true, symbols };
+}
+
+function parseHintsJson(stdout: string): ArchitectureHintsResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    return {
+      ok: false,
+      code: "provider_malformed",
+      detail: "stdout was not valid JSON",
+    };
+  }
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      code: "provider_malformed",
+      detail: "provider hints output was not a JSON array",
+    };
+  }
+  const hints = value.filter((h): h is string => typeof h === "string" && h.length > 0);
+  return { ok: true, hints };
+}
+
+function readStructuralSymbol(entry: unknown): StructuralSymbol | null {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+  const rec = entry as Record<string, unknown>;
+  const symbol = typeof rec.symbol === "string" ? rec.symbol.trim() : "";
+  if (!symbol) return null;
+  const path = typeof rec.path === "string" && rec.path.length > 0 ? rec.path : undefined;
+  const kind = typeof rec.kind === "string" && rec.kind.length > 0 ? rec.kind : undefined;
+  const item: StructuralSymbol =
+    path !== undefined && kind !== undefined
+      ? { symbol, path, kind }
+      : path !== undefined
+        ? { symbol, path }
+        : kind !== undefined
+          ? { symbol, kind }
+          : { symbol };
+  return item;
+}
+
+type StructuralContextError = {
+  readonly ok: false;
+  readonly code: StructuralContextErrorCode;
+  readonly detail?: string;
+};
+
+function classifySpawnError(err: unknown): StructuralContextError {
+  const message = err instanceof Error ? err.message : String(err);
+  // Node sets the child's `.killed` flag and surfaces an ETIMEDOUT-style
+  // message when `timeout` elapses; the regex keeps this robust to Node
+  // version wording differences.
+  if (/timeout|timed out|ETIMEDOUT/i.test(message)) {
+    return { ok: false, code: "provider_timeout", detail: message };
+  }
+  return { ok: false, code: "provider_error", detail: message };
+}
+
+function defaultSpawn(
+  command: string,
+  argv: readonly string[],
+  options: { timeout: number; signal?: AbortSignal },
+): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync(command, [...argv], {
+    timeout: options.timeout,
+    signal: options.signal,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Doctor probe — construct a one-shot provider from config and probe it
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Augment the pure {@link describeStructuralProviderStatus} with a LIVE probe
+ * so `remnic doctor` can render "configured / probed / last error code".
+ *
+ *   - `"none"`     → inactive (no probe).
+ *   - `"subprocess"` → builds a throwaway provider from
+ *                    `structuralProviderCommand`, probes it, disposes it.
+ *   - `"native"`   → asks `isCodingGraphInstalled()` whether the optional
+ *                    @remnic/coding-graph peer is present (the adapter that
+ *                    turns the engine into a provider lands in #1551).
+ *
+ * Never throws — a probe failure populates `probed.available = false`.
+ */
+export async function probeStructuralProviderForDoctor(
+  config: PluginConfig,
+): Promise<StructuralProviderStatus> {
+  const status = describeStructuralProviderStatus(config);
+  if (!status.active) return status;
+
+  const ck = config.codingKnowledge;
+  if (ck.structuralProvider === "subprocess") {
+    if (!ck.structuralProviderCommand) {
+      return {
+        ...status,
+        probed: { available: false, detail: "structuralProviderCommand is empty" },
+      };
+    }
+    const provider = createSubprocessStructuralProvider({
+      command: ck.structuralProviderCommand,
+    });
+    try {
+      const probed = await safeProbe(provider);
+      return { ...status, probed };
+    } finally {
+      void provider.close?.();
+    }
+  }
+
+  if (ck.structuralProvider === "native") {
+    const installed = await isCodingGraphInstalled().catch(() => false);
+    return {
+      ...status,
+      probed: {
+        available: installed,
+        detail: installed ? undefined : "@remnic/coding-graph not installed",
+      },
+    };
+  }
+
+  return status;
+}
+
+async function safeProbe(
+  provider: StructuralContextProvider,
+): Promise<{ available: boolean; detail?: string }> {
+  try {
+    return await provider.probe();
+  } catch (err) {
+    return { available: false, detail: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -453,9 +453,37 @@ export {
   parseTouchedFiles,
   rankReviewCandidates,
   packReviewContext,
+  packReviewContextStructural,
   type ReviewContext,
   type ReviewCandidate,
+  type PackReviewContextStructuralInput,
 } from "./coding/review-context.js";
+
+export {
+  structuralProviderActive,
+  describeStructuralProviderStatus,
+  renderStructuralProviderStatusLine,
+  registerStructuralContextProvider,
+  getStructuralContextProvider,
+  clearStructuralContextProvidersForTest,
+  toStructuralContextDegradation,
+  type StructuralContextProvider,
+  type StructuralContextDegradation,
+  type StructuralContextErrorCode,
+  type StructuralSymbol,
+  type SymbolsForDiffResult,
+  type SymbolsForDiffOk,
+  type SymbolsForDiffErr,
+  type ArchitectureHintsResult,
+  type StructuralProviderStatus,
+} from "./coding/structural-context.js";
+
+export {
+  createSubprocessStructuralProvider,
+  probeStructuralProviderForDoctor,
+  type SubprocessProviderOptions,
+  type StructuralSpawnFn,
+} from "./coding/structural-subprocess-provider.js";
 
 export {
   validateRequest,


### PR DESCRIPTION
## Summary

Track A PR 5 of #1548: the **structural-context provider seam** — the architectural boundary between Track A (durable coding-memory features) and Track B (the native `@remnic/coding-graph` engine). When a structural provider is configured (`codingKnowledge.structuralProvider != "none"`) and recall intent is review/code-shaped, review-context expands the diff's touched files into touched **symbols** via a provider port, so memories mentioning a changed symbol float up — not just the file path. Provider failures are visible in `remnic doctor` / xray, **never silent** (rule 34).

## What lands

**New modules** (all in `packages/remnic-core/src/coding/`):
- `structural-context.ts` — provider **port** interface, tagged-outcome types (`SymbolsForDiffResult` ok/false shaped like #1536 `SearchDegradation`), `StructuralContextDegradation`, instance-scoped registry (`Symbol.for`, mirrors `host-embedding-provider.ts`), the single gate predicate `structuralProviderActive` (rule 39), config-only doctor status summariser + renderer.
- `structural-subprocess-provider.ts` — built-in subprocess adapter (`execFile` argv array, never shell — rule 10), `statSync` probe cached per instance (rule 11), the **4-state failure matrix** (`provider_unavailable`/`timeout`/`malformed`/`error` — rule 34), and the async `probeStructuralProviderForDoctor` that constructs a one-shot provider from config so `remnic doctor` renders configured/probed/last-error-code.

**Wiring:**
- `review-context.ts` — pure `packReviewContext` **unchanged** (gate-off byte-identical). New async `packReviewContextStructural` consults a provider; on failure it falls back to file-path-only ranking **identical** to the pure packer and surfaces `structuralDegradation` so the failure is never silent (rule 34).
- `index.ts` — exports the new public surface.
- `remnic-cli/src/index.ts` — thin doctor wiring (one check line) that renders provider status via `probeStructuralProviderForDoctor`.

The port is the Track A/Track B boundary: `native` mode's enum value and doc note land here; the `@remnic/coding-graph` engine adapter (#1551/#1554) and codebase-memory-mcp subprocess are both providers of this port.

## Gate-off contract (prove-fail-before)

With `structuralProvider: "none"` (default), review-context runs the pure file-path-only ranker, **byte-identical to main**: zero new tool registrations, zero briefing changes, zero loader imports. The pure `packReviewContext` is untouched. Characterization tests capture this **before** asserting anything about the wired path.

## Tests

- **4-state matrix** (issue PR 5 acceptance): provider (a) unavailable / (b) returns symbols / (c) times out / (d) malformed JSON — assert (a)/(c)/(d) produce distinct `{ok:false}` codes recorded as `structuralDegradation` and that ranking falls back to file-path-only boosting *identically to today*, while (b) adds symbol matches.
- **Port tests**: registry (instance-scoped, overwrite-closes-previous), gate predicate (one path), doctor status summariser + renderer.
- **Subprocess adapter**: probe caching, argv-array contract (rule 10), malformed-shape rejection (rule 18), close() resets probe.
- 53 new tests across `structural-context.test.ts`, `structural-subprocess-provider.test.ts`, `review-context-structural.test.ts`.

## Gates

- `pnpm --filter @remnic/core build` — ESM + DTS green
- `pnpm --filter @remnic/cli build` — green (doctor wiring compiles)
- `node scripts/check-ratchets.mjs` — `[ratchet] OK` (no god-file growth)
- `node scripts/check-docs-parity.mjs` — OK
- `npm run test:entity-hardening` — **246/246 pass** (no recall-pipeline regression)
- `npm run preflight:quick` — check-types, ratchets, docs-parity, review-patterns all PASS
- `review-context.test.ts` + `config.test.ts` — 183/183 pass (no regression to existing review-context)

## Chokepoints used / not applicable

- **CapabilitySet gate**: `structuralProviderActive(config)` — the single predicate every review-context consumer consults (rule 39).
- **#1536 tagged-degradation shape**: `StructuralContextDegradation { backend: "structural-context", code, detail }`.
- **Storage chokepoint (#1522)**: not applicable — provider output is never persisted on failure (rule 44); on success only symbol names feed the in-memory match set.
- **#1525 validation boundary**: not applicable — no new MCP/HTTP/CLI tool surface in this PR (the port is a library seam; surfaces compose it later via #1554).

Part of #1548. Standards: #1520.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches review-context ranking and subprocess execution paths, but default-off gating preserves today’s recall behavior; main risk is misconfiguration or provider failures affecting ranking quality when the feature is enabled.
> 
> **Overview**
> Introduces the **structural-context provider** boundary (#1548 Track A PR 5): a pluggable port that maps a diff to touched **symbols**, so review-intent recall can boost memories that reference those symbols—not only touched file paths.
> 
> **New core surface:** `structural-context.ts` defines tagged outcomes (`SymbolsForDiffResult`), `StructuralContextDegradation`, instance-scoped registration, `structuralProviderActive`, and doctor status helpers. `structural-subprocess-provider.ts` implements the built-in `execFile` adapter (argv array, cached probe, distinct failure codes) plus `probeStructuralProviderForDoctor`.
> 
> **Review context:** `packReviewContext` is unchanged. New async `packReviewContextStructural` merges provider symbol names into the ranker’s match set on success; on any provider failure it ranks **identically** to the pure file-path packer and sets optional `structuralDegradation` so outages are not silent.
> 
> **CLI:** `remnic doctor` gains a **Structural-context provider** check (live probe when configured, warning + remediation when probed unavailable).
> 
> **Exports:** `@remnic/core` re-exports the port, subprocess factory, and structural packer. Orchestrator/recall hot-path wiring is left for follow-ups; with `structuralProvider: "none"` (default), behavior stays file-path-only.
> 
> Extensive unit tests cover gate-off parity, failure fallback, symbol expansion, registry/gate, and the subprocess 4-state matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61cc57dea32d3ae4f3af1c997de1938634fad88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->