### PR TITLE
refactor(core): extract identity continuity access surface

### DIFF
--- a/packages/remnic-core/src/access-identity-continuity-surface.test.ts
+++ b/packages/remnic-core/src/access-identity-continuity-surface.test.ts
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AccessIdentityContinuitySurface,
+  type AccessIdentityContinuitySurfaceDeps,
+} from "./access-identity-continuity-surface.js";
+import { EngramAccessInputError } from "./access-service.js";
+import { parseConfig } from "./config.js";
+import type { Orchestrator } from "./orchestrator.js";
+import type { StorageManager } from "./storage.js";
+
+interface HarnessOptions {
+  readonly config?: Record<string, unknown>;
+  readonly identityAnchor?: string | null;
+  readonly identityReflections?: string | null;
+  readonly closeIncidentFound?: boolean;
+  readonly reviewLoopFound?: boolean;
+}
+
+interface HarnessCalls {
+  readonly audit: Array<{ period: "weekly" | "monthly"; key?: string }>;
+  readonly storageNamespaces: string[];
+  readonly readableNamespaces: Array<{ namespace?: string; principal?: string }>;
+  readonly writableNamespaces: Array<{ namespace?: string; sessionKey?: string; principal?: string }>;
+  readonly incidentAppends: Array<{
+    symptom: string;
+    triggerWindow?: string;
+    suspectedCause?: string;
+  }>;
+  readonly incidentCloses: Array<{
+    id: string;
+    patch: { fixApplied: string; verificationResult: string; preventiveRule?: string };
+  }>;
+  readonly incidentReads: Array<{ limit: number; state: "open" | "closed" | "all" }>;
+  readonly loopUpserts: Array<Record<string, unknown>>;
+  readonly loopReviews: Array<{ id: string; patch: Record<string, unknown> }>;
+  readonly anchorWrites: string[];
+}
+
+function createHarness(options: HarnessOptions = {}): {
+  surface: AccessIdentityContinuitySurface;
+  calls: HarnessCalls;
+} {
+  const calls: HarnessCalls = {
+    audit: [],
+    storageNamespaces: [],
+    readableNamespaces: [],
+    writableNamespaces: [],
+    incidentAppends: [],
+    incidentCloses: [],
+    incidentReads: [],
+    loopUpserts: [],
+    loopReviews: [],
+    anchorWrites: [],
+  };
+
+  const storageFixture = {
+    async appendContinuityIncident(input: HarnessCalls["incidentAppends"][number]) {
+      calls.incidentAppends.push(input);
+      return { id: "incident-1", state: "open", ...input };
+    },
+    async closeContinuityIncident(id: string, patch: HarnessCalls["incidentCloses"][number]["patch"]) {
+      calls.incidentCloses.push({ id, patch });
+      return options.closeIncidentFound === false ? null : { id, state: "closed", ...patch };
+    },
+    async readContinuityIncidents(limit: number, state: "open" | "closed" | "all") {
+      calls.incidentReads.push({ limit, state });
+      return [{ id: "incident-1", state }];
+    },
+    async upsertIdentityImprovementLoop(input: Record<string, unknown>) {
+      calls.loopUpserts.push(input);
+      return input;
+    },
+    async reviewIdentityImprovementLoop(id: string, patch: Record<string, unknown>) {
+      calls.loopReviews.push({ id, patch });
+      return options.reviewLoopFound === false ? null : { id, ...patch };
+    },
+    async readIdentityAnchor() {
+      return options.identityAnchor ?? null;
+    },
+    async writeIdentityAnchor(content: string) {
+      calls.anchorWrites.push(content);
+    },
+    async readIdentityReflections() {
+      return options.identityReflections ?? null;
+    },
+  };
+  // The surface deliberately consumes only this storage subset; the cast keeps
+  // the fixture honest at each method while avoiding a full filesystem store.
+  const storage = storageFixture as unknown as StorageManager;
+
+  const config = parseConfig({
+    memoryDir: "/tmp/remnic-access-identity-test",
+    identityContinuityEnabled: true,
+    continuityIncidentLoggingEnabled: true,
+    continuityAuditEnabled: true,
+    compoundingEnabled: true,
+    ...options.config,
+  });
+  const orchestratorFixture = {
+    config,
+    compounding: {
+      async synthesizeContinuityAudit(input: { period: "weekly" | "monthly"; key?: string }) {
+        calls.audit.push(input);
+        return {
+          period: input.period,
+          key: input.key ?? "2026-W28",
+          reportPath: "/tmp/continuity-audit.md",
+        };
+      },
+    },
+    async getStorage(namespace: string) {
+      calls.storageNamespaces.push(namespace);
+      return storage;
+    },
+  };
+  // Access surfaces accept the live orchestrator; this named fixture supplies
+  // the exact members this surface owns and no unrelated runtime machinery.
+  const orchestrator = orchestratorFixture as unknown as Orchestrator;
+
+  const deps: AccessIdentityContinuitySurfaceDeps = {
+    orchestrator,
+    resolveReadableNamespace(namespace, principal) {
+      calls.readableNamespaces.push({ namespace, principal });
+      return "readable-ns";
+    },
+    writableNamespaceFor(namespace, sessionKey, principal) {
+      calls.writableNamespaces.push({ namespace, sessionKey, principal });
+      return "writable-ns";
+    },
+  };
+
+  return { surface: new AccessIdentityContinuitySurface(deps), calls };
+}
+
+test("continuity capability gates stop before storage or compounding work", async () => {
+  const { surface, calls } = createHarness({
+    config: { identityContinuityEnabled: false },
+  });
+
+  assert.deepEqual(await surface.continuityAuditGenerate({}), {
+    enabled: false,
+    reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`.",
+  });
+  assert.deepEqual(await surface.continuityIncidentOpen({ symptom: "lost context" }), {
+    enabled: false,
+    reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`.",
+  });
+  assert.deepEqual(calls.audit, []);
+  assert.deepEqual(calls.storageNamespaces, []);
+});
+
+test("continuity audits normalize inputs and forward to compounding", async () => {
+  const { surface, calls } = createHarness();
+
+  assert.deepEqual(await surface.continuityAuditGenerate({ period: "monthly", key: " 2026-07 " }), {
+    enabled: true,
+    period: "monthly",
+    key: "2026-07",
+    reportPath: "/tmp/continuity-audit.md",
+  });
+  assert.deepEqual(calls.audit, [{ period: "monthly", key: "2026-07" }]);
+});
+
+test("incident writes validate required fields and use writable namespace routing", async () => {
+  const { surface, calls } = createHarness();
+
+  await assert.rejects(
+    surface.continuityIncidentOpen({ symptom: "   " }),
+    (error: unknown) => error instanceof EngramAccessInputError && error.message === "symptom is required"
+  );
+  assert.deepEqual(
+    await surface.continuityIncidentOpen({
+      symptom: " lost context ",
+      namespace: "requested",
+      principal: "agent-a",
+      triggerWindow: " last hour ",
+      suspectedCause: " cache reset ",
+    }),
+    {
+      created: true,
+      incident: {
+        id: "incident-1",
+        state: "open",
+        symptom: "lost context",
+        triggerWindow: "last hour",
+        suspectedCause: "cache reset",
+      },
+    }
+  );
+  assert.deepEqual(calls.writableNamespaces, [{ namespace: "requested", sessionKey: undefined, principal: "agent-a" }]);
+  assert.deepEqual(calls.storageNamespaces, ["writable-ns"]);
+  assert.deepEqual(calls.incidentAppends, [
+    {
+      symptom: "lost context",
+      triggerWindow: "last hour",
+      suspectedCause: "cache reset",
+    },
+  ]);
+});
+
+test("incident reads clamp limits and use readable namespace routing", async () => {
+  const { surface, calls } = createHarness();
+
+  assert.deepEqual(
+    await surface.continuityIncidentList({
+      state: "all",
+      limit: 500,
+      namespace: "requested",
+      principal: "agent-a",
+    }),
+    {
+      state: "all",
+      incidents: [{ id: "incident-1", state: "all" }],
+      count: 1,
+    }
+  );
+  assert.deepEqual(calls.readableNamespaces, [{ namespace: "requested", principal: "agent-a" }]);
+  assert.deepEqual(calls.storageNamespaces, ["readable-ns"]);
+  assert.deepEqual(calls.incidentReads, [{ limit: 200, state: "all" }]);
+});
+
+test("incident close and continuity-loop operations preserve validation and forwarding", async () => {
+  const { surface, calls } = createHarness();
+
+  await assert.rejects(
+    surface.continuityIncidentClose({ id: "", fixApplied: "fixed", verificationResult: "green" }),
+    (error: unknown) => error instanceof EngramAccessInputError && error.message === "id is required"
+  );
+  assert.deepEqual(
+    await surface.continuityIncidentClose({
+      id: " incident-1 ",
+      fixApplied: " restored state ",
+      verificationResult: " replay passed ",
+      preventiveRule: " flush first ",
+    }),
+    {
+      closed: true,
+      incident: {
+        id: "incident-1",
+        state: "closed",
+        fixApplied: "restored state",
+        verificationResult: "replay passed",
+        preventiveRule: "flush first",
+      },
+    }
+  );
+  assert.deepEqual(
+    await surface.continuityLoopAddOrUpdate({
+      id: " loop-1 ",
+      cadence: "weekly",
+      purpose: " verify continuity ",
+      status: "active",
+      killCondition: " stable for a month ",
+      notes: " watch restarts ",
+    }),
+    {
+      saved: true,
+      loop: {
+        id: "loop-1",
+        cadence: "weekly",
+        purpose: "verify continuity",
+        status: "active",
+        killCondition: "stable for a month",
+        lastReviewed: undefined,
+        notes: "watch restarts",
+      },
+    }
+  );
+  assert.deepEqual(
+    await surface.continuityLoopReview({
+      id: " loop-1 ",
+      status: "paused",
+      reviewedAt: " 2026-07-10T00:00:00Z ",
+    }),
+    {
+      reviewed: true,
+      loop: {
+        id: "loop-1",
+        status: "paused",
+        notes: undefined,
+        reviewedAt: "2026-07-10T00:00:00Z",
+      },
+    }
+  );
+  assert.equal(calls.incidentCloses.length, 1);
+  assert.equal(calls.loopUpserts.length, 1);
+  assert.equal(calls.loopReviews.length, 1);
+});
+
+test("identity anchor updates merge conservatively without dropping custom sections", async () => {
+  const existingAnchor = [
+    "# Identity Continuity Anchor",
+    "",
+    "## Identity Traits",
+    "",
+    "- Careful",
+    "",
+    "## Communication Preferences",
+    "",
+    "- Brief",
+    "",
+    "## Custom Notes",
+    "",
+    "Keep me",
+    "",
+  ].join("\n");
+  const { surface, calls } = createHarness({ identityAnchor: existingAnchor });
+  const expectedAnchor = [
+    "# Identity Continuity Anchor",
+    "",
+    "## Identity Traits",
+    "",
+    "- Careful",
+    "",
+    "## Communication Preferences",
+    "",
+    "- Brief",
+    "- Direct",
+    "",
+    "## Operating Principles",
+    "",
+    "- Verify",
+    "",
+    "## Continuity Notes",
+    "",
+    "## Custom Notes",
+    "",
+    "Keep me",
+    "",
+  ].join("\n");
+
+  assert.deepEqual(
+    await surface.identityAnchorUpdate({
+      identityTraits: "- Careful",
+      communicationPreferences: "- Brief\n- Direct",
+      operatingPrinciples: "- Verify",
+    }),
+    {
+      updated: true,
+      sections: ["Identity Traits", "Communication Preferences", "Operating Principles"],
+      anchor: expectedAnchor,
+    }
+  );
+  assert.deepEqual(calls.anchorWrites, [expectedAnchor]);
+});
+
+test("identity reads use readable routing and preserve not-found results", async () => {
+  const foundHarness = createHarness({
+    identityAnchor: "# Identity Continuity Anchor\n",
+    identityReflections: "# Identity Reflections\n",
+  });
+
+  assert.deepEqual(await foundHarness.surface.identityAnchorGet({ namespace: "requested" }), {
+    found: true,
+    anchor: "# Identity Continuity Anchor\n",
+  });
+  assert.deepEqual(await foundHarness.surface.memoryIdentity({ namespace: "requested" }), {
+    found: true,
+    identity: "# Identity Reflections\n",
+  });
+  assert.deepEqual(foundHarness.calls.storageNamespaces, ["readable-ns", "readable-ns"]);
+
+  const missingHarness = createHarness();
+  assert.deepEqual(await missingHarness.surface.identityAnchorGet({}), {
+    found: false,
+    message: "No identity anchor found yet. Use identity_anchor_update to create one.",
+  });
+  assert.deepEqual(await missingHarness.surface.memoryIdentity({}), {
+    found: false,
+    message: "No identity reflections found.",
+  });
+});

