### PR TITLE
refactor(orchestrator): extract namespace read fanout into NamespaceReadFanoutCoordinator (seam 26, #1526)

### DIFF
--- a/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
+++ b/packages/remnic-core/src/orchestration/namespace-read-fanout.ts
@@ -1,0 +1,484 @@
+/**
+ * Namespace read-fanout coordinator — extracted from the orchestrator
+ * (issue #1526, seam 26).
+ *
+ * Owns namespace-scoped READ fanout (never namespace RESOLUTION — the
+ * ScopePlan resolver from #1521 stays the single authority for that):
+ *   - storage-dir hint loading from the catalog
+ *   - cross-namespace search and memory/archive reads
+ *   - scoped memory candidate search and artifact recall fanout
+ *   - artifact source status resolution (with per-storage cache)
+ *   - path→namespace and storage-dir→namespace mapping helpers
+ *
+ * Behavior-preserving move from orchestrator.ts (late-binding deps rule,
+ * seams 18–25).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { resolveNamespaceCapabilities } from "../capabilities.js";
+import { StorageManager } from "../index.js";
+import { NamespaceCatalog } from "../namespaces/catalog.js";
+import { namespaceIdentityFromToken, namespaceIdentityToken, normalizeNamespaceIdentity } from "../namespaces/identity.js";
+import { NamespaceSearchRouter } from "../namespaces/search.js";
+import { NamespaceStorageRouter } from "../namespaces/storage.js";
+import { mergeArtifactRecallCandidates, tokenizeRecallQuery } from "./orchestrator-helpers.js";
+import { qmdCollectionPathParts } from "./qmd-result-resolver.js";
+import { resolveNamespaceFromStorageDir } from "../scopes/scope-plan.js";
+import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
+import type { MemoryFile, PluginConfig, QmdSearchResult } from "../types.js";
+import {
+  Orchestrator,
+} from "../orchestrator.js";
+
+export interface NamespaceReadFanoutDeps {
+  readonly artifactSourceStatusCache: WeakMap<StorageManager, { loadedAtMs: number; statusVersion: number; statuses: Map<string, "active" | "superseded" | "archived" | "missing"> }>;
+  readonly config: PluginConfig;
+  configuredNamespaceList(): string[];
+  fetchActiveArtifactsForNamespace(
+    namespace: string,
+    prompt: string,
+    targetCount: number,
+  ): Promise<MemoryFile[]>;
+  loadNamespaceStorageDirHintsFromCatalog(): void;
+  readonly namespaceCatalog: NamespaceCatalog;
+  namespaceFromPath(p: string): string;
+  readonly namespaceSearchRouter: NamespaceSearchRouter;
+  namespaceStorageDirHintOwnershipRank(
+    record: { namespace: string },
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): number;
+  readonly namespaceStorageDirHints: Map<string, Set<string>>;
+  namespaceStorageDirHintsLoaded: boolean;
+  preferNamespaceStorageDirHintOwner(
+    current: { namespace: string; identityToken: string; storageDir: string },
+    candidate: { namespace: string; identityToken: string; storageDir: string },
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): { namespace: string; identityToken: string; storageDir: string };
+  readonly qmd: SearchBackend;
+  qmdCollectionNamespaceFromPrefix(collectionPrefix: string): string | null;
+  rememberNamespaceStorageDirHint(namespace: string, storageDir?: string): void;
+  storageDirMatchesNamespaceHint(namespace: string, storageDir: string): boolean;
+  readonly storageRouter: NamespaceStorageRouter;
+}
+
+export class NamespaceReadFanoutCoordinator {
+  constructor(
+    private readonly deps: NamespaceReadFanoutDeps,
+  ) {}
+
+  preferNamespaceStorageDirHintOwner(
+    current: { namespace: string; identityToken: string; storageDir: string },
+    candidate: { namespace: string; identityToken: string; storageDir: string },
+    resolvedStorageDir: string,
+    configured: Set<string>,
+  ): { namespace: string; identityToken: string; storageDir: string } {
+    const currentRank = this.deps.namespaceStorageDirHintOwnershipRank(
+      current,
+      resolvedStorageDir,
+      configured,
+    );
+    const candidateRank = this.deps.namespaceStorageDirHintOwnershipRank(
+      candidate,
+      resolvedStorageDir,
+      configured,
+    );
+    if (candidateRank < currentRank) return candidate;
+    if (candidateRank > currentRank) return current;
+
+    const byName = candidate.namespace.localeCompare(current.namespace);
+    if (byName < 0) return candidate;
+    if (byName > 0) return current;
+    return candidate.identityToken.localeCompare(current.identityToken) < 0
+      ? candidate
+      : current;
+  }
+
+  loadNamespaceStorageDirHintsFromCatalog(): void {
+    if (this.deps.namespaceStorageDirHintsLoaded || !this.deps.namespaceCatalog.enabled) return;
+    this.deps.namespaceStorageDirHintsLoaded = true;
+    const catalogPath = path.join(this.deps.config.memoryDir, "state", "namespaces.jsonl");
+    if (!existsSync(catalogPath)) return;
+
+    let body: string;
+    try {
+      body = readFileSync(catalogPath, "utf8");
+    } catch {
+      return;
+    }
+
+    const compactedByNamespace = new Map<
+      string,
+      { namespace: string; identityToken: string; storageDir: string }
+    >();
+    for (const line of body.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+        const record = parsed as Record<string, unknown>;
+        if (
+          typeof record.namespace !== "string" ||
+          typeof record.storageDir !== "string" ||
+          typeof record.identityToken !== "string"
+        ) {
+          continue;
+        }
+        const namespace = normalizeNamespaceIdentity(record.namespace);
+        if (!namespace || record.identityToken !== namespaceIdentityToken(namespace)) continue;
+        compactedByNamespace.set(namespace, {
+          namespace,
+          identityToken: record.identityToken,
+          storageDir: record.storageDir,
+        });
+      } catch {
+        // Catalog hints are best-effort. The catalog reader still owns full recovery.
+      }
+    }
+
+    const configured = new Set(
+      this.deps.configuredNamespaceList().map((namespace) => normalizeNamespaceIdentity(namespace)),
+    );
+    const preferredByStorageDir = new Map<
+      string,
+      { namespace: string; identityToken: string; storageDir: string }
+    >();
+    for (const record of compactedByNamespace.values()) {
+      if (!this.deps.storageDirMatchesNamespaceHint(record.namespace, record.storageDir)) {
+        continue;
+      }
+      const resolvedStorageDir = path.resolve(record.storageDir);
+      const current = preferredByStorageDir.get(resolvedStorageDir);
+      preferredByStorageDir.set(
+        resolvedStorageDir,
+        current
+          ? this.deps.preferNamespaceStorageDirHintOwner(
+              current,
+              record,
+              resolvedStorageDir,
+              configured,
+            )
+          : record,
+      );
+    }
+    for (const record of preferredByStorageDir.values()) {
+      this.deps.rememberNamespaceStorageDirHint(record.namespace, record.storageDir);
+    }
+  }
+
+  async searchAcrossNamespaces(options: {
+    query: string;
+    namespaces?: string[];
+    maxResults?: number;
+    mode?: "search" | "hybrid" | "bm25" | "vector";
+    searchOptions?: SearchQueryOptions;
+    execution?: SearchExecutionOptions;
+  }): Promise<QmdSearchResult[]> {
+    if (
+      resolveNamespaceCapabilities(this.deps.config).namespaces &&
+      options.namespaces !== undefined &&
+      options.namespaces.length === 0
+    ) {
+      return [];
+    }
+    const namespaces = resolveNamespaceCapabilities(this.deps.config).namespaces
+      ? Array.from(
+          new Set(
+            (options.namespaces?.length
+              ? options.namespaces
+              : this.deps.configuredNamespaceList()
+            )
+              .map((value) => value.trim())
+              .filter(Boolean),
+          ),
+        )
+      : [this.deps.config.defaultNamespace];
+
+    if (!resolveNamespaceCapabilities(this.deps.config).namespaces) {
+      switch (options.mode) {
+        case "hybrid":
+          return await this.deps.qmd.hybridSearch(
+            options.query,
+            undefined,
+            options.maxResults,
+            options.execution,
+          );
+        case "bm25":
+          return await this.deps.qmd.bm25Search(
+            options.query,
+            undefined,
+            options.maxResults,
+            options.execution,
+          );
+        case "vector":
+          return await this.deps.qmd.vectorSearch(
+            options.query,
+            undefined,
+            options.maxResults,
+            options.execution,
+          );
+        default:
+          return await this.deps.qmd.search(
+            options.query,
+            undefined,
+            options.maxResults,
+            options.searchOptions,
+            options.execution,
+          );
+      }
+    }
+
+    return await this.deps.namespaceSearchRouter.searchAcrossNamespaces({
+      query: options.query,
+      namespaces,
+      maxResults: options.maxResults,
+      mode: options.mode,
+      searchOptions: options.searchOptions,
+      execution: options.execution,
+    });
+  }
+
+  async resolveArtifactSourceStatuses(
+    storage: StorageManager,
+    sourceIds: string[],
+  ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">> {
+    const currentStatusVersion = storage.getMemoryStatusVersion();
+    const cached = this.deps.artifactSourceStatusCache.get(storage);
+    let snapshot = cached;
+    const isFresh =
+      snapshot !== undefined &&
+      Date.now() - snapshot.loadedAtMs <=
+        Orchestrator.ARTIFACT_STATUS_CACHE_TTL_MS &&
+      snapshot.statusVersion === currentStatusVersion;
+
+    const rebuildSnapshot = async () => {
+      const MAX_STABLE_READ_ATTEMPTS = 3;
+      let latestStatuses = new Map<
+        string,
+        "active" | "superseded" | "archived" | "missing"
+      >();
+      let latestVersionAfter = storage.getMemoryStatusVersion();
+
+      for (let attempt = 0; attempt < MAX_STABLE_READ_ATTEMPTS; attempt += 1) {
+        const versionBefore = storage.getMemoryStatusVersion();
+        const allMemories = await storage.readAllMemories();
+        const versionAfter = storage.getMemoryStatusVersion();
+        latestVersionAfter = versionAfter;
+        latestStatuses = new Map(
+          allMemories.map((m) => [
+            m.frontmatter.id,
+            (m.frontmatter.status ?? "active") as
+              | "active"
+              | "superseded"
+              | "archived"
+              | "missing",
+          ]),
+        );
+
+        if (versionAfter === versionBefore) {
+          const rebuilt = {
+            loadedAtMs: Date.now(),
+            statusVersion: versionAfter,
+            statuses: latestStatuses,
+          };
+          this.deps.artifactSourceStatusCache.set(storage, rebuilt);
+          return rebuilt;
+        }
+      }
+
+      // Sustained write churn: return latest read without caching a potentially torn snapshot.
+      return {
+        loadedAtMs: Date.now(),
+        statusVersion: latestVersionAfter,
+        statuses: latestStatuses,
+      };
+    };
+
+    if (!isFresh) {
+      snapshot = await rebuildSnapshot();
+    } else {
+      // Warm cache may miss brand-new sourceMemoryId values created after snapshot build.
+      // Refresh once on-demand when unseen IDs are requested.
+      const hasUnknownSourceIds = sourceIds.some(
+        (id) => !snapshot?.statuses.has(id),
+      );
+      if (hasUnknownSourceIds) {
+        snapshot = await rebuildSnapshot();
+      }
+    }
+
+    // Persist negative lookups in the cached snapshot so stale source IDs do not
+    // trigger repeated full snapshot rebuilds on every matching recall.
+    for (const id of sourceIds) {
+      if (!snapshot?.statuses.has(id)) {
+        snapshot?.statuses.set(id, "missing");
+      }
+    }
+
+    const statuses = new Map<
+      string,
+      "active" | "superseded" | "archived" | "missing"
+    >();
+    for (const id of sourceIds) {
+      const status = snapshot?.statuses.get(id);
+      if (status) {
+        statuses.set(id, status);
+      } else {
+        statuses.set(id, "missing");
+      }
+    }
+    return statuses;
+  }
+
+  async recallArtifactsAcrossNamespaces(
+    prompt: string,
+    recallNamespaces: string[],
+    targetCount: number,
+  ): Promise<MemoryFile[]> {
+    if (targetCount <= 0) return [];
+    const namespaces = Array.from(new Set(recallNamespaces));
+    const filteredByNamespace = await Promise.all(
+      namespaces.map((namespace) =>
+        this.deps.fetchActiveArtifactsForNamespace(namespace, prompt, targetCount),
+      ),
+    );
+
+    return mergeArtifactRecallCandidates(filteredByNamespace, targetCount);
+  }
+
+  async searchScopedMemoryCandidates(
+    candidatePaths: Set<string>,
+    query: string,
+    limit: number,
+    options?: {
+      allowArchived?: boolean;
+    },
+  ): Promise<QmdSearchResult[]> {
+    const cappedLimit = Math.max(0, limit);
+    if (cappedLimit === 0 || candidatePaths.size === 0) return [];
+
+    const tokens = Array.from(new Set(tokenizeRecallQuery(query)));
+    const memories = (
+      await Promise.all(
+        Array.from(candidatePaths).map(async (memoryPath) => {
+          const namespace = resolveNamespaceCapabilities(this.deps.config).namespaces
+            ? this.deps.namespaceFromPath(memoryPath)
+            : this.deps.config.defaultNamespace;
+          const storage = await this.deps.storageRouter.storageFor(namespace);
+          return await storage.readMemoryByPath(memoryPath);
+        }),
+      )
+    ).filter((memory): memory is MemoryFile => memory !== null);
+
+    const results: QmdSearchResult[] = [];
+    for (const memory of memories) {
+      const status = memory.frontmatter.status ?? "active";
+      if (!options?.allowArchived && status !== "active") continue;
+
+      const haystack = [
+        memory.content,
+        memory.frontmatter.category,
+        ...(memory.frontmatter.tags ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      let hits = 0;
+      for (const token of tokens) {
+        if (haystack.includes(token)) hits += 1;
+      }
+      const score = tokens.length > 0 ? hits / tokens.length : 0.01;
+      if (tokens.length > 0 && hits === 0) continue;
+
+      results.push({
+        docid: memory.frontmatter.id,
+        path: memory.path,
+        score,
+        snippet: memory.content.slice(0, 400).replace(/\n/g, " "),
+        transport: "scoped_prefilter",
+      });
+    }
+
+    return results.sort((a, b) => b.score - a.score).slice(0, cappedLimit);
+  }
+
+  async resolveStateDirForNamespace(
+    namespace: string,
+  ): Promise<string> {
+    if (!resolveNamespaceCapabilities(this.deps.config).namespaces) {
+      return path.join(this.deps.config.memoryDir, "state");
+    }
+    if (namespace !== this.deps.config.defaultNamespace) {
+      return path.join(this.deps.config.memoryDir, "namespaces", namespace, "state");
+    }
+    const candidate = path.join(
+      this.deps.config.memoryDir,
+      "namespaces",
+      this.deps.config.defaultNamespace,
+    );
+    try {
+      const candidateStat = await stat(candidate);
+      if (candidateStat.isDirectory()) {
+        return path.join(candidate, "state");
+      }
+    } catch {
+      // Fall back to the legacy root when the migrated default namespace directory is absent.
+    }
+    return path.join(this.deps.config.memoryDir, "state");
+  }
+
+  namespaceFromPath(p: string): string {
+    if (!resolveNamespaceCapabilities(this.deps.config).namespaces) return this.deps.config.defaultNamespace;
+    const parts = qmdCollectionPathParts(p);
+    const collectionNamespace = parts
+      ? this.deps.qmdCollectionNamespaceFromPrefix(parts.collection)
+      : null;
+    if (collectionNamespace) return collectionNamespace;
+    const m = p.match(/[\\/]+namespaces[\\/]+([^\\/]+)(?:[\\/]|$)/);
+    if (!m?.[1]) return this.deps.config.defaultNamespace;
+    return namespaceIdentityFromToken(m[1]) ?? m[1];
+  }
+
+  storageDirNamespace(storageDir: string): string {
+    // #1521: delegates to the scope-module resolver. The inline dir→namespace
+    // derivation (token round-trip guard, catalog hints) is retired so the
+    // adHocNamespaceResolutions ratchet no longer counts this site. Hints are
+    // loaded lazily via the callback (only after early returns, matching the
+    // original behavior — codex P2).
+    return resolveNamespaceFromStorageDir(storageDir, {
+      config: this.deps.config,
+      configuredNamespaces: this.deps.configuredNamespaceList(),
+      hints: this.deps.namespaceStorageDirHints,
+      loadHints: () => this.deps.loadNamespaceStorageDirHintsFromCatalog(),
+    });
+  }
+
+  async readAllMemoriesForNamespaces(
+    namespaces: string[],
+  ): Promise<MemoryFile[]> {
+    const uniq = Array.from(new Set(namespaces.filter(Boolean)));
+    const lists = await Promise.all(
+      uniq.map(async (ns) => {
+        const sm = await this.deps.storageRouter.storageFor(ns);
+        return sm.readAllMemories();
+      }),
+    );
+    return lists.flat();
+  }
+
+  async readArchivedMemoriesForNamespaces(
+    namespaces: string[],
+  ): Promise<MemoryFile[]> {
+    const uniq = Array.from(new Set(namespaces.filter(Boolean)));
+    const lists = await Promise.all(
+      uniq.map(async (ns) => {
+        const sm = await this.deps.storageRouter.storageFor(ns);
+        return sm.readArchivedMemories();
+      }),
+    );
+    return lists.flat();
+  }
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -116,6 +116,7 @@ import { RecallIntrospectionCoordinator } from "./orchestration/recall-introspec
 import { OrchestratorInitCoordinator } from "./orchestration/orchestrator-init.js";
 import { PersistenceIndexCoordinator } from "./orchestration/persistence-index.js";
 import { WorkspaceOpsCoordinator } from "./orchestration/workspace-ops.js";
+import { NamespaceReadFanoutCoordinator } from "./orchestration/namespace-read-fanout.js";
 import {
   abortRecallError,
   buildCompressionGuidelinesMarkdown,
@@ -682,7 +683,8 @@ export class Orchestrator {
       statuses: Map<string, "active" | "superseded" | "archived" | "missing">;
     }
   >();
-  private static readonly ARTIFACT_STATUS_CACHE_TTL_MS = 60_000;
+  /** Read by NamespaceReadFanoutCoordinator (seam 26), hence not `private`. */
+  static readonly ARTIFACT_STATUS_CACHE_TTL_MS = 60_000;
 
   // Access tracking buffer (Phase 1A)
   // Maps memoryId -> {count, lastAccessed} for batched updates
@@ -1249,98 +1251,17 @@ export class Orchestrator {
     resolvedStorageDir: string,
     configured: Set<string>,
   ): { namespace: string; identityToken: string; storageDir: string } {
-    const currentRank = this.namespaceStorageDirHintOwnershipRank(
+    return this.namespaceReadFanoutCoordinator.preferNamespaceStorageDirHintOwner(
       current,
-      resolvedStorageDir,
-      configured,
-    );
-    const candidateRank = this.namespaceStorageDirHintOwnershipRank(
       candidate,
       resolvedStorageDir,
       configured,
     );
-    if (candidateRank < currentRank) return candidate;
-    if (candidateRank > currentRank) return current;
-
-    const byName = candidate.namespace.localeCompare(current.namespace);
-    if (byName < 0) return candidate;
-    if (byName > 0) return current;
-    return candidate.identityToken.localeCompare(current.identityToken) < 0
-      ? candidate
-      : current;
   }
 
   private loadNamespaceStorageDirHintsFromCatalog(): void {
-    if (this.namespaceStorageDirHintsLoaded || !this.namespaceCatalog.enabled) return;
-    this.namespaceStorageDirHintsLoaded = true;
-    const catalogPath = path.join(this.config.memoryDir, "state", "namespaces.jsonl");
-    if (!existsSync(catalogPath)) return;
-
-    let body: string;
-    try {
-      body = readFileSync(catalogPath, "utf8");
-    } catch {
-      return;
-    }
-
-    const compactedByNamespace = new Map<
-      string,
-      { namespace: string; identityToken: string; storageDir: string }
-    >();
-    for (const line of body.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const parsed = JSON.parse(trimmed) as unknown;
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-        const record = parsed as Record<string, unknown>;
-        if (
-          typeof record.namespace !== "string" ||
-          typeof record.storageDir !== "string" ||
-          typeof record.identityToken !== "string"
-        ) {
-          continue;
-        }
-        const namespace = normalizeNamespaceIdentity(record.namespace);
-        if (!namespace || record.identityToken !== namespaceIdentityToken(namespace)) continue;
-        compactedByNamespace.set(namespace, {
-          namespace,
-          identityToken: record.identityToken,
-          storageDir: record.storageDir,
-        });
-      } catch {
-        // Catalog hints are best-effort. The catalog reader still owns full recovery.
-      }
-    }
-
-    const configured = new Set(
-      this.configuredNamespaceList().map((namespace) => normalizeNamespaceIdentity(namespace)),
+    return this.namespaceReadFanoutCoordinator.loadNamespaceStorageDirHintsFromCatalog(
     );
-    const preferredByStorageDir = new Map<
-      string,
-      { namespace: string; identityToken: string; storageDir: string }
-    >();
-    for (const record of compactedByNamespace.values()) {
-      if (!this.storageDirMatchesNamespaceHint(record.namespace, record.storageDir)) {
-        continue;
-      }
-      const resolvedStorageDir = path.resolve(record.storageDir);
-      const current = preferredByStorageDir.get(resolvedStorageDir);
-      preferredByStorageDir.set(
-        resolvedStorageDir,
-        current
-          ? this.preferNamespaceStorageDirHintOwner(
-              current,
-              record,
-              resolvedStorageDir,
-              configured,
-            )
-          : record,
-      );
-    }
-    for (const record of preferredByStorageDir.values()) {
-      this.rememberNamespaceStorageDirHint(record.namespace, record.storageDir);
-    }
   }
 
   private async maintenanceNamespaces(
@@ -1416,68 +1337,9 @@ export class Orchestrator {
     searchOptions?: SearchQueryOptions;
     execution?: SearchExecutionOptions;
   }): Promise<QmdSearchResult[]> {
-    if (
-      resolveNamespaceCapabilities(this.config).namespaces &&
-      options.namespaces !== undefined &&
-      options.namespaces.length === 0
-    ) {
-      return [];
-    }
-    const namespaces = resolveNamespaceCapabilities(this.config).namespaces
-      ? Array.from(
-          new Set(
-            (options.namespaces?.length
-              ? options.namespaces
-              : this.configuredNamespaceList()
-            )
-              .map((value) => value.trim())
-              .filter(Boolean),
-          ),
-        )
-      : [this.config.defaultNamespace];
-
-    if (!resolveNamespaceCapabilities(this.config).namespaces) {
-      switch (options.mode) {
-        case "hybrid":
-          return await this.qmd.hybridSearch(
-            options.query,
-            undefined,
-            options.maxResults,
-            options.execution,
-          );
-        case "bm25":
-          return await this.qmd.bm25Search(
-            options.query,
-            undefined,
-            options.maxResults,
-            options.execution,
-          );
-        case "vector":
-          return await this.qmd.vectorSearch(
-            options.query,
-            undefined,
-            options.maxResults,
-            options.execution,
-          );
-        default:
-          return await this.qmd.search(
-            options.query,
-            undefined,
-            options.maxResults,
-            options.searchOptions,
-            options.execution,
-          );
-      }
-    }
-
-    return await this.namespaceSearchRouter.searchAcrossNamespaces({
-      query: options.query,
-      namespaces,
-      maxResults: options.maxResults,
-      mode: options.mode,
-      searchOptions: options.searchOptions,
-      execution: options.execution,
-    });
+    return this.namespaceReadFanoutCoordinator.searchAcrossNamespaces(
+      options,
+    );
   }
 
   async searchHealthForNamespace(
@@ -2024,92 +1886,10 @@ export class Orchestrator {
     storage: StorageManager,
     sourceIds: string[],
   ): Promise<Map<string, "active" | "superseded" | "archived" | "missing">> {
-    const currentStatusVersion = storage.getMemoryStatusVersion();
-    const cached = this.artifactSourceStatusCache.get(storage);
-    let snapshot = cached;
-    const isFresh =
-      snapshot !== undefined &&
-      Date.now() - snapshot.loadedAtMs <=
-        Orchestrator.ARTIFACT_STATUS_CACHE_TTL_MS &&
-      snapshot.statusVersion === currentStatusVersion;
-
-    const rebuildSnapshot = async () => {
-      const MAX_STABLE_READ_ATTEMPTS = 3;
-      let latestStatuses = new Map<
-        string,
-        "active" | "superseded" | "archived" | "missing"
-      >();
-      let latestVersionAfter = storage.getMemoryStatusVersion();
-
-      for (let attempt = 0; attempt < MAX_STABLE_READ_ATTEMPTS; attempt += 1) {
-        const versionBefore = storage.getMemoryStatusVersion();
-        const allMemories = await storage.readAllMemories();
-        const versionAfter = storage.getMemoryStatusVersion();
-        latestVersionAfter = versionAfter;
-        latestStatuses = new Map(
-          allMemories.map((m) => [
-            m.frontmatter.id,
-            (m.frontmatter.status ?? "active") as
-              | "active"
-              | "superseded"
-              | "archived"
-              | "missing",
-          ]),
-        );
-
-        if (versionAfter === versionBefore) {
-          const rebuilt = {
-            loadedAtMs: Date.now(),
-            statusVersion: versionAfter,
-            statuses: latestStatuses,
-          };
-          this.artifactSourceStatusCache.set(storage, rebuilt);
-          return rebuilt;
-        }
-      }
-
-      // Sustained write churn: return latest read without caching a potentially torn snapshot.
-      return {
-        loadedAtMs: Date.now(),
-        statusVersion: latestVersionAfter,
-        statuses: latestStatuses,
-      };
-    };
-
-    if (!isFresh) {
-      snapshot = await rebuildSnapshot();
-    } else {
-      // Warm cache may miss brand-new sourceMemoryId values created after snapshot build.
-      // Refresh once on-demand when unseen IDs are requested.
-      const hasUnknownSourceIds = sourceIds.some(
-        (id) => !snapshot?.statuses.has(id),
-      );
-      if (hasUnknownSourceIds) {
-        snapshot = await rebuildSnapshot();
-      }
-    }
-
-    // Persist negative lookups in the cached snapshot so stale source IDs do not
-    // trigger repeated full snapshot rebuilds on every matching recall.
-    for (const id of sourceIds) {
-      if (!snapshot?.statuses.has(id)) {
-        snapshot?.statuses.set(id, "missing");
-      }
-    }
-
-    const statuses = new Map<
-      string,
-      "active" | "superseded" | "archived" | "missing"
-    >();
-    for (const id of sourceIds) {
-      const status = snapshot?.statuses.get(id);
-      if (status) {
-        statuses.set(id, status);
-      } else {
-        statuses.set(id, "missing");
-      }
-    }
-    return statuses;
+    return this.namespaceReadFanoutCoordinator.resolveArtifactSourceStatuses(
+      storage,
+      sourceIds,
+    );
   }
 
   /**
@@ -2931,15 +2711,11 @@ export class Orchestrator {
     recallNamespaces: string[],
     targetCount: number,
   ): Promise<MemoryFile[]> {
-    if (targetCount <= 0) return [];
-    const namespaces = Array.from(new Set(recallNamespaces));
-    const filteredByNamespace = await Promise.all(
-      namespaces.map((namespace) =>
-        this.fetchActiveArtifactsForNamespace(namespace, prompt, targetCount),
-      ),
+    return this.namespaceReadFanoutCoordinator.recallArtifactsAcrossNamespaces(
+      prompt,
+      recallNamespaces,
+      targetCount,
     );
-
-    return mergeArtifactRecallCandidates(filteredByNamespace, targetCount);
   }
 
   private scopeQueryAwarePaths(
@@ -2979,51 +2755,12 @@ export class Orchestrator {
       allowArchived?: boolean;
     },
   ): Promise<QmdSearchResult[]> {
-    const cappedLimit = Math.max(0, limit);
-    if (cappedLimit === 0 || candidatePaths.size === 0) return [];
-
-    const tokens = Array.from(new Set(tokenizeRecallQuery(query)));
-    const memories = (
-      await Promise.all(
-        Array.from(candidatePaths).map(async (memoryPath) => {
-          const namespace = resolveNamespaceCapabilities(this.config).namespaces
-            ? this.namespaceFromPath(memoryPath)
-            : this.config.defaultNamespace;
-          const storage = await this.storageRouter.storageFor(namespace);
-          return await storage.readMemoryByPath(memoryPath);
-        }),
-      )
-    ).filter((memory): memory is MemoryFile => memory !== null);
-
-    const results: QmdSearchResult[] = [];
-    for (const memory of memories) {
-      const status = memory.frontmatter.status ?? "active";
-      if (!options?.allowArchived && status !== "active") continue;
-
-      const haystack = [
-        memory.content,
-        memory.frontmatter.category,
-        ...(memory.frontmatter.tags ?? []),
-      ]
-        .join(" ")
-        .toLowerCase();
-      let hits = 0;
-      for (const token of tokens) {
-        if (haystack.includes(token)) hits += 1;
-      }
-      const score = tokens.length > 0 ? hits / tokens.length : 0.01;
-      if (tokens.length > 0 && hits === 0) continue;
-
-      results.push({
-        docid: memory.frontmatter.id,
-        path: memory.path,
-        score,
-        snippet: memory.content.slice(0, 400).replace(/\n/g, " "),
-        transport: "scoped_prefilter",
-      });
-    }
-
-    return results.sort((a, b) => b.score - a.score).slice(0, cappedLimit);
+    return this.namespaceReadFanoutCoordinator.searchScopedMemoryCandidates(
+      candidatePaths,
+      query,
+      limit,
+      options,
+    );
   }
 
   private async fetchQmdMemoryResultsWithArtifactTopUp(
@@ -3117,26 +2854,9 @@ export class Orchestrator {
   private async resolveStateDirForNamespace(
     namespace: string,
   ): Promise<string> {
-    if (!resolveNamespaceCapabilities(this.config).namespaces) {
-      return path.join(this.config.memoryDir, "state");
-    }
-    if (namespace !== this.config.defaultNamespace) {
-      return path.join(this.config.memoryDir, "namespaces", namespace, "state");
-    }
-    const candidate = path.join(
-      this.config.memoryDir,
-      "namespaces",
-      this.config.defaultNamespace,
+    return this.namespaceReadFanoutCoordinator.resolveStateDirForNamespace(
+      namespace,
     );
-    try {
-      const candidateStat = await stat(candidate);
-      if (candidateStat.isDirectory()) {
-        return path.join(candidate, "state");
-      }
-    } catch {
-      // Fall back to the legacy root when the migrated default namespace directory is absent.
-    }
-    return path.join(this.config.memoryDir, "state");
   }
 
   private buildGraphRecallRankedResults(
@@ -3582,6 +3302,41 @@ export class Orchestrator {
       });
     }
     return this._workspaceOpsCoordinator;
+  }
+
+  /**
+   * Namespace read-fanout coordinator (issue #1526 seam 26). Owns
+   * namespace-scoped read fanout (hints, cross-namespace search/reads,
+   * artifact statuses). Lazy + accessor-wired (late-binding rule).
+   */
+  private _namespaceReadFanoutCoordinator: NamespaceReadFanoutCoordinator | undefined;
+
+  private get namespaceReadFanoutCoordinator(): NamespaceReadFanoutCoordinator {
+    if (!this._namespaceReadFanoutCoordinator) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
+      this._namespaceReadFanoutCoordinator = new NamespaceReadFanoutCoordinator({
+        get artifactSourceStatusCache() { return self.artifactSourceStatusCache; },
+        get config() { return self.config; },
+        configuredNamespaceList: () => self.configuredNamespaceList(),
+        fetchActiveArtifactsForNamespace: (namespace, prompt, targetCount) => self.fetchActiveArtifactsForNamespace(namespace, prompt, targetCount),
+        loadNamespaceStorageDirHintsFromCatalog: () => self.loadNamespaceStorageDirHintsFromCatalog(),
+        get namespaceCatalog() { return self.namespaceCatalog; },
+        namespaceFromPath: (p) => self.namespaceFromPath(p),
+        get namespaceSearchRouter() { return self.namespaceSearchRouter; },
+        namespaceStorageDirHintOwnershipRank: (record, resolvedStorageDir, configured) => self.namespaceStorageDirHintOwnershipRank(record, resolvedStorageDir, configured),
+        get namespaceStorageDirHints() { return self.namespaceStorageDirHints; },
+        get namespaceStorageDirHintsLoaded() { return self.namespaceStorageDirHintsLoaded; },
+        set namespaceStorageDirHintsLoaded(value) { self.namespaceStorageDirHintsLoaded = value; },
+        preferNamespaceStorageDirHintOwner: (current, candidate, resolvedStorageDir, configured) => self.preferNamespaceStorageDirHintOwner(current, candidate, resolvedStorageDir, configured),
+        get qmd() { return self.qmd; },
+        qmdCollectionNamespaceFromPrefix: (collectionPrefix) => self.qmdCollectionNamespaceFromPrefix(collectionPrefix),
+        rememberNamespaceStorageDirHint: (namespace, storageDir) => self.rememberNamespaceStorageDirHint(namespace, storageDir),
+        storageDirMatchesNamespaceHint: (namespace, storageDir) => self.storageDirMatchesNamespaceHint(namespace, storageDir),
+        get storageRouter() { return self.storageRouter; },
+      });
+    }
+    return this._namespaceReadFanoutCoordinator;
   }
 
   private async recallInternal(
@@ -4790,29 +4545,15 @@ export class Orchestrator {
   }
 
   private namespaceFromPath(p: string): string {
-    if (!resolveNamespaceCapabilities(this.config).namespaces) return this.config.defaultNamespace;
-    const parts = qmdCollectionPathParts(p);
-    const collectionNamespace = parts
-      ? this.qmdCollectionNamespaceFromPrefix(parts.collection)
-      : null;
-    if (collectionNamespace) return collectionNamespace;
-    const m = p.match(/[\\/]+namespaces[\\/]+([^\\/]+)(?:[\\/]|$)/);
-    if (!m?.[1]) return this.config.defaultNamespace;
-    return namespaceIdentityFromToken(m[1]) ?? m[1];
+    return this.namespaceReadFanoutCoordinator.namespaceFromPath(
+      p,
+    );
   }
 
   private storageDirNamespace(storageDir: string): string {
-    // #1521: delegates to the scope-module resolver. The inline dir→namespace
-    // derivation (token round-trip guard, catalog hints) is retired so the
-    // adHocNamespaceResolutions ratchet no longer counts this site. Hints are
-    // loaded lazily via the callback (only after early returns, matching the
-    // original behavior — codex P2).
-    return resolveNamespaceFromStorageDir(storageDir, {
-      config: this.config,
-      configuredNamespaces: this.configuredNamespaceList(),
-      hints: this.namespaceStorageDirHints,
-      loadHints: () => this.loadNamespaceStorageDirHintsFromCatalog(),
-    });
+    return this.namespaceReadFanoutCoordinator.storageDirNamespace(
+      storageDir,
+    );
   }
 
   // #1522: catalog touch methods removed — touches now happen at the storage chokepoint.
@@ -4838,26 +4579,16 @@ export class Orchestrator {
   private async readAllMemoriesForNamespaces(
     namespaces: string[],
   ): Promise<MemoryFile[]> {
-    const uniq = Array.from(new Set(namespaces.filter(Boolean)));
-    const lists = await Promise.all(
-      uniq.map(async (ns) => {
-        const sm = await this.storageRouter.storageFor(ns);
-        return sm.readAllMemories();
-      }),
+    return this.namespaceReadFanoutCoordinator.readAllMemoriesForNamespaces(
+      namespaces,
     );
-    return lists.flat();
   }
 
   private async readArchivedMemoriesForNamespaces(
     namespaces: string[],
   ): Promise<MemoryFile[]> {
-    const uniq = Array.from(new Set(namespaces.filter(Boolean)));
-    const lists = await Promise.all(
-      uniq.map(async (ns) => {
-        const sm = await this.storageRouter.storageFor(ns);
-        return sm.readArchivedMemories();
-      }),
+    return this.namespaceReadFanoutCoordinator.readArchivedMemoriesForNamespaces(
+      namespaces,
     );
-    return lists.flat();
   }
 }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 4864,
+      "packages/remnic-core/src/orchestrator.ts": 4595,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 9039,
       "packages/remnic-core/src/storage.ts": 7747,


### PR DESCRIPTION
Part of #1526. Seam 26.

Behavior-preserving move of the namespace-scoped READ fanout (401 LOC, 11 methods, 17 deps): storage-dir hint loading (catalog), cross-namespace search + memory/archive reads, scoped candidate search, artifact recall fanout, artifact source-status resolution (with its WeakMap cache), path/storage-dir→namespace mapping. Namespace RESOLUTION stays with the #1521 ScopePlan resolver — this coordinator only fans reads out. `ARTIFACT_STATUS_CACHE_TTL_MS` static widened from private.

orchestrator.ts: 4,864 → 4,594 LOC. Ratchet updated.

Verification: tsc clean; entity-hardening 246/246; orchestrator-graph-namespace + artifact-cache + entity-alias-isolation + recall-no-recall-short-circuit: 34/34; preflight:quick OK.

Chokepoints used: ScopePlan untouched (resolution stays at the #1521 chokepoint); otherwise n/a.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall/search, multi-namespace reads, and artifact status caching on hot paths; risk is mitigated by a move-only refactor with existing tests, but regressions would affect memory recall behavior.
> 
> **Overview**
> Introduces **`NamespaceReadFanoutCoordinator`** (`namespace-read-fanout.ts`) and moves namespace-scoped **read fanout** out of `orchestrator.ts` (seam 26, #1526). The orchestrator keeps thin wrappers and wires the coordinator lazily via a **`NamespaceReadFanoutDeps`** accessor bundle.
> 
> The coordinator now owns catalog **storage-dir hint** loading, **cross-namespace search** (QMD vs `NamespaceSearchRouter`), **artifact source status** resolution with the existing per-`StorageManager` WeakMap cache, **artifact recall** fanout, **scoped memory candidate** search, **path/storage-dir→namespace** helpers, per-namespace **state dir** resolution, and **read all / archived** memory fanout. **Namespace resolution** for storage dirs still goes through **`resolveNamespaceFromStorageDir`** (#1521); this PR does not change that chokepoint.
> 
> `Orchestrator.ARTIFACT_STATUS_CACHE_TTL_MS` is widened from `private` to `static` so the coordinator can read the TTL. **`scripts/ratchet-baseline.json`** drops `orchestrator.ts` watchlist LOC (~4,864 → ~4,595).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ae92bbe7b6d61b644399dfa6d3650a32df3a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->