### PR TITLE
refactor(orchestrator): extract turn-ingestion entry points into TurnIngestionCoordinator (seam 20, #1526)

### DIFF
--- a/packages/remnic-core/src/orchestration/turn-ingestion.ts
+++ b/packages/remnic-core/src/orchestration/turn-ingestion.ts
@@ -1,0 +1,795 @@
+/**
+ * Turn-ingestion coordinator — extracted from the orchestrator
+ * (issue #1526, seam 20).
+ *
+ * Owns the buffer-side entry points that feed the extraction pipeline:
+ *   - processTurn (per-turn buffering + trigger-mode flush decisions)
+ *   - observeSessionHeartbeat (heartbeat-driven extraction observer)
+ *   - queueBufferedExtraction (dedupe-gated extraction queueing)
+ *   - ingestReplayBatch / ingestBulkImportBatch (batch ingestion)
+ *   - maybeCapturePassiveCorrections (passive correction capture)
+ *
+ * Behavior-preserving move from orchestrator.ts. The orchestrator keeps
+ * thin delegating methods; every member the moved code consults flows
+ * back through TurnIngestionDeps live accessors/arrows so prototype-call
+ * tests (Orchestrator.prototype.processTurn.call(fake, …)) and instance
+ * stubs keep working (same late-binding rule as seams 18/19).
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import path from "node:path";
+import { SmartBuffer } from "../buffer.js";
+import type { ImportTurn } from "../bulk-import/types.js";
+import { resolvePipelineProcessingCapabilities, resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
+import type { CorrectionService } from "../correction/correction-service.js";
+import { type PassiveCaptureConfig, capturePassiveCorrections } from "../correction/passive-capture.js";
+import { detectPassiveCorrections } from "../correction/passive-correction-detector.js";
+import { shouldSkipImplicitExtraction } from "../explicit-capture.js";
+import { StorageManager } from "../index.js";
+import { LcmEngine } from "../lcm/index.js";
+import { log } from "../logger.js";
+import { defaultNamespaceForPrincipal, resolvePrincipal } from "../namespaces/principal.js";
+import { ExtractionQueueCoordinator } from "./extraction-queue-coordinator.js";
+import { ExtractionRunCoordinator, type ExtractionRunResult } from "./extraction-run.js";
+import { resolveHandle, stripHandles } from "../recall-handles.js";
+import { type ReplayTurn, normalizeReplaySessionKey } from "../replay/types.js";
+import { SessionObserverState } from "../session-observer-state.js";
+import { CODEX_THREAD_KEY_PREFIX } from "../thread-key.js";
+import { ThreadingManager } from "../threading.js";
+import { TranscriptManager } from "../transcript.js";
+import type { BufferTurn, PluginConfig } from "../types.js";
+import {
+  BulkImportBatchPartialFailureError,
+  splitTurnsBySourceValidAt,
+  targetSourceValidAtSortMs,
+  type BulkImportBatchIngestResult,
+} from "../orchestrator.js";
+
+export interface TurnIngestionDeps {
+  readonly buffer: SmartBuffer;
+  bulkImportWriteNamespace(): string;
+  readonly config: PluginConfig;
+  readonly extractionQueueCoordinator: ExtractionQueueCoordinator;
+  getStorage(namespace?: string): Promise<StorageManager>;
+  readonly heartbeatObserverChains: Map<string, Promise<void>>;
+  readonly lcmEngine: LcmEngine | null;
+  readonly passiveCorrectionDedup: Set<string>;
+  passiveCorrectionService(): CorrectionService;
+  readonly passiveCorrectionTelemetry: {
+    detected: number;
+    queued: number;
+    autoApplied: number;
+    suppressedReasonCounts: Record<string, number>;
+  };
+  queueBufferedExtraction(
+    turnsToExtract: BufferTurn[],
+    reason: "trigger_mode" | "heartbeat_observer",
+    options?: {
+      skipDedupeCheck?: boolean;
+      clearBufferAfterExtraction?: boolean;
+      skipCharThreshold?: boolean;
+      skipUserTurnThreshold?: boolean;
+      extractionDeadlineMs?: number;
+      failOnExtractionFailure?: boolean;
+      onTaskSettled?: (
+        error?: unknown,
+        result?: ExtractionRunResult,
+      ) => void;
+      bufferKey?: string;
+      abortSignal?: AbortSignal;
+      /**
+       * Explicit namespace override for the write path (#460).  When set,
+       * `runExtraction` writes to this namespace instead of deriving one
+       * from `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))`.
+       * Used by bulk-import to pin writes to a deterministic namespace
+       * regardless of user-configured principal routing rules.
+       */
+      writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance principal (#1495 thread 1). Forwarded to
+       * `runExtraction` so access `observe` can record provenance under the
+       * authenticated principal instead of `resolvePrincipal(sessionKey)`.
+       */
+      principalOverride?: string;
+    },
+  ): Promise<void>;
+  resolveMemoryIdOrHandle(ref: string, sessionKey?: string): string;
+  runExtraction(
+    ...args: Parameters<ExtractionRunCoordinator["runExtraction"]>
+  ): Promise<ExtractionRunResult>;
+  readonly sessionObserver: SessionObserverState;
+  shouldQueueExtraction(
+    turns: BufferTurn[],
+    options?: { commit?: boolean; bufferKey?: string },
+  ): boolean;
+  readonly transcript: TranscriptManager;
+}
+
+export class TurnIngestionCoordinator {
+  constructor(
+    private readonly deps: TurnIngestionDeps,
+  ) {}
+
+  async processTurn(
+    role: "user" | "assistant",
+    content: string,
+    sessionKey?: string,
+    options: {
+      bufferKey?: string;
+      logicalSessionKey?: string;
+      providerThreadId?: string | null;
+      turnFingerprint?: string;
+      persistProcessedFingerprint?: boolean;
+    } = {},
+  ): Promise<void> {
+    if (role !== "user" && role !== "assistant") {
+      log.debug(`processTurn: ignoring unsupported role=${String(role)}`);
+      return;
+    }
+    if (shouldSkipImplicitExtraction(this.deps.config)) {
+      log.debug(
+        "processTurn: skipping implicit extraction because captureMode=explicit",
+      );
+      return;
+    }
+
+    const bufferKey =
+      typeof options.bufferKey === "string" && options.bufferKey.length > 0
+        ? options.bufferKey
+        : typeof sessionKey === "string" && sessionKey.length > 0
+          ? sessionKey
+          : "default";
+    const captureTimestamp = new Date().toISOString();
+    // Issue #1582 hygiene §2 — strip any echoed `[m:xxxx]` handle before the
+    // turn enters the extraction buffer so handles never become memory content
+    // or get QMD-indexed (rule 23). Gated on the feature flag: when handles are
+    // off none are ever injected, so there is nothing to strip and the buffer
+    // stays byte-identical to the pre-#1582 path.
+    const bufferedContent = this.deps.config.recallMemoryHandles
+      ? stripHandles(content)
+      : content;
+    const turn: BufferTurn = {
+      role,
+      content: bufferedContent,
+      timestamp: captureTimestamp,
+      // #1578: anchor live-capture turns to wall-clock when bi-temporal is on;
+      // replay/import turns carry sourceValidAt explicitly (codex P1).
+      ...(this.deps.config.temporalBiTemporal
+        ? { sourceValidAt: captureTimestamp }
+        : {}),
+      sessionKey,
+      logicalSessionKey: options.logicalSessionKey ?? bufferKey,
+      providerThreadId: options.providerThreadId ?? null,
+      turnFingerprint: options.turnFingerprint,
+      persistProcessedFingerprint: options.persistProcessedFingerprint === true,
+    };
+
+    const outcome =
+      typeof this.deps.buffer.addTurnWithOutcome === "function"
+        ? await this.deps.buffer.addTurnWithOutcome(bufferKey, turn)
+        : { decision: await this.deps.buffer.addTurn(bufferKey, turn) };
+
+    if (outcome.decision === "keep_buffering") return;
+    await this.deps.queueBufferedExtraction(
+      outcome.extractionTurns ?? this.deps.buffer.getTurns(bufferKey),
+      "trigger_mode",
+      { bufferKey },
+    );
+  }
+
+  async ingestReplayBatch(
+    turns: ReplayTurn[],
+    options: {
+      deadlineMs?: number;
+      archiveLcm?: boolean;
+      abortSignal?: AbortSignal;
+      /**
+       * Pin extraction writes to this namespace instead of deriving one from
+       * `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))` + the
+       * coding overlay (#1495). The access `observe` surface resolves a single
+       * effective scope plan and passes its `writeNamespace` here so the
+       * extracted memories land in the SAME namespace as LCM archival,
+       * objective-state snapshots, and project-scoped recall — without relying
+       * on re-deriving the namespace from a namespace-prefixed session key.
+       * Same hook bulk-import uses (#460).
+       */
+      writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance PRINCIPAL instead of deriving it from
+       * `resolvePrincipal(turn.sessionKey)` (#1495 thread 1). The access
+       * `observe` surface authenticates the caller at the transport layer and
+       * passes its resolved principal here so extracted-memory provenance uses
+       * the SAME identity the surface authorized — independent of storage
+       * routing (`writeNamespaceOverride`) and of whatever `resolvePrincipal`
+       * would parse from the raw session key. Mirrors the recall path's
+       * `principalOverride` (issue #570 PR 4).
+       */
+      principalOverride?: string;
+    } = {},
+  ): Promise<void> {
+    if (!Array.isArray(turns) || turns.length === 0) return;
+    if (options.abortSignal?.aborted) {
+      throw options.abortSignal.reason instanceof Error
+        ? options.abortSignal.reason
+        : new Error("ingestReplayBatch aborted");
+    }
+    if (shouldSkipImplicitExtraction(this.deps.config)) {
+      log.debug(
+        "ingestReplayBatch: skipping implicit extraction because captureMode=explicit",
+      );
+      return;
+    }
+
+    const bySession = new Map<string, BufferTurn[]>();
+    for (const turn of turns) {
+      if (turn.role !== "user" && turn.role !== "assistant") continue;
+      const key = normalizeReplaySessionKey(turn.sessionKey);
+      const list = bySession.get(key) ?? [];
+      list.push({
+        role: turn.role,
+        content: turn.content,
+        timestamp: turn.timestamp,
+        sourceValidAt: turn.sourceValidAt,
+        sessionKey: key,
+        parts: turn.parts,
+        rawContent: turn.rawContent,
+        sourceFormat: turn.sourceFormat,
+      });
+      bySession.set(key, list);
+    }
+
+    const replaySlices: Array<{
+      bufferKey: string;
+      order: number;
+      targetValidAtMs: number;
+      turns: BufferTurn[];
+    }> = [];
+    for (const [key, sessionTurns] of bySession.entries()) {
+      if (sessionTurns.length === 0) continue;
+      if (options.abortSignal?.aborted) {
+        throw options.abortSignal.reason instanceof Error
+          ? options.abortSignal.reason
+          : new Error("ingestReplayBatch aborted");
+      }
+      if (options.archiveLcm !== false && this.deps.lcmEngine?.enabled) {
+        await this.deps.lcmEngine.observeMessages(
+          key,
+          sessionTurns.map((turn) => ({
+            role: turn.role,
+            content: turn.content,
+            parts: turn.parts,
+            rawContent: turn.rawContent,
+            sourceFormat: turn.sourceFormat,
+          })),
+        );
+      }
+      for (const sessionSlice of splitTurnsBySourceValidAt(sessionTurns)) {
+        replaySlices.push({
+          bufferKey: key,
+          order: replaySlices.length,
+          targetValidAtMs: targetSourceValidAtSortMs(sessionSlice),
+          turns: sessionSlice,
+        });
+      }
+    }
+
+    const replayTasks = replaySlices
+      .sort((a, b) => {
+        if (a.targetValidAtMs < b.targetValidAtMs) return -1;
+        if (a.targetValidAtMs > b.targetValidAtMs) return 1;
+        if (a.order === b.order) return 0;
+        return a.order < b.order ? -1 : 1;
+      })
+      .map(
+        ({ bufferKey, turns: sessionSlice }) =>
+          new Promise<void>((resolve, reject) => {
+            void this.deps.queueBufferedExtraction(sessionSlice, "trigger_mode", {
+              skipDedupeCheck: true,
+              clearBufferAfterExtraction: false,
+              skipCharThreshold: true,
+              skipUserTurnThreshold: true,
+              bufferKey,
+              extractionDeadlineMs: options.deadlineMs,
+              abortSignal: options.abortSignal,
+              writeNamespaceOverride: options.writeNamespaceOverride,
+              principalOverride: options.principalOverride,
+              onTaskSettled: (err) => (err ? reject(err) : resolve()),
+            }).catch(reject);
+          }),
+      );
+    if (replayTasks.length > 0) {
+      const settled = await Promise.allSettled(replayTasks);
+      const firstRejected = settled.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (firstRejected) {
+        throw firstRejected.reason;
+      }
+    }
+  }
+
+  /**
+   * Ingest a batch of bulk-import turns (#460). Like ingestReplayBatch, this
+   * normalizes user/assistant turns into the extraction buffer and awaits
+   * settlement, but it intentionally bypasses the captureMode="explicit"
+   * gate because bulk-import is itself an explicit user action — the user
+   * ran `bulk-import --source <name> --file ...` and would be surprised to
+   * see the command silently no-op when capture is otherwise restricted.
+   *
+   * Turns with role="other" are skipped (not supported by the extraction
+   * pipeline).
+   *
+   * Two design decisions worth calling out:
+   *
+   * - **sessionKey is truthy and per-batch-unique.**
+   *   `ThreadingManager.shouldStartNewThread` only applies the session-key
+   *   boundary check when `turn.sessionKey` is truthy (threading.ts:82);
+   *   with an empty string, imported turns could attach to the current
+   *   live thread or merge across unrelated import batches. A unique
+   *   `bulk-import:batch:<timestamp>-<rand>` key forces a fresh thread per
+   *   batch without matching common prefix/map rules in
+   *   `principalFromSessionKeyRules`. (Catch-all regex rules could still
+   *   remap the principal, but that only affects metadata provenance —
+   *   see the next point for why write routing is unaffected.)
+   *
+   * - **writeNamespaceOverride pins the storage target.**
+   *   We pass `writeNamespaceOverride: this.deps.bulkImportWriteNamespace()` to
+   *   `queueBufferedExtraction`, which tells `runExtraction` to skip
+   *   `defaultNamespaceForPrincipal` and write directly into the
+   *   orchestrator's declared bulk-import write namespace. This keeps
+   *   writes deterministic even when namespace policies named `"default"`
+   *   exist alongside a different `config.defaultNamespace`, and also
+   *   guards against regex-catch-all principal rules steering bulk-import
+   *   into an unexpected tenant.
+   *
+   * Per-invocation namespace routing (letting callers target a namespace
+   * other than `bulkImportWriteNamespace()`) is a separate feature tracked
+   * as a follow-up — the hook is the `writeNamespaceOverride` option, but
+   * the CLI surface does not yet expose a `--namespace` flag.
+   */
+  async ingestBulkImportBatch(
+    turns: ImportTurn[],
+    options: {
+      deadlineMs?: number;
+      failOnExtractionFailure?: boolean;
+      includeSourceValidAtContext?: boolean;
+    } = {},
+  ): Promise<BulkImportBatchIngestResult> {
+    if (!Array.isArray(turns) || turns.length === 0) {
+      return {
+        attemptedTurnCount: 0,
+        extractionCount: 0,
+        persistedCount: 0,
+        durableOutputCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        postPersistMetadataFailureCount: 0,
+        processedTurnCount: 0,
+      };
+    }
+
+    // Per-batch unique sessionKey keeps threading honest without matching
+    // typical prefix/map routing rules.  Combined with writeNamespaceOverride
+    // below, the storage target is independent of principal resolution.
+    // Uses crypto.randomBytes (not Math.random) so CodeQL does not flag a
+    // security-context insecure-randomness use even though this value never
+    // leaves the process; the bytes just need to be collision-resistant
+    // across concurrent bulk-import batches.
+    const shouldUseStableBatchKey = turns.some(
+      (turn) =>
+        turn.persistProcessedFingerprint === true ||
+        (typeof turn.turnFingerprint === "string" &&
+          turn.turnFingerprint.length > 0),
+    );
+    const stableBatchFingerprint = shouldUseStableBatchKey
+      ? createHash("sha256")
+        .update(
+          turns
+            .map((turn) =>
+              [
+                turn.role,
+                typeof turn.turnFingerprint === "string" &&
+                turn.turnFingerprint.length > 0
+                  ? turn.turnFingerprint
+                  : turn.content.replace(/\s+/g, " ").trim(),
+              ].join(":"),
+            )
+            .join("\n"),
+        )
+        .digest("hex")
+        .slice(0, 32)
+      : undefined;
+    const sessionKey = stableBatchFingerprint
+      ? `bulk-import:batch:${stableBatchFingerprint}`
+      : `bulk-import:batch:${Date.now().toString(36)}-${randomBytes(6).toString("hex")}`;
+
+    const sessionTurns: BufferTurn[] = [];
+    for (const turn of turns) {
+      if (turn.role !== "user" && turn.role !== "assistant") continue;
+      sessionTurns.push({
+        role: turn.role,
+        content: turn.content,
+        timestamp: turn.timestamp,
+        sourceValidAt: turn.timestamp,
+        sessionKey,
+        parts: turn.parts,
+        rawContent: turn.rawContent,
+        sourceFormat: turn.sourceFormat,
+        importProvenance: turn.importProvenance,
+        turnFingerprint: turn.turnFingerprint,
+        persistProcessedFingerprint: turn.persistProcessedFingerprint === true,
+      });
+    }
+    if (sessionTurns.length === 0) {
+      return {
+        attemptedTurnCount: 0,
+        extractionCount: 0,
+        persistedCount: 0,
+        durableOutputCount: 0,
+        skippedCount: 0,
+        failedCount: 0,
+        postPersistMetadataFailureCount: 0,
+        processedTurnCount: 0,
+      };
+    }
+
+    if (this.deps.lcmEngine?.enabled) {
+      await this.deps.lcmEngine.observeMessages(
+        sessionKey,
+        sessionTurns.map((turn) => ({
+          role: turn.role,
+          content: turn.content,
+          parts: turn.parts,
+          rawContent: turn.rawContent,
+          sourceFormat: turn.sourceFormat,
+        })),
+      );
+    }
+
+    const sessionSlices = splitTurnsBySourceValidAt(sessionTurns, {
+      includeContext: options.includeSourceValidAtContext !== false,
+    });
+    const results: ExtractionRunResult[] = [];
+    let processedTurnCount = 0;
+    let firstRejected: unknown;
+    for (const sessionSlice of sessionSlices) {
+      try {
+        const result = await new Promise<ExtractionRunResult>(
+          (resolve, reject) => {
+            void this.deps.queueBufferedExtraction(sessionSlice, "trigger_mode", {
+              skipDedupeCheck: true,
+              clearBufferAfterExtraction: false,
+              skipCharThreshold: true,
+              skipUserTurnThreshold: true,
+              bufferKey: sessionKey,
+              extractionDeadlineMs: options.deadlineMs,
+              failOnExtractionFailure: options.failOnExtractionFailure === true,
+              writeNamespaceOverride: this.deps.bulkImportWriteNamespace(),
+              onTaskSettled: (err, result) =>
+                err
+                  ? reject(err)
+                  : resolve(
+                      result ?? {
+                        status: "skipped",
+                        reason: "missing_extraction_result",
+                        persistedCount: 0,
+                        durableOutputCount: 0,
+                      },
+                    ),
+            }).catch(reject);
+          },
+        );
+        results.push(result);
+        processedTurnCount += sessionSlice.filter(
+          (turn) => turn.extractionContextOnly !== true,
+        ).length;
+      } catch (err) {
+        firstRejected = err;
+        break;
+      }
+    }
+    const rejectedCount = firstRejected ? 1 : 0;
+    const ingestResult: BulkImportBatchIngestResult = {
+      attemptedTurnCount: sessionTurns.length,
+      extractionCount: results.length,
+      persistedCount: results.reduce(
+        (sum, result) => sum + result.persistedCount,
+        0,
+      ),
+      durableOutputCount: results.reduce(
+        (sum, result) => sum + result.durableOutputCount,
+        0,
+      ),
+      skippedCount: results.filter((result) => result.status === "skipped").length,
+      failedCount: rejectedCount,
+      postPersistMetadataFailureCount: results.filter(
+        (result) => result.postPersistMetadataFailed === true,
+      ).length,
+      processedTurnCount:
+        rejectedCount === 0 ? sessionTurns.length : processedTurnCount,
+    };
+    if (firstRejected) {
+      if (processedTurnCount > 0) {
+        throw new BulkImportBatchPartialFailureError(
+          "bulk import failed after partial processing",
+          ingestResult,
+          firstRejected,
+        );
+      }
+      throw firstRejected;
+    }
+    return ingestResult;
+  }
+
+  async observeSessionHeartbeat(
+    sessionKey: string,
+    options: { bufferKey?: string } = {},
+  ): Promise<void> {
+    if (resolvePipelineProcessingCapabilities(this.deps.config).sessionObserver !== true) return;
+    if (!sessionKey || sessionKey.length === 0) return;
+
+    const bufferKey =
+      typeof options.bufferKey === "string" && options.bufferKey.length > 0
+        ? options.bufferKey
+        : sessionKey;
+    const previous =
+      this.deps.heartbeatObserverChains.get(sessionKey) ?? Promise.resolve();
+    const next = previous
+      .catch(() => undefined)
+      .then(async () => {
+        const turns = this.deps.buffer.getTurns(bufferKey);
+        if (turns.length === 0) return;
+        const normalizedSessionKey = normalizeReplaySessionKey(sessionKey);
+        const allowSharedSessionBuffer = bufferKey.startsWith(
+          CODEX_THREAD_KEY_PREFIX,
+        );
+        if (
+          !allowSharedSessionBuffer &&
+          turns.some(
+            (turn) =>
+              turn.sessionKey &&
+              normalizeReplaySessionKey(turn.sessionKey) !== normalizedSessionKey,
+          )
+        ) {
+          log.debug(
+            `heartbeat observer skipped: mixed-session buffer contents for ${bufferKey}`,
+          );
+          return;
+        }
+        if (!this.deps.shouldQueueExtraction(turns, {
+          commit: false,
+          bufferKey,
+        })) {
+          log.debug(
+            `heartbeat observer skipped: extraction dedupe for ${bufferKey}`,
+          );
+          return;
+        }
+        const footprint =
+          await this.deps.transcript.estimateSessionFootprint(sessionKey);
+        const decision = await this.deps.sessionObserver.observe({
+          sessionKey,
+          totalBytes: footprint.bytes,
+          totalTokens: footprint.tokens,
+        });
+        if (!decision.triggered) return;
+        log.debug(
+          `heartbeat observer trigger: session=${sessionKey} deltaBytes=${decision.deltaBytes} deltaTokens=${decision.deltaTokens}`,
+        );
+        await this.deps.queueBufferedExtraction(turns, "heartbeat_observer", {
+          bufferKey,
+        });
+      });
+
+    this.deps.heartbeatObserverChains.set(sessionKey, next);
+    try {
+      await next;
+    } finally {
+      if (this.deps.heartbeatObserverChains.get(sessionKey) === next) {
+        this.deps.heartbeatObserverChains.delete(sessionKey);
+      }
+    }
+  }
+
+  async queueBufferedExtraction(
+    turnsToExtract: BufferTurn[],
+    reason: "trigger_mode" | "heartbeat_observer",
+    options: {
+      skipDedupeCheck?: boolean;
+      clearBufferAfterExtraction?: boolean;
+      skipCharThreshold?: boolean;
+      skipUserTurnThreshold?: boolean;
+      extractionDeadlineMs?: number;
+      failOnExtractionFailure?: boolean;
+      onTaskSettled?: (
+        error?: unknown,
+        result?: ExtractionRunResult,
+      ) => void;
+      bufferKey?: string;
+      abortSignal?: AbortSignal;
+      /**
+       * Explicit namespace override for the write path (#460).  When set,
+       * `runExtraction` writes to this namespace instead of deriving one
+       * from `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))`.
+       * Used by bulk-import to pin writes to a deterministic namespace
+       * regardless of user-configured principal routing rules.
+       */
+      writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance principal (#1495 thread 1). Forwarded to
+       * `runExtraction` so access `observe` can record provenance under the
+       * authenticated principal instead of `resolvePrincipal(sessionKey)`.
+       */
+      principalOverride?: string;
+    } = {},
+  ): Promise<void> {
+    const bufferKey = options.bufferKey ?? turnsToExtract[0]?.sessionKey ?? "default";
+    if (
+      !options.skipDedupeCheck &&
+      !this.deps.shouldQueueExtraction(turnsToExtract, { bufferKey })
+    ) {
+      log.debug(`extraction dedupe skip: preserving buffer (${reason})`);
+      options.onTaskSettled?.(undefined, {
+        status: "skipped",
+        reason: "dedupe",
+        persistedCount: 0,
+        durableOutputCount: 0,
+      });
+      return;
+    }
+
+    const extractionDeadlineMs =
+      typeof options.extractionDeadlineMs === "number" &&
+      Number.isFinite(options.extractionDeadlineMs)
+        ? options.extractionDeadlineMs
+        : undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    const clearQueueWaitTimer = (): void => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+    };
+    const settleTask = (
+      error?: unknown,
+      result?: ExtractionRunResult,
+    ): boolean => {
+      if (settled) return false;
+      settled = true;
+      clearQueueWaitTimer();
+      options.onTaskSettled?.(error, result);
+      return true;
+    };
+
+    if (typeof extractionDeadlineMs === "number") {
+      const remainingMs = extractionDeadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
+        return;
+      }
+      timeout = setTimeout(() => {
+        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
+      }, remainingMs);
+    }
+
+    this.deps.extractionQueueCoordinator.enqueue(async () => {
+      if (settled) return;
+      if (
+        typeof extractionDeadlineMs === "number" &&
+        extractionDeadlineMs <= Date.now()
+      ) {
+        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
+        return;
+      }
+      clearQueueWaitTimer();
+      try {
+        const result = await this.deps.runExtraction(turnsToExtract, {
+          clearBufferAfterExtraction:
+            options.clearBufferAfterExtraction ?? true,
+          skipCharThreshold: options.skipCharThreshold ?? false,
+          skipUserTurnThreshold: options.skipUserTurnThreshold ?? false,
+          deadlineMs: extractionDeadlineMs,
+          bufferKey,
+          abortSignal: options.abortSignal,
+          failOnExtractionFailure: options.failOnExtractionFailure === true,
+          writeNamespaceOverride: options.writeNamespaceOverride,
+          principalOverride: options.principalOverride,
+        });
+        settleTask(undefined, result);
+      } catch (err) {
+        if (settleTask(err)) {
+          throw err;
+        }
+      }
+    });
+
+    log.debug(`queued extraction from ${reason}`);
+  }
+
+  /**
+   * Passive correction capture (issue #1581) — detects corrections expressed
+   * passively in conversation turns and routes them to the Correction Contract
+   * (#1580). Called from `runExtraction` after persistence completes.
+   *
+   * Thin wiring: delegates ALL correction logic to the detector + capture
+   * modules + the CorrectionService. This method only checks gates, calls the
+   * detector, and routes results. Fail-open: capture errors never block the
+   * extraction return path.
+   */
+  async maybeCapturePassiveCorrections(
+    turns: readonly BufferTurn[],
+    opts: {
+      sessionKey: string;
+      principal?: string;
+      namespace: string;
+      bufferKey: string;
+      isLiveSession: boolean;
+    },
+  ): Promise<void> {
+    const mode = this.deps.config.correctionCaptureMode;
+    if (mode === "off") return;
+    if (!resolveRecallAuxiliaryCapabilities(this.deps.config).correction) return;
+
+    try {
+      const corrections = detectPassiveCorrections(
+        turns.map((t) => ({ role: t.role, content: t.content })),
+      );
+      if (corrections.length === 0) return;
+
+      // Replay/import: force queue-only mode even if config says auto.
+      const effectiveMode = opts.isLiveSession ? mode : "queue";
+      const captureConfig: PassiveCaptureConfig = {
+        mode: effectiveMode,
+        confidenceFloor: this.deps.config.correctionCaptureConfidenceFloor,
+        autoApplyMaxAffected: this.deps.config.correctionCaptureAutoApplyMaxAffected,
+      };
+
+      const service = this.deps.passiveCorrectionService();
+      const result = await capturePassiveCorrections(
+        corrections,
+        {
+          correctionEnabled: resolveRecallAuxiliaryCapabilities(this.deps.config).correction,
+          isLiveSession: opts.isLiveSession,
+          bufferKey: opts.bufferKey,
+          sessionKey: opts.sessionKey,
+          principal: opts.principal,
+          namespace: opts.namespace,
+        },
+        captureConfig,
+        {
+          planCorrection: (req) => service.plan(req),
+          applyCorrection: (planId, applyOpts) => service.apply(planId, applyOpts),
+          storageDir: async (ns) => (await this.deps.getStorage(ns)).dir,
+          // Resolve `[m:xxxx]` handles to concrete memory ids via the single
+          // shared helper (#1582). Returns null on miss/ambiguity so the
+          // capture loop drops the handle and the planner falls back to text
+          // search (review: "memory handles not resolved").
+          resolveHandle: (ref, sessionKey) => {
+            try {
+              return this.deps.resolveMemoryIdOrHandle(ref, sessionKey);
+            } catch {
+              return null;
+            }
+          },
+        },
+        this.deps.passiveCorrectionDedup,
+      );
+
+      // Accumulate telemetry
+      this.deps.passiveCorrectionTelemetry.detected += result.telemetry.detected;
+      this.deps.passiveCorrectionTelemetry.queued += result.telemetry.queued;
+      this.deps.passiveCorrectionTelemetry.autoApplied += result.telemetry.autoApplied;
+      for (const [reason, count] of Object.entries(result.telemetry.suppressedReasons)) {
+        this.deps.passiveCorrectionTelemetry.suppressedReasonCounts[reason] =
+          (this.deps.passiveCorrectionTelemetry.suppressedReasonCounts[reason] ?? 0) + count;
+      }
+    } catch (err) {
+      // Fail-open: passive capture never blocks extraction.
+      log.debug(
+        `passive-correction: capture failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/packages/remnic-core/src/orchestration/turn-ingestion.ts
+++ b/packages/remnic-core/src/orchestration/turn-ingestion.ts
@@ -17,7 +17,6 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
-import path from "node:path";
 import { SmartBuffer } from "../buffer.js";
 import type { ImportTurn } from "../bulk-import/types.js";
 import { resolvePipelineProcessingCapabilities, resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
@@ -28,14 +27,12 @@ import { shouldSkipImplicitExtraction } from "../explicit-capture.js";
 import { StorageManager } from "../index.js";
 import { LcmEngine } from "../lcm/index.js";
 import { log } from "../logger.js";
-import { defaultNamespaceForPrincipal, resolvePrincipal } from "../namespaces/principal.js";
 import { ExtractionQueueCoordinator } from "./extraction-queue-coordinator.js";
 import { ExtractionRunCoordinator, type ExtractionRunResult } from "./extraction-run.js";
-import { resolveHandle, stripHandles } from "../recall-handles.js";
+import { stripHandles } from "../recall-handles.js";
 import { type ReplayTurn, normalizeReplaySessionKey } from "../replay/types.js";
 import { SessionObserverState } from "../session-observer-state.js";
 import { CODEX_THREAD_KEY_PREFIX } from "../thread-key.js";
-import { ThreadingManager } from "../threading.js";
 import { TranscriptManager } from "../transcript.js";
 import type { BufferTurn, PluginConfig } from "../types.js";
 import {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -111,6 +111,7 @@ import { ConsolidationRunCoordinator } from "./orchestration/consolidation-run.j
 import { ExtractionPersistCoordinator } from "./orchestration/extraction-persist.js";
 import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
 import { RecallSearchPipelineCoordinator } from "./orchestration/recall-search-pipeline.js";
+import { TurnIngestionCoordinator } from "./orchestration/turn-ingestion.js";
 export { hasIdentityRecoveryIntent, resolveEffectiveIdentityInjectionMode } from "./orchestration/recall-result-formatter.js";
 import {
   GraphRecallCoordinator,
@@ -960,7 +961,7 @@ function sourceValidAtContextTurns(
     .map(({ turn }) => asExtractionContextTurn(turn));
 }
 
-function targetSourceValidAtSortMs(turns: readonly BufferTurn[]): number {
+export function targetSourceValidAtSortMs(turns: readonly BufferTurn[]): number {
   let latestMs: number | null = null;
   for (const turn of turns) {
     if (turn.extractionContextOnly === true) continue;
@@ -991,7 +992,7 @@ function sortSourceValidAtSlicesChronologically(
     .map((slice) => slice.turns);
 }
 
-function splitTurnsBySourceValidAt(
+export function splitTurnsBySourceValidAt(
   turns: readonly BufferTurn[],
   options: { includeContext?: boolean } = {},
 ): BufferTurn[][] {
@@ -6092,6 +6093,39 @@ export class Orchestrator {
     return this._recallSearchPipelineCoordinator;
   }
 
+  /**
+   * Turn-ingestion coordinator (issue #1526 seam 20). Owns the buffer-side
+   * extraction entry points. Lazy + accessor-wired so prototype-call tests
+   * and instance-level stubs stay live (same rule as seams 18/19).
+   */
+  private _turnIngestionCoordinator: TurnIngestionCoordinator | undefined;
+
+  private get turnIngestionCoordinator(): TurnIngestionCoordinator {
+    if (!this._turnIngestionCoordinator) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._turnIngestionCoordinator = new TurnIngestionCoordinator({
+        get buffer() { return self.buffer; },
+        bulkImportWriteNamespace: () => self.bulkImportWriteNamespace(),
+        get config() { return self.config; },
+        get extractionQueueCoordinator() { return self.extractionQueueCoordinator; },
+        getStorage: (namespace) => self.getStorage(namespace),
+        get heartbeatObserverChains() { return self.heartbeatObserverChains; },
+        get lcmEngine() { return self.lcmEngine; },
+        get passiveCorrectionDedup() { return self.passiveCorrectionDedup; },
+        passiveCorrectionService: () => self.passiveCorrectionService(),
+        get passiveCorrectionTelemetry() { return self.passiveCorrectionTelemetry; },
+        queueBufferedExtraction: (turnsToExtract, reason, options) => self.queueBufferedExtraction(turnsToExtract, reason, options),
+        resolveMemoryIdOrHandle: (ref, sessionKey) => self.resolveMemoryIdOrHandle(ref, sessionKey),
+        runExtraction: (...args) => self.runExtraction(...args),
+        get sessionObserver() { return self.sessionObserver; },
+        shouldQueueExtraction: (turns, options) => self.shouldQueueExtraction(turns, options),
+        get transcript() { return self.transcript; },
+      });
+    }
+    return this._turnIngestionCoordinator;
+  }
+
   private async recallInternal(
     prompt: string,
     sessionKey?: string,
@@ -6122,58 +6156,11 @@ export class Orchestrator {
       persistProcessedFingerprint?: boolean;
     } = {},
   ): Promise<void> {
-    if (role !== "user" && role !== "assistant") {
-      log.debug(`processTurn: ignoring unsupported role=${String(role)}`);
-      return;
-    }
-    if (shouldSkipImplicitExtraction(this.config)) {
-      log.debug(
-        "processTurn: skipping implicit extraction because captureMode=explicit",
-      );
-      return;
-    }
-
-    const bufferKey =
-      typeof options.bufferKey === "string" && options.bufferKey.length > 0
-        ? options.bufferKey
-        : typeof sessionKey === "string" && sessionKey.length > 0
-          ? sessionKey
-          : "default";
-    const captureTimestamp = new Date().toISOString();
-    // Issue #1582 hygiene §2 — strip any echoed `[m:xxxx]` handle before the
-    // turn enters the extraction buffer so handles never become memory content
-    // or get QMD-indexed (rule 23). Gated on the feature flag: when handles are
-    // off none are ever injected, so there is nothing to strip and the buffer
-    // stays byte-identical to the pre-#1582 path.
-    const bufferedContent = this.config.recallMemoryHandles
-      ? stripHandles(content)
-      : content;
-    const turn: BufferTurn = {
+    return this.turnIngestionCoordinator.processTurn(
       role,
-      content: bufferedContent,
-      timestamp: captureTimestamp,
-      // #1578: anchor live-capture turns to wall-clock when bi-temporal is on;
-      // replay/import turns carry sourceValidAt explicitly (codex P1).
-      ...(this.config.temporalBiTemporal
-        ? { sourceValidAt: captureTimestamp }
-        : {}),
+      content,
       sessionKey,
-      logicalSessionKey: options.logicalSessionKey ?? bufferKey,
-      providerThreadId: options.providerThreadId ?? null,
-      turnFingerprint: options.turnFingerprint,
-      persistProcessedFingerprint: options.persistProcessedFingerprint === true,
-    };
-
-    const outcome =
-      typeof this.buffer.addTurnWithOutcome === "function"
-        ? await this.buffer.addTurnWithOutcome(bufferKey, turn)
-        : { decision: await this.buffer.addTurn(bufferKey, turn) };
-
-    if (outcome.decision === "keep_buffering") return;
-    await this.queueBufferedExtraction(
-      outcome.extractionTurns ?? this.buffer.getTurns(bufferKey),
-      "trigger_mode",
-      { bufferKey },
+      options,
     );
   }
 
@@ -6250,106 +6237,10 @@ export class Orchestrator {
       principalOverride?: string;
     } = {},
   ): Promise<void> {
-    if (!Array.isArray(turns) || turns.length === 0) return;
-    if (options.abortSignal?.aborted) {
-      throw options.abortSignal.reason instanceof Error
-        ? options.abortSignal.reason
-        : new Error("ingestReplayBatch aborted");
-    }
-    if (shouldSkipImplicitExtraction(this.config)) {
-      log.debug(
-        "ingestReplayBatch: skipping implicit extraction because captureMode=explicit",
-      );
-      return;
-    }
-
-    const bySession = new Map<string, BufferTurn[]>();
-    for (const turn of turns) {
-      if (turn.role !== "user" && turn.role !== "assistant") continue;
-      const key = normalizeReplaySessionKey(turn.sessionKey);
-      const list = bySession.get(key) ?? [];
-      list.push({
-        role: turn.role,
-        content: turn.content,
-        timestamp: turn.timestamp,
-        sourceValidAt: turn.sourceValidAt,
-        sessionKey: key,
-        parts: turn.parts,
-        rawContent: turn.rawContent,
-        sourceFormat: turn.sourceFormat,
-      });
-      bySession.set(key, list);
-    }
-
-    const replaySlices: Array<{
-      bufferKey: string;
-      order: number;
-      targetValidAtMs: number;
-      turns: BufferTurn[];
-    }> = [];
-    for (const [key, sessionTurns] of bySession.entries()) {
-      if (sessionTurns.length === 0) continue;
-      if (options.abortSignal?.aborted) {
-        throw options.abortSignal.reason instanceof Error
-          ? options.abortSignal.reason
-          : new Error("ingestReplayBatch aborted");
-      }
-      if (options.archiveLcm !== false && this.lcmEngine?.enabled) {
-        await this.lcmEngine.observeMessages(
-          key,
-          sessionTurns.map((turn) => ({
-            role: turn.role,
-            content: turn.content,
-            parts: turn.parts,
-            rawContent: turn.rawContent,
-            sourceFormat: turn.sourceFormat,
-          })),
-        );
-      }
-      for (const sessionSlice of splitTurnsBySourceValidAt(sessionTurns)) {
-        replaySlices.push({
-          bufferKey: key,
-          order: replaySlices.length,
-          targetValidAtMs: targetSourceValidAtSortMs(sessionSlice),
-          turns: sessionSlice,
-        });
-      }
-    }
-
-    const replayTasks = replaySlices
-      .sort((a, b) => {
-        if (a.targetValidAtMs < b.targetValidAtMs) return -1;
-        if (a.targetValidAtMs > b.targetValidAtMs) return 1;
-        if (a.order === b.order) return 0;
-        return a.order < b.order ? -1 : 1;
-      })
-      .map(
-        ({ bufferKey, turns: sessionSlice }) =>
-          new Promise<void>((resolve, reject) => {
-            void this.queueBufferedExtraction(sessionSlice, "trigger_mode", {
-              skipDedupeCheck: true,
-              clearBufferAfterExtraction: false,
-              skipCharThreshold: true,
-              skipUserTurnThreshold: true,
-              bufferKey,
-              extractionDeadlineMs: options.deadlineMs,
-              abortSignal: options.abortSignal,
-              writeNamespaceOverride: options.writeNamespaceOverride,
-              principalOverride: options.principalOverride,
-              onTaskSettled: (err) => (err ? reject(err) : resolve()),
-            }).catch(reject);
-          }),
-      );
-    if (replayTasks.length > 0) {
-      const settled = await Promise.allSettled(replayTasks);
-      const firstRejected = settled.find(
-        (result): result is PromiseRejectedResult =>
-          result.status === "rejected",
-      );
-      if (firstRejected) {
-        throw firstRejected.reason;
-      }
-    }
+    return this.turnIngestionCoordinator.ingestReplayBatch(
+      turns,
+      options,
+    );
   }
 
   /**
@@ -6425,45 +6316,6 @@ export class Orchestrator {
     return this.wearablesServiceInstance;
   }
 
-  /**
-   * Ingest a batch of bulk-import turns (#460). Like ingestReplayBatch, this
-   * normalizes user/assistant turns into the extraction buffer and awaits
-   * settlement, but it intentionally bypasses the captureMode="explicit"
-   * gate because bulk-import is itself an explicit user action — the user
-   * ran `bulk-import --source <name> --file ...` and would be surprised to
-   * see the command silently no-op when capture is otherwise restricted.
-   *
-   * Turns with role="other" are skipped (not supported by the extraction
-   * pipeline).
-   *
-   * Two design decisions worth calling out:
-   *
-   * - **sessionKey is truthy and per-batch-unique.**
-   *   `ThreadingManager.shouldStartNewThread` only applies the session-key
-   *   boundary check when `turn.sessionKey` is truthy (threading.ts:82);
-   *   with an empty string, imported turns could attach to the current
-   *   live thread or merge across unrelated import batches. A unique
-   *   `bulk-import:batch:<timestamp>-<rand>` key forces a fresh thread per
-   *   batch without matching common prefix/map rules in
-   *   `principalFromSessionKeyRules`. (Catch-all regex rules could still
-   *   remap the principal, but that only affects metadata provenance —
-   *   see the next point for why write routing is unaffected.)
-   *
-   * - **writeNamespaceOverride pins the storage target.**
-   *   We pass `writeNamespaceOverride: this.bulkImportWriteNamespace()` to
-   *   `queueBufferedExtraction`, which tells `runExtraction` to skip
-   *   `defaultNamespaceForPrincipal` and write directly into the
-   *   orchestrator's declared bulk-import write namespace. This keeps
-   *   writes deterministic even when namespace policies named `"default"`
-   *   exist alongside a different `config.defaultNamespace`, and also
-   *   guards against regex-catch-all principal rules steering bulk-import
-   *   into an unexpected tenant.
-   *
-   * Per-invocation namespace routing (letting callers target a namespace
-   * other than `bulkImportWriteNamespace()`) is a separate feature tracked
-   * as a follow-up — the hook is the `writeNamespaceOverride` option, but
-   * the CLI surface does not yet expose a `--namespace` flag.
-   */
   async ingestBulkImportBatch(
     turns: ImportTurn[],
     options: {
@@ -6472,240 +6324,20 @@ export class Orchestrator {
       includeSourceValidAtContext?: boolean;
     } = {},
   ): Promise<BulkImportBatchIngestResult> {
-    if (!Array.isArray(turns) || turns.length === 0) {
-      return {
-        attemptedTurnCount: 0,
-        extractionCount: 0,
-        persistedCount: 0,
-        durableOutputCount: 0,
-        skippedCount: 0,
-        failedCount: 0,
-        postPersistMetadataFailureCount: 0,
-        processedTurnCount: 0,
-      };
-    }
-
-    // Per-batch unique sessionKey keeps threading honest without matching
-    // typical prefix/map routing rules.  Combined with writeNamespaceOverride
-    // below, the storage target is independent of principal resolution.
-    // Uses crypto.randomBytes (not Math.random) so CodeQL does not flag a
-    // security-context insecure-randomness use even though this value never
-    // leaves the process; the bytes just need to be collision-resistant
-    // across concurrent bulk-import batches.
-    const shouldUseStableBatchKey = turns.some(
-      (turn) =>
-        turn.persistProcessedFingerprint === true ||
-        (typeof turn.turnFingerprint === "string" &&
-          turn.turnFingerprint.length > 0),
+    return this.turnIngestionCoordinator.ingestBulkImportBatch(
+      turns,
+      options,
     );
-    const stableBatchFingerprint = shouldUseStableBatchKey
-      ? createHash("sha256")
-        .update(
-          turns
-            .map((turn) =>
-              [
-                turn.role,
-                typeof turn.turnFingerprint === "string" &&
-                turn.turnFingerprint.length > 0
-                  ? turn.turnFingerprint
-                  : turn.content.replace(/\s+/g, " ").trim(),
-              ].join(":"),
-            )
-            .join("\n"),
-        )
-        .digest("hex")
-        .slice(0, 32)
-      : undefined;
-    const sessionKey = stableBatchFingerprint
-      ? `bulk-import:batch:${stableBatchFingerprint}`
-      : `bulk-import:batch:${Date.now().toString(36)}-${randomBytes(6).toString("hex")}`;
-
-    const sessionTurns: BufferTurn[] = [];
-    for (const turn of turns) {
-      if (turn.role !== "user" && turn.role !== "assistant") continue;
-      sessionTurns.push({
-        role: turn.role,
-        content: turn.content,
-        timestamp: turn.timestamp,
-        sourceValidAt: turn.timestamp,
-        sessionKey,
-        parts: turn.parts,
-        rawContent: turn.rawContent,
-        sourceFormat: turn.sourceFormat,
-        importProvenance: turn.importProvenance,
-        turnFingerprint: turn.turnFingerprint,
-        persistProcessedFingerprint: turn.persistProcessedFingerprint === true,
-      });
-    }
-    if (sessionTurns.length === 0) {
-      return {
-        attemptedTurnCount: 0,
-        extractionCount: 0,
-        persistedCount: 0,
-        durableOutputCount: 0,
-        skippedCount: 0,
-        failedCount: 0,
-        postPersistMetadataFailureCount: 0,
-        processedTurnCount: 0,
-      };
-    }
-
-    if (this.lcmEngine?.enabled) {
-      await this.lcmEngine.observeMessages(
-        sessionKey,
-        sessionTurns.map((turn) => ({
-          role: turn.role,
-          content: turn.content,
-          parts: turn.parts,
-          rawContent: turn.rawContent,
-          sourceFormat: turn.sourceFormat,
-        })),
-      );
-    }
-
-    const sessionSlices = splitTurnsBySourceValidAt(sessionTurns, {
-      includeContext: options.includeSourceValidAtContext !== false,
-    });
-    const results: ExtractionRunResult[] = [];
-    let processedTurnCount = 0;
-    let firstRejected: unknown;
-    for (const sessionSlice of sessionSlices) {
-      try {
-        const result = await new Promise<ExtractionRunResult>(
-          (resolve, reject) => {
-            void this.queueBufferedExtraction(sessionSlice, "trigger_mode", {
-              skipDedupeCheck: true,
-              clearBufferAfterExtraction: false,
-              skipCharThreshold: true,
-              skipUserTurnThreshold: true,
-              bufferKey: sessionKey,
-              extractionDeadlineMs: options.deadlineMs,
-              failOnExtractionFailure: options.failOnExtractionFailure === true,
-              writeNamespaceOverride: this.bulkImportWriteNamespace(),
-              onTaskSettled: (err, result) =>
-                err
-                  ? reject(err)
-                  : resolve(
-                      result ?? {
-                        status: "skipped",
-                        reason: "missing_extraction_result",
-                        persistedCount: 0,
-                        durableOutputCount: 0,
-                      },
-                    ),
-            }).catch(reject);
-          },
-        );
-        results.push(result);
-        processedTurnCount += sessionSlice.filter(
-          (turn) => turn.extractionContextOnly !== true,
-        ).length;
-      } catch (err) {
-        firstRejected = err;
-        break;
-      }
-    }
-    const rejectedCount = firstRejected ? 1 : 0;
-    const ingestResult: BulkImportBatchIngestResult = {
-      attemptedTurnCount: sessionTurns.length,
-      extractionCount: results.length,
-      persistedCount: results.reduce(
-        (sum, result) => sum + result.persistedCount,
-        0,
-      ),
-      durableOutputCount: results.reduce(
-        (sum, result) => sum + result.durableOutputCount,
-        0,
-      ),
-      skippedCount: results.filter((result) => result.status === "skipped").length,
-      failedCount: rejectedCount,
-      postPersistMetadataFailureCount: results.filter(
-        (result) => result.postPersistMetadataFailed === true,
-      ).length,
-      processedTurnCount:
-        rejectedCount === 0 ? sessionTurns.length : processedTurnCount,
-    };
-    if (firstRejected) {
-      if (processedTurnCount > 0) {
-        throw new BulkImportBatchPartialFailureError(
-          "bulk import failed after partial processing",
-          ingestResult,
-          firstRejected,
-        );
-      }
-      throw firstRejected;
-    }
-    return ingestResult;
   }
 
   async observeSessionHeartbeat(
     sessionKey: string,
     options: { bufferKey?: string } = {},
   ): Promise<void> {
-    if (resolvePipelineProcessingCapabilities(this.config).sessionObserver !== true) return;
-    if (!sessionKey || sessionKey.length === 0) return;
-
-    const bufferKey =
-      typeof options.bufferKey === "string" && options.bufferKey.length > 0
-        ? options.bufferKey
-        : sessionKey;
-    const previous =
-      this.heartbeatObserverChains.get(sessionKey) ?? Promise.resolve();
-    const next = previous
-      .catch(() => undefined)
-      .then(async () => {
-        const turns = this.buffer.getTurns(bufferKey);
-        if (turns.length === 0) return;
-        const normalizedSessionKey = normalizeReplaySessionKey(sessionKey);
-        const allowSharedSessionBuffer = bufferKey.startsWith(
-          CODEX_THREAD_KEY_PREFIX,
-        );
-        if (
-          !allowSharedSessionBuffer &&
-          turns.some(
-            (turn) =>
-              turn.sessionKey &&
-              normalizeReplaySessionKey(turn.sessionKey) !== normalizedSessionKey,
-          )
-        ) {
-          log.debug(
-            `heartbeat observer skipped: mixed-session buffer contents for ${bufferKey}`,
-          );
-          return;
-        }
-        if (!this.shouldQueueExtraction(turns, {
-          commit: false,
-          bufferKey,
-        })) {
-          log.debug(
-            `heartbeat observer skipped: extraction dedupe for ${bufferKey}`,
-          );
-          return;
-        }
-        const footprint =
-          await this.transcript.estimateSessionFootprint(sessionKey);
-        const decision = await this.sessionObserver.observe({
-          sessionKey,
-          totalBytes: footprint.bytes,
-          totalTokens: footprint.tokens,
-        });
-        if (!decision.triggered) return;
-        log.debug(
-          `heartbeat observer trigger: session=${sessionKey} deltaBytes=${decision.deltaBytes} deltaTokens=${decision.deltaTokens}`,
-        );
-        await this.queueBufferedExtraction(turns, "heartbeat_observer", {
-          bufferKey,
-        });
-      });
-
-    this.heartbeatObserverChains.set(sessionKey, next);
-    try {
-      await next;
-    } finally {
-      if (this.heartbeatObserverChains.get(sessionKey) === next) {
-        this.heartbeatObserverChains.delete(sessionKey);
-      }
-    }
+    return this.turnIngestionCoordinator.observeSessionHeartbeat(
+      sessionKey,
+      options,
+    );
   }
 
   private async queueBufferedExtraction(
@@ -6740,88 +6372,11 @@ export class Orchestrator {
       principalOverride?: string;
     } = {},
   ): Promise<void> {
-    const bufferKey = options.bufferKey ?? turnsToExtract[0]?.sessionKey ?? "default";
-    if (
-      !options.skipDedupeCheck &&
-      !this.shouldQueueExtraction(turnsToExtract, { bufferKey })
-    ) {
-      log.debug(`extraction dedupe skip: preserving buffer (${reason})`);
-      options.onTaskSettled?.(undefined, {
-        status: "skipped",
-        reason: "dedupe",
-        persistedCount: 0,
-        durableOutputCount: 0,
-      });
-      return;
-    }
-
-    const extractionDeadlineMs =
-      typeof options.extractionDeadlineMs === "number" &&
-      Number.isFinite(options.extractionDeadlineMs)
-        ? options.extractionDeadlineMs
-        : undefined;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    let settled = false;
-    const clearQueueWaitTimer = (): void => {
-      if (timeout) {
-        clearTimeout(timeout);
-        timeout = undefined;
-      }
-    };
-    const settleTask = (
-      error?: unknown,
-      result?: ExtractionRunResult,
-    ): boolean => {
-      if (settled) return false;
-      settled = true;
-      clearQueueWaitTimer();
-      options.onTaskSettled?.(error, result);
-      return true;
-    };
-
-    if (typeof extractionDeadlineMs === "number") {
-      const remainingMs = extractionDeadlineMs - Date.now();
-      if (remainingMs <= 0) {
-        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
-        return;
-      }
-      timeout = setTimeout(() => {
-        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
-      }, remainingMs);
-    }
-
-    this.extractionQueueCoordinator.enqueue(async () => {
-      if (settled) return;
-      if (
-        typeof extractionDeadlineMs === "number" &&
-        extractionDeadlineMs <= Date.now()
-      ) {
-        settleTask(new Error("replay extraction deadline exceeded (queue_wait)"));
-        return;
-      }
-      clearQueueWaitTimer();
-      try {
-        const result = await this.runExtraction(turnsToExtract, {
-          clearBufferAfterExtraction:
-            options.clearBufferAfterExtraction ?? true,
-          skipCharThreshold: options.skipCharThreshold ?? false,
-          skipUserTurnThreshold: options.skipUserTurnThreshold ?? false,
-          deadlineMs: extractionDeadlineMs,
-          bufferKey,
-          abortSignal: options.abortSignal,
-          failOnExtractionFailure: options.failOnExtractionFailure === true,
-          writeNamespaceOverride: options.writeNamespaceOverride,
-          principalOverride: options.principalOverride,
-        });
-        settleTask(undefined, result);
-      } catch (err) {
-        if (settleTask(err)) {
-          throw err;
-        }
-      }
-    });
-
-    log.debug(`queued extraction from ${reason}`);
+    return this.turnIngestionCoordinator.queueBufferedExtraction(
+      turnsToExtract,
+      reason,
+      options,
+    );
   }
 
   private normalizeExtractionFingerprintTurns(turns: BufferTurn[]): string[] {
@@ -6839,16 +6394,6 @@ export class Orchestrator {
     return this.extractionRunCoordinator.shouldQueueExtraction(turns, options);
   }
 
-  /**
-   * Passive correction capture (issue #1581) — detects corrections expressed
-   * passively in conversation turns and routes them to the Correction Contract
-   * (#1580). Called from `runExtraction` after persistence completes.
-   *
-   * Thin wiring: delegates ALL correction logic to the detector + capture
-   * modules + the CorrectionService. This method only checks gates, calls the
-   * detector, and routes results. Fail-open: capture errors never block the
-   * extraction return path.
-   */
   private async maybeCapturePassiveCorrections(
     turns: readonly BufferTurn[],
     opts: {
@@ -6859,69 +6404,10 @@ export class Orchestrator {
       isLiveSession: boolean;
     },
   ): Promise<void> {
-    const mode = this.config.correctionCaptureMode;
-    if (mode === "off") return;
-    if (!resolveRecallAuxiliaryCapabilities(this.config).correction) return;
-
-    try {
-      const corrections = detectPassiveCorrections(
-        turns.map((t) => ({ role: t.role, content: t.content })),
-      );
-      if (corrections.length === 0) return;
-
-      // Replay/import: force queue-only mode even if config says auto.
-      const effectiveMode = opts.isLiveSession ? mode : "queue";
-      const captureConfig: PassiveCaptureConfig = {
-        mode: effectiveMode,
-        confidenceFloor: this.config.correctionCaptureConfidenceFloor,
-        autoApplyMaxAffected: this.config.correctionCaptureAutoApplyMaxAffected,
-      };
-
-      const service = this.passiveCorrectionService();
-      const result = await capturePassiveCorrections(
-        corrections,
-        {
-          correctionEnabled: resolveRecallAuxiliaryCapabilities(this.config).correction,
-          isLiveSession: opts.isLiveSession,
-          bufferKey: opts.bufferKey,
-          sessionKey: opts.sessionKey,
-          principal: opts.principal,
-          namespace: opts.namespace,
-        },
-        captureConfig,
-        {
-          planCorrection: (req) => service.plan(req),
-          applyCorrection: (planId, applyOpts) => service.apply(planId, applyOpts),
-          storageDir: async (ns) => (await this.getStorage(ns)).dir,
-          // Resolve `[m:xxxx]` handles to concrete memory ids via the single
-          // shared helper (#1582). Returns null on miss/ambiguity so the
-          // capture loop drops the handle and the planner falls back to text
-          // search (review: "memory handles not resolved").
-          resolveHandle: (ref, sessionKey) => {
-            try {
-              return this.resolveMemoryIdOrHandle(ref, sessionKey);
-            } catch {
-              return null;
-            }
-          },
-        },
-        this.passiveCorrectionDedup,
-      );
-
-      // Accumulate telemetry
-      this.passiveCorrectionTelemetry.detected += result.telemetry.detected;
-      this.passiveCorrectionTelemetry.queued += result.telemetry.queued;
-      this.passiveCorrectionTelemetry.autoApplied += result.telemetry.autoApplied;
-      for (const [reason, count] of Object.entries(result.telemetry.suppressedReasons)) {
-        this.passiveCorrectionTelemetry.suppressedReasonCounts[reason] =
-          (this.passiveCorrectionTelemetry.suppressedReasonCounts[reason] ?? 0) + count;
-      }
-    } catch (err) {
-      // Fail-open: passive capture never blocks extraction.
-      log.debug(
-        `passive-correction: capture failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    return this.turnIngestionCoordinator.maybeCapturePassiveCorrections(
+      turns,
+      opts,
+    );
   }
 
   /** Lazily construct the CorrectionService for passive capture. Stateless

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 8266,
+      "packages/remnic-core/src/orchestrator.ts": 7752,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 9017,
       "packages/remnic-core/src/storage.ts": 7747,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -380,7 +380,7 @@ tests/entity-contamination.test.ts(606,4): TS2352
 tests/entity-contamination.test.ts(627,4): TS2352
 tests/entity-retrieval.test.ts(307,7): TS2739
 tests/entity-retrieval.test.ts(308,7): TS2739
-tests/explicit-capture.test.ts(113,38): TS2345
+tests/explicit-capture.test.ts(114,38): TS2345
 tests/extraction-proactive.test.ts(506,23): TS7006
 tests/fallback-llm-builtin-provider.test.ts(43,7): TS2322
 tests/fallback-llm-builtin-provider.test.ts(58,7): TS2322

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/explicit-capture.js";
 import { ContentHashIndex } from "../src/storage.js";
 import { Orchestrator } from "../src/orchestrator.js";
+import { TurnIngestionCoordinator } from "../packages/remnic-core/src/orchestration/turn-ingestion.js";
 import { registerTools } from "../src/tools.js";
 
 test("parseConfig defaults captureMode to implicit and accepts explicit modes", () => {
@@ -38,7 +39,7 @@ test("processTurn skips buffering when captureMode=explicit", async () => {
     queueBufferedExtraction: async () => undefined,
   };
 
-  await Orchestrator.prototype.processTurn.call(fake, "user", "remember this later", "session-1");
+  await new TurnIngestionCoordinator(fake as any).processTurn("user", "remember this later", "session-1");
 
   assert.equal(addTurnCalls, 0);
 });

--- a/tests/heartbeat-observe-trigger.test.ts
+++ b/tests/heartbeat-observe-trigger.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { Orchestrator } from "../src/orchestrator.ts";
+import { TurnIngestionCoordinator } from "../packages/remnic-core/src/orchestration/turn-ingestion.js";
 import { ExtractionRunCoordinator } from "../packages/remnic-core/src/orchestration/extraction-run.ts";
 import type { BufferTurn } from "../src/types.js";
 
@@ -42,9 +43,7 @@ test("observeSessionHeartbeat queues buffered extraction when observer threshold
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
   );
 
   assert.equal(queued, true);
@@ -94,9 +93,7 @@ test("observeSessionHeartbeat uses an explicit logical buffer key when provided"
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
     { bufferKey: "codex-thread:thread-123" },
   );
 
@@ -126,9 +123,7 @@ test("observeSessionHeartbeat no-ops when observer is disabled", async () => {
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
   );
 
   assert.equal(invoked, false);
@@ -171,9 +166,7 @@ test("observeSessionHeartbeat skips when buffer contains mixed session turns", a
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
   );
 
   assert.equal(queued, false);
@@ -223,9 +216,7 @@ test("observeSessionHeartbeat allows shared Codex logical buffers with mixed ses
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
     { bufferKey: "codex-thread:thread-shared-1" },
   );
 
@@ -250,9 +241,7 @@ test("queueBufferedExtraction preserves buffered turns when dedupe skips enqueue
     },
   };
 
-  await (Orchestrator.prototype as any).queueBufferedExtraction.call(
-    fake,
-    [{ role: "user", content: "dup", timestamp: "2026-02-25T00:00:00.000Z" }],
+  await new TurnIngestionCoordinator(fake as any).queueBufferedExtraction([{ role: "user", content: "dup", timestamp: "2026-02-25T00:00:00.000Z" }],
     "heartbeat_observer",
   );
 
@@ -298,13 +287,9 @@ test("observeSessionHeartbeat serializes per-session observer runs", async () =>
   };
 
   await Promise.all([
-    (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-      fake,
-      "agent:generalist:main",
+    new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
     ),
-    (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-      fake,
-      "agent:generalist:main",
+    new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
     ),
   ]);
 
@@ -347,9 +332,7 @@ test("observeSessionHeartbeat skips observer state update when extraction dedupe
     },
   };
 
-  await (Orchestrator.prototype as any).observeSessionHeartbeat.call(
-    fake,
-    "agent:generalist:main",
+  await new TurnIngestionCoordinator(fake as any).observeSessionHeartbeat("agent:generalist:main",
   );
 
   assert.equal(observed, false);

--- a/tests/orchestrator-replay-ingestion.test.ts
+++ b/tests/orchestrator-replay-ingestion.test.ts
@@ -3,15 +3,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+// #1526 seam 20: ingestReplayBatch/queueBufferedExtraction moved to
+// orchestration/turn-ingestion.ts; member reads go through `this.deps`.
+const TURN_INGESTION_PATH = resolve(
+  import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestration", "turn-ingestion.ts",
+);
+
 test("ingestReplayBatch enqueues replay slices without clearing shared buffer", () => {
-  const source = readFileSync(
-    resolve(import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestrator.ts"),
-    "utf-8",
-  );
+  const source = readFileSync(TURN_INGESTION_PATH, "utf-8");
 
   assert.match(
     source,
-    /if \(shouldSkipImplicitExtraction\(this\.config\)\) \{[\s\S]*ingestReplayBatch: skipping implicit extraction because captureMode=explicit[\s\S]*return;\s*\}/m,
+    /if \(shouldSkipImplicitExtraction\(this\.deps\.config\)\) \{[\s\S]*ingestReplayBatch: skipping implicit extraction because captureMode=explicit[\s\S]*return;\s*\}/m,
     "replay ingestion should honor explicit capture mode and skip implicit extraction paths",
   );
   assert.match(
@@ -24,8 +27,12 @@ test("ingestReplayBatch enqueues replay slices without clearing shared buffer", 
     /for \(const sessionSlice of splitTurnsBySourceValidAt\(sessionTurns\)\) \{[\s\S]*bufferKey:\s*key,[\s\S]*targetValidAtMs:\s*targetSourceValidAtSortMs\(sessionSlice\),[\s\S]*\.sort\(\(a, b\) => \{[\s\S]*\.map\(\s*\(\{ bufferKey, turns: sessionSlice \}\) =>[\s\S]*skipDedupeCheck:\s*true,[\s\S]*clearBufferAfterExtraction:\s*false,[\s\S]*skipCharThreshold:\s*true,[\s\S]*skipUserTurnThreshold:\s*true,[\s\S]*bufferKey,/m,
     "replay ingestion should globally order source slices while preserving the session-specific buffer key and threshold bypasses",
   );
+  const orchestratorSource = readFileSync(
+    resolve(import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestrator.ts"),
+    "utf-8",
+  );
   assert.match(
-    source,
+    orchestratorSource,
     /function sourceValidAtContextTurns\([\s\S]*targetStart: number,[\s\S]*targetEnd: number,[\s\S]*contextValidAtMs > targetValidAtMs[\s\S]*\.sort\(\(a, b\) => \{[\s\S]*if \(a\.validAtMs < b\.validAtMs\) return -1;[\s\S]*if \(a\.validAtMs > b\.validAtMs\) return 1;[\s\S]*return a\.index < b\.index \? -1 : 1;[\s\S]*\.slice\(-SOURCE_VALID_AT_CONTEXT_TURNS\)[\s\S]*asExtractionContextTurn/m,
     "source-dated replay context should be selected by source time, not input adjacency, while excluding future-dated turns",
   );
@@ -37,10 +44,7 @@ test("ingestReplayBatch enqueues replay slices without clearing shared buffer", 
 });
 
 test("queueBufferedExtraction preserves explicit false clearBufferAfterExtraction", () => {
-  const source = readFileSync(
-    resolve(import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestrator.ts"),
-    "utf-8",
-  );
+  const source = readFileSync(TURN_INGESTION_PATH, "utf-8");
 
   assert.match(
     source,
@@ -83,14 +87,11 @@ test("runExtraction threshold bypasses are explicit and independent", () => {
 });
 
 test("queueBufferedExtraction settles task callbacks on dedupe skip", () => {
-  const source = readFileSync(
-    resolve(import.meta.dirname, "..", "packages", "remnic-core", "src", "orchestrator.ts"),
-    "utf-8",
-  );
+  const source = readFileSync(TURN_INGESTION_PATH, "utf-8");
 
   assert.match(
     source,
-    /if \(\s*!options\.skipDedupeCheck\s*&&\s*!this\.shouldQueueExtraction\(turnsToExtract,\s*\{\s*bufferKey\s*\}\)\s*\) \{[\s\S]*options\.onTaskSettled\?\.\(undefined,\s*\{[\s\S]*reason:\s*"dedupe"[\s\S]*\}\);[\s\S]*return;/m,
+    /if \(\s*!options\.skipDedupeCheck\s*&&\s*!this\.deps\.shouldQueueExtraction\(turnsToExtract,\s*\{\s*bufferKey\s*\}\)\s*\) \{[\s\S]*options\.onTaskSettled\?\.\(undefined,\s*\{[\s\S]*reason:\s*"dedupe"[\s\S]*\}\);[\s\S]*return;/m,
     "dedupe skip path should settle any task callback to avoid hanging replay promises",
   );
 });


### PR DESCRIPTION
Part of #1526 (orchestrator decomposition). Seam 20, on top of seam 19 (#1791).

## What moved
6 buffer-side extraction entry points (677 LOC) move verbatim into `orchestration/turn-ingestion.ts` as `TurnIngestionCoordinator`: `processTurn`, `observeSessionHeartbeat`, `queueBufferedExtraction`, `ingestReplayBatch`, `ingestBulkImportBatch`, `maybeCapturePassiveCorrections`.

- 16-member `TurnIngestionDeps`: 9 fields as live accessors, 7 methods as late-binding arrows (incl. rest-param forwarding for `runExtraction`). No written fields.
- ALL member access routes through deps; orchestrator keeps thin delegating methods with verbatim signatures.
- `splitTurnsBySourceValidAt` / `targetSourceValidAtSortMs` exported from orchestrator.ts (seam-16/18/19 precedent).
- Prototype-call tests (`Orchestrator.prototype.processTurn.call(fake, …)` style in explicit-capture + heartbeat-observe-trigger) repointed to `new TurnIngestionCoordinator(fake as any).method(…)` — deps property names match the orchestrator member names the fakes already stub, so the fakes work unchanged.
- Source-grep replay tests repointed to the new file (`this.` → `this.deps.` in patterns); the one still-in-orchestrator pattern (`sourceValidAtContextTurns`, module-level) stays pointed at orchestrator.ts.
- test-typecheck baseline: single entry shifted one line (import insertion in explicit-capture.test.ts moved a pre-existing TS2345 from L113→L114; 582→582 entries otherwise identical).

## Numbers
`orchestrator.ts`: 8,265 → 7,752 LOC (−513). Ratchet updated.

## Verification
- `tsc --noEmit` clean; post-rebase-on-main clean
- `npm run test:entity-hardening`: 246/246
- orchestrator-flush + heartbeat-observe-trigger + explicit-capture (the prototype-fake suites): 37/37
- replay suites (orchestrator-replay-ingestion, replay-normalizers, replay-types, root-replay-package-surface, cli-replay) + passive-capture: 64/64
- `npm run preflight:quick`: [preflight] OK (quick)

Chokepoints used: n/a (behavior-preserving extraction).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, behavior-preserving move on the core memory extraction and bulk-import/replay paths; regression risk is mitigated by unchanged logic and targeted test updates, but mistakes in deps wiring could affect ingestion silently.
> 
> **Overview**
> **Orchestrator decomposition (seam 20):** buffer-side extraction entry points move into new `orchestration/turn-ingestion.ts` as `TurnIngestionCoordinator`, with `TurnIngestionDeps` wiring back to the orchestrator via live getters and late-bound method arrows (same pattern as seams 18/19).
> 
> **Moved verbatim (behavior unchanged):** `processTurn`, `observeSessionHeartbeat`, `queueBufferedExtraction`, `ingestReplayBatch`, `ingestBulkImportBatch`, and `maybeCapturePassiveCorrections`. The orchestrator keeps the same public/private method signatures and delegates to a lazy `turnIngestionCoordinator` getter.
> 
> **Supporting changes:** `splitTurnsBySourceValidAt` and `targetSourceValidAtSortMs` are **exported** from `orchestrator.ts` for the coordinator import. `orchestrator.ts` LOC ratchet drops 8266 → 7752. Tests that used `Orchestrator.prototype.*.call(fake, …)` now construct `TurnIngestionCoordinator(fake)`; source-grep replay tests read `turn-ingestion.ts` and expect `this.deps.*` where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb639cab851f8f2afe5ea2986d9b41a79053252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->