### PR TITLE
config: retire 2 dead capability projections (#1780)

### DIFF
--- a/packages/remnic-core/src/capabilities.test.ts
+++ b/packages/remnic-core/src/capabilities.test.ts
@@ -1192,7 +1192,6 @@ const RECALL_ENH_FIELD_TO_FLAG: Record<keyof RecallEnhancementCapabilitySet, str
   compoundingInject: "compoundingInjectEnabled",
   accessTracking: "accessTrackingEnabled",
   autoPromoteToShared: "autoPromoteToSharedEnabled",
-  recallGraph: "recallGraphEnabled",
   feedback: "feedbackEnabled",
   identity: "identityEnabled",
 };
@@ -1293,7 +1292,6 @@ const CONV_CTX_FIELD_TO_FLAG: Record<keyof ConversationContextCapabilitySet, str
   cmcConsolidation: "cmcConsolidationEnabled",
   maintenanceNamespaceFanout: "maintenanceNamespaceFanoutEnabled",
   citations: "citationsEnabled",
-  behaviorLoopAutoTune: "behaviorLoopAutoTuneEnabled",
   semanticRulePromotion: "semanticRulePromotionEnabled",
   codexMarketplace: "codexMarketplaceEnabled",
 };

--- a/packages/remnic-core/src/capabilities.ts
+++ b/packages/remnic-core/src/capabilities.ts
@@ -19,6 +19,13 @@
  * This is plumbing, not a feature — there is deliberately NO `enabled` gate for
  * the CapabilitySet itself (rule 30 governs behavior changes; resolving and
  * threading a capability projection must stay behavior-preserving).
+ *
+ * Flag-retirement audit (#1780, 2026-07-08): all projected fields across 18
+ * capability sets were verified for live consumers. Two dead projections found
+ * and removed: recallGraph (RecallEnhancementCapabilitySet — production reads
+ * recallGraphEnabled directly via graph-recall.ts) and behaviorLoopAutoTune
+ * (ConversationContextCapabilitySet — production reads behaviorLoopAutoTuneEnabled
+ * directly via cli.ts). The flags themselves remain alive.
  */
 
 import type { PluginConfig } from "./types.js";
@@ -1053,7 +1060,6 @@ export interface RecallEnhancementCapabilitySet {
   readonly compoundingInject: boolean;
   readonly accessTracking: boolean;
   readonly autoPromoteToShared: boolean;
-  readonly recallGraph: boolean;
   readonly feedback: boolean;
   readonly identity: boolean;
 }
@@ -1084,7 +1090,6 @@ export type RecallEnhancementConfigProjection = Pick<
   | "compoundingInjectEnabled"
   | "accessTrackingEnabled"
   | "autoPromoteToSharedEnabled"
-  | "recallGraphEnabled"
   | "feedbackEnabled"
   | "identityEnabled"
 >;
@@ -1115,7 +1120,6 @@ export function resolveRecallEnhancementCapabilities(config: RecallEnhancementCo
     compoundingInject: config.compoundingInjectEnabled,
     accessTracking: config.accessTrackingEnabled,
     autoPromoteToShared: config.autoPromoteToSharedEnabled,
-    recallGraph: config.recallGraphEnabled,
     feedback: config.feedbackEnabled,
     identity: config.identityEnabled,
   });
@@ -1240,7 +1244,6 @@ export interface ConversationContextCapabilitySet {
   readonly cmcConsolidation: boolean;
   readonly maintenanceNamespaceFanout: boolean;
   readonly citations: boolean;
-  readonly behaviorLoopAutoTune: boolean;
   readonly semanticRulePromotion: boolean;
   readonly codexMarketplace: boolean;
 }
@@ -1259,7 +1262,6 @@ export type ConversationContextConfigProjection = Pick<
   | "cmcConsolidationEnabled"
   | "maintenanceNamespaceFanoutEnabled"
   | "citationsEnabled"
-  | "behaviorLoopAutoTuneEnabled"
   | "semanticRulePromotionEnabled"
   | "codexMarketplaceEnabled"
 >;
@@ -1278,7 +1280,6 @@ export function resolveConversationContextCapabilities(config: ConversationConte
     cmcConsolidation: config.cmcConsolidationEnabled,
     maintenanceNamespaceFanout: config.maintenanceNamespaceFanoutEnabled,
     citations: config.citationsEnabled,
-    behaviorLoopAutoTune: config.behaviorLoopAutoTuneEnabled,
     semanticRulePromotion: config.semanticRulePromotionEnabled,
     codexMarketplace: config.codexMarketplaceEnabled,
   });


### PR DESCRIPTION
## Summary

Issue #1780 mandated a flag-retirement pass: inventory all `*Enabled` flags with capability projections, identify any whose projection field is never read (dead gates), and delete them end-to-end.

**Result: 2 dead projections found and removed.** Audited all 18 capability sets (150+ projected fields) across `capabilities.ts`. Two fields were projected into a capability set but never consumed via the capability API — production code reads the underlying config flag directly instead.

Closes #1780.

## Dead projections removed

| # | Capability set | Field | Source flag | Why dead |
|---|---|---|---|---|
| 1 | `RecallEnhancementCapabilitySet` | `recallGraph` | `recallGraphEnabled` | Production reads `config.recallGraphEnabled` directly in `graph-recall.ts:113` |
| 2 | `ConversationContextCapabilitySet` | `behaviorLoopAutoTune` | `behaviorLoopAutoTuneEnabled` | Production reads `orchestrator.config.behaviorLoopAutoTuneEnabled` directly in `cli.ts:2433` |

Both flags themselves remain in `types.ts`, `config.ts`, and both `openclaw.plugin.json` schemas — they are alive (read directly from config). Only their unused capability projections were dead code.

## What was removed

For each dead projection:
- Interface field (`readonly recallGraph: boolean` / `readonly behaviorLoopAutoTune: boolean`)
- Resolver line (`recallGraph: config.recallGraphEnabled` / `behaviorLoopAutoTune: config.behaviorLoopAutoTuneEnabled`)
- Config-projection `Pick` entry (`"recallGraphEnabled"` / `"behaviorLoopAutoTuneEnabled"`)
- Test field-to-flag mapping entry
- Updated the audit-trail comment in the module docstring

## Verification

- Automated scan: all 18 capability sets × all fields — 148 live, 2 dead
- TypeScript: ✅ clean
- Config-contract: ✅ `PluginConfig=700, parseConfig.return=698, schema=698`
- Plugin-sync: ✅ no schema changes needed
- Ratchets: ✅ OK
- Capabilities tests: ✅ 65/65 pass
- `scatteredConfigFlagReads` ratchet: 0 (unchanged)

Chokepoints used: N/A (dead-code removal, no behavior change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unused capability fields and test mappings only; runtime still uses the same `*Enabled` config flags, so behavior should be unchanged.
> 
> **Overview**
> Completes the **#1780 flag-retirement audit** by dropping two capability fields that had **no production consumers** on the frozen capability sets.
> 
> **`recallGraph`** is removed from `RecallEnhancementCapabilitySet` (interface, config `Pick`, resolver, and parity test map). **`behaviorLoopAutoTune`** is removed the same way from `ConversationContextCapabilitySet`. **`recallGraphEnabled`** and **`behaviorLoopAutoTuneEnabled`** stay on `PluginConfig`; call sites keep reading them directly (e.g. graph recall and CLI policy status).
> 
> The `capabilities.ts` module doc now records the audit outcome and why those projections were dead. This is **plumbing cleanup only**—no change to how flags gate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bc5950f5c38ba2a0054983994a6335fc161689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->