### PR TITLE
fix(connector-omi): support Developer API key flow

### DIFF
--- a/docs/wearables.md
+++ b/docs/wearables.md
@@ -206,9 +206,7 @@ is `off`.
         "baseUrl": "http://127.0.0.1:8787"   // bee proxy (default)
       },
       "omi": {
-        "enabled": true,
-        "appId": "your-omi-app-id",
-        "userId": "your-omi-uid"
+        "enabled": true
       }
     }
   }
@@ -341,14 +339,19 @@ on the next QMD update after a sync (the sync triggers one).
 
 ### Omi (`@remnic/connector-omi`)
 
-- Auth: create an app with the External Integration capabilities
-  (`read_conversations`, `read_memories`) in the Omi app, generate an
-  `sk_...` API key, and configure `appId` + `userId` (your uid).
+- Auth: create a Developer API key in the Omi app under **Settings →
+  Developer → Create Key** and provide it via `REMNIC_OMI_API_KEY`,
+  `OMI_API_KEY`, or `apiKey`.
+- The current Developer API needs only that `omi_dev_...` key. Legacy
+  External Integration app installs remain supported when both `appId`
+  and `userId` are configured.
 - Conversations are fetched with full transcripts
-  (`max_transcript_segments=-1` — the API default silently truncates
-  to 100 segments otherwise) and completed status.
-- Segments carry `is_user` for the wearer plus `SPEAKER_NN` labels and
-  optional person ids; map labels via the speaker registry.
+  (`include_transcript=true`). Legacy integration mode also passes
+  `max_transcript_segments=-1` because that API default silently
+  truncates to 100 segments otherwise.
+- Developer API segments carry `speaker_name` and `speaker_id`; legacy
+  segments may carry `is_user`, `SPEAKER_NN` labels, and optional
+  person ids. Map labels via the speaker registry.
 - `importNativeMemories: "review"` imports Omi's "memories" (its
   extracted facts) into the review queue.
 

--- a/packages/connector-omi/README.md
+++ b/packages/connector-omi/README.md
@@ -16,17 +16,11 @@ Remnic discovers it at runtime. No further registration is needed.
 
 ## Setup
 
-The connector uses Omi's Integrations API, which is scoped to an app
-you create:
+The connector uses Omi's Developer API by default:
 
-1. In the Omi app: **Apps → Create App → External Integration**, and
-   grant the **read conversations** capability (plus **read memories**
-   if you want native-memory import). Install/enable the app for your
-   account.
-2. On the app's management page, create an **API key** (`sk_...`).
-3. Note your **app id** and your **uid** (Omi passes `?uid=` to your
-   app's links; it identifies the account to read).
-4. Configure:
+1. In the Omi app, open **Settings → Developer → Create Key**.
+2. Create a Developer API key (`omi_dev_...`).
+3. Configure:
 
 ```jsonc
 {
@@ -35,8 +29,6 @@ you create:
     "sources": {
       "omi": {
         "enabled": true,
-        "appId": "your-omi-app-id",
-        "userId": "your-omi-uid",
         "memoryMode": "smart",             // smart (default) | off | review | auto
         "importNativeMemories": "smart"    // Omi memories through the same trust pipeline
       }
@@ -46,7 +38,12 @@ you create:
 ```
 
 Provide the key via `OMI_API_KEY` (or `REMNIC_OMI_API_KEY`, or `apiKey`
-in config).
+in config). No app id or uid is needed for the current Developer API.
+
+Legacy External Integration app installs remain supported. If you are
+still using that older flow, configure both `appId` and `userId`; when
+both are present the connector uses Omi's app-scoped integration
+endpoints.
 
 ## Usage
 
@@ -58,9 +55,10 @@ remnic wearables transcript --date 2026-06-10 --source omi
 
 ## Speaker labels
 
