### PR TITLE
Cache compacted namespace catalog reads

### DIFF
--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -52,6 +52,10 @@ class CountingNamespaceCatalog extends NamespaceCatalog {
       this.catalogReadCount++;
     };
   }
+
+  setAfterAppendHook(hook: () => Promise<void>): void {
+    this.onAfterCatalogAppendForTest = hook;
+  }
 }
 
 test("markWrite registers a dynamic project namespace in the catalog", async () => {
@@ -113,6 +117,39 @@ test("repeated touches do not re-read an unchanged catalog", async () => {
     await catalog.markMaintenance("alpha", "test");
 
     assert.equal(catalog.catalogReadCount, 1);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("a foreign append between append and stat invalidates the cache", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new CountingNamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite("alpha", { discoveredBy: "write" });
+
+    const catalogPath = path.join(memoryDir, "state", "namespaces.jsonl");
+    const alpha = JSON.parse((await readFile(catalogPath, "utf8")).trim());
+    const externalNamespace = "racing-external";
+    catalog.setAfterAppendHook(async () => {
+      await appendFile(
+        catalogPath,
+        `${JSON.stringify({
+          ...alpha,
+          namespace: externalNamespace,
+          identityToken: namespaceIdentityToken(externalNamespace),
+          storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(externalNamespace)),
+        })}\n`,
+        "utf8",
+      );
+    });
+
+    await catalog.markRead("alpha");
+    const readsBeforeReload = catalog.catalogReadCount;
+    const records = await catalog.listNamespaces();
+
+    assert.equal(catalog.catalogReadCount, readsBeforeReload + 1);
+    assert.ok(records.some((record) => record.namespace === externalNamespace));
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -523,6 +523,20 @@ test("catalog tolerates corrupt / non-object JSONL lines on read", async () => {
   }
 });
 
+test("catalog read fails open when the catalog path is a directory", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    await mkdir(path.join(memoryDir, "state", "namespaces.jsonl"), { recursive: true });
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+
+    await assert.doesNotReject(async () => {
+      assert.deepEqual(await catalog.listNamespaces(), []);
+    });
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("catalog quarantines malformed JSONL record fields at the parse boundary", async () => {
   const memoryDir = await mkMemoryDir();
   try {

--- a/packages/remnic-core/src/namespaces/catalog.test.ts
+++ b/packages/remnic-core/src/namespaces/catalog.test.ts
@@ -1,5 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import {
+  appendFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,6 +43,17 @@ async function mkMemoryDir(): Promise<string> {
   return await mkdtemp(path.join(os.tmpdir(), "remnic-ns-catalog-"));
 }
 
+class CountingNamespaceCatalog extends NamespaceCatalog {
+  catalogReadCount = 0;
+
+  constructor(config: PluginConfig) {
+    super(config);
+    this.onCatalogReadForTest = () => {
+      this.catalogReadCount++;
+    };
+  }
+}
+
 test("markWrite registers a dynamic project namespace in the catalog", async () => {
   const memoryDir = await mkMemoryDir();
   try {
@@ -45,6 +67,52 @@ test("markWrite registers a dynamic project namespace in the catalog", async () 
     assert.ok(record?.lastWriteAt, "expected lastWriteAt to be set");
     assert.equal(record?.discoveredBy, "write");
     assert.ok(record?.storageDir.includes("namespaces"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("touch reloads the catalog after an external append", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new NamespaceCatalog(makeConfig(memoryDir));
+    await catalog.markWrite("alpha", { discoveredBy: "write" });
+
+    const catalogPath = path.join(memoryDir, "state", "namespaces.jsonl");
+    const alpha = JSON.parse((await readFile(catalogPath, "utf8")).trim());
+    const externalNamespace = "external";
+    await appendFile(
+      catalogPath,
+      `${JSON.stringify({
+        ...alpha,
+        namespace: externalNamespace,
+        identityToken: namespaceIdentityToken(externalNamespace),
+        storageDir: path.join(memoryDir, "namespaces", namespaceIdentityToken(externalNamespace)),
+      })}\n`,
+      "utf8",
+    );
+
+    await catalog.markRead("alpha");
+
+    assert.ok(
+      (await catalog.listNamespaces()).some((record) => record.namespace === externalNamespace),
+      "the touch must fold in a row appended through another file descriptor",
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("repeated touches do not re-read an unchanged catalog", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const catalog = new CountingNamespaceCatalog(makeConfig(memoryDir));
+
+    await catalog.markWrite("alpha", { discoveredBy: "write" });
+    await catalog.markRead("alpha");
+    await catalog.markMaintenance("alpha", "test");
+
+    assert.equal(catalog.catalogReadCount, 1);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -84,6 +152,19 @@ test("rebuildFromDisk finds existing tokenized namespace directories", async () 
     const reloaded = new NamespaceCatalog(makeConfig(memoryDir));
     const record = await reloaded.getNamespaceRecord(ns);
     assert.ok(record, "expected rebuilt record to persist");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildFromDisk accepts config without sharedNamespace", async () => {
+  const memoryDir = await mkMemoryDir();
+  try {
+    const config = makeConfig(memoryDir);
+    delete (config as Partial<PluginConfig>).sharedNamespace;
+    const catalog = new NamespaceCatalog(config);
+
+    await assert.doesNotReject(catalog.rebuildFromDisk());
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -5,8 +5,8 @@ import {
   appendFile,
   lstat,
   mkdir,
+  open,
   readdir,
-  readFile,
   realpath,
   rename,
   stat,
@@ -426,6 +426,17 @@ function inferKind(namespace: string, config: PluginConfig): NamespaceKind {
   return "explicit";
 }
 
+interface CatalogFileIdentity {
+  size: number;
+  mtimeMs: number;
+  ino: number;
+}
+
+interface CompactedCatalogCache {
+  identity: CatalogFileIdentity;
+  records: Map<string, NamespaceRecord>;
+}
+
 export class NamespaceCatalog {
   private readonly memoryDir: string;
   private readonly stateDir: string;
@@ -441,12 +452,16 @@ export class NamespaceCatalog {
   // neither mistakes the other's lock for self-held (round 6, codex P2 — NBsGP
   // invariant preserved and tightened).
   private readonly criticalSection = new MutationSerializer();
+  private compactedCache: CompactedCatalogCache | undefined;
   // Test-only seam (round 7 — NEZkA): fires inside a touch's HELD-lock critical
   // section, after the lock is acquired but BEFORE the read→merge→append. A
   // deterministic concurrency test installs a hook here to widen the (otherwise
   // microscopic) window and prove that a cross-process rebuild CANNOT run its
   // load→rename while a touch holds the lock. Never set in production code.
   protected onTouchCriticalSectionForTest?: () => Promise<void>;
+  // Test-only observation seam: fires only when the JSONL file is fully read.
+  // Cached loads do not invoke it.
+  protected onCatalogReadForTest?: () => void;
   // Test-only seam (round 7 — NEZkA): fires inside a mutating rebuild's HELD-lock
   // critical section, after the final cross-process re-merge `loadCompacted()` and
   // BEFORE the atomic `rename()`. This is the EXACT window in which a check-then-
@@ -597,19 +612,20 @@ export class NamespaceCatalog {
     }
     return [...byStorageDir.values()];
   }
-
-  private async loadSanitizedRecords(): Promise<NamespaceRecord[]> {
-    const records = await this.loadCompacted();
-    const sanitized = await Promise.all(
-      [...records.values()].map((r) => this.sanitizeRecordForRead(r)),
-    );
-    // Drop unsafe-namespace rows (sanitizer returned null) at the read boundary.
-    // Then collapse duplicate root aliases so maintenance/QMD see exactly one
-    // namespace owner for a physical storage root, matching rebuild ownership,
-    // while preserving touch recency from every alias row.
-    return this.dropDuplicateStorageRootAliases(
-      sanitized.filter((r): r is NamespaceRecord => r !== null),
-    );
+  private loadSanitizedRecords(): Promise<NamespaceRecord[]> {
+    return this.queueCritical(async () => {
+      const records = await this.loadCompacted();
+      const sanitized = await Promise.all(
+        [...records.values()].map((r) => this.sanitizeRecordForRead(r)),
+      );
+      // Drop unsafe-namespace rows (sanitizer returned null) at the read boundary.
+      // Then collapse duplicate root aliases so maintenance/QMD see exactly one
+      // namespace owner for a physical storage root, matching rebuild ownership,
+      // while preserving touch recency from every alias row.
+      return this.dropDuplicateStorageRootAliases(
+        sanitized.filter((r): r is NamespaceRecord => r !== null),
+      );
+    });
   }
 
   async listNamespaces(filter?: NamespaceCatalogFilter): Promise<NamespaceRecord[]> {
@@ -1897,53 +1913,90 @@ export class NamespaceCatalog {
     if (prior.parentNamespace !== undefined) merged.parentNamespace = prior.parentNamespace;
     return merged;
   }
-
   // ── Persistence ──────────────────────────────────────────────────────────
 
   /** Load the JSONL log and fold it into current state (last-record-wins). */
   private async loadCompacted(): Promise<Map<string, NamespaceRecord>> {
     const records = new Map<string, NamespaceRecord>();
-    let raw: string;
+    let handle;
     try {
-      raw = await readFile(this.catalogPath, "utf8");
+      handle = await open(this.catalogPath, "r");
     } catch {
+      this.compactedCache = undefined;
       return records;
     }
-    for (const line of raw.split("\n")) {
-      const trimmed = line.trim();
-      if (trimmed.length === 0) continue;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(trimmed);
-      } catch {
-        // Skip corrupt lines (CLAUDE.md rule #18 robustness).
-        continue;
+
+    let identity: CatalogFileIdentity | undefined;
+    try {
+      const fileStat = await handle.stat();
+      identity = {
+        size: fileStat.size,
+        mtimeMs: fileStat.mtimeMs,
+        ino: fileStat.ino,
+      };
+      if (
+        this.compactedCache &&
+        this.compactedCache.identity.size === identity.size &&
+        this.compactedCache.identity.mtimeMs === identity.mtimeMs &&
+        this.compactedCache.identity.ino === identity.ino
+      ) {
+        await handle.close();
+        return this.cloneCompactedRecords(this.compactedCache.records);
       }
-      const record = coerceRecord(parsed);
-      if (!record) continue;
-      // Field-level touch merge during compaction (round 6, codex P2 — ND6Cz).
-      // Touches run on PER-PROCESS write chains, so two processes (a gateway write
-      // racing a CLI/second-server read or maintenance touch) can each load the
-      // same prior record and append a full snapshot. Plain last-record-wins
-      // compaction would then discard the earlier snapshot's `lastReadAt` /
-      // `lastWriteAt` / `lastMaintenanceAt`, erasing a real touch and skewing
-      // `writtenSince`. We instead take the LATER record as the base (most recent
-      // identity/disk-derived state) and fold in the MAX of each touch field from
-      // both, so no cross-process touch recency is lost without locking the hot
-      // touch path. A destructive overwrite of real memory is never at stake here
-      // — only best-effort recency metadata.
-      const prior = records.get(record.namespace);
-      records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
+    } catch {
+      // A failed fstat cannot prove freshness. Read and parse the open file, but
+      // do not cache the result without a trustworthy identity.
     }
-    return records;
+
+    try {
+      this.onCatalogReadForTest?.();
+      const raw = await handle.readFile("utf8");
+      for (const line of raw.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) continue;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          // Skip corrupt lines (CLAUDE.md rule #18 robustness).
+          continue;
+        }
+        const record = coerceRecord(parsed);
+        if (!record) continue;
+        // Preserve each touch field across cross-process full-snapshot appends.
+        // Field-level touch merge preserves the newest value for every touch
+        // field when full-snapshot appends from separate processes interleave.
+        const prior = records.get(record.namespace);
+        records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
+      }
+    } finally {
+      await handle.close();
+    }
+
+    this.compactedCache = identity ? { identity, records } : undefined;
+    return this.cloneCompactedRecords(records);
+  }
+
+  private cloneCompactedRecords(
+    records: Map<string, NamespaceRecord>,
+  ): Map<string, NamespaceRecord> {
+    return new Map(
+      [...records].map(([namespace, record]) => [
+        namespace,
+        {
+          ...record,
+          lastMaintenanceAt: record.lastMaintenanceAt
+            ? { ...record.lastMaintenanceAt }
+            : undefined,
+        },
+      ]),
+    );
   }
 
   /**
    * Serialize an arbitrary read-modify-write critical section through the single
-   * per-instance chain. Every catalog mutation (touch read+merge+append, full
-   * rewrite) runs through this so they are mutually exclusive: a touch always
-   * reads the latest persisted state before appending, and a rebuild rewrite
-   * cannot interleave with a touch's append.
+   * per-instance chain. Every catalog mutation and cached catalog read runs
+   * through this queue, so cache validation and updates cannot race in-process.
    *
    * Issue #1524 adoption: delegates to the shared `MutationSerializer` (stored
    * as `criticalSection`). The util owns the rejection-recovery invariant
@@ -1966,6 +2019,7 @@ export class NamespaceCatalog {
     const line = serializeRecord(record) + "\n";
     await mkdir(this.stateDir, { recursive: true });
     await appendFile(this.catalogPath, line, "utf8");
+    await this.refreshCacheAfterAppend(record);
   }
 
   /**
@@ -1982,6 +2036,31 @@ export class NamespaceCatalog {
     const tmp = `${this.catalogPath}.${process.pid}.${Date.now()}.tmp`;
     await writeFile(tmp, body, "utf8");
     await rename(tmp, this.catalogPath);
+    await this.refreshCacheIdentity(new Map(records.map((record) => [record.namespace, record])));
+  }
+
+  private async refreshCacheAfterAppend(record: NamespaceRecord): Promise<void> {
+    const cachedRecords = this.compactedCache?.records;
+    if (!cachedRecords) return;
+    const prior = cachedRecords.get(record.namespace);
+    cachedRecords.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
+    await this.refreshCacheIdentity(cachedRecords);
+  }
+
+  private async refreshCacheIdentity(records: Map<string, NamespaceRecord>): Promise<void> {
+    try {
+      const fileStat = await stat(this.catalogPath);
+      this.compactedCache = {
+        identity: {
+          size: fileStat.size,
+          mtimeMs: fileStat.mtimeMs,
+          ino: fileStat.ino,
+        },
+        records,
+      };
+    } catch {
+      this.compactedCache = undefined;
+    }
   }
 }
 

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -429,6 +429,7 @@ function inferKind(namespace: string, config: PluginConfig): NamespaceKind {
 interface CatalogFileIdentity {
   size: number;
   mtimeMs: number;
+  ctimeMs: number;
   ino: number;
 }
 
@@ -1935,6 +1936,7 @@ export class NamespaceCatalog {
       identity = {
         size: fileStat.size,
         mtimeMs: fileStat.mtimeMs,
+        ctimeMs: fileStat.ctimeMs,
         ino: fileStat.ino,
       };
       if (
@@ -1942,9 +1944,10 @@ export class NamespaceCatalog {
         this.compactedCache &&
         this.compactedCache.identity.size === identity.size &&
         this.compactedCache.identity.mtimeMs === identity.mtimeMs &&
+        this.compactedCache.identity.ctimeMs === identity.ctimeMs &&
         this.compactedCache.identity.ino === identity.ino
       ) {
-        await handle.close();
+        await handle.close().catch(() => undefined);
         return this.cloneCompactedRecords(this.compactedCache.records);
       }
     } catch {
@@ -1973,8 +1976,11 @@ export class NamespaceCatalog {
         const prior = records.get(record.namespace);
         records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
       }
+    } catch {
+      this.compactedCache = undefined;
+      return new Map();
     } finally {
-      await handle.close();
+      await handle.close().catch(() => undefined);
     }
 
     this.compactedCache = identity ? { identity, records } : undefined;
@@ -2066,6 +2072,7 @@ export class NamespaceCatalog {
         identity: {
           size: fileStat.size,
           mtimeMs: fileStat.mtimeMs,
+          ctimeMs: fileStat.ctimeMs,
           ino: fileStat.ino,
         },
         records: cached.records,
@@ -2082,6 +2089,7 @@ export class NamespaceCatalog {
         identity: {
           size: fileStat.size,
           mtimeMs: fileStat.mtimeMs,
+          ctimeMs: fileStat.ctimeMs,
           ino: fileStat.ino,
         },
         records,

--- a/packages/remnic-core/src/namespaces/catalog.ts
+++ b/packages/remnic-core/src/namespaces/catalog.ts
@@ -462,6 +462,9 @@ export class NamespaceCatalog {
   // Test-only observation seam: fires only when the JSONL file is fully read.
   // Cached loads do not invoke it.
   protected onCatalogReadForTest?: () => void;
+  // Test-only seam: fires after this process appends but before it stats the
+  // file to refresh the cache identity.
+  protected onAfterCatalogAppendForTest?: () => Promise<void>;
   // Test-only seam (round 7 — NEZkA): fires inside a mutating rebuild's HELD-lock
   // critical section, after the final cross-process re-merge `loadCompacted()` and
   // BEFORE the atomic `rename()`. This is the EXACT window in which a check-then-
@@ -1717,7 +1720,7 @@ export class NamespaceCatalog {
       // scan, which the in-process `queueCritical` alone cannot see. Only runs
       // when we hold the lock (round 6, codex P2 — NBPmY): an unlocked rebuild
       // must not re-merge then rename, or it races a concurrent lock holder.
-      const latest = await this.loadCompacted();
+      const latest = await this.loadCompacted(true);
       for (const [ns, fresh] of latest) {
         const current = rebuilt.get(ns);
         if (!current) {
@@ -1916,7 +1919,7 @@ export class NamespaceCatalog {
   // ── Persistence ──────────────────────────────────────────────────────────
 
   /** Load the JSONL log and fold it into current state (last-record-wins). */
-  private async loadCompacted(): Promise<Map<string, NamespaceRecord>> {
+  private async loadCompacted(forceFresh = false): Promise<Map<string, NamespaceRecord>> {
     const records = new Map<string, NamespaceRecord>();
     let handle;
     try {
@@ -1935,6 +1938,7 @@ export class NamespaceCatalog {
         ino: fileStat.ino,
       };
       if (
+        !forceFresh &&
         this.compactedCache &&
         this.compactedCache.identity.size === identity.size &&
         this.compactedCache.identity.mtimeMs === identity.mtimeMs &&
@@ -2017,9 +2021,13 @@ export class NamespaceCatalog {
    */
   private async appendUnchained(record: NamespaceRecord): Promise<void> {
     const line = serializeRecord(record) + "\n";
+    const lineByteLength = Buffer.byteLength(line, "utf8");
     await mkdir(this.stateDir, { recursive: true });
     await appendFile(this.catalogPath, line, "utf8");
-    await this.refreshCacheAfterAppend(record);
+    if (this.onAfterCatalogAppendForTest) {
+      await this.onAfterCatalogAppendForTest();
+    }
+    await this.refreshCacheAfterAppend(record, lineByteLength);
   }
 
   /**
@@ -2039,12 +2047,32 @@ export class NamespaceCatalog {
     await this.refreshCacheIdentity(new Map(records.map((record) => [record.namespace, record])));
   }
 
-  private async refreshCacheAfterAppend(record: NamespaceRecord): Promise<void> {
-    const cachedRecords = this.compactedCache?.records;
-    if (!cachedRecords) return;
-    const prior = cachedRecords.get(record.namespace);
-    cachedRecords.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
-    await this.refreshCacheIdentity(cachedRecords);
+  private async refreshCacheAfterAppend(
+    record: NamespaceRecord,
+    lineByteLength: number,
+  ): Promise<void> {
+    const cached = this.compactedCache;
+    if (!cached) return;
+    const expectedSize = cached.identity.size + lineByteLength;
+    try {
+      const fileStat = await stat(this.catalogPath);
+      if (fileStat.size !== expectedSize || fileStat.ino !== cached.identity.ino) {
+        this.compactedCache = undefined;
+        return;
+      }
+      const prior = cached.records.get(record.namespace);
+      cached.records.set(record.namespace, prior ? mergeNewerTouchFields(record, prior) : record);
+      this.compactedCache = {
+        identity: {
+          size: fileStat.size,
+          mtimeMs: fileStat.mtimeMs,
+          ino: fileStat.ino,
+        },
+        records: cached.records,
+      };
+    } catch {
+      this.compactedCache = undefined;
+    }
   }
 
   private async refreshCacheIdentity(records: Map<string, NamespaceRecord>): Promise<void> {

--- a/packages/remnic-core/src/namespaces/identity.ts
+++ b/packages/remnic-core/src/namespaces/identity.ts
@@ -1,5 +1,5 @@
-export function normalizeNamespaceIdentity(namespace: string): string {
-  return namespace.trim();
+export function normalizeNamespaceIdentity(namespace: string | null | undefined): string {
+  return namespace?.trim() ?? "";
 }
 
 export function namespaceIdentityToken(namespace: string): string {


### PR DESCRIPTION
## What changed

`NamespaceCatalog` now caches the parsed `namespaces.jsonl` map. Each read checks the open file with `fstat`. The cache key uses `size`, `mtimeMs`, and `ino`. A changed file gets parsed again. A failed stat also forces a full parse.

The append and rewrite paths keep the cache in sync inside `queueCritical`. Reads now use that same queue. This keeps the current lock order and rebuild rules intact.

`normalizeNamespaceIdentity` now accepts null or missing values. A rebuild can handle old config objects that lack `sharedNamespace`.

## Tests

Added tests for an append through another file handle, cached touch reads, and a missing `sharedNamespace`. The current touch-field merge tests remain in place.

Ran `npm run preflight:quick`.

## Follow-up

This change does not schedule catalog compaction. Automatic compaction remains separate work.

Fixes #1820

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot read path and cache invalidation around concurrent catalog writes; behavior is serialized and heavily tested but still affects namespace enumeration correctness.
> 
> **Overview**
> **`NamespaceCatalog`** now keeps an in-process cache of the parsed `namespaces.jsonl` map. **`loadCompacted`** opens the file, uses **`fstat`** identity (`size`, `mtimeMs`, `ctimeMs`, `ino`) to skip re-parsing when unchanged, and **`loadSanitizedRecords`** runs through **`queueCritical`** so cache checks and mutations do not race in-process. Appends and full rewrites refresh or invalidate the cache (including when another writer changes the file between append and stat).
> 
> **`normalizeNamespaceIdentity`** now treats `null`/`undefined` as empty strings so rebuild paths tolerate config without **`sharedNamespace`**.
> 
> New tests cover external appends, cache hit/miss behavior, rebuild without shared namespace, and fail-open reads when the catalog path is a directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9365f628ad346acea69a9c0b0dc2a907dac56d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->