### PR TITLE
fix(core): drain recall writes before teardown

### DIFF
--- a/packages/remnic-core/src/orchestration/recall-background-writes.ts
+++ b/packages/remnic-core/src/orchestration/recall-background-writes.ts
@@ -1,0 +1,24 @@
+import { log } from "../logger.js";
+
+const pendingWritesByOwner = new WeakMap<object, Set<Promise<void>>>();
+
+export function trackRecallWrite(owner: object, promise: Promise<void>, label: string): void {
+  const observed = promise.catch((err) => {
+    log.debug(`${label} failed: ${err}`);
+  });
+  const pendingWrites = pendingWritesByOwner.get(owner) ?? new Set<Promise<void>>();
+  pendingWritesByOwner.set(owner, pendingWrites);
+  pendingWrites.add(observed);
+  void observed.finally(() => {
+    pendingWrites.delete(observed);
+    if (pendingWrites.size === 0) pendingWritesByOwner.delete(owner);
+  });
+}
+
+export async function drainRecallWrites(owner: object): Promise<void> {
+  while (true) {
+    const pendingWrites = pendingWritesByOwner.get(owner);
+    if (!pendingWrites || pendingWrites.size === 0) return;
+    await Promise.all(pendingWrites);
+  }
+}

--- a/packages/remnic-core/src/orchestration/recall-entry.ts
+++ b/packages/remnic-core/src/orchestration/recall-entry.ts
@@ -58,6 +58,7 @@ export interface RecallEntryDeps {
   readonly storage: StorageManager;
   suppressedRecallFailures: number;
   trackMemoryAccess(memoryIds: string[]): void;
+  trackRecallBackgroundWrite(promise: Promise<void>, label: string): void;
 }
 
 export class RecallEntryCoordinator {
@@ -248,6 +249,10 @@ export class RecallEntryCoordinator {
           log.debug(`eval shadow recall write failed: ${err}`);
         }
       });
