### PR TITLE
refactor(orchestrator): extract init lifecycle into OrchestratorInitCoordinator (seam 22, #1526)

### DIFF
--- a/packages/remnic-core/src/orchestration/orchestrator-init.ts
+++ b/packages/remnic-core/src/orchestration/orchestrator-init.ts
@@ -1,0 +1,712 @@
+/**
+ * Orchestrator-init coordinator — extracted from the orchestrator
+ * (issue #1526, seam 22).
+ *
+ * Owns the startup lifecycle:
+ *   - initialize(): directory/storage/alias/policy bring-up and the
+ *     init gate that recall() awaits
+ *   - deferredInitialize(): background QMD probe, warmup, caches, cron
+ *     wiring, and the deferredReady gate
+ *   - startupSearchSync(): the initial search-index reconciliation
+ *
+ * Behavior-preserving move from orchestrator.ts. The async init ORDERING
+ * is part of the gateway_start contract — the move keeps every await in
+ * place and mutates the orchestrator's own gate fields (initPromise,
+ * deferredReady, resolveDeferredReady, deferredInitAbort,
+ * deferredSyncSucceeded, …) through live get/set accessors, so
+ * stop/start reuse of one Orchestrator instance behaves identically.
+ */
+
+import { readdir, stat, unlink } from "node:fs/promises";
+import path from "node:path";
+import { SmartBuffer } from "../buffer.js";
+import { resolveIndexingCapabilities, resolveLocalLlmCapabilities, resolveMemoryLifecycleCapabilities, resolveNamespaceCapabilities, resolveQmdCapabilities, resolveRecallAuxiliaryCapabilities, resolveUtilityLearningCapabilities } from "../capabilities.js";
+import { CompoundingEngine } from "../compounding/engine.js";
+import type { ConversationIndexBackend } from "../conversation-index/backend.js";
+import type { CorrectionService } from "../correction/correction-service.js";
+import { EmbeddingFallback } from "../embedding-fallback.js";
+import { ContentHashIndex, StorageManager } from "../index.js";
+import { log } from "../logger.js";
+import { migrateFromEngram } from "../migrate/from-engram.js";
+import { NamespaceCatalog } from "../namespaces/catalog.js";
+import { NamespaceSearchRouter } from "../namespaces/search.js";
+import { NamespaceStorageRouter } from "../namespaces/storage.js";
+import { NegativeExampleStore } from "../negative.js";
+import { MaintenanceScheduler } from "./maintenance.js";
+import { PolicyRuntimeManager, type RuntimePolicyValues } from "../policy-runtime.js";
+import { LastRecallStore, RecallHandleHistoryStore, TierMigrationStatusStore } from "../recall-state.js";
+import { RelevanceStore } from "../relevance.js";
+import { NoopSearchBackend } from "../search/noop-backend.js";
+import type { SearchBackend } from "../search/port.js";
+import { SessionObserverState } from "../session-observer-state.js";
+import { SharedContextManager } from "../shared-context/manager.js";
+import { HourlySummarizer } from "../summarizer.js";
+import { TranscriptManager } from "../transcript.js";
+import type { PluginConfig } from "../types.js";
+import { type UtilityRuntimeValues, loadUtilityRuntimeValues } from "../utility-runtime.js";
+import { WearablesService } from "../wearables/service.js";
+import {
+  COMPACTION_SIGNAL_MAX_AGE_MS,
+  defaultWorkspaceDir,
+  qmdStartupCollectionCheckWithTimeout,
+} from "../orchestrator.js";
+
+export interface OrchestratorInitDeps {
+  readonly buffer: SmartBuffer;
+  readonly compounding?: CompoundingEngine;
+  readonly config: PluginConfig;
+  configuredNamespaceList(): string[];
+  contentHashIndex: ContentHashIndex | null;
+  readonly conversationIndexBackend?: ConversationIndexBackend;
+  deferredInitAbort: AbortController | null;
+  deferredInitialize(signal: AbortSignal): Promise<void>;
+  deferredReady: Promise<void>;
+  deferredSyncSucceeded: boolean;
+  disposeSearchBackendIfNeeded(): Promise<void>;
+  readonly embeddingFallback: EmbeddingFallback;
+  getWearablesService(): WearablesService;
+  readonly handleHistory: RecallHandleHistoryStore;
+  readonly lastRecall: LastRecallStore;
+  maintenanceNamespaces(
+    jobName?: string,
+    budgetMode?: "cycle" | "unbounded",
+  ): Promise<string[]>;
+  readonly maintenanceScheduler: MaintenanceScheduler;
+  readonly namespaceCatalog: NamespaceCatalog;
+  readonly namespaceSearchRouter: NamespaceSearchRouter;
+  readonly negatives: NegativeExampleStore;
+  passiveCorrectionService(): CorrectionService;
+  readonly policyRuntime: PolicyRuntimeManager;
+  qmd: SearchBackend;
+  readonly relevance: RelevanceStore;
+  resolveDeferredReady: (() => void) | null;
+  resolveInit: (() => void) | null;
+  runtimePolicyValues: RuntimePolicyValues | null;
+  readonly sessionObserver: SessionObserverState;
+  readonly sharedContext?: SharedContextManager;
+  readonly storage: StorageManager;
+  readonly storageRouter: NamespaceStorageRouter;
+  readonly summarizer: HourlySummarizer;
+  readonly tierMigrationStatus: TierMigrationStatusStore;
+  readonly transcript: TranscriptManager;
+  utilityRuntimeValues: UtilityRuntimeValues | null;
+  validateLocalLlmModel(): Promise<void>;
+  wearablesAutoSyncHandle: { stop(): Promise<void> } | null;
+}
+
+export class OrchestratorInitCoordinator {
+  constructor(
+    private readonly deps: OrchestratorInitDeps,
+  ) {}
+
+  async initialize(): Promise<void> {
+    // Recreate the deferred-ready gate on every initialize() call.
+    // The same Orchestrator instance may be reused across stop/start cycles
+    // (src/index.ts does this). Without this reset, the second cycle's
+    // `await orchestrator.deferredReady` resolves immediately (already settled
+    // from the first cycle) while the new deferredInitialize() is still running.
+    this.deps.deferredReady = new Promise<void>((resolve) => {
+      this.deps.resolveDeferredReady = resolve;
+    });
+
+    try {
+      await migrateFromEngram({
+        quiet: true,
+        logger: (message) => log.info(message),
+      });
+      await this.deps.storage.ensureDirectories();
+      await this.deps.storage.loadAliases();
+      if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
+        const namespaces = new Set<string>([
+          this.deps.config.defaultNamespace,
+          this.deps.config.sharedNamespace,
+          ...this.deps.config.namespacePolicies.map((p) => p.name),
+        ]);
+        for (const ns of namespaces) {
+          const sm = await this.deps.storageRouter.storageFor(ns);
+          await sm.ensureDirectories();
+          await sm.loadAliases().catch(() => undefined);
+        }
+        // Explicitly seed the catalog with all configured namespaces at startup
+        // (round 6, cursor Medium — NBLlR). The storageFor loop above fires the
+        // router's onResolve hook, but a warm router cache (reused instance
+        // across stop/start) can skip onResolve, leaving policy namespaces absent
+        // from the live catalog until an operator runs `rebuild --apply`. This
+        // call is cheap, idempotent, and best-effort: a catalog failure must
+        // never break initialization (rule #13, #40).
+        await this.deps.namespaceCatalog.registerConfiguredNamespaces().catch(() => undefined);
+      }
+      // #1713 Item 2: recover stale `applying` correction plans left behind
+      // by a process that died mid-apply. Best-effort — a failure here must
+      // never block initialization (rule 13). Runs for every configured
+      // namespace since correction plans can exist in any of them.
+      try {
+        // #1713 Item 2 + P2 (cursor): sweep ALL known namespaces — configured
+        // + catalog-discovered — so stale applying plans in derived namespaces
+        // (coding-scoped, session-derived) are also recovered.
+        const correctionNamespaces = new Set(this.deps.configuredNamespaceList());
+        if (this.deps.namespaceCatalog.enabled) {
+          try {
+            for (const rec of await this.deps.namespaceCatalog.listNamespaces()) {
+              correctionNamespaces.add(rec.namespace);
+            }
+          } catch { /* best-effort */ }
+        }
+        const recovered = await this.deps.passiveCorrectionService().recoverStaleApplyingPlans(
+          [...correctionNamespaces],
+        );
+        if (recovered > 0) {
+          log.info(`correction: recovered ${recovered} stale applying plan(s) on startup`);
+        }
+      } catch (staleErr) {
+        log.debug(`correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`);
+      }
+      await this.deps.relevance.load();
+      await this.deps.negatives.load();
+      await this.deps.lastRecall.load();
+      await this.deps.handleHistory.load();
+      await this.deps.tierMigrationStatus.load();
+      await this.deps.sessionObserver.load();
+      this.deps.runtimePolicyValues = await this.deps.policyRuntime.loadRuntimeValues();
+      this.deps.utilityRuntimeValues = await loadUtilityRuntimeValues({
+        memoryDir: this.deps.config.memoryDir,
+        memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(this.deps.config).memoryUtilityLearning,
+        promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(this.deps.config).promotionByOutcome,
+      });
+
+      // Initialize content-hash dedup index
+      if (resolveRecallAuxiliaryCapabilities(this.deps.config).factDeduplication) {
+        this.deps.contentHashIndex = this.deps.storage.createContentHashIndex();
+        await this.deps.contentHashIndex.load();
+        log.info(
+          `content-hash dedup: loaded ${this.deps.contentHashIndex.size} hashes`,
+        );
+      }
+      await this.deps.transcript.initialize();
+      await this.deps.summarizer.initialize();
+      if (this.deps.sharedContext) {
+        await this.deps.sharedContext.ensureStructure();
+      }
+      if (this.deps.compounding) {
+        await this.deps.compounding.ensureDirs();
+      }
+
+      // Buffer and compaction cleanup are fast and needed for basic operation —
+      // load them before the init gate so turn buffering works immediately.
+      try {
+        await this.deps.buffer.load();
+      } catch (bufErr) {
+        log.error(
+          `buffer.load() failed (init gate will still open): ${bufErr}`,
+        );
+        this.deps.buffer.resetToEmpty();
+      }
+      if (resolveRecallAuxiliaryCapabilities(this.deps.config).compactionReset) {
+        try {
+          const wsDir = this.deps.config.workspaceDir || defaultWorkspaceDir();
+          const files = await readdir(wsDir).catch(() => [] as string[]);
+          for (const f of files) {
+            if (!f.startsWith(".compaction-reset-signal-")) continue;
+            const fp = path.join(wsDir, f);
+            const s = await stat(fp).catch(() => null);
+            if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
+              await unlink(fp).catch(() => {});
+              log.debug(`initialize: removed stale compaction signal ${f}`);
+            }
+          }
+        } catch (err) {
+          log.debug("initialize: stale signal sweep failed:", err);
+        }
+      }
+
+      // QMD probe + collection check: determines the final QMD state (real
+      // client vs NoopSearchBackend). Must complete BEFORE the init gate opens
+      // so that recall() — which awaits initPromise — always observes the final
+      // QMD state. Without this ordering, a concurrent recall() could read
+      // this.deps.qmd while it's still the real client, then get errors when
+      // deferredInitialize() swaps it to NoopSearchBackend mid-query.
+      try {
+        const available = await this.deps.qmd.probe();
+        if (available) {
+          log.info(`Search backend: available ${this.deps.qmd.debugStatus()}`);
+          // Ensure collections at startup for the catalog-union namespace set, not
+          // just the configured set (issue #1499 sweep, same class as NHZEV): a
+          // dynamic namespace that exists only in the persisted catalog must have
+          // its QMD collection checked/ensured on boot so recall against it works
+          // after a restart. `registerConfiguredNamespaces()` already seeded the
+          // catalog above, so `maintenanceNamespaces()` is readable here; it falls
+          // back to the configured set on any catalog read failure.
+          const namespaces = resolveNamespaceCapabilities(this.deps.config).namespaces
+            ? await this.deps.maintenanceNamespaces()
+            : [this.deps.config.defaultNamespace];
+          const states = await Promise.all(
+            namespaces.map(async (namespace) => {
+              const collectionCheckAbort = new AbortController();
+              const state = await qmdStartupCollectionCheckWithTimeout(
+                resolveNamespaceCapabilities(this.deps.config).namespaces
+                  ? this.deps.namespaceSearchRouter.ensureNamespaceCollection(
+                      namespace,
+                      { signal: collectionCheckAbort.signal },
+                    )
+                  : this.deps.qmd.ensureCollection(
+                      this.deps.config.memoryDir,
+                      this.deps.config.qmdCollection,
+                      { signal: collectionCheckAbort.signal },
+                    ),
+                collectionCheckAbort,
+                namespace,
+              );
+              return { namespace, state };
+            }),
+          );
+          const defaultState =
+            states.find(
+              (entry) => entry.namespace === this.deps.config.defaultNamespace,
+            )?.state ?? "unknown";
+          if (defaultState === "missing") {
+            await this.deps.disposeSearchBackendIfNeeded();
+            this.deps.qmd = new NoopSearchBackend();
+            log.warn(
+              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
+            );
+          } else if (defaultState === "unknown") {
+            log.warn(
+              "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
+            );
+          } else if (defaultState === "skipped") {
+            log.debug(
+              "Search collection check skipped (remote or daemon-only mode)",
+            );
+          }
+          for (const entry of states) {
+            if (entry.namespace === this.deps.config.defaultNamespace) continue;
+            if (entry.state === "missing") {
+              log.warn(
+                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
+              );
+            }
+          }
+        } else if (this.deps.qmd instanceof NoopSearchBackend) {
+          log.debug(`Search backend: noop (search intentionally disabled)`);
+        } else {
+          log.warn(`Search backend: not available ${this.deps.qmd.debugStatus()}`);
+        }
+      } catch (err) {
+        log.error(`QMD probe/collection check failed (non-fatal): ${err}`);
+      }
+
+      // Open the init gate — essential state (storage, aliases, relevance,
+      // transcript, summarizer, buffer) is loaded AND QMD state is finalized
+      // (probe + collection check complete, NoopSearchBackend swap done if
+      // needed). Warmup, sync, caches, and remaining heavy operations run in
+      // the background after this point via deferredInitialize().
+      if (this.deps.resolveInit) {
+        this.deps.resolveInit();
+        this.deps.resolveInit = null;
+        log.info("init gate opened (essential state + QMD state loaded)");
+      }
+
+      // Deferred init: QMD sync, warmup, conversation index, caches, cron.
+      // Runs in background so gateway_start returns fast. On low-power hardware
+      // (Umbrel, RPi) QMD warmup/sync alone can take 30-60s and cause gateway
+      // restart loops when they block the startup path. See issue #462.
+      // Note: QMD probe + collection check (including NoopSearchBackend swap)
+      // already ran above before the init gate, so this.deps.qmd is finalized.
+      //
+      // Capture the resolver by value so a concurrent re-initialize() cannot
+      // overwrite this.deps.resolveDeferredReady before .finally() runs — that would
+      // cause the first cycle's .finally() to resolve the *second* cycle's
+      // promise prematurely while leaving the first cycle's promise pending.
+      const resolveDeferred = this.deps.resolveDeferredReady;
+      this.deps.resolveDeferredReady = null;
+      this.deps.deferredInitAbort = new AbortController();
+      this.deps.deferredInitialize(this.deps.deferredInitAbort.signal)
+        .catch((err) => {
+          log.error(`deferred initialization failed (non-fatal): ${err}`);
+        })
+        .finally(() => {
+          resolveDeferred?.();
+        });
+    } catch (err) {
+      // Resolve both gates so callers never hang on permanently-pending promises
+      // after catching the initialize() error:
+      //
+      // - initPromise: recall(), generateDaySummary(), etc. await this as a
+      //   readiness gate with a 15s timeout. Leaving it pending means every
+      //   subsequent call pays that timeout penalty.
+      //
+      // - deferredReady: CLI callers await this for full QMD readiness. Without
+      //   resolution it hangs forever since deferredInitialize() never ran.
+      if (this.deps.resolveInit) {
+        this.deps.resolveInit();
+        this.deps.resolveInit = null;
+      }
+      if (this.deps.resolveDeferredReady) {
+        this.deps.resolveDeferredReady();
+        this.deps.resolveDeferredReady = null;
+      }
+      throw err;
+    }
+  }
+
+  async deferredInitialize(signal: AbortSignal): Promise<void> {
+    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.deps.config);
+
+    // Sync QMD index with current disk state so recall finds recently-written
+    // facts. Without this, the index stays stale from the last extraction-
+    // triggered update — which can be days ago if the daemon restarted without
+    // new extractions. This is the root cause of "0 memories" recall results
+    // despite thousands of facts on disk.
+    if (this.deps.qmd.isAvailable() && resolveQmdCapabilities(this.deps.config).qmdMaintenance) {
+      try {
+        log.info("QMD startup sync: updating index to match current disk state");
+        if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
+          // Cover cataloged dynamic namespaces at startup too (NHZEV, codex P2):
+          // a dynamic namespace written before a daemon restart must be synced on
+          // boot, not only by the debounced runQmdMaintenance() path. Same union +
+          // catalog-read-failure fallback as runQmdMaintenance.
+          await this.deps.namespaceSearchRouter.updateNamespaces(
+            await this.deps.maintenanceNamespaces(),
+            { signal },
+          );
+        } else {
+          await this.deps.qmd.update({ signal });
+        }
+        log.info("QMD startup sync: complete");
+        this.deps.deferredSyncSucceeded = true;
+      } catch (err) {
+        log.warn(`QMD startup sync failed (non-fatal): ${err}`);
+        // deferredSyncSucceeded stays false — server retry will attempt sync
+      }
+    } else if (!(this.deps.qmd.isAvailable())) {
+      // QMD not available at deferred init time — server retry will handle it
+    } else {
+      // QMD available but maintenance disabled — consider sync not needed
+      this.deps.deferredSyncSucceeded = true;
+    }
+
+    if (signal.aborted) return;
+
+    // Warmup: run cheap searches to pre-load QMD embedding models and the
+    // embedding-fallback JSON index so the first real recall is fast.
+    const warmupPromises: Promise<void>[] = [];
+    if (this.deps.qmd.isAvailable()) {
+      const warmupNs = this.deps.config.defaultNamespace;
+      log.info("QMD warmup: pre-loading models with a test search");
+      warmupPromises.push(
+        this.deps.qmd
+          .search("warmup", warmupNs, 1, undefined, { signal })
+          .then(() => {
+            log.info("QMD warmup: complete");
+          })
+          .catch((err) => {
+            log.debug(`QMD warmup search failed (non-fatal): ${err}`);
+          }),
+      );
+    }
+    if (resolveMemoryLifecycleCapabilities(this.deps.config).embeddingFallback) {
+      warmupPromises.push(
+        this.deps.embeddingFallback
+          .isAvailable()
+          .then((ok) => {
+            log.info(
+              `Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`,
+            );
+          })
+          .catch((err) => {
+            log.debug(`Embedding fallback warmup failed (non-fatal): ${err}`);
+          }),
+      );
+    }
+    await Promise.all(warmupPromises);
+    if (signal.aborted) return;
+
+    // Pre-warm knowledge index, memory, and entity caches.
+    // Awaited so callers of `deferredReady` can rely on warmups being complete
+    // and shutdown sequencing does not race with in-flight cache builds.
+    const cacheWarmups: Promise<void>[] = [];
+    if (resolveRecallAuxiliaryCapabilities(this.deps.config).knowledgeIndex) {
+      cacheWarmups.push(
+        (async () => {
+          try {
+            const t0 = Date.now();
+            await this.deps.storage.buildKnowledgeIndex(this.deps.config);
+            log.info(`Knowledge Index warmup: complete in ${Date.now() - t0}ms`);
+          } catch (err) {
+            log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
+          }
+        })(),
+      );
+    }
+    cacheWarmups.push(this.deps.storage.readAllMemories().then(() => {}).catch(() => {}));
+    cacheWarmups.push(this.deps.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
+    await Promise.all(cacheWarmups);
+    if (signal.aborted) return;
+
+    if (resolveIndexingCapabilities(this.deps.config).conversationIndex && this.deps.conversationIndexBackend) {
+      try {
+        const init = await this.deps.conversationIndexBackend.initialize();
+        if (!init.enabled) {
+          this.deps.config.conversationIndexEnabled = false;
+        }
+        if (init.logLevel === "info") {
+          log.info(init.message);
+        } else if (init.logLevel === "warn") {
+          log.warn(init.message);
+        } else {
+          log.debug(init.message);
+        }
+      } catch (err) {
+        log.error(`Conversation index initialization failed (non-fatal): ${err}`);
+        this.deps.config.conversationIndexEnabled = false;
+      }
+    }
+
+    if (signal.aborted) return;
+
+    if (resolveLocalLlmCapabilities(this.deps.config).localLlm) {
+      try {
+        await this.deps.validateLocalLlmModel();
+      } catch (err) {
+        log.error(`Local LLM validation failed (non-fatal): ${err}`);
+      }
+    }
+
+    if (signal.aborted) return;
+
+    // Await cron auto-registration so callers that `await deferredReady` can
+    // rely on cron jobs being registered when it resolves. Without this, the
+    // fire-and-forget pattern lets deferredReady settle while cron writes are
+    // still in flight. Errors are non-fatal — catch individually.
+    // Auto-register every cron job in one pass. Each registration is gated
+    // by its config flag inside the scheduler and individually non-fatal
+    // (issue #1526 PR1 — moved to MaintenanceScheduler).
+    await this.deps.maintenanceScheduler.autoRegisterCrons(signal);
+
+    // First-start lifecycle migration (issue #686 retention-completion).
+    // When lifecyclePolicyEnabled is true and the memoryDir has never been
+    // touched by the lifecycle policy, run a one-time rate-limited demotion
+    // sweep (capped at 50 demotions) so the hot tier isn't flooded on the
+    // first real cron pass. Non-fatal — a failure here must not break init.
+    if (signal.aborted) return;
+    if (lifecycleCaps.lifecyclePolicy && resolveQmdCapabilities(this.deps.config).qmdTierMigration) {
+      try {
+        const { runFirstStartMigration } = await import("../maintenance/first-start-migration.js"
+        );
+        const result = await runFirstStartMigration({
+          storage: this.deps.storage,
+          config: this.deps.config,
+          qmd: this.deps.qmd,
+          hotCollection: this.deps.config.qmdCollection,
+          coldCollection: this.deps.config.qmdColdCollection,
+          signal,
+        });
+        if (!result.skipped) {
+          log.info(
+            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`,
+          );
+        } else {
+          log.debug(`first-start lifecycle migration skipped: ${result.skipReason}`);
+        }
+      } catch (err) {
+        log.warn(`first-start lifecycle migration failed (non-fatal): ${err}`);
+      }
+    }
+
+    // Wearables auto-sync: in-process periodic transcript refresh for
+    // long-lived hosts (default on). Today's transcript keeps growing
+    // while the wearable records; a once-per-local-day deep pass picks
+    // up late uploads and provider re-processing. Static config gate —
+    // sources can't appear at runtime, so checking once here is safe.
+    // The timer is unref'd, so one-shot CLI runs exit naturally without
+    // ever ticking; idempotent across stop/start cycles via the handle
+    // guard. Non-fatal: a failure to start must not break init.
+    if (signal.aborted) return;
+    if (
+      !this.deps.wearablesAutoSyncHandle &&
+      this.deps.config.wearables.enabled &&
+      this.deps.config.wearables.autoSyncEnabled &&
+      Object.values(this.deps.config.wearables.sources).some((source) => source.enabled)
+    ) {
+      try {
+        const { startWearablesAutoSync } = await import("../wearables/auto-sync.js");
+        // Re-check after the await: destroy() may have aborted while
+        // the import was in flight, having found no handle to stop —
+        // starting now would leave a live interval on a destroyed
+        // orchestrator (Cursor review on PR #1464). Handle creation
+        // below is synchronous, so no further window exists.
+        if (signal.aborted) return;
+        this.deps.wearablesAutoSyncHandle = startWearablesAutoSync(
+          {
+            intervalMinutes: this.deps.config.wearables.autoSyncIntervalMinutes,
+            days: this.deps.config.wearables.autoSyncDays,
+            deepDays: this.deps.config.wearables.autoSyncDeepDays,
+            ...(this.deps.config.wearables.timezone !== undefined
+              ? { timezone: this.deps.config.wearables.timezone }
+              : {}),
+          },
+          {
+            sync: (options) => this.deps.getWearablesService().sync(options),
+            log: {
+              info: (message) => log.info(message),
+              warn: (message) => log.warn(message),
+            },
+          },
+        );
+        log.info(
+          `wearables auto-sync started: every ${this.deps.config.wearables.autoSyncIntervalMinutes}m over ${this.deps.config.wearables.autoSyncDays}d (deep ${this.deps.config.wearables.autoSyncDeepDays}d daily)`,
+        );
+      } catch (err) {
+        const { displayErrorDetail } = await import("../runtime/better-sqlite.js");
+        log.warn(
+          `wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`,
+        );
+      }
+    }
+
+    log.info("orchestrator initialized (full — deferred steps complete)");
+  }
+
+  /**
+   * Namespace-aware startup search sync. Re-probes QMD, ensures collections
+   * (namespace-aware when namespacesEnabled), runs update, and warms up search.
+   * Designed for server retry paths that run after the deferred init completes
+   * when QMD was not available during initial startup.
+   *
+   * Accepts an optional AbortSignal so callers can interrupt the sync during
+   * shutdown. The signal is checked between phases and forwarded into the QMD
+   * update and warmup search calls so a long-running `qmd update` subprocess
+   * is killed promptly rather than left in flight after `httpServer.stop()`.
+   *
+   * Returns true if the sync succeeded (QMD now available), false otherwise.
+   */
+  async startupSearchSync(signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) return false;
+
+    const available = await this.deps.qmd.probe();
+    if (!available) return false;
+    if (signal?.aborted) {
+      log.debug("startupSearchSync: aborted after probe");
+      return false;
+    }
+
+    log.info(`startupSearchSync: backend now available ${this.deps.qmd.debugStatus()}`);
+
+    // Clear namespace router cache so re-probe picks up newly available backends
+    if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
+      this.deps.namespaceSearchRouter.clearCache();
+    }
+
+    // Ensure collections — namespace-aware when enabled.
+    // Use the catalog-union namespace set (issue #1499 sweep, same class as
+    // NHZEV): this is the QMD startup-recovery sync that ensures collections AND
+    // runs `updateNamespaces(...)` below over the SAME `namespaces` set. A dynamic
+    // namespace that exists only in the persisted catalog must be ensured and
+    // re-synced here too, otherwise after a backend-was-unavailable-at-boot
+    // recovery its collection stays stale. Falls back to the configured set on any
+    // catalog read failure.
+    const namespaces = resolveNamespaceCapabilities(this.deps.config).namespaces
+      ? await this.deps.maintenanceNamespaces()
+      : [this.deps.config.defaultNamespace];
+
+    const states = await Promise.all(
+      namespaces.map(async (namespace) => ({
+        namespace,
+        state: resolveNamespaceCapabilities(this.deps.config).namespaces
+          ? await this.deps.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
+          : await this.deps.qmd.ensureCollection(this.deps.config.memoryDir, this.deps.config.qmdCollection, { signal }),
+      })),
+    );
+
+    if (signal?.aborted) {
+      log.debug("startupSearchSync: aborted after ensureCollection");
+      return false;
+    }
+
+    const defaultState =
+      states.find((e) => e.namespace === this.deps.config.defaultNamespace)?.state ?? "unknown";
+    if (defaultState === "missing") {
+      // Reset the real backend's available flag before replacing it with noop.
+      // probe() set available=true earlier in this call; without this reset,
+      // any code that captured a reference to the old backend (e.g. a concurrent
+      // recall() that read this.deps.qmd before the reassignment) would observe
+      // isAvailable()===true against a backend with a missing collection.
+      if ("available" in this.deps.qmd) {
+        (this.deps.qmd as any).available = false;
+      }
+      await this.deps.disposeSearchBackendIfNeeded();
+      this.deps.qmd = new NoopSearchBackend();
+      log.warn("startupSearchSync: search collection missing; disabling search (fallback retrieval remains enabled)");
+      return false;
+    }
+
+    // Run index update — namespace-aware when enabled.
+    // qmd.update() swallows errors internally, so we: (1) snapshot fail/run
+    // timestamps, (2) reset throttles so the update isn't skipped by stale
+    // backoff, and (3) verify timestamps after update to confirm it executed
+    // and didn't fail silently.
+    // The abort signal is forwarded into the QMD subprocess call so the
+    // long-running `qmd update` process is killed promptly on shutdown.
+    if (resolveQmdCapabilities(this.deps.config).qmdMaintenance) {
+      try {
+        const failTsBefore = "lastUpdateFailedAtMs" in this.deps.qmd
+          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
+        const hasRunTs = "lastUpdateRanAtMs" in this.deps.qmd;
+        if ("resetUpdateThrottles" in this.deps.qmd) {
+          (this.deps.qmd as any).resetUpdateThrottles();
+        }
+        log.info("startupSearchSync: updating index to match current disk state");
+        let namespacesUpdated = 0;
+        if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
+          namespacesUpdated = await this.deps.namespaceSearchRouter.updateNamespaces(
+            namespaces,
+            { signal },
+          );
+        } else {
+          await this.deps.qmd.update({ signal });
+        }
+        if (signal?.aborted) {
+          log.debug("startupSearchSync: aborted after update");
+          return false;
+        }
+        const failTsAfter = "lastUpdateFailedAtMs" in this.deps.qmd
+          ? (this.deps.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
+        const runTsAfter = hasRunTs
+          ? (this.deps.qmd as any).lastUpdateRanAtMs as number | null
+          : null;
+        if (failTsAfter !== null && failTsAfter !== failTsBefore) {
+          log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
+          return false;
+        }
+        if (resolveNamespaceCapabilities(this.deps.config).namespaces) {
+          if (namespacesUpdated === 0) {
+            log.warn("startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)");
+            return false;
+          }
+          log.info(`startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`);
+        } else if (hasRunTs && runTsAfter === null) {
+          log.warn("startupSearchSync: update was throttled/skipped (run timestamp is null after reset + update)");
+          return false;
+        }
+        log.info("startupSearchSync: sync complete");
+      } catch (err) {
+        log.warn(`startupSearchSync: update failed: ${err}`);
+        return false;
+      }
+    }
+
+    // Warmup search to pre-load embedding models
+    if (!signal?.aborted) {
+      try {
+        await this.deps.qmd.search("warmup", this.deps.config.defaultNamespace, 1, undefined, { signal });
+        log.info("startupSearchSync: warmup complete");
+      } catch (err) {
+        log.debug(`startupSearchSync: warmup search failed (non-fatal): ${err}`);
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/remnic-core/src/orchestration/recall-introspection.ts
+++ b/packages/remnic-core/src/orchestration/recall-introspection.ts
@@ -1,0 +1,709 @@
+/**
+ * Recall-introspection coordinator — extracted from the orchestrator
+ * (issue #1526, seam 21).
+ *
+ * Owns the recall observability surfaces:
+ *   - last-intent / last-graph-recall / last-QMD-recall snapshot
+ *     recording, reading, and explain rendering
+ *   - console faithfulness distribution
+ *   - background direct-answer tier annotation (observation mode, #518)
+ *
+ * Behavior-preserving move from orchestrator.ts. The orchestrator keeps
+ * thin delegating methods; all member access flows back through
+ * RecallIntrospectionDeps live accessors/arrows (late-binding rule,
+ * seams 18–20).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { type CapabilitySet, resolveRecallAuxiliaryCapabilities } from "../capabilities.js";
+import { type DirectAnswerSources, tryDirectAnswer } from "../direct-answer-wiring.js";
+import type { FaithfulnessGateCounters } from "../extraction-faithfulness.js";
+import { StorageManager } from "../index.js";
+import { log } from "../logger.js";
+import { NamespaceStorageRouter } from "../namespaces/storage.js";
+import { GraphRecallCoordinator, type GraphRecallRankedResult, type GraphRecallShadowComparison } from "./graph-recall-coordinator.js";
+import { buildRecallQueryPolicy } from "../recall-query-policy.js";
+import { type GraphRecallExpandedEntry, LastRecallStore, clampGraphRecallExpandedEntries } from "../recall-state.js";
+import { resolveScopePlan } from "../scopes/scope-plan.js";
+import { DEFAULT_TAXONOMY } from "../taxonomy/index.js";
+import { listTrustZoneRecords } from "../trust-zones.js";
+import type { CodingContext, MemoryFile, MemoryIntent, PluginConfig, RecallPlanMode, RecallTierExplain } from "../types.js";
+import {
+  parseGraphRecallRankedResults,
+  parseMemoryIntentSnapshot,
+  parseQmdRecallResults,
+  type GraphRecallSnapshot,
+  type IntentDebugSnapshot,
+  type QmdRecallSnapshot,
+} from "../orchestrator.js";
+
+export interface RecallIntrospectionDeps {
+  annotateDirectAnswerTier(
+    prompt: string,
+    sessionKey: string,
+    namespaces: string[],
+    expectedIdentity:
+      | { writeNonce?: string; traceId?: string; recordedAt?: string }
+      | undefined,
+    caps: CapabilitySet,
+    _parentAbortSignal?: AbortSignal,
+  ): Promise<void>;
+  readonly config: PluginConfig;
+  directAnswerObservationChain: Promise<void>;
+  effectiveCronRecallInstructionHeavyTokenCap(): number;
+  readonly faithfulnessCounters: FaithfulnessGateCounters;
+  getCodingContextForSession(sessionKey: string | undefined): CodingContext | null;
+  getLastGraphRecallSnapshot(
+    namespace?: string,
+  ): Promise<GraphRecallSnapshot | null>;
+  getLastIntentSnapshot(
+    namespace?: string,
+  ): Promise<IntentDebugSnapshot | null>;
+  getLastQmdRecallSnapshot(
+    namespace?: string,
+  ): Promise<QmdRecallSnapshot | null>;
+  getStorage(namespace?: string): Promise<StorageManager>;
+  readonly graphRecallCoordinator: GraphRecallCoordinator;
+  readonly lastRecall: LastRecallStore;
+  resolveStateDirForNamespace(
+    namespace: string,
+  ): Promise<string>;
+  readonly storageRouter: NamespaceStorageRouter;
+}
+
+export class RecallIntrospectionCoordinator {
+  constructor(
+    private readonly deps: RecallIntrospectionDeps,
+  ) {}
+
+  /**
+   * Faithfulness gate verdict distribution (issue #1576). Consumed by the
+   * console-state aggregator so `remnic doctor` can render how the gate is
+   * performing. Returns a fresh object so callers cannot mutate the
+   * internal counters. Returns `undefined` when the gate is off so the
+   * console-state snapshot omits the faithfulness block entirely (cursor
+   * review: an all-zero block would otherwise always be truthy and leak
+   * into snapshots that document it as absent-when-off).
+   */
+  getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters | undefined {
+    if (this.deps.config.extractionFaithfulnessGate === "off") return undefined;
+    return { ...this.deps.faithfulnessCounters };
+  }
+
+  async getLastGraphRecallSnapshot(
+    namespace?: string,
+  ): Promise<GraphRecallSnapshot | null> {
+    const storage = await this.deps.getStorage(namespace);
+    const snapshotPath = path.join(
+      storage.dir,
+      "state",
+      "last_graph_recall.json",
+    );
+    try {
+      const raw = await readFile(snapshotPath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<GraphRecallSnapshot>;
+      if (!parsed || typeof parsed !== "object") return null;
+      return {
+        recordedAt:
+          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
+        mode: typeof parsed.mode === "string" ? parsed.mode : "full",
+        queryHash: typeof parsed.queryHash === "string" ? parsed.queryHash : "",
+        queryLength:
+          typeof parsed.queryLength === "number" ? parsed.queryLength : 0,
+        namespaces: Array.isArray(parsed.namespaces)
+          ? parsed.namespaces.filter((v): v is string => typeof v === "string")
+          : [],
+        seedCount: typeof parsed.seedCount === "number" ? parsed.seedCount : 0,
+        expandedCount:
+          typeof parsed.expandedCount === "number" ? parsed.expandedCount : 0,
+        seeds: Array.isArray(parsed.seeds)
+          ? parsed.seeds.filter((v): v is string => typeof v === "string")
+          : [],
+        expanded: clampGraphRecallExpandedEntries(parsed.expanded, 64),
+        status:
+          parsed.status === "completed" ||
+          parsed.status === "skipped" ||
+          parsed.status === "aborted"
+            ? parsed.status
+            : undefined,
+        reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+        shadowMode: parsed.shadowMode === true,
+        queryIntent: parseMemoryIntentSnapshot(parsed.queryIntent),
+        seedResults: parseGraphRecallRankedResults(parsed.seedResults),
+        finalResults: parseGraphRecallRankedResults(parsed.finalResults),
+        shadowComparison:
+          parsed.shadowComparison && typeof parsed.shadowComparison === "object"
+            ? {
+                baselineCount:
+                  typeof parsed.shadowComparison.baselineCount === "number"
+                    ? parsed.shadowComparison.baselineCount
+                    : 0,
+                graphCount:
+                  typeof parsed.shadowComparison.graphCount === "number"
+                    ? parsed.shadowComparison.graphCount
+                    : 0,
+                overlapCount:
+                  typeof parsed.shadowComparison.overlapCount === "number"
+                    ? parsed.shadowComparison.overlapCount
+                    : 0,
+                overlapRatio:
+                  typeof parsed.shadowComparison.overlapRatio === "number"
+                    ? parsed.shadowComparison.overlapRatio
+                    : 0,
+                averageOverlapDelta:
+                  typeof parsed.shadowComparison.averageOverlapDelta ===
+                  "number"
+                    ? parsed.shadowComparison.averageOverlapDelta
+                    : 0,
+              }
+            : undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async getLastIntentSnapshot(
+    namespace?: string,
+  ): Promise<IntentDebugSnapshot | null> {
+    const storage = await this.deps.getStorage(namespace);
+    const snapshotPath = path.join(storage.dir, "state", "last_intent.json");
+    try {
+      const raw = await readFile(snapshotPath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<IntentDebugSnapshot>;
+      if (!parsed || typeof parsed !== "object") return null;
+      const graphDecision =
+        parsed.graphDecision && typeof parsed.graphDecision === "object"
+          ? parsed.graphDecision
+          : undefined;
+      return {
+        recordedAt:
+          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
+        promptHash:
+          typeof parsed.promptHash === "string" ? parsed.promptHash : "",
+        promptLength:
+          typeof parsed.promptLength === "number" ? parsed.promptLength : 0,
+        retrievalQueryHash:
+          typeof parsed.retrievalQueryHash === "string"
+            ? parsed.retrievalQueryHash
+            : "",
+        retrievalQueryLength:
+          typeof parsed.retrievalQueryLength === "number"
+            ? parsed.retrievalQueryLength
+            : 0,
+        plannerEnabled: parsed.plannerEnabled !== false,
+        plannedMode:
+          parsed.plannedMode === "no_recall" ||
+          parsed.plannedMode === "minimal" ||
+          parsed.plannedMode === "full" ||
+          parsed.plannedMode === "graph_mode"
+            ? parsed.plannedMode
+            : "full",
+        effectiveMode:
+          parsed.effectiveMode === "no_recall" ||
+          parsed.effectiveMode === "minimal" ||
+          parsed.effectiveMode === "full" ||
+          parsed.effectiveMode === "graph_mode"
+            ? parsed.effectiveMode
+            : "full",
+        recallResultLimit:
+          typeof parsed.recallResultLimit === "number"
+            ? parsed.recallResultLimit
+            : 0,
+        queryIntent: parseMemoryIntentSnapshot(parsed.queryIntent),
+        graphExpandedIntentDetected:
+          parsed.graphExpandedIntentDetected === true,
+        graphDecision: {
+          status:
+            graphDecision?.status === "skipped" ||
+            graphDecision?.status === "completed" ||
+            graphDecision?.status === "aborted"
+              ? graphDecision.status
+              : "not_requested",
+          reason:
+            typeof graphDecision?.reason === "string"
+              ? graphDecision.reason
+              : undefined,
+          shadowMode: graphDecision?.shadowMode === true,
+          qmdAvailable: graphDecision?.qmdAvailable !== false,
+          graphRecallEnabled: graphDecision?.graphRecallEnabled !== false,
+          multiGraphMemoryEnabled:
+            graphDecision?.multiGraphMemoryEnabled !== false,
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async getLastQmdRecallSnapshot(
+    namespace?: string,
+  ): Promise<QmdRecallSnapshot | null> {
+    const storage = await this.deps.getStorage(namespace);
+    const snapshotPath = path.join(
+      storage.dir,
+      "state",
+      "last_qmd_recall.json",
+    );
+    try {
+      const raw = await readFile(snapshotPath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<QmdRecallSnapshot>;
+      if (!parsed || typeof parsed !== "object") return null;
+      return {
+        recordedAt:
+          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
+        queryHash: typeof parsed.queryHash === "string" ? parsed.queryHash : "",
+        queryLength:
+          typeof parsed.queryLength === "number" ? parsed.queryLength : 0,
+        collection:
+          typeof parsed.collection === "string" ? parsed.collection : undefined,
+        namespaces: Array.isArray(parsed.namespaces)
+          ? parsed.namespaces.filter(
+              (value): value is string => typeof value === "string",
+            )
+          : [],
+        fetchLimit:
+          typeof parsed.fetchLimit === "number" ? parsed.fetchLimit : 0,
+        primaryResultCount:
+          typeof parsed.primaryResultCount === "number"
+            ? parsed.primaryResultCount
+            : 0,
+        hybridResultCount:
+          typeof parsed.hybridResultCount === "number"
+            ? parsed.hybridResultCount
+            : 0,
+        queryAwareSeedCount:
+          typeof parsed.queryAwareSeedCount === "number"
+            ? parsed.queryAwareSeedCount
+            : 0,
+        resultCount:
+          typeof parsed.resultCount === "number" ? parsed.resultCount : 0,
+        intentHint:
+          typeof parsed.intentHint === "string" ? parsed.intentHint : undefined,
+        explainEnabled: parsed.explainEnabled === true,
+        hybridTopUpUsed: parsed.hybridTopUpUsed === true,
+        hybridTopUpSkippedReason:
+          typeof parsed.hybridTopUpSkippedReason === "string"
+            ? parsed.hybridTopUpSkippedReason
+            : undefined,
+        results: parseQmdRecallResults(parsed.results),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async explainLastGraphRecall(options?: {
+    namespace?: string;
+    maxExpanded?: number;
+  }): Promise<string> {
+    const snapshot = await this.deps.getLastGraphRecallSnapshot(options?.namespace);
+    if (!snapshot) return "No graph-recall snapshot found yet.";
+    const maxExpanded = Math.max(1, Math.min(50, options?.maxExpanded ?? 10));
+    const expanded = snapshot.expanded.slice(0, maxExpanded);
+    const seedResults = (snapshot.seedResults ?? []).slice(0, maxExpanded);
+    const finalResults = (snapshot.finalResults ?? []).slice(0, maxExpanded);
+    const queryIntent = snapshot.queryIntent ?? {
+      goal: "unknown",
+      actionType: "unknown",
+      entityTypes: [],
+    };
+    return [
+      "## Last Graph Recall",
+      "",
+      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
+      `Mode: ${snapshot.mode}`,
+      `Status: ${snapshot.status ?? "completed"}${snapshot.shadowMode ? " (shadow)" : ""}`,
+      `Reason: ${snapshot.reason ?? "n/a"}`,
+      `Query hash: ${snapshot.queryHash || "unknown"} (len=${snapshot.queryLength})`,
+      `Query intent: goal=${queryIntent.goal}, action=${queryIntent.actionType}, entityTypes=${queryIntent.entityTypes.length > 0 ? queryIntent.entityTypes.join(", ") : "none"}`,
+      `Namespaces: ${snapshot.namespaces.length > 0 ? snapshot.namespaces.join(", ") : "none"}`,
+      `Seed results (${snapshot.seedResults?.length ?? 0}, showing ${seedResults.length}):`,
+      ...seedResults.map(
+        (entry) =>
+          `- ${entry.path} (score=${entry.score.toFixed(3)}, sources=${entry.sourceLabels.join(",") || "baseline"})`,
+      ),
+      `Seed paths (${snapshot.seedCount}):`,
+      ...snapshot.seeds.map((p) => `- ${p}`),
+      `Expanded paths (${snapshot.expandedCount}, showing ${expanded.length}):`,
+      ...expanded.map((e) => {
+        // Issue #681 PR 3/3 — surface per-edge confidence in the
+        // graph-explain document. Legacy snapshots without
+        // `edgeConfidence` render as `conf=n/a` so older payloads
+        // remain readable.
+        const confLabel =
+          typeof e.edgeConfidence === "number" && Number.isFinite(e.edgeConfidence)
+            ? e.edgeConfidence.toFixed(2)
+            : "n/a";
+        return `- ${e.path} (score=${e.score.toFixed(3)}, ns=${e.namespace}, seed=${e.seed || "unknown"}, hop=${e.hopDepth}, w=${e.decayedWeight.toFixed(3)}, type=${e.graphType}, conf=${confLabel})`;
+      }),
+      `Final ranked results (${snapshot.finalResults?.length ?? 0}, showing ${finalResults.length}):`,
+      ...finalResults.map(
+        (entry) =>
+          `- ${entry.path} (score=${entry.score.toFixed(3)}, sources=${entry.sourceLabels.join(",") || "baseline"})`,
+      ),
+      ...(snapshot.shadowComparison
+        ? [
+            `Shadow comparison: baseline=${snapshot.shadowComparison.baselineCount}, graph=${snapshot.shadowComparison.graphCount}, overlap=${snapshot.shadowComparison.overlapCount} (${snapshot.shadowComparison.overlapRatio.toFixed(2)}), avgDelta=${snapshot.shadowComparison.averageOverlapDelta.toFixed(3)}`,
+          ]
+        : []),
+    ].join("\n");
+  }
+
+  async explainLastIntent(options?: { namespace?: string }): Promise<string> {
+    const snapshot = await this.deps.getLastIntentSnapshot(options?.namespace);
+    if (!snapshot) return "No intent-debug snapshot found yet.";
+    return [
+      "## Last Intent Debug",
+      "",
+      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
+      `Prompt hash: ${snapshot.promptHash || "unknown"} (len=${snapshot.promptLength})`,
+      `Retrieval query hash: ${snapshot.retrievalQueryHash || "unknown"} (len=${snapshot.retrievalQueryLength})`,
+      `Planner enabled: ${snapshot.plannerEnabled ? "yes" : "no"}`,
+      `Planned mode: ${snapshot.plannedMode}`,
+      `Effective mode: ${snapshot.effectiveMode}`,
+      `Recall result limit: ${snapshot.recallResultLimit}`,
+      `Query intent: goal=${snapshot.queryIntent.goal}, action=${snapshot.queryIntent.actionType}, entityTypes=${snapshot.queryIntent.entityTypes.length > 0 ? snapshot.queryIntent.entityTypes.join(", ") : "none"}`,
+      `Broad graph intent: ${snapshot.graphExpandedIntentDetected ? "yes" : "no"}`,
+      `Graph decision: status=${snapshot.graphDecision.status}, reason=${snapshot.graphDecision.reason ?? "n/a"}, shadow=${snapshot.graphDecision.shadowMode ? "yes" : "no"}, qmdAvailable=${snapshot.graphDecision.qmdAvailable ? "yes" : "no"}, graphRecallEnabled=${snapshot.graphDecision.graphRecallEnabled ? "yes" : "no"}, multiGraphMemoryEnabled=${snapshot.graphDecision.multiGraphMemoryEnabled ? "yes" : "no"}`,
+    ].join("\n");
+  }
+
+  async explainLastQmdRecall(options?: {
+    namespace?: string;
+    maxResults?: number;
+  }): Promise<string> {
+    const snapshot = await this.deps.getLastQmdRecallSnapshot(options?.namespace);
+    if (!snapshot) return "No QMD recall snapshot found yet.";
+    const maxResults = Math.max(1, Math.min(25, options?.maxResults ?? 10));
+    const shown = snapshot.results.slice(0, maxResults);
+    return [
+      "## Last QMD Recall",
+      "",
+      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
+      `Query hash: ${snapshot.queryHash || "unknown"} (len=${snapshot.queryLength})`,
+      `Collection: ${snapshot.collection ?? "default"}`,
+      `Namespaces: ${snapshot.namespaces.length > 0 ? snapshot.namespaces.join(", ") : "none"}`,
+      `Fetch limit: ${snapshot.fetchLimit}`,
+      `Primary results: ${snapshot.primaryResultCount}`,
+      `Hybrid top-up results: ${snapshot.hybridResultCount}`,
+      `Query-aware seeds: ${snapshot.queryAwareSeedCount}`,
+      `Final results: ${snapshot.resultCount}`,
+      `Intent hint: ${snapshot.intentHint ?? "none"}`,
+      `Explain enabled: ${snapshot.explainEnabled ? "yes" : "no"}`,
+      `Hybrid top-up used: ${snapshot.hybridTopUpUsed ? "yes" : "no"}`,
+      `Hybrid top-up skipped reason: ${snapshot.hybridTopUpSkippedReason ?? "n/a"}`,
+      `Top results (${shown.length}):`,
+      ...shown.map((result) => {
+        const explainParts = [
+          typeof result.explain?.blendedScore === "number"
+            ? `blended=${result.explain.blendedScore.toFixed(3)}`
+            : null,
+          typeof result.explain?.rerankScore === "number"
+            ? `rerank=${result.explain.rerankScore.toFixed(3)}`
+            : null,
+          typeof result.explain?.rrf === "number"
+            ? `rrf=${result.explain.rrf.toFixed(3)}`
+            : null,
+        ].filter((entry): entry is string => Boolean(entry));
+        const explainText =
+          explainParts.length > 0 ? `, explain=${explainParts.join("/")}` : "";
+        return `- ${result.path} (score=${result.score.toFixed(3)}, transport=${result.transport ?? "unknown"}${explainText})`;
+      }),
+    ].join("\n");
+  }
+
+  /**
+   * Await the in-flight observation-mode direct-answer annotation chain.
+   * Resolves to true when settled, false on timeout.
+   */
+  async waitForDirectAnswerObservationIdle(
+    timeoutMs: number = 60_000,
+  ): Promise<boolean> {
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    try {
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+      });
+      const result = await Promise.race([
+        this.deps.directAnswerObservationChain.then(() => "ok" as const),
+        timeoutPromise,
+      ]);
+      if (result === "timeout") {
+        log.warn(
+          `waitForDirectAnswerObservationIdle timed out after ${timeoutMs}ms`,
+        );
+        return false;
+      }
+      return true;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+  }
+
+  enqueueDirectAnswerObservation(
+    prompt: string,
+    sessionKey: string,
+    namespaceOverride: string | undefined,
+    principalOverride: string | undefined,
+    caps: CapabilitySet,
+    namespacesEnabled: boolean,
+  ): void {
+    const expectedSnapshot = this.deps.lastRecall.get(sessionKey);
+    if (expectedSnapshot === null) return;
+    if (expectedSnapshot.plannerMode === "no_recall") return;
+
+    // Resolve the observation namespace set through the SAME ScopePlan resolver
+    // the main recall path uses (#1521). The observe path does NOT throw on an
+    // unreadable override (it falls through to the coding/legacy branches), so
+    // we skip the readability gate the recall path enforces.
+    const observationScopePlan = resolveScopePlan({
+      config: this.deps.config,
+      sessionKey,
+      namespace: namespaceOverride,
+      principalOverride,
+      codingContext: sessionKey
+        ? this.deps.getCodingContextForSession(sessionKey)
+        : null,
+      namespacesEnabled,
+    });
+    const observationNamespaces = observationScopePlan.readNamespaces;
+    const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
+      cronRecallPolicyEnabled: resolveRecallAuxiliaryCapabilities(this.deps.config).cronRecallPolicy,
+      cronRecallNormalizedQueryMaxChars:
+        this.deps.config.cronRecallNormalizedQueryMaxChars,
+      cronRecallInstructionHeavyTokenCap:
+        this.deps.effectiveCronRecallInstructionHeavyTokenCap(),
+      cronConversationRecallMode: this.deps.config.cronConversationRecallMode,
+    });
+    const observationQuery = observationQueryPolicy.retrievalQuery || prompt;
+    const expectedIdentity = {
+      writeNonce: expectedSnapshot.writeNonce,
+      traceId: expectedSnapshot.traceId,
+      recordedAt: expectedSnapshot.recordedAt,
+    };
+    const previous = this.deps.directAnswerObservationChain;
+    this.deps.directAnswerObservationChain = previous
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await this.deps.annotateDirectAnswerTier(
+            observationQuery,
+            sessionKey,
+            observationNamespaces,
+            expectedIdentity,
+            caps,
+            undefined,
+          );
+        } catch (err) {
+          log.debug(`direct-answer observation chain error: ${err}`);
+        }
+      });
+  }
+
+  async annotateDirectAnswerTier(
+    prompt: string,
+    sessionKey: string,
+    namespaces: string[],
+    expectedIdentity:
+      | { writeNonce?: string; traceId?: string; recordedAt?: string }
+      | undefined,
+    caps: CapabilitySet,
+    _parentAbortSignal?: AbortSignal,
+  ): Promise<void> {
+    const tierStart = Date.now();
+    try {
+      if (namespaces.length === 0) return;
+
+      const trustZoneByNsAndRecordId = new Map<
+        string,
+        "quarantine" | "working" | "trusted"
+      >();
+      const trustZoneKey = (ns: string, recordId: string) =>
+        `${ns}\u0000${recordId}`;
+      const scopedStorages = new Map<
+        string,
+        Awaited<ReturnType<typeof this.deps.storageRouter.storageFor>>
+      >();
+
+      for (const ns of namespaces) {
+        const storage = await this.deps.storageRouter.storageFor(ns);
+        scopedStorages.set(ns, storage);
+        const trustZones = await listTrustZoneRecords({
+          memoryDir: storage.dir,
+          trustZoneStoreDir: this.deps.config.trustZoneStoreDir,
+          limit: 200,
+        }).catch(() => ({
+          allRecords: [] as Array<{
+            recordId: string;
+            zone: "quarantine" | "working" | "trusted";
+          }>,
+        }));
+        for (const record of trustZones.allRecords ?? []) {
+          trustZoneByNsAndRecordId.set(
+            trustZoneKey(ns, record.recordId),
+            record.zone,
+          );
+        }
+      }
+
+      const memoryNamespaceByPath = new Map<string, string>();
+      const memoryNamespaceById = new Map<string, string>();
+      let candidatesConsidered = 0;
+
+      const sources: DirectAnswerSources = {
+        taxonomy: DEFAULT_TAXONOMY,
+        listCandidateMemories: async (options: { namespace: string; abortSignal?: AbortSignal }) => {
+          const targetNs = options.namespace;
+          const storage =
+            scopedStorages.get(targetNs) ??
+            (await this.deps.storageRouter.storageFor(targetNs));
+          const all = await storage.readAllMemories();
+          const active: MemoryFile[] = [];
+          for (const m of all) {
+            if ((m.frontmatter.status ?? "active") === "active") {
+              active.push(m);
+              memoryNamespaceByPath.set(m.path, targetNs);
+              if (m.frontmatter.id) {
+                memoryNamespaceById.set(m.frontmatter.id, targetNs);
+              }
+            }
+          }
+          candidatesConsidered += active.length;
+          return active;
+        },
+        trustZoneFor: async (memoryId: string) => {
+          const ns = memoryNamespaceById.get(memoryId);
+          if (!ns) return null;
+          return (
+            trustZoneByNsAndRecordId.get(
+              trustZoneKey(ns, memoryId),
+            ) ?? null
+          );
+        },
+        importanceFor: (memory) =>
+          typeof memory.frontmatter.importance?.score === "number"
+            ? memory.frontmatter.importance.score
+            : 0,
+      };
+
+      let result: import("../direct-answer.js").DirectAnswerResult | undefined;
+      for (const ns of namespaces) {
+        const r = await tryDirectAnswer({
+          query: prompt,
+          namespace: ns,
+          config: this.deps.config,
+          enabled: caps.recallDirectAnswer,
+          sources,
+        });
+        if (r.eligible && r.winner) {
+          result = r;
+          break;
+        }
+      }
+
+      if (!result?.eligible || !result?.winner) return;
+
+      const explain: RecallTierExplain = {
+        tier: "direct-answer",
+        tierReason: result.narrative,
+        filteredBy: result.filteredBy,
+        candidatesConsidered,
+        latencyMs: Date.now() - tierStart,
+        sourceAnchors: [{ path: result.winner.memory.path }],
+      };
+
+      await this.deps.lastRecall.annotateTierExplain(
+        sessionKey,
+        explain,
+        expectedIdentity,
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      log.debug(`direct-answer observation failed: ${err}`);
+    }
+  }
+
+  // Issue #1526 (seam 14): graph-recall snapshot moved to
+  // GraphRecallCoordinator. Thin delegation keeps the private API stable.
+  async recordLastGraphRecallSnapshot(options: {
+    storage: StorageManager;
+    prompt: string;
+    recallMode: RecallPlanMode;
+    recallNamespaces: string[];
+    seedPaths: string[];
+    expandedPaths: GraphRecallExpandedEntry[];
+    status: "completed" | "skipped" | "aborted";
+    reason?: string;
+    shadowMode?: boolean;
+    queryIntent: MemoryIntent;
+    seedResults?: GraphRecallRankedResult[];
+    finalResults?: GraphRecallRankedResult[];
+    shadowComparison?: GraphRecallShadowComparison;
+  }): Promise<void> {
+    return this.deps.graphRecallCoordinator.recordLastGraphRecallSnapshot(options);
+  }
+
+  async recordLastIntentSnapshot(options: {
+    storage: StorageManager;
+    snapshot: IntentDebugSnapshot;
+  }): Promise<void> {
+    try {
+      const snapshotPath = path.join(
+        options.storage.dir,
+        "state",
+        "last_intent.json",
+      );
+      await mkdir(path.dirname(snapshotPath), { recursive: true });
+      await writeFile(
+        snapshotPath,
+        JSON.stringify(options.snapshot, null, 2),
+        "utf-8",
+      );
+    } catch (err) {
+      log.debug(`last intent write failed: ${err}`);
+    }
+  }
+
+  async recordLastQmdRecallSnapshot(options: {
+    storage: StorageManager;
+    snapshot: QmdRecallSnapshot;
+  }): Promise<void> {
+    try {
+      const snapshotPath = path.join(
+        options.storage.dir,
+        "state",
+        "last_qmd_recall.json",
+      );
+      await mkdir(path.dirname(snapshotPath), { recursive: true });
+      await writeFile(
+        snapshotPath,
+        JSON.stringify(options.snapshot, null, 2),
+        "utf-8",
+      );
+    } catch (err) {
+      log.debug(`last qmd recall write failed: ${err}`);
+    }
+  }
+
+  async recordLastIntentSnapshotForNamespace(options: {
+    namespace: string;
+    snapshot: IntentDebugSnapshot;
+  }): Promise<void> {
+    try {
+      const stateDir = await this.deps.resolveStateDirForNamespace(
+        options.namespace,
+      );
+      const snapshotPath = path.join(stateDir, "last_intent.json");
+      await mkdir(path.dirname(snapshotPath), { recursive: true });
+      await writeFile(
+        snapshotPath,
+        JSON.stringify(options.snapshot, null, 2),
+        "utf-8",
+      );
+    } catch (err) {
+      log.debug(`last intent write failed: ${err}`);
+    }
+  }
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -112,6 +112,7 @@ import { ExtractionPersistCoordinator } from "./orchestration/extraction-persist
 import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
 import { RecallSearchPipelineCoordinator } from "./orchestration/recall-search-pipeline.js";
 import { TurnIngestionCoordinator } from "./orchestration/turn-ingestion.js";
+import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspection.js";
 export { hasIdentityRecoveryIntent, resolveEffectiveIdentityInjectionMode } from "./orchestration/recall-result-formatter.js";
 import {
   GraphRecallCoordinator,
@@ -1346,7 +1347,7 @@ export function summarizeGraphShadowComparison(
   };
 }
 
-function parseGraphRecallRankedResults(
+export function parseGraphRecallRankedResults(
   value: unknown,
 ): GraphRecallRankedResult[] {
   if (!Array.isArray(value)) return [];
@@ -1373,7 +1374,7 @@ function parseGraphRecallRankedResults(
   return parsed.slice(0, 64);
 }
 
-function parseMemoryIntentSnapshot(value: unknown): MemoryIntent {
+export function parseMemoryIntentSnapshot(value: unknown): MemoryIntent {
   const candidate =
     value && typeof value === "object" ? (value as Partial<MemoryIntent>) : {};
   return {
@@ -1408,7 +1409,7 @@ function buildQmdIntentHint(intent: MemoryIntent): string | undefined {
   return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
-function parseQmdRecallResults(value: unknown): QmdSearchResult[] {
+export function parseQmdRecallResults(value: unknown): QmdSearchResult[] {
   if (!Array.isArray(value)) return [];
   const parsed: QmdSearchResult[] = [];
   for (const entry of value) {
@@ -1627,18 +1628,9 @@ export class Orchestrator {
     return this._fastGatewayLlm;
   }
 
-  /**
-   * Faithfulness gate verdict distribution (issue #1576). Consumed by the
-   * console-state aggregator so `remnic doctor` can render how the gate is
-   * performing. Returns a fresh object so callers cannot mutate the
-   * internal counters. Returns `undefined` when the gate is off so the
-   * console-state snapshot omits the faithfulness block entirely (cursor
-   * review: an all-zero block would otherwise always be truthy and leak
-   * into snapshots that document it as absent-when-off).
-   */
   getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters | undefined {
-    if (this.config.extractionFaithfulnessGate === "off") return undefined;
-    return { ...this.faithfulnessCounters };
+    return this.recallIntrospectionCoordinator.getConsoleFaithfulnessDistribution(
+    );
   }
   readonly modelRegistry: ModelRegistry;
   readonly relevance: RelevanceStore;
@@ -4694,324 +4686,49 @@ export class Orchestrator {
   async getLastGraphRecallSnapshot(
     namespace?: string,
   ): Promise<GraphRecallSnapshot | null> {
-    const storage = await this.getStorage(namespace);
-    const snapshotPath = path.join(
-      storage.dir,
-      "state",
-      "last_graph_recall.json",
+    return this.recallIntrospectionCoordinator.getLastGraphRecallSnapshot(
+      namespace,
     );
-    try {
-      const raw = await readFile(snapshotPath, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<GraphRecallSnapshot>;
-      if (!parsed || typeof parsed !== "object") return null;
-      return {
-        recordedAt:
-          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
-        mode: typeof parsed.mode === "string" ? parsed.mode : "full",
-        queryHash: typeof parsed.queryHash === "string" ? parsed.queryHash : "",
-        queryLength:
-          typeof parsed.queryLength === "number" ? parsed.queryLength : 0,
-        namespaces: Array.isArray(parsed.namespaces)
-          ? parsed.namespaces.filter((v): v is string => typeof v === "string")
-          : [],
-        seedCount: typeof parsed.seedCount === "number" ? parsed.seedCount : 0,
-        expandedCount:
-          typeof parsed.expandedCount === "number" ? parsed.expandedCount : 0,
-        seeds: Array.isArray(parsed.seeds)
-          ? parsed.seeds.filter((v): v is string => typeof v === "string")
-          : [],
-        expanded: clampGraphRecallExpandedEntries(parsed.expanded, 64),
-        status:
-          parsed.status === "completed" ||
-          parsed.status === "skipped" ||
-          parsed.status === "aborted"
-            ? parsed.status
-            : undefined,
-        reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
-        shadowMode: parsed.shadowMode === true,
-        queryIntent: parseMemoryIntentSnapshot(parsed.queryIntent),
-        seedResults: parseGraphRecallRankedResults(parsed.seedResults),
-        finalResults: parseGraphRecallRankedResults(parsed.finalResults),
-        shadowComparison:
-          parsed.shadowComparison && typeof parsed.shadowComparison === "object"
-            ? {
-                baselineCount:
-                  typeof parsed.shadowComparison.baselineCount === "number"
-                    ? parsed.shadowComparison.baselineCount
-                    : 0,
-                graphCount:
-                  typeof parsed.shadowComparison.graphCount === "number"
-                    ? parsed.shadowComparison.graphCount
-                    : 0,
-                overlapCount:
-                  typeof parsed.shadowComparison.overlapCount === "number"
-                    ? parsed.shadowComparison.overlapCount
-                    : 0,
-                overlapRatio:
-                  typeof parsed.shadowComparison.overlapRatio === "number"
-                    ? parsed.shadowComparison.overlapRatio
-                    : 0,
-                averageOverlapDelta:
-                  typeof parsed.shadowComparison.averageOverlapDelta ===
-                  "number"
-                    ? parsed.shadowComparison.averageOverlapDelta
-                    : 0,
-              }
-            : undefined,
-      };
-    } catch {
-      return null;
-    }
   }
 
   async getLastIntentSnapshot(
     namespace?: string,
   ): Promise<IntentDebugSnapshot | null> {
-    const storage = await this.getStorage(namespace);
-    const snapshotPath = path.join(storage.dir, "state", "last_intent.json");
-    try {
-      const raw = await readFile(snapshotPath, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<IntentDebugSnapshot>;
-      if (!parsed || typeof parsed !== "object") return null;
-      const graphDecision =
-        parsed.graphDecision && typeof parsed.graphDecision === "object"
-          ? parsed.graphDecision
-          : undefined;
-      return {
-        recordedAt:
-          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
-        promptHash:
-          typeof parsed.promptHash === "string" ? parsed.promptHash : "",
-        promptLength:
-          typeof parsed.promptLength === "number" ? parsed.promptLength : 0,
-        retrievalQueryHash:
-          typeof parsed.retrievalQueryHash === "string"
-            ? parsed.retrievalQueryHash
-            : "",
-        retrievalQueryLength:
-          typeof parsed.retrievalQueryLength === "number"
-            ? parsed.retrievalQueryLength
-            : 0,
-        plannerEnabled: parsed.plannerEnabled !== false,
-        plannedMode:
-          parsed.plannedMode === "no_recall" ||
-          parsed.plannedMode === "minimal" ||
-          parsed.plannedMode === "full" ||
-          parsed.plannedMode === "graph_mode"
-            ? parsed.plannedMode
-            : "full",
-        effectiveMode:
-          parsed.effectiveMode === "no_recall" ||
-          parsed.effectiveMode === "minimal" ||
-          parsed.effectiveMode === "full" ||
-          parsed.effectiveMode === "graph_mode"
-            ? parsed.effectiveMode
-            : "full",
-        recallResultLimit:
-          typeof parsed.recallResultLimit === "number"
-            ? parsed.recallResultLimit
-            : 0,
-        queryIntent: parseMemoryIntentSnapshot(parsed.queryIntent),
-        graphExpandedIntentDetected:
-          parsed.graphExpandedIntentDetected === true,
-        graphDecision: {
-          status:
-            graphDecision?.status === "skipped" ||
-            graphDecision?.status === "completed" ||
-            graphDecision?.status === "aborted"
-              ? graphDecision.status
-              : "not_requested",
-          reason:
-            typeof graphDecision?.reason === "string"
-              ? graphDecision.reason
-              : undefined,
-          shadowMode: graphDecision?.shadowMode === true,
-          qmdAvailable: graphDecision?.qmdAvailable !== false,
-          graphRecallEnabled: graphDecision?.graphRecallEnabled !== false,
-          multiGraphMemoryEnabled:
-            graphDecision?.multiGraphMemoryEnabled !== false,
-        },
-      };
-    } catch {
-      return null;
-    }
+    return this.recallIntrospectionCoordinator.getLastIntentSnapshot(
+      namespace,
+    );
   }
 
   async getLastQmdRecallSnapshot(
     namespace?: string,
   ): Promise<QmdRecallSnapshot | null> {
-    const storage = await this.getStorage(namespace);
-    const snapshotPath = path.join(
-      storage.dir,
-      "state",
-      "last_qmd_recall.json",
+    return this.recallIntrospectionCoordinator.getLastQmdRecallSnapshot(
+      namespace,
     );
-    try {
-      const raw = await readFile(snapshotPath, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<QmdRecallSnapshot>;
-      if (!parsed || typeof parsed !== "object") return null;
-      return {
-        recordedAt:
-          typeof parsed.recordedAt === "string" ? parsed.recordedAt : "",
-        queryHash: typeof parsed.queryHash === "string" ? parsed.queryHash : "",
-        queryLength:
-          typeof parsed.queryLength === "number" ? parsed.queryLength : 0,
-        collection:
-          typeof parsed.collection === "string" ? parsed.collection : undefined,
-        namespaces: Array.isArray(parsed.namespaces)
-          ? parsed.namespaces.filter(
-              (value): value is string => typeof value === "string",
-            )
-          : [],
-        fetchLimit:
-          typeof parsed.fetchLimit === "number" ? parsed.fetchLimit : 0,
-        primaryResultCount:
-          typeof parsed.primaryResultCount === "number"
-            ? parsed.primaryResultCount
-            : 0,
-        hybridResultCount:
-          typeof parsed.hybridResultCount === "number"
-            ? parsed.hybridResultCount
-            : 0,
-        queryAwareSeedCount:
-          typeof parsed.queryAwareSeedCount === "number"
-            ? parsed.queryAwareSeedCount
-            : 0,
-        resultCount:
-          typeof parsed.resultCount === "number" ? parsed.resultCount : 0,
-        intentHint:
-          typeof parsed.intentHint === "string" ? parsed.intentHint : undefined,
-        explainEnabled: parsed.explainEnabled === true,
-        hybridTopUpUsed: parsed.hybridTopUpUsed === true,
-        hybridTopUpSkippedReason:
-          typeof parsed.hybridTopUpSkippedReason === "string"
-            ? parsed.hybridTopUpSkippedReason
-            : undefined,
-        results: parseQmdRecallResults(parsed.results),
-      };
-    } catch {
-      return null;
-    }
   }
 
   async explainLastGraphRecall(options?: {
     namespace?: string;
     maxExpanded?: number;
   }): Promise<string> {
-    const snapshot = await this.getLastGraphRecallSnapshot(options?.namespace);
-    if (!snapshot) return "No graph-recall snapshot found yet.";
-    const maxExpanded = Math.max(1, Math.min(50, options?.maxExpanded ?? 10));
-    const expanded = snapshot.expanded.slice(0, maxExpanded);
-    const seedResults = (snapshot.seedResults ?? []).slice(0, maxExpanded);
-    const finalResults = (snapshot.finalResults ?? []).slice(0, maxExpanded);
-    const queryIntent = snapshot.queryIntent ?? {
-      goal: "unknown",
-      actionType: "unknown",
-      entityTypes: [],
-    };
-    return [
-      "## Last Graph Recall",
-      "",
-      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
-      `Mode: ${snapshot.mode}`,
-      `Status: ${snapshot.status ?? "completed"}${snapshot.shadowMode ? " (shadow)" : ""}`,
-      `Reason: ${snapshot.reason ?? "n/a"}`,
-      `Query hash: ${snapshot.queryHash || "unknown"} (len=${snapshot.queryLength})`,
-      `Query intent: goal=${queryIntent.goal}, action=${queryIntent.actionType}, entityTypes=${queryIntent.entityTypes.length > 0 ? queryIntent.entityTypes.join(", ") : "none"}`,
-      `Namespaces: ${snapshot.namespaces.length > 0 ? snapshot.namespaces.join(", ") : "none"}`,
-      `Seed results (${snapshot.seedResults?.length ?? 0}, showing ${seedResults.length}):`,
-      ...seedResults.map(
-        (entry) =>
-          `- ${entry.path} (score=${entry.score.toFixed(3)}, sources=${entry.sourceLabels.join(",") || "baseline"})`,
-      ),
-      `Seed paths (${snapshot.seedCount}):`,
-      ...snapshot.seeds.map((p) => `- ${p}`),
-      `Expanded paths (${snapshot.expandedCount}, showing ${expanded.length}):`,
-      ...expanded.map((e) => {
-        // Issue #681 PR 3/3 — surface per-edge confidence in the
-        // graph-explain document. Legacy snapshots without
-        // `edgeConfidence` render as `conf=n/a` so older payloads
-        // remain readable.
-        const confLabel =
-          typeof e.edgeConfidence === "number" && Number.isFinite(e.edgeConfidence)
-            ? e.edgeConfidence.toFixed(2)
-            : "n/a";
-        return `- ${e.path} (score=${e.score.toFixed(3)}, ns=${e.namespace}, seed=${e.seed || "unknown"}, hop=${e.hopDepth}, w=${e.decayedWeight.toFixed(3)}, type=${e.graphType}, conf=${confLabel})`;
-      }),
-      `Final ranked results (${snapshot.finalResults?.length ?? 0}, showing ${finalResults.length}):`,
-      ...finalResults.map(
-        (entry) =>
-          `- ${entry.path} (score=${entry.score.toFixed(3)}, sources=${entry.sourceLabels.join(",") || "baseline"})`,
-      ),
-      ...(snapshot.shadowComparison
-        ? [
-            `Shadow comparison: baseline=${snapshot.shadowComparison.baselineCount}, graph=${snapshot.shadowComparison.graphCount}, overlap=${snapshot.shadowComparison.overlapCount} (${snapshot.shadowComparison.overlapRatio.toFixed(2)}), avgDelta=${snapshot.shadowComparison.averageOverlapDelta.toFixed(3)}`,
-          ]
-        : []),
-    ].join("\n");
+    return this.recallIntrospectionCoordinator.explainLastGraphRecall(
+      options,
+    );
   }
 
   async explainLastIntent(options?: { namespace?: string }): Promise<string> {
-    const snapshot = await this.getLastIntentSnapshot(options?.namespace);
-    if (!snapshot) return "No intent-debug snapshot found yet.";
-    return [
-      "## Last Intent Debug",
-      "",
-      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
-      `Prompt hash: ${snapshot.promptHash || "unknown"} (len=${snapshot.promptLength})`,
-      `Retrieval query hash: ${snapshot.retrievalQueryHash || "unknown"} (len=${snapshot.retrievalQueryLength})`,
-      `Planner enabled: ${snapshot.plannerEnabled ? "yes" : "no"}`,
-      `Planned mode: ${snapshot.plannedMode}`,
-      `Effective mode: ${snapshot.effectiveMode}`,
-      `Recall result limit: ${snapshot.recallResultLimit}`,
-      `Query intent: goal=${snapshot.queryIntent.goal}, action=${snapshot.queryIntent.actionType}, entityTypes=${snapshot.queryIntent.entityTypes.length > 0 ? snapshot.queryIntent.entityTypes.join(", ") : "none"}`,
-      `Broad graph intent: ${snapshot.graphExpandedIntentDetected ? "yes" : "no"}`,
-      `Graph decision: status=${snapshot.graphDecision.status}, reason=${snapshot.graphDecision.reason ?? "n/a"}, shadow=${snapshot.graphDecision.shadowMode ? "yes" : "no"}, qmdAvailable=${snapshot.graphDecision.qmdAvailable ? "yes" : "no"}, graphRecallEnabled=${snapshot.graphDecision.graphRecallEnabled ? "yes" : "no"}, multiGraphMemoryEnabled=${snapshot.graphDecision.multiGraphMemoryEnabled ? "yes" : "no"}`,
-    ].join("\n");
+    return this.recallIntrospectionCoordinator.explainLastIntent(
+      options,
+    );
   }
 
   async explainLastQmdRecall(options?: {
     namespace?: string;
     maxResults?: number;
   }): Promise<string> {
-    const snapshot = await this.getLastQmdRecallSnapshot(options?.namespace);
-    if (!snapshot) return "No QMD recall snapshot found yet.";
-    const maxResults = Math.max(1, Math.min(25, options?.maxResults ?? 10));
-    const shown = snapshot.results.slice(0, maxResults);
-    return [
-      "## Last QMD Recall",
-      "",
-      `Recorded at: ${snapshot.recordedAt || "unknown"}`,
-      `Query hash: ${snapshot.queryHash || "unknown"} (len=${snapshot.queryLength})`,
-      `Collection: ${snapshot.collection ?? "default"}`,
-      `Namespaces: ${snapshot.namespaces.length > 0 ? snapshot.namespaces.join(", ") : "none"}`,
-      `Fetch limit: ${snapshot.fetchLimit}`,
-      `Primary results: ${snapshot.primaryResultCount}`,
-      `Hybrid top-up results: ${snapshot.hybridResultCount}`,
-      `Query-aware seeds: ${snapshot.queryAwareSeedCount}`,
-      `Final results: ${snapshot.resultCount}`,
-      `Intent hint: ${snapshot.intentHint ?? "none"}`,
-      `Explain enabled: ${snapshot.explainEnabled ? "yes" : "no"}`,
-      `Hybrid top-up used: ${snapshot.hybridTopUpUsed ? "yes" : "no"}`,
-      `Hybrid top-up skipped reason: ${snapshot.hybridTopUpSkippedReason ?? "n/a"}`,
-      `Top results (${shown.length}):`,
-      ...shown.map((result) => {
-        const explainParts = [
-          typeof result.explain?.blendedScore === "number"
-            ? `blended=${result.explain.blendedScore.toFixed(3)}`
-            : null,
-          typeof result.explain?.rerankScore === "number"
-            ? `rerank=${result.explain.rerankScore.toFixed(3)}`
-            : null,
-          typeof result.explain?.rrf === "number"
-            ? `rrf=${result.explain.rrf.toFixed(3)}`
-            : null,
-        ].filter((entry): entry is string => Boolean(entry));
-        const explainText =
-          explainParts.length > 0 ? `, explain=${explainParts.join("/")}` : "";
-        return `- ${result.path} (score=${result.score.toFixed(3)}, transport=${result.transport ?? "unknown"}${explainText})`;
-      }),
-    ].join("\n");
+    return this.recallIntrospectionCoordinator.explainLastQmdRecall(
+      options,
+    );
   }
 
   private async searchConversationRecallResults(
@@ -5323,32 +5040,12 @@ export class Orchestrator {
     this.lastXraySnapshot = null;
   }
 
-  /**
-   * Await the in-flight observation-mode direct-answer annotation chain.
-   * Resolves to true when settled, false on timeout.
-   */
   async waitForDirectAnswerObservationIdle(
     timeoutMs: number = 60_000,
   ): Promise<boolean> {
-    let timeoutHandle: NodeJS.Timeout | null = null;
-    try {
-      const timeoutPromise = new Promise<"timeout">((resolve) => {
-        timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
-      });
-      const result = await Promise.race([
-        this.directAnswerObservationChain.then(() => "ok" as const),
-        timeoutPromise,
-      ]);
-      if (result === "timeout") {
-        log.warn(
-          `waitForDirectAnswerObservationIdle timed out after ${timeoutMs}ms`,
-        );
-        return false;
-      }
-      return true;
-    } finally {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-    }
+    return this.recallIntrospectionCoordinator.waitForDirectAnswerObservationIdle(
+      timeoutMs,
+    );
   }
 
   private enqueueDirectAnswerObservation(
@@ -5359,56 +5056,14 @@ export class Orchestrator {
     caps: CapabilitySet,
     namespacesEnabled: boolean,
   ): void {
-    const expectedSnapshot = this.lastRecall.get(sessionKey);
-    if (expectedSnapshot === null) return;
-    if (expectedSnapshot.plannerMode === "no_recall") return;
-
-    // Resolve the observation namespace set through the SAME ScopePlan resolver
-    // the main recall path uses (#1521). The observe path does NOT throw on an
-    // unreadable override (it falls through to the coding/legacy branches), so
-    // we skip the readability gate the recall path enforces.
-    const observationScopePlan = resolveScopePlan({
-      config: this.config,
+    return this.recallIntrospectionCoordinator.enqueueDirectAnswerObservation(
+      prompt,
       sessionKey,
-      namespace: namespaceOverride,
+      namespaceOverride,
       principalOverride,
-      codingContext: sessionKey
-        ? this.getCodingContextForSession(sessionKey)
-        : null,
+      caps,
       namespacesEnabled,
-    });
-    const observationNamespaces = observationScopePlan.readNamespaces;
-    const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
-      cronRecallPolicyEnabled: resolveRecallAuxiliaryCapabilities(this.config).cronRecallPolicy,
-      cronRecallNormalizedQueryMaxChars:
-        this.config.cronRecallNormalizedQueryMaxChars,
-      cronRecallInstructionHeavyTokenCap:
-        this.effectiveCronRecallInstructionHeavyTokenCap(),
-      cronConversationRecallMode: this.config.cronConversationRecallMode,
-    });
-    const observationQuery = observationQueryPolicy.retrievalQuery || prompt;
-    const expectedIdentity = {
-      writeNonce: expectedSnapshot.writeNonce,
-      traceId: expectedSnapshot.traceId,
-      recordedAt: expectedSnapshot.recordedAt,
-    };
-    const previous = this.directAnswerObservationChain;
-    this.directAnswerObservationChain = previous
-      .catch(() => undefined)
-      .then(async () => {
-        try {
-          await this.annotateDirectAnswerTier(
-            observationQuery,
-            sessionKey,
-            observationNamespaces,
-            expectedIdentity,
-            caps,
-            undefined,
-          );
-        } catch (err) {
-          log.debug(`direct-answer observation chain error: ${err}`);
-        }
-      });
+    );
   }
 
   private async annotateDirectAnswerTier(
@@ -5421,117 +5076,14 @@ export class Orchestrator {
     caps: CapabilitySet,
     _parentAbortSignal?: AbortSignal,
   ): Promise<void> {
-    const tierStart = Date.now();
-    try {
-      if (namespaces.length === 0) return;
-
-      const trustZoneByNsAndRecordId = new Map<
-        string,
-        "quarantine" | "working" | "trusted"
-      >();
-      const trustZoneKey = (ns: string, recordId: string) =>
-        `${ns}\u0000${recordId}`;
-      const scopedStorages = new Map<
-        string,
-        Awaited<ReturnType<typeof this.storageRouter.storageFor>>
-      >();
-
-      for (const ns of namespaces) {
-        const storage = await this.storageRouter.storageFor(ns);
-        scopedStorages.set(ns, storage);
-        const trustZones = await listTrustZoneRecords({
-          memoryDir: storage.dir,
-          trustZoneStoreDir: this.config.trustZoneStoreDir,
-          limit: 200,
-        }).catch(() => ({
-          allRecords: [] as Array<{
-            recordId: string;
-            zone: "quarantine" | "working" | "trusted";
-          }>,
-        }));
-        for (const record of trustZones.allRecords ?? []) {
-          trustZoneByNsAndRecordId.set(
-            trustZoneKey(ns, record.recordId),
-            record.zone,
-          );
-        }
-      }
-
-      const memoryNamespaceByPath = new Map<string, string>();
-      const memoryNamespaceById = new Map<string, string>();
-      let candidatesConsidered = 0;
-
-      const sources: DirectAnswerSources = {
-        taxonomy: DEFAULT_TAXONOMY,
-        listCandidateMemories: async (options: { namespace: string; abortSignal?: AbortSignal }) => {
-          const targetNs = options.namespace;
-          const storage =
-            scopedStorages.get(targetNs) ??
-            (await this.storageRouter.storageFor(targetNs));
-          const all = await storage.readAllMemories();
-          const active: MemoryFile[] = [];
-          for (const m of all) {
-            if ((m.frontmatter.status ?? "active") === "active") {
-              active.push(m);
-              memoryNamespaceByPath.set(m.path, targetNs);
-              if (m.frontmatter.id) {
-                memoryNamespaceById.set(m.frontmatter.id, targetNs);
-              }
-            }
-          }
-          candidatesConsidered += active.length;
-          return active;
-        },
-        trustZoneFor: async (memoryId: string) => {
-          const ns = memoryNamespaceById.get(memoryId);
-          if (!ns) return null;
-          return (
-            trustZoneByNsAndRecordId.get(
-              trustZoneKey(ns, memoryId),
-            ) ?? null
-          );
-        },
-        importanceFor: (memory) =>
-          typeof memory.frontmatter.importance?.score === "number"
-            ? memory.frontmatter.importance.score
-            : 0,
-      };
-
-      let result: import("./direct-answer.js").DirectAnswerResult | undefined;
-      for (const ns of namespaces) {
-        const r = await tryDirectAnswer({
-          query: prompt,
-          namespace: ns,
-          config: this.config,
-          enabled: caps.recallDirectAnswer,
-          sources,
-        });
-        if (r.eligible && r.winner) {
-          result = r;
-          break;
-        }
-      }
-
-      if (!result?.eligible || !result?.winner) return;
-
-      const explain: RecallTierExplain = {
-        tier: "direct-answer",
-        tierReason: result.narrative,
-        filteredBy: result.filteredBy,
-        candidatesConsidered,
-        latencyMs: Date.now() - tierStart,
-        sourceAnchors: [{ path: result.winner.memory.path }],
-      };
-
-      await this.lastRecall.annotateTierExplain(
-        sessionKey,
-        explain,
-        expectedIdentity,
-      );
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") return;
-      log.debug(`direct-answer observation failed: ${err}`);
-    }
+    return this.recallIntrospectionCoordinator.annotateDirectAnswerTier(
+      prompt,
+      sessionKey,
+      namespaces,
+      expectedIdentity,
+      caps,
+      _parentAbortSignal,
+    );
   }
 
   private logRecallFailure(err: unknown): void {
@@ -5735,8 +5287,6 @@ export class Orchestrator {
   }> {
     return this.graphRecallCoordinator.expandResultsViaGraph(options);
   }
-  // Issue #1526 (seam 14): graph-recall snapshot moved to
-  // GraphRecallCoordinator. Thin delegation keeps the private API stable.
   private async recordLastGraphRecallSnapshot(options: {
     storage: StorageManager;
     prompt: string;
@@ -5752,68 +5302,35 @@ export class Orchestrator {
     finalResults?: GraphRecallRankedResult[];
     shadowComparison?: GraphRecallShadowComparison;
   }): Promise<void> {
-    return this.graphRecallCoordinator.recordLastGraphRecallSnapshot(options);
+    return this.recallIntrospectionCoordinator.recordLastGraphRecallSnapshot(
+      options,
+    );
   }
   private async recordLastIntentSnapshot(options: {
     storage: StorageManager;
     snapshot: IntentDebugSnapshot;
   }): Promise<void> {
-    try {
-      const snapshotPath = path.join(
-        options.storage.dir,
-        "state",
-        "last_intent.json",
-      );
-      await mkdir(path.dirname(snapshotPath), { recursive: true });
-      await writeFile(
-        snapshotPath,
-        JSON.stringify(options.snapshot, null, 2),
-        "utf-8",
-      );
-    } catch (err) {
-      log.debug(`last intent write failed: ${err}`);
-    }
+    return this.recallIntrospectionCoordinator.recordLastIntentSnapshot(
+      options,
+    );
   }
 
   private async recordLastQmdRecallSnapshot(options: {
     storage: StorageManager;
     snapshot: QmdRecallSnapshot;
   }): Promise<void> {
-    try {
-      const snapshotPath = path.join(
-        options.storage.dir,
-        "state",
-        "last_qmd_recall.json",
-      );
-      await mkdir(path.dirname(snapshotPath), { recursive: true });
-      await writeFile(
-        snapshotPath,
-        JSON.stringify(options.snapshot, null, 2),
-        "utf-8",
-      );
-    } catch (err) {
-      log.debug(`last qmd recall write failed: ${err}`);
-    }
+    return this.recallIntrospectionCoordinator.recordLastQmdRecallSnapshot(
+      options,
+    );
   }
 
   private async recordLastIntentSnapshotForNamespace(options: {
     namespace: string;
     snapshot: IntentDebugSnapshot;
   }): Promise<void> {
-    try {
-      const stateDir = await this.resolveStateDirForNamespace(
-        options.namespace,
-      );
-      const snapshotPath = path.join(stateDir, "last_intent.json");
-      await mkdir(path.dirname(snapshotPath), { recursive: true });
-      await writeFile(
-        snapshotPath,
-        JSON.stringify(options.snapshot, null, 2),
-        "utf-8",
-      );
-    } catch (err) {
-      log.debug(`last intent write failed: ${err}`);
-    }
+    return this.recallIntrospectionCoordinator.recordLastIntentSnapshotForNamespace(
+      options,
+    );
   }
 
   private async resolveStateDirForNamespace(
@@ -6124,6 +5641,38 @@ export class Orchestrator {
       });
     }
     return this._turnIngestionCoordinator;
+  }
+
+  /**
+   * Recall-introspection coordinator (issue #1526 seam 21). Owns the
+   * last-recall snapshot/explain surfaces and direct-answer annotation.
+   * Lazy + accessor-wired (late-binding rule, seams 18–20).
+   */
+  private _recallIntrospectionCoordinator: RecallIntrospectionCoordinator | undefined;
+
+  private get recallIntrospectionCoordinator(): RecallIntrospectionCoordinator {
+    if (!this._recallIntrospectionCoordinator) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._recallIntrospectionCoordinator = new RecallIntrospectionCoordinator({
+        annotateDirectAnswerTier: (prompt, sessionKey, namespaces, expectedIdentity, caps, _parentAbortSignal) => self.annotateDirectAnswerTier(prompt, sessionKey, namespaces, expectedIdentity, caps, _parentAbortSignal),
+        get config() { return self.config; },
+        get directAnswerObservationChain() { return self.directAnswerObservationChain; },
+        set directAnswerObservationChain(value) { self.directAnswerObservationChain = value; },
+        effectiveCronRecallInstructionHeavyTokenCap: () => self.effectiveCronRecallInstructionHeavyTokenCap(),
+        get faithfulnessCounters() { return self.faithfulnessCounters; },
+        getCodingContextForSession: (sessionKey) => self.getCodingContextForSession(sessionKey),
+        getLastGraphRecallSnapshot: (namespace) => self.getLastGraphRecallSnapshot(namespace),
+        getLastIntentSnapshot: (namespace) => self.getLastIntentSnapshot(namespace),
+        getLastQmdRecallSnapshot: (namespace) => self.getLastQmdRecallSnapshot(namespace),
+        getStorage: (namespace) => self.getStorage(namespace),
+        get graphRecallCoordinator() { return self.graphRecallCoordinator; },
+        get lastRecall() { return self.lastRecall; },
+        resolveStateDirForNamespace: (namespace) => self.resolveStateDirForNamespace(namespace),
+        get storageRouter() { return self.storageRouter; },
+      });
+    }
+    return this._recallIntrospectionCoordinator;
   }
 
   private async recallInternal(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -113,6 +113,7 @@ import { RecallInternalCoordinator } from "./orchestration/recall-internal.js";
 import { RecallSearchPipelineCoordinator } from "./orchestration/recall-search-pipeline.js";
 import { TurnIngestionCoordinator } from "./orchestration/turn-ingestion.js";
 import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspection.js";
+import { OrchestratorInitCoordinator } from "./orchestration/orchestrator-init.js";
 export { hasIdentityRecoveryIntent, resolveEffectiveIdentityInjectionMode } from "./orchestration/recall-result-formatter.js";
 import {
   GraphRecallCoordinator,
@@ -853,7 +854,7 @@ function qmdStartupCollectionCheckTimeoutMs(): number {
     : DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS;
 }
 
-async function qmdStartupCollectionCheckWithTimeout(
+export async function qmdStartupCollectionCheckWithTimeout(
   promise: Promise<SearchCollectionState>,
   controller: AbortController,
   label: string,
@@ -3355,615 +3356,20 @@ export class Orchestrator {
   }
 
   async initialize(): Promise<void> {
-    // Recreate the deferred-ready gate on every initialize() call.
-    // The same Orchestrator instance may be reused across stop/start cycles
-    // (src/index.ts does this). Without this reset, the second cycle's
-    // `await orchestrator.deferredReady` resolves immediately (already settled
-    // from the first cycle) while the new deferredInitialize() is still running.
-    this.deferredReady = new Promise<void>((resolve) => {
-      this.resolveDeferredReady = resolve;
-    });
-
-    try {
-      await migrateFromEngram({
-        quiet: true,
-        logger: (message) => log.info(message),
-      });
-      await this.storage.ensureDirectories();
-      await this.storage.loadAliases();
-      if (resolveNamespaceCapabilities(this.config).namespaces) {
-        const namespaces = new Set<string>([
-          this.config.defaultNamespace,
-          this.config.sharedNamespace,
-          ...this.config.namespacePolicies.map((p) => p.name),
-        ]);
-        for (const ns of namespaces) {
-          const sm = await this.storageRouter.storageFor(ns);
-          await sm.ensureDirectories();
-          await sm.loadAliases().catch(() => undefined);
-        }
-        // Explicitly seed the catalog with all configured namespaces at startup
-        // (round 6, cursor Medium — NBLlR). The storageFor loop above fires the
-        // router's onResolve hook, but a warm router cache (reused instance
-        // across stop/start) can skip onResolve, leaving policy namespaces absent
-        // from the live catalog until an operator runs `rebuild --apply`. This
-        // call is cheap, idempotent, and best-effort: a catalog failure must
-        // never break initialization (rule #13, #40).
-        await this.namespaceCatalog.registerConfiguredNamespaces().catch(() => undefined);
-      }
-      // #1713 Item 2: recover stale `applying` correction plans left behind
-      // by a process that died mid-apply. Best-effort — a failure here must
-      // never block initialization (rule 13). Runs for every configured
-      // namespace since correction plans can exist in any of them.
-      try {
-        // #1713 Item 2 + P2 (cursor): sweep ALL known namespaces — configured
-        // + catalog-discovered — so stale applying plans in derived namespaces
-        // (coding-scoped, session-derived) are also recovered.
-        const correctionNamespaces = new Set(this.configuredNamespaceList());
-        if (this.namespaceCatalog.enabled) {
-          try {
-            for (const rec of await this.namespaceCatalog.listNamespaces()) {
-              correctionNamespaces.add(rec.namespace);
-            }
-          } catch { /* best-effort */ }
-        }
-        const recovered = await this.passiveCorrectionService().recoverStaleApplyingPlans(
-          [...correctionNamespaces],
-        );
-        if (recovered > 0) {
-          log.info(`correction: recovered ${recovered} stale applying plan(s) on startup`);
-        }
-      } catch (staleErr) {
-        log.debug(`correction: stale-plan recovery skipped: ${staleErr instanceof Error ? staleErr.message : String(staleErr)}`);
-      }
-      await this.relevance.load();
-      await this.negatives.load();
-      await this.lastRecall.load();
-      await this.handleHistory.load();
-      await this.tierMigrationStatus.load();
-      await this.sessionObserver.load();
-      this.runtimePolicyValues = await this.policyRuntime.loadRuntimeValues();
-      this.utilityRuntimeValues = await loadUtilityRuntimeValues({
-        memoryDir: this.config.memoryDir,
-        memoryUtilityLearningEnabled: resolveUtilityLearningCapabilities(this.config).memoryUtilityLearning,
-        promotionByOutcomeEnabled: resolveUtilityLearningCapabilities(this.config).promotionByOutcome,
-      });
-
-      // Initialize content-hash dedup index
-      if (resolveRecallAuxiliaryCapabilities(this.config).factDeduplication) {
-        this.contentHashIndex = this.storage.createContentHashIndex();
-        await this.contentHashIndex.load();
-        log.info(
-          `content-hash dedup: loaded ${this.contentHashIndex.size} hashes`,
-        );
-      }
-      await this.transcript.initialize();
-      await this.summarizer.initialize();
-      if (this.sharedContext) {
-        await this.sharedContext.ensureStructure();
-      }
-      if (this.compounding) {
-        await this.compounding.ensureDirs();
-      }
-
-      // Buffer and compaction cleanup are fast and needed for basic operation —
-      // load them before the init gate so turn buffering works immediately.
-      try {
-        await this.buffer.load();
-      } catch (bufErr) {
-        log.error(
-          `buffer.load() failed (init gate will still open): ${bufErr}`,
-        );
-        this.buffer.resetToEmpty();
-      }
-      if (resolveRecallAuxiliaryCapabilities(this.config).compactionReset) {
-        try {
-          const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
-          const files = await readdir(wsDir).catch(() => [] as string[]);
-          for (const f of files) {
-            if (!f.startsWith(".compaction-reset-signal-")) continue;
-            const fp = path.join(wsDir, f);
-            const s = await stat(fp).catch(() => null);
-            if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
-              await unlink(fp).catch(() => {});
-              log.debug(`initialize: removed stale compaction signal ${f}`);
-            }
-          }
-        } catch (err) {
-          log.debug("initialize: stale signal sweep failed:", err);
-        }
-      }
-
-      // QMD probe + collection check: determines the final QMD state (real
-      // client vs NoopSearchBackend). Must complete BEFORE the init gate opens
-      // so that recall() — which awaits initPromise — always observes the final
-      // QMD state. Without this ordering, a concurrent recall() could read
-      // this.qmd while it's still the real client, then get errors when
-      // deferredInitialize() swaps it to NoopSearchBackend mid-query.
-      try {
-        const available = await this.qmd.probe();
-        if (available) {
-          log.info(`Search backend: available ${this.qmd.debugStatus()}`);
-          // Ensure collections at startup for the catalog-union namespace set, not
-          // just the configured set (issue #1499 sweep, same class as NHZEV): a
-          // dynamic namespace that exists only in the persisted catalog must have
-          // its QMD collection checked/ensured on boot so recall against it works
-          // after a restart. `registerConfiguredNamespaces()` already seeded the
-          // catalog above, so `maintenanceNamespaces()` is readable here; it falls
-          // back to the configured set on any catalog read failure.
-          const namespaces = resolveNamespaceCapabilities(this.config).namespaces
-            ? await this.maintenanceNamespaces()
-            : [this.config.defaultNamespace];
-          const states = await Promise.all(
-            namespaces.map(async (namespace) => {
-              const collectionCheckAbort = new AbortController();
-              const state = await qmdStartupCollectionCheckWithTimeout(
-                resolveNamespaceCapabilities(this.config).namespaces
-                  ? this.namespaceSearchRouter.ensureNamespaceCollection(
-                      namespace,
-                      { signal: collectionCheckAbort.signal },
-                    )
-                  : this.qmd.ensureCollection(
-                      this.config.memoryDir,
-                      this.config.qmdCollection,
-                      { signal: collectionCheckAbort.signal },
-                    ),
-                collectionCheckAbort,
-                namespace,
-              );
-              return { namespace, state };
-            }),
-          );
-          const defaultState =
-            states.find(
-              (entry) => entry.namespace === this.config.defaultNamespace,
-            )?.state ?? "unknown";
-          if (defaultState === "missing") {
-            await this.disposeSearchBackendIfNeeded();
-            this.qmd = new NoopSearchBackend();
-            log.warn(
-              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
-            );
-          } else if (defaultState === "unknown") {
-            log.warn(
-              "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
-            );
-          } else if (defaultState === "skipped") {
-            log.debug(
-              "Search collection check skipped (remote or daemon-only mode)",
-            );
-          }
-          for (const entry of states) {
-            if (entry.namespace === this.config.defaultNamespace) continue;
-            if (entry.state === "missing") {
-              log.warn(
-                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
-              );
-            }
-          }
-        } else if (this.qmd instanceof NoopSearchBackend) {
-          log.debug(`Search backend: noop (search intentionally disabled)`);
-        } else {
-          log.warn(`Search backend: not available ${this.qmd.debugStatus()}`);
-        }
-      } catch (err) {
-        log.error(`QMD probe/collection check failed (non-fatal): ${err}`);
-      }
-
-      // Open the init gate — essential state (storage, aliases, relevance,
-      // transcript, summarizer, buffer) is loaded AND QMD state is finalized
-      // (probe + collection check complete, NoopSearchBackend swap done if
-      // needed). Warmup, sync, caches, and remaining heavy operations run in
-      // the background after this point via deferredInitialize().
-      if (this.resolveInit) {
-        this.resolveInit();
-        this.resolveInit = null;
-        log.info("init gate opened (essential state + QMD state loaded)");
-      }
-
-      // Deferred init: QMD sync, warmup, conversation index, caches, cron.
-      // Runs in background so gateway_start returns fast. On low-power hardware
-      // (Umbrel, RPi) QMD warmup/sync alone can take 30-60s and cause gateway
-      // restart loops when they block the startup path. See issue #462.
-      // Note: QMD probe + collection check (including NoopSearchBackend swap)
-      // already ran above before the init gate, so this.qmd is finalized.
-      //
-      // Capture the resolver by value so a concurrent re-initialize() cannot
-      // overwrite this.resolveDeferredReady before .finally() runs — that would
-      // cause the first cycle's .finally() to resolve the *second* cycle's
-      // promise prematurely while leaving the first cycle's promise pending.
-      const resolveDeferred = this.resolveDeferredReady;
-      this.resolveDeferredReady = null;
-      this.deferredInitAbort = new AbortController();
-      this.deferredInitialize(this.deferredInitAbort.signal)
-        .catch((err) => {
-          log.error(`deferred initialization failed (non-fatal): ${err}`);
-        })
-        .finally(() => {
-          resolveDeferred?.();
-        });
-    } catch (err) {
-      // Resolve both gates so callers never hang on permanently-pending promises
-      // after catching the initialize() error:
-      //
-      // - initPromise: recall(), generateDaySummary(), etc. await this as a
-      //   readiness gate with a 15s timeout. Leaving it pending means every
-      //   subsequent call pays that timeout penalty.
-      //
-      // - deferredReady: CLI callers await this for full QMD readiness. Without
-      //   resolution it hangs forever since deferredInitialize() never ran.
-      if (this.resolveInit) {
-        this.resolveInit();
-        this.resolveInit = null;
-      }
-      if (this.resolveDeferredReady) {
-        this.resolveDeferredReady();
-        this.resolveDeferredReady = null;
-      }
-      throw err;
-    }
+    return this.orchestratorInitCoordinator.initialize(
+    );
   }
 
   private async deferredInitialize(signal: AbortSignal): Promise<void> {
-    const lifecycleCaps = resolveMemoryLifecycleCapabilities(this.config);
-
-    // Sync QMD index with current disk state so recall finds recently-written
-    // facts. Without this, the index stays stale from the last extraction-
-    // triggered update — which can be days ago if the daemon restarted without
-    // new extractions. This is the root cause of "0 memories" recall results
-    // despite thousands of facts on disk.
-    if (this.qmd.isAvailable() && resolveQmdCapabilities(this.config).qmdMaintenance) {
-      try {
-        log.info("QMD startup sync: updating index to match current disk state");
-        if (resolveNamespaceCapabilities(this.config).namespaces) {
-          // Cover cataloged dynamic namespaces at startup too (NHZEV, codex P2):
-          // a dynamic namespace written before a daemon restart must be synced on
-          // boot, not only by the debounced runQmdMaintenance() path. Same union +
-          // catalog-read-failure fallback as runQmdMaintenance.
-          await this.namespaceSearchRouter.updateNamespaces(
-            await this.maintenanceNamespaces(),
-            { signal },
-          );
-        } else {
-          await this.qmd.update({ signal });
-        }
-        log.info("QMD startup sync: complete");
-        this.deferredSyncSucceeded = true;
-      } catch (err) {
-        log.warn(`QMD startup sync failed (non-fatal): ${err}`);
-        // deferredSyncSucceeded stays false — server retry will attempt sync
-      }
-    } else if (!(this.qmd.isAvailable())) {
-      // QMD not available at deferred init time — server retry will handle it
-    } else {
-      // QMD available but maintenance disabled — consider sync not needed
-      this.deferredSyncSucceeded = true;
-    }
-
-    if (signal.aborted) return;
-
-    // Warmup: run cheap searches to pre-load QMD embedding models and the
-    // embedding-fallback JSON index so the first real recall is fast.
-    const warmupPromises: Promise<void>[] = [];
-    if (this.qmd.isAvailable()) {
-      const warmupNs = this.config.defaultNamespace;
-      log.info("QMD warmup: pre-loading models with a test search");
-      warmupPromises.push(
-        this.qmd
-          .search("warmup", warmupNs, 1, undefined, { signal })
-          .then(() => {
-            log.info("QMD warmup: complete");
-          })
-          .catch((err) => {
-            log.debug(`QMD warmup search failed (non-fatal): ${err}`);
-          }),
-      );
-    }
-    if (resolveMemoryLifecycleCapabilities(this.config).embeddingFallback) {
-      warmupPromises.push(
-        this.embeddingFallback
-          .isAvailable()
-          .then((ok) => {
-            log.info(
-              `Embedding fallback warmup: ${ok ? "available" : "unavailable (no provider)"}`,
-            );
-          })
-          .catch((err) => {
-            log.debug(`Embedding fallback warmup failed (non-fatal): ${err}`);
-          }),
-      );
-    }
-    await Promise.all(warmupPromises);
-    if (signal.aborted) return;
-
-    // Pre-warm knowledge index, memory, and entity caches.
-    // Awaited so callers of `deferredReady` can rely on warmups being complete
-    // and shutdown sequencing does not race with in-flight cache builds.
-    const cacheWarmups: Promise<void>[] = [];
-    if (resolveRecallAuxiliaryCapabilities(this.config).knowledgeIndex) {
-      cacheWarmups.push(
-        (async () => {
-          try {
-            const t0 = Date.now();
-            await this.storage.buildKnowledgeIndex(this.config);
-            log.info(`Knowledge Index warmup: complete in ${Date.now() - t0}ms`);
-          } catch (err) {
-            log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
-          }
-        })(),
-      );
-    }
-    cacheWarmups.push(this.storage.readAllMemories().then(() => {}).catch(() => {}));
-    cacheWarmups.push(this.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
-    await Promise.all(cacheWarmups);
-    if (signal.aborted) return;
-
-    if (resolveIndexingCapabilities(this.config).conversationIndex && this.conversationIndexBackend) {
-      try {
-        const init = await this.conversationIndexBackend.initialize();
-        if (!init.enabled) {
-          this.config.conversationIndexEnabled = false;
-        }
-        if (init.logLevel === "info") {
-          log.info(init.message);
-        } else if (init.logLevel === "warn") {
-          log.warn(init.message);
-        } else {
-          log.debug(init.message);
-        }
-      } catch (err) {
-        log.error(`Conversation index initialization failed (non-fatal): ${err}`);
-        this.config.conversationIndexEnabled = false;
-      }
-    }
-
-    if (signal.aborted) return;
-
-    if (resolveLocalLlmCapabilities(this.config).localLlm) {
-      try {
-        await this.validateLocalLlmModel();
-      } catch (err) {
-        log.error(`Local LLM validation failed (non-fatal): ${err}`);
-      }
-    }
-
-    if (signal.aborted) return;
-
-    // Await cron auto-registration so callers that `await deferredReady` can
-    // rely on cron jobs being registered when it resolves. Without this, the
-    // fire-and-forget pattern lets deferredReady settle while cron writes are
-    // still in flight. Errors are non-fatal — catch individually.
-    // Auto-register every cron job in one pass. Each registration is gated
-    // by its config flag inside the scheduler and individually non-fatal
-    // (issue #1526 PR1 — moved to MaintenanceScheduler).
-    await this.maintenanceScheduler.autoRegisterCrons(signal);
-
-    // First-start lifecycle migration (issue #686 retention-completion).
-    // When lifecyclePolicyEnabled is true and the memoryDir has never been
-    // touched by the lifecycle policy, run a one-time rate-limited demotion
-    // sweep (capped at 50 demotions) so the hot tier isn't flooded on the
-    // first real cron pass. Non-fatal — a failure here must not break init.
-    if (signal.aborted) return;
-    if (lifecycleCaps.lifecyclePolicy && resolveQmdCapabilities(this.config).qmdTierMigration) {
-      try {
-        const { runFirstStartMigration } = await import(
-          "./maintenance/first-start-migration.js"
-        );
-        const result = await runFirstStartMigration({
-          storage: this.storage,
-          config: this.config,
-          qmd: this.qmd,
-          hotCollection: this.config.qmdCollection,
-          coldCollection: this.config.qmdColdCollection,
-          signal,
-        });
-        if (!result.skipped) {
-          log.info(
-            `first-start lifecycle migration: demoted ${result.demotedCount} of ${result.candidateCount} candidates (cap=${result.cappedAt})`,
-          );
-        } else {
-          log.debug(`first-start lifecycle migration skipped: ${result.skipReason}`);
-        }
-      } catch (err) {
-        log.warn(`first-start lifecycle migration failed (non-fatal): ${err}`);
-      }
-    }
-
-    // Wearables auto-sync: in-process periodic transcript refresh for
-    // long-lived hosts (default on). Today's transcript keeps growing
-    // while the wearable records; a once-per-local-day deep pass picks
-    // up late uploads and provider re-processing. Static config gate —
-    // sources can't appear at runtime, so checking once here is safe.
-    // The timer is unref'd, so one-shot CLI runs exit naturally without
-    // ever ticking; idempotent across stop/start cycles via the handle
-    // guard. Non-fatal: a failure to start must not break init.
-    if (signal.aborted) return;
-    if (
-      !this.wearablesAutoSyncHandle &&
-      this.config.wearables.enabled &&
-      this.config.wearables.autoSyncEnabled &&
-      Object.values(this.config.wearables.sources).some((source) => source.enabled)
-    ) {
-      try {
-        const { startWearablesAutoSync } = await import("./wearables/auto-sync.js");
-        // Re-check after the await: destroy() may have aborted while
-        // the import was in flight, having found no handle to stop —
-        // starting now would leave a live interval on a destroyed
-        // orchestrator (Cursor review on PR #1464). Handle creation
-        // below is synchronous, so no further window exists.
-        if (signal.aborted) return;
-        this.wearablesAutoSyncHandle = startWearablesAutoSync(
-          {
-            intervalMinutes: this.config.wearables.autoSyncIntervalMinutes,
-            days: this.config.wearables.autoSyncDays,
-            deepDays: this.config.wearables.autoSyncDeepDays,
-            ...(this.config.wearables.timezone !== undefined
-              ? { timezone: this.config.wearables.timezone }
-              : {}),
-          },
-          {
-            sync: (options) => this.getWearablesService().sync(options),
-            log: {
-              info: (message) => log.info(message),
-              warn: (message) => log.warn(message),
-            },
-          },
-        );
-        log.info(
-          `wearables auto-sync started: every ${this.config.wearables.autoSyncIntervalMinutes}m over ${this.config.wearables.autoSyncDays}d (deep ${this.config.wearables.autoSyncDeepDays}d daily)`,
-        );
-      } catch (err) {
-        const { displayErrorDetail } = await import("./runtime/better-sqlite.js");
-        log.warn(
-          `wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`,
-        );
-      }
-    }
-
-    log.info("orchestrator initialized (full — deferred steps complete)");
+    return this.orchestratorInitCoordinator.deferredInitialize(
+      signal,
+    );
   }
 
-  /**
-   * Namespace-aware startup search sync. Re-probes QMD, ensures collections
-   * (namespace-aware when namespacesEnabled), runs update, and warms up search.
-   * Designed for server retry paths that run after the deferred init completes
-   * when QMD was not available during initial startup.
-   *
-   * Accepts an optional AbortSignal so callers can interrupt the sync during
-   * shutdown. The signal is checked between phases and forwarded into the QMD
-   * update and warmup search calls so a long-running `qmd update` subprocess
-   * is killed promptly rather than left in flight after `httpServer.stop()`.
-   *
-   * Returns true if the sync succeeded (QMD now available), false otherwise.
-   */
   async startupSearchSync(signal?: AbortSignal): Promise<boolean> {
-    if (signal?.aborted) return false;
-
-    const available = await this.qmd.probe();
-    if (!available) return false;
-    if (signal?.aborted) {
-      log.debug("startupSearchSync: aborted after probe");
-      return false;
-    }
-
-    log.info(`startupSearchSync: backend now available ${this.qmd.debugStatus()}`);
-
-    // Clear namespace router cache so re-probe picks up newly available backends
-    if (resolveNamespaceCapabilities(this.config).namespaces) {
-      this.namespaceSearchRouter.clearCache();
-    }
-
-    // Ensure collections — namespace-aware when enabled.
-    // Use the catalog-union namespace set (issue #1499 sweep, same class as
-    // NHZEV): this is the QMD startup-recovery sync that ensures collections AND
-    // runs `updateNamespaces(...)` below over the SAME `namespaces` set. A dynamic
-    // namespace that exists only in the persisted catalog must be ensured and
-    // re-synced here too, otherwise after a backend-was-unavailable-at-boot
-    // recovery its collection stays stale. Falls back to the configured set on any
-    // catalog read failure.
-    const namespaces = resolveNamespaceCapabilities(this.config).namespaces
-      ? await this.maintenanceNamespaces()
-      : [this.config.defaultNamespace];
-
-    const states = await Promise.all(
-      namespaces.map(async (namespace) => ({
-        namespace,
-        state: resolveNamespaceCapabilities(this.config).namespaces
-          ? await this.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
-          : await this.qmd.ensureCollection(this.config.memoryDir, this.config.qmdCollection, { signal }),
-      })),
+    return this.orchestratorInitCoordinator.startupSearchSync(
+      signal,
     );
-
-    if (signal?.aborted) {
-      log.debug("startupSearchSync: aborted after ensureCollection");
-      return false;
-    }
-
-    const defaultState =
-      states.find((e) => e.namespace === this.config.defaultNamespace)?.state ?? "unknown";
-    if (defaultState === "missing") {
-      // Reset the real backend's available flag before replacing it with noop.
-      // probe() set available=true earlier in this call; without this reset,
-      // any code that captured a reference to the old backend (e.g. a concurrent
-      // recall() that read this.qmd before the reassignment) would observe
-      // isAvailable()===true against a backend with a missing collection.
-      if ("available" in this.qmd) {
-        (this.qmd as any).available = false;
-      }
-      await this.disposeSearchBackendIfNeeded();
-      this.qmd = new NoopSearchBackend();
-      log.warn("startupSearchSync: search collection missing; disabling search (fallback retrieval remains enabled)");
-      return false;
-    }
-
-    // Run index update — namespace-aware when enabled.
-    // qmd.update() swallows errors internally, so we: (1) snapshot fail/run
-    // timestamps, (2) reset throttles so the update isn't skipped by stale
-    // backoff, and (3) verify timestamps after update to confirm it executed
-    // and didn't fail silently.
-    // The abort signal is forwarded into the QMD subprocess call so the
-    // long-running `qmd update` process is killed promptly on shutdown.
-    if (resolveQmdCapabilities(this.config).qmdMaintenance) {
-      try {
-        const failTsBefore = "lastUpdateFailedAtMs" in this.qmd
-          ? (this.qmd as any).lastUpdateFailedAtMs as number | null
-          : null;
-        const hasRunTs = "lastUpdateRanAtMs" in this.qmd;
-        if ("resetUpdateThrottles" in this.qmd) {
-          (this.qmd as any).resetUpdateThrottles();
-        }
-        log.info("startupSearchSync: updating index to match current disk state");
-        let namespacesUpdated = 0;
-        if (resolveNamespaceCapabilities(this.config).namespaces) {
-          namespacesUpdated = await this.namespaceSearchRouter.updateNamespaces(
-            namespaces,
-            { signal },
-          );
-        } else {
-          await this.qmd.update({ signal });
-        }
-        if (signal?.aborted) {
-          log.debug("startupSearchSync: aborted after update");
-          return false;
-        }
-        const failTsAfter = "lastUpdateFailedAtMs" in this.qmd
-          ? (this.qmd as any).lastUpdateFailedAtMs as number | null
-          : null;
-        const runTsAfter = hasRunTs
-          ? (this.qmd as any).lastUpdateRanAtMs as number | null
-          : null;
-        if (failTsAfter !== null && failTsAfter !== failTsBefore) {
-          log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
-          return false;
-        }
-        if (resolveNamespaceCapabilities(this.config).namespaces) {
-          if (namespacesUpdated === 0) {
-            log.warn("startupSearchSync: no namespace backends were eligible for update (all unavailable or collections missing)");
-            return false;
-          }
-          log.info(`startupSearchSync: namespace updates succeeded (${namespacesUpdated}/${namespaces.length} namespaces updated)`);
-        } else if (hasRunTs && runTsAfter === null) {
-          log.warn("startupSearchSync: update was throttled/skipped (run timestamp is null after reset + update)");
-          return false;
-        }
-        log.info("startupSearchSync: sync complete");
-      } catch (err) {
-        log.warn(`startupSearchSync: update failed: ${err}`);
-        return false;
-      }
-    }
-
-    // Warmup search to pre-load embedding models
-    if (!signal?.aborted) {
-      try {
-        await this.qmd.search("warmup", this.config.defaultNamespace, 1, undefined, { signal });
-        log.info("startupSearchSync: warmup complete");
-      } catch (err) {
-        log.debug(`startupSearchSync: warmup search failed (non-fatal): ${err}`);
-      }
-    }
-
-    return true;
   }
 
   /**
@@ -5673,6 +5079,71 @@ export class Orchestrator {
       });
     }
     return this._recallIntrospectionCoordinator;
+  }
+
+  /**
+   * Orchestrator-init coordinator (issue #1526 seam 22). Owns
+   * initialize/deferredInitialize/startupSearchSync. Lazy + accessor-wired
+   * (late-binding rule, seams 18–21); the init gate fields stay on the
+   * orchestrator and are mutated through set accessors.
+   */
+  private _orchestratorInitCoordinator: OrchestratorInitCoordinator | undefined;
+
+  private get orchestratorInitCoordinator(): OrchestratorInitCoordinator {
+    if (!this._orchestratorInitCoordinator) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._orchestratorInitCoordinator = new OrchestratorInitCoordinator({
+        get buffer() { return self.buffer; },
+        get compounding() { return self.compounding; },
+        get config() { return self.config; },
+        configuredNamespaceList: () => self.configuredNamespaceList(),
+        get contentHashIndex() { return self.contentHashIndex; },
+        set contentHashIndex(value) { self.contentHashIndex = value; },
+        get conversationIndexBackend() { return self.conversationIndexBackend; },
+        get deferredInitAbort() { return self.deferredInitAbort; },
+        set deferredInitAbort(value) { self.deferredInitAbort = value; },
+        deferredInitialize: (signal) => self.deferredInitialize(signal),
+        get deferredReady() { return self.deferredReady; },
+        set deferredReady(value) { self.deferredReady = value; },
+        get deferredSyncSucceeded() { return self.deferredSyncSucceeded; },
+        set deferredSyncSucceeded(value) { self.deferredSyncSucceeded = value; },
+        disposeSearchBackendIfNeeded: () => self.disposeSearchBackendIfNeeded(),
+        get embeddingFallback() { return self.embeddingFallback; },
+        getWearablesService: () => self.getWearablesService(),
+        get handleHistory() { return self.handleHistory; },
+        get lastRecall() { return self.lastRecall; },
+        maintenanceNamespaces: (jobName, budgetMode) => self.maintenanceNamespaces(jobName, budgetMode),
+        get maintenanceScheduler() { return self.maintenanceScheduler; },
+        get namespaceCatalog() { return self.namespaceCatalog; },
+        get namespaceSearchRouter() { return self.namespaceSearchRouter; },
+        get negatives() { return self.negatives; },
+        passiveCorrectionService: () => self.passiveCorrectionService(),
+        get policyRuntime() { return self.policyRuntime; },
+        get qmd() { return self.qmd; },
+        set qmd(value) { self.qmd = value; },
+        get relevance() { return self.relevance; },
+        get resolveDeferredReady() { return self.resolveDeferredReady; },
+        set resolveDeferredReady(value) { self.resolveDeferredReady = value; },
+        get resolveInit() { return self.resolveInit; },
+        set resolveInit(value) { self.resolveInit = value; },
+        get runtimePolicyValues() { return self.runtimePolicyValues; },
+        set runtimePolicyValues(value) { self.runtimePolicyValues = value; },
+        get sessionObserver() { return self.sessionObserver; },
+        get sharedContext() { return self.sharedContext; },
+        get storage() { return self.storage; },
+        get storageRouter() { return self.storageRouter; },
+        get summarizer() { return self.summarizer; },
+        get tierMigrationStatus() { return self.tierMigrationStatus; },
+        get transcript() { return self.transcript; },
+        get utilityRuntimeValues() { return self.utilityRuntimeValues; },
+        set utilityRuntimeValues(value) { self.utilityRuntimeValues = value; },
+        validateLocalLlmModel: () => self.validateLocalLlmModel(),
+        get wearablesAutoSyncHandle() { return self.wearablesAutoSyncHandle; },
+        set wearablesAutoSyncHandle(value) { self.wearablesAutoSyncHandle = value; },
+      });
+    }
+    return this._orchestratorInitCoordinator;
   }
 
   private async recallInternal(

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 7752,
+      "packages/remnic-core/src/orchestrator.ts": 7301,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 9017,
       "packages/remnic-core/src/storage.ts": 7747,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 7301,
+      "packages/remnic-core/src/orchestrator.ts": 6772,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 9017,
       "packages/remnic-core/src/storage.ts": 7747,


### PR DESCRIPTION
Part of #1526 (orchestrator decomposition). Seam 22, on top of seam 21 (#1794).

## What moved
The startup lifecycle (609 LOC) moves verbatim into `orchestration/orchestrator-init.ts` as `OrchestratorInitCoordinator`: `initialize`, `deferredInitialize`, `startupSearchSync`.

The async init ORDERING is a contract (gateway_start): every await stays in place, and the 10 written gate/runtime fields (`qmd`, `contentHashIndex`, `deferredReady`, `resolveInit`, `resolveDeferredReady`, `deferredInitAbort`, `deferredSyncSucceeded`, `runtimePolicyValues`, `utilityRuntimeValues`, `wearablesAutoSyncHandle`) are mutated through get/set accessors on the deps bundle, so the gates live on the orchestrator instance exactly as before — stop/start reuse of one Orchestrator (src/index.ts does this) and `recall()`'s init-gate await are unchanged. 37-member deps; `qmdStartupCollectionCheckWithTimeout` + previously-exported recall helpers imported from `../orchestrator.js`.

## Numbers
`orchestrator.ts`: 7,301 → 6,772 LOC (−529). Ratchet updated.

## Verification
- `tsc --noEmit` clean
- `npm run test:entity-hardening`: 246/246 (includes orchestrator-characterization)
- recall-hardening (exercises the initPromise gate + abort-before-init paths) + orchestrator-flush: 22/22
- `npm run preflight:quick`: [preflight] OK (quick)

Chokepoints used: n/a (behavior-preserving extraction).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gateway startup ordering, init/deferred gates, and QMD backend swapping—high-impact paths, but described as a verbatim move with characterization tests.
> 
> **Overview**
> Continues **#1526** orchestrator decomposition by moving startup and recall-debug logic out of `orchestrator.ts` into dedicated coordinators, with the public `Orchestrator` API unchanged via thin delegates.
> 
> **`OrchestratorInitCoordinator`** (`orchestration/orchestrator-init.ts`, seam 22) now owns `initialize`, `deferredInitialize`, and `startupSearchSync` verbatim. Init **ordering** (QMD probe/collection check before the init gate, background deferred work, gate resolution on failure) stays the same; gate fields (`deferredReady`, `qmd`, `deferredSyncSucceeded`, etc.) are still on the orchestrator and updated through a lazy **deps** bundle with get/set accessors for stop/start reuse.
> 
> **`RecallIntrospectionCoordinator`** (`orchestration/recall-introspection.ts`, seam 21) holds last intent/graph/QMD snapshot read/write/explain, faithfulness console stats, and direct-answer observation annotation; orchestrator methods forward to it.
> 
> Several snapshot parse helpers and `qmdStartupCollectionCheckWithTimeout` are **exported** from `orchestrator.ts` for the new modules. The structural ratchet drops `orchestrator.ts` from **7752 → 6772** LOC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c759454e42e026e5f7dbb78e7afc18a820f716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->