-Omi marks the wearer (`is_user`) automatically. Other voices arrive as
-`SPEAKER_NN` diarization labels — or stable person ids once you tag
-people in Omi. Map either form to a display name once:
+Omi Developer API segments carry `speaker_name` and `speaker_id`.
+Legacy integration segments may mark the wearer (`is_user`) and use
+`SPEAKER_NN` diarization labels or stable person ids once you tag
+people in Omi. Map any speaker key to a display name once:
 
 ```bash
 remnic wearables speakers set omi SPEAKER_01 "Jane Doe"
@@ -68,9 +66,10 @@ remnic wearables speakers set omi SPEAKER_01 "Jane Doe"
 
 ## Notes
 
-- Transcripts are fetched **unabridged**: the connector passes
-  `max_transcript_segments=-1` because the API's default silently
-  truncates conversations to their first 100 segments.
+- Transcripts are fetched with `include_transcript=true`. In legacy
+  integration mode, the connector also passes `max_transcript_segments=-1`
+  because that API's default silently truncates conversations to their
+  first 100 segments.
 - Day windows are timezone-correct: the connector computes local-day
   ISO bounds (DST-aware) for the API's `start_date`/`end_date` filters,
   and only `completed`, non-discarded conversations sync.

--- a/packages/connector-omi/package.json
+++ b/packages/connector-omi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remnic/connector-omi",
   "version": "9.3.752",
-  "description": "Omi AI wearable connector for Remnic — pull, clean, and remember necklace transcripts via the Omi Integrations API",
+  "description": "Omi AI wearable connector for Remnic — pull, clean, and remember necklace transcripts via the Omi Developer API",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/connector-omi/src/client.test.ts
+++ b/packages/connector-omi/src/client.test.ts
@@ -14,13 +14,12 @@ function jsonResponse(payload: unknown, status = 200): Response {
 
 function makeClient(
   responses: Array<Response | Error>,
+  options: Partial<ConstructorParameters<typeof OmiClient>[0]> = {},
 ): { client: OmiClient; calls: FetchCall[]; sleeps: number[] } {
   const calls: FetchCall[] = [];
   const sleeps: number[] = [];
   const client = new OmiClient({
-    apiKey: "sk_synthetic_not_real",
-    appId: "app-123",
-    userId: "uid-456",
+    apiKey: "omi_dev_synthetic_not_real",
     fetchImpl: (async (
       input: Parameters<typeof fetch>[0],
       init?: Parameters<typeof fetch>[1],
@@ -39,29 +38,25 @@ function makeClient(
     sleep: async (ms) => {
       sleeps.push(ms);
     },
+    ...options,
   });
   return { client, calls, sleeps };
 }
 
-test("constructor demands key, appId, and userId with actionable messages", () => {
+test("constructor demands a key and rejects partial legacy credentials", () => {
+  assert.throws(() => new OmiClient({ apiKey: "" }), /OMI_API_KEY/);
   assert.throws(
-    () => new OmiClient({ apiKey: "", appId: "a", userId: "u" }),
-    /OMI_API_KEY/,
+    () => new OmiClient({ apiKey: "omi_dev_x", appId: "app-123" }),
+    /both.*appId.*userId|userId.*both/s,
   );
   assert.throws(
-    () => new OmiClient({ apiKey: "sk_x", appId: " ", userId: "u" }),
-    /appId/,
-  );
-  assert.throws(
-    () => new OmiClient({ apiKey: "sk_x", appId: "a", userId: "" }),
-    /userId/,
+    () => new OmiClient({ apiKey: "omi_dev_x", userId: "uid-456" }),
+    /both.*appId.*userId|appId.*both/s,
   );
 });
 
-test("listConversations sends uid, day bounds, repeated statuses, and unlimited segments", async () => {
-  const { client, calls } = makeClient([
-    jsonResponse({ conversations: [] }),
-  ]);
+test("listConversations uses the Developer API with transcripts included", async () => {
+  const { client, calls } = makeClient([jsonResponse([])]);
   const page = await client.listConversations({
     startIso: "2026-06-10T00:00:00-05:00",
     endIso: "2026-06-11T00:00:00-05:00",
@@ -69,25 +64,41 @@ test("listConversations sends uid, day bounds, repeated statuses, and unlimited 
   assert.equal(page.conversations.length, 0);
   assert.equal(page.nextOffset, null);
   const url = new URL(calls[0].url);
-  assert.equal(url.pathname, "/v2/integrations/app-123/conversations");
-  assert.equal(url.searchParams.get("uid"), "uid-456");
+  assert.equal(url.pathname, "/v1/dev/user/conversations");
   assert.equal(url.searchParams.get("start_date"), "2026-06-10T00:00:00-05:00");
   assert.equal(url.searchParams.get("end_date"), "2026-06-11T00:00:00-05:00");
+  assert.equal(url.searchParams.get("include_transcript"), "true");
+  assert.equal(url.searchParams.get("limit"), "100");
+  assert.equal(url.searchParams.get("uid"), null);
+  assert.equal(calls[0].headers.Authorization, "Bearer omi_dev_synthetic_not_real");
+});
+
+test("legacy integration mode sends uid, repeated statuses, and unlimited segments", async () => {
+  const { client, calls } = makeClient([jsonResponse({ conversations: [] })], {
+    apiKey: "sk_synthetic_not_real",
+    appId: "app-123",
+    userId: "uid-456",
+  });
+  const page = await client.listConversations({
+    startIso: "2026-06-10T00:00:00-05:00",
+    endIso: "2026-06-11T00:00:00-05:00",
+  });
+  assert.equal(page.conversations.length, 0);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/v2/integrations/app-123/conversations");
+  assert.equal(url.searchParams.get("uid"), "uid-456");
   assert.equal(url.searchParams.get("max_transcript_segments"), "-1");
   assert.equal(url.searchParams.get("include_discarded"), "false");
   assert.deepEqual(url.searchParams.getAll("statuses"), ["completed"]);
-  assert.equal(calls[0].headers.Authorization, "Bearer sk_synthetic_not_real");
 });
 
 test("offset pagination advances only on full pages", async () => {
-  const fullPage = {
-    conversations: Array.from({ length: 100 }, (_, index) => ({
-      id: `c${index}`,
-    })),
-  };
+  const fullPage = Array.from({ length: 100 }, (_, index) => ({
+    id: `c${index}`,
+  }));
   const { client } = makeClient([
     jsonResponse(fullPage),
-    jsonResponse({ conversations: [{ id: "last" }] }),
+    jsonResponse([{ id: "last" }]),
   ]);
   const first = await client.listConversations({
     startIso: "2026-06-10T00:00:00Z",
@@ -102,18 +113,84 @@ test("offset pagination advances only on full pages", async () => {
   assert.equal(second.nextOffset, null);
 });
 
-test("listMemories paginates with uid and validates the envelope", async () => {
-  const { client, calls } = makeClient([
-    jsonResponse({ memories: [{ id: "m1", content: "User likes tea." }] }),
+test("listConversations keeps Remnic day windows half-open", async () => {
+  const { client } = makeClient([
+    jsonResponse([
+      { id: "inside", started_at: "2026-06-10T23:59:59.999-05:00" },
+      { id: "midnight", started_at: "2026-06-11T00:00:00-05:00" },
+    ]),
   ]);
+  const page = await client.listConversations({
+    startIso: "2026-06-10T00:00:00-05:00",
+    endIso: "2026-06-11T00:00:00-05:00",
+  });
+  assert.deepEqual(
+    page.conversations.map((conversation) => conversation.id),
+    ["inside"],
+  );
+});
+
+test("listConversations drops explicit non-completed statuses", async () => {
+  const { client } = makeClient([
+    jsonResponse([
+      { id: "statusless", started_at: "2026-06-10T12:00:00-05:00" },
+      {
+        id: "complete",
+        status: "completed",
+        started_at: "2026-06-10T13:00:00-05:00",
+      },
+      {
+        id: "in-progress",
+        status: "in_progress",
+        started_at: "2026-06-10T14:00:00-05:00",
+      },
+    ]),
+  ]);
+  const page = await client.listConversations({
+    startIso: "2026-06-10T00:00:00-05:00",
+    endIso: "2026-06-11T00:00:00-05:00",
+  });
+  assert.deepEqual(
+    page.conversations.map((conversation) => conversation.id),
+    ["statusless", "complete"],
+  );
+});
+
+test("listMemories uses Developer API arrays and validates shape", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse([{ id: "m1", content: "User likes tea." }]),
+  ]);
+  const page = await client.listMemories();
+  assert.equal(page.memories.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/v1/dev/user/memories");
+  assert.equal(url.searchParams.get("uid"), null);
+
+  const { client: badClient } = makeClient([jsonResponse({})]);
+  await assert.rejects(badClient.listMemories(), /unexpected memories shape/);
+});
+
+test("legacy listMemories paginates with uid and validates the envelope", async () => {
+  const { client, calls } = makeClient(
+    [jsonResponse({ memories: [{ id: "m1", content: "User likes tea." }] })],
+    {
+      apiKey: "sk_synthetic_not_real",
+      appId: "app-123",
+      userId: "uid-456",
+    },
+  );
   const page = await client.listMemories();
   assert.equal(page.memories.length, 1);
   const url = new URL(calls[0].url);
   assert.equal(url.pathname, "/v2/integrations/app-123/memories");
   assert.equal(url.searchParams.get("uid"), "uid-456");
 
-  const { client: badClient } = makeClient([jsonResponse({})]);
-  await assert.rejects(badClient.listMemories(), /unexpected memories shape/);
+  const { client: badClient } = makeClient([jsonResponse({})], {
+    apiKey: "sk_synthetic_not_real",
+    appId: "app-123",
+    userId: "uid-456",
+  });
+  await assert.rejects(badClient.listMemories(), /missing memories array/);
 });
 
 test("FastAPI detail strings surface in errors without leaking the key", async () => {
@@ -129,7 +206,7 @@ test("FastAPI detail strings surface in errors without leaking the key", async (
       err instanceof OmiApiError &&
       err.status === 403 &&
       err.detail === "App is not enabled for this user" &&
-      !err.message.includes("sk_synthetic_not_real"),
+      !err.message.includes("omi_dev_synthetic_not_real"),
   );
 });
 
@@ -140,7 +217,7 @@ test("retries 429 honoring Retry-After and 5xx with backoff", async () => {
       headers: { "Retry-After": "3" },
     }),
     jsonResponse({}, 502),
-    jsonResponse({ conversations: [] }),
+    jsonResponse([]),
   ]);
   const page = await client.listConversations({
     startIso: "2026-06-10T00:00:00Z",
@@ -170,16 +247,20 @@ test("verifyAuth maps the authorization chain to actionable detail", async () =>
     const result = await client.verifyAuth();
     assert.equal(result.ok, false);
     assert.match(result.detail ?? "", /Invalid API key/);
-    assert.match(result.detail ?? "", /read_conversations|not enabled|key rejected/);
+    assert.match(result.detail ?? "", /Developer API key rejected/);
   }
   {
-    const { client } = makeClient([jsonResponse({ detail: "not found" }, 404)]);
+    const { client } = makeClient([jsonResponse({ detail: "not found" }, 404)], {
+      apiKey: "sk_synthetic_not_real",
+      appId: "app-123",
+      userId: "uid-456",
+    });
     const result = await client.verifyAuth();
     assert.equal(result.ok, false);
     assert.match(result.detail ?? "", /appId/);
   }
   {
-    const { client } = makeClient([jsonResponse({ conversations: [] })]);
+    const { client } = makeClient([jsonResponse([])]);
     assert.deepEqual(await client.verifyAuth(), { ok: true });
   }
 });

--- a/packages/connector-omi/src/client.ts
+++ b/packages/connector-omi/src/client.ts
@@ -1,23 +1,19 @@
 /**
- * Minimal Omi Integrations API client (raw fetch, no SDK).
+ * Minimal Omi Developer API client (raw fetch, no SDK).
  *
- * Contract verified against docs.omi.me and the open-source backend
- * (`backend/routers/integration.py`, `models/integrations.py`) in
- * 2026-06:
+ * Current contract verified against docs.omi.me in 2026-07:
  *
- *  - base `https://api.omi.me`, auth `Authorization: Bearer sk_...`
- *    (an app API key created in the Omi app; the app needs the
- *    External Integration `read_conversations` / `read_memories`
- *    capabilities and must be enabled for the target user)
- *  - `uid` rides as a query parameter on every endpoint
- *  - `GET /v2/integrations/{app_id}/conversations` with
- *    `limit`/`offset` pagination, `start_date`/`end_date` (ISO 8601),
- *    repeated `statuses` params, and `max_transcript_segments=-1`
- *    (the API default silently truncates to the first 100 segments)
- *  - `GET /v2/integrations/{app_id}/memories` with `limit`/`offset`
- *  - responses serialize with exclude_none — every optional field may
- *    be entirely absent
+ *  - base `https://api.omi.me`, auth `Authorization: Bearer omi_dev_...`
+ *    (Developer API key from Settings → Developer → Create Key)
+ *  - `GET /v1/dev/user/conversations` with `limit`/`offset`
+ *    pagination, `start_date`/`end_date` (ISO 8601), and
+ *    `include_transcript=true`
+ *  - `GET /v1/dev/user/memories` with `limit`/`offset`
+ *  - responses are arrays; every optional field may be absent
  *  - errors are FastAPI-shaped `{"detail": "..."}`
