### PR TITLE
fix(config): preserve flat fallbacks in nested files

### DIFF
--- a/packages/remnic-cli/src/cli-command-surface.test.ts
+++ b/packages/remnic-cli/src/cli-command-surface.test.ts
@@ -241,6 +241,25 @@ test("doctor runs diagnostics and reports the Node.js version check", async () =
   assert.equal(result.exitCode, 0);
   assert.match(result.stdout, /Node\.js version/);
 });
+
+test("doctor reports malformed nested config without aborting diagnostics", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-doctor-invalid-config-"));
+  try {
+    fs.writeFileSync(
+      path.join(dir, "remnic.config.json"),
+      JSON.stringify({ remnic: [] }),
+      "utf8",
+    );
+
+    const result = await runCli(["doctor"], { cwd: dir });
+
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /Node\.js version/);
+    assert.match(result.stdout, /OPENAI_API_KEY: config parse failed/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 test("dedup against an empty memory dir reports zero duplicates", async () => {
   const result = await runCli(["dedup"]);
   assert.equal(result.exitCode, 0);

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -75,6 +75,30 @@ test("resolveMemoryDir expands home-relative env and config paths", async () => 
   }
 });
 
+test("resolveMemoryDir preserves flat fallback keys under a partial remnic block", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-memory-mixed-config-"));
+  try {
+    process.env.HOME = home;
+    delete process.env.REMNIC_MEMORY_DIR;
+    delete process.env.ENGRAM_MEMORY_DIR;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    process.env.REMNIC_CONFIG_PATH = path.join(home, "remnic.json");
+    await writeFile(
+      process.env.REMNIC_CONFIG_PATH,
+      JSON.stringify({
+        memoryDir: "${HOME}/configured-memory",
+        remnic: { wearables: { enabled: false } },
+        server: { principal: "fleet" },
+      }),
+    );
+
+    assert.equal(resolveMemoryDir(), path.join(home, "configured-memory"));
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
 test("resolveSyncSourceDir rejects bare source flags", () => {
   assert.equal(resolveSyncSourceDir([]), ".");
   assert.equal(resolveSyncSourceDir(["--source", "/tmp/source", "--json"]), "/tmp/source");

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5487,7 +5487,13 @@ async function cmdDoctor(): Promise<void> {
     }
   }
 
-  const memoryDir = resolveMemoryDir();
+  let memoryDir: string;
+  try {
+    memoryDir = resolveMemoryDir();
+  } catch {
+    // Doctor must keep running when the config it is diagnosing is malformed.
+    memoryDir = parseConfig({}).memoryDir;
+  }
   try {
     fs.mkdirSync(memoryDir, { recursive: true });
     checks.push({ name: "Memory directory", ok: true, detail: memoryDir });

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -44,6 +44,7 @@ import {
   parseConfig,
   isOpenaiApiKeyDisabled,
   resolveEnvVars,
+  resolveRemnicConfigRecord,
   Orchestrator,
   EngramAccessService,
   initLogger,
@@ -3903,7 +3904,7 @@ export function resolveMemoryDir(): string {
     const raw = fs.existsSync(configPath)
       ? JSON.parse(fs.readFileSync(configPath, "utf8"))
       : {};
-    const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+    const remnicCfg = resolveRemnicConfigRecord(raw);
     if (typeof remnicCfg.memoryDir === "string" && remnicCfg.memoryDir.length > 0) {
       return normalizeMemoryDirPath(remnicCfg.memoryDir);
     }
@@ -4456,7 +4457,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
@@ -4738,7 +4739,7 @@ async function cmdXray(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
@@ -4769,7 +4770,7 @@ async function cmdVersions(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   if (!config.versioningEnabled) {
@@ -4900,7 +4901,7 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   const subcommand = rest[0];
@@ -5212,7 +5213,7 @@ Shared with:
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   const memoryDir = expandTilde(
@@ -5236,7 +5237,7 @@ async function cmdExtensions(action: string, rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   const root = resolveExtensionsRoot(config);
@@ -5337,7 +5338,7 @@ async function cmdBriefing(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   if (!config.briefing.enabled) {
@@ -5478,12 +5479,8 @@ async function cmdDoctor(): Promise<void> {
   if (configExists) {
     try {
       const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      const remnicCfg = raw.remnic ?? raw.engram ?? raw;
-      standaloneOpenaiApiKeyExplicitlyFalse =
-        typeof remnicCfg === "object" &&
-        remnicCfg !== null &&
-        !Array.isArray(remnicCfg) &&
-        isOpenaiApiKeyDisabled((remnicCfg as Record<string, unknown>).openaiApiKey);
+      const remnicCfg = resolveRemnicConfigRecord(raw);
+      standaloneOpenaiApiKeyExplicitlyFalse = isOpenaiApiKeyDisabled(remnicCfg.openaiApiKey);
       standaloneConfig = parseConfig(remnicCfg);
     } catch (err) {
       standaloneConfigError = err instanceof Error ? err.message : String(err);
@@ -6070,7 +6067,7 @@ async function cmdReview(action: string, rest: string[]): Promise<void> {
       const rawCfg = fs.existsSync(configPath)
         ? JSON.parse(fs.readFileSync(configPath, "utf8"))
         : {};
-      const remnicCfg = rawCfg.remnic ?? rawCfg.engram ?? rawCfg;
+      const remnicCfg = resolveRemnicConfigRecord(rawCfg);
       const config = parseConfig(remnicCfg);
       tombstonesConfig = {
         enabled: config.tombstonesEnabled,
@@ -8595,7 +8592,7 @@ function resolveOfflineSyncUserExcludes(rest: string[]): RegExp[] {
     const raw = fs.existsSync(configPath)
       ? JSON.parse(fs.readFileSync(configPath, "utf8"))
       : {};
-    const remnicCfg = (raw.remnic ?? raw.engram ?? raw) as Record<string, unknown>;
+    const remnicCfg = resolveRemnicConfigRecord(raw);
     const configured = remnicCfg.offlineSyncExcludes;
     if (configured !== undefined && configured !== null) {
       if (!Array.isArray(configured)) {
@@ -9242,7 +9239,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     const raw = fs.existsSync(configPath)
       ? JSON.parse(fs.readFileSync(configPath, "utf8"))
       : {};
-    const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+    const remnicCfg = resolveRemnicConfigRecord(raw);
     const config = parseConfig(remnicCfg);
     const orchestrator = new Orchestrator(config);
     try {
@@ -9389,7 +9386,7 @@ async function cmdConnectorsMarketplace(
   // Unwrap the plugin-scoped config block (remnic or engram wrapper) so
   // parseConfig receives the correct inner object — same pattern used by
   // other CLI entrypoints (resolveMemoryDir, cmdBriefing, etc.).
-  const pluginConfig = rawConfig.remnic ?? rawConfig.engram ?? rawConfig;
+  const pluginConfig = resolveRemnicConfigRecord(rawConfig);
   const config = parseConfig(pluginConfig);
 
   if (subAction === "generate") {
@@ -9638,7 +9635,7 @@ async function cmdLegacyBenchmark(action: string, rest: string[], json: boolean)
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   const service = new EngramAccessService(orchestrator);
@@ -10400,7 +10397,7 @@ async function daemonStatus(): Promise<void> {
     const raw = fs.existsSync(configPath)
       ? JSON.parse(fs.readFileSync(configPath, "utf8"))
       : {};
-    const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+    const remnicCfg = resolveRemnicConfigRecord(raw);
     const config = parseConfig(remnicCfg);
     const extRoot = resolveExtensionsRoot(config);
     const noopLog = { warn: () => {}, debug: () => {} };
@@ -10632,7 +10629,7 @@ async function cmdBinary(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
   const memoryDir = resolveMemoryDir();
 
@@ -11155,7 +11152,7 @@ async function cmdTaxonomy(rest: string[]): Promise<void> {
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const remnicCfg = resolveRemnicConfigRecord(raw);
   const config = parseConfig(remnicCfg);
 
   if (!config.taxonomyEnabled) {
@@ -12175,12 +12172,7 @@ Other:
           const raw = fs.existsSync(configPath)
             ? JSON.parse(fs.readFileSync(configPath, "utf8"))
             : {};
-          const remnicCfg =
-            raw !== null && typeof raw === "object"
-              ? ((raw as Record<string, unknown>).remnic ??
-                (raw as Record<string, unknown>).engram ??
-                raw)
-              : {};
+          const remnicCfg = resolveRemnicConfigRecord(raw);
           const config = parseConfig(remnicCfg);
           wearablesOrchestrator = new Orchestrator(config);
           await wearablesOrchestrator.initialize();
@@ -12244,7 +12236,7 @@ Other:
           const raw = fs.existsSync(configPath)
             ? JSON.parse(fs.readFileSync(configPath, "utf8"))
             : {};
-          const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+          const remnicCfg = resolveRemnicConfigRecord(raw);
           const config = parseConfig(remnicCfg);
           orchestratorSingleton = new Orchestrator(config);
           await orchestratorSingleton.initialize();

--- a/packages/remnic-core/src/config-record.ts
+++ b/packages/remnic-core/src/config-record.ts
@@ -1,0 +1,25 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolve standalone config-file shapes into the core Remnic config record.
+ *
+ * Legacy files store core keys at the top level. During migration, a partial
+ * `remnic` or `engram` block may coexist with those keys. Flat top-level core
+ * keys remain fallbacks, while the selected nested block wins on key conflicts.
+ * Host-only blocks are never forwarded into core parsing.
+ */
+export function resolveRemnicConfigRecord(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) {
+    throw new Error("Top-level Remnic config must be a JSON object");
+  }
+
+  const { remnic, engram, server: _server, ...flat } = raw;
+  const nested = remnic ?? engram;
+  if (nested !== undefined && !isRecord(nested)) {
+    throw new Error("Nested remnic/engram config must be a JSON object");
+  }
+
+  return nested === undefined ? flat : { ...flat, ...nested };
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -27,6 +27,7 @@ export { resolvePluginEntry, type PluginEntryResolverOptions } from "./plugin-en
 // ---------------------------------------------------------------------------
 
 export { parseConfig, isOpenaiApiKeyDisabled, resolveEnvVars } from "./config.js";
+export { resolveRemnicConfigRecord } from "./config-record.js";
 export {
   parseFlexibleIsoTimestamp,
   parseIsoOffsetTimestamp,

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { loadConfigFile, mergeRemnicConfigForServer, parseServerConfig } from "./index.js";
+import { parseConfig } from "@remnic/core";
+import { createAdminControls, loadConfigFile, mergeRemnicConfigForServer, parseServerConfig } from "./index.js";
 
 async function writeConfig(content: string): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-config-"));
@@ -88,6 +89,57 @@ test("server config loader rejects non-object top-level JSON", async () => {
     } finally {
       await cleanup();
     }
+  }
+});
+
+test("server config loader merges partial remnic and engram blocks over legacy flat core keys", async () => {
+  for (const nestedKey of ["remnic", "engram"] as const) {
+    const { filePath, cleanup } = await writeConfig(JSON.stringify({
+      namespacesEnabled: true,
+      defaultNamespace: "generalist",
+      lcmEnabled: true,
+      wearables: { enabled: true, timezone: "America/Chicago" },
+      [nestedKey]: { wearables: { enabled: false } },
+      server: { principal: "fleet" },
+    }));
+    try {
+      const loaded = loadConfigFile(filePath);
+      assert.deepEqual(loaded.remnic, {
+        namespacesEnabled: true,
+        defaultNamespace: "generalist",
+        lcmEnabled: true,
+        wearables: { enabled: false },
+      });
+      assert.deepEqual(loaded.server, { principal: "fleet" });
+    } finally {
+      await cleanup();
+    }
+  }
+});
+
+test("admin null reset removes nested values and their flat fallbacks", async () => {
+  const { filePath, cleanup } = await writeConfig(JSON.stringify({
+    namespacesEnabled: true,
+    localLlmUrl: "http://127.0.0.1:1/v1",
+    remnic: { namespacesEnabled: false },
+    server: { adminConsoleEnabled: true },
+  }));
+  try {
+    const loaded = loadConfigFile(filePath);
+    const controls = createAdminControls(
+      filePath,
+      parseConfig(loaded.remnic),
+      parseServerConfig(loaded.server),
+    );
+
+    const status = await controls.update?.({ namespacesEnabled: null });
+    const written = JSON.parse(await readFile(filePath, "utf8"));
+
+    assert.equal(Object.hasOwn(written, "namespacesEnabled"), false);
+    assert.equal(Object.hasOwn(written.remnic, "namespacesEnabled"), false);
+    assert.equal(status?.config.values.namespacesEnabled, false);
+  } finally {
+    await cleanup();
   }
 });
 

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -14,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parseConfig, isOpenaiApiKeyDisabled, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
+import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -177,11 +177,11 @@ export function loadConfigFile(configPath: string): ServerConfig {
   if (!isPlainRecord(raw)) {
     throw new Error(`Invalid config file ${configPath}: top-level config must be a JSON object`);
   }
-  const remnic = requirePlainConfigBlock(raw, "remnic", configPath);
-  const engram = requirePlainConfigBlock(raw, "engram", configPath);
+  requirePlainConfigBlock(raw, "remnic", configPath);
+  requirePlainConfigBlock(raw, "engram", configPath);
   const server = requirePlainConfigBlock(raw, "server", configPath);
   return {
-    remnic: remnic ?? engram ?? raw,
+    remnic: resolveRemnicConfigRecord(raw),
     server: server ?? {},
   };
 }
@@ -606,7 +606,7 @@ function dashboardFeatures(config: PluginConfig) {
   }));
 }
 
-function createAdminControls(
+export function createAdminControls(
   configPath: string,
   config: PluginConfig,
   serverConfig: ParsedServerConfig,
@@ -649,17 +649,13 @@ function createAdminControls(
       for (const [key, value] of normalizedEntries) {
         if (value === null) {
           delete target[key];
+          if (target !== raw) delete raw[key];
         } else {
           target[key] = value;
         }
       }
 
-      const candidateRemnic = isPlainRecord(raw.remnic)
-        ? raw.remnic
-        : isPlainRecord(raw.engram)
-          ? raw.engram
-          : raw;
-      const nextDisplayConfig = parseConfig(candidateRemnic);
+      const nextDisplayConfig = parseConfig(resolveRemnicConfigRecord(raw));
 
       writeConfigFileAtomically(configPath, raw);
       displayConfig = nextDisplayConfig;

--- a/tests/openclaw-doctor-checks.test.ts
+++ b/tests/openclaw-doctor-checks.test.ts
@@ -182,7 +182,7 @@ test("doctor: OPENAI_API_KEY optionality is scoped to the active runtime mode", 
   );
   assert.ok(
     src.includes("isOpenaiApiKeyDisabled,") &&
-    src.includes("isOpenaiApiKeyDisabled((remnicCfg as Record<string, unknown>).openaiApiKey)"),
+      src.includes("isOpenaiApiKeyDisabled(remnicCfg.openaiApiKey)"),
     "doctor must use the shared core helper to treat CLI-style string false as an explicit standalone OpenAI key opt-out",
   );
   assert.ok(


### PR DESCRIPTION
## Summary

This change fixes mixed configuration files. Flat core keys remain as fallbacks when a file also has a partial `remnic` or `engram` block. Nested values still win. Server settings stay separate from core settings.

The server and command line now use the same resolver. An admin reset also removes the old flat fallback, so the deleted value does not return after reload.

## Verification

The server config tests passed. Command: `pnpm exec tsx --test packages/remnic-server/src/config.test.ts`.

The command line config tests passed. Command: `pnpm exec tsx --test packages/remnic-cli/src/config-path.test.ts`.

Type checks passed for core, CLI, and server. Commands: `npx tsc --noEmit -p packages/remnic-core`, `npx tsc --noEmit -p packages/remnic-cli`, and `npx tsc --noEmit -p packages/remnic-server`.

The hardening and quick preflight gates passed. Commands: `npm run test:entity-hardening` and `npm run preflight:quick`.

<!-- voice-guard v1.2.0 | lint pass | rubric 10/10 | mode report | fingerprint v1 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches centralized config resolution for CLI, server, and admin writes; incorrect merge or reset behavior could change runtime paths and feature flags across deployments.
> 
> **Overview**
> Introduces shared **`resolveRemnicConfigRecord`** in `@remnic/core` so mixed config files merge correctly: top-level core keys stay as fallbacks when a partial `remnic`/`engram` block exists, nested keys win on conflicts, and `server` is excluded from core parsing. Non-object nested blocks now fail with explicit errors.
> 
> **CLI and server** replace ad hoc `raw.remnic ?? raw.engram ?? raw` (and server’s “whole file if no block”) with this helper across command paths, `resolveMemoryDir`, and `loadConfigFile`.
> 
> **Admin config updates** on the server delete both nested and matching flat keys on `null` reset, and re-parse via the resolver so removed settings do not reappear from legacy fallbacks.
> 
> **`remnic doctor`** catches `resolveMemoryDir` failures from bad config and continues diagnostics (e.g. reports config parse failures) instead of aborting early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fa3668c98cc3a3fdfbbbee45485fa67ce780ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->