### PR TITLE
Cancel recall work when HTTP clients disconnect

### DIFF
--- a/packages/remnic-core/src/access-http-cancellation.test.ts
+++ b/packages/remnic-core/src/access-http-cancellation.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { request as httpRequest } from "node:http";
+import test from "node:test";
+
+import { EngramAccessHttpServer } from "./access-http.js";
+import { EngramAccessService, type EngramAccessRecallRequest } from "./access-service.js";
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function waitFor<T>(promise: Promise<T>, timeoutMs = 1_000): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+      timer.unref?.();
+    }),
+  ]);
+}
+
+test("HTTP recall aborts in-flight work when the client disconnects", async () => {
+  const recallStarted = deferred<void>();
+  const recallSettled = deferred<void>();
+  const forceRelease = deferred<void>();
+  let observedSignal: AbortSignal | undefined;
+  const service = {
+    recall: async (input: EngramAccessRecallRequest) => {
+      observedSignal = input.abortSignal;
+      recallStarted.resolve();
+      try {
+        await Promise.race([
+          forceRelease.promise,
+          new Promise<void>((_resolve, reject) => {
+            input.abortSignal?.addEventListener(
+              "abort",
+              () => reject(input.abortSignal?.reason),
+              { once: true },
+            );
+          }),
+        ]);
+      } finally {
+        recallSettled.resolve();
+      }
+      if (input.abortSignal?.aborted) {
+        throw input.abortSignal.reason;
+      }
+      return {} as never;
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+
+  try {
+    const client = httpRequest({
+      host: "127.0.0.1",
+      port: status.port,
+      path: "/engram/v1/recall",
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+    });
+    client.on("error", () => {});
+    client.end(JSON.stringify({ query: "slow recall" }));
+
+    await waitFor(recallStarted.promise);
+    assert.ok(observedSignal, "the HTTP request signal must reach the recall service");
+    client.destroy();
+
+    await waitFor(recallSettled.promise);
+    assert.equal(observedSignal.aborted, true);
+  } finally {
+    forceRelease.resolve();
+    await server.stop();
+  }
+});
+
+test("a disconnected recall queued on the principal budget lock never starts", async () => {
+  const firstStarted = deferred<void>();
+  const releaseFirst = deferred<void>();
+  let secondStarted = false;
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const lockHost = service as unknown as {
+    budgetLocks: Map<string, Promise<void>>;
+    withBudgetLock<T>(
+      principal: string,
+      abortSignal: AbortSignal | undefined,
+      operation: () => Promise<T>,
+    ): Promise<T>;
+  };
+  lockHost.budgetLocks = new Map();
+
+  const first = lockHost.withBudgetLock("principal", undefined, async () => {
+    firstStarted.resolve();
+    await releaseFirst.promise;
+  });
+  await firstStarted.promise;
+
+  const controller = new AbortController();
+  const second = lockHost.withBudgetLock("principal", controller.signal, async () => {
+    secondStarted = true;
+  });
+  controller.abort();
+  releaseFirst.resolve();
+
+  await first;
+  await assert.rejects(waitFor(second), (error: Error) => error.name === "AbortError");
+  assert.equal(secondStarted, false);
+});

--- a/packages/remnic-core/src/access-http-cancellation.test.ts
+++ b/packages/remnic-core/src/access-http-cancellation.test.ts
@@ -163,3 +163,78 @@ test("an aborted queued recall does not poison the principal budget lock", async
   assert.equal(secondStarted, false);
   assert.equal(thirdStarted, true);
 });
+
+function makeRecallServiceProbe(): {
+  service: EngramAccessService;
+  setExecuteRecall: (execute: () => Promise<void>) => void;
+  requestFingerprint: () => unknown;
+  stored: () => boolean;
+} {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  let executeRecall = async () => {};
+  let capturedFingerprint: unknown;
+  let didStore = false;
+  const host = service as unknown as {
+    budgetLocks: Map<string, Promise<void>>;
+    orchestrator: { config: Record<string, unknown> };
+    resolveRequestPrincipal: () => string;
+    executeRecall: () => Promise<{ response: Record<string, never>; budgetRecordPrincipal: null }>;
+    handleIdempotentRead: (options: {
+      requestFingerprint: unknown;
+      execute: () => Promise<Record<string, never>>;
+    }) => Promise<Record<string, never>>;
+  };
+  host.budgetLocks = new Map();
+  host.orchestrator = { config: {} };
+  host.resolveRequestPrincipal = () => "principal";
+  host.executeRecall = async () => {
+    await executeRecall();
+    return { response: {}, budgetRecordPrincipal: null };
+  };
+  host.handleIdempotentRead = async (options) => {
+    capturedFingerprint = options.requestFingerprint;
+    const response = await options.execute();
+    didStore = true;
+    return response;
+  };
+  return {
+    service,
+    setExecuteRecall: (execute) => {
+      executeRecall = execute;
+    },
+    requestFingerprint: () => capturedFingerprint,
+    stored: () => didStore,
+  };
+}
+
+test("recall excludes its abort signal from the idempotency fingerprint", async () => {
+  const probe = makeRecallServiceProbe();
+  await probe.service.recall({
+    query: "same payload",
+    idempotencyKey: "same-key",
+    abortSignal: new AbortController().signal,
+  });
+
+  assert.equal(
+    Object.hasOwn(probe.requestFingerprint() as object, "abortSignal"),
+    false,
+  );
+});
+
+test("recall does not store a result when the pipeline consumes an abort", async () => {
+  const probe = makeRecallServiceProbe();
+  const controller = new AbortController();
+  probe.setExecuteRecall(async () => {
+    controller.abort();
+  });
+
+  await assert.rejects(
+    probe.service.recall({
+      query: "cancelled",
+      idempotencyKey: "cancelled-key",
+      abortSignal: controller.signal,
+    }),
+    (error: Error) => error.name === "AbortError",
+  );
+  assert.equal(probe.stored(), false);
+});

--- a/packages/remnic-core/src/access-http-cancellation.test.ts
+++ b/packages/remnic-core/src/access-http-cancellation.test.ts
@@ -124,3 +124,42 @@ test("a disconnected recall queued on the principal budget lock never starts", a
   await assert.rejects(waitFor(second), (error: Error) => error.name === "AbortError");
   assert.equal(secondStarted, false);
 });