--- a/packages/remnic-core/src/access-identity-continuity-surface.ts
+++ b/packages/remnic-core/src/access-identity-continuity-surface.ts
@@ -1,0 +1,322 @@
+/**
+ * Access identity-continuity surface.
+ *
+ * Owns continuity audits, incident and improvement-loop operations, identity
+ * anchor access, and legacy identity-reflection reads. EngramAccessService
+ * remains the public facade and supplies live namespace/orchestrator bindings.
+ */
+
+import {
+  resolveConsolidationCapabilities,
+  resolveIdentityContinuityCapabilities,
+  resolveRecallAuxiliaryCapabilities,
+} from "./capabilities.js";
+import type { Orchestrator } from "./orchestrator.js";
+import { EngramAccessInputError } from "./access-service.js";
+
+export interface AccessIdentityContinuitySurfaceDeps {
+  readonly orchestrator: Orchestrator;
+  resolveReadableNamespace(namespace: string | undefined, principal?: string): string;
+  writableNamespaceFor(
+    namespace: string | undefined,
+    sessionKey: string | undefined,
+    authenticatedPrincipal?: string
+  ): string;
+}
+
+export class AccessIdentityContinuitySurface {
+  constructor(private readonly deps: AccessIdentityContinuitySurfaceDeps) {}
+
+  async continuityAuditGenerate(request: {
+    period?: "weekly" | "monthly";
+    key?: string;
+  }): Promise<{ enabled: boolean; reason?: string; period?: string; key?: string; reportPath?: string }> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return {
+        enabled: false,
+        reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`.",
+      };
+    }
+    if (!resolveConsolidationCapabilities(this.deps.orchestrator.config).continuityAudit) {
+      return {
+        enabled: false,
+        reason: "Continuity audits are disabled. Enable `continuityAuditEnabled: true`.",
+      };
+    }
+    if (!this.deps.orchestrator.compounding) {
+      return {
+        enabled: false,
+        reason: "Compounding engine is disabled. Enable `compoundingEnabled: true`.",
+      };
+    }
+    const period = request.period === "monthly" ? "monthly" : "weekly";
+    const key = request.key?.trim() || undefined;
+    const audit = await this.deps.orchestrator.compounding.synthesizeContinuityAudit({ period, key });
+    return { enabled: true, period: audit.period, key: audit.key, reportPath: audit.reportPath };
+  }
+
+  async continuityIncidentOpen(request: {
+    symptom: string;
+    namespace?: string;
+    principal?: string;
+    triggerWindow?: string;
+    suspectedCause?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return {
+        enabled: false,
+        reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`.",
+      };
+    }
+    if (!resolveRecallAuxiliaryCapabilities(this.deps.orchestrator.config).continuityIncidentLogging) {
+      return {
+        enabled: false,
+        reason: "Continuity incident logging is disabled. Enable `continuityIncidentLoggingEnabled: true`.",
+      };
+    }
+    const symptom = request.symptom?.trim();
+    if (!symptom) throw new EngramAccessInputError("symptom is required");
+    const resolvedNs = this.deps.writableNamespaceFor(request.namespace, undefined, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const created = await storage.appendContinuityIncident({
+      symptom,
+      triggerWindow: request.triggerWindow?.trim() || undefined,
+      suspectedCause: request.suspectedCause?.trim() || undefined,
+    });
+    return { created: true, incident: created };
+  }
+
+  async continuityIncidentClose(request: {
+    id: string;
+    namespace?: string;
+    principal?: string;
+    fixApplied: string;
+    verificationResult: string;
+    preventiveRule?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+    if (!resolveRecallAuxiliaryCapabilities(this.deps.orchestrator.config).continuityIncidentLogging) {
+      return { enabled: false, reason: "Continuity incident logging is disabled." };
+    }
+    const id = request.id?.trim();
+    if (!id) throw new EngramAccessInputError("id is required");
+    const fixApplied = request.fixApplied?.trim();
+    if (!fixApplied) throw new EngramAccessInputError("fixApplied is required");
+    const verificationResult = request.verificationResult?.trim();
+    if (!verificationResult) throw new EngramAccessInputError("verificationResult is required");
+    const resolvedNs = this.deps.writableNamespaceFor(request.namespace, undefined, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const closed = await storage.closeContinuityIncident(id, {
+      fixApplied,
+      verificationResult,
+      preventiveRule: request.preventiveRule?.trim() || undefined,
+    });
+    if (!closed) return { closed: false, reason: `Incident not found: ${id}` };
+    return { closed: true, incident: closed };
+  }
+
+  async continuityIncidentList(request: {
+    state?: "open" | "closed" | "all";
+    namespace?: string;
+    principal?: string;
+    limit?: number;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+    const state = request.state === "closed" || request.state === "all" ? request.state : "open";
+    const limit = Math.max(1, Math.min(200, Math.floor(request.limit ?? 25)));
+    const resolvedNs = this.deps.resolveReadableNamespace(request.namespace, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const incidents = await storage.readContinuityIncidents(limit, state);
+    return { state, incidents, count: incidents.length };
+  }
+
+  async continuityLoopAddOrUpdate(request: {
+    id: string;
+    cadence: "daily" | "weekly" | "monthly" | "quarterly";
+    purpose: string;
+    status: "active" | "paused" | "retired";
+    killCondition: string;
+    namespace?: string;
+    principal?: string;
+    lastReviewed?: string;
+    notes?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+    const resolvedNs = this.deps.writableNamespaceFor(request.namespace, undefined, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const loop = await storage.upsertIdentityImprovementLoop({
+      id: request.id?.trim() || "",
+      cadence: request.cadence,
+      purpose: request.purpose?.trim() || "",
+      status: request.status,
+      killCondition: request.killCondition?.trim() || "",
+      lastReviewed: request.lastReviewed?.trim() || undefined,
+      notes: request.notes?.trim() || undefined,
+    });
+    return { saved: true, loop };
+  }
+
+  async continuityLoopReview(request: {
+    id: string;
+    namespace?: string;
+    principal?: string;
+    status?: "active" | "paused" | "retired";
+    notes?: string;
+    reviewedAt?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+    const id = request.id?.trim();
+    if (!id) throw new EngramAccessInputError("id is required");
+    const resolvedNs = this.deps.writableNamespaceFor(request.namespace, undefined, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const reviewed = await storage.reviewIdentityImprovementLoop(id, {
+      status: request.status,
+      notes: request.notes?.trim() || undefined,
+      reviewedAt: request.reviewedAt?.trim() || undefined,
+    });
+    if (!reviewed) return { reviewed: false, reason: `Continuity loop not found: ${id}` };
+    return { reviewed: true, loop: reviewed };
+  }
+
+  async identityAnchorGet(request: {
+    namespace?: string;
+    principal?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+    const resolvedNs = this.deps.resolveReadableNamespace(request.namespace, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const anchor = await storage.readIdentityAnchor();
+    if (!anchor) {
+      return {
+        found: false,
+        message: "No identity anchor found yet. Use identity_anchor_update to create one.",
+      };
+    }
+    return { found: true, anchor };
+  }
+
+  async identityAnchorUpdate(request: {
+    namespace?: string;
+    principal?: string;
+    identityTraits?: string;
+    communicationPreferences?: string;
+    operatingPrinciples?: string;
+    continuityNotes?: string;
+  }): Promise<unknown> {
+    if (!resolveIdentityContinuityCapabilities(this.deps.orchestrator.config).identityContinuity) {
+      return { enabled: false, reason: "Identity continuity is disabled." };
+    }
+
+    const updates: Record<string, string | undefined> = {
+      "Identity Traits": request.identityTraits?.trim() || undefined,
+      "Communication Preferences": request.communicationPreferences?.trim() || undefined,
+      "Operating Principles": request.operatingPrinciples?.trim() || undefined,
+      "Continuity Notes": request.continuityNotes?.trim() || undefined,
+    };
+    const hasUpdate = Object.values(updates).some((value) => typeof value === "string" && value.length > 0);
+    if (!hasUpdate) {
+      throw new EngramAccessInputError("At least one section field is required.");
+    }
+
+    const resolvedNs = this.deps.writableNamespaceFor(request.namespace, undefined, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const existing = await storage.readIdentityAnchor();
+    const merged = this.mergeIdentityAnchorSections(existing, updates);
+    await storage.writeIdentityAnchor(merged);
+
+    const updatedSections = Object.entries(updates)
+      .filter(([, value]) => typeof value === "string" && value.length > 0)
+      .map(([name]) => name);
+    return { updated: true, sections: updatedSections, anchor: merged };
+  }
+
+  async memoryIdentity(request: {
+    namespace?: string;
+    principal?: string;
+  }): Promise<unknown> {
+    const resolvedNs = this.deps.resolveReadableNamespace(request.namespace, request.principal);
+    const storage = await this.deps.orchestrator.getStorage(resolvedNs);
+    const identity = await storage.readIdentityReflections();
+    if (!identity) return { found: false, message: "No identity reflections found." };
+    return { found: true, identity };
+  }
+
+  /** Conservative identity anchor section merge (matches tools.ts mergeIdentityAnchor logic). */
+  private mergeIdentityAnchorSections(existingRaw: string | null, updates: Record<string, string | undefined>): string {
+    const title = "# Identity Continuity Anchor";
+    const sectionOrder = ["Identity Traits", "Communication Preferences", "Operating Principles", "Continuity Notes"];
+
+    const lines = (existingRaw ?? "").replace(/\r/g, "").split("\n");
+    const headerLines: string[] = [];
+    const sectionContent = new Map<string, string[]>();
+    const order: string[] = [];
+    let current: string | null = null;
+    for (const line of lines) {
+      const match = line.match(/^##\s+(.+?)\s*$/);
+      if (match) {
+        current = match[1].trim();
+        if (!sectionContent.has(current)) {
+          sectionContent.set(current, []);
+          order.push(current);
+        }
+        continue;
+      }
+      if (!current) {
+        headerLines.push(line);
+      } else {
+        sectionContent.get(current)?.push(line);
+      }
+    }
+    const sections = new Map<string, string>();
+    for (const [name, contentLines] of sectionContent) {
+      sections.set(name, contentLines.join("\n").trim());
+    }
+
+    const header = headerLines.join("\n").trim() || title;
+    for (const sectionName of sectionOrder) {
+      const previous = sections.get(sectionName)?.trim();
+      const next = updates[sectionName]?.trim();
+      const existing = previous === "- (empty)" ? "" : previous;
+      if (!next) {
+        if (!sections.has(sectionName)) sections.set(sectionName, "");
+        continue;
+      }
+      if (!existing) {
+        sections.set(sectionName, next);
+        continue;
+      }
+      if (existing.includes(next)) continue;
+      if (next.includes(existing)) {
+        sections.set(sectionName, next);
+        continue;
+      }
+      sections.set(sectionName, `${existing}\n\n${next}`);
+    }
+
+    const finalOrder = [
+      ...sectionOrder.filter((section) => sections.has(section)),
+      ...order.filter((section) => !sectionOrder.includes(section) && sections.has(section)),
+    ];
+    const output: string[] = [header, ""];
+    for (const name of finalOrder) {
+      output.push(`## ${name}`, "");
+      const body = sections.get(name)?.trim();
+      if (body) output.push(body, "");
+      else output.push("");
+    }
+    return `${output
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trimEnd()}\n`;
+  }
+}

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -8,8 +8,7 @@ import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-i
 import { resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
   resolveQmdCapabilities,
-  resolveIdentityContinuityCapabilities,
-  resolveSecurityCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities, resolveConsolidationCapabilities, resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
+  resolveSecurityCapabilities, resolveObjectiveStateCapabilities, resolveCompressionCapabilities, resolveRecallAuxiliaryCapabilities } from "./capabilities.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
@@ -255,6 +254,7 @@ import { AccessObserveWriteSurface } from "./access-observe-write-surface.js";
 import { AccessLcmSurface } from "./access-lcm-surface.js";
 import { AccessAdminOpsSurface } from "./access-admin-ops-surface.js";
 import { AccessRecallSurface } from "./access-recall-surface.js";
+import { AccessIdentityContinuitySurface } from "./access-identity-continuity-surface.js";
 import { selfDeps } from "./orchestration/self-deps.js";
 
 export class EngramAccessInputError extends Error {}
@@ -1356,6 +1356,18 @@ export class EngramAccessService {
       );
     }
     return this._accessRecallSurface;
+  }
+
+  /** AccessIdentityContinuitySurface (access-service decomposition). Lazy; selfDeps live wiring. */
+  private _accessIdentityContinuitySurface: AccessIdentityContinuitySurface | undefined;
+
+  private get accessIdentityContinuitySurface(): AccessIdentityContinuitySurface {
+    if (!this._accessIdentityContinuitySurface) {
+      this._accessIdentityContinuitySurface = new AccessIdentityContinuitySurface(
+        selfDeps<ConstructorParameters<typeof AccessIdentityContinuitySurface>[0]>(this),
+      );
+    }
+    return this._accessIdentityContinuitySurface;
   }
 
   constructor(private readonly orchestrator: Orchestrator) {
@@ -4423,19 +4435,7 @@ export class EngramAccessService {
     period?: "weekly" | "monthly";
     key?: string;
   }): Promise<{ enabled: boolean; reason?: string; period?: string; key?: string; reportPath?: string }> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`." };
-    }
-    if (!resolveConsolidationCapabilities(this.orchestrator.config).continuityAudit) {
-      return { enabled: false, reason: "Continuity audits are disabled. Enable `continuityAuditEnabled: true`." };
-    }
-    if (!this.orchestrator.compounding) {
-      return { enabled: false, reason: "Compounding engine is disabled. Enable `compoundingEnabled: true`." };
-    }
-    const period = request.period === "monthly" ? "monthly" : "weekly";
-    const key = request.key?.trim() || undefined;
-    const audit = await this.orchestrator.compounding.synthesizeContinuityAudit({ period, key });
-    return { enabled: true, period: audit.period, key: audit.key, reportPath: audit.reportPath };
+    return this.accessIdentityContinuitySurface.continuityAuditGenerate(request);
   }
 
   async continuityIncidentOpen(request: {
@@ -4445,22 +4445,7 @@ export class EngramAccessService {
     triggerWindow?: string;
     suspectedCause?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled. Enable `identityContinuityEnabled: true`." };
-    }
-    if (!resolveRecallAuxiliaryCapabilities(this.orchestrator.config).continuityIncidentLogging) {
-      return { enabled: false, reason: "Continuity incident logging is disabled. Enable `continuityIncidentLoggingEnabled: true`." };
-    }
-    const symptom = request.symptom?.trim();
-    if (!symptom) throw new EngramAccessInputError("symptom is required");
-    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const created = await storage.appendContinuityIncident({
-      symptom,
-      triggerWindow: request.triggerWindow?.trim() || undefined,
-      suspectedCause: request.suspectedCause?.trim() || undefined,
-    });
-    return { created: true, incident: created };
+    return this.accessIdentityContinuitySurface.continuityIncidentOpen(request);
   }
 
   async continuityIncidentClose(request: {
@@ -4471,27 +4456,7 @@ export class EngramAccessService {
     verificationResult: string;
     preventiveRule?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-    if (!resolveRecallAuxiliaryCapabilities(this.orchestrator.config).continuityIncidentLogging) {
-      return { enabled: false, reason: "Continuity incident logging is disabled." };
-    }
-    const id = request.id?.trim();
-    if (!id) throw new EngramAccessInputError("id is required");
-    const fixApplied = request.fixApplied?.trim();
-    if (!fixApplied) throw new EngramAccessInputError("fixApplied is required");
-    const verificationResult = request.verificationResult?.trim();
-    if (!verificationResult) throw new EngramAccessInputError("verificationResult is required");
-    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const closed = await storage.closeContinuityIncident(id, {
-      fixApplied,
-      verificationResult,
-      preventiveRule: request.preventiveRule?.trim() || undefined,
-    });
-    if (!closed) return { closed: false, reason: `Incident not found: ${id}` };
-    return { closed: true, incident: closed };
+    return this.accessIdentityContinuitySurface.continuityIncidentClose(request);
   }
 
   async continuityIncidentList(request: {
@@ -4500,15 +4465,7 @@ export class EngramAccessService {
     principal?: string;
     limit?: number;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-    const state = request.state === "closed" || request.state === "all" ? request.state : "open";
-    const limit = Math.max(1, Math.min(200, Math.floor(request.limit ?? 25)));
-    const resolvedNs = this.resolveReadableNamespace(request.namespace, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const incidents = await storage.readContinuityIncidents(limit, state);
-    return { state, incidents, count: incidents.length };
+    return this.accessIdentityContinuitySurface.continuityIncidentList(request);
   }
 
   async continuityLoopAddOrUpdate(request: {
@@ -4522,21 +4479,7 @@ export class EngramAccessService {
     lastReviewed?: string;
     notes?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const loop = await storage.upsertIdentityImprovementLoop({
-      id: request.id?.trim() || "",
-      cadence: request.cadence,
-      purpose: request.purpose?.trim() || "",
-      status: request.status,
-      killCondition: request.killCondition?.trim() || "",
-      lastReviewed: request.lastReviewed?.trim() || undefined,
-      notes: request.notes?.trim() || undefined,
-    });
-    return { saved: true, loop };
+    return this.accessIdentityContinuitySurface.continuityLoopAddOrUpdate(request);
   }
 
   async continuityLoopReview(request: {
@@ -4547,34 +4490,14 @@ export class EngramAccessService {
     notes?: string;
     reviewedAt?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-    const id = request.id?.trim();
-    if (!id) throw new EngramAccessInputError("id is required");
-    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const reviewed = await storage.reviewIdentityImprovementLoop(id, {
-      status: request.status,
-      notes: request.notes?.trim() || undefined,
-      reviewedAt: request.reviewedAt?.trim() || undefined,
-    });
-    if (!reviewed) return { reviewed: false, reason: `Continuity loop not found: ${id}` };
-    return { reviewed: true, loop: reviewed };
+    return this.accessIdentityContinuitySurface.continuityLoopReview(request);
   }
 
   async identityAnchorGet(request: {
     namespace?: string;
     principal?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-    const resolvedNs = this.resolveReadableNamespace(request.namespace, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const anchor = await storage.readIdentityAnchor();
-    if (!anchor) return { found: false, message: "No identity anchor found yet. Use identity_anchor_update to create one." };
-    return { found: true, anchor };
+    return this.accessIdentityContinuitySurface.identityAnchorGet(request);
   }
 
   /**
@@ -4593,42 +4516,14 @@ export class EngramAccessService {
     operatingPrinciples?: string;
     continuityNotes?: string;
   }): Promise<unknown> {
-    if (!resolveIdentityContinuityCapabilities(this.orchestrator.config).identityContinuity) {
-      return { enabled: false, reason: "Identity continuity is disabled." };
-    }
-
-    const updates: Record<string, string | undefined> = {
-      "Identity Traits": request.identityTraits?.trim() || undefined,
-      "Communication Preferences": request.communicationPreferences?.trim() || undefined,
-      "Operating Principles": request.operatingPrinciples?.trim() || undefined,
-      "Continuity Notes": request.continuityNotes?.trim() || undefined,
-    };
-    const hasUpdate = Object.values(updates).some((v) => typeof v === "string" && v.length > 0);
-    if (!hasUpdate) throw new EngramAccessInputError("At least one section field is required.");
-
-    const resolvedNs = this.writableNamespaceFor(request.namespace, undefined, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const existing = await storage.readIdentityAnchor();
-
-    // Merge sections conservatively (append, don't overwrite)
-    const merged = this.mergeIdentityAnchorSections(existing, updates);
-    await storage.writeIdentityAnchor(merged);
-
-    const updatedSections = Object.entries(updates)
-      .filter(([, v]) => typeof v === "string" && v.length > 0)
-      .map(([name]) => name);
-    return { updated: true, sections: updatedSections, anchor: merged };
+    return this.accessIdentityContinuitySurface.identityAnchorUpdate(request);
   }
 
   async memoryIdentity(request: {
     namespace?: string;
     principal?: string;
   }): Promise<unknown> {
-    const resolvedNs = this.resolveReadableNamespace(request.namespace, request.principal);
-    const storage = await this.orchestrator.getStorage(resolvedNs);
-    const identity = await storage.readIdentityReflections();
-    if (!identity) return { found: false, message: "No identity reflections found." };
-    return { found: true, identity };
+    return this.accessIdentityContinuitySurface.memoryIdentity(request);
   }
 
   // ── Work Layer ──────────────────────────────────────────────────────────
@@ -4838,49 +4733,6 @@ export class EngramAccessService {
     });
   }
 
-  /** Conservative identity anchor section merge (matches tools.ts mergeIdentityAnchor logic). */
-  private mergeIdentityAnchorSections(
-    existingRaw: string | null,
-    updates: Record<string, string | undefined>,
-  ): string {
-    const TITLE = "# Identity Continuity Anchor";
-    const SECTION_ORDER = ["Identity Traits", "Communication Preferences", "Operating Principles", "Continuity Notes"];
-
-    const lines = (existingRaw ?? "").replace(/\r/g, "").split("\n");
-    const headerLines: string[] = [];
-    const sectionContent = new Map<string, string[]>();
-    const order: string[] = [];
-    let current: string | null = null;
-    for (const line of lines) {
-      const m = line.match(/^##\s+(.+?)\s*$/);
-      if (m) { current = m[1].trim(); if (!sectionContent.has(current)) { sectionContent.set(current, []); order.push(current); } continue; }
-      if (!current) { headerLines.push(line); } else { sectionContent.get(current)?.push(line); }
-    }
-    const sections = new Map<string, string>();
-    for (const [name, cLines] of sectionContent) sections.set(name, cLines.join("\n").trim());
-
-    const header = headerLines.join("\n").trim() || TITLE;
-    for (const sectionName of SECTION_ORDER) {
-      const prev = sections.get(sectionName)?.trim();
-      const next = updates[sectionName]?.trim();
-      const existing = prev === "- (empty)" ? "" : prev;
-      if (!next) { if (!sections.has(sectionName)) sections.set(sectionName, ""); continue; }
-      if (!existing) { sections.set(sectionName, next); continue; }
-      if (existing.includes(next)) continue;
-      if (next.includes(existing)) { sections.set(sectionName, next); continue; }
-      sections.set(sectionName, `${existing}\n\n${next}`);
-    }
-
-    const finalOrder = [...SECTION_ORDER.filter((s) => sections.has(s)), ...order.filter((s) => !SECTION_ORDER.includes(s) && sections.has(s))];
-    const out: string[] = [header, ""];
-    for (const name of finalOrder) {
-      out.push(`## ${name}`, "");
-      const body = sections.get(name)?.trim();
-      if (body) out.push(body, "");
-      else out.push("");
-    }
-    return out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
-  }
 
   // ── Memory search & debug ─────────────────────────────────────────────
 

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -6,7 +6,7 @@
     "watchlistLoc": {
       "packages/remnic-core/src/orchestrator.ts": 4020,
       "packages/remnic-core/src/cli.ts": 9395,
-      "packages/remnic-core/src/access-service.ts": 6050,
+      "packages/remnic-core/src/access-service.ts": 5902,
       "packages/remnic-core/src/storage.ts": 6550,
       "packages/remnic-core/src/config.ts": 4694
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical refactor with behavior preserved and new unit tests; no new auth paths or API contracts beyond moving implementation.
> 
> **Overview**
> Moves identity-continuity access logic out of `EngramAccessService` into a new **`AccessIdentityContinuitySurface`**, matching the existing recall/LCM/admin surface decomposition. The public methods on the access service (`continuityAuditGenerate`, incident/loop APIs, `identityAnchorGet`/`identityAnchorUpdate`, `memoryIdentity`) now **delegate** to a lazily wired surface via `selfDeps`; capability checks, namespace routing, storage calls, and conservative anchor merging live on the surface (including `mergeIdentityAnchorSections`, removed from `access-service.ts`).
> 
> Adds **`access-identity-continuity-surface.test.ts`** with harnessed unit tests for capability gating, input normalization/validation, read vs write namespace routing, and anchor merge behavior. Updates **`scripts/ratchet-baseline.json`** to reflect the smaller `access-service.ts` line count (~6050 → ~5902).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 480e617712475ad334b1bf739d095e484ceb6943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->