### PR TITLE
fix(storage): invalidate resolved question cache

### DIFF
--- a/packages/remnic-core/src/storage-contract/round-trip.test.ts
+++ b/packages/remnic-core/src/storage-contract/round-trip.test.ts
@@ -12,6 +12,8 @@
  */
 
 import assert from "node:assert/strict";
+import { utimes } from "node:fs/promises";
+import path from "node:path";
 import type { MemoryCategory } from "../types.js";
 import test from "node:test";
 
@@ -212,6 +214,9 @@ test("question-queue: writeQuestion → readQuestions → resolveQuestion round-
     // resolve marks it resolved
     const resolved = await storage.resolveQuestion(id);
     assert.equal(resolved, true);
+    // Directory mtimes are only a cross-process hint and may be coarser than
+    // the cache timestamp. Same-process resolution must invalidate directly.
+    await utimes(path.join(storage.dir, "questions"), new Date(0), new Date(0));
 
     const afterResolve = await storage.readQuestions({ unresolvedOnly: true });
     assert.ok(!afterResolve.some((x) => x.id === id), "resolved question must not appear in unresolvedOnly");

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -5463,9 +5463,7 @@ export class StorageManager {
       filePath: string;
     }>
   > {
-    return this.memoryReadStore.readQuestions(
-      opts,
-    );
+    return this.memoryReadStore.readQuestions(opts);
   }
 
   /** Invalidate the questions cache (call after writing a question). */

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -5535,6 +5535,7 @@ export class StorageManager {
       `resolvedAt: "${new Date().toISOString()}"\n---\n\n`,
     );
     await this.writeStorageSecureFile(q.filePath, raw);
+    this.invalidateQuestionsCache();
     log.debug(`resolved question ${id}`);
     return true;
   }

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -7,7 +7,7 @@
       "packages/remnic-core/src/orchestrator.ts": 4020,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 5902,
-      "packages/remnic-core/src/storage.ts": 6551,
+      "packages/remnic-core/src/storage.ts": 6549,
       "packages/remnic-core/src/config.ts": 4694
     },
     "oversizedFileCount": 11,

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -7,7 +7,7 @@
       "packages/remnic-core/src/orchestrator.ts": 4020,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 5902,
-      "packages/remnic-core/src/storage.ts": 6550,
+      "packages/remnic-core/src/storage.ts": 6551,
       "packages/remnic-core/src/config.ts": 4694
     },
     "oversizedFileCount": 11,


### PR DESCRIPTION
## Summary

Remnic now clears its cached question list after a question is marked resolved. This stops old unresolved data from being served when directory timestamps are coarse.

The test sets the directory time back before the next read. The old code fails this check every time. The fix passes without relying on filesystem timing.

## Test plan

The focused question test passed. The same test also passed 20 times in a row. Entity hardening and quick preflight passed.

The full package shard reached the fixed question test and passed it. It found separate failures in the benchmark timing test and two trust test cleanup paths. Those files are outside this change.

<!-- voice-guard v1.2.0 | lint pass | rubric 10/10 | mode update | fingerprint v1 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized cache-consistency fix in question resolution with a targeted contract test; no auth, security, or broad API changes.
> 
> **Overview**
> **`resolveQuestion`** now calls **`invalidateQuestionsCache()`** after updating the question file on disk, matching **`writeQuestion`** so **`readQuestions`** (including **`unresolvedOnly`**) does not keep serving stale unresolved entries from the in-process cache when directory mtimes are too coarse to trigger a refresh.
> 
> The **question-queue** contract test resets the **`questions/`** directory mtime with **`utimes`** before the post-resolve read so the assertion depends on explicit cache invalidation, not filesystem timing hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31885f9aede6411f10c60c12a0c971fff05b3d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->