+    this.deps.trackRecallBackgroundWrite(
+      this.deps.evalShadowWriteChain,
+      "eval shadow recall write",
+    );
   }
 
   publishRecallResults(options: {

--- a/packages/remnic-core/src/orchestration/recall-internal.ts
+++ b/packages/remnic-core/src/orchestration/recall-internal.ts
@@ -326,6 +326,7 @@ export interface RecallInternalDeps {
   ): number | undefined;
   getStorage(namespace?: string): Promise<StorageManager>;
   readonly handleHistory: RecallHandleHistoryStore;
+  trackRecallBackgroundWrite(promise: Promise<void>, label: string): void;
   isRecallSectionEnabled(
     sectionId: string,
     defaultEnabled?: boolean,
@@ -908,8 +909,8 @@ export class RecallInternalCoordinator {
         }
       }
       if (sessionKey) {
-        this.deps.lastRecall
-          .record({
+        this.deps.trackRecallBackgroundWrite(
+          this.deps.lastRecall.record({
             sessionKey,
             query: retrievalQuery,
             memoryIds: [],
@@ -935,8 +936,9 @@ export class RecallInternalCoordinator {
               injectedChars: identityInjectedChars,
               truncated: identityInjectionTruncated,
             },
-          })
-          .catch((err) => log.debug(`last recall record failed: ${err}`));
+          }),
+          "last recall record",
+        );
       }
       if (sessionKey) {
         this.deps.queueEvalShadowRecall({
@@ -5364,8 +5366,8 @@ export class RecallInternalCoordinator {
 
     if (sessionKey) {
       throwIfRecallAborted(options.abortSignal);
-      this.deps.lastRecall
-        .record({
+      this.deps.trackRecallBackgroundWrite(
+        this.deps.lastRecall.record({
           sessionKey,
           query: retrievalQuery,
           memoryIds: recalledMemoryIds,
@@ -5397,8 +5399,9 @@ export class RecallInternalCoordinator {
           // reviews on #1544).
           backendDegradations:
             backendDegradations.length > 0 ? backendDegradations : undefined,
-        })
-        .catch((err) => log.debug(`last recall record failed: ${err}`));
+        }),
+        "last recall record",
+      );
       // Issue #1582 — record the admitted memory-id set for handle resolution.
       // Only when handles are enabled: if injection is off, no handle is ever
       // rendered, so there is nothing to resolve and we skip the write.
@@ -5410,9 +5413,10 @@ export class RecallInternalCoordinator {
           MEMORY_ID_PATTERN.test(id),
         );
         if (handleEligibleIds.length > 0) {
-          this.deps.handleHistory
-            .record(sessionKey, handleEligibleIds)
-            .catch((err) => log.debug(`handle history record failed: ${err}`));
+          this.deps.trackRecallBackgroundWrite(
+            this.deps.handleHistory.record(sessionKey, handleEligibleIds),
+            "handle history record",
+          );
         }
       }
     }

--- a/packages/remnic-core/src/orchestration/recall-introspection.ts
+++ b/packages/remnic-core/src/orchestration/recall-introspection.ts
@@ -66,6 +66,7 @@ export interface RecallIntrospectionDeps {
   getStorage(namespace?: string): Promise<StorageManager>;
   readonly graphRecallCoordinator: GraphRecallCoordinator;
   readonly lastRecall: LastRecallStore;
+  trackRecallBackgroundWrite(promise: Promise<void>, label: string): void;
   resolveStateDirForNamespace(
     namespace: string,
   ): Promise<string>;
@@ -500,6 +501,10 @@ export class RecallIntrospectionCoordinator {
           log.debug(`direct-answer observation chain error: ${err}`);
         }
       });
+    this.deps.trackRecallBackgroundWrite(
+      this.deps.directAnswerObservationChain,
+      "direct-answer observation",
+    );
   }
 
   async annotateDirectAnswerTier(

--- a/packages/remnic-core/src/orchestrator-background-writes.test.ts
+++ b/packages/remnic-core/src/orchestrator-background-writes.test.ts
@@ -6,7 +6,7 @@ import test from "node:test";
 import { parseConfig } from "./config.js";
 import { Orchestrator } from "./orchestrator.js";
 
-test("destroy waits for tracked background writes before disposing runtime state", async () => {
+test("destroy cancels maintenance and waits for tracked writes before disposing search backends", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-background-writes-"));
   const orchestrator = new Orchestrator(
     parseConfig({
@@ -21,6 +21,14 @@ test("destroy waits for tracked background writes before disposing runtime state
       compoundingEnabled: false,
     })
   );
+  const maintenanceScheduler = (orchestrator as unknown as { maintenanceScheduler: { dispose(): void } })
+    .maintenanceScheduler;
+  const originalMaintenanceDispose = maintenanceScheduler.dispose.bind(maintenanceScheduler);
+  let maintenanceDisposed = false;
+  maintenanceScheduler.dispose = () => {
+    maintenanceDisposed = true;
+    originalMaintenanceDispose();
+  };
   const writeGate = Promise.withResolvers<void>();
   let destroySettled = false;
   let destroyPromise: Promise<void> | undefined;
@@ -33,6 +41,7 @@ test("destroy waits for tracked background writes before disposing runtime state
 
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.equal(destroySettled, false, "destroy must remain pending while a tracked write is pending");
+    assert.equal(maintenanceDisposed, true, "destroy must cancel maintenance before waiting for writes");
 
     writeGate.resolve();
     await destroyPromise;

--- a/packages/remnic-core/src/orchestrator-background-writes.test.ts
+++ b/packages/remnic-core/src/orchestrator-background-writes.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseConfig } from "./config.js";
+import { Orchestrator } from "./orchestrator.js";
+
+test("destroy waits for tracked background writes before disposing runtime state", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-background-writes-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      qmdEnabled: false,
+      knowledgeIndexEnabled: false,
+      identityContinuityEnabled: false,
+      transcriptEnabled: false,
+      hourlySummariesEnabled: false,
+      compoundingEnabled: false,
+    })
+  );
+  const writeGate = Promise.withResolvers<void>();
+  let destroySettled = false;
+  let destroyPromise: Promise<void> | undefined;
+
+  try {
+    orchestrator.trackRecallBackgroundWrite(writeGate.promise, "test background write");
+    destroyPromise = orchestrator.destroy().then(() => {
+      destroySettled = true;
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(destroySettled, false, "destroy must remain pending while a tracked write is pending");
+
+    writeGate.resolve();
+    await destroyPromise;
+    assert.equal(destroySettled, true);
+  } finally {
+    writeGate.resolve();
+    await (destroyPromise ?? orchestrator.destroy());
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("destroy waits for a recall-initiated last-recall write", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-recall-background-write-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      qmdEnabled: false,
+      knowledgeIndexEnabled: false,
+      identityContinuityEnabled: false,
+      transcriptEnabled: false,
+      hourlySummariesEnabled: false,
+      compoundingEnabled: false,
+    })
+  );
+  const writeStarted = Promise.withResolvers<void>();
+  const writeGate = Promise.withResolvers<void>();
+  const originalRecord = orchestrator.lastRecall.record.bind(orchestrator.lastRecall);
+  orchestrator.lastRecall.record = async (...args: Parameters<typeof originalRecord>) => {
+    writeStarted.resolve();
+    await writeGate.promise;
+    await originalRecord(...args);
+  };
+  let destroySettled = false;
+  let destroyPromise: Promise<void> | undefined;
+
+  try {
+    await orchestrator.initialize();
+    await orchestrator.recall("recall state drain contract", "session-background-write");
+    await writeStarted.promise;
+    destroyPromise = orchestrator.destroy().then(() => {
+      destroySettled = true;
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(destroySettled, false, "destroy must wait for the recall-initiated state write");
+
+    writeGate.resolve();
+    await destroyPromise;
+    assert.equal(destroySettled, true);
+  } finally {
+    writeGate.resolve();
+    await (destroyPromise ?? orchestrator.destroy());
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -949,8 +949,8 @@ export class Orchestrator {
       await this.wearablesAutoSyncHandle.stop();
       this.wearablesAutoSyncHandle = null;
     }
-    await drainRecallWrites(this);
     this.maintenanceScheduler.dispose();
+    await drainRecallWrites(this);
     await this.namespaceSearchRouter.dispose();
     await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
     if (this.conversationQmd && this.conversationQmd !== this.qmd) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -120,6 +120,7 @@ import { NamespaceReadFanoutCoordinator } from "./orchestration/namespace-read-f
 import { selfDeps } from "./orchestration/self-deps.js";
 import { RecallEntryCoordinator } from "./orchestration/recall-entry.js";
 import { SessionContextCoordinator } from "./orchestration/session-context.js";
+import { drainRecallWrites, trackRecallWrite } from "./orchestration/recall-background-writes.js";
 import {
   abortRecallError,
   buildCompressionGuidelinesMarkdown,
@@ -135,9 +136,8 @@ import {
   type QueryAwarePrefilter,
   type RecallInvocationOptions,
 } from "./orchestration/orchestrator-helpers.js";
-// Issue #1526 seam 25: module-level helpers moved to
-// orchestration/orchestrator-helpers.ts; re-exported here so existing
-// importers (coordinators, tests, root shims) keep working.
+// Issue #1526 seam 25: helpers moved to orchestration/orchestrator-helpers.ts and are
+// re-exported here so existing importers (coordinators, tests, root shims) keep working.
 export {
   BulkImportBatchPartialFailureError,
   COMPACTION_SIGNAL_MAX_AGE_MS,
@@ -701,8 +701,7 @@ export class Orchestrator {
   /** Read by NamespaceReadFanoutCoordinator (seam 26), hence not `private`. */
   static readonly ARTIFACT_STATUS_CACHE_TTL_MS = 60_000;
 
-  // Access tracking buffer (Phase 1A)
-  // Maps memoryId -> {count, lastAccessed} for batched updates
+  // Batched access-tracking counts and timestamps (Phase 1A).
   private accessTrackingBuffer: Map<
     string,
     { count: number; lastAccessed: string }
@@ -887,9 +886,7 @@ export class Orchestrator {
   private utilityRuntimeValues: UtilityRuntimeValues | null = null;
   private evalShadowWriteChain: Promise<void> = Promise.resolve();
 
-  // Pending background observation-mode direct-answer annotations (#518).
-  // Tracks fire-and-forget `annotateDirectAnswerTier` calls so callers (tests,
-  // waitForDirectAnswerObservationIdle) can await settlement.
+  // Pending fire-and-forget direct-answer tier annotations (#518).
   private directAnswerObservationChain: Promise<void> = Promise.resolve();
 
   // Initialization gate: recall() awaits this before proceeding
@@ -934,8 +931,9 @@ export class Orchestrator {
     }
   }
 
-  private async disposeSearchBackendIfNeeded(): Promise<void> {
-    await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
+  /** Track a recall-side write so destroy() can wait for it before teardown. @internal */
+  trackRecallBackgroundWrite(promise: Promise<void>, label: string): void {
+    trackRecallWrite(this, promise, label);
   }
 
   /**
@@ -951,9 +949,10 @@ export class Orchestrator {
       await this.wearablesAutoSyncHandle.stop();
       this.wearablesAutoSyncHandle = null;
     }
+    await drainRecallWrites(this);
     this.maintenanceScheduler.dispose();
     await this.namespaceSearchRouter.dispose();
-    await this.disposeSearchBackendIfNeeded();
+    await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
     if (this.conversationQmd && this.conversationQmd !== this.qmd) {
       await (this.conversationQmd as { dispose?: () => void | Promise<void> }).dispose?.();
     }
@@ -3713,8 +3712,9 @@ export class Orchestrator {
     if (
       this.accessTrackingBuffer.size >= this.config.accessTrackingBufferMaxSize
     ) {
-      this.flushAccessTracking().catch((err) =>
-        log.debug(`background access tracking flush failed: ${err}`),
+      this.trackRecallBackgroundWrite(
+        this.flushAccessTracking(),
+        "background access tracking flush",
       );
     }
   }

--- a/packages/remnic-core/src/trust-score-recall-paths.test.ts
+++ b/packages/remnic-core/src/trust-score-recall-paths.test.ts
@@ -119,6 +119,7 @@ test("TrustScore runs on the recent-scan path: trust map reaches the X-ray snaps
       );
     }
   } finally {
+    await orchestrator.destroy();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
@@ -152,6 +153,7 @@ test("TrustScore quarantine excludes a contradicted memory from injection but su
       "quarantined result carries a human-readable reason",
     );
   } finally {
+    await orchestrator.destroy();
     await rm(memoryDir, { recursive: true, force: true });
   }
 });

--- a/tests/shared-context-recall.test.ts
+++ b/tests/shared-context-recall.test.ts
@@ -13,6 +13,7 @@ function isoForDate(date: string, time: string): Date {
 test("shared context recall injects latest cross-signals summary when available", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-memory-"));
   const sharedDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-shared-"));
+  let orchestrator: Orchestrator | undefined;
 
   try {
     const cfg = parseConfig({
@@ -33,7 +34,7 @@ test("shared context recall injects latest cross-signals summary when available"
         { id: "shared-context", enabled: true },
       ],
     });
-    const orchestrator = new Orchestrator(cfg);
+    orchestrator = new Orchestrator(cfg);
     assert.ok(orchestrator.sharedContext);
     await orchestrator.sharedContext!.ensureStructure();
 
@@ -67,6 +68,7 @@ test("shared context recall injects latest cross-signals summary when available"
     assert.match(context, /Recurring Themes/);
     assert.match(context, /checkout/);
   } finally {
+    await orchestrator?.destroy();
     await rm(memoryDir, { recursive: true, force: true });
     await rm(sharedDir, { recursive: true, force: true });
   }
@@ -75,6 +77,7 @@ test("shared context recall injects latest cross-signals summary when available"
 test("scope profile recall omits shared context when serverShared is not readable", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-profile-memory-"));
   const sharedDir = await mkdtemp(path.join(os.tmpdir(), "engram-shared-recall-profile-shared-"));
+  let orchestrator: Orchestrator | undefined;
 
   try {
     const cfg = parseConfig({
@@ -109,7 +112,7 @@ test("scope profile recall omits shared context when serverShared is not readabl
         { id: "shared-context", enabled: true },
       ],
     });
-    const orchestrator = new Orchestrator(cfg);
+    orchestrator = new Orchestrator(cfg);
     assert.ok(orchestrator.sharedContext);
     await orchestrator.sharedContext!.ensureStructure();
     await orchestrator.sharedContext!.appendPrioritiesInbox({
@@ -125,6 +128,7 @@ test("scope profile recall omits shared context when serverShared is not readabl
     assert.doesNotMatch(context, /## Shared Context/);
     assert.doesNotMatch(context, /private-only profile must not inject/);
   } finally {
+    await orchestrator?.destroy();
     await rm(memoryDir, { recursive: true, force: true });
     await rm(sharedDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Recall could end before a file save was done. A test could then remove the temp folder too soon. The late save failed because the folder was gone.

Remnic now keeps a list of saves made by recall. Stop waits for those saves before it closes runtime tools. Recall itself does not wait. Failed saves still stay best effort.

The drain covers the last recall state, handle history, eval shadow data, direct answer notes, and access counts. The affected tests now stop Remnic before they delete temp folders.

## Verification

- Focused cleanup tests passed.
- Core type checks passed.
- Entity hardening passed with 246 tests.
- Quick preflight passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown ordering and recall side-effect bookkeeping; incorrect draining could delay teardown or miss writes, but scope is limited to best-effort background persistence rather than the primary recall response path.
> 
> **Overview**
> Adds **per-orchestrator tracking** of fire-and-forget recall side-effect writes and **awaits them in `destroy()`** before disposing search backends, so shutdown and tests do not tear down temp dirs while saves are still in flight.
> 
> New `trackRecallWrite` / `drainRecallWrites` use a `WeakMap` of pending promises with centralized debug logging on failure. Recall paths register writes instead of only attaching `.catch()` locally: **last-recall** snapshots, **handle history**, **eval shadow** chain, **direct-answer observation**, and **access-tracking** flushes. The recall hot path stays non-blocking; only teardown waits.
> 
> **`destroy()`** now calls `drainRecallWrites(this)` after maintenance disposal and before namespace/QMD disposal. Tests assert destroy stays pending until tracked writes finish, and several suites call `orchestrator.destroy()` before removing temp folders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0defdd5fc8ad565aa287f1c57d4109d3981cf3fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->