### PR TITLE
Fix projection rebuild conflict handling

### DIFF
--- a/packages/remnic-core/src/maintenance/rebuild-memory-lifecycle-ledger.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-lifecycle-ledger.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { stat } from "node:fs/promises";
 import { StorageManager } from "../storage.js";
+import { log } from "../logger.js";
 import type { MemoryLifecycleEvent } from "../types.js";
 import { toBackupStamp } from "./backup-stamp.js";
 import { writeFileAtomically } from "./atomic-file.js";
@@ -15,12 +16,24 @@ export interface RebuildMemoryLifecycleLedgerOptions {
   now?: Date;
 }
 
+export interface SkippedLifecycleBlankIdMemory {
+  path: string;
+}
+
+export interface SkippedDuplicateLifecycleEvent {
+  eventId: string;
+  keptPath: string;
+  skippedPath: string;
+}
+
 export interface RebuildMemoryLifecycleLedgerResult {
   dryRun: boolean;
   scannedMemories: number;
   rebuiltRows: number;
   outputPath: string;
   backupPath?: string;
+  skippedBlankIdMemories: SkippedLifecycleBlankIdMemory[];
+  skippedDuplicateEvents: SkippedDuplicateLifecycleEvent[];
 }
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
@@ -59,16 +72,52 @@ export async function rebuildMemoryLifecycleLedger(
   const now = options.now ?? new Date();
   const outputPath = path.join(options.memoryDir, "state", "memory-lifecycle-ledger.jsonl");
   const storage = new StorageManager(options.memoryDir);
-  const allMemories = [
-    ...await storage.readAllMemories(),
-    ...await storage.readAllColdMemories(),
-    ...await storage.readArchivedMemories(),
-  ]
-    .sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id));
+  const tiers = [
+    await storage.readAllMemories(),
+    await storage.readAllColdMemories(),
+    await storage.readArchivedMemories(),
+  ];
+  const allMemories = tiers.flat();
+  const skippedBlankIdMemories: SkippedLifecycleBlankIdMemory[] = [];
+  const eventCandidates: Array<{ event: MemoryLifecycleEvent; path: string }> = [];
+  for (const tier of tiers) {
+    for (const memory of [...tier].sort((left, right) => left.path.localeCompare(right.path))) {
+      if (!memory.frontmatter.id.trim()) {
+        skippedBlankIdMemories.push({ path: memory.path });
+        log.warn(`lifecycle ledger rebuild skipped blank memory id: path=${memory.path}`);
+        continue;
+      }
+      for (const event of buildLifecycleEventsForMemory(memory)) {
+        eventCandidates.push({ event, path: memory.path });
+      }
+    }
+  }
 
