### PR TITLE
refactor(caps): #1523 batch 8 — Presentation + Consolidation + RecallAuxiliary capability sets (-61 reads)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5,12 +5,11 @@ import { readdirSync, unlinkSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
-import {
-  resolveNamespaceCapabilities,
+import { resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
   resolveQmdCapabilities,
   resolveIdentityContinuityCapabilities,
-  resolveSecurityCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities, resolveConsolidationCapabilities, resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
@@ -2984,7 +2983,7 @@ export class EngramAccessService {
   async daySummary(
     request: EngramAccessDaySummaryRequest,
   ): Promise<import("./types.js").DaySummaryResult | null> {
-    if (!this.orchestrator.config.daySummaryEnabled) {
+    if (!resolveRecallAuxiliaryCapabilities(this.orchestrator.config).daySummary) {
       throw new EngramAccessInputError("day summary is disabled");
     }
 
@@ -6832,7 +6831,7 @@ export class EngramAccessService {
     if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
       return { enabled: false, reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`." };
     }
-    if (!this.orchestrator.config.continuityAuditEnabled) {
+    if (!resolveConsolidationCapabilities(this.orchestrator.config).continuityAudit) {
       return { enabled: false, reason: "Continuity audits are disabled. Enable `continuityAuditEnabled: true`." };
     }
     if (!this.orchestrator.compounding) {
@@ -6854,7 +6853,7 @@ export class EngramAccessService {
     if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
       return { enabled: false, reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`." };
     }
-    if (!this.orchestrator.config.continuityIncidentLoggingEnabled) {
+    if (!resolveRecallAuxiliaryCapabilities(this.orchestrator.config).continuityIncidentLogging) {
       return { enabled: false, reason: "Continuity incident logging is disabled. Enable `continuityIncidentLoggingEnabled: true`." };
     }
     const symptom = request.symptom?.trim();
@@ -6880,7 +6879,7 @@ export class EngramAccessService {
     if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
       return { enabled: false, reason: "Identity continuity is disabled." };
     }
-    if (!this.orchestrator.config.continuityIncidentLoggingEnabled) {
+    if (!resolveRecallAuxiliaryCapabilities(this.orchestrator.config).continuityIncidentLogging) {
       return { enabled: false, reason: "Continuity incident logging is disabled." };
     }
     const id = request.id?.trim();
@@ -8234,7 +8233,7 @@ export class EngramAccessService {
     const root = explicitRoot ?? storage.dir;
     const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
     const versioning = importOptions.versioning ?? {
-      enabled: this.orchestrator.config.versioningEnabled,
+      enabled: resolveRecallAuxiliaryCapabilities(this.orchestrator.config).versioning,
       maxVersionsPerPage: this.orchestrator.config.versioningMaxPerPage,
       sidecarDir: this.orchestrator.config.versioningSidecarDir,
     };

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -9,6 +9,7 @@ import type {
   PluginConfig,
   SignalLevel,
 } from "./types.js";
+import { resolvePresentationCapabilities } from "./capabilities.js";
 
 export type TriggerDecision = "extract_now" | "extract_batch" | "keep_buffering";
 
@@ -286,7 +287,7 @@ export class SmartBuffer {
     // *reduce* extraction frequency.
     if (
       decision === "keep_buffering" &&
-      this.config.bufferSurpriseTriggerEnabled &&
+      resolvePresentationCapabilities(this.config).bufferSurpriseTrigger &&
       this.surpriseProbe !== null &&
       // Matching the existing "smart" branch: surprise is a lower-tier
       // novelty signal that should not second-guess a high-signal hit

--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -14,6 +14,9 @@ import {
   resolveUtilityLearningCapabilities,
   resolveObjectiveStateCapabilities,
   resolveCompressionCapabilities,
+  resolvePresentationCapabilities,
+  resolveConsolidationCapabilities,
+  resolveRecallAuxiliaryCapabilities,
   type CapabilitySet,
   type AccessSetupCapabilitySet,
   type NamespaceCapabilitySet,
@@ -25,6 +28,9 @@ import {
   type UtilityLearningCapabilitySet,
   type ObjectiveStateCapabilitySet,
   type CompressionCapabilitySet,
+  type PresentationCapabilitySet,
+  type ConsolidationCapabilitySet,
+  type RecallAuxiliaryCapabilitySet,
 } from "./capabilities.js";
 
 /**
@@ -1020,4 +1026,135 @@ test("resolveCompressionCapabilities projects every field from its flag (false v
 test("resolveCompressionCapabilities returns a frozen object", () => {
   const caps = resolveCompressionCapabilities(parseConfig({}));
   assert.equal(Object.isFrozen(caps), true, "CompressionCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// PresentationCapabilitySet — gate-parity tests (issue #1523 batch 8).
+// ---------------------------------------------------------------------------
+
+const PRESENTATION_FIELD_TO_FLAG: Record<keyof PresentationCapabilitySet, string> = {
+  verbatimArtifacts: "verbatimArtifactsEnabled",
+  memoryBoxes: "memoryBoxesEnabled",
+  bufferSurpriseTrigger: "bufferSurpriseTriggerEnabled",
+  threading: "threadingEnabled",
+  episodeNoteMode: "episodeNoteModeEnabled",
+  transcript: "transcriptEnabled",
+  entitySummary: "entitySummaryEnabled",
+};
+
+const PRESENTATION_FIELDS = Object.keys(PRESENTATION_FIELD_TO_FLAG) as Array<keyof PresentationCapabilitySet>;
+
+test("resolvePresentationCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(PRESENTATION_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolvePresentationCapabilities(config);
+  for (const field of PRESENTATION_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolvePresentationCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(PRESENTATION_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolvePresentationCapabilities(config);
+  for (const field of PRESENTATION_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolvePresentationCapabilities returns a frozen object", () => {
+  const caps = resolvePresentationCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "PresentationCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// ConsolidationCapabilitySet — gate-parity tests (issue #1523 batch 8).
+// ---------------------------------------------------------------------------
+
+const CONSOLIDATION_FIELD_TO_FLAG: Record<keyof ConsolidationCapabilitySet, string> = {
+  compoundingSemantic: "compoundingSemanticEnabled",
+  abstractionAnchors: "abstractionAnchorsEnabled",
+  compounding: "compoundingEnabled",
+  calibration: "calibrationEnabled",
+  semanticConsolidation: "semanticConsolidationEnabled",
+  patternReinforcement: "patternReinforcementEnabled",
+  continuityAudit: "continuityAuditEnabled",
+  graphEdgeDecay: "graphEdgeDecayEnabled",
+};
+
+const CONSOLIDATION_FIELDS = Object.keys(CONSOLIDATION_FIELD_TO_FLAG) as Array<keyof ConsolidationCapabilitySet>;
+
+test("resolveConsolidationCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(CONSOLIDATION_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveConsolidationCapabilities(config);
+  for (const field of CONSOLIDATION_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveConsolidationCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(CONSOLIDATION_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveConsolidationCapabilities(config);
+  for (const field of CONSOLIDATION_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveConsolidationCapabilities returns a frozen object", () => {
+  const caps = resolveConsolidationCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "ConsolidationCapabilitySet must be frozen");
+});
+
+// ---------------------------------------------------------------------------
+// RecallAuxiliaryCapabilitySet — gate-parity tests (issue #1523 batch 8).
+// ---------------------------------------------------------------------------
+
+const RECALL_AUX_FIELD_TO_FLAG: Record<keyof RecallAuxiliaryCapabilitySet, string> = {
+  causalRuleExtraction: "causalRuleExtractionEnabled",
+  correction: "correctionEnabled",
+  continuityIncidentLogging: "continuityIncidentLoggingEnabled",
+  daySummary: "daySummaryEnabled",
+  versioning: "versioningEnabled",
+  verifiedRecall: "verifiedRecallEnabled",
+  semanticRuleVerification: "semanticRuleVerificationEnabled",
+  workProductRecall: "workProductRecallEnabled",
+  secureStore: "secureStoreEnabled",
+  knowledgeIndex: "knowledgeIndexEnabled",
+  factDeduplication: "factDeduplicationEnabled",
+  compactionReset: "compactionResetEnabled",
+  entityRetrieval: "entityRetrievalEnabled",
+  cronRecallPolicy: "cronRecallPolicyEnabled",
+};
+
+const RECALL_AUX_FIELDS = Object.keys(RECALL_AUX_FIELD_TO_FLAG) as Array<keyof RecallAuxiliaryCapabilitySet>;
+
+test("resolveRecallAuxiliaryCapabilities projects every field from its flag (true variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(RECALL_AUX_FIELD_TO_FLAG)) overrides[flag] = true;
+  const config = parseConfig(overrides);
+  const caps = resolveRecallAuxiliaryCapabilities(config);
+  for (const field of RECALL_AUX_FIELDS) {
+    assert.equal(caps[field], true, `${field} must be true`);
+  }
+});
+
+test("resolveRecallAuxiliaryCapabilities projects every field from its flag (false variant)", () => {
+  const overrides: Record<string, boolean> = {};
+  for (const flag of Object.values(RECALL_AUX_FIELD_TO_FLAG)) overrides[flag] = false;
+  const config = parseConfig(overrides);
+  const caps = resolveRecallAuxiliaryCapabilities(config);
+  for (const field of RECALL_AUX_FIELDS) {
+    assert.equal(caps[field], false, `${field} must be false`);
+  }
+});
+
+test("resolveRecallAuxiliaryCapabilities returns a frozen object", () => {
+  const caps = resolveRecallAuxiliaryCapabilities(parseConfig({}));
+  assert.equal(Object.isFrozen(caps), true, "RecallAuxiliaryCapabilitySet must be frozen");
 });

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -807,3 +807,212 @@ export function resolveCompressionCapabilities(config: CompressionConfigProjecti
     contextCompressionActions: config.contextCompressionActionsEnabled,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Presentation capability set (issue #1523 batch 8).
+//
+// These flags gate output formatting and presentation across the orchestrator, extraction
+// pipeline, consolidation engine, and related modules. Resolved ONCE per
+// operation entry rather than re-derived from raw config at each read site.
+// All flags are non-optional booleans on PluginConfig (defaults applied at
+// the parse boundary), so the projection is a pure pass-through.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of output formatting and presentation feature gates (issue #1523 batch 8).
+ */
+export interface PresentationCapabilitySet {
+  /** `verbatimArtifactsEnabled` — verbatim-artifact rendering in recall output. */
+  readonly verbatimArtifacts: boolean;
+  /** `memoryBoxesEnabled` — memory-box rendering in recall output. */
+  readonly memoryBoxes: boolean;
+  /** `bufferSurpriseTriggerEnabled` — buffer surprise-detection trigger. */
+  readonly bufferSurpriseTrigger: boolean;
+  /** `threadingEnabled` — conversation threading in output. */
+  readonly threading: boolean;
+  /** `episodeNoteModeEnabled` — episode note-mode formatting. */
+  readonly episodeNoteMode: boolean;
+  /** `transcriptEnabled` — transcript-mode output. */
+  readonly transcript: boolean;
+  /** `entitySummaryEnabled` — entity summary generation. */
+  readonly entitySummary: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolvePresentationCapabilities}.
+ */
+export type PresentationConfigProjection = Pick<
+  PluginConfig,
+  "verbatimArtifactsEnabled" |
+  "memoryBoxesEnabled" |
+  "bufferSurpriseTriggerEnabled" |
+  "threadingEnabled" |
+  "episodeNoteModeEnabled" |
+  "transcriptEnabled" |
+  "entitySummaryEnabled"
+>;
+
+/**
+ * Resolve the {@link PresentationCapabilitySet} from parsed config.
+ */
+export function resolvePresentationCapabilities(config: PresentationConfigProjection): PresentationCapabilitySet {
+  return Object.freeze({
+    verbatimArtifacts: config.verbatimArtifactsEnabled,
+    memoryBoxes: config.memoryBoxesEnabled,
+    bufferSurpriseTrigger: config.bufferSurpriseTriggerEnabled,
+    threading: config.threadingEnabled,
+    episodeNoteMode: config.episodeNoteModeEnabled,
+    transcript: config.transcriptEnabled,
+    entitySummary: config.entitySummaryEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Consolidation capability set (issue #1523 batch 8).
+//
+// These flags gate memory consolidation, compounding, and abstraction across the orchestrator, extraction
+// pipeline, consolidation engine, and related modules. Resolved ONCE per
+// operation entry rather than re-derived from raw config at each read site.
+// All flags are non-optional booleans on PluginConfig (defaults applied at
+// the parse boundary), so the projection is a pure pass-through.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of memory consolidation, compounding, and abstraction feature gates (issue #1523 batch 8).
+ */
+export interface ConsolidationCapabilitySet {
+  /** `compoundingSemanticEnabled` — semantic compounding of memories. */
+  readonly compoundingSemantic: boolean;
+  /** `abstractionAnchorsEnabled` — abstraction-anchor extraction. */
+  readonly abstractionAnchors: boolean;
+  /** `compoundingEnabled` — master compounding switch. */
+  readonly compounding: boolean;
+  /** `calibrationEnabled` — memory calibration pass. */
+  readonly calibration: boolean;
+  /** `semanticConsolidationEnabled` — semantic consolidation pass. */
+  readonly semanticConsolidation: boolean;
+  /** `patternReinforcementEnabled` — pattern reinforcement in consolidation. */
+  readonly patternReinforcement: boolean;
+  /** `continuityAuditEnabled` — continuity audit during consolidation. */
+  readonly continuityAudit: boolean;
+  /** `graphEdgeDecayEnabled` — graph edge decay in maintenance. */
+  readonly graphEdgeDecay: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveConsolidationCapabilities}.
+ */
+export type ConsolidationConfigProjection = Pick<
+  PluginConfig,
+  "compoundingSemanticEnabled" |
+  "abstractionAnchorsEnabled" |
+  "compoundingEnabled" |
+  "calibrationEnabled" |
+  "semanticConsolidationEnabled" |
+  "patternReinforcementEnabled" |
+  "continuityAuditEnabled" |
+  "graphEdgeDecayEnabled"
+>;
+
+/**
+ * Resolve the {@link ConsolidationCapabilitySet} from parsed config.
+ */
+export function resolveConsolidationCapabilities(config: ConsolidationConfigProjection): ConsolidationCapabilitySet {
+  return Object.freeze({
+    compoundingSemantic: config.compoundingSemanticEnabled,
+    abstractionAnchors: config.abstractionAnchorsEnabled,
+    compounding: config.compoundingEnabled,
+    calibration: config.calibrationEnabled,
+    semanticConsolidation: config.semanticConsolidationEnabled,
+    patternReinforcement: config.patternReinforcementEnabled,
+    continuityAudit: config.continuityAuditEnabled,
+    graphEdgeDecay: config.graphEdgeDecayEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RecallAuxiliary capability set (issue #1523 batch 8).
+//
+// These flags gate extraction pipeline details and auxiliary recall enrichment across the orchestrator, extraction
+// pipeline, consolidation engine, and related modules. Resolved ONCE per
+// operation entry rather than re-derived from raw config at each read site.
+// All flags are non-optional booleans on PluginConfig (defaults applied at
+// the parse boundary), so the projection is a pure pass-through.
+// ---------------------------------------------------------------------------
+
+/**
+ * Frozen projection of extraction pipeline details and auxiliary recall enrichment feature gates (issue #1523 batch 8).
+ */
+export interface RecallAuxiliaryCapabilitySet {
+  /** `causalRuleExtractionEnabled` — causal-rule extraction in pipeline. */
+  readonly causalRuleExtraction: boolean;
+  /** `correctionEnabled` — memory correction subsystem. */
+  readonly correction: boolean;
+  /** `continuityIncidentLoggingEnabled` — continuity incident logging. */
+  readonly continuityIncidentLogging: boolean;
+  /** `daySummaryEnabled` — day-summary generation. */
+  readonly daySummary: boolean;
+  /** `versioningEnabled` — memory versioning. */
+  readonly versioning: boolean;
+  /** `verifiedRecallEnabled` — verified-recall tier. */
+  readonly verifiedRecall: boolean;
+  /** `semanticRuleVerificationEnabled` — semantic-rule verification. */
+  readonly semanticRuleVerification: boolean;
+  /** `workProductRecallEnabled` — work-product recall tier. */
+  readonly workProductRecall: boolean;
+  /** `secureStoreEnabled` — secure storage mode. */
+  readonly secureStore: boolean;
+  /** `knowledgeIndexEnabled` — knowledge index in recall. */
+  readonly knowledgeIndex: boolean;
+  /** `factDeduplicationEnabled` — fact deduplication in recall. */
+  readonly factDeduplication: boolean;
+  /** `compactionResetEnabled` — compaction reset on re-ingest. */
+  readonly compactionReset: boolean;
+  /** `entityRetrievalEnabled` — entity retrieval tier. */
+  readonly entityRetrieval: boolean;
+  /** `cronRecallPolicyEnabled` — cron-based recall policy. */
+  readonly cronRecallPolicy: boolean;
+}
+
+/**
+ * Config projection consumed by {@link resolveRecallAuxiliaryCapabilities}.
+ */
+export type RecallAuxiliaryConfigProjection = Pick<
+  PluginConfig,
+  "causalRuleExtractionEnabled" |
+  "correctionEnabled" |
+  "continuityIncidentLoggingEnabled" |
+  "daySummaryEnabled" |
+  "versioningEnabled" |
+  "verifiedRecallEnabled" |
+  "semanticRuleVerificationEnabled" |
+  "workProductRecallEnabled" |
+  "secureStoreEnabled" |
+  "knowledgeIndexEnabled" |
+  "factDeduplicationEnabled" |
+  "compactionResetEnabled" |
+  "entityRetrievalEnabled" |
+  "cronRecallPolicyEnabled"
+>;
+
+/**
+ * Resolve the {@link RecallAuxiliaryCapabilitySet} from parsed config.
+ */
+export function resolveRecallAuxiliaryCapabilities(config: RecallAuxiliaryConfigProjection): RecallAuxiliaryCapabilitySet {
+  return Object.freeze({
+    causalRuleExtraction: config.causalRuleExtractionEnabled,
+    correction: config.correctionEnabled,
+    continuityIncidentLogging: config.continuityIncidentLoggingEnabled,
+    daySummary: config.daySummaryEnabled,
+    versioning: config.versioningEnabled,
+    verifiedRecall: config.verifiedRecallEnabled,
+    semanticRuleVerification: config.semanticRuleVerificationEnabled,
+    workProductRecall: config.workProductRecallEnabled,
+    secureStore: config.secureStoreEnabled,
+    knowledgeIndex: config.knowledgeIndexEnabled,
+    factDeduplication: config.factDeduplicationEnabled,
+    compactionReset: config.compactionResetEnabled,
+    entityRetrieval: config.entityRetrievalEnabled,
+    cronRecallPolicy: config.cronRecallPolicyEnabled,
+  });
+}

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4,11 +4,10 @@ import { access, lstat, readFile, readdir, realpath, unlink } from "node:fs/prom
 import { createHash } from "node:crypto";
 import type { Readable, Writable } from "node:stream";
 import type { Orchestrator } from "./orchestrator.js";
-import {
-  resolveNamespaceCapabilities,
+import { resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
   resolveIdentityContinuityCapabilities,
-  resolveSecurityCapabilities, resolveEvalCapabilities} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveEvalCapabilities, resolveConsolidationCapabilities, resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
 import { ThreadingManager } from "./threading.js";
 import { utcDayRange } from "./transcript.js";
 import { runWearablesCliCommand } from "./wearables/cli.js";
@@ -6259,7 +6258,7 @@ export function registerCli(
             : 3;
           const results = await runVerifiedRecallSearchCliCommand({
             memoryDir: orchestrator.config.memoryDir,
-            verifiedRecallEnabled: orchestrator.config.verifiedRecallEnabled,
+            verifiedRecallEnabled: resolveRecallAuxiliaryCapabilities(orchestrator.config).verifiedRecall,
             query,
             maxResults: Number.isFinite(maxResults) ? maxResults : 3,
             boxRecallDays: orchestrator.config.boxRecallDays,
@@ -6295,8 +6294,8 @@ export function registerCli(
           const options = (args[0] ?? {}) as Record<string, unknown>;
           const result = await runCompoundingPromoteCliCommand({
             memoryDir: orchestrator.config.memoryDir,
-            compoundingEnabled: orchestrator.config.compoundingEnabled,
-            compoundingSemanticEnabled: orchestrator.config.compoundingSemanticEnabled,
+            compoundingEnabled: resolveConsolidationCapabilities(orchestrator.config).compounding,
+            compoundingSemanticEnabled: resolveConsolidationCapabilities(orchestrator.config).compoundingSemantic,
             weekId: String(options.weekId ?? ""),
             candidateId: String(options.candidateId ?? ""),
             dryRun: options.dryRun === true,
@@ -6318,7 +6317,7 @@ export function registerCli(
             : 3;
           const results = await runSemanticRuleVerifyCliCommand({
             memoryDir: orchestrator.config.memoryDir,
-            semanticRuleVerificationEnabled: orchestrator.config.semanticRuleVerificationEnabled,
+            semanticRuleVerificationEnabled: resolveRecallAuxiliaryCapabilities(orchestrator.config).semanticRuleVerification,
             query,
             maxResults: Number.isFinite(maxResults) ? maxResults : 3,
           });
@@ -7805,7 +7804,7 @@ export function registerCli(
             memoryDir: orchestrator.config.memoryDir,
             targetPath,
             versioning: {
-              enabled: orchestrator.config.versioningEnabled,
+              enabled: resolveRecallAuxiliaryCapabilities(orchestrator.config).versioning,
               maxVersionsPerPage: orchestrator.config.versioningMaxPerPage,
               sidecarDir: orchestrator.config.versioningSidecarDir,
             },
@@ -7894,7 +7893,7 @@ export function registerCli(
             console.log("Identity continuity is disabled.");
             return;
           }
-          if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+          if (!resolveRecallAuxiliaryCapabilities(orchestrator.config).continuityIncidentLogging) {
             console.log("Continuity incident logging is disabled.");
             return;
           }
@@ -7925,7 +7924,7 @@ export function registerCli(
             console.log("Identity continuity is disabled.");
             return;
           }
-          if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+          if (!resolveRecallAuxiliaryCapabilities(orchestrator.config).continuityIncidentLogging) {
             console.log("Continuity incident logging is disabled.");
             return;
           }

--- a/packages/remnic-core/src/cli/creation-ledger-commands.ts
+++ b/packages/remnic-core/src/cli/creation-ledger-commands.ts
@@ -20,7 +20,7 @@ import type { CliCommand } from "../cli.js";
 import type { CommitmentLedgerEntry } from "../commitment-ledger.js";
 import type { WorkProductLedgerEntry } from "../work-product-ledger.js";
 import type { ResumeBundle } from "../resume-bundles.js";
-import { resolveCreationMemoryCapabilities, resolveObjectiveStateCapabilities} from "../capabilities.js";
+import { resolveCreationMemoryCapabilities, resolveObjectiveStateCapabilities, resolvePresentationCapabilities, resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
 import {
   runResumeBundleStatusCliCommand,
   runResumeBundleRecordCliCommand,
@@ -130,7 +130,7 @@ cmd
       commitmentLedgerDir: orchestrator.config.commitmentLedgerDir,
       creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
       resumeBundlesEnabled: resolveCreationMemoryCapabilities(orchestrator.config).resumeBundles,
-      transcriptEnabled: orchestrator.config.transcriptEnabled,
+      transcriptEnabled: resolvePresentationCapabilities(orchestrator.config).transcript,
       objectiveStateMemoryEnabled: resolveObjectiveStateCapabilities(orchestrator.config).objectiveStateMemory,
       commitmentLedgerEnabled: resolveCreationMemoryCapabilities(orchestrator.config).commitmentLedger,
       bundleId: String(options.bundleId ?? ""),
@@ -336,7 +336,7 @@ cmd
       memoryDir: orchestrator.config.memoryDir,
       workProductLedgerDir: orchestrator.config.workProductLedgerDir,
       creationMemoryEnabled: resolveCreationMemoryCapabilities(orchestrator.config).creationMemory,
-      workProductRecallEnabled: orchestrator.config.workProductRecallEnabled,
+      workProductRecallEnabled: resolveRecallAuxiliaryCapabilities(orchestrator.config).workProductRecall,
       query,
       maxResults: Number.isFinite(maxResults) ? maxResults : 3,
       sessionKey: typeof options.sessionKey === "string" ? options.sessionKey : undefined,

--- a/packages/remnic-core/src/cli/research-status-commands.ts
+++ b/packages/remnic-core/src/cli/research-status-commands.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Orchestrator } from "../orchestrator.js";
-import { resolveCapabilities, resolveSecurityCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities} from "../capabilities.js";
+import { resolveCapabilities, resolveSecurityCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities, resolveConsolidationCapabilities } from "../capabilities.js";
 import type { CliCommand } from "../cli.js";
 import type { UtilityTelemetryEvent } from "../utility-telemetry.js";
 import {
@@ -116,7 +116,7 @@ cmd
       memoryDir: orchestrator.config.memoryDir,
       abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
       harmonicRetrievalEnabled: caps.harmonicRetrieval,
-      abstractionAnchorsEnabled: orchestrator.config.abstractionAnchorsEnabled,
+      abstractionAnchorsEnabled: resolveConsolidationCapabilities(orchestrator.config).abstractionAnchors,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -130,7 +130,7 @@ cmd
       memoryDir: orchestrator.config.memoryDir,
       abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
       harmonicRetrievalEnabled: caps.harmonicRetrieval,
-      abstractionAnchorsEnabled: orchestrator.config.abstractionAnchorsEnabled,
+      abstractionAnchorsEnabled: resolveConsolidationCapabilities(orchestrator.config).abstractionAnchors,
     });
     console.log(JSON.stringify(status, null, 2));
     console.log("OK");
@@ -152,7 +152,7 @@ cmd
       memoryDir: orchestrator.config.memoryDir,
       abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
       harmonicRetrievalEnabled: caps.harmonicRetrieval,
-      abstractionAnchorsEnabled: orchestrator.config.abstractionAnchorsEnabled,
+      abstractionAnchorsEnabled: resolveConsolidationCapabilities(orchestrator.config).abstractionAnchors,
       query,
       maxResults: Number.isFinite(maxResults) ? maxResults : 3,
       sessionKey: typeof options.sessionKey === "string" ? options.sessionKey : undefined,

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -7,7 +7,7 @@ import { StorageManager } from "../storage.js";
 import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
 import { resolveSharedContextDir, SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
 import { parseContinuityImprovementLoops } from "../identity-continuity.js";
-import { resolveQmdCapabilities, type QmdConfigProjection } from "../capabilities.js";
+import { resolveQmdCapabilities, type QmdConfigProjection, resolveConsolidationCapabilities } from "../capabilities.js";
 
 type MistakesFile = {
   version?: number;
@@ -493,7 +493,7 @@ export class CompoundingEngine {
     const previousMistakes = await this.readMistakes();
     const mistakes = this.buildMistakes(entries, actionPatterns, weekId, previousMistakes?.registry ?? []);
     const rubrics = this.buildRubricSnapshot(entries, outcomeSummary);
-    let promotionCandidates = this.config.compoundingSemanticEnabled
+    let promotionCandidates = resolveConsolidationCapabilities(this.config).compoundingSemantic
       ? this.derivePromotionCandidates(outcomeSummary, mistakes.registry, rubrics)
       : [];
     if (this.config.cmcConsolidationEnabled) {
@@ -540,7 +540,7 @@ export class CompoundingEngine {
       }
     }
     // PEDC: Run calibration consolidation during weekly synthesis
-    if (this.config.calibrationEnabled) {
+    if (resolveConsolidationCapabilities(this.config).calibration) {
       try {
         const { runCalibrationConsolidation } = await import("../calibration.js");
         const calRules = await runCalibrationConsolidation({
@@ -555,7 +555,7 @@ export class CompoundingEngine {
         log.warn(`[calibration] weekly consolidation failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`);
       }
     }
-    const continuity = this.config.continuityAuditEnabled
+    const continuity = resolveConsolidationCapabilities(this.config).continuityAudit
       ? await this.readContinuityAuditReferences(weekId)
       : { monthId: monthIdFromIsoWeek(weekId), weeklyPath: null, monthlyPath: null };
 
@@ -641,7 +641,7 @@ export class CompoundingEngine {
     storage?: StorageManager;
   }): Promise<CompoundingPromotionReport> {
     const report: CompoundingPromotionReport = {
-      enabled: this.config.compoundingEnabled === true && this.config.compoundingSemanticEnabled === true,
+      enabled: resolveConsolidationCapabilities(this.config).compounding === true && resolveConsolidationCapabilities(this.config).compoundingSemantic === true,
       dryRun: opts.dryRun === true,
       weekId: opts.weekId,
       promoted: [],
@@ -1384,7 +1384,7 @@ export class CompoundingEngine {
     }
     lines.push("");
 
-    if (this.config.compoundingSemanticEnabled) {
+    if (resolveConsolidationCapabilities(this.config).compoundingSemantic) {
       lines.push("## Promotion Candidates (Advisory)");
       if (promotionCandidates.length === 0) {
         lines.push("- (no advisory promotion candidates this week)");
@@ -1403,7 +1403,7 @@ export class CompoundingEngine {
       lines.push("");
     }
 
-    if (this.config.continuityAuditEnabled) {
+    if (resolveConsolidationCapabilities(this.config).continuityAudit) {
       lines.push("## Continuity Audits");
       if (continuity.weeklyPath) {
         lines.push(`- weekly: ${continuity.weeklyPath}`);

--- a/packages/remnic-core/src/correction/correction-access-wiring.ts
+++ b/packages/remnic-core/src/correction/correction-access-wiring.ts
@@ -43,6 +43,7 @@ import {
 } from "./correction-planner.js";
 import { type ExecutorDeps, type ExecutorMemory } from "./correction-executor.js";
 import { CorrectionService, type CorrectionServiceDeps } from "./correction-service.js";
+import { resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
 
 // ---------------------------------------------------------------------------
 // Public entry: build a fully-wired CorrectionService
@@ -810,11 +811,11 @@ function toExecutorMemory(m: MemoryFile): ExecutorMemory {
  * Nested wins when present; both default to `true` (plan is read-only, safe on).
  */
 export function isCorrectionFeatureEnabled(config: PluginConfig): boolean {
-  // parseConfig now resolves this into `config.correctionEnabled` (review
+  // parseConfig now resolves this into `resolveRecallAuxiliaryCapabilities(config).correction` (review
   // thread Txp) — prefer the parsed boolean so operator config actually takes
   // effect. The loose nested/flat read stays as a fallback for PluginConfig-
   // shaped objects built without parseConfig (unit tests).
-  if (typeof config.correctionEnabled === "boolean") return config.correctionEnabled;
+  if (typeof resolveRecallAuxiliaryCapabilities(config).correction === "boolean") return resolveRecallAuxiliaryCapabilities(config).correction;
   const nested = (config as unknown as Record<string, unknown>).correction as
     | Record<string, unknown>
     | undefined;

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -38,10 +38,8 @@ import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
 import { looksLikeMechanicalTelemetryTranscript } from "./telemetry-transcript.js";
 import { buildFactProvenance, type ProvenanceTurnInput } from "./provenance.js";
-import {
-  resolveMemoryLifecycleCapabilities,
-  resolveLocalLlmCapabilities,
-} from "./capabilities.js";
+import { resolveMemoryLifecycleCapabilities,
+  resolveLocalLlmCapabilities,resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
@@ -1664,7 +1662,7 @@ Memory categories:
 - principle: Durable rules, values, or operating beliefs (e.g., "never use Chat Completions API")
 - commitment: Promises, obligations, or deadlines (e.g., "deploy by Friday", "call accountant Monday")
 - moment: Emotionally significant events or milestones (e.g., "first successful deployment of engram")
-- skill: Capabilities the user or agent has demonstrated (e.g., "user is proficient with Kubernetes")${this.config.causalRuleExtractionEnabled ? `
+- skill: Capabilities the user or agent has demonstrated (e.g., "user is proficient with Kubernetes")${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
 - rule: Causal rules discovered through experience (format: "IF <condition> THEN <action/outcome>", e.g., "IF Shopify API returns 401 THEN the admin token is missing read_products scope")` : ""}
 - procedure: A reusable workflow the user wants remembered the same way across sessions. Set category to "procedure". Use "content" for a short title that includes explicit trigger phrasing (e.g. "When you deploy to production…", "Whenever you ship a release…"). Add "procedureSteps": an array of at least two objects {"order": number, "intent": "concrete step description"} in execution order. Optional per-step "toolCall": {"kind": "…", "signature": "…"}, "expectedOutcome", "optional": true.
 - reasoning_trace: A stored solution chain / chain-of-thought the user walked through to solve a problem (e.g. "Here's how I debugged the latency spike: first I checked…, then I…, finally I…"). Set category to "reasoning_trace". Use "content" for a short title summarising the problem (e.g. "How I debugged the staging latency spike"). Add "reasoningTrace": {"steps": [{"order": number, "description": "what happened at this step"}, …], "finalAnswer": "the conclusion or answer", "observedOutcome": "optional confirmation of how it played out"}. Require at least two ordered steps AND a finalAnswer. Use this category only when the user explicitly narrates their reasoning — not for ordinary decisions (use "decision") or reusable workflows (use "procedure").
@@ -1672,7 +1670,7 @@ Memory categories:
 Rules:
 - Only extract genuinely NEW information worth remembering across sessions
 - Skip transient task details (file paths being edited, current errors, etc.)
-- Priority: corrections > principles${this.config.causalRuleExtractionEnabled ? " > rules" : ""} > preferences > commitments > decisions > relationships > entities > moments > skills > facts
+- Priority: corrections > principles${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? " > rules" : ""} > preferences > commitments > decisions > relationships > entities > moments > skills > facts
 - Corrections (user saying "actually, don't do X" or "I prefer Y") get highest confidence
 - Each fact should be a standalone, self-contained statement
 - Lines labelled [context user] or [context assistant] are reference context only. Use them to resolve pronouns and adjacent question/answer pairs, but do not extract a memory stated only in context lines unless a normal [user] or [assistant] line confirms or completes it.
@@ -1800,7 +1798,7 @@ Actions:
 
 Also:
 - Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${this.config.causalRuleExtractionEnabled ? `
+- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
 - When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}`,
         },
         {
@@ -1846,7 +1844,7 @@ Actions:
 
 Also:
 - Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${this.config.causalRuleExtractionEnabled ? `
+- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
 - When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}
 
 Current behavioral profile:
@@ -1944,7 +1942,7 @@ Actions:
 
 Also:
 - Suggest profile updates based on patterns across memories
-- Identify entity updates for entity tracking${this.config.causalRuleExtractionEnabled ? `
+- Identify entity updates for entity tracking${resolveRecallAuxiliaryCapabilities(this.config).causalRuleExtraction ? `
 - When merging or updating memories, look for IF→THEN causal patterns. If a memory describes "X failed/succeeded because Y" or "doing X led to Y", rewrite its content to make the causal rule explicit in the form "IF <condition> THEN <action/outcome>".` : ""}
 
 Current behavioral profile:
@@ -2689,7 +2687,7 @@ Respond with valid JSON matching this schema:
   }
 
   async generateDaySummary(memories: string | MemoryFile[]): Promise<DaySummaryResultShape | null> {
-    if (!this.config.daySummaryEnabled) {
+    if (!resolveRecallAuxiliaryCapabilities(this.config).daySummary) {
       log.warn("day summary skipped — disabled by config");
       return null;
     }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -24,12 +24,11 @@ import {
   type EvalHarnessStatus,
 } from "./evals.js";
 import { analyzeGraphHealth, type GraphHealthReport } from "./graph.js";
-import {
-  resolveAccessSetupCapabilities,
+import { resolveAccessSetupCapabilities,
   resolveCapabilities,
   resolveGraphConstructionCapabilities,
   resolveQmdCapabilities,
-  resolveEvalCapabilities} from "./capabilities.js";
+  resolveEvalCapabilities, resolvePresentationCapabilities, resolveConsolidationCapabilities } from "./capabilities.js";
 import {
   analyzeSessionIntegrity,
   applySessionRepair,
@@ -934,7 +933,7 @@ async function buildOperatorConfigReviewReport(input: {
     config.memoryOsPreset !== "research-max" &&
     config.memoryOsPreset !== "local-llm-heavy" &&
     resolveIndexingCapabilities(config).queryAwareIndexing === false &&
-    config.verbatimArtifactsEnabled === false &&
+    resolvePresentationCapabilities(config).verbatimArtifacts === false &&
     !caps.rerank
   ) {
     findings.push(buildConfigReviewFinding({
@@ -1565,11 +1564,11 @@ export async function summarizeBufferSurpriseDistribution(
       return {
         key: "buffer_surprise_distribution",
         status: "ok",
-        summary: config.bufferSurpriseTriggerEnabled
+        summary: resolvePresentationCapabilities(config).bufferSurpriseTrigger
           ? "Surprise trigger is enabled but no telemetry has been recorded yet."
           : "Surprise trigger is disabled; no telemetry expected.",
         details: {
-          enabled: config.bufferSurpriseTriggerEnabled,
+          enabled: resolvePresentationCapabilities(config).bufferSurpriseTrigger,
           distribution: dist,
         },
       };
@@ -1581,7 +1580,7 @@ export async function summarizeBufferSurpriseDistribution(
       status: "ok",
       summary: `Recent surprise: mean=${dist.mean.toFixed(3)}, median=${dist.median.toFixed(3)}, p90=${dist.p90.toFixed(3)}, triggered=${pct(dist.triggeredRate)}% over ${dist.count} turns (threshold=${dist.currentThreshold ?? config.bufferSurpriseThreshold}).`,
       details: {
-        enabled: config.bufferSurpriseTriggerEnabled,
+        enabled: resolvePresentationCapabilities(config).bufferSurpriseTrigger,
         distribution: dist,
       },
     };

--- a/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
@@ -36,6 +36,7 @@ import type {
   PluginConfig,
 } from "../types.js";
 import { log } from "../logger.js";
+import { resolvePresentationCapabilities } from "../capabilities.js";
 
 // ---------------------------------------------------------------------------
 // Evidence helpers (moved verbatim from orchestrator.ts module scope)
@@ -172,7 +173,7 @@ export class EntitySynthesisCoordinator {
   ): Promise<number> {
     const { config } = this.deps;
     if (
-      !config.entitySummaryEnabled
+      !resolvePresentationCapabilities(config).entitySummary
       || maxEntities <= 0
       || config.entitySynthesisMaxTokens <= 0
     ) return 0;

--- a/packages/remnic-core/src/orchestration/maintenance.ts
+++ b/packages/remnic-core/src/orchestration/maintenance.ts
@@ -19,10 +19,8 @@
  * `orchestrator.requestQmdMaintenance` etc. continue to work.
  */
 
-import {
-  resolveNamespaceCapabilities,
-  resolveQmdCapabilities,
-} from "../capabilities.js";
+import { resolveNamespaceCapabilities,
+  resolveQmdCapabilities,resolveConsolidationCapabilities, resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -109,7 +107,7 @@ export class MaintenanceScheduler {
    * `await deferredReady` can rely on jobs.json being current.
    */
   async autoRegisterCrons(_signal: AbortSignal): Promise<void> {
-    if (this.deps.config.daySummaryEnabled) {
+    if (resolveRecallAuxiliaryCapabilities(this.deps.config).daySummary) {
       try {
         await this.autoRegisterDaySummaryCron();
       } catch (err) {
@@ -137,14 +135,14 @@ export class MaintenanceScheduler {
         log.debug(`contradiction scan cron auto-register failed (non-fatal): ${err}`);
       }
     }
-    if (this.deps.config.patternReinforcementEnabled) {
+    if (resolveConsolidationCapabilities(this.deps.config).patternReinforcement) {
       try {
         await this.autoRegisterPatternReinforcementCron();
       } catch (err) {
         log.debug(`pattern reinforcement cron auto-register failed (non-fatal): ${err}`);
       }
     }
-    if (this.deps.config.graphEdgeDecayEnabled) {
+    if (resolveConsolidationCapabilities(this.deps.config).graphEdgeDecay) {
       try {
         await this.autoRegisterGraphEdgeDecayCron();
       } catch (err) {

--- a/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/semantic-consolidation-coordinator.ts
@@ -41,7 +41,7 @@ import {
   fallbackLlmRuntimeContextFromConfig,
   gatewayTaskChainOptions,
 } from "../fallback-llm.js";
-import { resolveIndexingCapabilities } from "../capabilities.js";
+import { resolveIndexingCapabilities, resolveConsolidationCapabilities } from "../capabilities.js";
 import { deindexMemory } from "../temporal-index.js";
 import { runPeerProfileReasoner } from "../peers/index.js";
 import type { StorageManager } from "../index.js";
@@ -101,7 +101,7 @@ export class SemanticConsolidationCoordinator {
       clusters: [],
     };
 
-    if (!this.config.semanticConsolidationEnabled && !options?.force) {
+    if (!resolveConsolidationCapabilities(this.config).semanticConsolidation && !options?.force) {
       log.debug("[semantic-consolidation] disabled in config");
       return result;
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -265,8 +265,7 @@ import {
   type TrustZoneSearchResult,
 } from "./trust-zones.js";
 import { tryDirectAnswer, type DirectAnswerSources } from "./direct-answer-wiring.js";
-import {
-  resolveNamespaceCapabilities,
+import { resolveNamespaceCapabilities,
   resolveCapabilities,
   resolveGraphConstructionCapabilities,
   resolveMemoryLifecycleCapabilities,
@@ -280,7 +279,7 @@ import {
   resolveQmdCapabilities,
   resolveIdentityContinuityCapabilities,
   resolveLocalLlmCapabilities,
-  resolveSecurityCapabilities, resolveEvalCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities} from "./capabilities.js";
+  resolveSecurityCapabilities, resolveEvalCapabilities, resolveUtilityLearningCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities, resolvePresentationCapabilities, resolveConsolidationCapabilities, resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
 import { DEFAULT_TAXONOMY } from "./taxonomy/index.js";
 import {
   searchHarmonicRetrieval,
@@ -2583,7 +2582,7 @@ export class Orchestrator {
   private async contentHashIndexForStorage(
     targetStorage: StorageManager,
   ): Promise<ContentHashIndex | null> {
-    if (!this.config.factDeduplicationEnabled) return null;
+    if (!resolveRecallAuxiliaryCapabilities(this.config).factDeduplication) return null;
 
     if (targetStorage.dir === this.storage.dir) {
       if (!this.contentHashIndex) {
@@ -2846,7 +2845,7 @@ export class Orchestrator {
     if (config.defaultNamespace) this.storageRouter.bindCatalogWriteHook(this.storage, config.defaultNamespace);
     // Wire page-level versioning (issue #371)
     this.storage.setVersioningConfig({
-      enabled: config.versioningEnabled,
+      enabled: resolveRecallAuxiliaryCapabilities(config).versioning,
       maxVersionsPerPage: config.versioningMaxPerPage,
       sidecarDir: config.versioningSidecarDir,
     });
@@ -2869,7 +2868,7 @@ export class Orchestrator {
     // Wire at-rest encryption (issue #690 PR 3/4).
     // If secureStoreEnabled, check whether the keyring already holds a key
     // for this memory dir (e.g. operator unlocked before daemon restart).
-    if (config.secureStoreEnabled) {
+    if (resolveRecallAuxiliaryCapabilities(config).secureStore) {
       // Mark the store as required so writes throw SecureStoreLockedError
       // instead of silently falling back to plaintext when locked (P1 finding
       // from Cursor review of PR #767).
@@ -2906,7 +2905,7 @@ export class Orchestrator {
     this.sharedContext = config.sharedContextEnabled
       ? new SharedContextManager(config)
       : undefined;
-    this.compounding = config.compoundingEnabled
+    this.compounding = resolveConsolidationCapabilities(config).compounding
       ? new CompoundingEngine(config, this.storage)
       : undefined;
     this.buffer = new SmartBuffer(config, this.storage);
@@ -3098,7 +3097,7 @@ export class Orchestrator {
       this.boxBuilders.set(
         dir,
         new BoxBuilder(dir, {
-          memoryBoxesEnabled: this.config.memoryBoxesEnabled,
+          memoryBoxesEnabled: resolvePresentationCapabilities(this.config).memoryBoxes,
           traceWeaverEnabled: this.config.traceWeaverEnabled,
           boxTopicShiftThreshold: this.config.boxTopicShiftThreshold,
           boxTimeGapMs: this.config.boxTimeGapMs,
@@ -3444,7 +3443,7 @@ export class Orchestrator {
       });
 
       // Initialize content-hash dedup index
-      if (this.config.factDeduplicationEnabled) {
+      if (resolveRecallAuxiliaryCapabilities(this.config).factDeduplication) {
         this.contentHashIndex = this.storage.createContentHashIndex();
         await this.contentHashIndex.load();
         log.info(
@@ -3470,7 +3469,7 @@ export class Orchestrator {
         );
         this.buffer.resetToEmpty();
       }
-      if (this.config.compactionResetEnabled) {
+      if (resolveRecallAuxiliaryCapabilities(this.config).compactionReset) {
         try {
           const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
           const files = await readdir(wsDir).catch(() => [] as string[]);
@@ -3694,7 +3693,7 @@ export class Orchestrator {
     // Awaited so callers of `deferredReady` can rely on warmups being complete
     // and shutdown sequencing does not race with in-flight cache builds.
     const cacheWarmups: Promise<void>[] = [];
-    if (this.config.knowledgeIndexEnabled) {
+    if (resolveRecallAuxiliaryCapabilities(this.config).knowledgeIndex) {
       cacheWarmups.push(
         (async () => {
           try {
@@ -4013,7 +4012,7 @@ export class Orchestrator {
     const cadenceKey = options.namespace ?? "";
     // Master switch: a disabled feature is never bypassed, even with
     // force=true.  `force` only relaxes the cadence floor below.
-    if (!this.config.patternReinforcementEnabled) {
+    if (!resolveConsolidationCapabilities(this.config).patternReinforcement) {
       return { ran: false, skippedReason: "disabled", namespace: cadenceKey };
     }
     const cadence = this.config.patternReinforcementCadenceMs;
@@ -4072,7 +4071,7 @@ export class Orchestrator {
           ? { itemCount: result.result.clustersFound }
           : { itemCount: 0 };
       },
-      { enabled: this.config.patternReinforcementEnabled },
+      { enabled: resolveConsolidationCapabilities(this.config).patternReinforcement },
     );
   }
 
@@ -4116,7 +4115,7 @@ export class Orchestrator {
         });
         return { itemCount: result.clustersFound };
       },
-      { enabled: this.config.semanticConsolidationEnabled },
+      { enabled: resolveConsolidationCapabilities(this.config).semanticConsolidation },
     );
   }
 
@@ -5447,7 +5446,7 @@ export class Orchestrator {
     // memory directory, reject recall with a clear human-readable error
     // rather than surfacing a cryptic SecureStoreLockedError from deep
     // inside the storage layer.
-    if (this.config.secureStoreEnabled && !this.storage.isSecureStoreUnlocked()) {
+    if (resolveRecallAuxiliaryCapabilities(this.config).secureStore && !this.storage.isSecureStoreUnlocked()) {
       const lockedMsg =
         "[secure-store locked] Memory store is encrypted and locked. " +
         "Unlock the secure-store inside this daemon process, or restart the daemon through a secure-store aware launcher that installs the key.";
@@ -5585,7 +5584,7 @@ export class Orchestrator {
     });
     const observationNamespaces = observationScopePlan.readNamespaces;
     const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
-      cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
+      cronRecallPolicyEnabled: resolveRecallAuxiliaryCapabilities(this.config).cronRecallPolicy,
       cronRecallNormalizedQueryMaxChars:
         this.config.cronRecallNormalizedQueryMaxChars,
       cronRecallInstructionHeavyTokenCap:
@@ -7011,7 +7010,7 @@ export class Orchestrator {
     // recall searches, incl. coding `readFallbacks`). See the
     // `lcmReadSessionIds` derivation after `recallNamespaces` is built.
     const queryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
-      cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
+      cronRecallPolicyEnabled: resolveRecallAuxiliaryCapabilities(this.config).cronRecallPolicy,
       cronRecallNormalizedQueryMaxChars:
         this.config.cronRecallNormalizedQueryMaxChars,
       cronRecallInstructionHeavyTokenCap:
@@ -7174,7 +7173,7 @@ export class Orchestrator {
           return limit;
         })()
       : 0;
-    const recallHeadroom = this.config.verbatimArtifactsEnabled
+    const recallHeadroom = resolvePresentationCapabilities(this.config).verbatimArtifacts
       ? Math.max(12, this.config.verbatimArtifactsMaxRecall * 4)
       : 12;
     const computedFetchLimit =
@@ -7187,7 +7186,7 @@ export class Orchestrator {
     const qmdFetchLimit = computedFetchLimit;
     const qmdHybridFetchLimit = computeQmdHybridFetchLimit(
       qmdFetchLimit,
-      this.config.verbatimArtifactsEnabled,
+      resolvePresentationCapabilities(this.config).verbatimArtifacts,
       this.config.verbatimArtifactsMaxRecall,
     );
     const embeddingFetchLimit = computedFetchLimit;
@@ -7879,11 +7878,11 @@ export class Orchestrator {
       if (
         !this.isRecallSectionEnabled(
           "entity-retrieval",
-          this.config.entityRetrievalEnabled,
+          resolveRecallAuxiliaryCapabilities(this.config).entityRetrieval,
         )
       )
         return null;
-      if (!this.config.entityRetrievalEnabled) return null;
+      if (!resolveRecallAuxiliaryCapabilities(this.config).entityRetrieval) return null;
       const maxChars =
         this.getRecallSectionMaxChars("entity-retrieval") ??
         this.config.entityRetrievalMaxChars;
@@ -7956,11 +7955,11 @@ export class Orchestrator {
       if (
         !this.isRecallSectionEnabled(
           "knowledge-index",
-          this.config.knowledgeIndexEnabled,
+          resolveRecallAuxiliaryCapabilities(this.config).knowledgeIndex,
         )
       )
         return null;
-      if (!this.config.knowledgeIndexEnabled) return null;
+      if (!resolveRecallAuxiliaryCapabilities(this.config).knowledgeIndex) return null;
       const t0 = Date.now();
       try {
         const knowledgeIndexMaxChars =
@@ -8051,11 +8050,11 @@ export class Orchestrator {
       if (
         !this.isRecallSectionEnabled(
           "verbatim-artifacts",
-          this.config.verbatimArtifactsEnabled === true,
+          resolvePresentationCapabilities(this.config).verbatimArtifacts === true,
         )
       )
         return [];
-      if (!this.config.verbatimArtifactsEnabled) return [];
+      if (!resolvePresentationCapabilities(this.config).verbatimArtifacts) return [];
       const t0 = Date.now();
       const targetCount = computeArtifactRecallLimit(
         recallMode,
@@ -8286,10 +8285,10 @@ export class Orchestrator {
     const calibrationPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.calibrationEnabled ||
+        !resolveConsolidationCapabilities(this.config).calibration ||
         !this.isRecallSectionEnabled(
           "calibration-rules",
-          this.config.calibrationEnabled === true,
+          resolveConsolidationCapabilities(this.config).calibration === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -8451,7 +8450,7 @@ export class Orchestrator {
               query: retrievalQuery,
               maxResults,
               sessionKey,
-              anchorsEnabled: this.config.abstractionAnchorsEnabled,
+              anchorsEnabled: resolveConsolidationCapabilities(this.config).abstractionAnchors,
               abortSignal: harmonicRetrievalAbort.signal,
             }),
           ),
@@ -8498,10 +8497,10 @@ export class Orchestrator {
     const verifiedRecallPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.verifiedRecallEnabled ||
+        !resolveRecallAuxiliaryCapabilities(this.config).verifiedRecall ||
         !this.isRecallSectionEnabled(
           "verified-episodes",
-          this.config.verifiedRecallEnabled === true,
+          resolveRecallAuxiliaryCapabilities(this.config).verifiedRecall === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -8587,10 +8586,10 @@ export class Orchestrator {
     const verifiedRulesPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.semanticRuleVerificationEnabled ||
+        !resolveRecallAuxiliaryCapabilities(this.config).semanticRuleVerification ||
         !this.isRecallSectionEnabled(
           "verified-rules",
-          this.config.semanticRuleVerificationEnabled === true,
+          resolveRecallAuxiliaryCapabilities(this.config).semanticRuleVerification === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -8676,10 +8675,10 @@ export class Orchestrator {
       const t0 = Date.now();
       if (
         !resolveCreationMemoryCapabilities(this.config).creationMemory ||
-        !this.config.workProductRecallEnabled ||
+        !resolveRecallAuxiliaryCapabilities(this.config).workProductRecall ||
         !this.isRecallSectionEnabled(
           "work-products",
-          this.config.workProductRecallEnabled === true,
+          resolveRecallAuxiliaryCapabilities(this.config).workProductRecall === true,
         )
       ) {
         recordRecallSectionMetric({
@@ -9187,7 +9186,7 @@ export class Orchestrator {
     const transcriptPromise = (async (): Promise<string | null> => {
       const t0 = Date.now();
       if (
-        !this.config.transcriptEnabled ||
+        !resolvePresentationCapabilities(this.config).transcript ||
         !this.isRecallSectionEnabled("transcript", true)
       ) {
         recordRecallSectionMetric({
@@ -9293,7 +9292,7 @@ export class Orchestrator {
         this._recallWorkspaceOverrides.get(effectiveSessionKey);
       this._recallWorkspaceOverrides.delete(effectiveSessionKey);
 
-      if (!this.config.compactionResetEnabled) return null;
+      if (!resolveRecallAuxiliaryCapabilities(this.config).compactionReset) return null;
 
       const workspaceDir =
         compactionWorkspaceDir ||
@@ -9646,9 +9645,9 @@ export class Orchestrator {
     const recentBoxesPromise = observeEnrichmentPromise(
       this.isRecallSectionEnabled(
         "memory-boxes",
-        this.config.memoryBoxesEnabled === true,
+        resolvePresentationCapabilities(this.config).memoryBoxes === true,
       ) &&
-        this.config.memoryBoxesEnabled &&
+        resolvePresentationCapabilities(this.config).memoryBoxes &&
         this.config.boxRecallDays > 0
         ? Promise.all(
             profileStorages.map((storage) =>
@@ -12751,7 +12750,7 @@ export class Orchestrator {
   ): Promise<void> {
     const mode = this.config.correctionCaptureMode;
     if (mode === "off") return;
-    if (!this.config.correctionEnabled) return;
+    if (!resolveRecallAuxiliaryCapabilities(this.config).correction) return;
 
     try {
       const corrections = detectPassiveCorrections(
@@ -12771,7 +12770,7 @@ export class Orchestrator {
       const result = await capturePassiveCorrections(
         corrections,
         {
-          correctionEnabled: this.config.correctionEnabled,
+          correctionEnabled: resolveRecallAuxiliaryCapabilities(this.config).correction,
           isLiveSession: opts.isLiveSession,
           bufferKey: opts.bufferKey,
           sessionKey: opts.sessionKey,
@@ -13205,7 +13204,7 @@ export class Orchestrator {
     }
 
     let threadIdForExtraction: string | null = null;
-    if (this.config.threadingEnabled && turns.length > 0) {
+    if (resolvePresentationCapabilities(this.config).threading && turns.length > 0) {
       const lastTurn = turns[turns.length - 1];
       try {
         threadIdForExtraction = await this.threading.processTurn(lastTurn, []);
@@ -13335,7 +13334,7 @@ export class Orchestrator {
     // Topics are derived from the current extraction's facts and entities only —
     // not from readAllMemories() — so box topics accurately reflect the current
     // session window and the call is free of expensive full-corpus I/O.
-    if (this.config.memoryBoxesEnabled && persistedIds.length > 0) {
+    if (resolvePresentationCapabilities(this.config).memoryBoxes && persistedIds.length > 0) {
       const extractionTopics = deriveTopicsFromExtraction(result);
       // Derive episodic metadata from buffer turns (REMem-inspired)
       const firstUserTurn = turns.find((t) => t.role === "user");
@@ -13356,7 +13355,7 @@ export class Orchestrator {
     // Batch-append persisted IDs so non-fact memories (entities/questions) are
     // always attached to the thread. The helper excludes pending_review ids (#1635).
     if (
-      this.config.threadingEnabled &&
+      resolvePresentationCapabilities(this.config).threading &&
       threadIdForExtraction &&
       persistedIds.length > 0
     ) {
@@ -13367,7 +13366,7 @@ export class Orchestrator {
     }
 
     // Thread title update for the already-established thread context.
-    if (this.config.threadingEnabled && threadIdForExtraction) {
+    if (resolvePresentationCapabilities(this.config).threading && threadIdForExtraction) {
       const conversationContent = turns.map((t) => t.content).join(" ");
       try {
         await this.threading.updateThreadTitle(
@@ -15268,7 +15267,7 @@ export class Orchestrator {
 
         if (chunkResult.chunked && chunkResult.chunks.length > 1) {
           // Classify memory kind (v8.0 Phase 2B: HiMem episode/note dual store)
-          const memoryKind = this.config.episodeNoteModeEnabled
+          const memoryKind = resolvePresentationCapabilities(this.config).episodeNoteMode
             ? classifyMemoryKind(fact.content, fact.tags ?? [], writeCategory)
             : undefined;
 
@@ -15525,7 +15524,7 @@ export class Orchestrator {
           }
           try {
             if (
-              this.config.verbatimArtifactsEnabled &&
+              resolvePresentationCapabilities(this.config).verbatimArtifacts &&
               this.config.verbatimArtifactCategories.includes(writeCategory) &&
               fact.confidence >= this.config.verbatimArtifactsMinConfidence &&
               !postWriteGuard
@@ -15622,7 +15621,7 @@ export class Orchestrator {
       const memoryKind =
         writeCategory === "procedure"
           ? undefined
-          : this.config.episodeNoteModeEnabled
+          : resolvePresentationCapabilities(this.config).episodeNoteMode
             ? classifyMemoryKind(fact.content, fact.tags ?? [], writeCategory)
             : undefined;
 
@@ -15822,7 +15821,7 @@ export class Orchestrator {
           }
         }
         if (
-          this.config.verbatimArtifactsEnabled &&
+          resolvePresentationCapabilities(this.config).verbatimArtifacts &&
           this.config.verbatimArtifactCategories.includes(writeCategory) &&
           fact.confidence >= this.config.verbatimArtifactsMinConfidence &&
           !postWriteGuard
@@ -16438,7 +16437,7 @@ export class Orchestrator {
       log.info(`merged ${entitiesMerged} fragmented entity files`);
     }
 
-    if (this.config.entitySummaryEnabled) {
+    if (resolvePresentationCapabilities(this.config).entitySummary) {
       try {
         const synthesized = await this.processEntitySynthesisQueue(
           this.config.defaultNamespace,
@@ -16582,7 +16581,7 @@ export class Orchestrator {
     }
 
     // Semantic consolidation pass — find similar memories, synthesize canonical versions
-    if (this.config.semanticConsolidationEnabled) {
+    if (resolveConsolidationCapabilities(this.config).semanticConsolidation) {
       try {
         const stateFilePath = path.join(
           this.config.memoryDir,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,14 +4,14 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19737,
-      "packages/remnic-core/src/cli.ts": 9394,
-      "packages/remnic-core/src/access-service.ts": 9017,
+      "packages/remnic-core/src/orchestrator.ts": 19736,
+      "packages/remnic-core/src/cli.ts": 9393,
+      "packages/remnic-core/src/access-service.ts": 9016,
       "packages/remnic-core/src/storage.ts": 7747,
       "packages/remnic-core/src/config.ts": 4689
     },
     "oversizedFileCount": 10,
-    "scatteredConfigFlagReads": 245,
+    "scatteredConfigFlagReads": 184,
     "adHocNamespaceResolutions": 0,
     "unmigratedHandlerCount": 0,
     "directStorageImports": 42

--- a/tests/orchestrator-threading-order.test.ts
+++ b/tests/orchestrator-threading-order.test.ts
@@ -36,7 +36,7 @@ test("runExtraction batch-appends persisted IDs after persistExtraction", () => 
 
   assert.match(
     source,
-    /if\s*\(\s*this\.config\.threadingEnabled\s*&&\s*threadIdForExtraction\s*&&\s*persistedIds\.length > 0\s*\)\s*\{[\s\S]*?await this\.appendPersistedThreadEpisodes\(\s*threadIdForExtraction,\s*persistedIds,?\s*\);/m,
+    /if\s*\(\s*resolvePresentationCapabilities\(this\.config\)\.threading\s*&&\s*threadIdForExtraction\s*&&\s*persistedIds\.length > 0\s*\)\s*\{[\s\S]*?await this\.appendPersistedThreadEpisodes\(\s*threadIdForExtraction,\s*persistedIds,?\s*\);/m,
     "runExtraction should batch-append persisted IDs after persistence for thread completeness",
   );
 });


### PR DESCRIPTION
## Summary

Migrates 29 `config.*Enabled` flags to 3 new CapabilitySet projections, reducing `scatteredConfigFlagReads` from **245 → 184** (-61).

### New capability sets

| Set | Flags | Read sites migrated |
|---|---|---|
| **PresentationCapabilitySet** | 7: verbatimArtifacts, memoryBoxes, bufferSurpriseTrigger, threading, episodeNoteMode, transcript, entitySummary | 27 |
| **ConsolidationCapabilitySet** | 8: compoundingSemantic, abstractionAnchors, compounding, calibration, semanticConsolidation, patternReinforcement, continuityAudit, graphEdgeDecay | 25 |
| **RecallAuxiliaryCapabilitySet** | 14: causalRuleExtraction, correction, continuityIncidentLogging, daySummary, versioning, verifiedRecall, semanticRuleVerification, workProductRecall, secureStore, knowledgeIndex, factDeduplication, compactionReset, entityRetrieval, cronRecallPolicy | 38 |

### Files modified (15 source + 2 test/baseline)

### Exclusions
- `messagePartsEnabled`: field lives on `LcmEngineConfig`, not `PluginConfig`
- `graphEdgeDecayEnabled` in `summarizeGraphEdgeDecayStatus()`: function receives `Pick<PluginConfig, ...>`

## Verification
- ✅ TypeScript: clean compile
- ✅ Entity-hardening: **246/246** pass
- ✅ Capabilities parity: **56/56** pass (47 existing + 9 new)
- ✅ Ratchet: `scatteredConfigFlagReads: 245 → 184` (DECREASED)
- ✅ Watchlist: all files same or smaller

Chokepoints used: CapabilitySet/caps.* (#1523/#1566)

Refs #1523

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical 1:1 pass-through from existing booleans with characterization tests; behavior should match prior gates, though the broad recall/orchestrator touch surface warrants normal regression checks.
> 
> **Overview**
> Adds three frozen **CapabilitySet** projections in `capabilities.ts`—**Presentation** (7 flags), **Consolidation** (8), and **RecallAuxiliary** (14)—and replaces scattered `config.*Enabled` checks across orchestrator, access-service, extraction, compounding, CLI, and related modules with `resolvePresentationCapabilities`, `resolveConsolidationCapabilities`, and `resolveRecallAuxiliaryCapabilities`.
> 
> Gate-parity tests lock each field to its matching `*Enabled` config flag; the structural ratchet updates **`scatteredConfigFlagReads` 245 → 184**. A threading-order test now asserts the presentation resolver for `threading`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed43cf1b88bd950c0ff83f01712205d5f93fafc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->