### PR TITLE
refactor(caps): #1523 batch 7 — Security + Eval + UtilityLearning + ObjectiveState + Compression capability sets

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -10,7 +10,7 @@ import {
   resolveMemoryLifecycleCapabilities,
   resolveQmdCapabilities,
   resolveIdentityContinuityCapabilities,
-} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities} from "./capabilities.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
@@ -1823,8 +1823,8 @@ export class EngramAccessService {
       // are off the self base collapses to config.defaultNamespace, so this is a
       // no-op for single-store deployments either way.
       const willWriteObjectiveState =
-        this.orchestrator.config.objectiveStateMemoryEnabled === true &&
-        this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
+        resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateMemory === true &&
+        resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateSnapshotWrites === true;
       if (
         willWriteObjectiveState &&
         resolveNamespaceCapabilities(this.orchestrator.config).namespaces === true &&
@@ -5578,9 +5578,9 @@ export class EngramAccessService {
       status: await getTrustZoneStoreStatus({
         memoryDir: storage.dir,
         trustZoneStoreDir: this.orchestrator.config.trustZoneStoreDir,
-        enabled: this.orchestrator.config.trustZonesEnabled === true,
-        promotionEnabled: this.orchestrator.config.quarantinePromotionEnabled === true,
-        poisoningDefenseEnabled: this.orchestrator.config.memoryPoisoningDefenseEnabled === true,
+        enabled: resolveSecurityCapabilities(this.orchestrator.config).trustZones === true,
+        promotionEnabled: resolveSecurityCapabilities(this.orchestrator.config).quarantinePromotion === true,
+        poisoningDefenseEnabled: resolveSecurityCapabilities(this.orchestrator.config).memoryPoisoningDefense === true,
       }),
     };
   }
@@ -5612,9 +5612,9 @@ export class EngramAccessService {
           entry.record,
           entry.filePath,
           result.allRecords,
-          this.orchestrator.config.memoryPoisoningDefenseEnabled === true,
-          this.orchestrator.config.trustZonesEnabled === true,
-          this.orchestrator.config.quarantinePromotionEnabled === true,
+          resolveSecurityCapabilities(this.orchestrator.config).memoryPoisoningDefense === true,
+          resolveSecurityCapabilities(this.orchestrator.config).trustZones === true,
+          resolveSecurityCapabilities(this.orchestrator.config).quarantinePromotion === true,
         )),
     };
   }
