### PR TITLE
refactor(orchestrator): extract compression-guideline learning into CompressionGuidelineCoordinator (#1526)

### DIFF
--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1695,6 +1695,16 @@
       "remnic-source": "./src/orchestration/maintenance.ts",
       "import": "./dist/orchestration/maintenance.js"
     },
+    "./orchestration/compression-guideline-coordinator": {
+      "types": "./dist/orchestration/compression-guideline-coordinator.d.ts",
+      "remnic-source": "./src/orchestration/compression-guideline-coordinator.ts",
+      "import": "./dist/orchestration/compression-guideline-coordinator.js"
+    },
+    "./orchestration/compression-guideline-coordinator.js": {
+      "types": "./dist/orchestration/compression-guideline-coordinator.d.ts",
+      "remnic-source": "./src/orchestration/compression-guideline-coordinator.ts",
+      "import": "./dist/orchestration/compression-guideline-coordinator.js"
+    },
     "./page-versioning": {
       "types": "./dist/page-versioning.d.ts",
       "remnic-source": "./src/page-versioning.ts",

--- a/packages/remnic-core/src/orchestration/compression-guideline-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/compression-guideline-coordinator.ts
@@ -1,0 +1,449 @@
+/**
+ * Compression-guideline learning coordinator — extracted from the
+ * orchestrator (issue #1526, seam 4).
+ *
+ * Owns the compression-guideline learning lifecycle:
+ *   - candidate computation from recorded memory-action events
+ *   - optional LLM semantic refinement of the candidate
+ *   - draft persistence + activation (optimizer/draft state files)
+ *   - the recall section that surfaces active guidelines during recall
+ *   - the consolidation-time learning pass that recomputes the draft
+ *
+ * The orchestrator constructs one instance and delegates the public
+ * entrypoints (`optimizeCompressionGuidelines`,
+ * `activateCompressionGuidelineDraft`) plus the two internal hooks
+ * (`runCompressionGuidelineLearningPass`, called from the consolidation
+ * loop; `buildCompressionGuidelineRecallSection`, called from the recall
+ * pipeline) to it. Storage is the orchestrator's stable `this.storage`;
+ * the fast-tier LLM call arrives as a callback so gateway routing stays
+ * owned by the orchestrator.
+ *
+ * Behavior-preserving move from orchestrator.ts. No logic changes — the
+ * orchestrator keeps thin delegating methods so existing call sites and
+ * tests that exercise the public API continue to work.
+ */
+
+import { createHash } from "node:crypto";
+
+// StorageManager type comes from the package barrel (type-only) so this
+// module does not add a direct storage.ts import (#1533 ratchet).
+import type { StorageManager } from "../index.js";
+import type { PluginConfig, MemoryActionType, MemoryActionEvent } from "../types.js";
+import { log } from "../logger.js";
+import {
+  computeCompressionGuidelineCandidate,
+  refineCompressionGuidelineCandidateSemantically,
+  renderCompressionGuidelinesMarkdown,
+} from "../compression-optimizer.js";
+
+/** Dependencies injected by the orchestrator. All stable references or
+ *  live accessors. */
+export interface CompressionGuidelineCoordinatorDeps {
+  config: PluginConfig;
+  /** Live accessor: the orchestrator's storage manager (stable post-ctor). */
+  getStorage: () => StorageManager;
+  /** Fast-tier LLM call used for optional semantic refinement. Routes
+   *  through the gateway chain when configured — owned by the
+   *  orchestrator, injected here so this module stays LLM-agnostic. */
+  fastChatCompletion: (
+    messages: Array<{ role: string; content: string }>,
+    options: {
+      temperature?: number;
+      maxTokens?: number;
+      timeoutMs?: number;
+      operation?: string;
+      priority?: "background" | "recall-critical";
+    },
+  ) => Promise<{ content: string } | null>;
+}
+
+/**
+ * Coordinates compression-guideline learning. Holds no mutable state of
+ * its own — all persistence flows through the injected storage manager.
+ */
+export class CompressionGuidelineCoordinator {
+  constructor(private readonly deps: CompressionGuidelineCoordinatorDeps) {}
+
+  private get storage(): StorageManager {
+    return this.deps.getStorage();
+  }
+
+  private get config(): PluginConfig {
+    return this.deps.config;
+  }
+
+  async optimizeCompressionGuidelines(options?: {
+    dryRun?: boolean;
+    eventLimit?: number;
+  }): Promise<{
+    enabled: boolean;
+    dryRun: boolean;
+    eventCount: number;
+    previousGuidelineVersion: number | null;
+    nextGuidelineVersion: number;
+    changedRules: number;
+    semanticRefinementApplied: boolean;
+    persisted: boolean;
+    draftContentHash: string | null;
+  }> {
+    const dryRun = options?.dryRun === true;
+    const eventLimit =
+      typeof options?.eventLimit === "number"
+        ? Math.max(0, Math.floor(options.eventLimit))
+        : 500;
+
+    const [activeState, draftState] = await Promise.all([
+      this.storage.readCompressionGuidelineOptimizerState(),
+      this.storage.readCompressionGuidelineDraftState().catch(() => null),
+    ]);
+    const previousState =
+      draftState &&
+      ((activeState?.guidelineVersion ?? 0) < draftState.guidelineVersion ||
+        (activeState?.guidelineVersion ?? 0) === draftState.guidelineVersion)
+        ? draftState
+        : activeState;
+
+    if (!this.config.compressionGuidelineLearningEnabled) {
+      return {
+        enabled: false,
+        dryRun,
+        eventCount: 0,
+        previousGuidelineVersion: previousState?.guidelineVersion ?? null,
+        nextGuidelineVersion: previousState?.guidelineVersion ?? 0,
+        changedRules: 0,
+        semanticRefinementApplied: false,
+        persisted: false,
+        draftContentHash: null,
+      };
+    }
+
+    let events = await this.storage.readMemoryActionEvents(eventLimit);
+    if (eventLimit > 0) {
+      let effectiveEvents = events.filter((event) => event.dryRun !== true);
+      let fetchLimit = eventLimit;
+      while (
+        effectiveEvents.length < eventLimit &&
+        events.length === fetchLimit
+      ) {
+        fetchLimit = Math.min(fetchLimit * 2, fetchLimit + 1000);
+        if (fetchLimit <= events.length) break;
+        events = await this.storage.readMemoryActionEvents(fetchLimit);
+        effectiveEvents = events.filter((event) => event.dryRun !== true);
+      }
+      events = effectiveEvents.slice(-eventLimit);
+    }
+    const generatedAt = new Date().toISOString();
+    const candidate = computeCompressionGuidelineCandidate(events, {
+      generatedAtIso: generatedAt,
+      previousState,
+    });
+    if (candidate.eventCounts.total === 0) {
+      return {
+        enabled: true,
+        dryRun,
+        eventCount: 0,
+        previousGuidelineVersion: previousState?.guidelineVersion ?? null,
+        nextGuidelineVersion: previousState?.guidelineVersion ?? 0,
+        changedRules: 0,
+        semanticRefinementApplied: false,
+        persisted: false,
+        draftContentHash: null,
+      };
+    }
+    const refinedCandidate =
+      await refineCompressionGuidelineCandidateSemantically(candidate, {
+        enabled: this.config.compressionGuidelineSemanticRefinementEnabled,
+        timeoutMs: this.config.compressionGuidelineSemanticTimeoutMs,
+        runRefinement: async (baseline) => {
+          const prompt = [
+            "You refine compression policy suggestions conservatively.",
+            "Return JSON only in this shape:",
+            '{"updates":[{"action":"summarize_node","delta":0.02,"confidence":"medium","note":"..."}]}',
+            "Constraints:",
+            "- Keep updates sparse and conservative.",
+            "- delta must stay between -0.15 and 0.15.",
+            "- Only include actions present in the input.",
+            "Input candidate:",
+            JSON.stringify(baseline),
+          ].join("\n");
+
+          const response = await this.deps.fastChatCompletion(
+            [
+              {
+                role: "system",
+                content: "Respond with strict JSON only. No markdown.",
+              },
+              { role: "user", content: prompt },
+            ],
+            {
+              temperature: 0.1,
+              maxTokens: 400,
+              operation: "compression_guideline_semantic_refinement",
+              priority: "background",
+            },
+          );
+
+          return this.parseCompressionSemanticRefinement(
+            response?.content ?? "",
+          );
+        },
+      });
+
+    const content = renderCompressionGuidelinesMarkdown(refinedCandidate);
+    const contentHash = createHash("sha256").update(content).digest("hex");
+    const semanticRefinementApplied =
+      JSON.stringify(refinedCandidate.ruleUpdates) !==
+      JSON.stringify(candidate.ruleUpdates);
+    const changedRules = refinedCandidate.ruleUpdates.filter(
+      (rule) => rule.delta !== 0,
+    ).length;
+
+    if (!dryRun) {
+      await this.storage.writeCompressionGuidelineDraft(content);
+      await this.storage.writeCompressionGuidelineDraftState({
+        version: refinedCandidate.optimizerVersion,
+        updatedAt: refinedCandidate.generatedAt,
+        sourceWindow: refinedCandidate.sourceWindow,
+        eventCounts: refinedCandidate.eventCounts,
+        guidelineVersion: refinedCandidate.guidelineVersion,
+        contentHash,
+        activationState: "draft",
+        actionSummaries: refinedCandidate.actionSummaries,
+        ruleUpdates: refinedCandidate.ruleUpdates,
+      });
+    }
+
+    return {
+      enabled: true,
+      dryRun,
+      eventCount: candidate.eventCounts.total,
+      previousGuidelineVersion: previousState?.guidelineVersion ?? null,
+      nextGuidelineVersion: refinedCandidate.guidelineVersion,
+      changedRules,
+      semanticRefinementApplied,
+      persisted: !dryRun,
+      draftContentHash: dryRun ? null : contentHash,
+    };
+  }
+
+  async activateCompressionGuidelineDraft(options?: {
+    expectedContentHash?: string;
+    expectedGuidelineVersion?: number;
+  }): Promise<{
+    enabled: boolean;
+    activated: boolean;
+    guidelineVersion: number | null;
+    reason?:
+      | "disabled"
+      | "missing_draft"
+      | "expected_revision_required"
+      | "content_hash_mismatch"
+      | "guideline_version_mismatch"
+      | "draft_changed";
+  }> {
+    if (!this.config.compressionGuidelineLearningEnabled) {
+      return {
+        enabled: false,
+        activated: false,
+        guidelineVersion: null,
+        reason: "disabled",
+      };
+    }
+
+    const draftState = await this.storage.readCompressionGuidelineDraftState();
+    if (!draftState) {
+      return {
+        enabled: true,
+        activated: false,
+        guidelineVersion: null,
+        reason: "missing_draft",
+      };
+    }
+
+    const expectedContentHash = options?.expectedContentHash?.trim();
+    const expectedGuidelineVersion = options?.expectedGuidelineVersion;
+
+    if (
+      (!expectedContentHash || expectedContentHash.length === 0) &&
+      typeof expectedGuidelineVersion !== "number"
+    ) {
+      return {
+        enabled: true,
+        activated: false,
+        guidelineVersion: null,
+        reason: "expected_revision_required",
+      };
+    }
+
+    if (expectedContentHash && draftState.contentHash !== expectedContentHash) {
+      return {
+        enabled: true,
+        activated: false,
+        guidelineVersion: null,
+        reason: "content_hash_mismatch",
+      };
+    }
+
+    if (
+      typeof expectedGuidelineVersion === "number" &&
+      draftState.guidelineVersion !== expectedGuidelineVersion
+    ) {
+      return {
+        enabled: true,
+        activated: false,
+        guidelineVersion: null,
+        reason: "guideline_version_mismatch",
+      };
+    }
+
+    const activated = await this.storage.activateCompressionGuidelineDraft({
+      ...(expectedContentHash ? { expectedContentHash } : {}),
+      ...(typeof expectedGuidelineVersion === "number"
+        ? { expectedGuidelineVersion }
+        : {}),
+    });
+    return {
+      enabled: true,
+      activated,
+      guidelineVersion: activated ? draftState.guidelineVersion : null,
+      ...(activated ? {} : { reason: "draft_changed" as const }),
+    };
+  }
+
+  /** Consolidation-time hook: recompute the draft from recent events. */
+  async runCompressionGuidelineLearningPass(): Promise<void> {
+    if (!this.config.compressionGuidelineLearningEnabled) return;
+    try {
+      const result = await this.optimizeCompressionGuidelines({
+        dryRun: false,
+        eventLimit: 500,
+      });
+      log.info(
+        `compression guideline learning updated (${result.eventCount} events)`,
+      );
+    } catch (err) {
+      log.warn(`compression guideline learning failed (ignored): ${err}`);
+    }
+  }
+
+  /** Recall-time hook: surface active guidelines as a recall section. */
+  async buildCompressionGuidelineRecallSection(): Promise<string | null> {
+    if (!this.config.contextCompressionActionsEnabled) return null;
+    if (!this.config.compressionGuidelineLearningEnabled) return null;
+
+    const state = await this.storage
+      .readCompressionGuidelineOptimizerState()
+      .catch(() => null);
+    if (!state || state.guidelineVersion <= 0) return null;
+
+    const raw = await this.storage
+      .readCompressionGuidelines()
+      .catch(() => null);
+    const summary = raw ? formatCompressionGuidelinesForRecall(raw, 5) : null;
+    if (!summary) return null;
+
+    return [
+      "## Active Compression Guidelines",
+      "",
+      `Guideline version: ${state.guidelineVersion}`,
+      `Updated: ${state.updatedAt}`,
+      "",
+      summary,
+    ].join("\n");
+  }
+
+  private parseCompressionSemanticRefinement(raw: string): {
+    updates: Array<{
+      action: MemoryActionType;
+      delta?: number;
+      confidence?: "low" | "medium" | "high";
+      note?: string;
+    }>;
+  } | null {
+    if (typeof raw !== "string" || raw.trim().length === 0) return null;
+    const trimmed = raw.trim();
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start === -1 || end === -1 || end <= start) return null;
+
+    try {
+      const parsed = JSON.parse(trimmed.slice(start, end + 1)) as {
+        updates?: Array<{
+          action?: unknown;
+          delta?: unknown;
+          confidence?: unknown;
+          note?: unknown;
+        }>;
+      };
+      if (!Array.isArray(parsed?.updates)) return null;
+
+      const validActions = new Set<MemoryActionType>([
+        "store_episode",
+        "store_note",
+        "update_note",
+        "create_artifact",
+        "summarize_node",
+        "discard",
+        "link_graph",
+      ]);
+
+      const updates = parsed.updates
+        .filter(
+          (item) =>
+            item &&
+            typeof item.action === "string" &&
+            validActions.has(item.action as MemoryActionType),
+        )
+        .map((item) => {
+          const confidence: "low" | "medium" | "high" | undefined =
+            item.confidence === "low" ||
+            item.confidence === "medium" ||
+            item.confidence === "high"
+              ? item.confidence
+              : undefined;
+          return {
+            action: item.action as MemoryActionType,
+            delta:
+              typeof item.delta === "number" && Number.isFinite(item.delta)
+                ? item.delta
+                : undefined,
+            confidence,
+            note: typeof item.note === "string" ? item.note : undefined,
+          };
+        });
+
+      return { updates };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Format the active compression-guidelines section for recall. Extracted
+ * from the orchestrator (was a module-level export there); re-exported by
+ * the orchestrator barrel to preserve the public API. Pure — no state.
+ */
+export function formatCompressionGuidelinesForRecall(
+  raw: string,
+  maxLines: number = 5,
+): string | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const sectionMatch = raw.match(
+    // End the section at `\n## ` or end-of-string. Plain $ (not \s*$): the
+    // \s* branch overlapped the lazy body and backtracked polynomially
+    // (CodeQL js/polynomial-redos). Captured lines are trimmed/filtered below,
+    // so trailing whitespace handling is unchanged.
+    /## Suggested Guidelines\s*\n([\s\S]*?)(?:\n##\s+|$)/i,
+  );
+  if (!sectionMatch) return null;
+
+  const lines = sectionMatch[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .slice(0, Math.max(1, Math.floor(maxLines)));
+  if (lines.length === 0) return null;
+
+  return lines.join("\n");
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -100,6 +100,7 @@ import {
 import { MaintenanceScheduler } from "./orchestration/maintenance.js";
 import { TierMigrationCoordinator } from "./orchestration/tier-migration-coordinator.js";
 import { ExtractionQueueCoordinator } from "./orchestration/extraction-queue-coordinator.js";
+import { CompressionGuidelineCoordinator } from "./orchestration/compression-guideline-coordinator.js";
 import {
   runLiveConnectorsOnce,
   type LiveConnectorsRunSummary,
@@ -224,10 +225,8 @@ import { parseMemoryActionEligibilityContext } from "./schemas.js";
 import { evaluateMemoryActionPolicy } from "./memory-action-policy.js";
 import {
   buildCompressionGuidelinesMarkdown as buildCompressionGuidelinesMarkdownV2,
-  computeCompressionGuidelineCandidate,
-  refineCompressionGuidelineCandidateSemantically,
-  renderCompressionGuidelinesMarkdown,
 } from "./compression-optimizer.js";
+export { formatCompressionGuidelinesForRecall } from "./orchestration/compression-guideline-coordinator.js";
 import { createRecallSectionMetricRecorder } from "./recall-qos.js";
 import { BoxBuilder, type BoxFrontmatter } from "./boxes.js";
 import { classifyMemoryKind } from "./himem.js";
@@ -1206,30 +1205,6 @@ export function buildCompressionGuidelinesMarkdown(
   return buildCompressionGuidelinesMarkdownV2(events, generatedAtIso);
 }
 
-export function formatCompressionGuidelinesForRecall(
-  raw: string,
-  maxLines: number = 5,
-): string | null {
-  if (typeof raw !== "string" || raw.trim().length === 0) return null;
-  const sectionMatch = raw.match(
-    // End the section at `\n## ` or end-of-string. Plain $ (not \s*$): the
-    // \s* branch overlapped the lazy body and backtracked polynomially
-    // (CodeQL js/polynomial-redos). Captured lines are trimmed/filtered below,
-    // so trailing whitespace handling is unchanged.
-    /## Suggested Guidelines\s*\n([\s\S]*?)(?:\n##\s+|$)/i,
-  );
-  if (!sectionMatch) return null;
-
-  const lines = sectionMatch[1]
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith("- "))
-    .slice(0, Math.max(1, Math.floor(maxLines)));
-  if (lines.length === 0) return null;
-
-  return lines.join("\n");
-}
-
 export function filterRecallCandidates(
   candidates: QmdSearchResult[],
   options: {
@@ -1920,6 +1895,7 @@ export class Orchestrator {
   readonly handleHistory: RecallHandleHistoryStore;
   readonly tierMigrationStatus: TierMigrationStatusStore;
   readonly tierMigrationCoordinator: TierMigrationCoordinator;
+  readonly compressionGuidelineCoordinator: CompressionGuidelineCoordinator;
   /**
    * In-memory X-ray snapshot from the most recent `recall()` call that
    * was invoked with `xrayCapture: true` (issue #570 PR 1).  Scope is
@@ -3036,6 +3012,12 @@ export class Orchestrator {
       getUtilityRuntimeValues: () => this.utilityRuntimeValues,
       getCompounding: () => this.compounding,
       createColdStorage: (parentDir) => new StorageManager(parentDir),
+    });
+    this.compressionGuidelineCoordinator = new CompressionGuidelineCoordinator({
+      config,
+      getStorage: () => this.storage,
+      fastChatCompletion: (messages, options) =>
+        this.fastChatCompletion(messages, options),
     });
     this.sessionObserver = new SessionObserverState({
       memoryDir: config.memoryDir,
@@ -17352,347 +17334,26 @@ export class Orchestrator {
   async optimizeCompressionGuidelines(options?: {
     dryRun?: boolean;
     eventLimit?: number;
-  }): Promise<{
-    enabled: boolean;
-    dryRun: boolean;
-    eventCount: number;
-    previousGuidelineVersion: number | null;
-    nextGuidelineVersion: number;
-    changedRules: number;
-    semanticRefinementApplied: boolean;
-    persisted: boolean;
-    draftContentHash: string | null;
-  }> {
-    const dryRun = options?.dryRun === true;
-    const eventLimit =
-      typeof options?.eventLimit === "number"
-        ? Math.max(0, Math.floor(options.eventLimit))
-        : 500;
-
-    const [activeState, draftState] = await Promise.all([
-      this.storage.readCompressionGuidelineOptimizerState(),
-      this.storage.readCompressionGuidelineDraftState().catch(() => null),
-    ]);
-    const previousState =
-      draftState &&
-      ((activeState?.guidelineVersion ?? 0) < draftState.guidelineVersion ||
-        (activeState?.guidelineVersion ?? 0) === draftState.guidelineVersion)
-        ? draftState
-        : activeState;
-
-    if (!this.config.compressionGuidelineLearningEnabled) {
-      return {
-        enabled: false,
-        dryRun,
-        eventCount: 0,
-        previousGuidelineVersion: previousState?.guidelineVersion ?? null,
-        nextGuidelineVersion: previousState?.guidelineVersion ?? 0,
-        changedRules: 0,
-        semanticRefinementApplied: false,
-        persisted: false,
-        draftContentHash: null,
-      };
-    }
-
-    let events = await this.storage.readMemoryActionEvents(eventLimit);
-    if (eventLimit > 0) {
-      let effectiveEvents = events.filter((event) => event.dryRun !== true);
-      let fetchLimit = eventLimit;
-      while (
-        effectiveEvents.length < eventLimit &&
-        events.length === fetchLimit
-      ) {
-        fetchLimit = Math.min(fetchLimit * 2, fetchLimit + 1000);
-        if (fetchLimit <= events.length) break;
-        events = await this.storage.readMemoryActionEvents(fetchLimit);
-        effectiveEvents = events.filter((event) => event.dryRun !== true);
-      }
-      events = effectiveEvents.slice(-eventLimit);
-    }
-    const generatedAt = new Date().toISOString();
-    const candidate = computeCompressionGuidelineCandidate(events, {
-      generatedAtIso: generatedAt,
-      previousState,
-    });
-    if (candidate.eventCounts.total === 0) {
-      return {
-        enabled: true,
-        dryRun,
-        eventCount: 0,
-        previousGuidelineVersion: previousState?.guidelineVersion ?? null,
-        nextGuidelineVersion: previousState?.guidelineVersion ?? 0,
-        changedRules: 0,
-        semanticRefinementApplied: false,
-        persisted: false,
-        draftContentHash: null,
-      };
-    }
-    const refinedCandidate =
-      await refineCompressionGuidelineCandidateSemantically(candidate, {
-        enabled: this.config.compressionGuidelineSemanticRefinementEnabled,
-        timeoutMs: this.config.compressionGuidelineSemanticTimeoutMs,
-        runRefinement: async (baseline) => {
-          const prompt = [
-            "You refine compression policy suggestions conservatively.",
-            "Return JSON only in this shape:",
-            '{"updates":[{"action":"summarize_node","delta":0.02,"confidence":"medium","note":"..."}]}',
-            "Constraints:",
-            "- Keep updates sparse and conservative.",
-            "- delta must stay between -0.15 and 0.15.",
-            "- Only include actions present in the input.",
-            "Input candidate:",
-            JSON.stringify(baseline),
-          ].join("\n");
-
-          const response = await this.fastChatCompletion(
-            [
-              {
-                role: "system",
-                content: "Respond with strict JSON only. No markdown.",
-              },
-              { role: "user", content: prompt },
-            ],
-            {
-              temperature: 0.1,
-              maxTokens: 400,
-              operation: "compression_guideline_semantic_refinement",
-              priority: "background",
-            },
-          );
-
-          return this.parseCompressionSemanticRefinement(
-            response?.content ?? "",
-          );
-        },
-      });
-
-    const content = renderCompressionGuidelinesMarkdown(refinedCandidate);
-    const contentHash = createHash("sha256").update(content).digest("hex");
-    const semanticRefinementApplied =
-      JSON.stringify(refinedCandidate.ruleUpdates) !==
-      JSON.stringify(candidate.ruleUpdates);
-    const changedRules = refinedCandidate.ruleUpdates.filter(
-      (rule) => rule.delta !== 0,
-    ).length;
-
-    if (!dryRun) {
-      await this.storage.writeCompressionGuidelineDraft(content);
-      await this.storage.writeCompressionGuidelineDraftState({
-        version: refinedCandidate.optimizerVersion,
-        updatedAt: refinedCandidate.generatedAt,
-        sourceWindow: refinedCandidate.sourceWindow,
-        eventCounts: refinedCandidate.eventCounts,
-        guidelineVersion: refinedCandidate.guidelineVersion,
-        contentHash,
-        activationState: "draft",
-        actionSummaries: refinedCandidate.actionSummaries,
-        ruleUpdates: refinedCandidate.ruleUpdates,
-      });
-    }
-
-    return {
-      enabled: true,
-      dryRun,
-      eventCount: candidate.eventCounts.total,
-      previousGuidelineVersion: previousState?.guidelineVersion ?? null,
-      nextGuidelineVersion: refinedCandidate.guidelineVersion,
-      changedRules,
-      semanticRefinementApplied,
-      persisted: !dryRun,
-      draftContentHash: dryRun ? null : contentHash,
-    };
+  }) {
+    return this.compressionGuidelineCoordinator.optimizeCompressionGuidelines(options);
   }
 
   async activateCompressionGuidelineDraft(options?: {
     expectedContentHash?: string;
     expectedGuidelineVersion?: number;
-  }): Promise<{
-    enabled: boolean;
-    activated: boolean;
-    guidelineVersion: number | null;
-    reason?:
-      | "disabled"
-      | "missing_draft"
-      | "expected_revision_required"
-      | "content_hash_mismatch"
-      | "guideline_version_mismatch"
-      | "draft_changed";
-  }> {
-    if (!this.config.compressionGuidelineLearningEnabled) {
-      return {
-        enabled: false,
-        activated: false,
-        guidelineVersion: null,
-        reason: "disabled",
-      };
-    }
-
-    const draftState = await this.storage.readCompressionGuidelineDraftState();
-    if (!draftState) {
-      return {
-        enabled: true,
-        activated: false,
-        guidelineVersion: null,
-        reason: "missing_draft",
-      };
-    }
-
-    const expectedContentHash = options?.expectedContentHash?.trim();
-    const expectedGuidelineVersion = options?.expectedGuidelineVersion;
-
-    if (
-      (!expectedContentHash || expectedContentHash.length === 0) &&
-      typeof expectedGuidelineVersion !== "number"
-    ) {
-      return {
-        enabled: true,
-        activated: false,
-        guidelineVersion: null,
-        reason: "expected_revision_required",
-      };
-    }
-
-    if (expectedContentHash && draftState.contentHash !== expectedContentHash) {
-      return {
-        enabled: true,
-        activated: false,
-        guidelineVersion: null,
-        reason: "content_hash_mismatch",
-      };
-    }
-
-    if (
-      typeof expectedGuidelineVersion === "number" &&
-      draftState.guidelineVersion !== expectedGuidelineVersion
-    ) {
-      return {
-        enabled: true,
-        activated: false,
-        guidelineVersion: null,
-        reason: "guideline_version_mismatch",
-      };
-    }
-
-    const activated = await this.storage.activateCompressionGuidelineDraft({
-      ...(expectedContentHash ? { expectedContentHash } : {}),
-      ...(typeof expectedGuidelineVersion === "number"
-        ? { expectedGuidelineVersion }
-        : {}),
-    });
-    return {
-      enabled: true,
-      activated,
-      guidelineVersion: activated ? draftState.guidelineVersion : null,
-      ...(activated ? {} : { reason: "draft_changed" as const }),
-    };
+  }) {
+    return this.compressionGuidelineCoordinator.activateCompressionGuidelineDraft(options);
   }
 
+  // Issue #1526 (seam 4): compression-guideline learning moved to
+  // CompressionGuidelineCoordinator. Thin delegation keeps the
+  // consolidation-loop hook + recall-section hook call sites stable.
   private async runCompressionGuidelineLearningPass(): Promise<void> {
-    if (!this.config.compressionGuidelineLearningEnabled) return;
-    try {
-      const result = await this.optimizeCompressionGuidelines({
-        dryRun: false,
-        eventLimit: 500,
-      });
-      log.info(
-        `compression guideline learning updated (${result.eventCount} events)`,
-      );
-    } catch (err) {
-      log.warn(`compression guideline learning failed (ignored): ${err}`);
-    }
+    return this.compressionGuidelineCoordinator.runCompressionGuidelineLearningPass();
   }
 
-  private async buildCompressionGuidelineRecallSection(): Promise<
-    string | null
-  > {
-    if (!this.config.contextCompressionActionsEnabled) return null;
-    if (!this.config.compressionGuidelineLearningEnabled) return null;
-
-    const state = await this.storage
-      .readCompressionGuidelineOptimizerState()
-      .catch(() => null);
-    if (!state || state.guidelineVersion <= 0) return null;
-
-    const raw = await this.storage
-      .readCompressionGuidelines()
-      .catch(() => null);
-    const summary = raw ? formatCompressionGuidelinesForRecall(raw, 5) : null;
-    if (!summary) return null;
-
-    return [
-      "## Active Compression Guidelines",
-      "",
-      `Guideline version: ${state.guidelineVersion}`,
-      `Updated: ${state.updatedAt}`,
-      "",
-      summary,
-    ].join("\n");
-  }
-
-  private parseCompressionSemanticRefinement(raw: string): {
-    updates: Array<{
-      action: MemoryActionType;
-      delta?: number;
-      confidence?: "low" | "medium" | "high";
-      note?: string;
-    }>;
-  } | null {
-    if (typeof raw !== "string" || raw.trim().length === 0) return null;
-    const trimmed = raw.trim();
-    const start = trimmed.indexOf("{");
-    const end = trimmed.lastIndexOf("}");
-    if (start === -1 || end === -1 || end <= start) return null;
-
-    try {
-      const parsed = JSON.parse(trimmed.slice(start, end + 1)) as {
-        updates?: Array<{
-          action?: unknown;
-          delta?: unknown;
-          confidence?: unknown;
-          note?: unknown;
-        }>;
-      };
-      if (!Array.isArray(parsed?.updates)) return null;
-
-      const validActions = new Set<MemoryActionType>([
-        "store_episode",
-        "store_note",
-        "update_note",
-        "create_artifact",
-        "summarize_node",
-        "discard",
-        "link_graph",
-      ]);
-
-      const updates = parsed.updates
-        .filter(
-          (item) =>
-            item &&
-            typeof item.action === "string" &&
-            validActions.has(item.action as MemoryActionType),
-        )
-        .map((item) => {
-          const confidence: "low" | "medium" | "high" | undefined =
-            item.confidence === "low" ||
-            item.confidence === "medium" ||
-            item.confidence === "high"
-              ? item.confidence
-              : undefined;
-          return {
-            action: item.action as MemoryActionType,
-            delta:
-              typeof item.delta === "number" && Number.isFinite(item.delta)
-                ? item.delta
-                : undefined,
-            confidence,
-            note: typeof item.note === "string" ? item.note : undefined,
-          };
-        });
-
-      return { updates };
-    } catch {
-      return null;
-    }
+  private async buildCompressionGuidelineRecallSection(): Promise<string | null> {
+    return this.compressionGuidelineCoordinator.buildCompressionGuidelineRecallSection();
   }
 
   private actionOutcomePriorDelta(event: MemoryActionEvent): number {

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20993,
+      "packages/remnic-core/src/orchestrator.ts": 20654,
       "packages/remnic-core/src/cli.ts": 9390,
       "packages/remnic-core/src/access-service.ts": 9012,
       "packages/remnic-core/src/storage.ts": 7747,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -497,7 +497,7 @@ tests/operator-toolkit.test.ts(438,83): TS2345
 tests/operator-toolkit.test.ts(464,82): TS2345
 tests/operator-toolkit.test.ts(533,82): TS2345
 tests/operator-toolkit.test.ts(534,83): TS2345
-tests/orchestrator-compression-guidelines.test.ts(322,18): TS2540
+tests/orchestrator-compression-guidelines.test.ts(336,18): TS2540
 tests/orchestrator-path-filter.test.ts(30,43): TS2345
 tests/orchestrator-path-filter.test.ts(55,43): TS2345
 tests/orchestrator-path-filter.test.ts(86,8): TS2322

--- a/src/orchestration/compression-guideline-coordinator.ts
+++ b/src/orchestration/compression-guideline-coordinator.ts
@@ -1,0 +1,1 @@
+export * from "@remnic/core/orchestration/compression-guideline-coordinator";

--- a/tests/orchestrator-compression-guidelines.test.ts
+++ b/tests/orchestrator-compression-guidelines.test.ts
@@ -5,7 +5,18 @@ import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { buildCompressionGuidelinesMarkdown, Orchestrator } from "../src/orchestrator.ts";
+import { CompressionGuidelineCoordinator } from "../src/orchestration/compression-guideline-coordinator.js";
 import type { MemoryActionEvent } from "../src/types.ts";
+/** Build a CompressionGuidelineCoordinator from a fake ctx (config + storage),
+ *  mirroring the old Orchestrator.prototype-based unit tests. The logic now
+ *  lives on the coordinator (#1526 seam 4). */
+function makeCoordinator(ctx: any): CompressionGuidelineCoordinator {
+  return new CompressionGuidelineCoordinator({
+    config: ctx.config,
+    getStorage: () => ctx.storage,
+    fastChatCompletion: async () => null,
+  });
+}
 
 test("buildCompressionGuidelinesMarkdown emits conservative guidance with no telemetry", () => {
   const doc = buildCompressionGuidelinesMarkdown([], "2026-02-23T00:00:00.000Z");
@@ -43,25 +54,28 @@ test("buildCompressionGuidelinesMarkdown includes stable guidance when outcomes 
 test("runCompressionGuidelineLearningPass delegates to optimizeCompressionGuidelines when enabled", async () => {
   let called = 0;
   let received: { dryRun?: boolean; eventLimit?: number } | null = null;
-  const ctx: any = {
-    config: { compressionGuidelineLearningEnabled: true },
-    optimizeCompressionGuidelines: async (options: { dryRun?: boolean; eventLimit?: number }) => {
-      called += 1;
-      received = options;
-      return {
-        enabled: true,
-        dryRun: false,
-        eventCount: 1,
-        previousGuidelineVersion: null,
-        nextGuidelineVersion: 1,
-        changedRules: 0,
-        semanticRefinementApplied: false,
-        persisted: true,
-      };
-    },
+  const coordinator = new CompressionGuidelineCoordinator({
+    config: { compressionGuidelineLearningEnabled: true } as any,
+    getStorage: () => ({}) as any,
+    fastChatCompletion: async () => null,
+  });
+  coordinator.optimizeCompressionGuidelines = async (options: { dryRun?: boolean; eventLimit?: number }) => {
+    called += 1;
+    received = options;
+    return {
+      enabled: true,
+      dryRun: false,
+      eventCount: 1,
+      previousGuidelineVersion: null,
+      nextGuidelineVersion: 1,
+      changedRules: 0,
+      semanticRefinementApplied: false,
+      persisted: true,
+      draftContentHash: null,
+    };
   };
 
-  await (Orchestrator.prototype as any).runCompressionGuidelineLearningPass.call(ctx);
+  await coordinator.runCompressionGuidelineLearningPass();
   assert.equal(called, 1);
   assert.deepEqual(received, { dryRun: false, eventLimit: 500 });
 });
@@ -82,7 +96,7 @@ test("runCompressionGuidelineLearningPass is a no-op when disabled", async () =>
     },
   };
 
-  await (Orchestrator.prototype as any).runCompressionGuidelineLearningPass.call(ctx);
+  await makeCoordinator(ctx).runCompressionGuidelineLearningPass();
   assert.equal(readCalled, 0);
   assert.equal(writeCalled, 0);
 });
@@ -118,7 +132,7 @@ test("optimizeCompressionGuidelines does not publish new state for dry-run-only 
     },
   };
 
-  const result = await (Orchestrator.prototype as any).optimizeCompressionGuidelines.call(ctx, {
+  const result = await makeCoordinator(ctx).optimizeCompressionGuidelines({
     dryRun: false,
     eventLimit: 500,
   });
@@ -168,7 +182,7 @@ test("optimizeCompressionGuidelines over-fetches until it collects enough non-dr
     },
   };
 
-  const result = await (Orchestrator.prototype as any).optimizeCompressionGuidelines.call(ctx, {
+  const result = await makeCoordinator(ctx).optimizeCompressionGuidelines({
     dryRun: false,
     eventLimit: 2,
   });

--- a/tests/recall-compression-guideline-application.test.ts
+++ b/tests/recall-compression-guideline-application.test.ts
@@ -1,6 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { formatCompressionGuidelinesForRecall, Orchestrator } from "../src/orchestrator.ts";
+import { formatCompressionGuidelinesForRecall } from "../src/orchestrator.ts";
+import { CompressionGuidelineCoordinator } from "../src/orchestration/compression-guideline-coordinator.js";
+/** Build a CompressionGuidelineCoordinator from a fake ctx (config + storage),
+ *  mirroring the old Orchestrator.prototype-based unit tests. The logic now
+ *  lives on the coordinator (#1526 seam 4). */
+function makeCoordinator(ctx: any): CompressionGuidelineCoordinator {
+  return new CompressionGuidelineCoordinator({
+    config: ctx.config,
+    getStorage: () => ctx.storage,
+    fastChatCompletion: async () => null,
+  });
+}
 
 test("formatCompressionGuidelinesForRecall extracts suggested guideline bullets", () => {
   const raw = [
@@ -47,7 +58,7 @@ test("buildCompressionGuidelineRecallSection keeps zero-change path when optimiz
     },
   };
 
-  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  const section = await makeCoordinator(ctx).buildCompressionGuidelineRecallSection();
   assert.equal(section, null);
   assert.equal(stateReads, 0);
   assert.equal(guidelineReads, 0);
@@ -82,7 +93,7 @@ test("buildCompressionGuidelineRecallSection emits active guideline section when
     },
   };
 
-  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  const section = await makeCoordinator(ctx).buildCompressionGuidelineRecallSection();
   assert.ok(section);
   assert.match(section ?? "", /## Active Compression Guidelines/);
   assert.match(section ?? "", /Guideline version: 3/);
@@ -130,7 +141,7 @@ test("buildCompressionGuidelineRecallSection keeps the active guideline visible 
     },
   };
 
-  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  const section = await makeCoordinator(ctx).buildCompressionGuidelineRecallSection();
   assert.ok(section);
   assert.match(section ?? "", /Guideline version: 3/);
   assert.doesNotMatch(section ?? "", /Guideline version: 4/);
@@ -148,6 +159,6 @@ test("buildCompressionGuidelineRecallSection fail-opens on malformed guideline s
     },
   };
 
-  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  const section = await makeCoordinator(ctx).buildCompressionGuidelineRecallSection();
   assert.equal(section, null);
 });


### PR DESCRIPTION
Seam 4 of the orchestrator decomposition (#1526), following the MaintenanceScheduler (#1625), TierMigrationCoordinator (#1696), and ExtractionQueueCoordinator (#1749) extractions.

## What

Moves the **compression-guideline learning lifecycle** out of the 20.9k-LOC orchestrator god file into a new dependency-injected `orchestration/compression-guideline-coordinator.ts`:

- `optimizeCompressionGuidelines` — candidate computation from recorded memory-action events + optional LLM semantic refinement + draft persistence
- `activateCompressionGuidelineDraft` — draft activation with revision guards
- `runCompressionGuidelineLearningPass` — consolidation-loop hook
- `buildCompressionGuidelineRecallSection` — recall-pipeline hook
- `parseCompressionSemanticRefinement` — private JSON-parsing helper
- `formatCompressionGuidelinesForRecall` — pure recall formatter (moved + re-exported to preserve the public surface)

The orchestrator constructs one `CompressionGuidelineCoordinator` and delegates via thin methods, so the public API and the two internal hooks (consolidation loop at `runConsolidation`, recall section assembly) are unchanged. Storage arrives via a live accessor; the fast-tier LLM call arrives as a callback so gateway routing stays owned by the orchestrator.

## Why this seam

After the three landed seams, the compression-guideline learning block (~345 LOC) was the largest remaining cohesive, self-contained lifecycle seam with a clean dependency boundary (storage + config + one LLM callback). Recall-context assembly is lane R2 (#1539); the consolidation master loop is too entangled with orchestrator state to move cleanly in one pass.

## Behavior-preserving

- Code moved byte-for-byte; only `this.fastChatCompletion` → `this.deps.fastChatCompletion` and `this.parseCompressionSemanticRefinement` stays internal to the coordinator.
- `orchestrator-characterization` snapshots unchanged.
- `formatCompressionGuidelinesForRecall` re-exported from the orchestrator barrel — no public-API change.

## Metrics

- `orchestrator.ts`: **20989 → 20650 LOC (−339)**
- ratchet baseline tightened (`watchlistLoc`).

## Verification

- `pnpm --filter @remnic/core build` ✓
- `pnpm run test:entity-hardening` → **246/246 pass**
- `node scripts/check-ratchets.mjs` → OK (improvement detected, baseline updated)
- `preflight:quick`: lint ✓, check-types ✓, ratchets ✓, docs-parity ✓, review-patterns PASSED ✓

Chokepoints used: none (pure behavior-preserving extraction, no new surfaces).
Refs #1526.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor with delegation-only orchestrator changes; recall and consolidation hooks unchanged.
> 
> **Overview**
> Moves compression-guideline learning (~340 LOC) out of `orchestrator.ts` into a new **`CompressionGuidelineCoordinator`** module, continuing the orchestrator decomposition (#1526 seam 4).
> 
> The coordinator owns optimize/activate, consolidation learning pass, recall section assembly, semantic-refinement parsing, and **`formatCompressionGuidelinesForRecall`** (still re-exported from the orchestrator for API stability). The orchestrator wires it with config, a storage accessor, and a **`fastChatCompletion`** callback so LLM gateway routing stays in the orchestrator.
> 
> **`orchestrator.ts`** shrinks (ratchet **20993 → 20654** LOC); package exports and a root re-export add **`@remnic/core/orchestration/compression-guideline-coordinator`**. Unit tests target the coordinator via **`makeCoordinator`** instead of **`Orchestrator.prototype`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be2e0f416948a8c0969780e02dc75b30867adef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->