-  const events: MemoryLifecycleEvent[] = sortMemoryLifecycleEvents(
-    allMemories.flatMap((memory) => buildLifecycleEventsForMemory(memory)),
+  const orderedEvents = sortMemoryLifecycleEvents(eventCandidates.map((candidate) => candidate.event));
+  const candidateByEvent = new Map(
+    eventCandidates.map((candidate) => [candidate.event, candidate]),
   );
+  const keptByEventId = new Map<string, { event: MemoryLifecycleEvent; path: string }>();
+  const events: MemoryLifecycleEvent[] = [];
+  const skippedDuplicateEvents: SkippedDuplicateLifecycleEvent[] = [];
+  for (const event of orderedEvents) {
+    const candidate = candidateByEvent.get(event)!;
+    const kept = keptByEventId.get(event.eventId);
+    if (kept) {
+      skippedDuplicateEvents.push({
+        eventId: event.eventId,
+        keptPath: kept.path,
+        skippedPath: candidate.path,
+      });
+      log.warn(
+        `lifecycle ledger rebuild skipped duplicate event_id=${event.eventId}: `
+        + `kept=${kept.path} skipped=${candidate.path}`,
+      );
+      continue;
+    }
+    keptByEventId.set(event.eventId, candidate);
+    events.push(event);
+  }
 
   let backupPath: string | undefined;
   if (!dryRun) {
@@ -87,5 +136,7 @@ export async function rebuildMemoryLifecycleLedger(
     rebuiltRows: events.length,
     outputPath,
     backupPath,
+    skippedBlankIdMemories,
+    skippedDuplicateEvents,
   };
 }

--- a/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
+++ b/packages/remnic-core/src/maintenance/rebuild-memory-projection.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { mkdir, rm, stat } from "node:fs/promises";
 import { StorageManager } from "../storage.js";
+import { log } from "../logger.js";
 import {
   listMemoryGovernanceRuns,
   readMemoryGovernanceRunArtifact,
@@ -51,6 +52,27 @@ export interface RebuildMemoryProjectionOptions {
   updatedBefore?: string;
 }
 
+export interface SkippedDuplicateMemory {
+  memoryId: string;
+  keptPath: string;
+  skippedPath: string;
+}
+
+export interface SkippedBlankIdMemory {
+  path: string;
+}
+
+export interface SkippedDuplicateTimelineEvent {
+  eventId: string;
+  keptPath: string;
+  skippedPath: string;
+}
+
+export interface SkippedBlankIdTimelineEvent {
+  eventId: string;
+  path: string;
+}
+
 export interface RebuildMemoryProjectionResult {
   dryRun: boolean;
   scannedMemories: number;
@@ -62,6 +84,10 @@ export interface RebuildMemoryProjectionResult {
   outputPath: string;
   backupPath?: string;
   usedLifecycleLedger: boolean;
+  skippedDuplicateMemories: SkippedDuplicateMemory[];
+  skippedBlankIdMemories: SkippedBlankIdMemory[];
+  skippedDuplicateTimelineEvents: SkippedDuplicateTimelineEvent[];
+  skippedBlankIdTimelineEvents: SkippedBlankIdTimelineEvent[];
   scope: {
     updatedAfter: string | null;
     updatedBefore: string | null;
@@ -435,6 +461,91 @@ function serializeGovernanceReviewQueueRow(
   });
 }
 
+function selectProjectionMemories(
+  tiers: MemoryFile[][],
+): {
+  allMemories: MemoryFile[];
+  memories: MemoryFile[];
+  skippedDuplicateMemories: SkippedDuplicateMemory[];
+  skippedBlankIdMemories: SkippedBlankIdMemory[];
+} {
+  const allMemories = tiers.flat();
+  const memories: MemoryFile[] = [];
+  const keptById = new Map<string, MemoryFile>();
+  const skippedDuplicateMemories: SkippedDuplicateMemory[] = [];
+  const skippedBlankIdMemories: SkippedBlankIdMemory[] = [];
+
+  // Tier order is authoritative: hot wins over cold, and cold wins over archive.
+  // Paths break ties within a tier so the winner does not depend on readdir order.
+  for (const tier of tiers) {
+    for (const memory of [...tier].sort((left, right) => left.path.localeCompare(right.path))) {
+      const memoryId = memory.frontmatter.id.trim();
+      if (!memoryId) {
+        skippedBlankIdMemories.push({ path: memory.path });
+        log.warn(`projection rebuild skipped blank memory id: path=${memory.path}`);
+        continue;
+      }
+      const kept = keptById.get(memoryId);
+      if (kept) {
+        skippedDuplicateMemories.push({
+          memoryId,
+          keptPath: kept.path,
+          skippedPath: memory.path,
+        });
+        log.warn(
+          `projection rebuild skipped duplicate memory id=${memoryId}: kept=${kept.path} skipped=${memory.path}`,
+        );
+        continue;
+      }
+      keptById.set(memoryId, memory);
+      memories.push(memory);
+    }
+  }
+
+  return { allMemories, memories, skippedDuplicateMemories, skippedBlankIdMemories };
+}
+
+function deduplicateTimelineEvents(
+  events: MemoryLifecycleEvent[],
+  sourcePathFor: (event: MemoryLifecycleEvent) => string,
+): {
+  events: MemoryLifecycleEvent[];
+  skipped: SkippedDuplicateTimelineEvent[];
+  skippedBlankIds: SkippedBlankIdTimelineEvent[];
+} {
+  const keptById = new Map<string, { event: MemoryLifecycleEvent; path: string }>();
+  const unique: MemoryLifecycleEvent[] = [];
+  const skipped: SkippedDuplicateTimelineEvent[] = [];
+  const skippedBlankIds: SkippedBlankIdTimelineEvent[] = [];
+  for (const event of sortMemoryLifecycleEvents(events)) {
+    const sourcePath = sourcePathFor(event);
+    if (!event.memoryId.trim()) {
+      skippedBlankIds.push({ eventId: event.eventId, path: sourcePath });
+      log.warn(
+        `projection rebuild skipped timeline event with blank memory id: `
+        + `event_id=${event.eventId} path=${sourcePath}`,
+      );
+      continue;
+    }
+    const kept = keptById.get(event.eventId);
+    if (kept) {
+      skipped.push({
+        eventId: event.eventId,
+        keptPath: kept.path,
+        skippedPath: sourcePath,
+      });
+      log.warn(
+        `projection rebuild skipped duplicate timeline event_id=${event.eventId}: `
+        + `kept=${kept.path} skipped=${sourcePath}`,
+      );
+      continue;
+    }
+    keptById.set(event.eventId, { event, path: sourcePath });
+    unique.push(event);
+  }
+  return { events: unique, skipped, skippedBlankIds };
+}
+
 async function loadAuthoritativeProjectionSnapshot(options: {
   memoryDir: string;
   defaultNamespace?: string;
@@ -464,22 +575,43 @@ async function loadAuthoritativeProjectionSnapshot(options: {
     updatedAfter: string | null;
     updatedBefore: string | null;
   };
+  skippedDuplicateMemories: SkippedDuplicateMemory[];
+  skippedBlankIdMemories: SkippedBlankIdMemory[];
+  skippedDuplicateTimelineEvents: SkippedDuplicateTimelineEvent[];
+  skippedBlankIdTimelineEvents: SkippedBlankIdTimelineEvent[];
 }> {
   const storage = new StorageManager(options.memoryDir);
   // Force a fresh disk read — projection verify/rebuild must see the true
   // on-disk state, not a potentially stale in-process cache.
   storage.invalidateAllMemoriesCacheForDir();
-  const allMemories = [
-    ...await storage.readAllMemories(),
-    ...await storage.readAllColdMemories(),
-    ...await storage.readArchivedMemories(),
-  ]
-    .sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id));
+  const selected = selectProjectionMemories([
+    await storage.readAllMemories(),
+    await storage.readAllColdMemories(),
+    await storage.readArchivedMemories(),
+  ]);
+  const allMemories = selected.allMemories;
+  const projectionMemories = selected.memories;
   const lifecycleEvents = await storage.readAllMemoryLifecycleEvents();
-  const { events, usedLifecycleLedger } = loadTimelineEvents(allMemories, lifecycleEvents);
-  const currentRows = allMemories.map((memory) => toCurrentStateRow(options.memoryDir, memory));
+  const timeline = loadTimelineEvents(projectionMemories, lifecycleEvents);
+  const lifecycleLedgerPath = path.join(
+    options.memoryDir,
+    "state",
+    "memory-lifecycle-ledger.jsonl",
+  );
+  const memoryPathById = new Map(
+    projectionMemories.map((memory) => [memory.frontmatter.id, memory.path]),
+  );
+  const deduplicatedTimeline = deduplicateTimelineEvents(
+    timeline.events,
+    (event) => timeline.usedLifecycleLedger
+      ? lifecycleLedgerPath
+      : memoryPathById.get(event.memoryId) ?? lifecycleLedgerPath,
+  );
+  const events = deduplicatedTimeline.events;
+  const usedLifecycleLedger = timeline.usedLifecycleLedger;
+  const currentRows = projectionMemories.map((memory) => toCurrentStateRow(options.memoryDir, memory));
   const scope = normalizeProjectionScope(options);
-  const scopedMemories = filterMemoriesForProjectionScope(allMemories, scope);
+  const scopedMemories = filterMemoriesForProjectionScope(projectionMemories, scope);
   const scopedMemoryIds = new Set(scopedMemories.map((memory) => memory.frontmatter.id));
   const nativeKnowledgeRows = await loadPersistedNativeKnowledgeChunks({
     memoryDir: options.memoryDir,
@@ -516,6 +648,10 @@ async function loadAuthoritativeProjectionSnapshot(options: {
     governance,
     usedLifecycleLedger,
     scope,
+    skippedDuplicateMemories: selected.skippedDuplicateMemories,
+    skippedBlankIdMemories: selected.skippedBlankIdMemories,
+    skippedDuplicateTimelineEvents: deduplicatedTimeline.skipped,
+    skippedBlankIdTimelineEvents: deduplicatedTimeline.skippedBlankIds,
   };
 }
 
@@ -1040,6 +1176,10 @@ export async function rebuildMemoryProjection(
     outputPath,
     backupPath,
     usedLifecycleLedger: snapshot.usedLifecycleLedger,
+    skippedDuplicateMemories: snapshot.skippedDuplicateMemories,
+    skippedBlankIdMemories: snapshot.skippedBlankIdMemories,
+    skippedDuplicateTimelineEvents: snapshot.skippedDuplicateTimelineEvents,
+    skippedBlankIdTimelineEvents: snapshot.skippedBlankIdTimelineEvents,
     scope: snapshot.scope,
   };
 }

--- a/packages/remnic-core/src/storage-guards.ts
+++ b/packages/remnic-core/src/storage-guards.ts
@@ -1,0 +1,22 @@
+import { log } from "./logger.js";
+
+const PROJECTION_FALLBACK_WARN_INTERVAL_MS = 5 * 60_000;
+const projectionFallbackWarnedAt = new Map<string, number>();
+
+export function assertMemoryFrontmatterId(id: string): string {
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error("memory frontmatter id must not be blank");
+  }
+  return "---";
+}
+
+export function warnProjectionFallback(memoryDir: string, consumer: string): null {
+  const key = `${memoryDir}\0${consumer}`;
+  const now = Date.now();
+  const warnedAt = projectionFallbackWarnedAt.get(key) ?? 0;
+  if (now - warnedAt >= PROJECTION_FALLBACK_WARN_INTERVAL_MS) {
+    projectionFallbackWarnedAt.set(key, now);
+    log.warn(`storage.${consumer}: memory projection absent or empty; falling back to full corpus`);
+  }
+  return null;
+}

--- a/packages/remnic-core/src/storage-guards.ts
+++ b/packages/remnic-core/src/storage-guards.ts
@@ -3,11 +3,19 @@ import { log } from "./logger.js";
 const PROJECTION_FALLBACK_WARN_INTERVAL_MS = 5 * 60_000;
 const projectionFallbackWarnedAt = new Map<string, number>();
 
-export function assertMemoryFrontmatterId(id: string): string {
-  if (typeof id !== "string" || id.trim().length === 0) {
-    throw new Error("memory frontmatter id must not be blank");
+export function assertMemoryFrontmatterId(
+  fm: { id: string; category?: string; created?: string; entityRef?: string },
+): void {
+  if (typeof fm.id !== "string" || fm.id.trim().length === 0) {
+    const context = [
+      fm.category ? `category=${fm.category}` : null,
+      fm.created ? `created=${fm.created}` : null,
+      fm.entityRef ? `entityRef=${fm.entityRef}` : null,
+    ].filter(Boolean).join(" ");
+    throw new Error(
+      `memory frontmatter id must not be blank${context ? ` (${context})` : ""}`,
+    );
   }
-  return "---";
 }
 
 export function warnProjectionFallback(memoryDir: string, consumer: string): null {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -305,8 +305,9 @@ function stripCitationMarkersForHashRemoval(value: string, template: string): st
 }
 
 function serializeFrontmatter(fm: MemoryFrontmatter): string {
+  assertMemoryFrontmatterId(fm);
   const lines = [
-    assertMemoryFrontmatterId(fm.id),
+    "---",
     `id: ${fm.id}`,
     `category: ${fm.category}`,
     `created: ${fm.created}`,
@@ -6038,8 +6039,8 @@ export class StorageManager {
         lastAccessed: entry.lastAccessed,
       };
 
-      const fileContent = `${serializeFrontmatter(newFm)}\n\n${memory.content}\n`;
       try {
+        const fileContent = `${serializeFrontmatter(newFm)}\n\n${memory.content}\n`;
         await this.writeStorageSecureFile(memory.path, fileContent);
         updated++;
       } catch (err) {
@@ -6399,9 +6400,8 @@ export class StorageManager {
         updated: now,
       };
 
-      const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${memory.content}\n`;
-
       try {
+        const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${memory.content}\n`;
         await this.writeStorageSecureFile(memory.path, fileContent);
         await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.archiveMemories", {
           memoryId: id,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto"
 import { normalizeContent, computeContentHash } from "./content-hash.js";;
 import path from "node:path";
 import { log } from "./logger.js";
+import { assertMemoryFrontmatterId, warnProjectionFallback } from "./storage-guards.js";
 import { MemoryReadStore } from "./storage/memory-read-store.js";
 import { selfDeps } from "./orchestration/self-deps.js";
 import { EntityStore } from "./storage/entity-store.js";
@@ -305,7 +306,7 @@ function stripCitationMarkersForHashRemoval(value: string, template: string): st
 
 function serializeFrontmatter(fm: MemoryFrontmatter): string {
   const lines = [
-    "---",
+    assertMemoryFrontmatterId(fm.id),
     `id: ${fm.id}`,
     `category: ${fm.category}`,
     `created: ${fm.created}`,
@@ -6087,8 +6088,7 @@ export class StorageManager {
 
   async getProjectedMemoryState(id: string): Promise<MemoryProjectionCurrentState | null> {
     const projected = readProjectedMemoryState(this.baseDir, id);
-    if (projected) return projected;
-
+    if (projected) return projected; warnProjectionFallback(this.baseDir, "getProjectedMemoryState");
     const active = await this.getMemoryById(id);
     if (active) return this.toProjectedCurrentState(active, "active");
 
@@ -6101,7 +6101,8 @@ export class StorageManager {
   async browseProjectedMemories(
     options: ProjectedMemoryBrowseOptions,
   ): Promise<ProjectedMemoryBrowsePage | null> {
-    return readProjectedMemoryBrowse(this.baseDir, options);
+    return readProjectedMemoryBrowse(this.baseDir, options)
+      ?? warnProjectionFallback(this.baseDir, "browseProjectedMemories");
   }
 
   async getProjectedGovernanceRecord(): Promise<ReturnType<typeof readProjectedGovernanceRecord>> {
@@ -6141,8 +6142,7 @@ export class StorageManager {
     if (cappedLimit === 0) return [];
 
     const projected = readProjectedMemoryTimeline(this.baseDir, memoryId, cappedLimit);
-    if (projected && projected.length > 0) return projected;
-
+    if (projected && projected.length > 0) return projected; warnProjectionFallback(this.baseDir, "getMemoryTimeline");
     const events = await this.readAllMemoryLifecycleEvents();
     return events.filter((event) => event.memoryId === memoryId).slice(-cappedLimit);
   }

--- a/tests/memory-lifecycle-ledger.test.ts
+++ b/tests/memory-lifecycle-ledger.test.ts
@@ -598,3 +598,38 @@ alpha
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("rebuildMemoryLifecycleLedger skips duplicate events and blank IDs without aborting", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-rebuild-memory-lifecycle-anomalies-"));
+  try {
+    const duplicate = `---
+id: duplicate-id
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T01:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: []
+---
+
+duplicate
+`;
+    await writeText(memoryDir, "facts/2026-03-08/hot.md", duplicate);
+    await writeText(memoryDir, "cold/facts/2026-03-08/cold.md", duplicate);
+    await writeText(memoryDir, "facts/2026-03-08/blank-a.md", duplicate.replace("id: duplicate-id", "id:"));
+    await writeText(memoryDir, "archive/2026-03-08/blank-b.md", duplicate.replace("id: duplicate-id", "id:   "));
+
+    const result = await rebuildMemoryLifecycleLedger({ memoryDir, dryRun: false });
+
+    assert.equal(result.scannedMemories, 4);
+    assert.equal(result.rebuiltRows, 2);
+    assert.equal(result.skippedBlankIdMemories.length, 2);
+    assert.equal(result.skippedDuplicateEvents.length, 2);
+    assert.equal(result.skippedDuplicateEvents.every((entry) => entry.eventId.includes("duplicate-id")), true);
+    const rows = (await readFile(result.outputPath, "utf-8")).trim().split("\n");
+    assert.equal(rows.length, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { initLogger } from "../src/logger.ts";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
@@ -1611,7 +1612,6 @@ test("rebuildMemoryProjection projects entity mentions, native knowledge chunks,
       sourceHash: "hash-identity",
       preview: "Alex maintains the Engram memory system.",
     });
-
     const projectedReviewQueue = readProjectedLatestReviewQueue(memoryDir);
     assert.ok(projectedReviewQueue?.found);
     assert.equal(projectedReviewQueue?.runId, governance.runId);
@@ -1793,5 +1793,126 @@ test("projection browse filters realpath-invalid rows before counting and pagina
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(outsidePath, { force: true });
+  }
+});
+
+test("rebuildMemoryProjection keeps hot duplicate IDs and reports skipped cold and blank records", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-anomalies-"));
+  const warnings: string[] = [];
+  const logger = {
+    info() {},
+    warn(message: string) { warnings.push(message); },
+    error() {},
+  };
+  initLogger(logger);
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/hot.md",
+      memoryDoc({ id: "duplicate-id", content: "hot winner" }),
+    );
+    await writeText(
+      memoryDir,
+      "cold/facts/2026-03-08/cold.md",
+      memoryDoc({ id: "duplicate-id", content: "cold loser" }),
+    );
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/blank-a.md",
+      memoryDoc({ id: "", content: "blank one" }),
+    );
+    await writeText(
+      memoryDir,
+      "archive/2026-03-08/blank-b.md",
+      memoryDoc({ id: "   ", content: "blank two" }),
+    );
+    const duplicateEvent = {
+      eventId: "duplicate-event",
+      memoryId: "duplicate-id",
+      eventType: "created",
+      timestamp: "2026-03-08T00:00:00.000Z",
+      actor: "test",
+      ruleVersion: "memory-lifecycle-ledger.v1",
+    };
+    await writeText(
+      memoryDir,
+      "state/memory-lifecycle-ledger.jsonl",
+      `${JSON.stringify(duplicateEvent)}\n${JSON.stringify(duplicateEvent)}\n`,
+    );
+
+    const result = await rebuildMemoryProjection({ memoryDir, dryRun: false });
+
+    assert.equal(result.currentRows, 1);
+    assert.equal(readProjectedMemoryState(memoryDir, "duplicate-id")?.preview, "hot winner");
+    assert.equal(result.skippedDuplicateMemories.length, 1);
+    assert.equal(result.skippedDuplicateTimelineEvents.length, 1);
+    assert.equal(result.skippedBlankIdMemories.length, 2);
+    assert.match(result.skippedDuplicateMemories[0]!.keptPath, /facts\/2026-03-08\/hot\.md$/);
+    assert.match(result.skippedDuplicateMemories[0]!.skippedPath, /cold\/facts\/2026-03-08\/cold\.md$/);
+    assert.equal(warnings.some((message) => message.includes("duplicate-id") && message.includes("hot.md") && message.includes("cold.md")), true);
+    assert.equal(warnings.filter((message) => message.includes("blank memory id")).length, 2);
+  } finally {
+    initLogger();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager rejects blank frontmatter IDs before writing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-blank-id-write-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const { id } = await storage.writeMemory("fact", "valid memory", { source: "test" });
+    const memory = await storage.getMemoryById(id);
+    assert.ok(memory);
+
+    await assert.rejects(
+      () => storage.writeMemoryFrontmatter(memory!, { id: " \t " }),
+      /memory frontmatter id must not be blank/,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager rate-limits warnings for projection fallbacks by consumer", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-warning-"));
+  const warnings: string[] = [];
+  const originalDateNow = Date.now;
+  initLogger({
+    info() {},
+    warn(message) { warnings.push(message); },
+    error() {},
+  });
+  try {
+    const storage = new StorageManager(memoryDir);
+    const { id } = await storage.writeMemory("fact", "fallback warning", { source: "test" });
+    let now = originalDateNow();
+    Date.now = () => now;
+
+    await storage.getMemoryTimeline(id);
+    await storage.getMemoryTimeline(id);
+    await storage.getProjectedMemoryState(id);
+    await storage.getProjectedMemoryState(id);
+    await storage.browseProjectedMemories({ limit: 10, offset: 0 });
+    await storage.browseProjectedMemories({ limit: 10, offset: 0 });
+    now += 5 * 60_000;
+    await storage.getMemoryTimeline(id);
+
+    assert.equal(
+      warnings.filter((message) => message.includes("getMemoryTimeline") && message.includes("projection")).length,
+      2,
+    );
+    assert.equal(
+      warnings.filter((message) => message.includes("getProjectedMemoryState") && message.includes("projection")).length,
+      1,
+    );
+    assert.equal(
+      warnings.filter((message) => message.includes("browseProjectedMemories") && message.includes("projection")).length,
+      1,
+    );
+  } finally {
+    Date.now = originalDateNow;
+    initLogger();
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Keep the first row when IDs match.
- Read hot files first, cold files next, and old files last. Sort paths in each group.
- Skip blank IDs and repeat events. Log each skipped row. Add each row to the rebuild result.
- Reject blank IDs before a frontmatter write.
- Warn when an index read needs a full scan. Limit each warning by store and caller.

## Tests

- `pnpm exec tsx --test tests/memory-projection.test.ts tests/memory-lifecycle-ledger.test.ts`
- `npm run preflight:quick`
- `npm run test:entity-hardening`

Fixes #1821

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authoritative rebuild winner rules and write-time frontmatter validation for memory storage; behavior is covered by new tests but affects projection and ledger correctness on conflicted corpora.
> 
> **Overview**
> Makes **memory projection and lifecycle ledger rebuilds** tolerate bad on-disk data instead of letting duplicate IDs or blank frontmatter skew indexes unpredictably.
> 
> **Projection rebuild** now walks corpus tiers in fixed order (hot, then cold, then archive), breaks ties by path within a tier, and keeps the first winner per `memoryId`. Blank IDs are skipped; duplicate memories and timeline `eventId`s are logged and returned on the rebuild result. **Lifecycle ledger rebuild** applies the same tier/path scan, skips blank IDs, and deduplicates lifecycle events by `eventId` while reporting what was kept vs skipped.
> 
> Adds **`storage-guards`**: `serializeFrontmatter` **rejects blank memory IDs** before any write, and projection reads (`getProjectedMemoryState`, `browseProjectedMemories`, `getMemoryTimeline`) emit **rate-limited warnings** when falling back to a full corpus scan because the SQLite projection is missing or empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb3182422ae6496c6ed800c152e9acdfcf02a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Review follow-up

A write with a blank id now throws with category, created, and entityRef in the message, so the bad file is easy to find. The batch sweeps (`archiveMemories` and the access flush) build their file text inside each item's try block. One legacy blank-id file logs and gets skipped; the rest of the sweep goes on. A single write still throws loudly, by design.
