### PR TITLE
fix(ci): tolerate ClawHub backend read limits

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -688,9 +688,8 @@ jobs:
               rm -f "${publish_log}"
               exit 0
             fi
-            if grep -q "Too many bytes read in a single function execution" "${publish_log}" \
-              && grep -qE "syncPackage[A-Za-z]*SearchDigests?" "${publish_log}"; then
-              echo "::notice title=ClawHub publish skipped::ClawHub publish failed in its backend search-digest sync. npm and GitHub release publication already completed; retry the ClawHub publish after ClawHub fixes or clears the digest limit."
+            if grep -q "Too many bytes read in a single function execution" "${publish_log}"; then
+              echo "::notice title=ClawHub publish skipped::ClawHub publish hit its backend read limit. npm and GitHub release publication already completed; retry the ClawHub publish after ClawHub fixes or clears the limit."
               rm -f "${publish_log}"
               exit 0
             fi

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -83,7 +83,7 @@ test("release workflow verifies the OpenClaw ClawHub packlist after build", asyn
   );
 });
 
-test("release workflow treats known ClawHub backend digest limits as nonfatal", async () => {
+test("release workflow treats known ClawHub backend read limits as nonfatal", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
 
   assert.match(
@@ -92,14 +92,14 @@ test("release workflow treats known ClawHub backend digest limits as nonfatal", 
     "release workflow must recognize ClawHub's Convex read-limit backend failure",
   );
   assert.ok(
-    workflow.includes("syncPackage[A-Za-z]*SearchDigests?"),
-    "release workflow must constrain the nonfatal skip to ClawHub search-digest failures " +
-      "(matching both syncPackageSearchDigest and syncPackageCapabilitySearchDigests)",
+    !workflow.includes("syncPackage[A-Za-z]*SearchDigests?"),
+    "release workflow must select the nonfatal path on the Convex read-limit string alone, " +
+      "without requiring the internal syncPackage...SearchDigest stack frame",
   );
   assert.match(
     workflow,
-    /ClawHub publish failed in its backend search-digest sync[\s\S]*exit 0/,
-    "known external ClawHub backend failures should not block GitHub release creation after npm publish",
+    /ClawHub publish hit its backend read limit[\s\S]*exit 0/,
+    "known external ClawHub backend read-limit failures should not block GitHub release creation after npm publish",
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Change

- Match ClawHub's exact read-limit error.
- Do not require a helper name in the error stack.
- Keep all other ClawHub errors fatal.

## Reason

Version 9.3.760 was live on npm and GitHub. ClawHub then hit its known 16 MiB read limit. The error did not name the old helper. The workflow missed the known error and failed after the release went live.

## Test

- `pnpm exec tsx --test tests/release-workflow-public-packages.test.ts`

<!-- voice-guard v1.2.0 | lint pass | rubric 10/10 | mode update | fingerprint v1 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only error-handling in the ClawHub publish step; npm/GitHub release behavior is unchanged and unknown publish failures remain fatal.
> 
> **Overview**
> **Release workflow** now treats ClawHub publish failures as **nonfatal** when the log contains Convex’s `Too many bytes read in a single function execution` message **alone**, without also requiring a `syncPackage…SearchDigest` stack frame.
> 
> That change fixes cases where npm and the GitHub release already succeeded but the job still failed because ClawHub’s error no longer named the old helper. The skip notice text is updated to refer to a generic backend read limit; other ClawHub errors still fail the step.
> 
> Tests in `release-workflow-public-packages.test.ts` assert the broader match and the updated notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b25f8222ffd0dca7840c7a7b67ed044eacd5def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->