+ *
+ * The older app-scoped Integrations API remains supported when both
+ * `appId` and `userId` are configured.
  *
  * The API key is never logged and never appears in thrown error
  * messages.
@@ -34,6 +30,8 @@ const PAGE_SIZE = 100;
 export interface OmiTranscriptSegment {
   text?: string;
   speaker?: string;
+  speaker_id?: number | string | null;
+  speaker_name?: string | null;
   is_user?: boolean;
   person_id?: string | null;
   start?: number;
@@ -77,13 +75,15 @@ export interface OmiMemoriesPage {
 
 export interface OmiClientOptions {
   apiKey: string;
-  appId: string;
-  userId: string;
+  appId?: string;
+  userId?: string;
   baseUrl?: string;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
   sleep?: (ms: number) => Promise<void>;
 }
+
+type OmiApiMode = "developer" | "integration";
 
 export class OmiApiError extends Error {
   constructor(
@@ -99,8 +99,9 @@ export class OmiApiError extends Error {
 
 export class OmiClient {
   private readonly apiKey: string;
-  private readonly appId: string;
-  private readonly userId: string;
+  private readonly appId?: string;
+  private readonly userId?: string;
+  private readonly mode: OmiApiMode;
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
@@ -110,25 +111,31 @@ export class OmiClient {
     if (typeof options.apiKey !== "string" || options.apiKey.trim().length === 0) {
       throw new OmiApiError(
         "Omi API key is missing. Set wearables.sources.omi.apiKey or the " +
-          "OMI_API_KEY environment variable (create a key under your app's " +
-          "API Keys in the Omi app).",
+          "OMI_API_KEY environment variable (create a Developer API key in " +
+          "Settings → Developer → Create Key in the Omi app).",
       );
     }
-    if (typeof options.appId !== "string" || options.appId.trim().length === 0) {
+
+    const appId =
+      typeof options.appId === "string" && options.appId.trim().length > 0
+        ? options.appId.trim()
+        : undefined;
+    const userId =
+      typeof options.userId === "string" && options.userId.trim().length > 0
+        ? options.userId.trim()
+        : undefined;
+    if ((appId === undefined) !== (userId === undefined)) {
       throw new OmiApiError(
-        "Omi app id is missing. Set wearables.sources.omi.appId to your " +
-          "integration app's id.",
+        "Omi legacy integration mode requires both wearables.sources.omi.appId " +
+          "and wearables.sources.omi.userId. Omit both to use the Developer " +
+          "API key-only process.",
       );
     }
-    if (typeof options.userId !== "string" || options.userId.trim().length === 0) {
-      throw new OmiApiError(
-        "Omi user id is missing. Set wearables.sources.omi.userId to the " +
-          "target uid (shown when the user installs/opens your Omi app).",
-      );
-    }
+
     this.apiKey = options.apiKey.trim();
-    this.appId = options.appId.trim();
-    this.userId = options.userId.trim();
+    this.appId = appId;
+    this.userId = userId;
+    this.mode = appId !== undefined && userId !== undefined ? "integration" : "developer";
     this.baseUrl = stripTrailingSlashes(options.baseUrl ?? OMI_DEFAULT_BASE_URL);
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -145,26 +152,40 @@ export class OmiClient {
   }): Promise<OmiConversationsPage> {
     const offset = params.offset ?? 0;
     const search = new URLSearchParams({
-      uid: this.userId,
       limit: String(PAGE_SIZE),
       offset: String(offset),
       start_date: params.startIso,
       end_date: params.endIso,
-      include_discarded: "false",
-      // -1 = unlimited; the API default silently truncates transcripts
-      // to their first 100 segments.
-      max_transcript_segments: "-1",
     });
-    // Repeated param (FastAPI List[str]) — comma-joining does NOT work.
-    search.append("statuses", "completed");
-    const payload = await this.requestJson(
-      `/v2/integrations/${encodeURIComponent(this.appId)}/conversations?${search.toString()}`,
-      params.signal,
-    );
-    const conversations = (payload as { conversations?: unknown }).conversations;
+    let payload: unknown;
+    if (this.mode === "developer") {
+      search.set("include_transcript", "true");
+      payload = await this.requestJson(
+        `/v1/dev/user/conversations?${search.toString()}`,
+        params.signal,
+      );
+    } else {
+      search.set("uid", this.userId ?? "");
+      search.set("include_discarded", "false");
+      // -1 = unlimited; the legacy API default silently truncates
+      // transcripts to their first 100 segments.
+      search.set("max_transcript_segments", "-1");
+      // Repeated param (FastAPI List[str]) — comma-joining does NOT work.
+      search.append("statuses", "completed");
+      payload = await this.requestJson(
+        `/v2/integrations/${encodeURIComponent(this.appId ?? "")}/conversations?${search.toString()}`,
+        params.signal,
+      );
+    }
+    const conversations =
+      this.mode === "developer"
+        ? payload
+        : (payload as { conversations?: unknown }).conversations;
     if (!Array.isArray(conversations)) {
       throw new OmiApiError(
-        "Omi API returned an unexpected conversations shape (missing conversations array)",
+        this.mode === "developer"
+          ? "Omi API returned an unexpected conversations shape (expected array)"
+          : "Omi API returned an unexpected conversations shape (missing conversations array)",
       );
     }
     const valid = conversations.filter(
@@ -172,7 +193,11 @@ export class OmiClient {
         entry !== null &&
         typeof entry === "object" &&
         typeof (entry as { id?: unknown }).id === "string",
-    );
+    )
+      .filter(isCompletedOrStatuslessConversation)
+      .filter((conversation) =>
+        startsInsideHalfOpenWindow(conversation, params.startIso, params.endIso),
+      );
     return {
       conversations: valid,
       nextOffset: conversations.length === PAGE_SIZE ? offset + PAGE_SIZE : null,
@@ -186,18 +211,29 @@ export class OmiClient {
   } = {}): Promise<OmiMemoriesPage> {
     const offset = params.offset ?? 0;
     const search = new URLSearchParams({
-      uid: this.userId,
       limit: String(PAGE_SIZE),
       offset: String(offset),
     });
-    const payload = await this.requestJson(
-      `/v2/integrations/${encodeURIComponent(this.appId)}/memories?${search.toString()}`,
-      params.signal,
-    );
-    const memories = (payload as { memories?: unknown }).memories;
+    let payload: unknown;
+    if (this.mode === "developer") {
+      payload = await this.requestJson(
+        `/v1/dev/user/memories?${search.toString()}`,
+        params.signal,
+      );
+    } else {
+      search.set("uid", this.userId ?? "");
+      payload = await this.requestJson(
+        `/v2/integrations/${encodeURIComponent(this.appId ?? "")}/memories?${search.toString()}`,
+        params.signal,
+      );
+    }
+    const memories =
+      this.mode === "developer" ? payload : (payload as { memories?: unknown }).memories;
     if (!Array.isArray(memories)) {
       throw new OmiApiError(
-        "Omi API returned an unexpected memories shape (missing memories array)",
+        this.mode === "developer"
+          ? "Omi API returned an unexpected memories shape (expected array)"
+          : "Omi API returned an unexpected memories shape (missing memories array)",
       );
     }
     const valid = memories.filter(
@@ -215,28 +251,40 @@ export class OmiClient {
   async verifyAuth(signal?: AbortSignal): Promise<{ ok: boolean; detail?: string }> {
     try {
       const search = new URLSearchParams({
-        uid: this.userId,
         limit: "1",
         offset: "0",
-        max_transcript_segments: "1",
       });
-      await this.requestJson(
-        `/v2/integrations/${encodeURIComponent(this.appId)}/conversations?${search.toString()}`,
-        signal,
-      );
+      if (this.mode === "developer") {
+        search.set("include_transcript", "false");
+        await this.requestJson(
+          `/v1/dev/user/conversations?${search.toString()}`,
+          signal,
+        );
+      } else {
+        search.set("uid", this.userId ?? "");
+        search.set("max_transcript_segments", "1");
+        await this.requestJson(
+          `/v2/integrations/${encodeURIComponent(this.appId ?? "")}/conversations?${search.toString()}`,
+          signal,
+        );
+      }
       return { ok: true };
     } catch (err) {
       if (err instanceof OmiApiError && err.status !== undefined) {
-        // The backend's authorization chain yields distinct, actionable
-        // detail strings: bad key (403), app not enabled for the user
-        // (403), missing capability (403), app not found (404).
+        // The auth chain yields distinct, actionable detail strings.
+        // Legacy integration mode can also surface app/user capability
+        // failures, so keep those hints mode-specific.
         const hint =
           err.status === 401
             ? "missing/malformed Authorization header"
             : err.status === 403
-              ? "key rejected, app not enabled for this uid, or missing read_conversations capability"
+              ? this.mode === "developer"
+                ? "Developer API key rejected or missing conversation access"
+                : "key rejected, app not enabled for this uid, or missing read_conversations capability"
               : err.status === 404
-                ? "app not found — check wearables.sources.omi.appId"
+                ? this.mode === "developer"
+                  ? "Developer API endpoint not found — check the configured baseUrl"
+                  : "app not found — check wearables.sources.omi.appId"
                 : undefined;
         return {
           ok: false,
@@ -328,6 +376,34 @@ function stripTrailingSlashes(value: string): string {
   let end = value.length;
   while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end--;
   return value.slice(0, end);
+}
+
+function startsInsideHalfOpenWindow(
+  conversation: OmiConversation,
+  startIso: string,
+  endIso: string,
+): boolean {
+  const startMs = Date.parse(startIso);
+  const endMs = Date.parse(endIso);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return true;
+
+  const conversationIso =
+    typeof conversation.started_at === "string"
+      ? conversation.started_at
+      : conversation.created_at;
+  if (typeof conversationIso !== "string" || conversationIso.length === 0) {
+    return true;
+  }
+  const conversationMs = Date.parse(conversationIso);
+  if (!Number.isFinite(conversationMs)) return true;
+  return conversationMs >= startMs && conversationMs < endMs;
+}
+
+function isCompletedOrStatuslessConversation(conversation: OmiConversation): boolean {
+  if (typeof conversation.status !== "string" || conversation.status.length === 0) {
+    return true;
+  }
+  return conversation.status === "completed";
 }
 
 async function readDetail(response: Response): Promise<string | undefined> {

--- a/packages/connector-omi/src/index.test.ts
+++ b/packages/connector-omi/src/index.test.ts
@@ -14,9 +14,7 @@ import {
 function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
   return {
     enabled: true,
-    apiKey: "sk_synthetic_not_real",
-    appId: "app-123",
-    userId: "uid-456",
+    apiKey: "omi_dev_synthetic_not_real",
     memoryMode: "review",
     sourceTrust: 0.8,
     autoApproveTrust: 0.7,
@@ -78,20 +76,26 @@ test("resolveOmiApiKey prefers config, then REMNIC_*, then provider env", () => 
 
 test("fetchConversations applies timezone day bounds and maps cursors to offsets", async () => {
   const stub = stubFetch((url) => {
+    assert.equal(url.pathname, "/v1/dev/user/conversations");
     assert.equal(url.searchParams.get("start_date"), "2026-06-10T00:00:00-05:00");
     assert.equal(url.searchParams.get("end_date"), "2026-06-11T00:00:00-05:00");
-    return {
-      conversations: [
-        {
-          id: "c1",
-          started_at: "2026-06-10T15:00:00+00:00",
-          transcript_segments: [
-            { text: "Planning the launch.", speaker: "SPEAKER_00", is_user: true, start: 0, end: 4 },
-          ],
-        },
-        { id: "c2", started_at: "2026-06-10T16:00:00+00:00", discarded: true },
-      ],
-    };
+    assert.equal(url.searchParams.get("include_transcript"), "true");
+    return [
+      {
+        id: "c1",
+        started_at: "2026-06-10T15:00:00+00:00",
+        transcript_segments: [
+          {
+            text: "Planning the launch.",
+            speaker_name: "Joshua",
+            speaker_id: 1,
+            start: 0,
+            end: 4,
+          },
+        ],
+      },
+      { id: "c2", started_at: "2026-06-10T16:00:00+00:00", discarded: true },
+    ];
   });
   try {
     const connector = createOmiConnector({
@@ -106,6 +110,27 @@ test("fetchConversations applies timezone day bounds and maps cursors to offsets
     assert.deepEqual(page.conversations.map((c) => c.id), ["c1"], "discarded filtered");
     assert.equal(page.nextCursor, null, "partial page ends pagination");
     assert.equal(stub.urls[0].searchParams.get("offset"), "200");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("fetchConversations preserves legacy app and uid configuration", async () => {
+  const stub = stubFetch((url) => {
+    assert.equal(url.pathname, "/v2/integrations/app-123/conversations");
+    assert.equal(url.searchParams.get("uid"), "uid-456");
+    assert.deepEqual(url.searchParams.getAll("statuses"), ["completed"]);
+    return { conversations: [] };
+  });
+  try {
+    const connector = createOmiConnector({
+      settings: settings({ appId: "app-123", userId: "uid-456" }),
+      timezone: "America/Chicago",
+    });
+    await connector.fetchConversations({
+      date: "2026-06-10",
+      timezone: "America/Chicago",
+    });
   } finally {
     stub.restore();
   }
@@ -132,12 +157,13 @@ test("missing credentials surface actionable errors at call time, not constructi
 });
 
 test("fetchNativeMemories maps Omi memories and skips empty content", async () => {
-  const stub = stubFetch(() => ({
-    memories: [
+  const stub = stubFetch((url) => {
+    assert.equal(url.pathname, "/v1/dev/user/memories");
+    return [
       { id: "m1", content: "User runs on Saturdays." },
       { id: "m2", content: "" },
-    ],
-  }));
+    ];
+  });
   try {
     const connector = createOmiConnector({ settings: settings(), timezone: "UTC" });
     assert.ok(connector.fetchNativeMemories, "omi connector must support native memories");

--- a/packages/connector-omi/src/index.ts
+++ b/packages/connector-omi/src/index.ts
@@ -4,12 +4,13 @@
  * À-la-carte optional companion of @remnic/core (computed-specifier
  * discovery; importing this module self-registers idempotently).
  *
- * Requires an Omi integration app with the External Integration
- * `read_conversations` (and, for native-memory import,
- * `read_memories`) capabilities:
- *   - `wearables.sources.omi.appId`  — the app id
- *   - `wearables.sources.omi.userId` — the target uid
+ * Requires an Omi Developer API key from Settings → Developer →
+ * Create Key:
  *   - key via `REMNIC_OMI_API_KEY` / `OMI_API_KEY` env (or `apiKey`)
+ *
+ * Legacy External Integration app installs remain supported when both
+ * `wearables.sources.omi.appId` and `wearables.sources.omi.userId`
+ * are configured.
  */
 
 import {

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -78,6 +78,27 @@ test("wearer keys as 'user'; known people key by person_id", () => {
   assert.equal(other.speakerName, "SPEAKER_01");
 });
 
+test("maps Developer API speaker_name and speaker_id segments", () => {
+  const conversation = conversationToWearable({
+    id: "omi-dev-1",
+    started_at: "2026-06-10T14:00:00+00:00",
+    transcript_segments: [
+      {
+        text: "The new Omi process is working.",
+        speaker_name: "Joshua",
+        speaker_id: 123,
+        start: 2,
+        end: 6,
+      },
+    ],
+  });
+  assert.equal(conversation.segments.length, 1);
+  assert.equal(conversation.segments[0].speakerName, "Joshua");
+  assert.equal(conversation.segments[0].speakerKey, "123");
+  assert.equal(conversation.segments[0].startIso, "2026-06-10T14:00:02.000Z");
+  assert.equal(conversation.segments[0].endIso, "2026-06-10T14:00:06.000Z");
+});
+
 test("tolerates absent optional fields (exclude_none serialization)", () => {
   const conversation = conversationToWearable({ id: "sparse-1" });
   assert.equal(conversation.segments.length, 0);

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -3,9 +3,11 @@
  * `WearableConversation` shape, plus the timezone-aware day-window
  * helpers the Omi API needs (its date filters are ISO datetimes).
  *
- * Omi segments carry `is_user` for the wearer, opaque `SPEAKER_NN`
- * diarization labels, optional `person_id`s (user-defined people), and
- * start/end offsets in seconds relative to the conversation start.
+ * Legacy Omi integration segments carry `is_user` for the wearer,
+ * opaque `SPEAKER_NN` diarization labels, optional `person_id`s
+ * (user-defined people), and start/end offsets in seconds relative to
+ * the conversation start. The current Developer API returns
+ * `speaker_name`/`speaker_id` instead; normalize both shapes.
  */
 
 import type {
@@ -78,10 +80,16 @@ export function conversationToWearable(
       typeof segment.person_id === "string" && segment.person_id.length > 0
         ? segment.person_id
         : undefined;
-    const label =
-      typeof segment.speaker === "string" && segment.speaker.trim().length > 0
-        ? segment.speaker.trim()
+    const speakerId =
+      typeof segment.speaker_id === "string" || typeof segment.speaker_id === "number"
+        ? String(segment.speaker_id)
         : undefined;
+    const label =
+      typeof segment.speaker_name === "string" && segment.speaker_name.trim().length > 0
+        ? segment.speaker_name.trim()
+        : typeof segment.speaker === "string" && segment.speaker.trim().length > 0
+          ? segment.speaker.trim()
+          : undefined;
     const startIso =
       !Number.isNaN(startedAtMs) && typeof segment.start === "number"
         ? new Date(startedAtMs + segment.start * 1_000).toISOString()
@@ -93,9 +101,10 @@ export function conversationToWearable(
     segments.push({
       text,
       // person_id is the most stable key when the user has tagged the
-      // speaker as a known person in Omi; the diarization label
-      // otherwise.
-      speakerKey: isWearer ? "user" : (personId ?? label ?? "unknown"),
+      // speaker as a known person in Omi. The Developer API's
+      // speaker_id is the next best stable key, then the diarization
+      // label.
+      speakerKey: isWearer ? "user" : (personId ?? speakerId ?? label ?? "unknown"),
       ...(label !== undefined ? { speakerName: label } : {}),
       ...(isWearer ? { isWearer: true } : {}),
       ...(startIso !== undefined ? { startIso } : {}),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live Omi API endpoints and credential rules for the default path; legacy integration remains but misconfiguration could break sync until keys are rotated.
> 
> **Overview**
> **Switches the Omi connector’s default setup to Omi’s Developer API** using only an `omi_dev_...` key (`REMNIC_OMI_API_KEY` / `OMI_API_KEY` / config `apiKey`). Config no longer requires `appId` and `userId` for the common path; wearables docs and `@remnic/connector-omi` README describe the new flow.
> 
> **`OmiClient` now runs in two modes.** Developer mode calls `GET /v1/dev/user/conversations` and `/memories` (array responses, `include_transcript=true` for conversations). When both `appId` and `userId` are set, it still uses the v2 integration endpoints with `uid`, `statuses=completed`, and `max_transcript_segments=-1`. Partial legacy credentials are rejected at construction.
> 
> **Developer-mode listing adds client-side guards** the integration API used to enforce via query params: conversations are limited to half-open local day windows, and non-`completed` statuses are dropped (missing status is still allowed). **Transcript normalization** maps Developer API `speaker_name` / `speaker_id` (preferring `speaker_id` for `speakerKey` after `person_id`) alongside legacy `is_user` / `SPEAKER_*` / `person_id`. Tests and package description are updated for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4585a369f38e44d9f7ba3a60f0023e43c64fdd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->