### PR TITLE
refactor(orchestrator): extract workspace ops into WorkspaceOpsCoordinator (seam 24, #1526)

### DIFF
--- a/packages/remnic-core/src/orchestration/workspace-ops.ts
+++ b/packages/remnic-core/src/orchestration/workspace-ops.ts
@@ -1,0 +1,789 @@
+/**
+ * Workspace-ops coordinator — extracted from the orchestrator
+ * (issue #1526, seam 24).
+ *
+ * Owns the periodic workspace/operations surfaces:
+ *   - day-summary fact gathering (gatherTodayFacts)
+ *   - memory-action policy preview (previewMemoryActionEvent)
+ *   - file hygiene runs and identity auto-consolidation
+ *   - wearables service construction
+ *   - local-LLM model validation
+ *   - pattern-reinforcement runs and their namespace fanout
+ *   - access-tracking flush
+ *
+ * Behavior-preserving move from orchestrator.ts (late-binding deps rule,
+ * seams 18–23).
+ */
+
+import { lstat, mkdir, readFile, readdir, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { resolveCompressionCapabilities, resolveConsolidationCapabilities, resolveNamespaceCapabilities } from "../capabilities.js";
+import { formatDaySummaryMemories } from "../day-summary.js";
+import { type JudgeVerdict, judgeFactDurability } from "../extraction-judge.js";
+import { ExtractionEngine } from "../extraction.js";
+import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig } from "../fallback-llm.js";
+import { lintWorkspaceFiles, rotateMarkdownFileToArchive } from "../hygiene.js";
+import { StorageManager } from "../index.js";
+import { LocalLlmClient } from "../local-llm.js";
+import { log } from "../logger.js";
+import type { NamespaceMaintenanceFanoutRunnerContext } from "../maintenance/namespace-maintenance-fanout.js";
+import type { NamespaceMaintenanceSummary } from "../maintenance/namespace-planner.js";
+import { type PatternReinforcementResult, runPatternReinforcement } from "../maintenance/pattern-reinforcement.js";
+import { evaluateMemoryActionPolicy } from "../memory-action-policy.js";
+import { NamespaceStorageRouter } from "../namespaces/storage.js";
+import { parseMemoryActionEligibilityContext } from "../schemas.js";
+import type { SearchBackend } from "../search/port.js";
+import { type AccessTrackingEntry, type MemoryActionEvent, type MemoryFile, type PluginConfig, confidenceTier } from "../types.js";
+import { RECALL_FALLBACK_DIRS } from "../utils/category-dir.js";
+import { assertPathInsideRoot } from "../utils/path-containment.js";
+import { WearablesService } from "../wearables/service.js";
+import {
+  Orchestrator,
+  filterHourlySummaryMarkdownForLocalDay,
+  formatDateInTimeZone,
+  normalizeIanaTimeZone,
+  parseFiniteDate,
+  utcDateKeysForLocalDay,
+  type DaySummaryGatherOptions,
+} from "../orchestrator.js";
+
+export interface WorkspaceOpsDeps {
+  readonly accessTrackingBuffer: Map<string, { count: number; lastAccessed: string }>;
+  bulkImportWriteNamespace(): string;
+  readonly config: PluginConfig;
+  readonly extraction: ExtractionEngine;
+  getStorage(namespace?: string): Promise<StorageManager>;
+  getStorageForNamespace(namespace?: string): Promise<StorageManager>;
+  readonly judgeDeferCounts: Map<string, number>;
+  readonly judgeVerdictCache: Map<string, JudgeVerdict>;
+  lastFileHygieneRunAtMs: number;
+  readonly lastPatternReinforcementAtByNs: Map<string, number>;
+  readonly localLlm: LocalLlmClient;
+  maintenanceNamespaces(
+    jobName?: string,
+    budgetMode?: "cycle" | "unbounded",
+  ): Promise<string[]>;
+  namespaceFromPath(p: string): string;
+  readonly qmd: SearchBackend;
+  readAllMemoriesForNamespaces(
+    namespaces: string[],
+  ): Promise<MemoryFile[]>;
+  runNamespaceMaintenanceFanoutForJob(
+    jobName: string,
+    runner: (ctx: NamespaceMaintenanceFanoutRunnerContext) => Promise<{ itemCount?: number } | undefined>,
+    options?: { enabled?: boolean },
+  ): Promise<NamespaceMaintenanceSummary>;
+  runPatternReinforcement(options?: {
+    force?: boolean;
+    namespace?: string;
+  }): Promise<{
+    ran: boolean;
+    skippedReason?: "disabled" | "cadence";
+    namespace: string;
+    result?: PatternReinforcementResult;
+  }>;
+  readonly storage: StorageManager;
+  readonly storageRouter: NamespaceStorageRouter;
+  wearablesServiceInstance: WearablesService | null;
+}
+
+export class WorkspaceOpsCoordinator {
+  constructor(
+    private readonly deps: WorkspaceOpsDeps,
+  ) {}
+
+  /**
+   * Run the pattern-reinforcement maintenance job (issue #687 PR 2/4).
+   *
+   * Cadence-gated on `patternReinforcementCadenceMs` so every caller
+   * (orchestrator cron path, MCP tool, CLI) shares a single floor —
+   * none can call this on a hot loop and burn the corpus.  When the
+   * feature is disabled or the cadence has not elapsed, returns a
+   * synthetic "skipped" result rather than throwing.
+   *
+   * Cadence tracking is per-namespace so a tenant-scoped MCP run in
+   * one namespace does not silence a cron run in another (PR #730
+   * review feedback, Codex P2).  Pass `force: true` for ad-hoc
+   * operator runs that must bypass the cadence floor — mirrors the
+   * pattern used by other maintenance MCP tools.
+   *
+   * `force` deliberately does NOT bypass the master
+   * `patternReinforcementEnabled` flag (PR #730 review feedback,
+   * Cursor Medium).  Operators who have explicitly disabled the
+   * feature must not have their corpus mutated by an MCP tool call —
+   * the only way to run the job is to enable the feature in config.
+   */
+  async runPatternReinforcement(options: {
+    force?: boolean;
+    namespace?: string;
+  } = {}): Promise<{
+    ran: boolean;
+    skippedReason?: "disabled" | "cadence";
+    namespace: string;
+    result?: PatternReinforcementResult;
+  }> {
+    const cadenceKey = options.namespace ?? "";
+    // Master switch: a disabled feature is never bypassed, even with
+    // force=true.  `force` only relaxes the cadence floor below.
+    if (!resolveConsolidationCapabilities(this.deps.config).patternReinforcement) {
+      return { ran: false, skippedReason: "disabled", namespace: cadenceKey };
+    }
+    const cadence = this.deps.config.patternReinforcementCadenceMs;
+    const lastAt = this.deps.lastPatternReinforcementAtByNs.get(cadenceKey);
+    if (
+      !options.force &&
+      cadence > 0 &&
+      lastAt !== undefined &&
+      Date.now() - lastAt < cadence
+    ) {
+      return { ran: false, skippedReason: "cadence", namespace: cadenceKey };
+    }
+    const storage = options.namespace
+      ? await this.deps.getStorage(options.namespace)
+      : this.deps.storage;
+    const result = await runPatternReinforcement(storage, {
+      categories: this.deps.config.patternReinforcementCategories,
+      minCount: this.deps.config.patternReinforcementMinCount,
+    });
+    this.deps.lastPatternReinforcementAtByNs.set(cadenceKey, Date.now());
+    log.debug(
+      `pattern reinforcement [ns=${cadenceKey || "(default)"}]: clusters=${result.clustersFound} canonicalsUpdated=${result.canonicalsUpdated} duplicatesSuperseded=${result.duplicatesSuperseded}`,
+    );
+    return { ran: true, result, namespace: cadenceKey };
+  }
+
+  /**
+   * Fan out pattern reinforcement across all maintained namespaces (issue #1500).
+   * Delegates per-namespace execution to {@link runPatternReinforcement} while
+   * the planner handles discovery, budgeting, locking, and status recording.
+   * When namespaces are disabled, runs once against default storage.
+   */
+  async runPatternReinforcementFanout(options: {
+    force?: boolean;
+  } = {}): Promise<NamespaceMaintenanceSummary> {
+    return this.deps.runNamespaceMaintenanceFanoutForJob(
+      "pattern-reinforcement",
+      async (ctx) => {
+        const result = await this.deps.runPatternReinforcement({
+          namespace: ctx.candidate.namespace,
+          force: options.force,
+        });
+        // runPatternReinforcement has its own per-namespace cadence gate
+        // (lastPatternReinforcementAtByNs). When it throttles (ran:false),
+        // signal skip so the planner records state:"skipped" and does NOT
+        // touch lastMaintenanceAt — otherwise a throttled namespace would
+        // look maintained while pattern reinforcement never ran (#1500
+        // review: cadence-skip accuracy).
+        if (!result.ran) {
+          return {
+            skipped: true,
+            skipReason: result.skippedReason ?? "throttled",
+          };
+        }
+        return result.result
+          ? { itemCount: result.result.clustersFound }
+          : { itemCount: 0 };
+      },
+      { enabled: resolveConsolidationCapabilities(this.deps.config).patternReinforcement },
+    );
+  }
+
+  async maybeRunFileHygiene(): Promise<void> {
+    const hygiene = this.deps.config.fileHygiene;
+    if (!hygiene?.enabled) return;
+
+    const now = Date.now();
+    if (now - this.deps.lastFileHygieneRunAtMs < hygiene.runMinIntervalMs) return;
+    this.deps.lastFileHygieneRunAtMs = now;
+
+    // Rotation first (keeps bootstrap files small).
+    if (hygiene.rotateEnabled) {
+      for (const rel of hygiene.rotatePaths) {
+        const abs = path.isAbsolute(rel)
+          ? rel
+          : path.join(this.deps.config.workspaceDir, rel);
+        try {
+          const raw = await readFile(abs, "utf-8");
+          if (raw.length > hygiene.rotateMaxBytes) {
+            const archiveDir = path.join(
+              this.deps.config.workspaceDir,
+              hygiene.archiveDir,
+            );
+            const base = path.basename(abs);
+            const prefix =
+              base
+                .toUpperCase()
+                .replace(/\.MD$/i, "")
+                .replace(/[^A-Z0-9]+/g, "-") || "FILE";
+            const { newContent } = await rotateMarkdownFileToArchive({
+              filePath: abs,
+              archiveDir,
+              archivePrefix: prefix,
+              keepTailChars: hygiene.rotateKeepTailChars,
+            });
+            await writeFile(abs, newContent, "utf-8");
+          }
+        } catch {
+          // ignore missing/unreadable targets
+        }
+      }
+    }
+
+    // Lint (warn before truncation risk).
+    if (hygiene.lintEnabled) {
+      const warnings = await lintWorkspaceFiles({
+        workspaceDir: this.deps.config.workspaceDir,
+        paths: hygiene.lintPaths,
+        budgetBytes: hygiene.lintBudgetBytes,
+        warnRatio: hygiene.lintWarnRatio,
+      });
+      for (const w of warnings) {
+        log.warn(w.message);
+      }
+
+      if (hygiene.warningsLogEnabled && warnings.length > 0) {
+        const fp = path.join(this.deps.config.memoryDir, hygiene.warningsLogPath);
+        await mkdir(path.dirname(fp), { recursive: true });
+        const stamp = new Date().toISOString();
+        const block =
+          `\n\n## ${stamp}\n\n` +
+          warnings.map((w) => `- ${w.message}`).join("\n") +
+          "\n";
+        let existing = "";
+        try {
+          existing = await readFile(fp, "utf-8");
+        } catch {
+          existing = "# Engram File Hygiene Warnings\n";
+        }
+        await writeFile(fp, existing + block, "utf-8");
+      }
+    }
+  }
+
+  /**
+   * Read today's facts and hourly summaries from storage, returning them
+   * as a formatted string suitable for generateDaySummary().
+   */
+  async gatherTodayFacts(
+    namespace?: string,
+    options: DaySummaryGatherOptions = {},
+  ): Promise<string> {
+    const ns =
+      namespace && namespace.length > 0
+        ? namespace
+        : this.deps.config.defaultNamespace;
+    const storage = await this.deps.storageRouter.storageFor(ns);
+    const configuredTimeZone = normalizeIanaTimeZone(options.timeZone)
+      ?? normalizeIanaTimeZone(this.deps.config.daySummaryTimezone);
+    const timeZone =
+      configuredTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const now = options.now instanceof Date && Number.isFinite(options.now.getTime())
+      ? options.now
+      : new Date();
+    const targetLocalDate = formatDateInTimeZone(now, timeZone);
+    // Facts are stored under UTC date directories, while the summary target is
+    // a local calendar day. Scan the UTC-date envelope that overlaps the local
+    // day, then filter parseable fact timestamps to that configured local day.
+    const datesToScan = utcDateKeysForLocalDay(now, timeZone);
+    const MAX_CHARS = 100_000;
+
+    // --- Read memory files from each category dir × date directory ---
+    // Iterate every recall category dir (RECALL_FALLBACK_DIRS — single source
+    // of truth) so the day summary includes decisions/, moments/, ... not just
+    // facts/ (#1546). corrections/ is flat, so corrections/<date>/ never exists
+    // and is skipped by the ENOENT guard — preserving the prior exclusion. The
+    // per-file created→local-day filter below is unchanged.
+    //
+    // Symlink/containment hardening (mirrors scanDir / the CLI walker): the
+    // gathered contents feed the day-summary LLM input, so a symlinked category
+    // dir (decisions/ → outside memoryDir) must not be followed and leak files.
+    // Resolve the store root once; skip symlinked / out-of-root dirs and
+    // entries; skip the scan gracefully if the root can't be resolved.
+    const facts: MemoryFile[] = [];
+    let memoryRootReal: string | null = null;
+    try {
+      memoryRootReal = await realpath(storage.dir);
+    } catch {
+      memoryRootReal = null;
+    }
+    for (const categoryDir of RECALL_FALLBACK_DIRS) {
+      if (memoryRootReal === null) break;
+      for (const date of datesToScan) {
+        const dateDir = path.join(storage.dir, categoryDir, date);
+        try {
+          const dirStat = await lstat(dateDir);
+          if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) continue;
+          assertPathInsideRoot(memoryRootReal, await realpath(dateDir), dateDir);
+          const entries = await readdir(dateDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (entry.isSymbolicLink()) continue;
+            if (!entry.name.endsWith(".md")) continue;
+            const fullPath = path.join(dateDir, entry.name);
+            try {
+              assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
+              const raw = await readFile(fullPath, "utf-8");
+              const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+              if (!fmMatch) continue;
+              const fmBlock = fmMatch[1];
+              const content = fmMatch[2].trim();
+              const fm: Record<string, string> = {};
+              for (const line of fmBlock.split("\n")) {
+                const colonIdx = line.indexOf(":");
+                if (colonIdx === -1) continue;
+                fm[line.slice(0, colonIdx).trim()] = line
+                  .slice(colonIdx + 1)
+                  .trim();
+              }
+              const created = fm.created || "unknown";
+              const createdAt = parseFiniteDate(created);
+              if (
+                createdAt &&
+                formatDateInTimeZone(createdAt, timeZone) !== targetLocalDate
+              ) {
+                continue;
+              }
+              facts.push({
+                path: fullPath,
+                frontmatter: {
+                  id: fm.id || path.basename(entry.name, ".md"),
+                  category: (fm.category as any) || "fact",
+                  created,
+                  updated: fm.updated || created,
+                  source: fm.source || "unknown",
+                  confidence: parseFloat(fm.confidence || "0.8"),
+                  confidenceTier: (fm.confidenceTier as any) || "implied",
+                  tags: [],
+                },
+                content,
+              });
+            } catch {
+              // Skip unreadable files
+            }
+          }
+        } catch {
+          // Absent dir (ENOENT), symlinked/out-of-root dir, or containment
+          // violation — skip this category/date without aborting the summary.
+        }
+      }
+    }
+
+    // Sort facts by created timestamp (most recent last) so truncation keeps newest
+    facts.sort((a, b) => {
+      if (a.frontmatter.created === b.frontmatter.created) return 0;
+      return a.frontmatter.created < b.frontmatter.created ? -1 : 1;
+    });
+
+    // --- Read hourly summaries for the scanned dates ---
+    const hourlySummaries: string[] = [];
+    const hourlyBaseDir = path.join(storage.dir, "summaries", "hourly");
+    try {
+      const sessionKeys = await readdir(hourlyBaseDir, { withFileTypes: true });
+      for (const sk of sessionKeys) {
+        if (!sk.isDirectory()) continue;
+        for (const date of datesToScan) {
+          const summaryFile = path.join(hourlyBaseDir, sk.name, `${date}.md`);
+          try {
+            const raw = await readFile(summaryFile, "utf-8");
+            const filtered = filterHourlySummaryMarkdownForLocalDay(
+              raw,
+              date,
+              timeZone,
+              targetLocalDate,
+            );
+            if (filtered) {
+              hourlySummaries.push(filtered);
+            }
+          } catch {
+            // No summary file for this session/date
+          }
+        }
+      }
+    } catch {
+      // No hourly summaries directory
+    }
+
+    // --- Format and truncate ---
+    let formatted = formatDaySummaryMemories(facts);
+    if (hourlySummaries.length > 0) {
+      formatted +=
+        "\n\n---\n## Hourly Summaries\n\n" +
+        hourlySummaries.join("\n\n---\n\n");
+    }
+
+    // Truncate intelligently if over budget: drop oldest facts first
+    if (formatted.length > MAX_CHARS) {
+      // Re-build with fewer facts, keeping most recent
+      while (facts.length > 1 && formatted.length > MAX_CHARS) {
+        facts.shift(); // drop oldest
+        formatted = formatDaySummaryMemories(facts);
+        if (hourlySummaries.length > 0) {
+          formatted +=
+            "\n\n---\n## Hourly Summaries\n\n" +
+            hourlySummaries.join("\n\n---\n\n");
+        }
+      }
+      // If still over, hard truncate
+      if (formatted.length > MAX_CHARS) {
+        formatted = formatted.slice(0, MAX_CHARS);
+      }
+    }
+
+    log.info(
+      `gatherTodayFacts: collected ${facts.length} facts, ${hourlySummaries.length} hourly summaries for ${targetLocalDate} (${timeZone}, ${formatted.length} chars)`,
+    );
+
+    return formatted;
+  }
+
+  previewMemoryActionEvent(
+    event: Omit<MemoryActionEvent, "timestamp"> & { timestamp?: string },
+  ): MemoryActionEvent {
+    const namespace =
+      typeof event.namespace === "string" && event.namespace.length > 0
+        ? event.namespace
+        : this.deps.config.defaultNamespace;
+    const eligibility = parseMemoryActionEligibilityContext(
+      event.policyEligibility,
+    );
+    const policy = evaluateMemoryActionPolicy({
+      action: event.action,
+      eligibility,
+      options: {
+        actionsEnabled: resolveCompressionCapabilities(this.deps.config).contextCompressionActions,
+        maxCompressionTokensPerHour: this.deps.config.maxCompressionTokensPerHour,
+      },
+    });
+    const dryRun = event.dryRun === true;
+
+    const normalizedOutcome = dryRun
+      ? event.outcome === "failed"
+        ? "failed"
+        : "skipped"
+      : policy.decision === "allow"
+        ? event.outcome
+        : event.outcome === "failed"
+          ? "failed"
+          : "skipped";
+    const sourceSessionKey =
+      typeof event.sourceSessionKey === "string" &&
+      event.sourceSessionKey.length > 0
+        ? event.sourceSessionKey
+        : typeof event.sessionKey === "string" && event.sessionKey.length > 0
+          ? event.sessionKey
+          : undefined;
+    const outputMemoryIds = Array.isArray(event.outputMemoryIds)
+      ? Array.from(
+          new Set(
+            event.outputMemoryIds.filter(
+              (value): value is string =>
+                typeof value === "string" && value.length > 0,
+            ),
+          ),
+        )
+      : [];
+
+    const reasonParts = [
+      event.reason,
+      `policy:${policy.decision}`,
+      policy.rationale,
+    ].filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    );
+
+    return {
+      ...event,
+      schemaVersion: event.schemaVersion ?? 1,
+      actionId:
+        typeof event.actionId === "string" && event.actionId.length > 0
+          ? event.actionId
+          : `memact-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      outcome: normalizedOutcome,
+      status:
+        event.status ??
+        (dryRun && policy.decision === "allow" && event.outcome !== "failed"
+          ? "validated"
+          : normalizedOutcome === "applied"
+            ? "applied"
+            : "rejected"),
+      actor:
+        typeof event.actor === "string" && event.actor.length > 0
+          ? event.actor
+          : "engram",
+      subsystem:
+        typeof event.subsystem === "string" && event.subsystem.length > 0
+          ? event.subsystem
+          : "memory_action",
+      reason: reasonParts.join(" | "),
+      namespace,
+      sessionKey: sourceSessionKey ?? event.sessionKey,
+      sourceSessionKey,
+      inputSummary:
+        typeof event.inputSummary === "string" && event.inputSummary.length > 0
+          ? event.inputSummary
+          : undefined,
+      outputMemoryIds,
+      dryRun,
+      policyVersion:
+        typeof event.policyVersion === "string" &&
+        event.policyVersion.length > 0
+          ? event.policyVersion
+          : "memory-action-policy.v1",
+      timestamp:
+        typeof event.timestamp === "string" && event.timestamp.length > 0
+          ? event.timestamp
+          : new Date().toISOString(),
+      policyDecision: policy.decision,
+      policyRationale: policy.rationale,
+      policyEligibility: eligibility,
+    };
+  }
+
+  /**
+   * Validate local LLM model availability and context window compatibility.
+   * Warns the user if there's a mismatch.
+   */
+  async validateLocalLlmModel(): Promise<void> {
+    log.debug("Local LLM: validating model configuration");
+    try {
+      const modelInfo = await this.deps.localLlm.getLoadedModelInfo();
+      if (!modelInfo) {
+        log.warn(
+          "Local LLM validation: Could not query model info from server",
+        );
+        log.warn(
+          "Local LLM validation: Could not query model info. " +
+            "Ensure LM Studio/Ollama is running with the model loaded.",
+        );
+        return;
+      }
+
+      // Check for context window mismatch
+      const configuredMaxContext = this.deps.config.localLlmMaxContext;
+
+      if (modelInfo.contextWindow) {
+        log.debug(
+          `Local LLM: ${modelInfo.id} loaded with ${modelInfo.contextWindow.toLocaleString()} token context window`,
+        );
+
+        if (
+          configuredMaxContext &&
+          configuredMaxContext > modelInfo.contextWindow
+        ) {
+          log.warn(
+            `Local LLM context mismatch: engram configured for ${configuredMaxContext.toLocaleString()} tokens, ` +
+              `but ${modelInfo.id} only supports ${modelInfo.contextWindow.toLocaleString()}. ` +
+              `Reducing to ${modelInfo.contextWindow.toLocaleString()} to avoid errors.`,
+          );
+          // Update the config in-memory to match actual capability
+          // (This is a temporary fix - user should update their config)
+          (this.deps.config as { localLlmMaxContext?: number }).localLlmMaxContext =
+            modelInfo.contextWindow;
+        }
+      } else {
+        log.debug(
+          `Local LLM: ${modelInfo.id} loaded (context window not reported by server)`,
+        );
+
+        if (!configuredMaxContext) {
+          log.warn(
+            "Local LLM: Server did not report context window. " +
+              "If you get 'context length exceeded' errors, set localLlmMaxContext in your config. " +
+              "Common defaults: LM Studio (32K), Ollama (2K-128K depending on model).",
+          );
+        }
+      }
+    } catch (err) {
+      log.warn(`Local LLM validation failed: ${err}`);
+    }
+  }
+
+  /**
+   * Lazily-constructed wearables service (Limitless / Bee / Omi
+   * transcript ingestion). All wearables surfaces — CLI, MCP tools,
+   * HTTP routes — share this one instance so sync state, search, and
+   * memory writes stay consistent. Writes are pinned to the same
+   * deterministic namespace bulk-import uses.
+   */
+  getWearablesService(): WearablesService {
+    if (!this.deps.wearablesServiceInstance) {
+      this.deps.wearablesServiceInstance = new WearablesService({
+        config: this.deps.config.wearables,
+        getStorage: async () =>
+          await this.deps.getStorageForNamespace(this.deps.bulkImportWriteNamespace()),
+        extract: (turns) => this.deps.extraction.extract(turns),
+        // Smart memoryMode runs candidates through the SAME extraction
+        // judge (cache + defer counters included) the live extraction
+        // pipeline uses, so wearable facts get identical LLM-as-judge
+        // durability gating.
+        judgeFacts: (candidates) =>
+          judgeFactDurability(
+            candidates,
+            this.deps.config,
+            this.deps.localLlm,
+            new FallbackLlmClient(
+              this.deps.config.gatewayConfig,
+              fallbackLlmRuntimeContextFromConfig(this.deps.config),
+            ),
+            this.deps.judgeVerdictCache,
+            this.deps.judgeDeferCounts,
+          ),
+        searchBackend: {
+          search: async (query, maxResults) => {
+            if (!this.deps.qmd.isAvailable()) return null;
+            try {
+              const results = await this.deps.qmd.search(query, undefined, maxResults);
+              return results.map((result) => ({
+                path: result.path,
+                score: result.score,
+                preview: result.snippet,
+              }));
+            } catch {
+              // Backend hiccup → tell the service "unavailable" so it
+              // runs its bounded scan fallback instead of returning a
+              // silent empty result (CLAUDE.md rule 34).
+              return null;
+            }
+          },
+        },
+        reindexSearch: async () => {
+          await this.deps.qmd.update();
+        },
+      });
+    }
+    return this.deps.wearablesServiceInstance;
+  }
+
+  async autoConsolidateIdentity(): Promise<void> {
+    // Fan out over the catalog-union namespace set (issue #1499 sweep): a dynamic
+    // namespace that accumulated IDENTITY.md reflections must also be eligible for
+    // auto-consolidation, otherwise its identity file grows unbounded and is never
+    // consolidated. Falls back to the configured set on any catalog read failure.
+    const namespaces = resolveNamespaceCapabilities(this.deps.config).namespaces
+      ? await this.deps.maintenanceNamespaces()
+      : [this.deps.config.defaultNamespace];
+
+    for (const namespace of namespaces) {
+      const storage = await this.deps.storageRouter.storageFor(namespace);
+      const identityNamespace =
+        resolveNamespaceCapabilities(this.deps.config).namespaces &&
+        namespace !== this.deps.config.defaultNamespace
+          ? namespace
+          : undefined;
+      const reflectionsContent =
+        (await storage.readIdentityReflections()) ?? "";
+
+      const existingIdentity = await storage.readIdentity(
+        this.deps.config.workspaceDir,
+        identityNamespace,
+      );
+      const headerEnd =
+        existingIdentity.indexOf("## Learned Patterns") !== -1
+          ? existingIdentity.indexOf("## Learned Patterns")
+          : existingIdentity.indexOf("## Reflection");
+      const staticHeader =
+        (headerEnd !== -1
+          ? existingIdentity.slice(0, headerEnd)
+          : existingIdentity
+        ).trimEnd() || "# IDENTITY";
+      const identityContent = `${staticHeader}\n\n${reflectionsContent.trim()}\n`;
+      if (identityContent.length < Orchestrator.IDENTITY_CONSOLIDATE_THRESHOLD)
+        continue;
+
+      log.info(
+        `IDENTITY(${namespace}) is ${identityContent.length} chars — auto-consolidating reflections`,
+      );
+      const result = await this.deps.extraction.consolidateIdentity(
+        identityContent,
+        "## Reflection",
+      );
+
+      if (!result || result.learnedPatterns.length === 0) {
+        log.warn(
+          `identity consolidation produced no patterns for namespace=${namespace}`,
+        );
+        continue;
+      }
+
+      const patternsSection = [
+        "## Learned Patterns (consolidated from reflections, " +
+          new Date().toISOString().slice(0, 10) +
+          ")",
+        "",
+        ...result.learnedPatterns.map((p) => `- ${p}`),
+        "",
+      ].join("\n");
+
+      const newContent = staticHeader + "\n\n" + patternsSection + "\n";
+
+      await storage.writeIdentity(
+        this.deps.config.workspaceDir,
+        newContent,
+        identityNamespace,
+      );
+      await storage.writeIdentityReflections("");
+      // NRcCL (codex P2): record a per-namespace catalog write for THIS namespace
+      // after the identity files are updated. This fan-out can mutate a dynamic
+      // namespace via `writeIdentity`/`writeIdentityReflections`, but the
+      // consolidation pass's only consolidated touch covers `this.deps.storage` (the
+      // default) and only fires when `memoryItemMutated` was set by OTHER work — so
+      // a namespace whose sole mutation in the pass is identity consolidation would
+      // otherwise keep a stale `lastWriteAt`, making `listNamespaces({ writtenSince })`
+      // and catalog-recency consumers miss the write. Best-effort and
+      // failure-tolerant (the storage chokepoint (#1522) swallows errors, never crashing the
+      // consolidation; gotcha #13, rule #40). No double-count with the consolidated
+      // touch above: that one is gated on `memoryItemMutated` (which identity
+      // consolidation does not set), and `markWrite` is idempotent regardless.
+      log.info(
+        `IDENTITY(${namespace}) consolidated: ${identityContent.length} → ${newContent.length} chars, ${result.learnedPatterns.length} patterns`,
+      );
+    }
+  }
+
+  /**
+   * Flush access tracking buffer to disk.
+   * Called during consolidation or when buffer is full.
+   */
+  async flushAccessTracking(): Promise<void> {
+    if (this.deps.accessTrackingBuffer.size === 0) return;
+
+    // Build entries from buffer, merging with existing counts
+    const entries: AccessTrackingEntry[] = [];
+    const namespaces = resolveNamespaceCapabilities(this.deps.config).namespaces
+      ? Array.from(
+          new Set<string>([
+            this.deps.config.defaultNamespace,
+            this.deps.config.sharedNamespace,
+            ...this.deps.config.namespacePolicies.map((p) => p.name),
+          ]),
+        )
+      : [this.deps.config.defaultNamespace];
+    const memories = await this.deps.readAllMemoriesForNamespaces(namespaces);
+    const memoryMap = new Map(memories.map((m) => [m.frontmatter.id, m]));
+
+    for (const [memoryId, update] of this.deps.accessTrackingBuffer) {
+      const memory = memoryMap.get(memoryId);
+      const existingCount = memory?.frontmatter.accessCount ?? 0;
+      entries.push({
+        memoryId,
+        newCount: existingCount + update.count,
+        lastAccessed: update.lastAccessed,
+      });
+    }
+
+    const byNamespace = new Map<string, AccessTrackingEntry[]>();
+    for (const e of entries) {
+      const m = memoryMap.get(e.memoryId);
+      if (!m) continue;
+      const ns = this.deps.namespaceFromPath(m.path);
+      const list = byNamespace.get(ns) ?? [];
+      list.push(e);
+      byNamespace.set(ns, list);
+    }
+    for (const [ns, list] of byNamespace) {
+      const sm = await this.deps.storageRouter.storageFor(ns);
+      await sm.flushAccessTracking(list);
+    }
+    this.deps.accessTrackingBuffer.clear();
+    log.debug(`flushed ${entries.length} access tracking entries`);
+  }
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -115,6 +115,7 @@ import { TurnIngestionCoordinator } from "./orchestration/turn-ingestion.js";
 import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspection.js";
 import { OrchestratorInitCoordinator } from "./orchestration/orchestrator-init.js";
 import { PersistenceIndexCoordinator } from "./orchestration/persistence-index.js";
+import { WorkspaceOpsCoordinator } from "./orchestration/workspace-ops.js";
 export { hasIdentityRecoveryIntent, resolveEffectiveIdentityInjectionMode } from "./orchestration/recall-result-formatter.js";
 import {
   GraphRecallCoordinator,
@@ -743,12 +744,12 @@ export async function raceRecallAbort<T>(
 export const COMPACTION_SIGNAL_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS = 10_000;
 
-type DaySummaryGatherOptions = {
+export type DaySummaryGatherOptions = {
   timeZone?: string;
   now?: Date;
 };
 
-function normalizeIanaTimeZone(value: unknown): string | undefined {
+export function normalizeIanaTimeZone(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (!trimmed) return undefined;
@@ -760,7 +761,7 @@ function normalizeIanaTimeZone(value: unknown): string | undefined {
   }
 }
 
-function formatDateInTimeZone(date: Date, timeZone: string): string {
+export function formatDateInTimeZone(date: Date, timeZone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone,
     year: "numeric",
@@ -785,7 +786,7 @@ function utcDateKeysAround(date: Date): string[] {
   return keys.filter((value, index, array) => array.indexOf(value) === index);
 }
 
-function utcDateKeysForLocalDay(date: Date, timeZone: string): string[] {
+export function utcDateKeysForLocalDay(date: Date, timeZone: string): string[] {
   const targetLocalDate = formatDateInTimeZone(date, timeZone);
   const keys = new Set<string>();
   const hourMs = 3_600_000;
@@ -800,13 +801,13 @@ function utcDateKeysForLocalDay(date: Date, timeZone: string): string[] {
   return keys.size > 0 ? [...keys].sort() : utcDateKeysAround(date);
 }
 
-function parseFiniteDate(value: unknown): Date | null {
+export function parseFiniteDate(value: unknown): Date | null {
   if (typeof value !== "string" || value.trim().length === 0) return null;
   const parsed = new Date(value);
   return Number.isFinite(parsed.getTime()) ? parsed : null;
 }
 
-function filterHourlySummaryMarkdownForLocalDay(
+export function filterHourlySummaryMarkdownForLocalDay(
   raw: string,
   utcDate: string,
   timeZone: string,
@@ -3226,27 +3227,6 @@ export class Orchestrator {
     );
   }
 
-  /**
-   * Run the pattern-reinforcement maintenance job (issue #687 PR 2/4).
-   *
-   * Cadence-gated on `patternReinforcementCadenceMs` so every caller
-   * (orchestrator cron path, MCP tool, CLI) shares a single floor —
-   * none can call this on a hot loop and burn the corpus.  When the
-   * feature is disabled or the cadence has not elapsed, returns a
-   * synthetic "skipped" result rather than throwing.
-   *
-   * Cadence tracking is per-namespace so a tenant-scoped MCP run in
-   * one namespace does not silence a cron run in another (PR #730
-   * review feedback, Codex P2).  Pass `force: true` for ad-hoc
-   * operator runs that must bypass the cadence floor — mirrors the
-   * pattern used by other maintenance MCP tools.
-   *
-   * `force` deliberately does NOT bypass the master
-   * `patternReinforcementEnabled` flag (PR #730 review feedback,
-   * Cursor Medium).  Operators who have explicitly disabled the
-   * feature must not have their corpus mutated by an MCP tool call —
-   * the only way to run the job is to enable the feature in config.
-   */
   async runPatternReinforcement(options: {
     force?: boolean;
     namespace?: string;
@@ -3256,69 +3236,16 @@ export class Orchestrator {
     namespace: string;
     result?: PatternReinforcementResult;
   }> {
-    const cadenceKey = options.namespace ?? "";
-    // Master switch: a disabled feature is never bypassed, even with
-    // force=true.  `force` only relaxes the cadence floor below.
-    if (!resolveConsolidationCapabilities(this.config).patternReinforcement) {
-      return { ran: false, skippedReason: "disabled", namespace: cadenceKey };
-    }
-    const cadence = this.config.patternReinforcementCadenceMs;
-    const lastAt = this.lastPatternReinforcementAtByNs.get(cadenceKey);
-    if (
-      !options.force &&
-      cadence > 0 &&
-      lastAt !== undefined &&
-      Date.now() - lastAt < cadence
-    ) {
-      return { ran: false, skippedReason: "cadence", namespace: cadenceKey };
-    }
-    const storage = options.namespace
-      ? await this.getStorage(options.namespace)
-      : this.storage;
-    const result = await runPatternReinforcement(storage, {
-      categories: this.config.patternReinforcementCategories,
-      minCount: this.config.patternReinforcementMinCount,
-    });
-    this.lastPatternReinforcementAtByNs.set(cadenceKey, Date.now());
-    log.debug(
-      `pattern reinforcement [ns=${cadenceKey || "(default)"}]: clusters=${result.clustersFound} canonicalsUpdated=${result.canonicalsUpdated} duplicatesSuperseded=${result.duplicatesSuperseded}`,
+    return this.workspaceOpsCoordinator.runPatternReinforcement(
+      options,
     );
-    return { ran: true, result, namespace: cadenceKey };
   }
 
-  /**
-   * Fan out pattern reinforcement across all maintained namespaces (issue #1500).
-   * Delegates per-namespace execution to {@link runPatternReinforcement} while
-   * the planner handles discovery, budgeting, locking, and status recording.
-   * When namespaces are disabled, runs once against default storage.
-   */
   async runPatternReinforcementFanout(options: {
     force?: boolean;
   } = {}): Promise<NamespaceMaintenanceSummary> {
-    return this.runNamespaceMaintenanceFanoutForJob(
-      "pattern-reinforcement",
-      async (ctx) => {
-        const result = await this.runPatternReinforcement({
-          namespace: ctx.candidate.namespace,
-          force: options.force,
-        });
-        // runPatternReinforcement has its own per-namespace cadence gate
-        // (lastPatternReinforcementAtByNs). When it throttles (ran:false),
-        // signal skip so the planner records state:"skipped" and does NOT
-        // touch lastMaintenanceAt — otherwise a throttled namespace would
-        // look maintained while pattern reinforcement never ran (#1500
-        // review: cadence-skip accuracy).
-        if (!result.ran) {
-          return {
-            skipped: true,
-            skipReason: result.skippedReason ?? "throttled",
-          };
-        }
-        return result.result
-          ? { itemCount: result.result.clustersFound }
-          : { itemCount: 0 };
-      },
-      { enabled: resolveConsolidationCapabilities(this.config).patternReinforcement },
+    return this.workspaceOpsCoordinator.runPatternReinforcementFanout(
+      options,
     );
   }
 
@@ -3432,75 +3359,8 @@ export class Orchestrator {
   }
 
   async maybeRunFileHygiene(): Promise<void> {
-    const hygiene = this.config.fileHygiene;
-    if (!hygiene?.enabled) return;
-
-    const now = Date.now();
-    if (now - this.lastFileHygieneRunAtMs < hygiene.runMinIntervalMs) return;
-    this.lastFileHygieneRunAtMs = now;
-
-    // Rotation first (keeps bootstrap files small).
-    if (hygiene.rotateEnabled) {
-      for (const rel of hygiene.rotatePaths) {
-        const abs = path.isAbsolute(rel)
-          ? rel
-          : path.join(this.config.workspaceDir, rel);
-        try {
-          const raw = await readFile(abs, "utf-8");
-          if (raw.length > hygiene.rotateMaxBytes) {
-            const archiveDir = path.join(
-              this.config.workspaceDir,
-              hygiene.archiveDir,
-            );
-            const base = path.basename(abs);
-            const prefix =
-              base
-                .toUpperCase()
-                .replace(/\.MD$/i, "")
-                .replace(/[^A-Z0-9]+/g, "-") || "FILE";
-            const { newContent } = await rotateMarkdownFileToArchive({
-              filePath: abs,
-              archiveDir,
-              archivePrefix: prefix,
-              keepTailChars: hygiene.rotateKeepTailChars,
-            });
-            await writeFile(abs, newContent, "utf-8");
-          }
-        } catch {
-          // ignore missing/unreadable targets
-        }
-      }
-    }
-
-    // Lint (warn before truncation risk).
-    if (hygiene.lintEnabled) {
-      const warnings = await lintWorkspaceFiles({
-        workspaceDir: this.config.workspaceDir,
-        paths: hygiene.lintPaths,
-        budgetBytes: hygiene.lintBudgetBytes,
-        warnRatio: hygiene.lintWarnRatio,
-      });
-      for (const w of warnings) {
-        log.warn(w.message);
-      }
-
-      if (hygiene.warningsLogEnabled && warnings.length > 0) {
-        const fp = path.join(this.config.memoryDir, hygiene.warningsLogPath);
-        await mkdir(path.dirname(fp), { recursive: true });
-        const stamp = new Date().toISOString();
-        const block =
-          `\n\n## ${stamp}\n\n` +
-          warnings.map((w) => `- ${w.message}`).join("\n") +
-          "\n";
-        let existing = "";
-        try {
-          existing = await readFile(fp, "utf-8");
-        } catch {
-          existing = "# Engram File Hygiene Warnings\n";
-        }
-        await writeFile(fp, existing + block, "utf-8");
-      }
-    }
+    return this.workspaceOpsCoordinator.maybeRunFileHygiene(
+    );
   }
 
   async runBootstrap(options: BootstrapOptions): Promise<BootstrapResult> {
@@ -3651,282 +3511,22 @@ export class Orchestrator {
     return this.generateDaySummary(gathered);
   }
 
-  /**
-   * Read today's facts and hourly summaries from storage, returning them
-   * as a formatted string suitable for generateDaySummary().
-   */
   async gatherTodayFacts(
     namespace?: string,
     options: DaySummaryGatherOptions = {},
   ): Promise<string> {
-    const ns =
-      namespace && namespace.length > 0
-        ? namespace
-        : this.config.defaultNamespace;
-    const storage = await this.storageRouter.storageFor(ns);
-    const configuredTimeZone = normalizeIanaTimeZone(options.timeZone)
-      ?? normalizeIanaTimeZone(this.config.daySummaryTimezone);
-    const timeZone =
-      configuredTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const now = options.now instanceof Date && Number.isFinite(options.now.getTime())
-      ? options.now
-      : new Date();
-    const targetLocalDate = formatDateInTimeZone(now, timeZone);
-    // Facts are stored under UTC date directories, while the summary target is
-    // a local calendar day. Scan the UTC-date envelope that overlaps the local
-    // day, then filter parseable fact timestamps to that configured local day.
-    const datesToScan = utcDateKeysForLocalDay(now, timeZone);
-    const MAX_CHARS = 100_000;
-
-    // --- Read memory files from each category dir × date directory ---
-    // Iterate every recall category dir (RECALL_FALLBACK_DIRS — single source
-    // of truth) so the day summary includes decisions/, moments/, ... not just
-    // facts/ (#1546). corrections/ is flat, so corrections/<date>/ never exists
-    // and is skipped by the ENOENT guard — preserving the prior exclusion. The
-    // per-file created→local-day filter below is unchanged.
-    //
-    // Symlink/containment hardening (mirrors scanDir / the CLI walker): the
-    // gathered contents feed the day-summary LLM input, so a symlinked category
-    // dir (decisions/ → outside memoryDir) must not be followed and leak files.
-    // Resolve the store root once; skip symlinked / out-of-root dirs and
-    // entries; skip the scan gracefully if the root can't be resolved.
-    const facts: MemoryFile[] = [];
-    let memoryRootReal: string | null = null;
-    try {
-      memoryRootReal = await realpath(storage.dir);
-    } catch {
-      memoryRootReal = null;
-    }
-    for (const categoryDir of RECALL_FALLBACK_DIRS) {
-      if (memoryRootReal === null) break;
-      for (const date of datesToScan) {
-        const dateDir = path.join(storage.dir, categoryDir, date);
-        try {
-          const dirStat = await lstat(dateDir);
-          if (dirStat.isSymbolicLink() || !dirStat.isDirectory()) continue;
-          assertPathInsideRoot(memoryRootReal, await realpath(dateDir), dateDir);
-          const entries = await readdir(dateDir, { withFileTypes: true });
-          for (const entry of entries) {
-            if (entry.isSymbolicLink()) continue;
-            if (!entry.name.endsWith(".md")) continue;
-            const fullPath = path.join(dateDir, entry.name);
-            try {
-              assertPathInsideRoot(memoryRootReal, await realpath(fullPath), fullPath);
-              const raw = await readFile(fullPath, "utf-8");
-              const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-              if (!fmMatch) continue;
-              const fmBlock = fmMatch[1];
-              const content = fmMatch[2].trim();
-              const fm: Record<string, string> = {};
-              for (const line of fmBlock.split("\n")) {
-                const colonIdx = line.indexOf(":");
-                if (colonIdx === -1) continue;
-                fm[line.slice(0, colonIdx).trim()] = line
-                  .slice(colonIdx + 1)
-                  .trim();
-              }
-              const created = fm.created || "unknown";
-              const createdAt = parseFiniteDate(created);
-              if (
-                createdAt &&
-                formatDateInTimeZone(createdAt, timeZone) !== targetLocalDate
-              ) {
-                continue;
-              }
-              facts.push({
-                path: fullPath,
-                frontmatter: {
-                  id: fm.id || path.basename(entry.name, ".md"),
-                  category: (fm.category as any) || "fact",
-                  created,
-                  updated: fm.updated || created,
-                  source: fm.source || "unknown",
-                  confidence: parseFloat(fm.confidence || "0.8"),
-                  confidenceTier: (fm.confidenceTier as any) || "implied",
-                  tags: [],
-                },
-                content,
-              });
-            } catch {
-              // Skip unreadable files
-            }
-          }
-        } catch {
-          // Absent dir (ENOENT), symlinked/out-of-root dir, or containment
-          // violation — skip this category/date without aborting the summary.
-        }
-      }
-    }
-
-    // Sort facts by created timestamp (most recent last) so truncation keeps newest
-    facts.sort((a, b) => {
-      if (a.frontmatter.created === b.frontmatter.created) return 0;
-      return a.frontmatter.created < b.frontmatter.created ? -1 : 1;
-    });
-
-    // --- Read hourly summaries for the scanned dates ---
-    const hourlySummaries: string[] = [];
-    const hourlyBaseDir = path.join(storage.dir, "summaries", "hourly");
-    try {
-      const sessionKeys = await readdir(hourlyBaseDir, { withFileTypes: true });
-      for (const sk of sessionKeys) {
-        if (!sk.isDirectory()) continue;
-        for (const date of datesToScan) {
-          const summaryFile = path.join(hourlyBaseDir, sk.name, `${date}.md`);
-          try {
-            const raw = await readFile(summaryFile, "utf-8");
-            const filtered = filterHourlySummaryMarkdownForLocalDay(
-              raw,
-              date,
-              timeZone,
-              targetLocalDate,
-            );
-            if (filtered) {
-              hourlySummaries.push(filtered);
-            }
-          } catch {
-            // No summary file for this session/date
-          }
-        }
-      }
-    } catch {
-      // No hourly summaries directory
-    }
-
-    // --- Format and truncate ---
-    let formatted = formatDaySummaryMemories(facts);
-    if (hourlySummaries.length > 0) {
-      formatted +=
-        "\n\n---\n## Hourly Summaries\n\n" +
-        hourlySummaries.join("\n\n---\n\n");
-    }
-
-    // Truncate intelligently if over budget: drop oldest facts first
-    if (formatted.length > MAX_CHARS) {
-      // Re-build with fewer facts, keeping most recent
-      while (facts.length > 1 && formatted.length > MAX_CHARS) {
-        facts.shift(); // drop oldest
-        formatted = formatDaySummaryMemories(facts);
-        if (hourlySummaries.length > 0) {
-          formatted +=
-            "\n\n---\n## Hourly Summaries\n\n" +
-            hourlySummaries.join("\n\n---\n\n");
-        }
-      }
-      // If still over, hard truncate
-      if (formatted.length > MAX_CHARS) {
-        formatted = formatted.slice(0, MAX_CHARS);
-      }
-    }
-
-    log.info(
-      `gatherTodayFacts: collected ${facts.length} facts, ${hourlySummaries.length} hourly summaries for ${targetLocalDate} (${timeZone}, ${formatted.length} chars)`,
+    return this.workspaceOpsCoordinator.gatherTodayFacts(
+      namespace,
+      options,
     );
-
-    return formatted;
   }
 
   previewMemoryActionEvent(
     event: Omit<MemoryActionEvent, "timestamp"> & { timestamp?: string },
   ): MemoryActionEvent {
-    const namespace =
-      typeof event.namespace === "string" && event.namespace.length > 0
-        ? event.namespace
-        : this.config.defaultNamespace;
-    const eligibility = parseMemoryActionEligibilityContext(
-      event.policyEligibility,
+    return this.workspaceOpsCoordinator.previewMemoryActionEvent(
+      event,
     );
-    const policy = evaluateMemoryActionPolicy({
-      action: event.action,
-      eligibility,
-      options: {
-        actionsEnabled: resolveCompressionCapabilities(this.config).contextCompressionActions,
-        maxCompressionTokensPerHour: this.config.maxCompressionTokensPerHour,
-      },
-    });
-    const dryRun = event.dryRun === true;
-
-    const normalizedOutcome = dryRun
-      ? event.outcome === "failed"
-        ? "failed"
-        : "skipped"
-      : policy.decision === "allow"
-        ? event.outcome
-        : event.outcome === "failed"
-          ? "failed"
-          : "skipped";
-    const sourceSessionKey =
-      typeof event.sourceSessionKey === "string" &&
-      event.sourceSessionKey.length > 0
-        ? event.sourceSessionKey
-        : typeof event.sessionKey === "string" && event.sessionKey.length > 0
-          ? event.sessionKey
-          : undefined;
-    const outputMemoryIds = Array.isArray(event.outputMemoryIds)
-      ? Array.from(
-          new Set(
-            event.outputMemoryIds.filter(
-              (value): value is string =>
-                typeof value === "string" && value.length > 0,
-            ),
-          ),
-        )
-      : [];
-
-    const reasonParts = [
-      event.reason,
-      `policy:${policy.decision}`,
-      policy.rationale,
-    ].filter(
-      (part): part is string => typeof part === "string" && part.length > 0,
-    );
-
-    return {
-      ...event,
-      schemaVersion: event.schemaVersion ?? 1,
-      actionId:
-        typeof event.actionId === "string" && event.actionId.length > 0
-          ? event.actionId
-          : `memact-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      outcome: normalizedOutcome,
-      status:
-        event.status ??
-        (dryRun && policy.decision === "allow" && event.outcome !== "failed"
-          ? "validated"
-          : normalizedOutcome === "applied"
-            ? "applied"
-            : "rejected"),
-      actor:
-        typeof event.actor === "string" && event.actor.length > 0
-          ? event.actor
-          : "engram",
-      subsystem:
-        typeof event.subsystem === "string" && event.subsystem.length > 0
-          ? event.subsystem
-          : "memory_action",
-      reason: reasonParts.join(" | "),
-      namespace,
-      sessionKey: sourceSessionKey ?? event.sessionKey,
-      sourceSessionKey,
-      inputSummary:
-        typeof event.inputSummary === "string" && event.inputSummary.length > 0
-          ? event.inputSummary
-          : undefined,
-      outputMemoryIds,
-      dryRun,
-      policyVersion:
-        typeof event.policyVersion === "string" &&
-        event.policyVersion.length > 0
-          ? event.policyVersion
-          : "memory-action-policy.v1",
-      timestamp:
-        typeof event.timestamp === "string" && event.timestamp.length > 0
-          ? event.timestamp
-          : new Date().toISOString(),
-      policyDecision: policy.decision,
-      policyRationale: policy.rationale,
-      policyEligibility: eligibility,
-    };
   }
 
   async appendMemoryActionEvent(
@@ -4087,63 +3687,9 @@ export class Orchestrator {
     return this.conversationIndexCoordinator.rebuild(sessionKey, hours, opts);
   }
 
-  /**
-   * Validate local LLM model availability and context window compatibility.
-   * Warns the user if there's a mismatch.
-   */
   private async validateLocalLlmModel(): Promise<void> {
-    log.debug("Local LLM: validating model configuration");
-    try {
-      const modelInfo = await this.localLlm.getLoadedModelInfo();
-      if (!modelInfo) {
-        log.warn(
-          "Local LLM validation: Could not query model info from server",
-        );
-        log.warn(
-          "Local LLM validation: Could not query model info. " +
-            "Ensure LM Studio/Ollama is running with the model loaded.",
-        );
-        return;
-      }
-
-      // Check for context window mismatch
-      const configuredMaxContext = this.config.localLlmMaxContext;
-
-      if (modelInfo.contextWindow) {
-        log.debug(
-          `Local LLM: ${modelInfo.id} loaded with ${modelInfo.contextWindow.toLocaleString()} token context window`,
-        );
-
-        if (
-          configuredMaxContext &&
-          configuredMaxContext > modelInfo.contextWindow
-        ) {
-          log.warn(
-            `Local LLM context mismatch: engram configured for ${configuredMaxContext.toLocaleString()} tokens, ` +
-              `but ${modelInfo.id} only supports ${modelInfo.contextWindow.toLocaleString()}. ` +
-              `Reducing to ${modelInfo.contextWindow.toLocaleString()} to avoid errors.`,
-          );
-          // Update the config in-memory to match actual capability
-          // (This is a temporary fix - user should update their config)
-          (this.config as { localLlmMaxContext?: number }).localLlmMaxContext =
-            modelInfo.contextWindow;
-        }
-      } else {
-        log.debug(
-          `Local LLM: ${modelInfo.id} loaded (context window not reported by server)`,
-        );
-
-        if (!configuredMaxContext) {
-          log.warn(
-            "Local LLM: Server did not report context window. " +
-              "If you get 'context length exceeded' errors, set localLlmMaxContext in your config. " +
-              "Common defaults: LM Studio (32K), Ollama (2K-128K depending on model).",
-          );
-        }
-      }
-    } catch (err) {
-      log.warn(`Local LLM validation failed: ${err}`);
-    }
+    return this.workspaceOpsCoordinator.validateLocalLlmModel(
+    );
   }
 
   async recall(
@@ -5025,6 +4571,45 @@ export class Orchestrator {
     return this._persistenceIndexCoordinator;
   }
 
+  /**
+   * Workspace-ops coordinator (issue #1526 seam 24). Owns periodic
+   * workspace/operations surfaces. Lazy + accessor-wired (late-binding
+   * rule, seams 18–23).
+   */
+  private _workspaceOpsCoordinator: WorkspaceOpsCoordinator | undefined;
+
+  private get workspaceOpsCoordinator(): WorkspaceOpsCoordinator {
+    if (!this._workspaceOpsCoordinator) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._workspaceOpsCoordinator = new WorkspaceOpsCoordinator({
+        get accessTrackingBuffer() { return self.accessTrackingBuffer; },
+        bulkImportWriteNamespace: () => self.bulkImportWriteNamespace(),
+        get config() { return self.config; },
+        get extraction() { return self.extraction; },
+        getStorage: (namespace) => self.getStorage(namespace),
+        getStorageForNamespace: (namespace) => self.getStorageForNamespace(namespace),
+        get judgeDeferCounts() { return self.judgeDeferCounts; },
+        get judgeVerdictCache() { return self.judgeVerdictCache; },
+        get lastFileHygieneRunAtMs() { return self.lastFileHygieneRunAtMs; },
+        set lastFileHygieneRunAtMs(value) { self.lastFileHygieneRunAtMs = value; },
+        get lastPatternReinforcementAtByNs() { return self.lastPatternReinforcementAtByNs; },
+        get localLlm() { return self.localLlm; },
+        maintenanceNamespaces: (jobName, budgetMode) => self.maintenanceNamespaces(jobName, budgetMode),
+        namespaceFromPath: (p) => self.namespaceFromPath(p),
+        get qmd() { return self.qmd; },
+        readAllMemoriesForNamespaces: (namespaces) => self.readAllMemoriesForNamespaces(namespaces),
+        runNamespaceMaintenanceFanoutForJob: (jobName, runner, options) => self.runNamespaceMaintenanceFanoutForJob(jobName, runner, options),
+        runPatternReinforcement: (options) => self.runPatternReinforcement(options),
+        get storage() { return self.storage; },
+        get storageRouter() { return self.storageRouter; },
+        get wearablesServiceInstance() { return self.wearablesServiceInstance; },
+        set wearablesServiceInstance(value) { self.wearablesServiceInstance = value; },
+      });
+    }
+    return this._workspaceOpsCoordinator;
+  }
+
   private async recallInternal(
     prompt: string,
     sessionKey?: string,
@@ -5159,60 +4744,9 @@ export class Orchestrator {
     return this.config.defaultNamespace;
   }
 
-  /**
-   * Lazily-constructed wearables service (Limitless / Bee / Omi
-   * transcript ingestion). All wearables surfaces — CLI, MCP tools,
-   * HTTP routes — share this one instance so sync state, search, and
-   * memory writes stay consistent. Writes are pinned to the same
-   * deterministic namespace bulk-import uses.
-   */
   getWearablesService(): WearablesService {
-    if (!this.wearablesServiceInstance) {
-      this.wearablesServiceInstance = new WearablesService({
-        config: this.config.wearables,
-        getStorage: async () =>
-          await this.getStorageForNamespace(this.bulkImportWriteNamespace()),
-        extract: (turns) => this.extraction.extract(turns),
-        // Smart memoryMode runs candidates through the SAME extraction
-        // judge (cache + defer counters included) the live extraction
-        // pipeline uses, so wearable facts get identical LLM-as-judge
-        // durability gating.
-        judgeFacts: (candidates) =>
-          judgeFactDurability(
-            candidates,
-            this.config,
-            this.localLlm,
-            new FallbackLlmClient(
-              this.config.gatewayConfig,
-              fallbackLlmRuntimeContextFromConfig(this.config),
-            ),
-            this.judgeVerdictCache,
-            this.judgeDeferCounts,
-          ),
-        searchBackend: {
-          search: async (query, maxResults) => {
-            if (!this.qmd.isAvailable()) return null;
-            try {
-              const results = await this.qmd.search(query, undefined, maxResults);
-              return results.map((result) => ({
-                path: result.path,
-                score: result.score,
-                preview: result.snippet,
-              }));
-            } catch {
-              // Backend hiccup → tell the service "unavailable" so it
-              // runs its bounded scan fallback instead of returning a
-              // silent empty result (CLAUDE.md rule 34).
-              return null;
-            }
-          },
-        },
-        reindexSearch: async () => {
-          await this.qmd.update();
-        },
-      });
-    }
-    return this.wearablesServiceInstance;
+    return this.workspaceOpsCoordinator.getWearablesService(
+    );
   }
 
   async ingestBulkImportBatch(
@@ -5571,93 +5105,16 @@ export class Orchestrator {
   ): Promise<number> {
     return this.lifecyclePolicyCoordinator.runLifecyclePolicyPass(allMemories, storage);
   }
-  /** Threshold (bytes) at which IDENTITY.md reflections get auto-consolidated */
-  private static readonly IDENTITY_CONSOLIDATE_THRESHOLD = 8_000;
+  /**
+   * Threshold (bytes) at which IDENTITY.md reflections get auto-consolidated.
+   * Read by WorkspaceOpsCoordinator (seam 24) via `Orchestrator.…`, hence
+   * not `private`.
+   */
+  static readonly IDENTITY_CONSOLIDATE_THRESHOLD = 8_000;
 
   private async autoConsolidateIdentity(): Promise<void> {
-    // Fan out over the catalog-union namespace set (issue #1499 sweep): a dynamic
-    // namespace that accumulated IDENTITY.md reflections must also be eligible for
-    // auto-consolidation, otherwise its identity file grows unbounded and is never
-    // consolidated. Falls back to the configured set on any catalog read failure.
-    const namespaces = resolveNamespaceCapabilities(this.config).namespaces
-      ? await this.maintenanceNamespaces()
-      : [this.config.defaultNamespace];
-
-    for (const namespace of namespaces) {
-      const storage = await this.storageRouter.storageFor(namespace);
-      const identityNamespace =
-        resolveNamespaceCapabilities(this.config).namespaces &&
-        namespace !== this.config.defaultNamespace
-          ? namespace
-          : undefined;
-      const reflectionsContent =
-        (await storage.readIdentityReflections()) ?? "";
-
-      const existingIdentity = await storage.readIdentity(
-        this.config.workspaceDir,
-        identityNamespace,
-      );
-      const headerEnd =
-        existingIdentity.indexOf("## Learned Patterns") !== -1
-          ? existingIdentity.indexOf("## Learned Patterns")
-          : existingIdentity.indexOf("## Reflection");
-      const staticHeader =
-        (headerEnd !== -1
-          ? existingIdentity.slice(0, headerEnd)
-          : existingIdentity
-        ).trimEnd() || "# IDENTITY";
-      const identityContent = `${staticHeader}\n\n${reflectionsContent.trim()}\n`;
-      if (identityContent.length < Orchestrator.IDENTITY_CONSOLIDATE_THRESHOLD)
-        continue;
-
-      log.info(
-        `IDENTITY(${namespace}) is ${identityContent.length} chars — auto-consolidating reflections`,
-      );
-      const result = await this.extraction.consolidateIdentity(
-        identityContent,
-        "## Reflection",
-      );
-
-      if (!result || result.learnedPatterns.length === 0) {
-        log.warn(
-          `identity consolidation produced no patterns for namespace=${namespace}`,
-        );
-        continue;
-      }
-
-      const patternsSection = [
-        "## Learned Patterns (consolidated from reflections, " +
-          new Date().toISOString().slice(0, 10) +
-          ")",
-        "",
-        ...result.learnedPatterns.map((p) => `- ${p}`),
-        "",
-      ].join("\n");
-
-      const newContent = staticHeader + "\n\n" + patternsSection + "\n";
-
-      await storage.writeIdentity(
-        this.config.workspaceDir,
-        newContent,
-        identityNamespace,
-      );
-      await storage.writeIdentityReflections("");
-      // NRcCL (codex P2): record a per-namespace catalog write for THIS namespace
-      // after the identity files are updated. This fan-out can mutate a dynamic
-      // namespace via `writeIdentity`/`writeIdentityReflections`, but the
-      // consolidation pass's only consolidated touch covers `this.storage` (the
-      // default) and only fires when `memoryItemMutated` was set by OTHER work — so
-      // a namespace whose sole mutation in the pass is identity consolidation would
-      // otherwise keep a stale `lastWriteAt`, making `listNamespaces({ writtenSince })`
-      // and catalog-recency consumers miss the write. Best-effort and
-      // failure-tolerant (the storage chokepoint (#1522) swallows errors, never crashing the
-      // consolidation; gotcha #13, rule #40). No double-count with the consolidated
-      // touch above: that one is gated on `memoryItemMutated` (which identity
-      // consolidation does not set), and `markWrite` is idempotent regardless.
-      log.info(
-        `IDENTITY(${namespace}) consolidated: ${identityContent.length} → ${newContent.length} chars, ${result.learnedPatterns.length} patterns`,
-      );
-    }
+    return this.workspaceOpsCoordinator.autoConsolidateIdentity(
+    );
   }
 
   // Issue #1526: recall result formatting moved to RecallResultFormatter. Thin
@@ -6108,52 +5565,9 @@ export class Orchestrator {
     }
   }
 
-  /**
-   * Flush access tracking buffer to disk.
-   * Called during consolidation or when buffer is full.
-   */
   async flushAccessTracking(): Promise<void> {
-    if (this.accessTrackingBuffer.size === 0) return;
-
-    // Build entries from buffer, merging with existing counts
-    const entries: AccessTrackingEntry[] = [];
-    const namespaces = resolveNamespaceCapabilities(this.config).namespaces
-      ? Array.from(
-          new Set<string>([
-            this.config.defaultNamespace,
-            this.config.sharedNamespace,
-            ...this.config.namespacePolicies.map((p) => p.name),
-          ]),
-        )
-      : [this.config.defaultNamespace];
-    const memories = await this.readAllMemoriesForNamespaces(namespaces);
-    const memoryMap = new Map(memories.map((m) => [m.frontmatter.id, m]));
-
-    for (const [memoryId, update] of this.accessTrackingBuffer) {
-      const memory = memoryMap.get(memoryId);
-      const existingCount = memory?.frontmatter.accessCount ?? 0;
-      entries.push({
-        memoryId,
-        newCount: existingCount + update.count,
-        lastAccessed: update.lastAccessed,
-      });
-    }
-
-    const byNamespace = new Map<string, AccessTrackingEntry[]>();
-    for (const e of entries) {
-      const m = memoryMap.get(e.memoryId);
-      if (!m) continue;
-      const ns = this.namespaceFromPath(m.path);
-      const list = byNamespace.get(ns) ?? [];
-      list.push(e);
-      byNamespace.set(ns, list);
-    }
-    for (const [ns, list] of byNamespace) {
-      const sm = await this.storageRouter.storageFor(ns);
-      await sm.flushAccessTracking(list);
-    }
-    this.accessTrackingBuffer.clear();
-    log.debug(`flushed ${entries.length} access tracking entries`);
+    return this.workspaceOpsCoordinator.flushAccessTracking(
+    );
   }
 
   private async loadSearchResultMemoryMap(

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 6476,
+      "packages/remnic-core/src/orchestrator.ts": 5890,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 9017,
       "packages/remnic-core/src/storage.ts": 7747,


### PR DESCRIPTION
Part of #1526. Seam 24, stacked on seam 23 (#1796).

Behavior-preserving move of 9 periodic workspace/ops methods (686 LOC) into `orchestration/workspace-ops.ts`: `gatherTodayFacts`, `previewMemoryActionEvent`, `maybeRunFileHygiene`, `autoConsolidateIdentity`, `getWearablesService`, `validateLocalLlmModel`, `runPatternReinforcement` (+ fanout), `flushAccessTracking`. 20-member deps (2 written fields via get/set accessors — wearables handle + hygiene timestamp). `IDENTITY_CONSOLIDATE_THRESHOLD` static widened from `private` for the coordinator read.

orchestrator.ts: 6,476 → 5,890 LOC. Ratchet updated.

Verification: tsc clean; entity-hardening 246/246; day-summary-cron-routing + file-hygiene + access-service-pattern-reinforcement: 12/12; preflight:quick OK.

Chokepoints used: n/a (behavior-preserving extraction).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large structural move across maintenance, identity writes, wearables, and access-tracking paths; intended as behavior-preserving but regressions would affect cron/MCP/CLI surfaces that share these methods.
> 
> **Overview**
> **Behavior-preserving seam 24 (#1526):** periodic workspace/ops logic moves out of `orchestrator.ts` into new `orchestration/workspace-ops.ts` as `WorkspaceOpsCoordinator`, wired through a lazy getter and a 20-member `WorkspaceOpsDeps` bag (including get/set for `lastFileHygieneRunAtMs` and `wearablesServiceInstance`).
> 
> **Orchestrator** keeps the same public API but each call now delegates: pattern reinforcement (+ fanout), file hygiene, `gatherTodayFacts`, memory-action preview, local LLM validation, wearables service, identity auto-consolidation, and access-tracking flush. Day-summary helpers (`DaySummaryGatherOptions`, timezone/date parsing, hourly filter) are **exported** from `orchestrator.ts` so the coordinator can reuse them. `IDENTITY_CONSOLIDATE_THRESHOLD` is widened from `private` to `static readonly` for coordinator access.
> 
> **Ratchet:** `orchestrator.ts` watchlist LOC **6,476 → 5,890** in `scripts/ratchet-baseline.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070ff4663357c990c6c1edff148cb6ef390171da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->