### PR TITLE
docs(coding): #1548 point structural-provider section at PR #1754

### DIFF
--- a/docs/coding-knowledge.md
+++ b/docs/coding-knowledge.md
@@ -21,7 +21,7 @@ The features, all gated by the `codingKnowledge` config block:
    these files."
 4. [Structural provider (reserved)](#structural-provider-reserved) — the
    config knob for symbol-anchored review-intent recall; the provider modules
-   ship in a follow-up PR.
+   ship in [#1754](https://github.com/joshuaswarren/remnic/pull/1754) (in progress).
 
 ## Gate contract
 
@@ -290,7 +290,7 @@ are both providers of the same port.
 
 The config field is parsed and validated today; the provider modules
 themselves (the port interface, the subprocess provider, the native adapter)
-ship in a follow-up PR. **Until then, review-intent recall is file-path-only
+ship in [#1754 (in progress)](https://github.com/joshuaswarren/remnic/pull/1754). **Until then, review-intent recall is file-path-only
 regardless of this setting** — setting `structuralProvider` to `"subprocess"`
 or `"native"` is accepted by the parser but has no effect on recall. This is
 documented honestly rather than implied.


### PR DESCRIPTION
Part of #1548 (Track A PR6 docs follow-up).

## What

Tiny follow-up to the merged coding-knowledge docs (#1748). The merged doc referenced the structural-context provider as a generic "follow-up PR". That PR is now open (#1754 — `feat(coding): structural-context provider port + symbol-aware review-intent recall`), so this links it concretely.

## Change

Two-line edit to `docs/coding-knowledge.md`: the intro list item and the "Structural provider (reserved)" section body now link [#1754](https://github.com/joshuaswarren/remnic/pull/1754) (in progress) instead of saying "a follow-up PR". The config field remains parsed-and-validated on main; the provider modules themselves ship in #1754, which is open but not yet merged — documented honestly.

## Verification

- `node scripts/check-docs-parity.mjs` → OK (40 documented commands resolve; no coding CLI commands invented).
- Diff is 2 lines in one doc file.

## Chokepoints used / not applicable

Docs-only; no code paths touched. One-source rule (#1527) honoured — no paraphrase duplication of coding-agent.md or coding-graph.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit with no runtime or config behavior changes.
> 
> **Overview**
> Updates **`docs/coding-knowledge.md`** so the structural-provider (reserved) feature no longer refers to a generic “follow-up PR” and instead points at **[#1754](https://github.com/joshuaswarren/remnic/pull/1754)** as *in progress*.
> 
> The change appears in the feature list intro and in the **Structural provider (reserved)** section; wording that **`structuralProvider` is parsed today but recall stays file-path-only until the provider ships** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d971952bea07db4e423799601854b6c83bceb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->