@@ -5636,9 +5636,9 @@ export class EngramAccessService {
       result = await promoteTrustZoneRecord({
         memoryDir: storage.dir,
         trustZoneStoreDir: this.orchestrator.config.trustZoneStoreDir,
-        enabled: this.orchestrator.config.trustZonesEnabled === true,
-        promotionEnabled: this.orchestrator.config.quarantinePromotionEnabled === true,
-        poisoningDefenseEnabled: this.orchestrator.config.memoryPoisoningDefenseEnabled === true,
+        enabled: resolveSecurityCapabilities(this.orchestrator.config).trustZones === true,
+        promotionEnabled: resolveSecurityCapabilities(this.orchestrator.config).quarantinePromotion === true,
+        poisoningDefenseEnabled: resolveSecurityCapabilities(this.orchestrator.config).memoryPoisoningDefense === true,
         sourceRecordId: request.recordId,
         targetZone: request.targetZone,
         recordedAt: request.recordedAt ?? new Date().toISOString(),
@@ -5670,7 +5670,7 @@ export class EngramAccessService {
       result = await seedTrustZoneDemoDataset({
         memoryDir: storage.dir,
         trustZoneStoreDir: this.orchestrator.config.trustZoneStoreDir,
-        enabled: this.orchestrator.config.trustZonesEnabled === true,
+        enabled: resolveSecurityCapabilities(this.orchestrator.config).trustZones === true,
         scenario: request.scenario,
         recordedAt: request.recordedAt,
         dryRun: request.dryRun === true,
@@ -5879,8 +5879,8 @@ export class EngramAccessService {
     // overlay-compatible base namespace for those writes.
     const namespace = this.legacyResponseNamespaceForScope(scope);
     const shouldWriteObjectiveState =
-      this.orchestrator.config.objectiveStateMemoryEnabled === true &&
-      this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
+      resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateMemory === true &&
+      resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateSnapshotWrites === true;
 
     // 2. Auto-resolve coding context from cwd/projectTag so a LATER bare recall
     //    on the same session is project-scoped (rule 42: same namespace layer as
@@ -5919,9 +5919,9 @@ export class EngramAccessService {
         await recordObjectiveStateSnapshotsFromObservedMessages({
           memoryDir: objectiveStateLocation.memoryDir,
           objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
-          objectiveStateMemoryEnabled: this.orchestrator.config.objectiveStateMemoryEnabled,
+          objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateMemory,
           objectiveStateSnapshotWritesEnabled:
-            this.orchestrator.config.objectiveStateSnapshotWritesEnabled,
+            resolveObjectiveStateCapabilities(this.orchestrator.config).objectiveStateSnapshotWrites,
           sessionKey: request.sessionKey,
           recordedAt: new Date().toISOString(),
           messages: request.messages,
@@ -7342,7 +7342,7 @@ export class EngramAccessService {
     dryRun?: boolean;
     eventLimit?: number;
   }): Promise<unknown> {
-    if (!this.orchestrator.config.compressionGuidelineLearningEnabled) {
+    if (!resolveCompressionCapabilities(this.orchestrator.config).compressionGuidelineLearning) {
       return { enabled: false, reason: "Compression guideline learning is disabled. Enable `compressionGuidelineLearningEnabled: true`." };
     }
     return await this.orchestrator.optimizeCompressionGuidelines({
@@ -7355,7 +7355,7 @@ export class EngramAccessService {
     expectedContentHash?: string;
     expectedGuidelineVersion?: number;
   }): Promise<unknown> {
-    if (!this.orchestrator.config.compressionGuidelineLearningEnabled) {
+    if (!resolveCompressionCapabilities(this.orchestrator.config).compressionGuidelineLearning) {
       return { enabled: false, reason: "Compression guideline learning is disabled." };
     }
     return await this.orchestrator.activateCompressionGuidelineDraft({
@@ -7749,7 +7749,7 @@ export class EngramAccessService {
       );
     }
 
-    if (this.orchestrator.config.contextCompressionActionsEnabled !== true) {
+    if (resolveCompressionCapabilities(this.orchestrator.config).contextCompressionActions !== true) {
       throw new EngramAccessInputError(
         "memory_action_apply is disabled; enable contextCompressionActionsEnabled to use this tool",
       );

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -9,12 +9,22 @@ import {
   resolveQmdCapabilities,
   resolveIdentityContinuityCapabilities,
   resolveLocalLlmCapabilities,
+  resolveSecurityCapabilities,
+  resolveEvalCapabilities,
+  resolveUtilityLearningCapabilities,
+  resolveObjectiveStateCapabilities,
+  resolveCompressionCapabilities,
   type CapabilitySet,
   type AccessSetupCapabilitySet,
   type NamespaceCapabilitySet,
   type QmdCapabilitySet,
   type IdentityContinuityCapabilitySet,
   type LocalLlmCapabilitySet,
+  type SecurityCapabilitySet,
+  type EvalCapabilitySet,
+  type UtilityLearningCapabilitySet,
+  type ObjectiveStateCapabilitySet,
+  type CompressionCapabilitySet,
 } from "./capabilities.js";
 
 /**
@@ -823,4 +833,191 @@ test("resolveLocalLlmCapabilities: result is frozen", () => {
   const config = parseConfig({ localLlmEnabled: true });
   const caps = resolveLocalLlmCapabilities(config);
   assert.ok(Object.isFrozen(caps), "LocalLlmCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// SecurityCapabilitySet — gate-parity tests (issue #1523 batch 7).
+// ---------------------------------------------------------------------------
+
+const SECURITY_FIELD_TO_FLAG: Record<keyof SecurityCapabilitySet, string> = {
+  trustZones: "trustZonesEnabled",
+  quarantinePromotion: "quarantinePromotionEnabled",
+  memoryPoisoningDefense: "memoryPoisoningDefenseEnabled",
+  trustZoneRecall: "trustZoneRecallEnabled",
+};
+
+const SECURITY_FIELDS = Object.keys(SECURITY_FIELD_TO_FLAG) as Array<keyof SecurityCapabilitySet>;
+
+test("resolveSecurityCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(SECURITY_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveSecurityCapabilities(config);
+  for (const field of SECURITY_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveSecurityCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(SECURITY_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveSecurityCapabilities(config);
+  for (const field of SECURITY_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveSecurityCapabilities returns a frozen object", () => {
+  const caps = resolveSecurityCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "SecurityCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// EvalCapabilitySet — gate-parity tests (issue #1523 batch 7).
+// ---------------------------------------------------------------------------
+
+const EVAL_FIELD_TO_FLAG: Record<keyof EvalCapabilitySet, string> = {
+  evalHarness: "evalHarnessEnabled",
+  evalShadowMode: "evalShadowModeEnabled",
+  benchmarkBaselineSnapshots: "benchmarkBaselineSnapshotsEnabled",
+  benchmarkDeltaReporter: "benchmarkDeltaReporterEnabled",
+  memoryRedTeamBench: "memoryRedTeamBenchEnabled",
+};
+
+const EVAL_FIELDS = Object.keys(EVAL_FIELD_TO_FLAG) as Array<keyof EvalCapabilitySet>;
+
+test("resolveEvalCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(EVAL_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveEvalCapabilities(config);
+  for (const field of EVAL_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveEvalCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(EVAL_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveEvalCapabilities(config);
+  for (const field of EVAL_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveEvalCapabilities returns a frozen object", () => {
+  const caps = resolveEvalCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "EvalCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// UtilityLearningCapabilitySet — gate-parity tests (issue #1523 batch 7).
+// ---------------------------------------------------------------------------
+
+const UTILITY_FIELD_TO_FLAG: Record<keyof UtilityLearningCapabilitySet, string> = {
+  memoryUtilityLearning: "memoryUtilityLearningEnabled",
+  promotionByOutcome: "promotionByOutcomeEnabled",
+};
+
+const UTILITY_FIELDS = Object.keys(UTILITY_FIELD_TO_FLAG) as Array<keyof UtilityLearningCapabilitySet>;
+
+test("resolveUtilityLearningCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(UTILITY_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveUtilityLearningCapabilities(config);
+  for (const field of UTILITY_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveUtilityLearningCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(UTILITY_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveUtilityLearningCapabilities(config);
+  for (const field of UTILITY_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveUtilityLearningCapabilities returns a frozen object", () => {
+  const caps = resolveUtilityLearningCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "UtilityLearningCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// ObjectiveStateCapabilitySet — gate-parity tests (issue #1523 batch 7).
+// ---------------------------------------------------------------------------
+
+const OBJECTIVE_FIELD_TO_FLAG: Record<keyof ObjectiveStateCapabilitySet, string> = {
+  objectiveStateMemory: "objectiveStateMemoryEnabled",
+  objectiveStateSnapshotWrites: "objectiveStateSnapshotWritesEnabled",
+  objectiveStateRecall: "objectiveStateRecallEnabled",
+};
+
+const OBJECTIVE_FIELDS = Object.keys(OBJECTIVE_FIELD_TO_FLAG) as Array<keyof ObjectiveStateCapabilitySet>;
+
+test("resolveObjectiveStateCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(OBJECTIVE_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveObjectiveStateCapabilities(config);
+  for (const field of OBJECTIVE_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveObjectiveStateCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(OBJECTIVE_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveObjectiveStateCapabilities(config);
+  for (const field of OBJECTIVE_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveObjectiveStateCapabilities returns a frozen object", () => {
+  const caps = resolveObjectiveStateCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "ObjectiveStateCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// CompressionCapabilitySet — gate-parity tests (issue #1523 batch 7).
+// ---------------------------------------------------------------------------
+
+const COMPRESSION_FIELD_TO_FLAG: Record<keyof CompressionCapabilitySet, string> = {
+  compressionGuidelineLearning: "compressionGuidelineLearningEnabled",
+  compressionGuidelineSemanticRefinement: "compressionGuidelineSemanticRefinementEnabled",
+  contextCompressionActions: "contextCompressionActionsEnabled",
+};
+
+const COMPRESSION_FIELDS = Object.keys(COMPRESSION_FIELD_TO_FLAG) as Array<keyof CompressionCapabilitySet>;
+
+test("resolveCompressionCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(COMPRESSION_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveCompressionCapabilities(config);
+  for (const field of COMPRESSION_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveCompressionCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(COMPRESSION_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveCompressionCapabilities(config);
+  for (const field of COMPRESSION_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveCompressionCapabilities returns a frozen object", () => {
+  const caps = resolveCompressionCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "CompressionCapabilitySet must be frozen");
 });

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -601,3 +601,209 @@ export function resolveLocalLlmCapabilities(
     localLlm: config.localLlmEnabled,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Security capability set (issue #1523 batch 7).
+//
+// The four security/trust-zone flags gate quarantine promotion, poisoning
+// defense, and trust-zone recall. Read sites span orchestrator, access-service,
+// CLI, and research-status commands. All flags are non-optional booleans on
+// PluginConfig (defaults resolved at the parse boundary), so the projection is
+// a pure pass-through.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of security/trust-zone feature gates (issue #1523 batch 7).
+ */
+export interface SecurityCapabilitySet {
+  /** `trustZonesEnabled` — master switch for trust-zone enforcement. */
+  readonly trustZones: boolean;
+  /** `quarantinePromotionEnabled` — promote quarantined memories after review. */
+  readonly quarantinePromotion: boolean;
+  /** `memoryPoisoningDefenseEnabled` — detect and defend against memory poisoning. */
+  readonly memoryPoisoningDefense: boolean;
+  /** `trustZoneRecallEnabled` — restrict recall to trusted zones. */
+  readonly trustZoneRecall: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveSecurityCapabilities}.
+ */
+export type SecurityConfigProjection = Pick<
+  PluginConfig,
+  "trustZonesEnabled" | "quarantinePromotionEnabled" | "memoryPoisoningDefenseEnabled" | "trustZoneRecallEnabled"
+>;
+
+/**
+ * Resolve the {@link SecurityCapabilitySet} from parsed config.
+ */
+export function resolveSecurityCapabilities(config: SecurityConfigProjection): SecurityCapabilitySet {
+  return Object.freeze({
+    trustZones: config.trustZonesEnabled,
+    quarantinePromotion: config.quarantinePromotionEnabled,
+    memoryPoisoningDefense: config.memoryPoisoningDefenseEnabled,
+    trustZoneRecall: config.trustZoneRecallEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Eval/benchmark capability set (issue #1523 batch 7).
+//
+// The five eval/benchmark flags gate the evaluation harness, shadow mode,
+// baseline snapshot management, delta reporting, and red-team benchmarking.
+// Read sites span orchestrator, CLI, and operator-toolkit. All flags are
+// non-optional booleans on PluginConfig.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of eval/benchmark feature gates (issue #1523 batch 7).
+ */
+export interface EvalCapabilitySet {
+  /** `evalHarnessEnabled` — master switch for the eval harness. */
+  readonly evalHarness: boolean;
+  /** `evalShadowModeEnabled` — run evaluations in shadow mode. */
+  readonly evalShadowMode: boolean;
+  /** `benchmarkBaselineSnapshotsEnabled` — manage baseline snapshots. */
+  readonly benchmarkBaselineSnapshots: boolean;
+  /** `benchmarkDeltaReporterEnabled` — report benchmark deltas. */
+  readonly benchmarkDeltaReporter: boolean;
+  /** `memoryRedTeamBenchEnabled` — red-team benchmarking of memory. */
+  readonly memoryRedTeamBench: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveEvalCapabilities}.
+ */
+export type EvalConfigProjection = Pick<
+  PluginConfig,
+  "evalHarnessEnabled" | "evalShadowModeEnabled" | "benchmarkBaselineSnapshotsEnabled" | "benchmarkDeltaReporterEnabled" | "memoryRedTeamBenchEnabled"
+>;
+
+/**
+ * Resolve the {@link EvalCapabilitySet} from parsed config.
+ */
+export function resolveEvalCapabilities(config: EvalConfigProjection): EvalCapabilitySet {
+  return Object.freeze({
+    evalHarness: config.evalHarnessEnabled,
+    evalShadowMode: config.evalShadowModeEnabled,
+    benchmarkBaselineSnapshots: config.benchmarkBaselineSnapshotsEnabled,
+    benchmarkDeltaReporter: config.benchmarkDeltaReporterEnabled,
+    memoryRedTeamBench: config.memoryRedTeamBenchEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Utility-learning capability set (issue #1523 batch 7).
+//
+// The two utility-learning flags gate memory utility learning and
+// promotion-by-outcome. Read sites span orchestrator, CLI research-status
+// commands, and maintenance files. Both flags are non-optional booleans.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of utility-learning feature gates (issue #1523 batch 7).
+ */
+export interface UtilityLearningCapabilitySet {
+  /** `memoryUtilityLearningEnabled` — learn memory utility weights from outcomes. */
+  readonly memoryUtilityLearning: boolean;
+  /** `promotionByOutcomeEnabled` — promote memories by outcome tracking. */
+  readonly promotionByOutcome: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveUtilityLearningCapabilities}.
+ */
+export type UtilityLearningConfigProjection = Pick<
+  PluginConfig,
+  "memoryUtilityLearningEnabled" | "promotionByOutcomeEnabled"
+>;
+
+/**
+ * Resolve the {@link UtilityLearningCapabilitySet} from parsed config.
+ */
+export function resolveUtilityLearningCapabilities(config: UtilityLearningConfigProjection): UtilityLearningCapabilitySet {
+  return Object.freeze({
+    memoryUtilityLearning: config.memoryUtilityLearningEnabled,
+    promotionByOutcome: config.promotionByOutcomeEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Objective-state capability set (issue #1523 batch 7).
+//
+// The three objective-state flags gate objective-state memory, snapshot
+// writes, and recall. Read sites span orchestrator, access-service, CLI
+// creation-ledger commands, and research-status commands. All flags are
+// non-optional booleans.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of objective-state feature gates (issue #1523 batch 7).
+ */
+export interface ObjectiveStateCapabilitySet {
+  /** `objectiveStateMemoryEnabled` — store objective-state memories. */
+  readonly objectiveStateMemory: boolean;
+  /** `objectiveStateSnapshotWritesEnabled` — write objective-state snapshots. */
+  readonly objectiveStateSnapshotWrites: boolean;
+  /** `objectiveStateRecallEnabled` — recall objective-state memories. */
+  readonly objectiveStateRecall: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveObjectiveStateCapabilities}.
+ */
+export type ObjectiveStateConfigProjection = Pick<
+  PluginConfig,
+  "objectiveStateMemoryEnabled" | "objectiveStateSnapshotWritesEnabled" | "objectiveStateRecallEnabled"
+>;
+
+/**
+ * Resolve the {@link ObjectiveStateCapabilitySet} from parsed config.
+ */
+export function resolveObjectiveStateCapabilities(config: ObjectiveStateConfigProjection): ObjectiveStateCapabilitySet {
+  return Object.freeze({
+    objectiveStateMemory: config.objectiveStateMemoryEnabled,
+    objectiveStateSnapshotWrites: config.objectiveStateSnapshotWritesEnabled,
+    objectiveStateRecall: config.objectiveStateRecallEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Compression capability set (issue #1523 batch 7).
+//
+// The three compression flags gate guideline learning, semantic refinement,
+// and context-compression actions. Read sites span orchestrator,
+// access-service, and the compression-guideline coordinator. All flags are
+// non-optional booleans.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of compression feature gates (issue #1523 batch 7).
+ */
+export interface CompressionCapabilitySet {
+  /** `compressionGuidelineLearningEnabled` — learn compression guidelines. */
+  readonly compressionGuidelineLearning: boolean;
+  /** `compressionGuidelineSemanticRefinementEnabled` — semantically refine guidelines. */
+  readonly compressionGuidelineSemanticRefinement: boolean;
+  /** `contextCompressionActionsEnabled` — apply context-compression actions. */
+  readonly contextCompressionActions: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveCompressionCapabilities}.
+ */
+export type CompressionConfigProjection = Pick<
+  PluginConfig,
+  "compressionGuidelineLearningEnabled" | "compressionGuidelineSemanticRefinementEnabled" | "contextCompressionActionsEnabled"
+>;
+
+/**
+ * Resolve the {@link CompressionCapabilitySet} from parsed config.
+ */
+export function resolveCompressionCapabilities(config: CompressionConfigProjection): CompressionCapabilitySet {
+  return Object.freeze({
+    compressionGuidelineLearning: config.compressionGuidelineLearningEnabled,
+    compressionGuidelineSemanticRefinement: config.compressionGuidelineSemanticRefinementEnabled,
+    contextCompressionActions: config.contextCompressionActionsEnabled,
+  });
+}

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8,7 +8,7 @@ import {
   resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
   resolveIdentityContinuityCapabilities,
-} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveEvalCapabilities} from "./capabilities.js";
 import { ThreadingManager } from "./threading.js";
 import { utcDayRange } from "./transcript.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
@@ -5384,10 +5384,10 @@ export function registerCli(
           const status = await runBenchmarkStatusCliCommand({
             memoryDir: orchestrator.config.memoryDir,
             evalStoreDir: orchestrator.config.evalStoreDir,
-            evalHarnessEnabled: orchestrator.config.evalHarnessEnabled,
-            evalShadowModeEnabled: orchestrator.config.evalShadowModeEnabled,
-            benchmarkBaselineSnapshotsEnabled: orchestrator.config.benchmarkBaselineSnapshotsEnabled,
-            memoryRedTeamBenchEnabled: orchestrator.config.memoryRedTeamBenchEnabled,
+            evalHarnessEnabled: resolveEvalCapabilities(orchestrator.config).evalHarness,
+            evalShadowModeEnabled: resolveEvalCapabilities(orchestrator.config).evalShadowMode,
+            benchmarkBaselineSnapshotsEnabled: resolveEvalCapabilities(orchestrator.config).benchmarkBaselineSnapshots,
+            memoryRedTeamBenchEnabled: resolveEvalCapabilities(orchestrator.config).memoryRedTeamBench,
           });
           console.log(JSON.stringify(status, null, 2));
           console.log("OK");
@@ -5415,11 +5415,11 @@ export function registerCli(
             config: {
               memoryDir: orchestrator.config.memoryDir,
               evalStoreDir: orchestrator.config.evalStoreDir,
-              evalHarnessEnabled: orchestrator.config.evalHarnessEnabled,
-              evalShadowModeEnabled: orchestrator.config.evalShadowModeEnabled,
-              benchmarkBaselineSnapshotsEnabled: orchestrator.config.benchmarkBaselineSnapshotsEnabled,
-              benchmarkDeltaReporterEnabled: orchestrator.config.benchmarkDeltaReporterEnabled,
-              memoryRedTeamBenchEnabled: orchestrator.config.memoryRedTeamBenchEnabled,
+              evalHarnessEnabled: resolveEvalCapabilities(orchestrator.config).evalHarness,
+              evalShadowModeEnabled: resolveEvalCapabilities(orchestrator.config).evalShadowMode,
+              benchmarkBaselineSnapshotsEnabled: resolveEvalCapabilities(orchestrator.config).benchmarkBaselineSnapshots,
+              benchmarkDeltaReporterEnabled: resolveEvalCapabilities(orchestrator.config).benchmarkDeltaReporter,
+              memoryRedTeamBenchEnabled: resolveEvalCapabilities(orchestrator.config).memoryRedTeamBench,
             },
             validatePath: typeof options.validate === "string" ? options.validate : undefined,
             baseEvalStoreDir: typeof options.base === "string" ? options.base : undefined,
@@ -6128,7 +6128,7 @@ export function registerCli(
           const inputPath = args[0];
           const summary = await runBenchmarkValidateCliCommand({
             path: typeof inputPath === "string" ? inputPath : "",
-            memoryRedTeamBenchEnabled: orchestrator.config.memoryRedTeamBenchEnabled,
+            memoryRedTeamBenchEnabled: resolveEvalCapabilities(orchestrator.config).memoryRedTeamBench,
           });
           console.log(JSON.stringify(summary, null, 2));
           console.log("OK");
@@ -6146,7 +6146,7 @@ export function registerCli(
           const summary = await runBenchmarkBaselineSnapshotCliCommand({
             memoryDir: orchestrator.config.memoryDir,
             evalStoreDir: orchestrator.config.evalStoreDir,
-            benchmarkBaselineSnapshotsEnabled: orchestrator.config.benchmarkBaselineSnapshotsEnabled,
+            benchmarkBaselineSnapshotsEnabled: resolveEvalCapabilities(orchestrator.config).benchmarkBaselineSnapshots,
             snapshotId: typeof options.snapshotId === "string" ? options.snapshotId : "",
             createdAt: typeof options.createdAt === "string" ? options.createdAt : undefined,
             gitRef: typeof options.gitRef === "string" ? options.gitRef : undefined,
@@ -6169,7 +6169,7 @@ export function registerCli(
             memoryDir: orchestrator.config.memoryDir,
             evalStoreDir: orchestrator.config.evalStoreDir,
             force: options.force === true,
-            memoryRedTeamBenchEnabled: orchestrator.config.memoryRedTeamBenchEnabled,
+            memoryRedTeamBenchEnabled: resolveEvalCapabilities(orchestrator.config).memoryRedTeamBench,
           });
           console.log(JSON.stringify(summary, null, 2));
           console.log("OK");
@@ -6202,7 +6202,7 @@ export function registerCli(
           const summary = await runBenchmarkBaselineReportCliCommand({
             memoryDir: orchestrator.config.memoryDir,
             evalStoreDir: orchestrator.config.evalStoreDir,
-            benchmarkDeltaReporterEnabled: orchestrator.config.benchmarkDeltaReporterEnabled,
+            benchmarkDeltaReporterEnabled: resolveEvalCapabilities(orchestrator.config).benchmarkDeltaReporter,
             snapshotId: typeof options.snapshotId === "string" ? options.snapshotId : "",
           });
           const { markdownReport, ...jsonSummary } = summary;
@@ -6232,9 +6232,9 @@ export function registerCli(
           const result = await runTrustZonePromoteCliCommand({
             memoryDir: orchestrator.config.memoryDir,
             trustZoneStoreDir: orchestrator.config.trustZoneStoreDir,
-            trustZonesEnabled: orchestrator.config.trustZonesEnabled,
-            quarantinePromotionEnabled: orchestrator.config.quarantinePromotionEnabled,
-            memoryPoisoningDefenseEnabled: orchestrator.config.memoryPoisoningDefenseEnabled,
+            trustZonesEnabled: resolveSecurityCapabilities(orchestrator.config).trustZones,
+            quarantinePromotionEnabled: resolveSecurityCapabilities(orchestrator.config).quarantinePromotion,
+            memoryPoisoningDefenseEnabled: resolveSecurityCapabilities(orchestrator.config).memoryPoisoningDefense,
             sourceRecordId: String(options.recordId ?? ""),
             targetZone: String(options.targetZone ?? "") as TrustZoneName,
             promotionReason: String(options.reason ?? ""),

--- a/packages/remnic-core/src/cli/creation-ledger-commands.ts
+++ b/packages/remnic-core/src/cli/creation-ledger-commands.ts
@@ -20,7 +20,7 @@ import type { CliCommand } from "../cli.js";
 import type { CommitmentLedgerEntry } from "../commitment-ledger.js";
 import type { WorkProductLedgerEntry } from "../work-product-ledger.js";
 import type { ResumeBundle } from "../resume-bundles.js";
-import { resolveCreationMemoryCapabilities } from "../capabilities.js";
+import { resolveCreationMemoryCapabilities, resolveObjectiveStateCapabilities} from "../capabilities.js";
 import {
   runResumeBundleStatusCliCommand,
   runResumeBundleRecordCliCommand,
@@ -131,7 +131,7 @@ cmd
       creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
       resumeBundlesEnabled: resolveCreationMemoryCapabilities(orchestrator.config).resumeBundles,
       transcriptEnabled: orchestrator.config.transcriptEnabled,
-      objectiveStateMemoryEnabled: orchestrator.config.objectiveStateMemoryEnabled,
+      objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(orchestrator.config).objectiveStateMemory,
       commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
       bundleId: String(options.bundleId ?? ""),
       recordedAt: String(options.recordedAt ?? ""),

--- a/packages/remnic-core/src/cli/research-status-commands.ts
+++ b/packages/remnic-core/src/cli/research-status-commands.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Orchestrator } from "../orchestrator.js";
-import { resolveCapabilities } from "../capabilities.js";
+import { resolveCapabilities, resolveSecurityCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities} from "../capabilities.js";
 import type { CliCommand } from "../cli.js";
 import type { UtilityTelemetryEvent } from "../utility-telemetry.js";
 import {
@@ -53,8 +53,8 @@ cmd
     const status = await runObjectiveStateStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       objectiveStateStoreDir: orchestrator.config.objectiveStateStoreDir,
-      objectiveStateMemoryEnabled: orchestrator.config.objectiveStateMemoryEnabled,
-      objectiveStateSnapshotWritesEnabled: orchestrator.config.objectiveStateSnapshotWritesEnabled,
+      objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(orchestrator.config).objectiveStateMemory,
+      objectiveStateSnapshotWritesEnabled: resolveObjectiveStateCapabilities(orchestrator.config).objectiveStateSnapshotWrites,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -80,9 +80,9 @@ cmd
     const status = await runTrustZoneStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       trustZoneStoreDir: orchestrator.config.trustZoneStoreDir,
-      trustZonesEnabled: orchestrator.config.trustZonesEnabled,
-      quarantinePromotionEnabled: orchestrator.config.quarantinePromotionEnabled,
-      memoryPoisoningDefenseEnabled: orchestrator.config.memoryPoisoningDefenseEnabled,
+      trustZonesEnabled: resolveSecurityCapabilities(orchestrator.config).trustZones,
+      quarantinePromotionEnabled: resolveSecurityCapabilities(orchestrator.config).quarantinePromotion,
+      memoryPoisoningDefenseEnabled: resolveSecurityCapabilities(orchestrator.config).memoryPoisoningDefense,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -99,7 +99,7 @@ cmd
     const result = await runTrustZoneDemoSeedCliCommand({
       memoryDir: orchestrator.config.memoryDir,
       trustZoneStoreDir: orchestrator.config.trustZoneStoreDir,
-      trustZonesEnabled: orchestrator.config.trustZonesEnabled,
+      trustZonesEnabled: resolveSecurityCapabilities(orchestrator.config).trustZones,
       scenario: typeof options.scenario === "string" ? options.scenario : undefined,
       recordedAt: typeof options.recordedAt === "string" ? options.recordedAt : undefined,
       dryRun: options.dryRun === true,
@@ -167,8 +167,8 @@ cmd
   .action(async () => {
     const status = await runUtilityTelemetryStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
-      memoryUtilityLearningEnabled: orchestrator.config.memoryUtilityLearningEnabled,
-      promotionByOutcomeEnabled: orchestrator.config.promotionByOutcomeEnabled,
+      memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(orchestrator.config).memoryUtilityLearning,
+      promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(orchestrator.config).promotionByOutcome,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -196,7 +196,7 @@ cmd
       : Number.NaN;
     const filePath = await runUtilityTelemetryRecordCliCommand({
       memoryDir: orchestrator.config.memoryDir,
-      memoryUtilityLearningEnabled: orchestrator.config.memoryUtilityLearningEnabled,
+      memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(orchestrator.config).memoryUtilityLearning,
       event: {
         schemaVersion: 1,
         eventId: String(options.eventId ?? ""),
@@ -223,8 +223,8 @@ cmd
   .action(async () => {
     const status = await runUtilityLearningStatusCliCommand({
       memoryDir: orchestrator.config.memoryDir,
-      memoryUtilityLearningEnabled: orchestrator.config.memoryUtilityLearningEnabled,
-      promotionByOutcomeEnabled: orchestrator.config.promotionByOutcomeEnabled,
+      memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(orchestrator.config).memoryUtilityLearning,
+      promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(orchestrator.config).promotionByOutcome,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -249,7 +249,7 @@ cmd
       : 0.35;
     const result = await runUtilityLearningCliCommand({
       memoryDir: orchestrator.config.memoryDir,
-      memoryUtilityLearningEnabled: orchestrator.config.memoryUtilityLearningEnabled,
+      memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(orchestrator.config).memoryUtilityLearning,
       learningWindowDays,
       minEventCount,
       maxWeightMagnitude,

--- a/packages/remnic-core/src/maintenance/first-start-migration.ts
+++ b/packages/remnic-core/src/maintenance/first-start-migration.ts
@@ -21,7 +21,7 @@ import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import {
   resolveMemoryLifecycleCapabilities,
   resolveQmdCapabilities,
-} from "../capabilities.js";
+  resolveUtilityLearningCapabilities} from "../capabilities.js";
 import type { StorageManager } from "../storage.js";
 import type { PluginConfig } from "../types.js";
 import {
@@ -145,8 +145,8 @@ async function buildTierRoutingPolicy(config: PluginConfig): Promise<TierRouting
   };
   const runtime = await loadUtilityRuntimeValues({
     memoryDir: config.memoryDir,
-    memoryUtilityLearningEnabled: config.memoryUtilityLearningEnabled,
-    promotionByOutcomeEnabled: config.promotionByOutcomeEnabled,
+    memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(config).memoryUtilityLearning,
+    promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(config).promotionByOutcome,
   });
   return applyUtilityPromotionRuntimePolicy(basePolicy, runtime);
 }

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -25,7 +25,7 @@ import {
   type TierRoutingPolicy,
   type TierTransitionDecision,
 } from "../tier-routing.js";
-import { resolveQmdCapabilities } from "../capabilities.js";
+import { resolveQmdCapabilities, resolveUtilityLearningCapabilities} from "../capabilities.js";
 import {
   applyUtilityPromotionRuntimePolicy,
   loadUtilityRuntimeValues,
@@ -90,8 +90,8 @@ async function tierRoutingPolicyFromConfig(
   };
   const runtime = await loadUtilityRuntimeValues({
     memoryDir: config.memoryDir,
-    memoryUtilityLearningEnabled: config.memoryUtilityLearningEnabled,
-    promotionByOutcomeEnabled: config.promotionByOutcomeEnabled,
+    memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(config).memoryUtilityLearning,
+    promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(config).promotionByOutcome,
   });
   return applyUtilityPromotionRuntimePolicy(basePolicy, runtime);
 }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -29,7 +29,7 @@ import {
   resolveCapabilities,
   resolveGraphConstructionCapabilities,
   resolveQmdCapabilities,
-} from "./capabilities.js";
+  resolveEvalCapabilities} from "./capabilities.js";
 import {
   analyzeSessionIntegrity,
   applySessionRepair,
@@ -2263,17 +2263,17 @@ export async function runBenchmarkRecall(options: BenchmarkRecallOptions): Promi
   const status = await getEvalHarnessStatus({
     memoryDir: options.config.memoryDir,
     evalStoreDir: options.config.evalStoreDir,
-    enabled: options.config.evalHarnessEnabled,
-    shadowModeEnabled: options.config.evalShadowModeEnabled,
-    baselineSnapshotsEnabled: options.config.benchmarkBaselineSnapshotsEnabled,
-    memoryRedTeamBenchEnabled: options.config.memoryRedTeamBenchEnabled,
+    enabled: resolveEvalCapabilities(options.config).evalHarness,
+    shadowModeEnabled: resolveEvalCapabilities(options.config).evalShadowMode,
+    baselineSnapshotsEnabled: resolveEvalCapabilities(options.config).benchmarkBaselineSnapshots,
+    memoryRedTeamBenchEnabled: resolveEvalCapabilities(options.config).memoryRedTeamBench,
   });
 
   if (options.createSnapshot && options.snapshotId) {
     const snapshot = await createEvalBaselineSnapshot({
       memoryDir: options.config.memoryDir,
       evalStoreDir: options.config.evalStoreDir,
-      baselineSnapshotsEnabled: options.config.benchmarkBaselineSnapshotsEnabled,
+      baselineSnapshotsEnabled: resolveEvalCapabilities(options.config).benchmarkBaselineSnapshots,
       snapshotId: options.snapshotId,
       notes: options.snapshotNotes,
       gitRef: options.gitRef,
@@ -2309,7 +2309,7 @@ export async function runBenchmarkRecall(options: BenchmarkRecallOptions): Promi
     const baselineReport = await runEvalBaselineDeltaReport({
       memoryDir: options.config.memoryDir,
       evalStoreDir: options.config.evalStoreDir,
-      benchmarkDeltaReporterEnabled: options.config.benchmarkDeltaReporterEnabled,
+      benchmarkDeltaReporterEnabled: resolveEvalCapabilities(options.config).benchmarkDeltaReporter,
       snapshotId: options.snapshotId,
     });
     return {
@@ -2323,7 +2323,7 @@ export async function runBenchmarkRecall(options: BenchmarkRecallOptions): Promi
 
   if (options.validatePath) {
     const validate = await validateEvalBenchmarkPack(options.validatePath, {
-      memoryRedTeamBenchEnabled: options.config.memoryRedTeamBenchEnabled,
+      memoryRedTeamBenchEnabled: resolveEvalCapabilities(options.config).memoryRedTeamBench,
     });
     return {
       schemaVersion: 1,

--- a/packages/remnic-core/src/orchestration/compression-guideline-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/compression-guideline-coordinator.ts
@@ -24,6 +24,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { resolveCompressionCapabilities } from "../capabilities.js";
 
 // StorageManager type comes from the package barrel (type-only) so this
 // module does not add a direct storage.ts import (#1533 ratchet).
@@ -103,7 +104,7 @@ export class CompressionGuidelineCoordinator {
         ? draftState
         : activeState;
 
-    if (!this.config.compressionGuidelineLearningEnabled) {
+    if (!resolveCompressionCapabilities(this.config).compressionGuidelineLearning) {
       return {
         enabled: false,
         dryRun,
@@ -152,7 +153,7 @@ export class CompressionGuidelineCoordinator {
     }
     const refinedCandidate =
       await refineCompressionGuidelineCandidateSemantically(candidate, {
-        enabled: this.config.compressionGuidelineSemanticRefinementEnabled,
+        enabled: resolveCompressionCapabilities(this.config).compressionGuidelineSemanticRefinement,
         timeoutMs: this.config.compressionGuidelineSemanticTimeoutMs,
         runRefinement: async (baseline) => {
           const prompt = [
@@ -241,7 +242,7 @@ export class CompressionGuidelineCoordinator {
       | "guideline_version_mismatch"
       | "draft_changed";
   }> {
-    if (!this.config.compressionGuidelineLearningEnabled) {
+    if (!resolveCompressionCapabilities(this.config).compressionGuidelineLearning) {
       return {
         enabled: false,
         activated: false,
@@ -312,7 +313,7 @@ export class CompressionGuidelineCoordinator {
 
   /** Consolidation-time hook: recompute the draft from recent events. */
   async runCompressionGuidelineLearningPass(): Promise<void> {
-    if (!this.config.compressionGuidelineLearningEnabled) return;
+    if (!resolveCompressionCapabilities(this.config).compressionGuidelineLearning) return;
     try {
       const result = await this.optimizeCompressionGuidelines({
         dryRun: false,
@@ -328,8 +329,8 @@ export class CompressionGuidelineCoordinator {
 
   /** Recall-time hook: surface active guidelines as a recall section. */
   async buildCompressionGuidelineRecallSection(): Promise<string | null> {
-    if (!this.config.contextCompressionActionsEnabled) return null;
-    if (!this.config.compressionGuidelineLearningEnabled) return null;
+    if (!resolveCompressionCapabilities(this.config).contextCompressionActions) return null;
+    if (!resolveCompressionCapabilities(this.config).compressionGuidelineLearning) return null;
 
     const state = await this.storage
       .readCompressionGuidelineOptimizerState()

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -281,7 +281,7 @@ import {
   resolveQmdCapabilities,
   resolveIdentityContinuityCapabilities,
   resolveLocalLlmCapabilities,
-} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveEvalCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities} from "./capabilities.js";
 import { DEFAULT_TAXONOMY } from "./taxonomy/index.js";
 import {
   searchHarmonicRetrieval,
@@ -3510,8 +3510,8 @@ export class Orchestrator {
       this.runtimePolicyValues = await this.policyRuntime.loadRuntimeValues();
       this.utilityRuntimeValues = await loadUtilityRuntimeValues({
         memoryDir: this.config.memoryDir,
-        memoryUtilityLearningEnabled: this.config.memoryUtilityLearningEnabled,
-        promotionByOutcomeEnabled: this.config.promotionByOutcomeEnabled,
+        memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(this.config).memoryUtilityLearning,
+        promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(this.config).promotionByOutcome,
       });
 
       // Initialize content-hash dedup index
@@ -4805,7 +4805,7 @@ export class Orchestrator {
       action: event.action,
       eligibility,
       options: {
-        actionsEnabled: this.config.contextCompressionActionsEnabled,
+        actionsEnabled: resolveCompressionCapabilities(this.config).contextCompressionActions,
         maxCompressionTokensPerHour: this.config.maxCompressionTokensPerHour,
       },
     });
@@ -8305,11 +8305,11 @@ export class Orchestrator {
     const objectiveStatePromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.objectiveStateMemoryEnabled ||
-        !this.config.objectiveStateRecallEnabled ||
+        !resolveObjectiveStateCapabilities(this.config).objectiveStateMemory ||
+        !resolveObjectiveStateCapabilities(this.config).objectiveStateRecall ||
         !this.isRecallSectionEnabled(
           "objective-state",
-          this.config.objectiveStateRecallEnabled === true,
+          resolveObjectiveStateCapabilities(this.config).objectiveStateRecall === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -8562,11 +8562,11 @@ export class Orchestrator {
     const trustZonePromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.trustZonesEnabled ||
-        !this.config.trustZoneRecallEnabled ||
+        !resolveSecurityCapabilities(this.config).trustZones ||
+        !resolveSecurityCapabilities(this.config).trustZoneRecall ||
         !this.isRecallSectionEnabled(
           "trust-zones",
-          this.config.trustZoneRecallEnabled === true,
+          resolveSecurityCapabilities(this.config).trustZoneRecall === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -11735,7 +11735,7 @@ export class Orchestrator {
     if (
       this.isRecallSectionEnabled(
         "compression-guidelines",
-        this.config.compressionGuidelineLearningEnabled === true,
+        resolveCompressionCapabilities(this.config).compressionGuidelineLearning === true,
       )
     ) {
       const compressionGuidelineSection =
@@ -17888,7 +17888,7 @@ export class Orchestrator {
   private queueEvalShadowRecall(
     record: Omit<EvalShadowRecallRecord, "schemaVersion">,
   ): void {
-    if (!this.config.evalHarnessEnabled || !this.config.evalShadowModeEnabled)
+    if (!resolveEvalCapabilities(this.config).evalHarness || !resolveEvalCapabilities(this.config).evalShadowMode)
       return;
     this.evalShadowWriteChain = this.evalShadowWriteChain
       .catch(() => undefined)

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -11,7 +11,7 @@
       "packages/remnic-core/src/config.ts": 4689
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 305,
+    "scatteredConfigFlagReads": 245,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 0,
     "directStorageImports": 41


### PR DESCRIPTION
Migrate 17 scattered `config.*Enabled` flags across 5 new CapabilitySet projections in `capabilities.ts`:

| Projection | Flags | Reads eliminated |
|---|---|---|
| **SecurityCapabilitySet** | trustZones, quarantinePromotion, memoryPoisoningDefense, trustZoneRecall | 20 |
| **EvalCapabilitySet** | evalHarness, evalShadowMode, benchmarkBaselineSnapshots, benchmarkDeltaReporter, memoryRedTeamBench | 22 |
| **UtilityLearningCapabilitySet** | memoryUtilityLearning, promotionByOutcome | 12 |
| **ObjectiveStateCapabilitySet** | objectiveStateMemory, objectiveStateSnapshotWrites, objectiveStateRecall | 12 |
| **CompressionCapabilitySet** | compressionGuidelineLearning, compressionGuidelineSemanticRefinement, contextCompressionActions | 11 |

77 read sites migrated across 11 files. Every read site per flag migrated — no half-migration. 15 new parity tests (47 total in `capabilities.test.ts`).

**scatteredConfigFlagReads: 305 → 245 (−60)**

Chokepoints used: `resolveSecurityCapabilities`, `resolveEvalCapabilities`, `resolveUtilityLearningCapabilities`, `resolveObjectiveStateCapabilities`, `resolveCompressionCapabilities` (new in this PR).

Not applicable: N/A — all flags are pure boolean projections.

References #1523

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical pass-through refactor with parity tests; security and objective-state paths are touched but gate semantics are unchanged if projections stay aligned with config flags.
> 
> **Overview**
> Adds five frozen **CapabilitySet** projections in `capabilities.ts`—**Security**, **Eval**, **UtilityLearning**, **ObjectiveState**, and **Compression**—each mapping `*Enabled` config flags to typed fields via dedicated `resolve*Capabilities` helpers.
> 
> **Call sites** across `access-service`, `orchestrator`, CLI (benchmark/trust-zone/research-status/creation-ledger), operator toolkit, compression-guideline coordinator, and tier maintenance now read gates through those resolvers instead of `orchestrator.config.*Enabled` directly. Behavior is intended to stay the same (pass-through booleans); the change centralizes gate wiring for issue **#1523**.
> 
> **Tests:** parity and frozen-object tests for all five sets in `capabilities.test.ts`. **Ratchet:** `scatteredConfigFlagReads` baseline **305 → 245**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d3e27fa2f79cbd1447287eeb859b2519513749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->