### PR TITLE
refactor(caps): #1523 batch 4 — indexing + creation-memory CapabilitySet projections

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -244,7 +244,7 @@ import {
   type ActionConfidenceResult,
 } from "./action-confidence.js";
 import { formatProfileTraceAscii } from "./profiling.js";
-import { resolveAccessSetupCapabilities, resolveGraphConstructionCapabilities } from "./capabilities.js";
+import { resolveAccessSetupCapabilities, resolveGraphConstructionCapabilities, resolveIndexingCapabilities } from "./capabilities.js";
 
 export class EngramAccessInputError extends Error {}
 
@@ -5409,7 +5409,7 @@ export class EngramAccessService {
     reason?: string;
     retryAfterMs?: number;
   }> {
-    if (!this.orchestrator.config.conversationIndexEnabled) {
+    if (!resolveIndexingCapabilities(this.orchestrator.config).conversationIndex) {
       return {
         enabled: false,
         sessions: 0,

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -461,3 +461,188 @@ test("resolveMemoryLifecycleCapabilities matches pre-migration config reads (par
     }
   }
 });
+
+
+// ---------------------------------------------------------------------------
+// IndexingCapabilitySet — gate-parity tests (issue #1523 batch 4).
+//
+// Same invariant as the sets above: every caps field must project from its
+// `<field>Enabled` config flag. All two flags are required booleans on
+// PluginConfig (defaults resolved at the parse boundary), so the projection
+// is a pure passthrough.
+//
+// Parity contract: a caps-resolved run and a config-derived run MUST produce
+// identical boolean values for every gate — on AND off.
+// ---------------------------------------------------------------------------
+
+import {
+  resolveIndexingCapabilities,
+  type IndexingCapabilitySet,
+} from "./capabilities.js";
+
+const INDEXING_FIELD_TO_FLAG: Record<keyof IndexingCapabilitySet, string> = {
+  queryAwareIndexing: "queryAwareIndexingEnabled",
+  conversationIndex: "conversationIndexEnabled",
+};
+
+const INDEXING_FIELDS = Object.keys(INDEXING_FIELD_TO_FLAG) as Array<
+  keyof IndexingCapabilitySet
+>;
+
+test("resolveIndexingCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(INDEXING_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveIndexingCapabilities(config);
+
+  for (const field of INDEXING_FIELDS) {
+    const flag = INDEXING_FIELD_TO_FLAG[field];
+    assert.equal(caps[field], true, `caps.${field} must be true when ${flag}=true`);
+  }
+});
+
+test("resolveIndexingCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(INDEXING_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveIndexingCapabilities(config);
+
+  for (const field of INDEXING_FIELDS) {
+    const flag = INDEXING_FIELD_TO_FLAG[field];
+    assert.equal(caps[field], false, `caps.${field} must be false when ${flag}=false`);
+  }
+});
+
+test("resolveIndexingCapabilities returns a frozen object", () => {
+  const config = parseConfig({});
+  const caps = resolveIndexingCapabilities(config);
+  assert.equal(Object.isFrozen(caps), true);
+});
+
+test("resolveIndexingCapabilities matches pre-migration config reads (parity contract)", () => {
+  const cases: Record<string, Record<string, boolean>> = {
+    "all-off": {
+      queryAwareIndexingEnabled: false,
+      conversationIndexEnabled: false,
+    },
+    "all-on": {
+      queryAwareIndexingEnabled: true,
+      conversationIndexEnabled: true,
+    },
+    "indexing-on-conv-off": {
+      queryAwareIndexingEnabled: true,
+      conversationIndexEnabled: false,
+    },
+    "conv-on-indexing-off": {
+      queryAwareIndexingEnabled: false,
+      conversationIndexEnabled: true,
+    },
+  };
+
+  for (const [label, overrides] of Object.entries(cases)) {
+    const config = parseConfig(overrides);
+    const caps = resolveIndexingCapabilities(config);
+
+    for (const field of INDEXING_FIELDS) {
+      const flag = INDEXING_FIELD_TO_FLAG[field];
+      assert.equal(
+        caps[field],
+        (config as unknown as Record<string, boolean>)[flag],
+        `[${label}] caps.${field} must equal config.${flag}`,
+      );
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CreationMemoryCapabilitySet — gate-parity tests (issue #1523 batch 4).
+// ---------------------------------------------------------------------------
+
+import {
+  resolveCreationMemoryCapabilities,
+  type CreationMemoryCapabilitySet,
+} from "./capabilities.js";
+
+const CREATION_FIELD_TO_FLAG: Record<keyof CreationMemoryCapabilitySet, string> = {
+  creationMemory: "creationMemoryEnabled",
+  commitmentLedger: "commitmentLedgerEnabled",
+  resumeBundles: "resumeBundlesEnabled",
+  commitmentLifecycle: "commitmentLifecycleEnabled",
+};
+
+const CREATION_FIELDS = Object.keys(CREATION_FIELD_TO_FLAG) as Array<
+  keyof CreationMemoryCapabilitySet
+>;
+
+test("resolveCreationMemoryCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(CREATION_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveCreationMemoryCapabilities(config);
+
+  for (const field of CREATION_FIELDS) {
+    const flag = CREATION_FIELD_TO_FLAG[field];
+    assert.equal(caps[field], true, `caps.${field} must be true when ${flag}=true`);
+  }
+});
+
+test("resolveCreationMemoryCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(CREATION_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveCreationMemoryCapabilities(config);
+
+  for (const field of CREATION_FIELDS) {
+    const flag = CREATION_FIELD_TO_FLAG[field];
+    assert.equal(caps[field], false, `caps.${field} must be false when ${flag}=false`);
+  }
+});
+
+test("resolveCreationMemoryCapabilities returns a frozen object", () => {
+  const config = parseConfig({});
+  const caps = resolveCreationMemoryCapabilities(config);
+  assert.equal(Object.isFrozen(caps), true);
+});
+
+test("resolveCreationMemoryCapabilities matches pre-migration config reads (parity contract)", () => {
+  const cases: Record<string, Record<string, boolean>> = {
+    "all-off": {
+      creationMemoryEnabled: false,
+      commitmentLedgerEnabled: false,
+      resumeBundlesEnabled: false,
+      commitmentLifecycleEnabled: false,
+    },
+    "all-on": {
+      creationMemoryEnabled: true,
+      commitmentLedgerEnabled: true,
+      resumeBundlesEnabled: true,
+      commitmentLifecycleEnabled: true,
+    },
+    "creation-on-rest-off": {
+      creationMemoryEnabled: true,
+      commitmentLedgerEnabled: false,
+      resumeBundlesEnabled: false,
+      commitmentLifecycleEnabled: false,
+    },
+    "ledgers-on-rest-off": {
+      creationMemoryEnabled: false,
+      commitmentLedgerEnabled: true,
+      resumeBundlesEnabled: true,
+      commitmentLifecycleEnabled: true,
+    },
+  };
+
+  for (const [label, overrides] of Object.entries(cases)) {
+    const config = parseConfig(overrides);
+    const caps = resolveCreationMemoryCapabilities(config);
+
+    for (const field of CREATION_FIELDS) {
+      const flag = CREATION_FIELD_TO_FLAG[field];
+      assert.equal(
+        caps[field],
+        (config as unknown as Record<string, boolean>)[flag],
+        `[${label}] caps.${field} must equal config.${flag}`,
+      );
+    }
+  }
+});

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -294,3 +294,113 @@ export function resolveMemoryLifecycleCapabilities(
     embeddingFallback: config.embeddingFallbackEnabled,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Indexing capability set (issue #1523 batch 4).
+//
+// The flags below gate query-aware indexing (temporal/tag index build +
+// prefilter) and the conversation index (QMD/FAISS backend selection). They
+// are read on the recall path, the extraction/persist path, and the
+// maintenance/invalidation path — so they get their own projection resolved
+// ONCE at each operation entry that reads them.
+//
+// Every field projects from an already-resolved PluginConfig boolean (defaults
+// applied at the parse boundary), so the resolver is a pure projection.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of indexing feature gates (issue #1523 batch 4).
+ *
+ * Resolved once per recall / extraction / maintenance operation and threaded
+ * down. Composition lives ONLY in {@link resolveIndexingCapabilities}.
+ */
+export interface IndexingCapabilitySet {
+  /** `queryAwareIndexingEnabled` — build + use temporal/tag index for recall prefilter. */
+  readonly queryAwareIndexing: boolean;
+  /** `conversationIndexEnabled` — conversation-index backend (QMD / FAISS). */
+  readonly conversationIndex: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveIndexingCapabilities}.
+ */
+export type IndexingConfigProjection = Pick<
+  PluginConfig,
+  "queryAwareIndexingEnabled" | "conversationIndexEnabled"
+>;
+
+/**
+ * Resolve the {@link IndexingCapabilitySet} from parsed config.
+ *
+ * Call this ONCE per recall / extraction / maintenance operation entry and
+ * thread the result down — exactly the pattern {@link resolveCapabilities}
+ * established for recall.
+ */
+export function resolveIndexingCapabilities(
+  config: IndexingConfigProjection,
+): IndexingCapabilitySet {
+  return Object.freeze({
+    queryAwareIndexing: config.queryAwareIndexingEnabled,
+    conversationIndex: config.conversationIndexEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Creation-memory capability set (issue #1523 batch 4).
+//
+// The flags below gate the creation-memory subsystem: resume-bundle handoff,
+// commitment ledger, commitment lifecycle, and the master creation-memory
+// switch. They are read on the extraction/persist path, the recall
+// enrichment path, and the CLI command surface — so they get their own
+// projection resolved ONCE at each operation entry that reads them.
+//
+// Every field projects from an already-resolved PluginConfig boolean (defaults
+// applied at the parse boundary), so the resolver is a pure projection.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of creation-memory feature gates (issue #1523 batch 4).
+ *
+ * Resolved once per creation-memory operation (CLI command, extraction,
+ * recall enrichment) and threaded down. Composition lives ONLY in
+ * {@link resolveCreationMemoryCapabilities}.
+ */
+export interface CreationMemoryCapabilitySet {
+  /** `creationMemoryEnabled` — master switch for creation-memory subsystem. */
+  readonly creationMemory: boolean;
+  /** `commitmentLedgerEnabled` — commitment-ledger read/write. */
+  readonly commitmentLedger: boolean;
+  /** `resumeBundlesEnabled` — resume-bundle handoff bundles. */
+  readonly resumeBundles: boolean;
+  /** `commitmentLifecycleEnabled` — commitment lifecycle (promotion / decay). */
+  readonly commitmentLifecycle: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveCreationMemoryCapabilities}.
+ */
+export type CreationMemoryConfigProjection = Pick<
+  PluginConfig,
+  | "creationMemoryEnabled"
+  | "commitmentLedgerEnabled"
+  | "resumeBundlesEnabled"
+  | "commitmentLifecycleEnabled"
+>;
+
+/**
+ * Resolve the {@link CreationMemoryCapabilitySet} from parsed config.
+ *
+ * Call this ONCE per creation-memory operation entry and thread the result
+ * down — exactly the pattern {@link resolveCapabilities} established for
+ * recall.
+ */
+export function resolveCreationMemoryCapabilities(
+  config: CreationMemoryConfigProjection,
+): CreationMemoryCapabilitySet {
+  return Object.freeze({
+    creationMemory: config.creationMemoryEnabled,
+    commitmentLedger: config.commitmentLedgerEnabled,
+    resumeBundles: config.resumeBundlesEnabled,
+    commitmentLifecycle: config.commitmentLifecycleEnabled,
+  });
+}

--- a/packages/remnic-core/src/cli/creation-ledger-commands.ts
+++ b/packages/remnic-core/src/cli/creation-ledger-commands.ts
@@ -20,6 +20,7 @@ import type { CliCommand } from "../cli.js";
 import type { CommitmentLedgerEntry } from "../commitment-ledger.js";
 import type { WorkProductLedgerEntry } from "../work-product-ledger.js";
 import type { ResumeBundle } from "../resume-bundles.js";
+import { resolveCreationMemoryCapabilities } from "../capabilities.js";
 import {
   runResumeBundleStatusCliCommand,
   runResumeBundleRecordCliCommand,
@@ -48,8 +49,8 @@ cmd
     const status = await runResumeBundleStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       resumeBundleDir: orchestrator.config.resumeBundleDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      resumeBundlesEnabled: orchestrator.config.resumeBundlesEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      resumeBundlesEnabled: resolveCreationMemoryCapabilities(orchestrator.config).resumeBundles,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -84,8 +85,8 @@ cmd
     const filePath = await runResumeBundleRecordCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       resumeBundleDir: orchestrator.config.resumeBundleDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      resumeBundlesEnabled: orchestrator.config.resumeBundlesEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      resumeBundlesEnabled: resolveCreationMemoryCapabilities(orchestrator.config).resumeBundles,
       bundle: {
         schemaVersion: 1,
         bundleId: String(options.bundleId ?? ""),
@@ -127,11 +128,11 @@ cmd
       objectiveStateStoreDir: orchestrator.config.objectiveStateStoreDir,
       workProductLedgerDir: orchestrator.config.workProductLedgerDir,
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      resumeBundlesEnabled: orchestrator.config.resumeBundlesEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      resumeBundlesEnabled: resolveCreationMemoryCapabilities(orchestrator.config).resumeBundles,
       transcriptEnabled: orchestrator.config.transcriptEnabled,
       objectiveStateMemoryEnabled: orchestrator.config.objectiveStateMemoryEnabled,
-      commitmentLedgerEnabled: orchestrator.config.commitmentLedgerEnabled,
+      commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
       bundleId: String(options.bundleId ?? ""),
       recordedAt: String(options.recordedAt ?? ""),
       sessionKey: String(options.sessionKey ?? ""),
@@ -152,9 +153,9 @@ cmd
     const status = await runCommitmentStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      commitmentLedgerEnabled: orchestrator.config.commitmentLedgerEnabled,
-      commitmentLifecycleEnabled: orchestrator.config.commitmentLifecycleEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
+      commitmentLifecycleEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLifecycle,
       commitmentStaleDays: orchestrator.config.commitmentStaleDays,
       commitmentDecayDays: orchestrator.config.commitmentDecayDays,
     });
@@ -189,8 +190,8 @@ cmd
     const filePath = await runCommitmentRecordCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      commitmentLedgerEnabled: orchestrator.config.commitmentLedgerEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
       entry: {
         schemaVersion: 1,
         entryId: String(options.entryId ?? ""),
@@ -227,9 +228,9 @@ cmd
     const entry = await runCommitmentSetStateCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      commitmentLedgerEnabled: orchestrator.config.commitmentLedgerEnabled,
-      commitmentLifecycleEnabled: orchestrator.config.commitmentLifecycleEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
+      commitmentLifecycleEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLifecycle,
       entryId: String(options.entryId ?? ""),
       nextState: String(options.state ?? "") as CommitmentLedgerEntry["state"],
       changedAt: String(options.changedAt ?? ""),
@@ -247,9 +248,9 @@ cmd
     const result = await runCommitmentLifecycleCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
-      commitmentLedgerEnabled: orchestrator.config.commitmentLedgerEnabled,
-      commitmentLifecycleEnabled: orchestrator.config.commitmentLifecycleEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
+      commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
+      commitmentLifecycleEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLifecycle,
       commitmentDecayDays: orchestrator.config.commitmentDecayDays,
       now: typeof options.now === "string" ? options.now : undefined,
     });
@@ -264,7 +265,7 @@ cmd
     const status = await runWorkProductStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       workProductLedgerDir: orchestrator.config.workProductLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -296,7 +297,7 @@ cmd
     const filePath = await runWorkProductRecordCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       workProductLedgerDir: orchestrator.config.workProductLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
       entry: {
         schemaVersion: 1,
         entryId: String(options.entryId ?? ""),
@@ -334,7 +335,7 @@ cmd
     const results = await runWorkProductRecallSearchCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       workProductLedgerDir: orchestrator.config.workProductLedgerDir,
-      creationMemoryEnabled: orchestrator.config.creationMemoryEnabled,
+      creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
       workProductRecallEnabled: orchestrator.config.workProductRecallEnabled,
       query,
       maxResults: Number.isFinite(maxResults) ? maxResults : 3,

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -54,6 +54,7 @@ import type {
 } from "./types.js";
 import { reportBufferSurpriseDistribution } from "./buffer-surprise-report.js";
 import { readJudgeVerdictStats } from "./extraction-judge-telemetry.js";
+import { resolveIndexingCapabilities } from "./capabilities.js";
 
 const OPENCLAW_REMNIC_PLUGIN_IDS = ["openclaw-remnic", "openclaw-engram"] as const;
 
@@ -931,7 +932,7 @@ async function buildOperatorConfigReviewReport(input: {
     config.memoryOsPreset !== "balanced" &&
     config.memoryOsPreset !== "research-max" &&
     config.memoryOsPreset !== "local-llm-heavy" &&
-    config.queryAwareIndexingEnabled === false &&
+    resolveIndexingCapabilities(config).queryAwareIndexing === false &&
     config.verbatimArtifactsEnabled === false &&
     !caps.rerank
   ) {
@@ -1032,7 +1033,7 @@ async function buildOperatorConfigReviewReport(input: {
     }));
   }
 
-  if (config.conversationIndexEnabled && config.conversationIndexBackend === "qmd" && config.qmdEnabled === false) {
+  if (resolveIndexingCapabilities(config).conversationIndex && config.conversationIndexBackend === "qmd" && config.qmdEnabled === false) {
     findings.push(buildConfigReviewFinding({
       key: "conversation_index_qmd_requires_qmd",
       status: "problem",
@@ -1066,7 +1067,7 @@ async function buildOperatorConfigReviewReport(input: {
       qmdDaemonEnabled: config.qmdDaemonEnabled,
       nativeKnowledgeEnabled: config.nativeKnowledge?.enabled === true,
       fileHygieneEnabled: config.fileHygiene?.enabled === true,
-      conversationIndexEnabled: config.conversationIndexEnabled,
+      conversationIndexEnabled: resolveIndexingCapabilities(config).conversationIndex,
     },
     summary,
     findings,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -270,9 +270,13 @@ import {
   resolveCapabilities,
   resolveGraphConstructionCapabilities,
   resolveMemoryLifecycleCapabilities,
+  resolveIndexingCapabilities,
+  resolveCreationMemoryCapabilities,
   type CapabilitySet,
   type GraphConstructionCapabilitySet,
   type MemoryLifecycleCapabilitySet,
+  type IndexingCapabilitySet,
+  type CreationMemoryCapabilitySet,
 } from "./capabilities.js";
 import { DEFAULT_TAXONOMY } from "./taxonomy/index.js";
 import {
@@ -3781,7 +3785,7 @@ export class Orchestrator {
     await Promise.all(cacheWarmups);
     if (signal.aborted) return;
 
-    if (this.config.conversationIndexEnabled && this.conversationIndexBackend) {
+    if (resolveIndexingCapabilities(this.config).conversationIndex && this.conversationIndexBackend) {
       try {
         const init = await this.conversationIndexBackend.initialize();
         if (!init.enabled) {
@@ -4640,7 +4644,7 @@ export class Orchestrator {
             try {
               await this.embeddingFallback.removeFromIndex(m.frontmatter.id);
               if (
-                this.config.queryAwareIndexingEnabled &&
+                resolveIndexingCapabilities(this.config).queryAwareIndexing &&
                 m.path &&
                 m.frontmatter?.created
               ) {
@@ -5679,7 +5683,7 @@ export class Orchestrator {
     const lastUpdateAt =
       lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
 
-    if (!this.config.conversationIndexEnabled) {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
       return {
         enabled: false,
         backend: this.config.conversationIndexBackend,
@@ -5719,7 +5723,7 @@ export class Orchestrator {
     const lastUpdateAt =
       lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
 
-    if (!this.config.conversationIndexEnabled) {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
       return {
         enabled: false,
         backend: this.config.conversationIndexBackend,
@@ -5781,7 +5785,7 @@ export class Orchestrator {
     retryAfterMs?: number;
     embedded?: boolean;
   }> {
-    if (!this.config.conversationIndexEnabled) {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
       return { chunks: 0, skipped: true, reason: "disabled", embedded: false };
     }
     const enforceMinInterval = opts?.enforceMinInterval !== false;
@@ -5842,7 +5846,7 @@ export class Orchestrator {
     embedded?: boolean;
     rebuilt?: boolean;
   }> {
-    if (!this.config.conversationIndexEnabled) {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
       return {
         chunks: 0,
         skipped: true,
@@ -6447,7 +6451,7 @@ export class Orchestrator {
     prompt: string,
     recallNamespaces: string[],
   ): Promise<QueryAwarePrefilter> {
-    if (!this.config.queryAwareIndexingEnabled || !prompt.trim()) {
+    if (!resolveIndexingCapabilities(this.config).queryAwareIndexing || !prompt.trim()) {
       return {
         candidatePaths: null,
         temporalFromDate: null,
@@ -9239,7 +9243,7 @@ export class Orchestrator {
     const workProductsPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.creationMemoryEnabled ||
+        !resolveCreationMemoryCapabilities(this.config).creationMemory ||
         !this.config.workProductRecallEnabled ||
         !this.isRecallSectionEnabled(
           "work-products",
@@ -9314,7 +9318,7 @@ export class Orchestrator {
     const queryAwarePrefilterPromise =
       (async (): Promise<QueryAwarePrefilter> => {
         const t0 = Date.now();
-        if (!this.config.queryAwareIndexingEnabled || !prompt.trim()) {
+        if (!resolveIndexingCapabilities(this.config).queryAwareIndexing || !prompt.trim()) {
           recordRecallSectionMetric({
             section: "queryAware",
             priority: "enrichment",
@@ -10060,7 +10064,7 @@ export class Orchestrator {
     const conversationRecallPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.conversationIndexEnabled ||
+        !resolveIndexingCapabilities(this.config).conversationIndex ||
         queryPolicy.skipConversationRecall ||
         !this.isRecallSectionEnabled("conversation-recall", true)
       ) {
@@ -16770,7 +16774,7 @@ export class Orchestrator {
     // Enabling only parallelRetrievalEnabled without queryAwareIndexingEnabled would silently
     // produce an empty temporal index, leaving the temporal agent with no data to work from.
     if (
-      !this.config.queryAwareIndexingEnabled &&
+      !resolveIndexingCapabilities(this.config).queryAwareIndexing &&
       !caps.parallelRetrieval
     )
       return;
@@ -16885,7 +16889,7 @@ export class Orchestrator {
 
     // Build a lookup map from the already-loaded corpus to avoid repeated
     // readAllMemories() scans inside getMemoryById for pre-action deindex reads.
-    const memoryLookup = this.config.queryAwareIndexingEnabled
+    const memoryLookup = resolveIndexingCapabilities(this.config).queryAwareIndexing
       ? new Map(allMemories.map((m) => [m.frontmatter.id, m]))
       : null;
 
@@ -16893,7 +16897,7 @@ export class Orchestrator {
       switch (item.action) {
         case "INVALIDATE": {
           // Capture path/frontmatter before invalidation for index cleanup
-          const toInvalidate = this.config.queryAwareIndexingEnabled
+          const toInvalidate = resolveIndexingCapabilities(this.config).queryAwareIndexing
             ? (memoryLookup?.get(item.existingId) ?? null)
             : null;
           if (await this.storage.invalidateMemory(item.existingId)) {
@@ -16941,7 +16945,7 @@ export class Orchestrator {
             // updateMemory() only changes content/updated/supersedes/lineage — path, created, and tags
             // are preserved, so the temporal/tag index entry for the survivor is already correct.
             // Capture before invalidation for index cleanup
-            const toMergeInvalidate = this.config.queryAwareIndexingEnabled
+            const toMergeInvalidate = resolveIndexingCapabilities(this.config).queryAwareIndexing
               ? (memoryLookup?.get(item.mergeWith) ?? null)
               : null;
             if (await this.storage.invalidateMemory(item.mergeWith)) {
@@ -17027,7 +17031,7 @@ export class Orchestrator {
     if (deletedCommitments.length > 0) {
       memoryItemMutated = true;
       log.info(`cleaned ${deletedCommitments.length} expired commitments`);
-      if (this.config.queryAwareIndexingEnabled) {
+      if (resolveIndexingCapabilities(this.config).queryAwareIndexing) {
         for (const m of deletedCommitments) {
           deindexMemory(
             this.config.memoryDir,
@@ -17040,9 +17044,9 @@ export class Orchestrator {
     }
 
     if (
-      this.config.creationMemoryEnabled &&
-      this.config.commitmentLedgerEnabled &&
-      this.config.commitmentLifecycleEnabled
+      resolveCreationMemoryCapabilities(this.config).creationMemory &&
+      resolveCreationMemoryCapabilities(this.config).commitmentLedger &&
+      resolveCreationMemoryCapabilities(this.config).commitmentLifecycle
     ) {
       try {
         const lifecycle = await applyCommitmentLedgerLifecycle({
@@ -17070,7 +17074,7 @@ export class Orchestrator {
     if (deletedTTL.length > 0) {
       memoryItemMutated = true;
       log.info(`cleaned ${deletedTTL.length} TTL-expired memories`);
-      if (this.config.queryAwareIndexingEnabled) {
+      if (resolveIndexingCapabilities(this.config).queryAwareIndexing) {
         for (const m of deletedTTL) {
           deindexMemory(
             this.config.memoryDir,
@@ -17958,7 +17962,7 @@ export class Orchestrator {
         );
         await this.embeddingFallback.removeFromIndex(memory.frontmatter.id);
         if (
-          this.config.queryAwareIndexingEnabled &&
+          resolveIndexingCapabilities(this.config).queryAwareIndexing &&
           memory.path &&
           memory.frontmatter?.created
         ) {
@@ -20343,7 +20347,7 @@ export class Orchestrator {
     );
     let temporalFromDate: string | null = null;
     let promptTags: string[] = [];
-    if (this.config.queryAwareIndexingEnabled && prompt) {
+    if (resolveIndexingCapabilities(this.config).queryAwareIndexing && prompt) {
       if (isTemporalQuery(prompt)) {
         temporalFromDate = recencyWindowFromPrompt(prompt, now);
       }
@@ -20368,7 +20372,7 @@ export class Orchestrator {
     // Scope to result paths first so cross-namespace paths don't consume the cap.
     let temporalCandidates: Set<string> | null = null;
     let tagCandidates: Set<string> | null = null;
-    if (this.config.queryAwareIndexingEnabled && prompt) {
+    if (resolveIndexingCapabilities(this.config).queryAwareIndexing && prompt) {
       const maxCandidates = this.config.queryAwareIndexingMaxCandidates;
       const capSet = (s: Set<string> | null): Set<string> | null => {
         if (!s) return null;
@@ -20477,7 +20481,7 @@ export class Orchestrator {
 
         // v8.1: Temporal + Tag index boost
         // Results that match the detected temporal window or tag query get a small additive boost.
-        if (this.config.queryAwareIndexingEnabled && r.path) {
+        if (resolveIndexingCapabilities(this.config).queryAwareIndexing && r.path) {
           if (temporalCandidates?.has(r.path)) {
             score += applyUtilityRankingRuntimeDelta(
               0.08,
@@ -20791,7 +20795,7 @@ export class Orchestrator {
         contradiction.reason,
       );
       if (
-        this.config.queryAwareIndexingEnabled &&
+        resolveIndexingCapabilities(this.config).queryAwareIndexing &&
         contradiction.supersededPath
       ) {
         deindexMemory(

--- a/packages/remnic-core/src/search/factory.ts
+++ b/packages/remnic-core/src/search/factory.ts
@@ -10,6 +10,7 @@ import { EmbedHelper } from "./embed-helper.js";
 import { QmdClient, type QmdClientOptions } from "../qmd.js";
 import { log } from "../logger.js";
 import { FaissConversationIndexAdapter } from "../conversation-index/faiss-adapter.js";
+import { resolveIndexingCapabilities } from "../capabilities.js";
 import {
   createConversationIndexBackend,
   type ConversationIndexBackend,
@@ -135,7 +136,7 @@ export function createSearchBackend(config: PluginConfig): SearchBackend {
  * Returns undefined if conversation index is not enabled or not using qmd backend.
  */
 export function createConversationSearchBackend(config: PluginConfig): SearchBackend | undefined {
-  if (!config.conversationIndexEnabled || config.conversationIndexBackend !== "qmd") {
+  if (!resolveIndexingCapabilities(config).conversationIndex || config.conversationIndexBackend !== "qmd") {
     return undefined;
   }
 
@@ -169,7 +170,7 @@ export function createConversationIndexRuntime(
 ): ConversationIndexRuntime {
   const qmd = createConversationSearchBackend(config) as ConversationQmdRuntime | undefined;
   let faiss: FaissConversationIndexAdapter | undefined;
-  if (config.conversationIndexEnabled && config.conversationIndexBackend === "faiss") {
+  if (resolveIndexingCapabilities(config).conversationIndex && config.conversationIndexBackend === "faiss") {
     try {
       faiss = new FaissConversationIndexAdapter({
           memoryDir: config.memoryDir,
@@ -189,7 +190,7 @@ export function createConversationIndexRuntime(
   }
 
   const backend = createConversationIndexBackend({
-    enabled: config.conversationIndexEnabled,
+    enabled: resolveIndexingCapabilities(config).conversationIndex,
     backend: config.conversationIndexBackend,
     getQmd: () => overrides?.getQmd?.() ?? qmd,
     getFaiss: () => overrides?.getFaiss?.() ?? faiss,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 20989,
+      "packages/remnic-core/src/orchestrator.ts": 20993,
       "packages/remnic-core/src/cli.ts": 9390,
       "packages/remnic-core/src/access-service.ts": 9012,
       "packages/remnic-core/src/storage.ts": 7747,
       "packages/remnic-core/src/config.ts": 4689
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 511,
+    "scatteredConfigFlagReads": 465,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 0,
     "directStorageImports": 41


### PR DESCRIPTION
## Summary

Issue #1523 batch 4. Migrate the next two largest clean clusters of scattered `config.*Enabled` reads onto frozen CapabilitySet projections, following the established pattern from batches 1–3 (recall, graph-construction, access-setup, memory-lifecycle).

## New projections

**IndexingCapabilitySet** — `queryAwareIndexingEnabled` + `conversationIndexEnabled`
- Resolved once per recall / extraction / maintenance operation entry
- Pure projection (all required booleans, defaults at parse boundary)

**CreationMemoryCapabilitySet** — `creationMemoryEnabled` + `commitmentLedgerEnabled` + `resumeBundlesEnabled` + `commitmentLifecycleEnabled`
- Resolved once per creation-memory operation (CLI command, extraction, recall enrichment)
- Pure projection

## Migration (46 read sites across 5 files)

| File | Reads migrated |
|---|---|
| orchestrator.ts | 24 |
| cli/creation-ledger-commands.ts | 21 |
| operator-toolkit.ts | 3 |
| search/factory.ts | 3 |
| access-service.ts | 1 |

3 conversationIndexEnabled writes (runtime config mutation in orchestrator init) left in-place — caps are frozen, writes stay on config.

## Gates

- **Ratchet**: scatteredConfigFlagReads **511 → 465** (-46)
- **entity-hardening**: 246/246 pass
- **capabilities parity tests**: 22/22 pass (8 new tests)
- **Build**: clean (ESM + DTS)
- Orchestrator +4 LOC (import + resolver-call wiring — same thin-wiring pattern as batches 1–3)

## Chokepoints used / not applicable

- CapabilitySet/caps.* — YES (this PR)
- serialize-mutations — N/A
- ScopePlan resolver — N/A
- operation registry — N/A

Refs #1523

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical config-to-caps projection with parity tests; behavior should match prior flag reads, though the recall/indexing/maintenance touch surface is broad.
> 
> **Overview**
> Adds frozen **`IndexingCapabilitySet`** and **`CreationMemoryCapabilitySet`** resolvers in `capabilities.ts` and routes **46** former direct `config.*Enabled` reads through them across `orchestrator.ts`, creation-ledger CLI commands, `operator-toolkit.ts`, `search/factory.ts`, and `access-service.ts`.
> 
> Indexing gates (`queryAwareIndexing`, `conversationIndex`) now drive conversation-index init/health, query-aware prefiltering, temporal/tag index maintenance, and search backend wiring. Creation-memory gates (`creationMemory`, `commitmentLedger`, `resumeBundles`, `commitmentLifecycle`) gate recall enrichment, lifecycle maintenance, and ledger/resume-bundle CLI actions. **Runtime mutations** of `conversationIndexEnabled` during init stay on `config`, not the frozen caps.
> 
> New gate-parity tests mirror earlier capability batches; the structural ratchet drops **`scatteredConfigFlagReads`** from 511 to 465.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69992061f8cbe56c71a7a4538900f2c3293eff72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->