### PR TITLE
Bound projection browse work to each page

### DIFF
--- a/packages/remnic-core/src/maintenance/purge.test.ts
+++ b/packages/remnic-core/src/maintenance/purge.test.ts
@@ -5,6 +5,9 @@ import path from "node:path";
 import test from "node:test";
 
 import { purgeMemories } from "./purge.js";
+import { rebuildMemoryProjection } from "./rebuild-memory-projection.js";
+import { readProjectedMemoryBrowse } from "../memory-projection-store.js";
+import { StorageManager } from "../storage.js";
 import type { MemoryFile } from "../types.js";
 
 test("purgeMemories records audit errors without blocking hard delete", async () => {
@@ -49,6 +52,79 @@ test("purgeMemories records audit errors without blocking hard delete", async ()
     assert.equal(result.errors[0]?.id, "(purge-audit)");
     assert.equal(result.errors[1]?.id, "(purge-audit)");
     assert.equal(await fileExists(memoryPath), false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("purgeMemories invalidates projection rows for hard-deleted memories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-purge-projection-"));
+  try {
+    const storage = new StorageManager(dir);
+    const { id } = await storage.writeMemory("fact", "purge projection target", {
+      source: "test",
+    });
+    const memory = await storage.getMemoryById(id);
+    assert.ok(memory);
+    await rebuildMemoryProjection({ memoryDir: dir, dryRun: false });
+    assert.equal(readProjectedMemoryBrowse(dir, { limit: 5, offset: 0 })?.total, 1);
+
+    const result = await purgeMemories({
+      storage,
+      olderThanMs: 1,
+      tier: "all",
+      dryRun: false,
+      now: () => new Date(Date.now() + 86_400_000),
+    });
+
+    assert.equal(result.purgedCount, 1);
+    assert.equal(readProjectedMemoryBrowse(dir, { limit: 5, offset: 0 })?.total, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("purgeMemories invalidates projection rows for already-absent files but not failed deletes, and dry-run never mutates", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-purge-projection-branches-"));
+  try {
+    // Real projection with two rows; candidates come from a mock storage so the
+    // unlink outcomes are deterministic: one path is already absent (ENOENT),
+    // the other is a non-empty directory (unlink fails, not ENOENT).
+    const realStorage = new StorageManager(dir);
+    const first = await realStorage.writeMemory("fact", "purge branch enoent", { source: "test" });
+    const second = await realStorage.writeMemory("fact", "purge branch failure", { source: "test" });
+    await rebuildMemoryProjection({ memoryDir: dir, dryRun: false });
+    assert.equal(readProjectedMemoryBrowse(dir, { limit: 5, offset: 0 })?.total, 2);
+
+    const firstMemory = await realStorage.getMemoryById(first.id);
+    const secondMemory = await realStorage.getMemoryById(second.id);
+    assert.ok(firstMemory && secondMemory);
+    await rm(firstMemory.path);
+    await rm(secondMemory.path);
+    await mkdir(secondMemory.path);
+    await writeFile(path.join(secondMemory.path, "block.txt"), "x", "utf8");
+
+    const mockStorage = {
+      dir,
+      readAllMemories: async () => [firstMemory, secondMemory],
+      readAllColdMemories: async () => [],
+      readArchivedMemories: async () => [],
+    };
+    const future = () => new Date(Date.now() + 86_400_000);
+
+    // Dry-run: no projection mutation.
+    await purgeMemories({ storage: mockStorage as never, olderThanMs: 1, tier: "all", dryRun: true, now: future });
+    assert.equal(readProjectedMemoryBrowse(dir, { limit: 5, offset: 0 })?.total, 2);
+
+    const result = await purgeMemories({ storage: mockStorage as never, olderThanMs: 1, tier: "all", dryRun: false, now: future });
+
+    assert.equal(result.alreadyAbsentCount, 1);
+    assert.equal(result.purgedCount, 0);
+    assert.equal(result.errors.filter((e) => e.id === second.id).length, 1);
+    const page = readProjectedMemoryBrowse(dir, { limit: 5, offset: 0 });
+    assert.ok(page);
+    // ENOENT row invalidated; failed-delete row keeps its projection entry.
+    assert.equal(page.total, 1);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/maintenance/purge.ts
+++ b/packages/remnic-core/src/maintenance/purge.ts
@@ -23,6 +23,7 @@ import path from "node:path";
 import { appendFile, mkdir, unlink } from "node:fs/promises";
 import type { StorageManager } from "../storage.js";
 import type { MemoryFile } from "../types.js";
+import { markProjectedMemoryPathInvalid } from "../memory-projection-store.js";
 import type { SearchBackend } from "../search/port.js";
 
 export type PurgeTierFilter = "cold" | "all";
@@ -236,12 +237,14 @@ export async function purgeMemories(
       await unlink(candidate.path);
       actuallyPurged.push(candidate);
       addCollectionForCandidate(candidate);
+      markProjectedMemoryPathInvalid(storage.dir, candidate.id);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       // ENOENT is fine — already gone
       if (hasErrorCode(err, "ENOENT")) {
         alreadyAbsent.push(candidate);
         addCollectionForCandidate(candidate);
+        markProjectedMemoryPathInvalid(storage.dir, candidate.id);
       } else {
         errors.push({ id: candidate.id, path: candidate.path, error: message });
       }

--- a/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
@@ -23,6 +23,7 @@ import {
 import {
   getMemoryProjectionPath,
   initializeMemoryProjectionDb,
+  isProjectedMemoryPathValid,
   type ProjectedEntityMentionRow,
   type MemoryProjectionGovernanceAppliedActionRow,
   type MemoryProjectionGovernanceReviewQueueRow,
@@ -658,6 +659,7 @@ function writeProjectionDb(
   usedLifecycleLedger: boolean,
 ): void {
   const db = openBetterSqlite3(dbPath);
+  const memoryDir = path.dirname(path.dirname(dbPath));
   try {
     initializeMemoryProjectionDb(db);
 
@@ -674,6 +676,7 @@ function writeProjectionDb(
         status,
         lifecycle_state,
         path_rel,
+        path_valid,
         created_at,
         updated_at,
         archived_at,
@@ -687,7 +690,7 @@ function writeProjectionDb(
         last_accessed,
         tags_json,
         preview_text
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const insertTimeline = db.prepare(`
@@ -785,6 +788,7 @@ function writeProjectionDb(
           row.status,
           row.lifecycleState ?? null,
           row.pathRel,
+          isProjectedMemoryPathValid(memoryDir, row.pathRel) ? 1 : 0,
           row.created,
           row.updated,
           row.archivedAt ?? null,

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -17,7 +17,7 @@ import {
   type BetterSqlite3Database,
 } from "./runtime/better-sqlite.js";
 
-export const MEMORY_PROJECTION_SCHEMA_VERSION = 2;
+export const MEMORY_PROJECTION_SCHEMA_VERSION = 3;
 
 export interface ProjectedMemoryBrowseOptions {
   query?: string;
@@ -153,11 +153,13 @@ function migrateProjectionSchemaIfNeeded(memoryDir: string): void {
 export function memoryCurrentSelectExpressions(db: BetterSqlite3Database): {
   tagsJson: string;
   previewText: string;
+  hasPathValid: boolean;
 } {
   const columns = listTableColumns(db, "memory_current");
   return {
     tagsJson: columns.has("tags_json") ? "tags_json" : `'[]' AS tags_json`,
     previewText: columns.has("preview_text") ? "preview_text" : `'' AS preview_text`,
+    hasPathValid: columns.has("path_valid"),
   };
 }
 
@@ -174,6 +176,7 @@ export function initializeMemoryProjectionDb(db: BetterSqlite3Database): void {
       status TEXT NOT NULL,
       lifecycle_state TEXT,
       path_rel TEXT NOT NULL,
+      path_valid INTEGER NOT NULL DEFAULT 0 CHECK (path_valid IN (0, 1)),
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       archived_at TEXT,
@@ -195,8 +198,6 @@ export function initializeMemoryProjectionDb(db: BetterSqlite3Database): void {
     CREATE INDEX IF NOT EXISTS idx_memory_current_category
       ON memory_current(category);
 
-    CREATE INDEX IF NOT EXISTS idx_memory_current_updated
-      ON memory_current(updated_at DESC);
 
     CREATE TABLE IF NOT EXISTS memory_timeline (
       event_id TEXT PRIMARY KEY,
@@ -297,6 +298,18 @@ export function initializeMemoryProjectionDb(db: BetterSqlite3Database): void {
   `);
 
   migrateMemoryCurrentTable(db);
+  if (listTableColumns(db, "memory_current").has("path_valid")) {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_memory_current_browse_updated_desc
+        ON memory_current(path_valid, updated_at DESC, created_at DESC, memory_id ASC);
+      CREATE INDEX IF NOT EXISTS idx_memory_current_browse_updated_asc
+        ON memory_current(path_valid, updated_at ASC, created_at ASC, memory_id ASC);
+      CREATE INDEX IF NOT EXISTS idx_memory_current_browse_created_desc
+        ON memory_current(path_valid, created_at DESC, updated_at DESC, memory_id ASC);
+      CREATE INDEX IF NOT EXISTS idx_memory_current_browse_created_asc
+        ON memory_current(path_valid, created_at ASC, updated_at ASC, memory_id ASC);
+    `);
+  }
   db.prepare("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)")
     .run("schemaVersion", String(MEMORY_PROJECTION_SCHEMA_VERSION));
 }
@@ -375,6 +388,10 @@ function resolveProjectedMemoryPath(memoryDir: string, pathRel: string): string 
     // Missing files are handled by callers. Still keep the lexical guard above.
   }
   return candidate;
+}
+
+export function isProjectedMemoryPathValid(memoryDir: string, pathRel: string): boolean {
+  return resolveProjectedMemoryPath(memoryDir, pathRel) !== null;
 }
 
 function projectedBrowseRowFromCurrentRow(
@@ -613,8 +630,15 @@ export function readProjectedMemoryBrowse(
     const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
 
     if (normalizedQuery) {
-      // Query-based browse: fetch all matching rows, filter by full file content, then paginate in JS
-      const allRows = db
+      // Full-content search still examines every eligible row so totals and
+      // matches stay exact, but iteration keeps memory use proportional to the page.
+      const queryWhereClauses = currentSelect.hasPathValid
+        ? [...whereClauses, ...projectedBrowsePathSqlClauses(), "path_valid = 1"]
+        : whereClauses;
+      const queryWhereSql = queryWhereClauses.length > 0
+        ? `WHERE ${queryWhereClauses.join(" AND ")}`
+        : "";
+      const rows = db
         .prepare(`
           SELECT
             memory_id,
@@ -627,47 +651,79 @@ export function readProjectedMemoryBrowse(
             ${currentSelect.tagsJson},
             ${currentSelect.previewText}
           FROM memory_current
-          ${whereSql}
+          ${queryWhereSql}
           ORDER BY ${orderBySql}
         `)
-        .all(...params) as Array<Record<string, unknown>>;
+        .iterate(...params) as Iterable<Record<string, unknown>>;
+      const pageRows: ProjectedMemoryBrowseRow[] = [];
+      let total = 0;
 
-      const filtered = allRows.filter((row) => {
-        if (typeof row.memory_id !== "string" || typeof row.path_rel !== "string") return false;
+      for (const row of rows) {
+        if (typeof row.memory_id !== "string" || typeof row.path_rel !== "string") continue;
         const filePath = resolveProjectedMemoryPath(memoryDir, row.path_rel);
-        if (!filePath) return false;
-        // Check preview, category, entity_ref, tags first (fast)
+        if (!filePath) continue;
         const preview = typeof row.preview_text === "string" ? row.preview_text.toLowerCase() : "";
         const category = typeof row.category === "string" ? row.category.toLowerCase() : "";
         const entityRef = typeof row.entity_ref === "string" ? row.entity_ref.toLowerCase() : "";
         const tags = typeof row.tags_json === "string" ? row.tags_json.toLowerCase() : "";
-        if (preview.includes(normalizedQuery) || category.includes(normalizedQuery) ||
-            entityRef.includes(normalizedQuery) || tags.includes(normalizedQuery)) {
-          return true;
+        let matches = preview.includes(normalizedQuery) || category.includes(normalizedQuery) ||
+          entityRef.includes(normalizedQuery) || tags.includes(normalizedQuery);
+        if (!matches) {
+          try {
+            matches = fs.readFileSync(filePath, "utf-8").toLowerCase().includes(normalizedQuery);
+          } catch {
+            matches = false;
+          }
         }
-        // Fall back to reading full file content from disk
-        try {
-          const content = fs.readFileSync(filePath, "utf-8").toLowerCase();
-          return content.includes(normalizedQuery);
-        } catch {
-          return false;
+        if (!matches) continue;
+        if (total >= options.offset && pageRows.length < options.limit) {
+          const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row);
+          if (browseRow) pageRows.push(browseRow);
         }
-      });
+        total += 1;
+      }
 
-      const pageRows = filtered.slice(options.offset, options.offset + options.limit);
+      return { total, memories: pageRows };
+    }
+
+    const browseWhereClauses = [...whereClauses, ...projectedBrowsePathSqlClauses()];
+    if (currentSelect.hasPathValid) {
+      browseWhereClauses.push("path_valid = 1");
+    }
+    const browseWhereSql = `WHERE ${browseWhereClauses.join(" AND ")}`;
+
+    if (currentSelect.hasPathValid) {
+      const totalRow = db
+        .prepare(`SELECT COUNT(*) AS total FROM memory_current ${browseWhereSql}`)
+        .get(...params) as { total: number };
+      const rows = db
+        .prepare(`
+          SELECT
+            memory_id,
+            path_rel,
+            category,
+            status,
+            created_at,
+            updated_at,
+            entity_ref,
+            ${currentSelect.tagsJson},
+            ${currentSelect.previewText}
+          FROM memory_current
+          ${browseWhereSql}
+          ORDER BY ${orderBySql}
+          LIMIT ? OFFSET ?
+        `)
+        .all(...params, options.limit, options.offset) as Array<Record<string, unknown>>;
       return {
-        total: filtered.length,
-        memories: pageRows
+        total: totalRow.total,
+        memories: rows
           .map((row) => projectedBrowseRowFromCurrentRow(memoryDir, row))
           .filter((row): row is ProjectedMemoryBrowseRow => row !== null),
       };
     }
 
-    // No query: push lexical path safety into SQL, then count through the same
-    // realpath-aware row parser used for returned rows so symlink escapes do not
-    // inflate totals.
-    const browseWhereClauses = [...whereClauses, ...projectedBrowsePathSqlClauses()];
-    const browseWhereSql = `WHERE ${browseWhereClauses.join(" AND ")}`;
+    // Legacy projections have no materialized path validity. Preserve the
+    // realpath-aware full scan rather than trusting rows from an older writer.
     const pageRows: ProjectedMemoryBrowseRow[] = [];
     const fetchSize = Math.max(options.limit * 2, 50);
     let validRowsSeen = 0;

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -322,6 +322,41 @@ function openProjectionReadonly(memoryDir: string): BetterSqlite3Database | null
     return null;
   }
 }
+function updateProjectionBestEffort(
+  memoryDir: string,
+  sql: string,
+  params: unknown[],
+): void {
+  let db: BetterSqlite3Database | null = null;
+  try {
+    db = openBetterSqlite3(getMemoryProjectionPath(memoryDir), { fileMustExist: true });
+    db.prepare(sql).run(...params);
+  } catch {
+    // Projection updates must never block the canonical filesystem mutation.
+  } finally {
+    db?.close();
+  }
+}
+
+export function markProjectedMemoryPathInvalid(memoryDir: string, memoryId: string): void {
+  updateProjectionBestEffort(
+    memoryDir,
+    "UPDATE memory_current SET path_valid = 0 WHERE memory_id = ?",
+    [memoryId],
+  );
+}
+
+export function updateProjectedMemoryPath(
+  memoryDir: string,
+  memoryId: string,
+  pathRel: string,
+): void {
+  updateProjectionBestEffort(
+    memoryDir,
+    "UPDATE memory_current SET path_rel = ?, path_valid = 1 WHERE memory_id = ?",
+    [pathRel, memoryId],
+  );
+}
 
 function withProjectionReadonly<T>(
   memoryDir: string,
@@ -376,7 +411,11 @@ function isPathInsideRoot(candidatePath: string, rootPath: string): boolean {
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-function resolveProjectedMemoryPath(memoryDir: string, pathRel: string): string | null {
+function resolveProjectedMemoryPath(
+  memoryDir: string,
+  pathRel: string,
+  requireExisting = false,
+): string | null {
   if (path.isAbsolute(pathRel)) return null;
   const root = resolveMemoryDirRoot(memoryDir);
   const candidate = path.resolve(root, pathRel);
@@ -385,6 +424,7 @@ function resolveProjectedMemoryPath(memoryDir: string, pathRel: string): string 
     const realCandidate = fs.realpathSync(candidate);
     if (!isPathInsideRoot(realCandidate, root)) return null;
   } catch {
+    if (requireExisting) return null;
     // Missing files are handled by callers. Still keep the lexical guard above.
   }
   return candidate;
@@ -397,6 +437,7 @@ export function isProjectedMemoryPathValid(memoryDir: string, pathRel: string): 
 function projectedBrowseRowFromCurrentRow(
   memoryDir: string,
   row: Record<string, unknown>,
+  requireExisting = false,
 ): ProjectedMemoryBrowseRow | null {
   if (
     typeof row.memory_id !== "string" ||
@@ -406,7 +447,7 @@ function projectedBrowseRowFromCurrentRow(
   ) {
     return null;
   }
-  const filePath = resolveProjectedMemoryPath(memoryDir, row.path_rel);
+  const filePath = resolveProjectedMemoryPath(memoryDir, row.path_rel, requireExisting);
   if (!filePath) return null;
   return {
     id: row.memory_id,
@@ -693,9 +734,6 @@ export function readProjectedMemoryBrowse(
     const browseWhereSql = `WHERE ${browseWhereClauses.join(" AND ")}`;
 
     if (currentSelect.hasPathValid) {
-      const totalRow = db
-        .prepare(`SELECT COUNT(*) AS total FROM memory_current ${browseWhereSql}`)
-        .get(...params) as { total: number };
       const rows = db
         .prepare(`
           SELECT
@@ -711,15 +749,23 @@ export function readProjectedMemoryBrowse(
           FROM memory_current
           ${browseWhereSql}
           ORDER BY ${orderBySql}
-          LIMIT ? OFFSET ?
         `)
-        .all(...params, options.limit, options.offset) as Array<Record<string, unknown>>;
-      return {
-        total: totalRow.total,
-        memories: rows
-          .map((row) => projectedBrowseRowFromCurrentRow(memoryDir, row))
-          .filter((row): row is ProjectedMemoryBrowseRow => row !== null),
-      };
+        .iterate(...params) as Iterable<Record<string, unknown>>;
+      const pageRows: ProjectedMemoryBrowseRow[] = [];
+      let validRowsSeen = 0;
+      for (const row of rows) {
+        const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row, true);
+        if (!browseRow) continue;
+        if (validRowsSeen >= options.offset) {
+          pageRows.push(browseRow);
+          if (pageRows.length >= options.limit) break;
+        }
+        validRowsSeen += 1;
+      }
+      const totalRow = db
+        .prepare(`SELECT COUNT(*) AS total FROM memory_current ${browseWhereSql}`)
+        .get(...params) as { total: number };
+      return { total: totalRow.total, memories: pageRows };
     }
 
     // Legacy projections have no materialized path validity. Preserve the

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -351,10 +351,11 @@ export function updateProjectedMemoryPath(
   memoryId: string,
   pathRel: string,
 ): void {
+  const pathValid = isProjectedMemoryPathValid(memoryDir, pathRel) ? 1 : 0;
   updateProjectionBestEffort(
     memoryDir,
-    "UPDATE memory_current SET path_rel = ?, path_valid = 1 WHERE memory_id = ?",
-    [pathRel, memoryId],
+    "UPDATE memory_current SET path_rel = ?, path_valid = ? WHERE memory_id = ?",
+    [pathRel, pathValid, memoryId],
   );
 }
 

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -702,7 +702,11 @@ export function readProjectedMemoryBrowse(
 
       for (const row of rows) {
         if (typeof row.memory_id !== "string" || typeof row.path_rel !== "string") continue;
-        const filePath = resolveProjectedMemoryPath(memoryDir, row.path_rel);
+        const filePath = resolveProjectedMemoryPath(
+          memoryDir,
+          row.path_rel,
+          currentSelect.hasPathValid,
+        );
         if (!filePath) continue;
         const preview = typeof row.preview_text === "string" ? row.preview_text.toLowerCase() : "";
         const category = typeof row.category === "string" ? row.category.toLowerCase() : "";

--- a/packages/remnic-core/src/memory-projection-store.ts
+++ b/packages/remnic-core/src/memory-projection-store.ts
@@ -437,6 +437,7 @@ export function isProjectedMemoryPathValid(memoryDir: string, pathRel: string): 
 function projectedBrowseRowFromCurrentRow(
   memoryDir: string,
   row: Record<string, unknown>,
+  resolvedFilePath?: string,
   requireExisting = false,
 ): ProjectedMemoryBrowseRow | null {
   if (
@@ -447,7 +448,7 @@ function projectedBrowseRowFromCurrentRow(
   ) {
     return null;
   }
-  const filePath = resolveProjectedMemoryPath(memoryDir, row.path_rel, requireExisting);
+  const filePath = resolvedFilePath ?? resolveProjectedMemoryPath(memoryDir, row.path_rel, requireExisting);
   if (!filePath) return null;
   return {
     id: row.memory_id,
@@ -718,7 +719,7 @@ export function readProjectedMemoryBrowse(
         }
         if (!matches) continue;
         if (total >= options.offset && pageRows.length < options.limit) {
-          const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row);
+          const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row, filePath);
           if (browseRow) pageRows.push(browseRow);
         }
         total += 1;
@@ -754,7 +755,7 @@ export function readProjectedMemoryBrowse(
       const pageRows: ProjectedMemoryBrowseRow[] = [];
       let validRowsSeen = 0;
       for (const row of rows) {
-        const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row, true);
+        const browseRow = projectedBrowseRowFromCurrentRow(memoryDir, row, undefined, true);
         if (!browseRow) continue;
         if (validRowsSeen >= options.offset) {
           pageRows.push(browseRow);

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -98,11 +98,11 @@ import type {
 import { confidenceTier, SPECULATIVE_TTL_DAYS } from "./types.js";
 import {
   type ProjectedMemoryBrowseOptions,
-  type ProjectedMemoryBrowsePage,
+  type ProjectedMemoryBrowsePage, markProjectedMemoryPathInvalid,
   readProjectedMemoryState,
   readProjectedMemoryBrowse,
   readProjectedGovernanceRecord,
-  readProjectedMemoryTimeline,
+  readProjectedMemoryTimeline, updateProjectedMemoryPath,
 } from "./memory-projection-store.js";
 import {
   inferMemoryStatus,
@@ -4560,14 +4560,12 @@ export class StorageManager {
     const dir = categoryDirName(memory.frontmatter.category);
     return path.join(root, dir, this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
   }
-
   private async writeMemoryFileAtomic(targetPath: string, memory: MemoryFile): Promise<void> {
     const fileContent = `${serializeFrontmatter(memory.frontmatter)}\n\n${memory.content}\n`;
     await writeMaybeEncryptedFile(targetPath, fileContent, this.resolveWriteKey(), {}, this.baseDir);
     this.invalidateAllMemoriesCache();
     this.notifyCatalogWrite();
   }
-
   async moveMemoryToPath(memory: MemoryFile, targetPath: string): Promise<void> {
     await this.writeMemoryFileAtomic(targetPath, memory);
     const sourcePath = path.resolve(memory.path);
@@ -4585,6 +4583,7 @@ export class StorageManager {
       // invalidated, but a concurrent readAllMemories() may have re-populated
       // the cache between the write and the unlink.
       this.invalidateAllMemoriesCache();
+      updateProjectedMemoryPath(this.baseDir, memory.frontmatter.id, toMemoryPathRel(this.baseDir, targetPath));
     }
   }
 
@@ -4609,6 +4608,7 @@ export class StorageManager {
           throw err;
         }
       }
+      updateProjectedMemoryPath(this.baseDir, memory.frontmatter.id, toMemoryPathRel(this.baseDir, targetPath));
       this.bumpMemoryStatusVersion();
       return { changed: false, targetPath };
     }
@@ -4656,7 +4656,7 @@ export class StorageManager {
 
       // Write to archive location first (encrypted if applicable), then remove original.
       await this.writeStorageSecureFile(destPath, fileContent);
-      await unlink(memory.path);
+      await unlink(memory.path); markProjectedMemoryPathInvalid(this.baseDir, memory.frontmatter.id);
       this.invalidateAllMemoriesCache();
       await this.appendGeneratedMemoryLifecycleEventFailOpen(
         "storage.archiveMemory",
@@ -4761,7 +4761,7 @@ export class StorageManager {
     if (!memory) return false;
 
     try {
-      await unlink(memory.path);
+      await unlink(memory.path); markProjectedMemoryPathInvalid(this.baseDir, id);
       this.invalidateAllMemoriesCache();
       this.bumpMemoryStatusVersion();
       log.debug(`invalidated memory ${id}`);
@@ -4900,7 +4900,7 @@ export class StorageManager {
       const expiresAt = new Date(m.frontmatter.expiresAt).getTime();
       if (expiresAt < now) {
         try {
-          await unlink(m.path);
+          await unlink(m.path); markProjectedMemoryPathInvalid(this.baseDir, m.frontmatter.id);
           deleted.push(m);
           log.debug(`cleaned expired memory ${m.frontmatter.id} (TTL expired)`);
         } catch {
@@ -5996,7 +5996,7 @@ export class StorageManager {
       if (updatedAt < cutoff) {
         // Remove the file
         try {
-          await unlink(m.path);
+          await unlink(m.path); markProjectedMemoryPathInvalid(this.baseDir, m.frontmatter.id);
           deleted.push(m);
           log.debug(`cleaned expired commitment ${m.frontmatter.id}`);
         } catch {

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -468,7 +468,6 @@ tests/memory-governance.test.ts(1117,61): TS7006
 tests/memory-governance.test.ts(1122,34): TS2339
 tests/memory-governance.test.ts(1128,43): TS7006
 tests/memory-observation-type-shape.test.ts(24,15): TS2614
-tests/memory-projection.test.ts(1619,18): TS18048
 tests/migrate-observations.test.ts(188,9): TS2322
 tests/namespace-migrate.test.ts(22,3): TS2740
 tests/namespace-migrate.test.ts(223,20): TS2339

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -468,7 +468,7 @@ tests/memory-governance.test.ts(1117,61): TS7006
 tests/memory-governance.test.ts(1122,34): TS2339
 tests/memory-governance.test.ts(1128,43): TS7006
 tests/memory-observation-type-shape.test.ts(24,15): TS2614
-tests/memory-projection.test.ts(1618,18): TS18048
+tests/memory-projection.test.ts(1619,18): TS18048
 tests/migrate-observations.test.ts(188,9): TS2322
 tests/namespace-migrate.test.ts(22,3): TS2740
 tests/namespace-migrate.test.ts(223,20): TS2339

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -2153,3 +2153,30 @@ test("StorageManager rate-limits warnings for projection fallbacks by consumer",
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("updateProjectedMemoryPath derives validity for symlink-escaping targets", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-move-escape-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-move-outside-"));
+  try {
+    await writeText(memoryDir, "facts/fact-escape.md", memoryDoc({
+      id: "fact-escape",
+      content: "projected memory",
+    }));
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+
+    const outsidePath = path.join(outsideDir, "escaped.md");
+    await writeFile(outsidePath, "escaped body", "utf-8");
+    await mkdir(path.join(memoryDir, "cold", "facts"), { recursive: true });
+    await symlink(outsidePath, path.join(memoryDir, "cold", "facts", "fact-escape.md"));
+
+    updateProjectedMemoryPath(memoryDir, "fact-escape", "cold/facts/fact-escape.md");
+
+    const browse = readProjectedMemoryBrowse(memoryDir, { limit: 5, offset: 0 });
+    assert.ok(browse);
+    assert.equal(browse.total, 0);
+    assert.equal(browse.memories.length, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -1614,9 +1614,10 @@ test("rebuildMemoryProjection projects entity mentions, native knowledge chunks,
     });
 
     const projectedReviewQueue = readProjectedLatestReviewQueue(memoryDir);
-    assert.ok(projectedReviewQueue?.found);
-    assert.equal(projectedReviewQueue?.runId, governance.runId);
-    assert.equal(projectedReviewQueue?.reviewQueue.some((entry) => entry.reasonCode === "exact_duplicate"), true);
+    assert.ok(projectedReviewQueue);
+    assert.ok(projectedReviewQueue.found);
+    assert.equal(projectedReviewQueue.runId, governance.runId);
+    assert.equal(projectedReviewQueue.reviewQueue?.some((entry) => entry.reasonCode === "exact_duplicate"), true);
 
     const verify = await verifyMemoryProjection({ memoryDir, defaultNamespace: "global" });
     assert.equal(verify.ok, true);

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -1776,7 +1776,7 @@ test("projection browse filters realpath-invalid rows before counting and pagina
     await symlink(outsidePath, path.join(memoryDir, "facts/2026-03-08/fact-invalid-link.md"));
     const db = new Database(getMemoryProjectionPath(memoryDir));
     try {
-      db.prepare("UPDATE memory_current SET path_rel = ? WHERE memory_id = ?")
+      db.prepare("UPDATE memory_current SET path_rel = ?, path_valid = 0 WHERE memory_id = ?")
         .run("facts/2026-03-08/fact-invalid-link.md", "fact-invalid");
     } finally {
       db.close();
@@ -1795,3 +1795,54 @@ test("projection browse filters realpath-invalid rows before counting and pagina
     await rm(outsidePath, { force: true });
   }
 });
+test("projection browse validates only the returned page for current schemas", async (t) => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-page-cost-"));
+  try {
+    const projectionPath = getMemoryProjectionPath(memoryDir);
+    await mkdir(path.dirname(projectionPath), { recursive: true });
+    await writeText(memoryDir, "facts/page.md", "page row");
+    const db = new Database(projectionPath);
+    try {
+      initializeMemoryProjectionDb(db);
+      const insert = db.prepare(`
+        INSERT INTO memory_current (
+          memory_id, category, status, lifecycle_state, path_rel, path_valid,
+          created_at, updated_at, archived_at, superseded_at, entity_ref,
+          source, confidence, confidence_tier, memory_kind, access_count,
+          last_accessed, tags_json, preview_text
+        ) VALUES (?, 'fact', 'active', NULL, 'facts/page.md', 1,
+          ?, ?, NULL, NULL, NULL, 'test', 0.8, 'implied', NULL, NULL, NULL, '[]', '')
+      `);
+      const insertMany = db.transaction(() => {
+        for (let index = 0; index < 3_000; index += 1) {
+          const timestamp = new Date(Date.UTC(2026, 2, 8, 0, 0, 0, index)).toISOString();
+          insert.run(`fact-${String(index).padStart(4, "0")}`, timestamp, timestamp);
+        }
+      });
+      insertMany();
+    } finally {
+      db.close();
+    }
+
+    const fs = process.getBuiltinModule("fs");
+    const originalRealpathSync = fs.realpathSync;
+    let realpathCalls = 0;
+    t.mock.method(fs, "realpathSync", (...args: Parameters<typeof fs.realpathSync>) => {
+      realpathCalls += 1;
+      return originalRealpathSync(...args);
+    });
+
+    const browse = readProjectedMemoryBrowse(memoryDir, {
+      limit: 1,
+      offset: 0,
+    });
+
+    assert.ok(browse);
+    assert.equal(browse.total, 3_000);
+    assert.equal(browse.memories.length, 1);
+    assert.ok(realpathCalls <= 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -14,10 +14,10 @@ import {
 import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import {
   getMemoryProjectionPath,
-  initializeMemoryProjectionDb,
+  initializeMemoryProjectionDb, markProjectedMemoryPathInvalid,
   readProjectedEntityMentions,
   readProjectedLatestReviewQueue,
-  readProjectedMemoryBrowse,
+  readProjectedMemoryBrowse, updateProjectedMemoryPath,
   readProjectedMemoryState,
   readProjectedMemoryTimeline,
   readProjectedNativeKnowledgeChunks,
@@ -1845,4 +1845,138 @@ test("projection browse validates only the returned page for current schemas", a
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+test("projection browse fills pages after a managed archive updates path validity", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-moved-page-"));
+  try {
+    for (let index = 1; index <= 3; index += 1) {
+      await writeText(
+        memoryDir,
+        `facts/2026-03-08/fact-${index}.md`,
+        memoryDoc({
+          id: `fact-${index}`,
+          content: `projected memory ${index}`,
+          created: `2026-03-08T0${index}:00:00.000Z`,
+          updated: `2026-03-08T0${index}:00:00.000Z`,
+        }),
+      );
+    }
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T12:00:00.000Z"),
+    });
+    const storage = new StorageManager(memoryDir);
+    const archivedMemory = (await storage.readAllMemories())
+      .find((memory) => memory.frontmatter.id === "fact-3");
+    assert.ok(archivedMemory);
+    assert.equal(typeof await storage.archiveMemory(archivedMemory), "string");
+
+    const firstBrowse = readProjectedMemoryBrowse(memoryDir, {
+      limit: 2,
+      offset: 0,
+    });
+    assert.ok(firstBrowse);
+    assert.deepEqual(firstBrowse.memories.map((memory) => memory.id), ["fact-2", "fact-1"]);
+    assert.equal(firstBrowse.total, 2);
+
+    const secondBrowse = readProjectedMemoryBrowse(memoryDir, {
+      limit: 2,
+      offset: 0,
+    });
+    assert.ok(secondBrowse);
+    assert.deepEqual(secondBrowse.memories.map((memory) => memory.id), ["fact-2", "fact-1"]);
+    assert.equal(secondBrowse.total, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+test("markProjectedMemoryPathInvalid removes a row from projected totals", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-mark-invalid-"));
+  try {
+    await writeText(memoryDir, "facts/fact-invalid.md", memoryDoc({
+      id: "fact-invalid",
+      content: "projected memory",
+    }));
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+
+    markProjectedMemoryPathInvalid(memoryDir, "fact-invalid");
+
+    assert.equal(readProjectedMemoryBrowse(memoryDir, { limit: 1, offset: 0 })?.total, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("updateProjectedMemoryPath follows a moved memory file", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-update-path-"));
+  try {
+    await writeText(memoryDir, "facts/fact-moved.md", memoryDoc({
+      id: "fact-moved",
+      content: "projected memory",
+    }));
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+
+    updateProjectedMemoryPath(memoryDir, "fact-moved", "cold/facts/fact-moved.md");
+
+    const db = new Database(getMemoryProjectionPath(memoryDir), { readonly: true });
+    try {
+      const row = db.prepare("SELECT path_rel, path_valid FROM memory_current WHERE memory_id = ?")
+        .get("fact-moved") as { path_rel: string; path_valid: number };
+      assert.deepEqual(row, { path_rel: "cold/facts/fact-moved.md", path_valid: 1 });
+    } finally {
+      db.close();
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("tier migration updates the projected memory path", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-tier-move-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory("fact", "projected memory", { source: "test" });
+    const memory = (await storage.readAllMemories())[0];
+    assert.ok(memory);
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+
+    const migrated = await storage.migrateMemoryToTier(memory, "cold");
+    const projected = readProjectedMemoryBrowse(memoryDir, { limit: 1, offset: 0 });
+
+    assert.ok(projected);
+    assert.equal(projected.memories[0]?.path, migrated.targetPath);
+    assert.equal(projected.total, 1);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("projection browse drops unmanaged missing files but leaves totals stale", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-unmanaged-rm-"));
+  try {
+    for (let index = 1; index <= 3; index += 1) {
+      await writeText(
+        memoryDir,
+        `facts/fact-${index}.md`,
+        memoryDoc({
+          id: `fact-${index}`,
+          content: `projected memory ${index}`,
+          updated: `2026-03-08T0${index}:00:00.000Z`,
+        }),
+      );
+    }
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+    await rm(path.join(memoryDir, "facts", "fact-3.md"));
+
+    const browse = readProjectedMemoryBrowse(memoryDir, { limit: 2, offset: 0 });
+
+    assert.ok(browse);
+    assert.deepEqual(browse.memories.map((memory) => memory.id), ["fact-2", "fact-1"]);
+    assert.equal(browse.total, 3);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+
 

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -2006,6 +2006,31 @@ test("projection text browse reuses the resolved path for returned rows", async 
   }
 });
 
+test("projection text browse drops deleted files that match on stored metadata", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-query-deleted-"));
+  try {
+    for (const suffix of ["kept", "gone"]) {
+      await writeText(memoryDir, `facts/fact-${suffix}.md`, memoryDoc({
+        id: `fact-${suffix}`,
+        content: `shared metadata needle ${suffix}`,
+      }));
+    }
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+    await rm(path.join(memoryDir, "facts", "fact-gone.md"));
+
+    const browse = readProjectedMemoryBrowse(memoryDir, {
+      query: "shared metadata needle",
+      limit: 10,
+      offset: 0,
+    });
+
+    assert.ok(browse);
+    assert.deepEqual(browse.memories.map((memory) => memory.id), ["fact-kept"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 
 
 

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -1977,6 +1977,35 @@ test("projection browse drops unmanaged missing files but leaves totals stale", 
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+test("projection text browse reuses the resolved path for returned rows", async (t) => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-query-resolve-"));
+  try {
+    await writeText(memoryDir, "facts/fact-query.md", memoryDoc({
+      id: "fact-query",
+      content: "query resolution needle",
+    }));
+    await rebuildMemoryProjection({ memoryDir, dryRun: false });
+    const fs = process.getBuiltinModule("fs");
+    const originalRealpathSync = fs.realpathSync;
+    let realpathCalls = 0;
+    t.mock.method(fs, "realpathSync", (...args: Parameters<typeof fs.realpathSync>) => {
+      realpathCalls += 1;
+      return originalRealpathSync(...args);
+    });
+
+    const browse = readProjectedMemoryBrowse(memoryDir, {
+      query: "query resolution needle",
+      limit: 1,
+      offset: 0,
+    });
+
+    assert.equal(browse?.memories[0]?.id, "fact-query");
+    assert.ok(realpathCalls <= 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 
 
 


### PR DESCRIPTION
## Summary

- New projection files store `path_valid`.
- The rebuild checks each path before it writes that flag.
- An indexed row walk fills each page. A `COUNT(*)` call gets the total.
- Text search now streams rows. Full file search and exact totals stay the same.
- Old files with no `path_valid` field still use the safe full scan.
- Remnic updates `path_valid` or `path_rel` when it moves or deletes a file.
- Those updates fail open if the projection cannot be changed.
- Each page row gets a new real path check.
- An outside file change can make the total stale until rebuild. It still cannot expose the row.

## Mutation scan

I searched `packages/remnic-core/src/storage.ts`.
The pattern had `rename(` and `renameSync(`.
It also had `rm(` and `unlink(`.
Last, it had `archive` and `supersed`.

The scan found these 6 file move or delete paths.

- `moveMemoryToPath()`.
- `migrateMemoryToTier()`.
- `archiveMemory()`.
- `invalidateMemory()`.
- `cleanExpiredTTL()`.
- `cleanExpiredCommitments()`.

`supersedeMemory()` and `archiveMemories()` write in place. Their paths stay valid.

## Tests

- `pnpm exec tsx --test tests/memory-projection.test.ts`.
- `npm run preflight:quick`.
- `npm run test:entity-hardening`.

Fixes #1819

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core memory browse and projection consistency across many delete/move paths; behavior is mostly fail-open on projection errors, but totals can be stale until rebuild.
> 
> **Overview**
> Adds **`path_valid`** to the memory projection (schema v3) so browse can trust indexed rows instead of re-validating every memory on each request. Rebuild writes the flag from on-disk path checks; **storage** and **purge** keep it in sync via best-effort `markProjectedMemoryPathInvalid` / `updateProjectedMemoryPath` on deletes, archives, tier moves, and TTL cleanup (projection failures never block filesystem writes).
> 
> **Browse** now filters `path_valid = 1`, uses composite indexes for sort/pagination, fills pages with bounded iteration (and `COUNT(*)` for totals on the current schema), and streams text search while preserving exact match counts. Legacy DBs without the column still use the old realpath-heavy full scan.
> 
> Unmanaged file deletes can leave **stale totals** until rebuild, but invalid rows stay out of returned pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3bcd1451367acedb5beee519e7127bdc1483e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Upgrade contract

Existing deployments keep their v2 projection and the old slow-but-correct read path until an operator runs `rebuild-memory-projection` once per memory root after upgrading. That rebuild writes the v3 schema with `path_valid` and the browse indexes, and the fast path turns on from the next request. The new write helpers are safe on v2 databases in the meantime: the update targets a missing column and is swallowed. Deployment checklists and release notes must include the rebuild step, and a deployment is not done until a `limit=1` browse on the upgraded host returns in well under a second.
