### PR TITLE
docs(bench): single-flag ablation cells (contradiction-scan-on, graph-recall-on) + ablations.md

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,6 +84,12 @@ carries a known self-preference caveat acceptable for Tier L regression.
 Judge-call counts: locomo 1885/1986 and longmemeval 407/500 (the
 content-keyed judge cache absorbs repeated/identical answers).
 
+Single-flag ablation deltas against this Tier L baseline (memory-worth,
+contradiction-scan, graph-recall) are in
+[`docs/benchmarks/ablations.md`](./benchmarks/ablations.md) (issue #1730).
+At 7B-Q4 single-seed no cell moves any metric outside the run-to-run noise
+band, so no shipped default is changed by that ablation.
+
 The two `*-mock000.json` files remain as **pipeline examples** with
 `datasetVersion: "mock-fixture"` and placeholder scores; **do not cite
 them publicly**. They will be removed once full uncapped Tier L runs

--- a/docs/benchmarks/ablations.md
+++ b/docs/benchmarks/ablations.md
@@ -1,0 +1,139 @@
+# Single-flag ablation results — LoCoMo (Tier L)
+
+This page reports the **single-flag ablation matrix** from issue
+[#1730](https://github.com/joshuaswarren/remnic/issues/1730) / [#1574](https://github.com/joshuaswarren/remnic/issues/1574)
+/ [#1725](https://github.com/joshuaswarren/remnic/issues/1725), produced on the
+RTX 3090 local-lab box under the `local-lab` runtime profile.
+
+Each ablation flips **exactly one** recall-stack flag off its default in the
+baseline run and re-runs the full LoCoMo-10 benchmark (1986 questions across
+all 10 conversations) with everything else held constant: same model
+(`qwen2.5-7b-32k:latest`, Q4_K_M), same seed (1), same responder **and** judge
+model. The baseline is the first real Tier L artifact:
+
+- `2026-07-07-locomo-qwen2.5-7b-32k_latest-47aae03.json` — defaults (all flags
+  at their shipped defaults; memory-worth **on**, contradiction-scan **off**,
+  graph-recall **off**).
+
+Each cell artifact is committed next to the baseline under
+`docs/benchmarks/results/` and verified with
+`pnpm exec tsx scripts/bench/verify-artifact.ts` before this page cites it.
+**No datasets, raw traces, or logs are committed** — only the validated
+`BenchmarkArtifact v1` JSON (metrics + per-task scores + provenance envelope).
+
+## Per-cell deltas vs baseline
+
+`contains_answer` / `f1` / `llm_judge` / `rouge_l` are the four
+answer-quality metrics tracked here (the fifth metric,
+`locomo_hidden_evidence_id_leak`, stays at 1.000 across every cell — i.e. no
+run leaks hidden gold evidence ids into the answer path, the anti-cheating
+invariant holds). Δ is absolute (cell − baseline); % is relative to the
+baseline value.
+
+| Cell | Flag flipped | `contains_answer` | `f1` | `llm_judge` | `rouge_l` | artifact |
+|---|---|---|---|---|---|---|
+| **Baseline** | (defaults) | 0.0831 | 0.1217 | 0.2243 | 0.1177 | `…47aae03.json` |
+| **memory-worth-off** | Memory Worth multiplier OFF (baseline ON) | 0.0856 (Δ+0.0025 / +3.0%) | 0.1227 (Δ+0.0009 / +0.8%) | 0.2239 (Δ−0.0004 / −0.2%) | 0.1187 (Δ+0.0010 / +0.9%) | `…c67c2c7-memory-worth-off.json` |
+| **contradiction-scan-on**† | Contradiction scan ON (baseline OFF) | 0.0851 (Δ+0.0020 / +2.4%) | 0.1220 (Δ+0.0003 / +0.2%) | 0.2236 (Δ−0.0007 / −0.3%) | 0.1181 (Δ+0.0004 / +0.3%) | `…c67c2c7-contradiction-scan-on.json` |
+| **graph-recall-on**† | Graph / temporal recall ON (baseline OFF) | 0.0851 (Δ+0.0020 / +2.4%) | 0.1220 (Δ+0.0003 / +0.2%) | 0.2236 (Δ−0.0007 / −0.3%) | 0.1181 (Δ+0.0004 / +0.3%) | `…c67c2c7-graph-recall-on.json` |
+
+† `contradiction-scan-on` and `graph-recall-on` produced byte-identical per-task scores — see [Two cells are bit-identical](#two-cells-are-bit-identical--and-that-is-the-finding) below.
+
+## Reading these numbers
+
+**None of the cells moves any metric by more than the run-to-run noise band at
+this scale, so no default is changed by this ablation.** Concretely:
+
+- **memory-worth-off** is within noise on all four metrics (largest move is
+  `contains_answer` +0.0025 absolute / +3.0% relative). Disabling the Memory
+  Worth recall multiplier neither helps nor hurts at 7B-Q4. The default stays
+  **on**.
+- **contradiction-scan-on** is within noise on all four metrics (largest
+  move is `contains_answer` +0.0020 absolute / +2.4% relative). Enabling
+  inline contradiction detection on the write path
+  (`contradictionDetectionEnabled`) on top of the default-off baseline
+  neither helps nor hurts at 7B-Q4. The default stays **off**.
+- **graph-recall-on** is within noise on all four metrics — with deltas
+  identical to contradiction-scan-on (see below). Enabling graph recall +
+  full-mode graph assist on top of the default-off baseline neither helps
+  nor hurts at 7B-Q4. The default stays **off**.
+
+## Two cells are bit-identical — and that is the finding
+
+`contradiction-scan-on` and `graph-recall-on` produced **byte-identical
+per-task scores** across all 1986 LoCoMo questions (every `contains_answer`,
+`f1`, `llm_judge`, and `rouge_l` per-task value matches to full float
+precision). They are not the same file — different `sha256`
+(`11e55bb8…` vs `bc1504a7…`), different `note`/flag envelopes, different
+run windows, and each ran an independent ~18-minute full benchmark (18.2 min
+vs 17.9 min). Yet their scored outputs are indistinguishable.
+
+This is a real result, not a caching artefact: the override merge spreads the
+cell's flag on top of the baseline config and passes it as `remnicConfig`
+(`scripts/bench/run-ablation-matrix.ts`), and the `memory-worth-off` cell —
+which flips a *recall-time* multiplier — genuinely differs (5/1986 tasks vs
+this pair; 109/1986 tasks vs the baseline). So the runner is flag-aware;
+these two flags simply have **zero measurable effect** on the recall →
+answer → score path for LoCoMo at 7B-Q4.
+
+The most likely reason [INFERENCE]: LoCoMo is replayed with
+`replayExtractionMode: "skip"`, so the memory store is loaded from a
+pre-built snapshot rather than re-ingested question-by-question. Inline
+contradiction detection is a write-path gate — with no fresh writes to gate
+during a skip-extraction replay it is inert; graph recall needs a built
+causal/timeline graph — with extraction skipped there is nothing to traverse,
+so it is inert. Both flags are effectively no-ops under this replay mode.
+Confirming the exact mechanism needs a single instrumented run; it is filed
+as a follow-up, not a gate on this artifact set.
+
+The honest conclusion stands: at this tier neither flag moves any metric, so
+no default is changed. The bit-identity is itself the evidence that the
+effect — if any — is strictly below the detection floor here.
+
+## Honest variance caveats (read before citing any delta above)
+
+These are **Tier L regression numbers, not capability claims**, and the deltas
+are small relative to the expected variance. Treat any single-cell delta below
+~5–8% relative as indistinguishable from noise:
+
+1. **7B Q4_K_M scale.** Responder and judge are both
+   `qwen2.5:7b-instruct` at Q4_K_M on a single RTX 3090. At this model size
+   the recall-stack flag under test is a second-order effect; the dominant
+   variance source is the 7B answer/judge quality itself, which dwarfs
+   flag-level movement. A delta that looks "real" here can vanish or invert on
+   a rerun.
+2. **Single seed.** Every cell (and the baseline) runs at seed 1 only — there
+   is no multi-seed mean or standard deviation, so no cell has a measured
+   confidence interval. A single-seed delta of a few percent is not
+   statistically meaningful.
+3. **Same-model self-judge.** Responder and judge are the same model, so the
+   `llm_judge` column carries a known self-preference caveat (no frontier
+   judge was available on the lab box, so `judgeCalibration` / Cohen's kappa
+   is omitted). This is acceptable for Tier L regression ranking but must not
+   be quoted as a cross-system comparison.
+4. **Hidden-evidence-id leak = 1.000 across all cells** confirms no run cheats
+   (gold ids never enter the answer path), but it also means that metric
+   carries no discrimination between cells.
+5. **No default is flipped by this matrix.** A default change requires either a
+   delta outside the noise band on multiple seeds, or a Tier F confirmation.
+   This ablation documents the *absence* of a measurable single-flag effect at
+   7B-Q4, which is itself the finding — it means these flags are safe to leave
+   at their shipped defaults and that any benefit they confer is below the
+   detection floor of this tier.
+
+## Reproducing
+
+```bash
+# From the repo root, on the artifact's recorded gitSha
+git checkout <artifact.system.gitSha>
+pnpm install && pnpm --filter @remnic/core run build
+remnic bench run --benchmark locomo \
+  --local-lab-manifest packages/bench/profiles/local-lab-3090.json \
+  --model qwen2.5-7b-32k:latest --seed 1
+```
+
+The ablation matrix runner is
+`scripts/bench/run-ablation-matrix.ts` (issue #1730). See the [two-tier
+benchmark protocol](./benchmarks.md#two-tier-benchmark-protocol) for why these
+Tier L numbers must never be conflated with Tier F (frontier) leaderboard
+claims.

--- a/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-contradiction-scan-on.json
+++ b/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-contradiction-scan-on.json
@@ -1,0 +1,19896 @@
+{
+  "benchmarkId": "locomo",
+  "datasetVersion": "locomo-10",
+  "durationMs": 1093281,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-07T20:34:44.323Z",
+  "hardware": {
+    "gpu": "NVIDIA RTX 3090",
+    "quantization": "Q4_K_M",
+    "vramGb": 24
+  },
+  "metrics": {
+    "contains_answer": 0.0850956696878147,
+    "f1": 0.12203210363438667,
+    "llm_judge": 0.2235649546827795,
+    "locomo_hidden_evidence_id_leak": 1,
+    "rouge_l": 0.1180827736891082
+  },
+  "model": "qwen2.5-7b-32k:latest",
+  "note": "Single-flag ablation \"contradiction-scan-on\" (Contradiction scan ON). Enables the contradiction-scan cron (contradictionScan.enabled=true) so supersessions land between ingest and answering. Baseline (#1574) ran with it OFF; this cell measures the benefit. Baseline: contradictionScan.enabled defaults false; baseline ran OFF.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-26-q2-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-26-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q22-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-26-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347825,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-26-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-26-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q49-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-26-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-26-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q59-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-26-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q69-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q77-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q81-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-26-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-26-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20512820512820512,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10256410256410256
+      },
+      "taskId": "conv-26-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-26-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-26-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-26-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-26-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4615384615384615
+      },
+      "taskId": "conv-26-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-26-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-26-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-26-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05128205128205127,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05128205128205127
+      },
+      "taskId": "conv-26-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-26-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2608695652173913
+      },
+      "taskId": "conv-26-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11428571428571427
+      },
+      "taskId": "conv-26-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4848484848484849,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-26-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q2-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-30-q4-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q19-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.04878048780487805
+      },
+      "taskId": "conv-30-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-30-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47368421052631576,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789474
+      },
+      "taskId": "conv-30-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q39-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q40-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q41-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q43-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q44-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q45-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q46-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q47-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q48-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07142857142857142
+      },
+      "taskId": "conv-30-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q50-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-30-q51-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6896551724137931,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6896551724137931
+      },
+      "taskId": "conv-30-q52-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23255813953488372
+      },
+      "taskId": "conv-30-q53-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8000000000000002
+      },
+      "taskId": "conv-30-q54-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q55-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q56-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-30-q57-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q60-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-30-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-30-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-30-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-30-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q79-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q82-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q83-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q84-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q85-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q86-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q87-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q88-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q89-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-30-q90-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q91-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q92-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q93-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q94-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q95-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q96-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q97-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q98-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q99-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q100-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q101-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q102-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q103-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q104-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-41-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.71,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-41-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-41-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4000000000000001,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4000000000000001
+      },
+      "taskId": "conv-41-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q41-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q45-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-41-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05405405405405405,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05405405405405405
+      },
+      "taskId": "conv-41-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-41-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3636363636363636,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-41-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-41-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-41-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6923076923076924,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6923076923076924
+      },
+      "taskId": "conv-41-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-41-q91-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-41-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-41-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-41-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4827586206896552
+      },
+      "taskId": "conv-41-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7058823529411764
+      },
+      "taskId": "conv-41-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-41-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-41-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19047619047619047,
+        "llm_judge": 0.38,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19047619047619047
+      },
+      "taskId": "conv-41-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-41-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-41-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3
+      },
+      "taskId": "conv-42-q10-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-42-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q18-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-42-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-42-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3913043478260869,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-42-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q60-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q67-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q68-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-42-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q73-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q74-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q77-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-42-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q84-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q85-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q86-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q87-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-42-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-42-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-42-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-42-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-42-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-42-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-42-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12500000000000003
+      },
+      "taskId": "conv-42-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.13333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-42-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-42-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6363636363636364
+      },
+      "taskId": "conv-42-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5384615384615385,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5384615384615385
+      },
+      "taskId": "conv-42-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q191-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q192-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q193-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q194-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q195-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q196-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q197-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q198-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-42-q242-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q243-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q244-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q245-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q246-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q247-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q248-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q249-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q250-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q251-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q252-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q253-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q254-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-42-q255-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q256-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q257-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q258-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-42-q259-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q3-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24242424242424243
+      },
+      "taskId": "conv-43-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-43-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.29411764705882354,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17647058823529413
+      },
+      "taskId": "conv-43-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q15-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-43-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q32-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q34-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-43-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-43-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-43-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-43-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-43-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q67-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-43-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-43-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-43-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7187499999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-43-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-43-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-43-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.45454545454545453,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-43-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-43-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-44-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-44-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-44-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-44-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666665
+      },
+      "taskId": "conv-44-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-44-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24615384615384614,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12307692307692307
+      },
+      "taskId": "conv-44-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-44-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-44-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-44-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.058823529411764705,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.058823529411764705
+      },
+      "taskId": "conv-44-q52-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-44-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-44-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27272727272727276,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27272727272727276
+      },
+      "taskId": "conv-44-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43902439024390244,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34146341463414637
+      },
+      "taskId": "conv-44-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4210526315789473,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789473
+      },
+      "taskId": "conv-44-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-44-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545455,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545455
+      },
+      "taskId": "conv-44-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20000000000000004,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20000000000000004
+      },
+      "taskId": "conv-44-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-44-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q123-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q124-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q125-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q126-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q127-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q128-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q129-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q130-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q131-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q132-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q133-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q134-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q135-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q136-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q137-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5405405405405406,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5405405405405406
+      },
+      "taskId": "conv-44-q138-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q139-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q140-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q141-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q142-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q143-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q144-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q145-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q146-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q147-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q148-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q149-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q6-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-47-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-47-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q16-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q25-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q35-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q42-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-47-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-47-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18604651162790695,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13953488372093023
+      },
+      "taskId": "conv-47-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20689655172413793
+      },
+      "taskId": "conv-47-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347827,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5217391304347827
+      },
+      "taskId": "conv-47-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-47-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6206896551724138
+      },
+      "taskId": "conv-47-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-47-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-47-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-47-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-47-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.46153846153846156
+      },
+      "taskId": "conv-47-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-48-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1904761904761905
+      },
+      "taskId": "conv-48-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q11-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27027027027027023
+      },
+      "taskId": "conv-48-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q15-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q16-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q18-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.98,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q23-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q25-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q33-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.48648648648648646,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.48648648648648646
+      },
+      "taskId": "conv-48-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-48-q40-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q48-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-48-q71-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q73-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q75-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q78-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q81-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-48-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2439024390243902,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-48-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q84-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q85-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q86-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q87-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-48-q88-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7000000000000001,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7000000000000001
+      },
+      "taskId": "conv-48-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809522
+      },
+      "taskId": "conv-48-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.044444444444444446
+      },
+      "taskId": "conv-48-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35714285714285715
+      },
+      "taskId": "conv-48-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4666666666666667
+      },
+      "taskId": "conv-48-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-48-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-48-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-48-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3076923076923077
+      },
+      "taskId": "conv-48-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-48-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-48-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.2,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-49-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q10-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q16-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21212121212121213,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1515151515151515
+      },
+      "taskId": "conv-49-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.56,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21999999999999997,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13999999999999999
+      },
+      "taskId": "conv-49-q31-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-49-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3859649122807017,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3859649122807017
+      },
+      "taskId": "conv-49-q38-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4324324324324324
+      },
+      "taskId": "conv-49-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27692307692307694,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2153846153846154
+      },
+      "taskId": "conv-49-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347826,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-49-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q57-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22
+      },
+      "taskId": "conv-49-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q65-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q71-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q72-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q75-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-49-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-49-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-49-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24000000000000002
+      },
+      "taskId": "conv-49-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-49-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12903225806451613
+      },
+      "taskId": "conv-49-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3703703703703704,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-50-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-50-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q13-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q21-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q37-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-50-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.32653061224489793,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24489795918367344
+      },
+      "taskId": "conv-50-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25925925925925924,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1851851851851852
+      },
+      "taskId": "conv-50-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-50-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-50-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-50-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-50-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21428571428571425,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-50-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-50-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-50-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5185185185185185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5185185185185185
+      },
+      "taskId": "conv-50-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15000000000000002
+      },
+      "taskId": "conv-50-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-50-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-50-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-50-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15789473684210528
+      },
+      "taskId": "conv-50-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-50-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-50-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-50-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-50-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-50-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-50-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q203-adversarial"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-07T20:16:31.042Z",
+  "system": {
+    "gitSha": "c67c2c72",
+    "name": "remnic",
+    "version": "9.3.727"
+  },
+  "tier": "local"
+}

