### PR TITLE
refactor(core): extract conversation-index seam from orchestrator (#1526 seam 9)

### DIFF
--- a/packages/remnic-core/src/orchestration/conversation-index-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/conversation-index-coordinator.ts
@@ -1,0 +1,333 @@
+/**
+ * Conversation index coordinator — extracted from the orchestrator (issue #1526).
+ *
+ * Owns the conversation-index subsystem: semantic recall over past
+ * conversations, plus the build / update / rebuild / inspect / health
+ * lifecycle of the on-disk chunk store and its pluggable search backend
+ * (qmd or faiss). Behavior-preserving move from orchestrator.ts — no logic
+ * changes; the orchestrator constructs one instance and keeps thin
+ * delegating methods so existing call sites and tests that exercise the
+ * private API continue to work.
+ */
+
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { resolveIndexingCapabilities } from "../capabilities.js";
+import { cleanupConversationChunks } from "../conversation-index/cleanup.js";
+import { chunkTranscriptEntries } from "../conversation-index/chunker.js";
+import type { ConversationChunk } from "../conversation-index/chunker.js";
+import { writeConversationChunks } from "../conversation-index/indexer.js";
+import type {
+  ConversationIndexBackend,
+  ConversationIndexBackendHealth,
+  ConversationIndexBackendInspection,
+} from "../conversation-index/backend.js";
+import type { ConversationSearchResult } from "../conversation-index/search.js";
+import type { TranscriptManager } from "../transcript.js";
+import type { PluginConfig } from "../types.js";
+
+/**
+ * Coordinator for the conversation-index subsystem.
+ *
+ * Holds the per-session last-update timestamps (previously an orchestrator
+ * field) and delegates chunk building / persistence / embedding to the
+ * configured backend.
+ */
+export class ConversationIndexCoordinator {
+  private readonly config: PluginConfig;
+  private readonly transcript: TranscriptManager;
+  private readonly backend: ConversationIndexBackend | undefined;
+  private readonly indexDir: string;
+  private readonly lastUpdateAtMs = new Map<string, number>();
+
+  constructor(options: {
+    config: PluginConfig;
+    transcript: TranscriptManager;
+    backend: ConversationIndexBackend | undefined;
+    indexDir: string;
+  }) {
+    this.config = options.config;
+    this.transcript = options.transcript;
+    this.backend = options.backend;
+    this.indexDir = options.indexDir;
+  }
+
+  /** Semantic recall over past-conversation chunks (fail-open: empty on miss). */
+  async search(
+    retrievalQuery: string,
+    topK: number,
+  ): Promise<ConversationSearchResult[]> {
+    if (this.backend) {
+      return this.backend.search(retrievalQuery, topK);
+    }
+    return [];
+  }
+
+  /** Render conversation-recall search hits as a budgeted markdown section. */
+  formatRecallSection(
+    results: ConversationSearchResult[],
+    maxChars: number,
+  ): string | null {
+    if (!Array.isArray(results) || results.length === 0) return null;
+    const lines: string[] = ["## Semantic Recall (Past Conversations)", ""];
+    let used = 0;
+    for (const r of results) {
+      if (!r?.snippet) continue;
+      const chunk =
+        `### ${r.path}\n` +
+        `Score: ${r.score.toFixed(3)}\n\n` +
+        `${r.snippet.trim()}\n`;
+      if (used + chunk.length > maxChars) break;
+      lines.push(chunk);
+      used += chunk.length;
+    }
+    return used > 0 ? lines.join("\n") : null;
+  }
+
+  /** Recursively count `.md` chunk documents under a directory. */
+  async countChunkDocs(dir: string): Promise<number> {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      let total = 0;
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          total += await this.countChunkDocs(fullPath);
+          continue;
+        }
+        if (entry.isFile() && entry.name.endsWith(".md")) {
+          total += 1;
+        }
+      }
+      return total;
+    } catch {
+      return 0;
+    }
+  }
+
+  /** Read recent transcript entries and chunk them for indexing. */
+  async buildChunks(
+    sessionKey?: string,
+    hours: number = 24,
+  ): Promise<ConversationChunk[]> {
+    const entries = await this.transcript.readRecent(hours, sessionKey);
+    const effectiveSessionKey = sessionKey ?? "all-sessions";
+    return chunkTranscriptEntries(effectiveSessionKey, entries, {
+      maxChars: this.config.conversationRecallMaxChars * 2,
+      maxTurns: Math.max(10, this.config.hourlySummariesMaxTurnsPerRun),
+    });
+  }
+
+  async getHealth(): Promise<{
+    enabled: boolean;
+    backend: "qmd" | "faiss";
+    status: "ok" | "degraded" | "disabled";
+    chunkDocCount: number;
+    lastUpdateAt: string | null;
+    qmdAvailable?: boolean;
+    faiss?: {
+      ok: boolean;
+      status: "ok" | "degraded" | "error";
+      indexPath: string;
+      message?: string;
+      manifest?: {
+        version: number;
+        modelId: string;
+        normalizedModelId: string;
+        dimension: number;
+        chunkCount: number;
+        updatedAt: string;
+        lastSuccessfulRebuildAt: string;
+      };
+    };
+  }> {
+    const chunkDocCount = await this.countChunkDocs(this.indexDir);
+    const lastUpdateAtMs = Math.max(0, ...this.lastUpdateAtMs.values());
+    const lastUpdateAt =
+      lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
+
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
+      return {
+        enabled: false,
+        backend: this.config.conversationIndexBackend,
+        status: "disabled",
+        chunkDocCount,
+        lastUpdateAt,
+      };
+    }
+    const backendHealth: ConversationIndexBackendHealth = this.backend
+      ? await this.backend.health()
+      : {
+          backend: this.config.conversationIndexBackend,
+          status: "degraded" as const,
+        };
+    return {
+      enabled: true,
+      chunkDocCount,
+      lastUpdateAt,
+      ...backendHealth,
+    };
+  }
+
+  async inspect(): Promise<
+    ConversationIndexBackendInspection & {
+      enabled: boolean;
+      chunkDocCount: number;
+      lastUpdateAt: string | null;
+    }
+  > {
+    const chunkDocCount = await this.countChunkDocs(this.indexDir);
+    const lastUpdateAtMs = Math.max(0, ...this.lastUpdateAtMs.values());
+    const lastUpdateAt =
+      lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
+
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
+      return {
+        enabled: false,
+        backend: this.config.conversationIndexBackend,
+        status: "disabled",
+        available: false,
+        indexPath: this.indexDir,
+        supportsIncrementalUpdate: true,
+        message: "Conversation index disabled by config",
+        metadata: {
+          chunkCount: chunkDocCount,
+        },
+        chunkDocCount,
+        lastUpdateAt,
+      };
+    }
+
+    const inspection: ConversationIndexBackendInspection = this.backend
+      ? await this.backend.inspect()
+      : {
+          backend: this.config.conversationIndexBackend,
+          status: "degraded" as const,
+          available: false,
+          indexPath: this.indexDir,
+          supportsIncrementalUpdate: true,
+          message: "Conversation index backend unavailable",
+          metadata: {
+            chunkCount: chunkDocCount,
+          },
+        };
+
+    return {
+      enabled: true,
+      chunkDocCount,
+      lastUpdateAt,
+      ...inspection,
+    };
+  }
+
+  async update(
+    sessionKey: string,
+    hours: number = 24,
+    opts?: { embed?: boolean; enforceMinInterval?: boolean },
+  ): Promise<{
+    chunks: number;
+    skipped: boolean;
+    reason?: string;
+    retryAfterMs?: number;
+    embedded?: boolean;
+  }> {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
+      return { chunks: 0, skipped: true, reason: "disabled", embedded: false };
+    }
+    const enforceMinInterval = opts?.enforceMinInterval !== false;
+    if (enforceMinInterval) {
+      const minIntervalMs = Math.max(
+        0,
+        this.config.conversationIndexMinUpdateIntervalMs,
+      );
+      const now = Date.now();
+      const last = this.lastUpdateAtMs.get(sessionKey) ?? 0;
+      const elapsed = now - last;
+      if (minIntervalMs > 0 && elapsed < minIntervalMs) {
+        return {
+          chunks: 0,
+          skipped: true,
+          reason: "min_interval",
+          retryAfterMs: minIntervalMs - elapsed,
+          embedded: false,
+        };
+      }
+    }
+    const chunks = await this.buildChunks(sessionKey, hours);
+    await writeConversationChunks(this.indexDir, chunks);
+    const retentionCutoffMs =
+      Number.isFinite(this.config.conversationIndexRetentionDays) &&
+      this.config.conversationIndexRetentionDays > 0
+        ? Date.now() -
+          this.config.conversationIndexRetentionDays * 24 * 60 * 60 * 1000
+        : undefined;
+    await cleanupConversationChunks(
+      this.indexDir,
+      this.config.conversationIndexRetentionDays,
+    );
+    const shouldEmbed =
+      opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
+    let embedded = false;
+
+    if (this.backend) {
+      const result = await this.backend.update(chunks, {
+        embed: shouldEmbed,
+        ...(retentionCutoffMs !== undefined ? { retentionCutoffMs } : {}),
+      });
+      embedded = result.embedded;
+    }
+
+    this.lastUpdateAtMs.set(sessionKey, Date.now());
+    return { chunks: chunks.length, skipped: false, embedded };
+  }
+
+  async rebuild(
+    sessionKey?: string,
+    hours: number = 24,
+    opts?: { embed?: boolean },
+  ): Promise<{
+    chunks: number;
+    skipped: boolean;
+    reason?: string;
+    embedded?: boolean;
+    rebuilt?: boolean;
+  }> {
+    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
+      return {
+        chunks: 0,
+        skipped: true,
+        reason: "disabled",
+        embedded: false,
+        rebuilt: false,
+      };
+    }
+
+    const chunks = await this.buildChunks(sessionKey, hours);
+    await writeConversationChunks(this.indexDir, chunks);
+    await cleanupConversationChunks(
+      this.indexDir,
+      this.config.conversationIndexRetentionDays,
+    );
+
+    const shouldEmbed =
+      opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
+    let embedded = false;
+    let rebuilt = false;
+    if (this.backend) {
+      const result = await this.backend.rebuild(chunks, {
+        embed: shouldEmbed,
+      });
+      embedded = result.embedded;
+      rebuilt = result.rebuilt;
+    }
+
+    const stamp = Date.now();
+    if (sessionKey) {
+      this.lastUpdateAtMs.set(sessionKey, stamp);
+    } else {
+      this.lastUpdateAtMs.set("__rebuild__", stamp);
+    }
+    return { chunks: chunks.length, skipped: false, embedded, rebuilt };
+  }
+}