+
+test("an aborted queued recall does not poison the principal budget lock", async () => {
+  const firstStarted = deferred<void>();
+  const releaseFirst = deferred<void>();
+  let secondStarted = false;
+  let thirdStarted = false;
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const lockHost = service as unknown as {
+    budgetLocks: Map<string, Promise<void>>;
+    withBudgetLock<T>(
+      principal: string,
+      abortSignal: AbortSignal | undefined,
+      operation: () => Promise<T>,
+    ): Promise<T>;
+  };
+  lockHost.budgetLocks = new Map();
+
+  const first = lockHost.withBudgetLock("principal", undefined, async () => {
+    firstStarted.resolve();
+    await releaseFirst.promise;
+  });
+  await firstStarted.promise;
+
+  const controller = new AbortController();
+  const second = lockHost.withBudgetLock("principal", controller.signal, async () => {
+    secondStarted = true;
+  });
+  const third = lockHost.withBudgetLock("principal", undefined, async () => {
+    thirdStarted = true;
+  });
+  controller.abort();
+  releaseFirst.resolve();
+
+  await first;
+  await assert.rejects(waitFor(second), (error: Error) => error.name === "AbortError");
+  await waitFor(third);
+  assert.equal(secondStarted, false);
+  assert.equal(thirdStarted, true);
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { log } from "./logger.js";
+import { abortError, isAbortError } from "./abort-error.js";
 import { EngramAccessInputError, type EngramAccessService, type EngramAccessMemoryResponse, type EngramAccessWriteResponse } from "./access-service.js";
 import { CorrectionContractError } from "./correction/correction-contract.js";
 import { WearablesInputError } from "./wearables/errors.js";
@@ -344,8 +345,22 @@ export class EngramAccessHttpServer {
 
     const server = createServer((req, res) => {
       const correlationId = randomUUID();
+      const abortController = new AbortController();
+      const abortDisconnectedRequest = () => {
+        if (!res.writableFinished && !abortController.signal.aborted) {
+          abortController.abort(abortError("HTTP client disconnected"));
+        }
+      };
+      req.once("aborted", abortDisconnectedRequest);
+      res.once("close", abortDisconnectedRequest);
       correlationIdStore.run(correlationId, () => {
-        void this.handle(req, res, correlationId).catch((err) => {
+        void this.handle(req, res, correlationId, abortController.signal).catch((err) => {
+          if (isAbortError(err) || abortController.signal.aborted) {
+            if (!res.destroyed && !res.writableEnded) {
+              res.end();
+            }
+            return;
+          }
           log.debug(`engram access HTTP request failed [${correlationId}]: ${err}`);
           if (err instanceof HttpError) {
             const payload: Record<string, unknown> = { error: err.message, code: err.code };
@@ -370,6 +385,9 @@ export class EngramAccessHttpServer {
             err,
           );
           this.respondJson(res, 500, { error: "internal_error", code: "internal_error" });
+        }).finally(() => {
+          req.off("aborted", abortDisconnectedRequest);
+          res.off("close", abortDisconnectedRequest);
         });
       });
     });
@@ -583,7 +601,12 @@ export class EngramAccessHttpServer {
     return queryDisclosure;
   }
 
-  private async handle(req: IncomingMessage, res: ServerResponse, correlationId: string): Promise<void> {
+  private async handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+    correlationId: string,
+    abortSignal: AbortSignal,
+  ): Promise<void> {
     const parsed = new URL(req.url ?? "/", `http://${hostToUrlAuthority(this.host)}`);
     const pathname = parsed.pathname;
 
@@ -767,6 +790,7 @@ export class EngramAccessHttpServer {
         ...(tags !== undefined ? { tags } : {}),
         ...(tagMatch !== undefined ? { tagMatch } : {}),
         ...(includeLowConfidence ? { includeLowConfidence: true } : {}),
+        abortSignal,
       });
       this.respondJson(res, 200, response);
       return;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -355,7 +355,7 @@ export class EngramAccessHttpServer {
       res.once("close", abortDisconnectedRequest);
       correlationIdStore.run(correlationId, () => {
         void this.handle(req, res, correlationId, abortController.signal).catch((err) => {
-          if (isAbortError(err) || abortController.signal.aborted) {
+          if (isAbortError(err)) {
             if (!res.destroyed && !res.writableEnded) {
               res.end();
             }

--- a/packages/remnic-core/src/access-recall-surface.ts
+++ b/packages/remnic-core/src/access-recall-surface.ts
@@ -823,6 +823,7 @@ export class AccessRecallSurface {
       ...(authenticatedPrincipal ? { principalOverride: authenticatedPrincipal } : {}),
       ...(asOf !== undefined ? { asOf } : {}),
       ...(request.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
+      ...(request.abortSignal ? { abortSignal: request.abortSignal } : {}),
     };
     const startedAt = Date.now();
     const context = await this.deps.orchestrator.recall(query, request.sessionKey, recallOptions);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5,6 +5,7 @@ import { readdirSync, unlinkSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
+import { throwIfAborted } from "./abort-error.js";
 import { resolveNamespaceCapabilities,
   resolveMemoryLifecycleCapabilities,
   resolveQmdCapabilities,
@@ -403,11 +404,8 @@ export interface EngramAccessRecallRequest {
   includeDebug?: boolean;
   abortSignal?: AbortSignal;
   /**
-   * Recall disclosure depth (issue #677).  Selects how much content each
-   * result returns: `"chunk"` (default), `"section"`, or `"raw"`.  Omitting
-   * this field is equivalent to passing `"chunk"` and preserves pre-#677
-   * behavior.  Surfaces (CLI / HTTP / MCP) and per-level token telemetry
-   * are wired in subsequent PRs of #677.
+   * Recall disclosure depth. Omitting it preserves the `"chunk"` default.
+   * Other accepted values are `"section"` and `"raw"`.
    */
   disclosure?: RecallDisclosure;
   /**
@@ -2433,7 +2431,7 @@ export class EngramAccessService {
     this.budgetLocks.set(key, queued);
     await previous.catch(() => {});
     try {
-      abortSignal?.throwIfAborted();
+      throwIfAborted(abortSignal);
       return await fn();
     } finally {
       release();
@@ -2737,6 +2735,7 @@ export class EngramAccessService {
       throw new EngramAccessInputError("query is required");
     }
     const normalizedRequest = { ...request, query };
+    const { abortSignal: _abortSignal, ...requestFingerprint } = normalizedRequest;
     const authenticatedPrincipal = request.authenticatedPrincipal?.trim();
     const principal = this.resolveRequestPrincipal(request.sessionKey, authenticatedPrincipal);
     if (resolveNamespaceCapabilities(this.orchestrator.config).namespaces && !principal) {
@@ -2749,9 +2748,10 @@ export class EngramAccessService {
       const response = await this.handleIdempotentRead({
         operation: "recall",
         idempotencyKey: request.idempotencyKey,
-        requestFingerprint: normalizedRequest,
+        requestFingerprint,
         execute: async () => {
           const result = await this.executeRecall(normalizedRequest);
+          throwIfAborted(request.abortSignal);
           budgetRecordPrincipal = result.budgetRecordPrincipal;
           return result.response;
         },

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -401,6 +401,7 @@ export interface EngramAccessRecallRequest {
   topK?: number;
   mode?: RecallPlanMode | "auto";
   includeDebug?: boolean;
+  abortSignal?: AbortSignal;
   /**
    * Recall disclosure depth (issue #677).  Selects how much content each
    * result returns: `"chunk"` (default), `"section"`, or `"raw"`.  Omitting
@@ -2421,7 +2422,7 @@ export class EngramAccessService {
     }
   }
 
-  private async withBudgetLock<T>(principal: string, fn: () => Promise<T>): Promise<T> {
+  private async withBudgetLock<T>(principal: string, abortSignal: AbortSignal | undefined, fn: () => Promise<T>): Promise<T> {
     const key = principal || "__anonymous__";
     const previous = this.budgetLocks.get(key) ?? Promise.resolve();
     let release!: () => void;
@@ -2430,9 +2431,9 @@ export class EngramAccessService {
     });
     const queued = previous.then(() => current, () => current);
     this.budgetLocks.set(key, queued);
-
     await previous.catch(() => {});
     try {
+      abortSignal?.throwIfAborted();
       return await fn();
     } finally {
       release();
@@ -2743,8 +2744,7 @@ export class EngramAccessService {
         "authentication required: namespaces are enabled and no principal was supplied",
       );
     }
-    const budgetLockPrincipal = principal ?? "default";
-    return this.withBudgetLock(budgetLockPrincipal, async () => {
+    return this.withBudgetLock(principal ?? "default", request.abortSignal, async () => {
       let budgetRecordPrincipal: string | null = null;
       const response = await this.handleIdempotentRead({
         operation: "recall",


### PR DESCRIPTION
## Summary

This change stops recall work when the client drops the HTTP link. The request signal now reaches the recall code. A recall that drops while in line does not start. An abort ends the handler with no reply.

## Tests

I added a socket drop test for an active recall. I added a queue test for a recall that drops before it starts. I ran the HTTP tests and the quick preflight gate.

Fixes #1827

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall HTTP handling, per-principal serialization, and idempotency caching; behavior changes when clients disconnect but scope is limited to recall cancellation paths with dedicated tests.
> 
> **Overview**
> **HTTP recall now stops when the client drops the connection.** Each request gets an `AbortController` wired to `req` `aborted` and `res` `close`; that signal is passed into `service.recall` on `POST /engram/v1/recall`. Abort errors end the handler quietly (no JSON error body).
> 
> **Recall plumbing honors cancellation end-to-end.** `EngramAccessRecallRequest` gains optional `abortSignal`. The principal **budget lock** checks the signal before running queued work so an aborted recall never starts and does not block later recalls. After execute, `throwIfAborted` runs so aborted pipelines do not persist idempotent results; `abortSignal` is stripped from the idempotency fingerprint. The signal is forwarded into orchestrator recall via `access-recall-surface`.
> 
> **Tests** cover socket disconnect during in-flight recall, queued abort on the budget lock, lock recovery after abort, fingerprint exclusion, and no idempotency store on abort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaaa7b8c87d9ac5984ec3f4b47b1a76f19ad26a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->