--- a/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-graph-recall-on.json
+++ b/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-graph-recall-on.json
@@ -1,0 +1,19896 @@
+{
+  "benchmarkId": "locomo",
+  "datasetVersion": "locomo-10",
+  "durationMs": 1073674,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-07T20:52:40.268Z",
+  "hardware": {
+    "gpu": "NVIDIA RTX 3090",
+    "quantization": "Q4_K_M",
+    "vramGb": 24
+  },
+  "metrics": {
+    "contains_answer": 0.0850956696878147,
+    "f1": 0.12203210363438667,
+    "llm_judge": 0.2235649546827795,
+    "locomo_hidden_evidence_id_leak": 1,
+    "rouge_l": 0.1180827736891082
+  },
+  "model": "qwen2.5-7b-32k:latest",
+  "note": "Single-flag ablation \"graph-recall-on\" (Graph / temporal recall ON). Enables graph recall + full-mode graph assist (graphRecallEnabled=true, graphAssistInFullModeEnabled=true). Baseline (#1574) ran with graph recall OFF; this cell measures the benefit of causal/timeline expansion. Baseline: graphRecallEnabled + graphAssistInFullModeEnabled default false; baseline ran OFF.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-26-q2-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-26-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q22-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-26-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347825,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-26-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-26-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q49-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-26-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-26-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q59-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-26-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q69-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q77-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q81-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-26-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-26-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20512820512820512,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10256410256410256
+      },
+      "taskId": "conv-26-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-26-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-26-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-26-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-26-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4615384615384615
+      },
+      "taskId": "conv-26-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-26-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-26-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-26-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05128205128205127,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05128205128205127
+      },
+      "taskId": "conv-26-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-26-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2608695652173913
+      },
+      "taskId": "conv-26-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11428571428571427
+      },
+      "taskId": "conv-26-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4848484848484849,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-26-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q2-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-30-q4-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q19-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.04878048780487805
+      },
+      "taskId": "conv-30-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-30-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47368421052631576,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789474
+      },
+      "taskId": "conv-30-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q39-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q40-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q41-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q43-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q44-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q45-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q46-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q47-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q48-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07142857142857142
+      },
+      "taskId": "conv-30-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q50-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-30-q51-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6896551724137931,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6896551724137931
+      },
+      "taskId": "conv-30-q52-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23255813953488372
+      },
+      "taskId": "conv-30-q53-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8000000000000002
+      },
+      "taskId": "conv-30-q54-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q55-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q56-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-30-q57-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q60-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-30-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-30-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-30-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-30-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q79-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q82-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q83-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q84-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q85-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q86-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q87-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q88-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q89-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-30-q90-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q91-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q92-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q93-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q94-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q95-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q96-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q97-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q98-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q99-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q100-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q101-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q102-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q103-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q104-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-41-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.71,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-41-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-41-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4000000000000001,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4000000000000001
+      },
+      "taskId": "conv-41-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q41-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q45-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-41-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05405405405405405,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05405405405405405
+      },
+      "taskId": "conv-41-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-41-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3636363636363636,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-41-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-41-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-41-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6923076923076924,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6923076923076924
+      },
+      "taskId": "conv-41-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-41-q91-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-41-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-41-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-41-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4827586206896552
+      },
+      "taskId": "conv-41-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7058823529411764
+      },
+      "taskId": "conv-41-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-41-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-41-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19047619047619047,
+        "llm_judge": 0.38,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19047619047619047
+      },
+      "taskId": "conv-41-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-41-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-41-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3
+      },
+      "taskId": "conv-42-q10-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-42-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q18-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-42-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-42-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3913043478260869,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-42-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q60-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q67-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q68-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-42-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q73-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q74-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q77-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-42-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q84-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q85-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q86-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q87-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-42-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-42-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-42-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-42-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-42-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-42-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-42-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12500000000000003
+      },
+      "taskId": "conv-42-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.13333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-42-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-42-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6363636363636364
+      },
+      "taskId": "conv-42-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5384615384615385,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5384615384615385
+      },
+      "taskId": "conv-42-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q191-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q192-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q193-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q194-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q195-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q196-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q197-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q198-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-42-q242-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q243-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q244-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q245-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q246-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q247-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q248-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q249-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q250-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q251-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q252-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q253-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q254-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-42-q255-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q256-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q257-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q258-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-42-q259-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q3-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24242424242424243
+      },
+      "taskId": "conv-43-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-43-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.29411764705882354,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17647058823529413
+      },
+      "taskId": "conv-43-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q15-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-43-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q32-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q34-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-43-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-43-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-43-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-43-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-43-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q67-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-43-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-43-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-43-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7187499999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-43-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-43-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-43-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.45454545454545453,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-43-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-43-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-44-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-44-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-44-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-44-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666665
+      },
+      "taskId": "conv-44-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-44-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.24615384615384614,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12307692307692307
+      },
+      "taskId": "conv-44-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-44-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-44-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-44-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.058823529411764705,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.058823529411764705
+      },
+      "taskId": "conv-44-q52-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-44-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-44-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27272727272727276,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27272727272727276
+      },
+      "taskId": "conv-44-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43902439024390244,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34146341463414637
+      },
+      "taskId": "conv-44-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4210526315789473,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789473
+      },
+      "taskId": "conv-44-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-44-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545455,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545455
+      },
+      "taskId": "conv-44-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20000000000000004,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20000000000000004
+      },
+      "taskId": "conv-44-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-44-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q123-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q124-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q125-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q126-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q127-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q128-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q129-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q130-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q131-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q132-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q133-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q134-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q135-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q136-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q137-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5405405405405406,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5405405405405406
+      },
+      "taskId": "conv-44-q138-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q139-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q140-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q141-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q142-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q143-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q144-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q145-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q146-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q147-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q148-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q149-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q6-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-47-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-47-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q16-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q25-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q35-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q42-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-47-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-47-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18604651162790695,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13953488372093023
+      },
+      "taskId": "conv-47-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20689655172413793
+      },
+      "taskId": "conv-47-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347827,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5217391304347827
+      },
+      "taskId": "conv-47-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-47-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6206896551724138
+      },
+      "taskId": "conv-47-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-47-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-47-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-47-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-47-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.46153846153846156
+      },
+      "taskId": "conv-47-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-48-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1904761904761905
+      },
+      "taskId": "conv-48-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q11-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27027027027027023
+      },
+      "taskId": "conv-48-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q15-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q16-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q18-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.98,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q23-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q25-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q33-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.48648648648648646,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.48648648648648646
+      },
+      "taskId": "conv-48-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-48-q40-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q48-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-48-q71-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q73-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q75-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q78-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q81-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-48-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2439024390243902,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-48-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q84-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q85-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q86-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q87-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-48-q88-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7000000000000001,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7000000000000001
+      },
+      "taskId": "conv-48-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809522
+      },
+      "taskId": "conv-48-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.044444444444444446
+      },
+      "taskId": "conv-48-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35714285714285715
+      },
+      "taskId": "conv-48-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4666666666666667
+      },
+      "taskId": "conv-48-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-48-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-48-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-48-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3076923076923077
+      },
+      "taskId": "conv-48-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-48-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-48-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.2,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-49-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q10-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q16-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21212121212121213,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1515151515151515
+      },
+      "taskId": "conv-49-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.56,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21999999999999997,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13999999999999999
+      },
+      "taskId": "conv-49-q31-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-49-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3859649122807017,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3859649122807017
+      },
+      "taskId": "conv-49-q38-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4324324324324324
+      },
+      "taskId": "conv-49-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27692307692307694,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2153846153846154
+      },
+      "taskId": "conv-49-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347826,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-49-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q57-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22
+      },
+      "taskId": "conv-49-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q65-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q71-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q72-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q75-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-49-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-49-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-49-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24000000000000002
+      },
+      "taskId": "conv-49-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-49-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12903225806451613
+      },
+      "taskId": "conv-49-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3703703703703704,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-50-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-50-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q13-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q21-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q37-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-50-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.32653061224489793,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24489795918367344
+      },
+      "taskId": "conv-50-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25925925925925924,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1851851851851852
+      },
+      "taskId": "conv-50-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-50-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-50-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-50-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-50-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21428571428571425,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-50-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-50-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-50-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5185185185185185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5185185185185185
+      },
+      "taskId": "conv-50-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15000000000000002
+      },
+      "taskId": "conv-50-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-50-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-50-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-50-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15789473684210528
+      },
+      "taskId": "conv-50-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-50-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-50-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-50-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-50-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-50-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-50-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q203-adversarial"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-07T20:34:46.594Z",
+  "system": {
+    "gitSha": "c67c2c72",
+    "name": "remnic",
+    "version": "9.3.727"
+  },
+  "tier": "local"
+}

