### PR TITLE
fix(storage): stream lifecycle ledger reads

### DIFF
--- a/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
+++ b/packages/remnic-core/src/storage-memory-lifecycle-ledger.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { StorageManager } from "./storage.js";
+import { encryptFileBody, filePathAad } from "./secure-store/secure-fs.js";
+import type { MemoryLifecycleEvent } from "./types.js";
+
+function lifecycleEvent(
+  eventId: string,
+  memoryId: string,
+  timestamp: string,
+): MemoryLifecycleEvent {
+  return {
+    eventId,
+    memoryId,
+    eventType: "created",
+    timestamp,
+    actor: "test",
+    ruleVersion: "1",
+  };
+}
+
+async function withLifecycleLedger(
+  rows: string[],
+  run: (storage: StorageManager, ledgerPath: string) => Promise<void>,
+): Promise<void> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lifecycle-stream-"));
+  const ledgerPath = path.join(memoryDir, "state", "memory-lifecycle-ledger.jsonl");
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+  await writeFile(ledgerPath, `${rows.join("\n")}\n`, "utf8");
+  try {
+    await run(new StorageManager(memoryDir), ledgerPath);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+}
+
+test("readAllMemoryLifecycleEvents streams plaintext rows and preserves fail-open sorting", async () => {
+  const later = lifecycleEvent("event-z", "memory-b", "2026-01-03T00:00:00.000Z");
+  const earlier = lifecycleEvent("event-a", "memory-a", "2026-01-02T00:00:00.000Z");
+  const earliest = lifecycleEvent("event-b", "memory-a", "2026-01-01T00:00:00.000Z");
+
+  await withLifecycleLedger([
+    JSON.stringify(later),
+    "{malformed-json",
+    JSON.stringify({ ...earlier, actor: 42 }),
+    JSON.stringify(earlier),
+    "   ",
+    JSON.stringify(earliest),
+  ], async (storage) => {
+    let secureWholeFileReads = 0;
+    const privateStorage = storage as unknown as {
+      readStorageSecureFile(filePath: string): Promise<string>;
+    };
+    privateStorage.readStorageSecureFile = async () => {
+      secureWholeFileReads += 1;
+      throw new Error("plaintext lifecycle ledger must not use whole-file reads");
+    };
+
+    const events = await storage.readAllMemoryLifecycleEvents();
+
+    assert.deepEqual(events, [earliest, earlier, later]);
+    assert.equal(secureWholeFileReads, 0);
+  });
+});
+
+test("readMemoryLifecycleEvents applies its limit after streamed lifecycle sorting", async () => {
+  const first = lifecycleEvent("event-1", "memory-a", "2026-01-01T00:00:00.000Z");
+  const second = lifecycleEvent("event-2", "memory-a", "2026-01-02T00:00:00.000Z");
+  const third = lifecycleEvent("event-3", "memory-b", "2026-01-01T00:00:00.000Z");
+
+  await withLifecycleLedger([
+    JSON.stringify(third),
+    JSON.stringify(first),
+    JSON.stringify(second),
+  ], async (storage) => {
+    assert.deepEqual(await storage.readMemoryLifecycleEvents(2), [second, third]);
+  });
+});
+
+test("readAllMemoryLifecycleEvents keeps the authenticated encrypted-file fallback", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lifecycle-encrypted-"));
+  const ledgerPath = path.join(memoryDir, "state", "memory-lifecycle-ledger.jsonl");
+  const event = lifecycleEvent("event-encrypted", "memory-a", "2026-01-01T00:00:00.000Z");
+  const key = Buffer.alloc(32, 7);
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+  await writeFile(
+    ledgerPath,
+    encryptFileBody(`${JSON.stringify(event)}\n`, key, filePathAad(ledgerPath, memoryDir)),
+  );
+  try {
+    const storage = new StorageManager(memoryDir);
+    storage.setSecureStoreKey(key);
+    assert.deepEqual(await storage.readAllMemoryLifecycleEvents(), [event]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("readMemoryActionEventRows streams the action ledger and keeps source line numbers", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-action-stream-"));
+  const ledgerPath = path.join(memoryDir, "state", "memory-actions.jsonl");
+  const first = { timestamp: "2026-01-01T00:00:00.000Z", action: "store_note", outcome: "applied" };
+  const second = { timestamp: "2026-01-02T00:00:00.000Z", action: "discard", outcome: "skipped" };
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+  await writeFile(
+    ledgerPath,
+    `${JSON.stringify(first)}\n{malformed-json\n${JSON.stringify(second)}\n`,
+    "utf8",
+  );
+  try {
+    const storage = new StorageManager(memoryDir);
+    let secureWholeFileReads = 0;
+    const privateStorage = storage as unknown as {
+      readStorageSecureFile(filePath: string): Promise<string>;
+    };
+    privateStorage.readStorageSecureFile = async () => {
+      secureWholeFileReads += 1;
+      throw new Error("plaintext action ledger must not use whole-file reads");
+    };
+
+    assert.deepEqual(await storage.readMemoryActionEventRows(1), [{ line: 3, event: second }]);
+    assert.equal(secureWholeFileReads, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,5 +1,6 @@
 import { access, lstat, readdir, readFile, realpath, stat, writeFile, mkdir, unlink, rename, appendFile, open } from "node:fs/promises";
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
+import { createInterface } from "node:readline";
 import { createHash } from "node:crypto"
 import { normalizeContent, computeContentHash } from "./content-hash.js";;
 import path from "node:path";
@@ -2814,6 +2815,39 @@ export class StorageManager {
   private readStorageSecureFile(filePath: string): Promise<string> {
     return readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
   }
+  /**
+   * Plain JSONL ledgers stream one row at a time so their total size is not
+   * bounded by V8's maximum string length. Encrypted files still use the
+   * authenticated whole-file decrypt path.
+   */
+  private async *readStorageSecureLines(filePath: string): AsyncGenerator<string> {
+    const file = await open(filePath, "r");
+    const header = Buffer.alloc(MAGIC_HEADER_SIZE);
+    try {
+      const { bytesRead } = await file.read(header, 0, header.length, 0);
+      if (isEncryptedFile(header.subarray(0, bytesRead))) {
+        yield* (await this.readStorageSecureFile(filePath)).split("\n");
+        return;
+      }
+
+      const input = createReadStream(filePath, {
+        autoClose: false,
+        encoding: "utf8",
+        fd: file.fd,
+        start: 0,
+      });
+      const lines = createInterface({ input, crlfDelay: Infinity });
+      try {
+        for await (const line of lines) {
+          yield line;
+        }
+      } finally {
+        lines.close();
+      }
+    } finally {
+      await file.close();
+    }
+  }
   private writeStorageSecureFile(filePath: string, content: string | Buffer): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir)
       .then(() => this.notifyCatalogWrite());
@@ -5180,14 +5214,15 @@ export class StorageManager {
 
   async readMemoryActionEventRows(limit: number = 200): Promise<Array<{ line: number; event: MemoryActionEvent }>> {
     const cappedLimit = Math.max(0, Math.floor(limit));
-    if (cappedLimit === 0) return [];
+    if (cappedLimit === 0 || Number.isNaN(cappedLimit)) return [];
 
     try {
-      const raw = await this.readStorageSecureFile(this.memoryActionsPath);
       const out: Array<{ line: number; event: MemoryActionEvent }> = [];
-      const lines = raw.split("\n");
-      for (let i = lines.length - 1; i >= 0 && out.length < cappedLimit; i -= 1) {
-        const line = lines[i]?.trim();
+      let writeIndex = 0;
+      let lineNumber = 0;
+      for await (const row of this.readStorageSecureLines(this.memoryActionsPath)) {
+        lineNumber += 1;
+        const line = row.trim();
         if (!line) continue;
         try {
           const parsed = JSON.parse(line) as Partial<MemoryActionEvent>;
@@ -5199,19 +5234,25 @@ export class StorageManager {
             typeof parsed.action === "string" &&
             outcome !== null
           ) {
-            out.push({
-              line: i + 1,
+            const entry = {
+              line: lineNumber,
               event: {
                 ...parsed,
                 outcome,
               } as MemoryActionEvent,
-            });
+            };
+            if (out.length < cappedLimit) {
+              out.push(entry);
+            } else {
+              out[writeIndex] = entry;
+              writeIndex = (writeIndex + 1) % cappedLimit;
+            }
           }
         } catch {
           // Ignore malformed rows (fail-open).
         }
       }
-      return out.reverse();
+      return writeIndex === 0 ? out : [...out.slice(writeIndex), ...out.slice(0, writeIndex)];
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
       if (!isErrnoCode(err, "ENOENT")) throw err;
@@ -5221,10 +5262,8 @@ export class StorageManager {
 
   async readAllMemoryLifecycleEvents(): Promise<MemoryLifecycleEvent[]> {
     try {
-      const raw = await this.readStorageSecureFile(this.memoryLifecycleLedgerPath);
       const out: MemoryLifecycleEvent[] = [];
-      const lines = raw.split("\n");
-      for (const line of lines) {
+      for await (const line of this.readStorageSecureLines(this.memoryLifecycleLedgerPath)) {
         const row = line.trim();
         if (!row) continue;
         try {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1,11 +1,14 @@
 import { access, lstat, readdir, readFile, realpath, stat, writeFile, mkdir, unlink, rename, appendFile, open } from "node:fs/promises";
 import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync, type Dirent } from "node:fs";
-import { createInterface } from "node:readline";
 import { createHash } from "node:crypto"
 import { normalizeContent, computeContentHash } from "./content-hash.js";;
 import path from "node:path";
 import { log } from "./logger.js";
 import { MemoryReadStore } from "./storage/memory-read-store.js";
+import {
+  readMaybeEncryptedLines,
+  readMemoryActionEventRowsFromLines,
+} from "./storage/secure-line-reader.js";
 import { selfDeps } from "./orchestration/self-deps.js";
 import { EntityStore } from "./storage/entity-store.js";
 import { IdentityContinuityStore } from "./storage/identity-continuity-store.js";
@@ -2815,39 +2818,6 @@ export class StorageManager {
   private readStorageSecureFile(filePath: string): Promise<string> {
     return readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
   }
-  /**
-   * Plain JSONL ledgers stream one row at a time so their total size is not
-   * bounded by V8's maximum string length. Encrypted files still use the
-   * authenticated whole-file decrypt path.
-   */
-  private async *readStorageSecureLines(filePath: string): AsyncGenerator<string> {
-    const file = await open(filePath, "r");
-    const header = Buffer.alloc(MAGIC_HEADER_SIZE);
-    try {
-      const { bytesRead } = await file.read(header, 0, header.length, 0);
-      if (isEncryptedFile(header.subarray(0, bytesRead))) {
-        yield* (await this.readStorageSecureFile(filePath)).split("\n");
-        return;
-      }
-
-      const input = createReadStream(filePath, {
-        autoClose: false,
-        encoding: "utf8",
-        fd: file.fd,
-        start: 0,
-      });
-      const lines = createInterface({ input, crlfDelay: Infinity });
-      try {
-        for await (const line of lines) {
-          yield line;
-        }
-      } finally {
-        lines.close();
-      }
-    } finally {
-      await file.close();
-    }
-  }
   private writeStorageSecureFile(filePath: string, content: string | Buffer): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir)
       .then(() => this.notifyCatalogWrite());
@@ -5217,42 +5187,13 @@ export class StorageManager {
     if (cappedLimit === 0 || Number.isNaN(cappedLimit)) return [];
 
     try {
-      const out: Array<{ line: number; event: MemoryActionEvent }> = [];
-      let writeIndex = 0;
-      let lineNumber = 0;
-      for await (const row of this.readStorageSecureLines(this.memoryActionsPath)) {
-        lineNumber += 1;
-        const line = row.trim();
-        if (!line) continue;
-        try {
-          const parsed = JSON.parse(line) as Partial<MemoryActionEvent>;
-          const outcome = parsed.outcome === "applied" || parsed.outcome === "skipped" || parsed.outcome === "failed"
-            ? parsed.outcome
-            : null;
-          if (
-            typeof parsed.timestamp === "string" &&
-            typeof parsed.action === "string" &&
-            outcome !== null
-          ) {
-            const entry = {
-              line: lineNumber,
-              event: {
-                ...parsed,
-                outcome,
-              } as MemoryActionEvent,
-            };
-            if (out.length < cappedLimit) {
-              out.push(entry);
-            } else {
-              out[writeIndex] = entry;
-              writeIndex = (writeIndex + 1) % cappedLimit;
-            }
-          }
-        } catch {
-          // Ignore malformed rows (fail-open).
-        }
-      }
-      return writeIndex === 0 ? out : [...out.slice(writeIndex), ...out.slice(0, writeIndex)];
+      return await readMemoryActionEventRowsFromLines(
+        readMaybeEncryptedLines(
+          this.memoryActionsPath,
+          () => this.readStorageSecureFile(this.memoryActionsPath),
+        ),
+        cappedLimit,
+      );
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
       if (!isErrnoCode(err, "ENOENT")) throw err;
@@ -5263,7 +5204,10 @@ export class StorageManager {
   async readAllMemoryLifecycleEvents(): Promise<MemoryLifecycleEvent[]> {
     try {
       const out: MemoryLifecycleEvent[] = [];
-      for await (const line of this.readStorageSecureLines(this.memoryLifecycleLedgerPath)) {
+      for await (const line of readMaybeEncryptedLines(
+        this.memoryLifecycleLedgerPath,
+        () => this.readStorageSecureFile(this.memoryLifecycleLedgerPath),
+      )) {
         const row = line.trim();
         if (!row) continue;
         try {

--- a/packages/remnic-core/src/storage/secure-line-reader.ts
+++ b/packages/remnic-core/src/storage/secure-line-reader.ts
@@ -1,0 +1,79 @@
+import { createReadStream } from "node:fs";
+import { open } from "node:fs/promises";
+import { createInterface } from "node:readline";
+
+import { isEncryptedFile, MAGIC_HEADER_SIZE } from "../secure-store/secure-fs.js";
+import type { MemoryActionEvent } from "../types.js";
+
+/**
+ * Stream plaintext files by line while preserving authenticated whole-file
+ * reads for encrypted files.
+ */
+export async function* readMaybeEncryptedLines(
+  filePath: string,
+  readEncryptedFile: () => Promise<string>,
+): AsyncGenerator<string> {
+  const file = await open(filePath, "r");
+  const header = Buffer.alloc(MAGIC_HEADER_SIZE);
+  try {
+    const { bytesRead } = await file.read(header, 0, header.length, 0);
+    if (isEncryptedFile(header.subarray(0, bytesRead))) {
+      yield* (await readEncryptedFile()).split("\n");
+      return;
+    }
+
+    const input = createReadStream(filePath, {
+      autoClose: false,
+      encoding: "utf8",
+      fd: file.fd,
+      start: 0,
+    });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    try {
+      for await (const line of lines) yield line;
+    } finally {
+      lines.close();
+    }
+  } finally {
+    await file.close();
+  }
+}
+
+export async function readMemoryActionEventRowsFromLines(
+  lines: AsyncIterable<string>,
+  limit: number,
+): Promise<Array<{ line: number; event: MemoryActionEvent }>> {
+  const out: Array<{ line: number; event: MemoryActionEvent }> = [];
+  let writeIndex = 0;
+  let lineNumber = 0;
+  for await (const row of lines) {
+    lineNumber += 1;
+    const line = row.trim();
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line) as Partial<MemoryActionEvent>;
+      const outcome = parsed.outcome === "applied" || parsed.outcome === "skipped" || parsed.outcome === "failed"
+        ? parsed.outcome
+        : null;
+      if (
+        typeof parsed.timestamp === "string" &&
+        typeof parsed.action === "string" &&
+        outcome !== null
+      ) {
+        const entry = {
+          line: lineNumber,
+          event: { ...parsed, outcome } as MemoryActionEvent,
+        };
+        if (out.length < limit) {
+          out.push(entry);
+        } else {
+          out[writeIndex] = entry;
+          writeIndex = (writeIndex + 1) % limit;
+        }
+      }
+    } catch {
+      // Ignore malformed rows (fail-open).
+    }
+  }
+  return writeIndex === 0 ? out : [...out.slice(writeIndex), ...out.slice(0, writeIndex)];
+}


### PR DESCRIPTION
## Summary

- Read plain `memory-lifecycle-ledger.jsonl` files one line at a time.
- Keep the same row checks and sort order.
- Skip bad rows as before.
- Use the full-file path for files sealed with AES-GCM. The tag needs the full file.
- Read `memory-actions.jsonl` the same way. Keep its line counts and row limit.

## Tests

- Mix good and bad rows in one file.
- Check sort order and the row limit.
- Check that plain files skip the full-file reader.
- Check the sealed-file path.
- Run `npm run preflight:quick`.
- Run `npm run test:entity-hardening`.

Fixes #1818

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secure-store read paths and changes how large plaintext ledgers are consumed; behavior is heavily tested but ledger parsing is storage-critical.
> 
> **Overview**
> Plaintext `memory-lifecycle-ledger.jsonl` and `memory-actions.jsonl` are no longer loaded through `readStorageSecureFile` in one shot. A new **`readMaybeEncryptedLines`** helper peeks the file header: plaintext files stream line-by-line via `readline`; AES-GCM sealed files still use the authenticated whole-file read path.
> 
> **`readAllMemoryLifecycleEvents`** iterates streamed lines with the same validation, fail-open skips, and **`sortMemoryLifecycleEvents`** ordering. **`readMemoryActionEventRows`** delegates parsing and the capped “last N valid rows” behavior (with **source line numbers**) to **`readMemoryActionEventRowsFromLines`**, and treats **`NaN`** limits like zero.
> 
> New tests cover mixed valid/malformed rows, lifecycle sort and limit, encrypted lifecycle fallback, and that plaintext ledgers never trigger whole-file secure reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95035dda41b9123e03dcde547822d020ee974ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->