--- a/packages/remnic-core/src/orchestration/conversation-index-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/conversation-index-coordinator.ts
@@ -8,6 +8,12 @@
  * changes; the orchestrator constructs one instance and keeps thin
  * delegating methods so existing call sites and tests that exercise the
  * private API continue to work.
+ *
+ * The backend and transcript are read through getters (not captured at
+ * construction) so that post-construction reassignment of the orchestrator's
+ * live fields — exercised by the conversation-index integration tests and by
+ * backend swap-in at deferred-init time — is honored. This mirrors the
+ * TierMigrationCoordinator accessor pattern.
  */
 
 import { readdir } from "node:fs/promises";
@@ -36,20 +42,20 @@ import type { PluginConfig } from "../types.js";
  */
 export class ConversationIndexCoordinator {
   private readonly config: PluginConfig;
-  private readonly transcript: TranscriptManager;
-  private readonly backend: ConversationIndexBackend | undefined;
+  private readonly getTranscript: () => TranscriptManager;
+  private readonly getBackend: () => ConversationIndexBackend | undefined;
   private readonly indexDir: string;
   private readonly lastUpdateAtMs = new Map<string, number>();
 
   constructor(options: {
     config: PluginConfig;
-    transcript: TranscriptManager;
-    backend: ConversationIndexBackend | undefined;
+    getTranscript: () => TranscriptManager;
+    getBackend: () => ConversationIndexBackend | undefined;
     indexDir: string;
   }) {
     this.config = options.config;
-    this.transcript = options.transcript;
-    this.backend = options.backend;
+    this.getTranscript = options.getTranscript;
+    this.getBackend = options.getBackend;
     this.indexDir = options.indexDir;
   }
 
@@ -58,8 +64,9 @@ export class ConversationIndexCoordinator {
     retrievalQuery: string,
     topK: number,
   ): Promise<ConversationSearchResult[]> {
-    if (this.backend) {
-      return this.backend.search(retrievalQuery, topK);
+    const backend = this.getBackend();
+    if (backend) {
+      return backend.search(retrievalQuery, topK);
     }
     return [];
   }
@@ -111,7 +118,7 @@ export class ConversationIndexCoordinator {
     sessionKey?: string,
     hours: number = 24,
   ): Promise<ConversationChunk[]> {
-    const entries = await this.transcript.readRecent(hours, sessionKey);
+    const entries = await this.getTranscript().readRecent(hours, sessionKey);
     const effectiveSessionKey = sessionKey ?? "all-sessions";
     return chunkTranscriptEntries(effectiveSessionKey, entries, {
       maxChars: this.config.conversationRecallMaxChars * 2,
@@ -156,8 +163,9 @@ export class ConversationIndexCoordinator {
         lastUpdateAt,
       };
     }
-    const backendHealth: ConversationIndexBackendHealth = this.backend
-      ? await this.backend.health()
+    const backend = this.getBackend();
+    const backendHealth: ConversationIndexBackendHealth = backend
+      ? await backend.health()
       : {
           backend: this.config.conversationIndexBackend,
           status: "degraded" as const,
@@ -199,8 +207,9 @@ export class ConversationIndexCoordinator {
       };
     }
 
-    const inspection: ConversationIndexBackendInspection = this.backend
-      ? await this.backend.inspect()
+    const backend = this.getBackend();
+    const inspection: ConversationIndexBackendInspection = backend
+      ? await backend.inspect()
       : {
           backend: this.config.conversationIndexBackend,
           status: "degraded" as const,
@@ -270,8 +279,9 @@ export class ConversationIndexCoordinator {
       opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
     let embedded = false;
 
-    if (this.backend) {
-      const result = await this.backend.update(chunks, {
+    const backend = this.getBackend();
+    if (backend) {
+      const result = await backend.update(chunks, {
         embed: shouldEmbed,
         ...(retentionCutoffMs !== undefined ? { retentionCutoffMs } : {}),
       });
@@ -314,8 +324,9 @@ export class ConversationIndexCoordinator {
       opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
     let embedded = false;
     let rebuilt = false;
-    if (this.backend) {
-      const result = await this.backend.rebuild(chunks, {
+    const backend = this.getBackend();
+    if (backend) {
+      const result = await backend.rebuild(chunks, {
         embed: shouldEmbed,
       });
       embedded = result.embedded;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -102,6 +102,7 @@ import { SemanticConsolidationCoordinator } from "./orchestration/semantic-conso
 import { LifecyclePolicyCoordinator } from "./orchestration/lifecycle-policy-coordinator.js";
 import { EntitySynthesisCoordinator } from "./orchestration/entity-synthesis-coordinator.js";
 import { RecallResultFormatter } from "./orchestration/recall-result-formatter.js";
+import { ConversationIndexCoordinator } from "./orchestration/conversation-index-coordinator.js";
 export { hasIdentityRecoveryIntent, resolveEffectiveIdentityInjectionMode } from "./orchestration/recall-result-formatter.js";
 import {
   runLiveConnectorsOnce,
@@ -330,9 +331,6 @@ import {
   type SemanticConsolidationLlmOperator,
   type SemanticConsolidationResult,
 } from "./semantic-consolidation.js";
-import { chunkTranscriptEntries } from "./conversation-index/chunker.js";
-import { writeConversationChunks } from "./conversation-index/indexer.js";
-import { cleanupConversationChunks } from "./conversation-index/cleanup.js";
 import {
   type ConversationIndexBackend,
   type ConversationIndexBackendInspection,
@@ -1909,6 +1907,11 @@ export class Orchestrator {
    * to RecallResultFormatter.
    */
   readonly recallResultFormatter: RecallResultFormatter;
+  /**
+   * Issue #1526: conversation-index subsystem moved to
+   * ConversationIndexCoordinator.
+   */
+  readonly conversationIndexCoordinator: ConversationIndexCoordinator;
   private heartbeatObserverChains = new Map<string, Promise<void>>();
   private recentExtractionFingerprints = new Map<string, number>();
   private readonly consolidationObservers = new Set<
@@ -1917,7 +1920,6 @@ export class Orchestrator {
   private wearablesServiceInstance: WearablesService | null = null;
   private wearablesAutoSyncHandle: { stop(): Promise<void> } | null = null;
   private lastQmdReprobeAtMs = 0;
-  private readonly conversationIndexLastUpdateAtMs = new Map<string, number>();
   private lastFileHygieneRunAtMs = 0;
   // Pattern-reinforcement cadence gate (issue #687 PR 2/4).  Tracks the
   // last successful run so `runPatternReinforcement` can short-circuit
@@ -2898,6 +2900,12 @@ export class Orchestrator {
       "conversation-index",
       "chunks",
     );
+    this.conversationIndexCoordinator = new ConversationIndexCoordinator({
+      config,
+      transcript: this.transcript,
+      backend: this.conversationIndexBackend,
+      indexDir: this.conversationIndexDir,
+    });
     this.modelRegistry = new ModelRegistry(config.memoryDir);
     this.relevance = new RelevanceStore(config.memoryDir);
     this.negatives = new NegativeExampleStore(config.memoryDir);
@@ -5006,63 +5014,21 @@ export class Orchestrator {
     retrievalQuery: string,
     topK: number,
   ): Promise<Array<{ path: string; snippet: string; score: number }>> {
-    if (this.conversationIndexBackend) {
-      return this.conversationIndexBackend.search(retrievalQuery, topK);
-    }
-    return [];
+    return this.conversationIndexCoordinator.search(retrievalQuery, topK);
   }
 
   private formatConversationRecallSection(
     results: Array<{ path: string; snippet: string; score: number }>,
     maxChars: number,
   ): string | null {
-    if (!Array.isArray(results) || results.length === 0) return null;
-    const lines: string[] = ["## Semantic Recall (Past Conversations)", ""];
-    let used = 0;
-    for (const r of results) {
-      if (!r?.snippet) continue;
-      const chunk =
-        `### ${r.path}\n` +
-        `Score: ${r.score.toFixed(3)}\n\n` +
-        `${r.snippet.trim()}\n`;
-      if (used + chunk.length > maxChars) break;
-      lines.push(chunk);
-      used += chunk.length;
-    }
-    return used > 0 ? lines.join("\n") : null;
+    return this.conversationIndexCoordinator.formatRecallSection(
+      results,
+      maxChars,
+    );
   }
 
-  private async countConversationChunkDocs(dir: string): Promise<number> {
-    try {
-      const entries = await readdir(dir, { withFileTypes: true });
-      let total = 0;
-      for (const entry of entries) {
-        const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-          total += await this.countConversationChunkDocs(fullPath);
-          continue;
-        }
-        if (entry.isFile() && entry.name.endsWith(".md")) {
-          total += 1;
-        }
-      }
-      return total;
-    } catch {
-      return 0;
-    }
-  }
-
-  private async buildConversationIndexChunks(
-    sessionKey?: string,
-    hours: number = 24,
-  ): Promise<ReturnType<typeof chunkTranscriptEntries>> {
-    const entries = await this.transcript.readRecent(hours, sessionKey);
-    const effectiveSessionKey = sessionKey ?? "all-sessions";
-    return chunkTranscriptEntries(effectiveSessionKey, entries, {
-      maxChars: this.config.conversationRecallMaxChars * 2,
-      maxTurns: Math.max(10, this.config.hourlySummariesMaxTurnsPerRun),
-    });
-  }
+  // Issue #1526: countConversationChunkDocs / buildConversationIndexChunks moved
+  // to ConversationIndexCoordinator (internal helpers, no orchestrator callers).
 
   async getConversationIndexHealth(): Promise<{
     enabled: boolean;
@@ -5087,37 +5053,7 @@ export class Orchestrator {
       };
     };
   }> {
-    const chunkDocCount = await this.countConversationChunkDocs(
-      this.conversationIndexDir,
-    );
-    const lastUpdateAtMs = Math.max(
-      0,
-      ...this.conversationIndexLastUpdateAtMs.values(),
-    );
-    const lastUpdateAt =
-      lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
-
-    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
-      return {
-        enabled: false,
-        backend: this.config.conversationIndexBackend,
-        status: "disabled",
-        chunkDocCount,
-        lastUpdateAt,
-      };
-    }
-    const backendHealth = this.conversationIndexBackend
-      ? await this.conversationIndexBackend.health()
-      : {
-          backend: this.config.conversationIndexBackend,
-          status: "degraded" as const,
-        };
-    return {
-      enabled: true,
-      chunkDocCount,
-      lastUpdateAt,
-      ...backendHealth,
-    };
+    return this.conversationIndexCoordinator.getHealth();
   }
 
   async inspectConversationIndex(): Promise<
@@ -5127,53 +5063,7 @@ export class Orchestrator {
       lastUpdateAt: string | null;
     }
   > {
-    const chunkDocCount = await this.countConversationChunkDocs(
-      this.conversationIndexDir,
-    );
-    const lastUpdateAtMs = Math.max(
-      0,
-      ...this.conversationIndexLastUpdateAtMs.values(),
-    );
-    const lastUpdateAt =
-      lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
-
-    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
-      return {
-        enabled: false,
-        backend: this.config.conversationIndexBackend,
-        status: "disabled",
-        available: false,
-        indexPath: this.conversationIndexDir,
-        supportsIncrementalUpdate: true,
-        message: "Conversation index disabled by config",
-        metadata: {
-          chunkCount: chunkDocCount,
-        },
-        chunkDocCount,
-        lastUpdateAt,
-      };
-    }
-
-    const inspection = this.conversationIndexBackend
-      ? await this.conversationIndexBackend.inspect()
-      : {
-          backend: this.config.conversationIndexBackend,
-          status: "degraded" as const,
-          available: false,
-          indexPath: this.conversationIndexDir,
-          supportsIncrementalUpdate: true,
-          message: "Conversation index backend unavailable",
-          metadata: {
-            chunkCount: chunkDocCount,
-          },
-        };
-
-    return {
-      enabled: true,
-      chunkDocCount,
-      lastUpdateAt,
-      ...inspection,
-    };
+    return this.conversationIndexCoordinator.inspect();
   }
 
   async getRecoverySummary(sessionKey?: string): Promise<{
@@ -5199,54 +5089,7 @@ export class Orchestrator {
     retryAfterMs?: number;
     embedded?: boolean;
   }> {
-    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
-      return { chunks: 0, skipped: true, reason: "disabled", embedded: false };
-    }
-    const enforceMinInterval = opts?.enforceMinInterval !== false;
-    if (enforceMinInterval) {
-      const minIntervalMs = Math.max(
-        0,
-        this.config.conversationIndexMinUpdateIntervalMs,
-      );
-      const now = Date.now();
-      const last = this.conversationIndexLastUpdateAtMs.get(sessionKey) ?? 0;
-      const elapsed = now - last;
-      if (minIntervalMs > 0 && elapsed < minIntervalMs) {
-        return {
-          chunks: 0,
-          skipped: true,
-          reason: "min_interval",
-          retryAfterMs: minIntervalMs - elapsed,
-          embedded: false,
-        };
-      }
-    }
-    const chunks = await this.buildConversationIndexChunks(sessionKey, hours);
-    await writeConversationChunks(this.conversationIndexDir, chunks);
-    const retentionCutoffMs =
-      Number.isFinite(this.config.conversationIndexRetentionDays) &&
-      this.config.conversationIndexRetentionDays > 0
-        ? Date.now() -
-          this.config.conversationIndexRetentionDays * 24 * 60 * 60 * 1000
-        : undefined;
-    await cleanupConversationChunks(
-      this.conversationIndexDir,
-      this.config.conversationIndexRetentionDays,
-    );
-    const shouldEmbed =
-      opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
-    let embedded = false;
-
-    if (this.conversationIndexBackend) {
-      const result = await this.conversationIndexBackend.update(chunks, {
-        embed: shouldEmbed,
-        ...(retentionCutoffMs !== undefined ? { retentionCutoffMs } : {}),
-      });
-      embedded = result.embedded;
-    }
-
-    this.conversationIndexLastUpdateAtMs.set(sessionKey, Date.now());
-    return { chunks: chunks.length, skipped: false, embedded };
+    return this.conversationIndexCoordinator.update(sessionKey, hours, opts);
   }
 
   async rebuildConversationIndex(
@@ -5260,42 +5103,7 @@ export class Orchestrator {
     embedded?: boolean;
     rebuilt?: boolean;
   }> {
-    if (!resolveIndexingCapabilities(this.config).conversationIndex) {
-      return {
-        chunks: 0,
-        skipped: true,
-        reason: "disabled",
-        embedded: false,
-        rebuilt: false,
-      };
-    }
-
-    const chunks = await this.buildConversationIndexChunks(sessionKey, hours);
-    await writeConversationChunks(this.conversationIndexDir, chunks);
-    await cleanupConversationChunks(
-      this.conversationIndexDir,
-      this.config.conversationIndexRetentionDays,
-    );
-
-    const shouldEmbed =
-      opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
-    let embedded = false;
-    let rebuilt = false;
-    if (this.conversationIndexBackend) {
-      const result = await this.conversationIndexBackend.rebuild(chunks, {
-        embed: shouldEmbed,
-      });
-      embedded = result.embedded;
-      rebuilt = result.rebuilt;
-    }
-
-    const stamp = Date.now();
-    if (sessionKey) {
-      this.conversationIndexLastUpdateAtMs.set(sessionKey, stamp);
-    } else {
-      this.conversationIndexLastUpdateAtMs.set("__rebuild__", stamp);
-    }
-    return { chunks: chunks.length, skipped: false, embedded, rebuilt };
+    return this.conversationIndexCoordinator.rebuild(sessionKey, hours, opts);
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2902,8 +2902,8 @@ export class Orchestrator {
     );
     this.conversationIndexCoordinator = new ConversationIndexCoordinator({
       config,
-      transcript: this.transcript,
-      backend: this.conversationIndexBackend,
+      getTranscript: () => this.transcript,
+      getBackend: () => this.conversationIndexBackend,
       indexDir: this.conversationIndexDir,
     });
     this.modelRegistry = new ModelRegistry(config.memoryDir);

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 19453,
+      "packages/remnic-core/src/orchestrator.ts": 19261,
       "packages/remnic-core/src/cli.ts": 9393,
       "packages/remnic-core/src/access-service.ts": 9016,
       "packages/remnic-core/src/storage.ts": 7747,


### PR DESCRIPTION
## Summary

Seam 9 of the #1526 orchestrator decomposition. Extracts the **conversation-index subsystem** — the largest remaining cohesive seam not owned by another lane — out of the 19.9k-LOC `orchestrator.ts` into a new `ConversationIndexCoordinator` under `orchestration/`.

## What moved

All conversation-index logic is now in `orchestration/conversation-index-coordinator.ts`:
- `searchConversationRecallResults` → `coordinator.search()` (semantic recall over past conversations)
- `formatConversationRecallSection` → `coordinator.formatRecallSection()`
- `countConversationChunkDocs` → `coordinator.countChunkDocs()` (internal helper, no orchestrator callers)
- `buildConversationIndexChunks` → `coordinator.buildChunks()` (internal helper, no orchestrator callers)
- `getConversationIndexHealth` → `coordinator.getHealth()`
- `inspectConversationIndex` → `coordinator.inspect()`
- `updateConversationIndex` → `coordinator.update()`
- `rebuildConversationIndex` → `coordinator.rebuild()`
- The `conversationIndexLastUpdateAtMs` per-session timestamp map moves into the coordinator.

## Behavior-preserving

The orchestrator keeps thin delegating methods with **identical signatures**, so every public/private call site (`cli.ts`, `access-service.ts`, `operator-toolkit.ts`, `recallInternal`) and every test is unchanged. No logic changes — pure move.

The internal `countConversationChunkDocs` / `buildConversationIndexChunks` helpers had no orchestrator-level callers outside the moved block, so they are not re-exported.

## LOC change

`orchestrator.ts`: **19454 → 19262** (−192). Ratchet baseline tightened via `check-ratchets --update`.

## Verification

- `tsc --noEmit` (core): clean
- `npm run lint` (biome): clean
- `npm run test:entity-hardening`: **246/246 pass**
- `node scripts/check-ratchets.mjs`: OK (improvement detected & baseline tightened)
- `check-ratchets.test.mjs`: pass
- `conversation-index/indexer.test.ts`: pass

## Chokepoints used / not applicable

Not applicable — pure behavior-preserving extraction, no new MCP tool / HTTP route / CLI command / config flag surface.

Refs #1526.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural extraction with identical orchestrator APIs and getter-based backend/transcript access; risk is limited to accidental wiring mistakes rather than new product behavior.
> 
> **Overview**
> **Orchestrator decomposition (#1526 seam 9):** conversation-index behavior moves into new `ConversationIndexCoordinator` under `orchestration/`, including semantic recall search, recall markdown formatting, chunk build/write/cleanup, per-session update throttling, and health/inspect/update/rebuild against the qmd/faiss backend.
> 
> The orchestrator **wires** the coordinator at construction (transcript and backend via getters so deferred backend swap still works), **drops** `conversationIndexLastUpdateAtMs` from its own state, and **replaces** inlined implementations with thin delegates on the same public/private method names so external call sites stay unchanged.
> 
> `scripts/ratchet-baseline.json` tightens the `orchestrator.ts` watchlist LOC cap (~19453 → ~19261) to match the shrink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c05c812898c8069e95a57b13ab30deac481d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->