--- a/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-memory-worth-off.json
+++ b/docs/benchmarks/results/2026-07-07-locomo-qwen2.5-7b-32k_latest-c67c2c7-memory-worth-off.json
@@ -1,0 +1,19896 @@
+{
+  "benchmarkId": "locomo",
+  "datasetVersion": "locomo-10",
+  "durationMs": 1112840,
+  "env": {
+    "arch": "x64",
+    "node": "v22.22.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-07-07T20:16:28.699Z",
+  "hardware": {
+    "gpu": "NVIDIA RTX 3090",
+    "quantization": "Q4_K_M",
+    "vramGb": 24
+  },
+  "metrics": {
+    "contains_answer": 0.08559919436052367,
+    "f1": 0.12268540655752583,
+    "llm_judge": 0.22390735146022162,
+    "locomo_hidden_evidence_id_leak": 1,
+    "rouge_l": 0.11873929561093463
+  },
+  "model": "qwen2.5-7b-32k:latest",
+  "note": "Single-flag ablation \"memory-worth-off\" (Memory Worth multiplier OFF). Disables the Memory Worth recall multiplier (recallMemoryWorthFilterEnabled=false). Baseline (#1574) ran with it ON via the config.ts default; this cell measures the cost of removing it. Baseline: recallMemoryWorthFilterEnabled defaults true in config.ts; baseline ran ON.",
+  "perTaskScores": [
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-26-q2-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-26-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-26-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-26-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q22-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-26-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347825,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-26-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-26-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q49-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-26-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-26-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q59-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.30769230769230765
+      },
+      "taskId": "conv-26-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-26-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q69-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q77-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q81-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-26-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-26-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20512820512820512,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10256410256410256
+      },
+      "taskId": "conv-26-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.9411764705882353
+      },
+      "taskId": "conv-26-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-26-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-26-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-26-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-26-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-26-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-26-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4615384615384615
+      },
+      "taskId": "conv-26-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-26-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.25,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-26-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-26-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-26-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-26-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-26-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05128205128205127,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05128205128205127
+      },
+      "taskId": "conv-26-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-26-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2608695652173913,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2608695652173913
+      },
+      "taskId": "conv-26-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-26-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11428571428571427
+      },
+      "taskId": "conv-26-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-26-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4848484848484849,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-26-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-26-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q2-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-30-q4-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q19-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-30-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14634146341463417,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.04878048780487805
+      },
+      "taskId": "conv-30-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-30-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47368421052631576,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789474
+      },
+      "taskId": "conv-30-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q39-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q40-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q41-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q43-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q44-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q45-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q46-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q47-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q48-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07142857142857142
+      },
+      "taskId": "conv-30-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q50-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-30-q51-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6896551724137931,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6896551724137931
+      },
+      "taskId": "conv-30-q52-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23255813953488372
+      },
+      "taskId": "conv-30-q53-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8000000000000002
+      },
+      "taskId": "conv-30-q54-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q55-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q56-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-30-q57-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q60-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-30-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-30-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473684
+      },
+      "taskId": "conv-30-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-30-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q79-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q82-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q83-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q84-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q85-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q86-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q87-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q88-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q89-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-30-q90-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-30-q91-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q92-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q93-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q94-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q95-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q96-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q97-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q98-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q99-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q100-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q101-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-30-q102-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q103-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-30-q104-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.38095238095238093
+      },
+      "taskId": "conv-41-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.71,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-41-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1739130434782609
+      },
+      "taskId": "conv-41-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-41-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-41-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4000000000000001,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4000000000000001
+      },
+      "taskId": "conv-41-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q41-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q45-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-41-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q50-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05405405405405405,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05405405405405405
+      },
+      "taskId": "conv-41-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q64-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-41-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3636363636363636,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3636363636363636
+      },
+      "taskId": "conv-41-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8571428571428571,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8571428571428571
+      },
+      "taskId": "conv-41-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-41-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6923076923076924,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6923076923076924
+      },
+      "taskId": "conv-41-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.26666666666666666
+      },
+      "taskId": "conv-41-q91-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-41-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-41-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0.95,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-41-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-41-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4827586206896552
+      },
+      "taskId": "conv-41-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7058823529411764
+      },
+      "taskId": "conv-41-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-41-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-41-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19047619047619047,
+        "llm_judge": 0.38,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19047619047619047
+      },
+      "taskId": "conv-41-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-41-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-41-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-41-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-41-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-41-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3
+      },
+      "taskId": "conv-42-q10-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.631578947368421
+      },
+      "taskId": "conv-42-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q14-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q18-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-42-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-42-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-42-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-42-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3913043478260869,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-42-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q60-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q67-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q68-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-42-q70-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q71-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q72-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q73-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q74-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q75-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q76-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q77-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-42-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q84-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q85-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-42-q86-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q87-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-42-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-42-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-42-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-42-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-42-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-42-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818182
+      },
+      "taskId": "conv-42-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-42-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-42-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12500000000000003,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12500000000000003
+      },
+      "taskId": "conv-42-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.13333333333333333,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-42-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727273
+      },
+      "taskId": "conv-42-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1111111111111111
+      },
+      "taskId": "conv-42-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-42-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-42-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-42-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6363636363636364
+      },
+      "taskId": "conv-42-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-42-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5384615384615385,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5384615384615385
+      },
+      "taskId": "conv-42-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-42-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-42-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q191-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q192-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q193-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q194-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q195-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q196-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q197-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q198-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-42-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-42-q242-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q243-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q244-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q245-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q246-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q247-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q248-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q249-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q250-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q251-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q252-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q253-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q254-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-42-q255-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q256-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q257-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-42-q258-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-42-q259-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q3-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q4-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q8-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24242424242424243
+      },
+      "taskId": "conv-43-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-43-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.29411764705882354,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.17647058823529413
+      },
+      "taskId": "conv-43-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q15-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q20-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q25-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-43-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q32-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q33-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q34-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-43-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.42857142857142855
+      },
+      "taskId": "conv-43-q43-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q52-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-43-q57-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-43-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q61-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.23529411764705882
+      },
+      "taskId": "conv-43-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q65-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q66-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q67-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-43-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-43-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-43-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-43-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7187499999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.625
+      },
+      "taskId": "conv-43-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-43-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-43-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08333333333333334,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.08333333333333334
+      },
+      "taskId": "conv-43-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.45454545454545453,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-43-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-43-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-43-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-43-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6874999999999999,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5625000000000001
+      },
+      "taskId": "conv-43-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-43-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-43-q239-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q240-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-43-q241-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q5-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q6-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-44-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q12-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-44-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q17-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-44-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-44-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666665
+      },
+      "taskId": "conv-44-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.10526315789473685
+      },
+      "taskId": "conv-44-q31-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727272,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727272
+      },
+      "taskId": "conv-44-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-44-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q35-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-44-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-44-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.125,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-44-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.058823529411764705,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.058823529411764705
+      },
+      "taskId": "conv-44-q52-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q53-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13793103448275862
+      },
+      "taskId": "conv-44-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-44-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q65-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q66-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27272727272727276,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.27272727272727276
+      },
+      "taskId": "conv-44-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.43902439024390244,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34146341463414637
+      },
+      "taskId": "conv-44-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-44-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4210526315789473,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4210526315789473
+      },
+      "taskId": "conv-44-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2222222222222222
+      },
+      "taskId": "conv-44-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-44-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5454545454545455,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545455
+      },
+      "taskId": "conv-44-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.20000000000000004,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20000000000000004
+      },
+      "taskId": "conv-44-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-44-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-44-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-44-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q123-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q124-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q125-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q126-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q127-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q128-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q129-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q130-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q131-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q132-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q133-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q134-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q135-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q136-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q137-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5405405405405406,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5405405405405406
+      },
+      "taskId": "conv-44-q138-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q139-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.45454545454545453
+      },
+      "taskId": "conv-44-q140-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q141-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q142-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q143-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q144-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q145-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q146-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q147-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q148-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q149-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-44-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q0-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q1-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q6-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q9-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q11-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q12-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5714285714285715
+      },
+      "taskId": "conv-47-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.16666666666666666
+      },
+      "taskId": "conv-47-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q15-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q16-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q17-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q25-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q27-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q28-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q30-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q33-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q35-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q38-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q42-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q44-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q51-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-47-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-47-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q64-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q68-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q70-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18604651162790695,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13953488372093023
+      },
+      "taskId": "conv-47-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.20689655172413793
+      },
+      "taskId": "conv-47-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347827,
+        "llm_judge": 0.94,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5217391304347827
+      },
+      "taskId": "conv-47-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.06896551724137931
+      },
+      "taskId": "conv-47-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6206896551724138
+      },
+      "taskId": "conv-47-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-47-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-47-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6
+      },
+      "taskId": "conv-47-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-47-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.19999999999999998
+      },
+      "taskId": "conv-47-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.39999999999999997
+      },
+      "taskId": "conv-47-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714285
+      },
+      "taskId": "conv-47-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-47-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q150-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-47-q151-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q152-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q153-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q154-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.46153846153846156
+      },
+      "taskId": "conv-47-q155-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.25,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-47-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-47-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-48-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q3-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q7-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1904761904761905
+      },
+      "taskId": "conv-48-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q11-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.41025641025641024,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2564102564102564
+      },
+      "taskId": "conv-48-q13-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q15-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q16-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q18-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q21-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 0.98,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q23-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q25-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q28-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-48-q29-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q32-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q33-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q36-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q37-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.48648648648648646,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.48648648648648646
+      },
+      "taskId": "conv-48-q39-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-48-q40-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q42-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q46-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q48-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q49-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q54-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q56-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q58-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q59-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q61-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q62-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q63-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q64-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q67-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q69-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q70-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-48-q71-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q73-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q75-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.28571428571428575
+      },
+      "taskId": "conv-48-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q78-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q79-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q80-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q81-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0.6,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11111111111111112
+      },
+      "taskId": "conv-48-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2439024390243902,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14634146341463417
+      },
+      "taskId": "conv-48-q83-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-48-q84-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q85-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q86-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q87-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2
+      },
+      "taskId": "conv-48-q88-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7000000000000001,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7000000000000001
+      },
+      "taskId": "conv-48-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809522
+      },
+      "taskId": "conv-48-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.044444444444444446
+      },
+      "taskId": "conv-48-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.35714285714285715
+      },
+      "taskId": "conv-48-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4666666666666667,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4666666666666667
+      },
+      "taskId": "conv-48-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.18181818181818185
+      },
+      "taskId": "conv-48-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727274,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7272727272727274
+      },
+      "taskId": "conv-48-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3157894736842105
+      },
+      "taskId": "conv-48-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3076923076923077
+      },
+      "taskId": "conv-48-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-48-q158-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q159-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444445
+      },
+      "taskId": "conv-48-q160-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q161-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-48-q162-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q163-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q164-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q165-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q166-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q167-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q168-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-48-q169-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q170-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q171-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q172-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q173-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q174-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q175-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q176-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q177-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q178-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q179-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q180-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q181-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q182-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q183-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q184-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q185-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q186-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q187-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q188-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q189-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q190-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q203-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q204-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q205-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q206-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q207-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q208-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q209-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q210-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q211-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q212-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4
+      },
+      "taskId": "conv-48-q213-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q214-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q215-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q216-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q217-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q218-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q219-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q220-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-48-q221-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q222-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q223-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q224-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q225-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q226-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q227-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q228-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q229-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q230-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q231-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q232-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q233-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q234-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q235-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q236-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q237-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-48-q238-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q0-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q2-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q4-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q5-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0.2,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.33333333333333337
+      },
+      "taskId": "conv-49-q7-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q8-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q10-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q13-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q14-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q16-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21212121212121213,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1515151515151515
+      },
+      "taskId": "conv-49-q19-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q20-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.56,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q21-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q22-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q23-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q24-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q26-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.8,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-49-q27-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q30-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21999999999999997,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13999999999999999
+      },
+      "taskId": "conv-49-q31-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4444444444444444
+      },
+      "taskId": "conv-49-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q34-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q36-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q37-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3859649122807017,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3859649122807017
+      },
+      "taskId": "conv-49-q38-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q39-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q40-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q41-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q42-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q43-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q44-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q45-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.4324324324324324
+      },
+      "taskId": "conv-49-q46-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q47-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q48-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q50-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.27692307692307694,
+        "llm_judge": 0.75,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2153846153846154
+      },
+      "taskId": "conv-49-q51-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q53-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q55-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5217391304347826,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.34782608695652173
+      },
+      "taskId": "conv-49-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q57-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q58-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q59-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q60-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.46,
+        "llm_judge": 0.65,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22
+      },
+      "taskId": "conv-49-q62-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q63-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q65-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q66-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q69-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q71-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q72-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q73-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.22222222222222224
+      },
+      "taskId": "conv-49-q74-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q75-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q76-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q77-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q78-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q79-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q80-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q81-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q82-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.11764705882352941
+      },
+      "taskId": "conv-49-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5454545454545454
+      },
+      "taskId": "conv-49-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-49-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.14285714285714288,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-49-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615385
+      },
+      "taskId": "conv-49-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24000000000000002
+      },
+      "taskId": "conv-49-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.36363636363636365
+      },
+      "taskId": "conv-49-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.12903225806451613
+      },
+      "taskId": "conv-49-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q156-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q157-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.83,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.13333333333333333
+      },
+      "taskId": "conv-49-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.25
+      },
+      "taskId": "conv-49-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-49-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-49-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-49-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q0-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q1-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q2-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q3-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q4-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3703703703703704,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2962962962962963
+      },
+      "taskId": "conv-50-q5-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8
+      },
+      "taskId": "conv-50-q6-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q7-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q8-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q9-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q10-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q11-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q12-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q13-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q14-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q15-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q16-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q17-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q18-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q19-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q20-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q21-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q22-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q23-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q24-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q25-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q26-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q27-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q28-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q29-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q30-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q31-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q32-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q33-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q34-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q35-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q36-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q37-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q38-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q39-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q40-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q41-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q42-temporal"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q43-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q44-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q45-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1818181818181818
+      },
+      "taskId": "conv-50-q46-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q47-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q48-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q49-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q50-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q51-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q52-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q53-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.32653061224489793,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.24489795918367344
+      },
+      "taskId": "conv-50-q54-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q55-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q56-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q57-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.25925925925925924,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1851851851851852
+      },
+      "taskId": "conv-50-q58-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q59-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q60-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q61-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q62-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q63-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q64-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q65-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q66-single_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q67-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q68-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q69-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q70-multi_hop"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q71-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q72-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q73-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6153846153846153
+      },
+      "taskId": "conv-50-q74-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q75-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.125
+      },
+      "taskId": "conv-50-q76-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q77-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q78-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q79-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07692307692307693
+      },
+      "taskId": "conv-50-q80-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q81-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q82-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q83-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.5,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5
+      },
+      "taskId": "conv-50-q84-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q85-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q86-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q87-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q88-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q89-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q90-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q91-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q92-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0.8,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.2857142857142857
+      },
+      "taskId": "conv-50-q93-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q94-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q95-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q96-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q97-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21428571428571425,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14285714285714288
+      },
+      "taskId": "conv-50-q98-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7499999999999999
+      },
+      "taskId": "conv-50-q99-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.6666666666666666
+      },
+      "taskId": "conv-50-q100-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q101-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q102-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q103-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q104-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q105-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q106-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q107-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q108-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q109-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q110-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q111-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.1
+      },
+      "taskId": "conv-50-q112-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5185185185185185,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5185185185185185
+      },
+      "taskId": "conv-50-q113-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q114-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q115-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q116-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15000000000000002
+      },
+      "taskId": "conv-50-q117-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.75
+      },
+      "taskId": "conv-50-q118-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09523809523809525
+      },
+      "taskId": "conv-50-q119-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.05714285714285715,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.05714285714285715
+      },
+      "taskId": "conv-50-q120-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q121-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q122-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15789473684210528
+      },
+      "taskId": "conv-50-q123-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q124-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q125-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q126-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q127-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q128-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q129-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q130-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q131-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.09090909090909091
+      },
+      "taskId": "conv-50-q132-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q133-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q134-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.7692307692307693
+      },
+      "taskId": "conv-50-q135-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q136-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q137-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q138-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q139-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q140-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q141-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q142-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q143-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.5263157894736842
+      },
+      "taskId": "conv-50-q144-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.8333333333333333,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.8333333333333333
+      },
+      "taskId": "conv-50-q145-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q146-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.3333333333333333
+      },
+      "taskId": "conv-50-q147-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.67,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.07407407407407407
+      },
+      "taskId": "conv-50-q148-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.14814814814814814
+      },
+      "taskId": "conv-50-q149-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.5,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q150-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q151-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q152-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q153-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q154-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q155-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q156-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.37037037037037035
+      },
+      "taskId": "conv-50-q157-open_domain"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q158-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q159-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q160-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.14,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q161-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q162-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q163-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q164-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0.85,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0.15384615384615383
+      },
+      "taskId": "conv-50-q165-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q166-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q167-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q168-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q169-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q170-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q171-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q172-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q173-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q174-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q175-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q176-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q177-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q178-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q179-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q180-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q181-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q182-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q183-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q184-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q185-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q186-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q187-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 1
+      },
+      "taskId": "conv-50-q188-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q189-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.33,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q190-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q191-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q192-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q193-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q194-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0.13,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q195-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q196-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q197-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q198-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q199-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q200-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q201-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q202-adversarial"
+    },
+    {
+      "scores": {
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0,
+        "locomo_hidden_evidence_id_leak": 1,
+        "rouge_l": 0
+      },
+      "taskId": "conv-50-q203-adversarial"
+    }
+  ],
+  "schemaVersion": 1,
+  "seed": 1,
+  "startedAt": "2026-07-07T19:57:55.859Z",
+  "system": {
+    "gitSha": "c67c2c72",
+    "name": "remnic",
+    "version": "9.3.727"
+  },
+  "tier": "local"
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, benchmark harness, or default-config behavior changes in the diff.
> 
> **Overview**
> Documents the issue **#1730** single-flag ablation matrix for **LoCoMo** on Tier L (RTX 3090, `qwen2.5-7b-32k`, seed 1): **memory-worth-off**, **contradiction-scan-on**, and **graph-recall-on** vs the baseline artifact `…47aae03.json`.
> 
> The new **`docs/benchmarks/ablations.md`** adds a per-cell metrics table (Δ vs baseline), states that **no shipped recall-stack default changes** because all moves sit inside run-to-run noise, and explains that **contradiction-scan-on** and **graph-recall-on** scored **byte-identical** per-task outputs—likely no-ops under `replayExtractionMode: "skip"`—with variance and self-judge caveats plus repro steps via `scripts/bench/run-ablation-matrix.ts`.
> 
> **`docs/benchmarks.md`** gains a short pointer to that page and the same “within noise / no default change” conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7785bf112adf1e9647f1d4f1c53c0e13daaedec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->