### PR TITLE
Gate health on search warm-up

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -38,6 +38,12 @@ import { handleChatMessage, handleChatEventsSSE } from "./chat/chat-http.js";
 // server lifecycle (issue #1685 item 1 / #1687 Thread 21).
 import { cleanupExpiredChatSessions } from "./chat/chat-session.js";
 
+export interface AccessHttpReadinessState {
+  ready: boolean;
+  warmupAttempts: number;
+  lastError?: string | null;
+}
+
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
   host?: string;
@@ -67,10 +73,10 @@ export interface EngramAccessHttpServerOptions {
   /** Optional authenticated admin dashboard/config controls supplied by the host server. */
   adminControls?: RemnicAdminControls;
   /**
-   * Standalone readiness gate. Defaults to ready so embedded hosts keep their
+   * Standalone readiness state. Defaults to ready so embedded hosts keep their
    * existing health behavior.
    */
-  isReady?: () => boolean;
+  readiness?: () => AccessHttpReadinessState;
 }
 
 export interface EngramAccessHttpServerStatus {
@@ -284,7 +290,7 @@ export class EngramAccessHttpServer {
   private readonly adminControls?: RemnicAdminControls;
   private readonly trustPrincipalHeader: boolean;
   private readonly adapterRegistry: AdapterRegistry | null;
-  private readonly isReady: () => boolean;
+  private readonly readiness: () => AccessHttpReadinessState;
   private readonly writeRequestTimestamps: number[] = [];
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
@@ -325,7 +331,7 @@ export class EngramAccessHttpServer {
     this.adminConsolePrefillToken = options.adminConsolePrefillToken === true ? this.authToken : undefined;
     this.adminControls = options.adminControls;
     this.trustPrincipalHeader = options.trustPrincipalHeader === true;
-    this.isReady = options.isReady ?? (() => true);
+    this.readiness = options.readiness ?? (() => ({ ready: true, warmupAttempts: 0 }));
     this.adapterRegistry = options.enableAdapters !== false
       ? (options.adapterRegistry ?? new AdapterRegistry())
       : null;
@@ -598,17 +604,19 @@ export class EngramAccessHttpServer {
       return;
     }
 
-    if (
-      req.method === "GET" &&
-      pathname === "/engram/v1/health" &&
-      !this.isReady()
-    ) {
-      this.respondJson(res, 503, {
-        ok: false,
-        ready: false,
-        code: "not_ready",
-      });
-      return;
+    if (req.method === "GET" && pathname === "/engram/v1/health") {
+      const readiness = this.readiness();
+      if (!readiness.ready) {
+        this.respondJson(res, 503, {
+          ok: false,
+          ready: false,
+          warmupAttempts: readiness.warmupAttempts,
+          lastError: readiness.lastError ?? null,
+          code: "not_ready",
+        });
+        return;
+      }
+
     }
 
     if (!this.isAuthorized(req, pathname)) {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -66,6 +66,11 @@ export interface EngramAccessHttpServerOptions {
   emitLegacyTools?: boolean;
   /** Optional authenticated admin dashboard/config controls supplied by the host server. */
   adminControls?: RemnicAdminControls;
+  /**
+   * Standalone readiness gate. Defaults to ready so embedded hosts keep their
+   * existing health behavior.
+   */
+  isReady?: () => boolean;
 }
 
 export interface EngramAccessHttpServerStatus {
@@ -279,6 +284,7 @@ export class EngramAccessHttpServer {
   private readonly adminControls?: RemnicAdminControls;
   private readonly trustPrincipalHeader: boolean;
   private readonly adapterRegistry: AdapterRegistry | null;
+  private readonly isReady: () => boolean;
   private readonly writeRequestTimestamps: number[] = [];
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
@@ -319,6 +325,7 @@ export class EngramAccessHttpServer {
     this.adminConsolePrefillToken = options.adminConsolePrefillToken === true ? this.authToken : undefined;
     this.adminControls = options.adminControls;
     this.trustPrincipalHeader = options.trustPrincipalHeader === true;
+    this.isReady = options.isReady ?? (() => true);
     this.adapterRegistry = options.enableAdapters !== false
       ? (options.adapterRegistry ?? new AdapterRegistry())
       : null;
@@ -588,6 +595,19 @@ export class EngramAccessHttpServer {
     const pathname = parsed.pathname;
 
     if (this.adminConsoleEnabled && await this.handleAdminConsole(req, res, pathname)) {
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      pathname === "/engram/v1/health" &&
+      !this.isReady()
+    ) {
+      this.respondJson(res, 503, {
+        ok: false,
+        ready: false,
+        code: "not_ready",
+      });
       return;
     }
 

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -1,5 +1,6 @@
 import { log } from "../logger.js";
 import {
+  reportSearchDegradation,
   resolveEnsureCollectionArgs,
   type SearchBackend,
   type SearchExecutionOptions,
@@ -492,7 +493,7 @@ export class LanceDbBackend implements SearchBackend {
     } catch (err) {
       log.debug(`LanceDbBackend search (${mode}) failed: ${err}`);
       if (!isSearchAborted(execution)) {
-        execution?.onDegradation?.({
+        reportSearchDegradation(execution, {
           backend: "lancedb",
           code: "backend_error",
           detail: err instanceof Error ? err.name : typeof err,

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -491,6 +491,13 @@ export class LanceDbBackend implements SearchBackend {
       }
     } catch (err) {
       log.debug(`LanceDbBackend search (${mode}) failed: ${err}`);
+      if (!isSearchAborted(execution)) {
+        execution?.onDegradation?.({
+          backend: "lancedb",
+          code: "backend_error",
+          detail: err instanceof Error ? err.name : typeof err,
+        });
+      }
       return [];
     }
   }

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -1,5 +1,6 @@
 import { log } from "../logger.js";
 import {
+  reportSearchDegradation,
   resolveEnsureCollectionArgs,
   type SearchBackend,
   type SearchExecutionOptions,
@@ -283,7 +284,7 @@ export class MeilisearchBackend implements SearchBackend {
       log.debug(`MeilisearchBackend search failed: ${err}`);
       if (rethrow) throw err;
       if (!isSearchAborted(execution)) {
-        execution?.onDegradation?.({
+        reportSearchDegradation(execution, {
           backend: "meilisearch",
           code: "backend_error",
           detail: err instanceof Error ? err.name : typeof err,

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -282,6 +282,13 @@ export class MeilisearchBackend implements SearchBackend {
     } catch (err) {
       log.debug(`MeilisearchBackend search failed: ${err}`);
       if (rethrow) throw err;
+      if (!isSearchAborted(execution)) {
+        execution?.onDegradation?.({
+          backend: "meilisearch",
+          code: "backend_error",
+          detail: err instanceof Error ? err.name : typeof err,
+        });
+      }
       return [];
     }
   }

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { log } from "../logger.js";
 import {
+  reportSearchDegradation,
   resolveEnsureCollectionArgs,
   type SearchBackend,
   type SearchExecutionOptions,
@@ -582,7 +583,7 @@ export class OramaBackend implements SearchBackend {
     } catch (err) {
       log.debug(`OramaBackend search (${mode}) failed: ${err}`);
       if (!isSearchAborted(execution)) {
-        execution?.onDegradation?.({
+        reportSearchDegradation(execution, {
           backend: "orama",
           code: "backend_error",
           detail: err instanceof Error ? err.name : typeof err,

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -581,6 +581,13 @@ export class OramaBackend implements SearchBackend {
       }));
     } catch (err) {
       log.debug(`OramaBackend search (${mode}) failed: ${err}`);
+      if (!isSearchAborted(execution)) {
+        execution?.onDegradation?.({
+          backend: "orama",
+          code: "backend_error",
+          detail: err instanceof Error ? err.name : typeof err,
+        });
+      }
       return [];
     }
   }

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -43,6 +43,17 @@ export interface SearchExecutionOptions {
   onDegradation?: (degradation: SearchDegradation) => void;
 }
 
+export function reportSearchDegradation(
+  execution: SearchExecutionOptions | undefined,
+  degradation: SearchDegradation,
+): void {
+  try {
+    execution?.onDegradation?.(degradation);
+  } catch {
+    // Observability must never break search.
+  }
+}
+
 export function resolveEnsureCollectionArgs(
   collectionOrExecution?: string | SearchExecutionOptions,
   execution?: SearchExecutionOptions,

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -19,13 +19,14 @@ export interface SearchQueryOptions {
  * rule 34).
  */
 export interface SearchDegradation {
-  backend: "qmd";
+  backend: "qmd" | "remote";
   code:
     | "backend_unavailable"
     | "daemon_timeout"
     | "daemon_loading"
     | "subprocess_error"
-    | "deadline_exceeded";
+    | "deadline_exceeded"
+    | "remote_error";
   detail?: string;
 }
 

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -19,9 +19,10 @@ export interface SearchQueryOptions {
  * rule 34).
  */
 export interface SearchDegradation {
-  backend: "qmd" | "remote";
+  backend: "qmd" | "remote" | "meilisearch" | "orama" | "lancedb";
   code:
     | "backend_unavailable"
+    | "backend_error"
     | "daemon_timeout"
     | "daemon_loading"
     | "subprocess_error"

--- a/packages/remnic-core/src/search/remote-backend.ts
+++ b/packages/remnic-core/src/search/remote-backend.ts
@@ -1,5 +1,11 @@
 import { log } from "../logger.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions, SearchResult } from "./port.js";
+import {
+  reportSearchDegradation,
+  type SearchBackend,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+  type SearchResult,
+} from "./port.js";
 
 export interface RemoteSearchBackendOptions {
   baseUrl: string;
@@ -104,7 +110,7 @@ export class RemoteSearchBackend implements SearchBackend {
     execution?: SearchExecutionOptions,
   ): Promise<SearchResult[]> {
     if (!this.available) {
-      execution?.onDegradation?.({
+      reportSearchDegradation(execution, {
         backend: "remote",
         code: "backend_unavailable",
       });
@@ -121,7 +127,7 @@ export class RemoteSearchBackend implements SearchBackend {
       });
       if (!res.ok) {
         log.debug(`RemoteSearchBackend ${endpoint} returned ${res.status}`);
-        execution?.onDegradation?.({
+        reportSearchDegradation(execution, {
           backend: "remote",
           code: "remote_error",
           detail: `HTTP ${res.status}`,
@@ -130,7 +136,7 @@ export class RemoteSearchBackend implements SearchBackend {
       }
       const data = await res.json();
       if (!Array.isArray(data)) {
-        execution?.onDegradation?.({
+        reportSearchDegradation(execution, {
           backend: "remote",
           code: "remote_error",
           detail: "invalid response body",
@@ -140,7 +146,7 @@ export class RemoteSearchBackend implements SearchBackend {
       return data as SearchResult[];
     } catch (err) {
       log.debug(`RemoteSearchBackend ${endpoint} failed: ${err}`);
-      execution?.onDegradation?.({
+      reportSearchDegradation(execution, {
         backend: "remote",
         code: "remote_error",
         detail: err instanceof Error ? err.name : typeof err,

--- a/packages/remnic-core/src/search/remote-backend.ts
+++ b/packages/remnic-core/src/search/remote-backend.ts
@@ -103,7 +103,13 @@ export class RemoteSearchBackend implements SearchBackend {
     body: Record<string, unknown>,
     execution?: SearchExecutionOptions,
   ): Promise<SearchResult[]> {
-    if (!this.available) return [];
+    if (!this.available) {
+      execution?.onDegradation?.({
+        backend: "remote",
+        code: "backend_unavailable",
+      });
+      return [];
+    }
     try {
       const res = await fetch(`${this.baseUrl}${endpoint}`, {
         method: "POST",
@@ -115,13 +121,30 @@ export class RemoteSearchBackend implements SearchBackend {
       });
       if (!res.ok) {
         log.debug(`RemoteSearchBackend ${endpoint} returned ${res.status}`);
+        execution?.onDegradation?.({
+          backend: "remote",
+          code: "remote_error",
+          detail: `HTTP ${res.status}`,
+        });
         return [];
       }
       const data = await res.json();
-      if (!Array.isArray(data)) return [];
+      if (!Array.isArray(data)) {
+        execution?.onDegradation?.({
+          backend: "remote",
+          code: "remote_error",
+          detail: "invalid response body",
+        });
+        return [];
+      }
       return data as SearchResult[];
     } catch (err) {
       log.debug(`RemoteSearchBackend ${endpoint} failed: ${err}`);
+      execution?.onDegradation?.({
+        backend: "remote",
+        code: "remote_error",
+        detail: err instanceof Error ? err.name : typeof err,
+      });
       return [];
     }
   }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -29,6 +29,7 @@ export interface ServerConfig {
     adminConsoleEnabled?: boolean;
     adminConsolePublicDir?: string;
     adminConsolePrefillToken?: boolean;
+    readinessOverride?: boolean;
   };
 }
 
@@ -99,6 +100,7 @@ export interface ParsedServerConfig {
   adminConsoleEnabled: boolean;
   adminConsolePublicDir?: string;
   adminConsolePrefillToken: boolean;
+  readinessOverride: boolean;
 }
 
 export function parseServerConfig(
@@ -116,6 +118,7 @@ export function parseServerConfig(
     adminConsoleEnabled: parseOptionalBoolean(raw.adminConsoleEnabled, "server.adminConsoleEnabled") ?? false,
     adminConsolePublicDir: parseOptionalString(raw.adminConsolePublicDir, "server.adminConsolePublicDir"),
     adminConsolePrefillToken: parseOptionalBoolean(raw.adminConsolePrefillToken, "server.adminConsolePrefillToken") ?? false,
+    readinessOverride: parseOptionalBoolean(raw.readinessOverride, "server.readinessOverride") ?? false,
   };
 }
 
@@ -215,12 +218,14 @@ function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<str
   const adminConsoleEnabled = readCompatEnv("REMNIC_ADMIN_CONSOLE_ENABLED", "ENGRAM_ADMIN_CONSOLE_ENABLED");
   const adminConsolePublicDir = readCompatEnv("REMNIC_ADMIN_CONSOLE_PUBLIC_DIR", "ENGRAM_ADMIN_CONSOLE_PUBLIC_DIR");
   const adminConsolePrefillToken = readCompatEnv("REMNIC_ADMIN_CONSOLE_PREFILL_TOKEN", "ENGRAM_ADMIN_CONSOLE_PREFILL_TOKEN");
+  const readinessOverride = process.env.REMNIC_READY_OVERRIDE;
   if (port) overrides.port = port;
   if (host) overrides.host = host;
   if (authToken) overrides.authToken = authToken;
   if (adminConsoleEnabled) overrides.adminConsoleEnabled = adminConsoleEnabled;
   if (adminConsolePublicDir) overrides.adminConsolePublicDir = adminConsolePublicDir;
   if (adminConsolePrefillToken) overrides.adminConsolePrefillToken = adminConsolePrefillToken;
+  if (readinessOverride !== undefined) overrides.readinessOverride = readinessOverride;
 
   if (process.env.OPENAI_API_KEY) remnic.openaiApiKey = process.env.OPENAI_API_KEY;
   const memoryDir = readCompatEnv("REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR");
@@ -693,72 +698,107 @@ function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
 }
 
 const STARTUP_WARMUP_TIMEOUT_MS = 20_000;
+const STARTUP_WARMUP_RETRY_INTERVAL_MS = 30_000;
 
-export type StartupReadinessOutcome = "warmed" | "failed-open" | "cancelled";
+export interface StartupReadinessState {
+  ready: boolean;
+  warmupAttempts: number;
+  lastError?: string | null;
+}
+
+export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden";
 
 export async function completeStartupReadiness(options: {
   deferredReady: Promise<void>;
   warmup: (signal: AbortSignal) => Promise<unknown>;
+  state: StartupReadinessState;
   timeoutMs?: number;
+  retryIntervalMs?: number;
+  override?: boolean;
   openGate: () => void;
   shutdownSignal?: AbortSignal;
   warn?: (message: string) => void;
   info?: (message: string) => void;
+  error?: (message: string) => void;
 }): Promise<StartupReadinessOutcome> {
   const timeoutMs = options.timeoutMs ?? STARTUP_WARMUP_TIMEOUT_MS;
+  const retryIntervalMs = options.retryIntervalMs ?? STARTUP_WARMUP_RETRY_INTERVAL_MS;
   const warn = options.warn ?? ((message: string) => log.warn(message));
   const info = options.info ?? ((message: string) => log.info(message));
+  const error = options.error ?? ((message: string) => log.error(message));
+
+  options.state.ready = false;
+  options.state.lastError = null;
+  if (options.override) {
+    options.openGate();
+    options.state.ready = true;
+    error(
+      "CRITICAL: emergency readiness override enabled; exposing a cold search backend to traffic",
+    );
+    return "overridden";
+  }
 
   try {
     await options.deferredReady;
   } catch (err) {
     if (options.shutdownSignal?.aborted) return "cancelled";
-    warn(`Standalone deferred initialization failed; opening readiness gate: ${err}`);
-    options.openGate();
-    info("Standalone init gate opened after deferred initialization failure (fail-open)");
-    return "failed-open";
+    options.state.lastError = err instanceof Error ? err.name : typeof err;
+    warn(`Standalone deferred initialization failed; warm-up retries will continue: ${err}`);
   }
   if (options.shutdownSignal?.aborted) return "cancelled";
 
-  const warmupAbort = new AbortController();
-  const onShutdown = () => warmupAbort.abort(options.shutdownSignal?.reason);
+  const lifecycleAbort = new AbortController();
+  const onShutdown = () => lifecycleAbort.abort(options.shutdownSignal?.reason);
   options.shutdownSignal?.addEventListener("abort", onShutdown, { once: true });
-  const timeout = (Promise as PromiseConstructorWithResolvers).withResolvers<never>();
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    warmupAbort.abort();
-    timeout.reject(new Error(`startup warm-up timed out after ${timeoutMs}ms`));
-  }, timeoutMs);
-  timer.unref();
 
-  let outcome: StartupReadinessOutcome = "warmed";
   try {
-    await Promise.race([options.warmup(warmupAbort.signal), timeout.promise]);
-  } catch (err) {
-    if (options.shutdownSignal?.aborted) {
-      outcome = "cancelled";
-    } else {
-      outcome = "failed-open";
-      warn(
-        timedOut
-          ? `Standalone startup warm-up timed out after ${timeoutMs}ms; opening readiness gate`
-          : `Standalone startup warm-up failed; opening readiness gate: ${err}`,
-      );
+    while (!lifecycleAbort.signal.aborted) {
+      options.state.warmupAttempts += 1;
+      const warmupAbort = new AbortController();
+      const onLifecycleAbort = () => warmupAbort.abort(lifecycleAbort.signal.reason);
+      lifecycleAbort.signal.addEventListener("abort", onLifecycleAbort, { once: true });
+      const timeout = (Promise as PromiseConstructorWithResolvers).withResolvers<never>();
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        warmupAbort.abort();
+        timeout.reject(new Error(`startup warm-up timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref();
+
+      try {
+        await Promise.race([options.warmup(warmupAbort.signal), timeout.promise]);
+        if (lifecycleAbort.signal.aborted) return "cancelled";
+        options.state.lastError = null;
+        options.openGate();
+        options.state.ready = true;
+        info(
+          `Standalone init gate opened after search warm-up attempt ${options.state.warmupAttempts}`,
+        );
+        return "warmed";
+      } catch (err) {
+        if (lifecycleAbort.signal.aborted) return "cancelled";
+        options.state.lastError = timedOut
+          ? "TimeoutError"
+          : err instanceof Error
+            ? err.name
+            : typeof err;
+        warn(
+          timedOut
+            ? `Standalone startup warm-up attempt ${options.state.warmupAttempts} timed out after ${timeoutMs}ms; retrying in ${retryIntervalMs}ms`
+            : `Standalone startup warm-up attempt ${options.state.warmupAttempts} failed (${options.state.lastError}); retrying in ${retryIntervalMs}ms`,
+        );
+      } finally {
+        clearTimeout(timer);
+        lifecycleAbort.signal.removeEventListener("abort", onLifecycleAbort);
+      }
+
+      await abortableDelay(retryIntervalMs, lifecycleAbort.signal);
     }
+    return "cancelled";
   } finally {
-    clearTimeout(timer);
     options.shutdownSignal?.removeEventListener("abort", onShutdown);
   }
-
-  if (outcome === "cancelled" || options.shutdownSignal?.aborted) return "cancelled";
-  options.openGate();
-  info(
-    outcome === "warmed"
-      ? "Standalone init gate opened (startup sync and search warm-up complete)"
-      : "Standalone init gate opened after warm-up failure (fail-open)",
-  );
-  return outcome;
 }
 
 async function cleanupFailedStartup(
@@ -834,7 +874,7 @@ export async function startServer(options?: {
   // Start the HTTP server immediately so health checks, MCP handshakes,
   // and liveness probes can connect while deferred init is still running.
   const service = new EngramAccessService(orchestrator);
-  let ready = false;
+  const readiness: StartupReadinessState = { ready: false, warmupAttempts: 0, lastError: null };
 
   const authToken = parsedServerConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";
 
@@ -850,7 +890,7 @@ export async function startServer(options?: {
     port: parsedServerConfig.port,
     authToken: authToken || undefined,
     authTokensGetter: () => getAllValidTokensCached(),
-    isReady: () => ready,
+    readiness: () => readiness,
     principal: parsedServerConfig.principal,
     maxBodyBytes: parsedServerConfig.maxBodyBytes,
     adminConsoleEnabled: parsedServerConfig.adminConsoleEnabled,
@@ -890,13 +930,13 @@ export async function startServer(options?: {
         undefined,
         { signal },
       ),
+    state: readiness,
+    override: parsedServerConfig.readinessOverride,
     openGate: () => {
-      ready = true;
+      readiness.ready = true;
     },
     shutdownSignal: startupSyncAbort.signal,
   });
-
-
   // Wrap httpServer.stop() so that existing callers also get full lifecycle
   // cleanup: retry timers, deferred init, HTTP listener, and orchestrator.
   const originalStop = httpServer.stop.bind(httpServer);

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -706,7 +706,7 @@ export interface StartupReadinessState {
   lastError?: string | null;
 }
 
-export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden";
+export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden" | "search-disabled";
 
 class StartupWarmupDegradationError extends Error {
   constructor(code: string) {
@@ -738,6 +738,7 @@ export async function completeStartupReadiness(options: {
   timeoutMs?: number;
   retryIntervalMs?: number;
   override?: boolean;
+  skipWarmup?: () => boolean;
   openGate: () => void;
   shutdownSignal?: AbortSignal;
   warn?: (message: string) => void;
@@ -769,6 +770,12 @@ export async function completeStartupReadiness(options: {
     warn(`Standalone deferred initialization failed; warm-up retries will continue: ${err}`);
   }
   if (options.shutdownSignal?.aborted) return "cancelled";
+  if (options.skipWarmup?.()) {
+    options.openGate();
+    options.state.ready = true;
+    info("Standalone init gate opened without search warm-up (search intentionally disabled)");
+    return "search-disabled";
+  }
 
   const lifecycleAbort = new AbortController();
   const onShutdown = () => lifecycleAbort.abort(options.shutdownSignal?.reason);
@@ -964,6 +971,8 @@ export async function startServer(options?: {
       }),
     state: readiness,
     override: parsedServerConfig.readinessOverride,
+    skipWarmup: () =>
+      !config.qmdEnabled || orchestrator.qmd.debugStatus() === "backend=noop",
     openGate: () => {
       readiness.ready = true;
     },

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -791,6 +791,12 @@ export async function completeStartupReadiness(options: {
 
   try {
     while (!lifecycleAbort.signal.aborted) {
+      if (options.skipWarmup?.()) {
+        options.openGate();
+        options.state.ready = true;
+        info("Standalone init gate opened without search warm-up (search intentionally disabled)");
+        return "search-disabled";
+      }
       options.state.warmupAttempts += 1;
       const warmupAbort = new AbortController();
       const onLifecycleAbort = () => warmupAbort.abort(lifecycleAbort.signal.reason);
@@ -980,7 +986,7 @@ export async function startServer(options?: {
       if (startupSyncInFlight === attempt) startupSyncInFlight = undefined;
     }
   };
-  void completeStartupReadiness({
+  const readinessTask = completeStartupReadiness({
     deferredReady: orchestrator.deferredReady,
     warmup: (signal) =>
       runStartupSearchWarmup({
@@ -1021,7 +1027,11 @@ export async function startServer(options?: {
       try {
         await originalStop();
       } finally {
-        await orchestrator.destroy();
+        try {
+          await readinessTask;
+        } finally {
+          await orchestrator.destroy();
+        }
       }
     })();
     return stopPromise;

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -943,6 +943,7 @@ export async function startServer(options?: {
   // block the server listener — connections are accepted immediately above.
   // An AbortController allows the shutdown handler to cancel pending retries.
   const startupSyncAbort = new AbortController();
+  const readinessAbort = new AbortController();
   void completeStartupReadiness({
     deferredReady: orchestrator.deferredReady,
     warmup: (signal) =>
@@ -966,7 +967,7 @@ export async function startServer(options?: {
     openGate: () => {
       readiness.ready = true;
     },
-    shutdownSignal: startupSyncAbort.signal,
+    shutdownSignal: readinessAbort.signal,
   });
   // Wrap httpServer.stop() so that existing callers also get full lifecycle
   // cleanup: retry timers, deferred init, HTTP listener, and orchestrator.
@@ -976,6 +977,7 @@ export async function startServer(options?: {
     if (stopPromise) return stopPromise;
     stopPromise = (async () => {
       startupSyncAbort.abort();
+      readinessAbort.abort();
       orchestrator.abortDeferredInit();
       try {
         await originalStop();

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -770,12 +770,29 @@ export async function completeStartupReadiness(options: {
     return "overridden";
   }
 
+  let removeDeferredShutdownListener: () => void = () => undefined;
+  const deferredShutdown = new Promise<"shutdown">((resolve) => {
+    if (options.shutdownSignal?.aborted) {
+      resolve("shutdown");
+      return;
+    }
+    const onDeferredShutdown = () => resolve("shutdown");
+    options.shutdownSignal?.addEventListener("abort", onDeferredShutdown, { once: true });
+    removeDeferredShutdownListener = () =>
+      options.shutdownSignal?.removeEventListener("abort", onDeferredShutdown);
+  });
   try {
-    await options.deferredReady;
+    const deferredOutcome = await Promise.race([
+      options.deferredReady.then(() => "ready" as const),
+      deferredShutdown,
+    ]);
+    if (deferredOutcome === "shutdown") return "cancelled";
   } catch (err) {
     if (options.shutdownSignal?.aborted) return "cancelled";
     options.state.lastError = err instanceof Error ? err.name : typeof err;
     warn(`Standalone deferred initialization failed; warm-up retries will continue: ${err}`);
+  } finally {
+    removeDeferredShutdownListener();
   }
   if (options.shutdownSignal?.aborted) return "cancelled";
   if (options.skipWarmup?.()) {

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -769,6 +769,13 @@ export async function completeStartupReadiness(options: {
     );
     return "overridden";
   }
+  if (options.skipWarmup?.()) {
+    options.openGate();
+    options.state.ready = true;
+    info("Standalone init gate opened without search warm-up (search intentionally disabled)");
+    return "search-disabled";
+  }
+
 
   let removeDeferredShutdownListener: () => void = () => undefined;
   const deferredShutdown = new Promise<"shutdown">((resolve) => {
@@ -795,12 +802,6 @@ export async function completeStartupReadiness(options: {
     removeDeferredShutdownListener();
   }
   if (options.shutdownSignal?.aborted) return "cancelled";
-  if (options.skipWarmup?.()) {
-    options.openGate();
-    options.state.ready = true;
-    info("Standalone init gate opened without search warm-up (search intentionally disabled)");
-    return "search-disabled";
-  }
 
   const lifecycleAbort = new AbortController();
   const onShutdown = () => lifecycleAbort.abort(options.shutdownSignal?.reason);

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -1007,8 +1007,7 @@ export async function startServer(options?: {
     prepareWarmup: ensureStartupSync,
     state: readiness,
     override: parsedServerConfig.readinessOverride,
-    skipWarmup: () =>
-      !config.qmdEnabled || orchestrator.qmd.debugStatus() === "backend=noop",
+    skipWarmup: () => orchestrator.qmd.debugStatus() === "backend=noop",
     openGate: () => {
       readiness.ready = true;
     },

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -715,6 +715,13 @@ class StartupWarmupDegradationError extends Error {
   }
 }
 
+class StartupSyncPendingError extends Error {
+  constructor() {
+    super("startup search sync is not complete");
+    this.name = "StartupSyncPendingError";
+  }
+}
+
 export async function runStartupSearchWarmup(options: {
   signal: AbortSignal;
   isAvailable: () => boolean;
@@ -734,6 +741,7 @@ export async function runStartupSearchWarmup(options: {
 export async function completeStartupReadiness(options: {
   deferredReady: Promise<void>;
   warmup: (signal: AbortSignal) => Promise<unknown>;
+  prepareWarmup?: (signal: AbortSignal) => Promise<boolean>;
   state: StartupReadinessState;
   timeoutMs?: number;
   retryIntervalMs?: number;
@@ -797,7 +805,13 @@ export async function completeStartupReadiness(options: {
       timer.unref();
 
       try {
-        await Promise.race([options.warmup(warmupAbort.signal), timeout.promise]);
+        const attempt = async () => {
+          if (options.prepareWarmup && !await options.prepareWarmup(warmupAbort.signal)) {
+            throw new StartupSyncPendingError();
+          }
+          return options.warmup(warmupAbort.signal);
+        };
+        await Promise.race([attempt(), timeout.promise]);
         if (lifecycleAbort.signal.aborted) return "cancelled";
         options.state.lastError = null;
         options.openGate();
@@ -951,6 +965,21 @@ export async function startServer(options?: {
   // An AbortController allows the shutdown handler to cancel pending retries.
   const startupSyncAbort = new AbortController();
   const readinessAbort = new AbortController();
+  let startupSyncInFlight: Promise<boolean> | undefined;
+  const ensureStartupSync = async (signal: AbortSignal): Promise<boolean> => {
+    if (orchestrator.deferredSyncSucceeded) return true;
+    if (startupSyncInFlight) return startupSyncInFlight;
+    const attempt = orchestrator.startupSearchSync(signal).then((synced) => {
+      if (synced) orchestrator.deferredSyncSucceeded = true;
+      return synced;
+    });
+    startupSyncInFlight = attempt;
+    try {
+      return await attempt;
+    } finally {
+      if (startupSyncInFlight === attempt) startupSyncInFlight = undefined;
+    }
+  };
   void completeStartupReadiness({
     deferredReady: orchestrator.deferredReady,
     warmup: (signal) =>
@@ -969,6 +998,7 @@ export async function startServer(options?: {
             },
           ),
       }),
+    prepareWarmup: ensureStartupSync,
     state: readiness,
     override: parsedServerConfig.readinessOverride,
     skipWarmup: () =>
@@ -1039,7 +1069,7 @@ export async function startServer(options?: {
           return;
         }
 
-        const synced = await orchestrator.startupSearchSync(startupSyncAbort.signal);
+        const synced = await ensureStartupSync(startupSyncAbort.signal);
         if (!synced) {
           if (orchestrator.qmd.debugStatus() === "backend=noop") {
             log.debug("QMD startup-sync retry: search intentionally disabled; stopping retries");

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -708,6 +708,29 @@ export interface StartupReadinessState {
 
 export type StartupReadinessOutcome = "warmed" | "cancelled" | "overridden";
 
+class StartupWarmupDegradationError extends Error {
+  constructor(code: string) {
+    super(`startup search degraded: ${code}`);
+    this.name = "StartupWarmupDegradationError";
+  }
+}
+
+export async function runStartupSearchWarmup(options: {
+  signal: AbortSignal;
+  isAvailable: () => boolean;
+  search: (onDegradation: (code: string) => void) => Promise<unknown>;
+}): Promise<void> {
+  let degradationCode: string | undefined;
+  await options.search((code) => {
+    degradationCode = code;
+  });
+  if (options.signal.aborted) return;
+  if (degradationCode) throw new StartupWarmupDegradationError(degradationCode);
+  if (!options.isAvailable()) {
+    throw new StartupWarmupDegradationError("backend_unavailable");
+  }
+}
+
 export async function completeStartupReadiness(options: {
   deferredReady: Promise<void>;
   warmup: (signal: AbortSignal) => Promise<unknown>;
@@ -923,13 +946,21 @@ export async function startServer(options?: {
   void completeStartupReadiness({
     deferredReady: orchestrator.deferredReady,
     warmup: (signal) =>
-      orchestrator.qmd.search(
-        "remnic startup readiness",
-        config.defaultNamespace,
-        1,
-        undefined,
-        { signal },
-      ),
+      runStartupSearchWarmup({
+        signal,
+        isAvailable: () => orchestrator.qmd.isAvailable(),
+        search: (onDegradation) =>
+          orchestrator.qmd.search(
+            "remnic startup readiness",
+            config.defaultNamespace,
+            1,
+            undefined,
+            {
+              signal,
+              onDegradation: (degradation) => onDegradation(degradation.code),
+            },
+          ),
+      }),
     state: readiness,
     override: parsedServerConfig.readinessOverride,
     openGate: () => {

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -665,6 +665,16 @@ export function createAdminControls(
   };
 }
 
+interface PromiseResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+type PromiseConstructorWithResolvers = PromiseConstructor & {
+  withResolvers<T>(): PromiseResolvers<T>;
+};
+
 /**
  * Like `setTimeout` wrapped in a Promise, but respects an `AbortSignal`.
  * Resolves immediately (without throwing) when the signal fires so the
@@ -672,14 +682,83 @@ export function createAdminControls(
  */
 function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();
-  return new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
+  const { promise, resolve } = (Promise as PromiseConstructorWithResolvers).withResolvers<void>();
+  const timer = setTimeout(resolve, ms);
+  const onAbort = () => {
+    clearTimeout(timer);
+    resolve();
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  return promise.finally(() => signal.removeEventListener("abort", onAbort));
+}
+
+const STARTUP_WARMUP_TIMEOUT_MS = 20_000;
+
+export type StartupReadinessOutcome = "warmed" | "failed-open" | "cancelled";
+
+export async function completeStartupReadiness(options: {
+  deferredReady: Promise<void>;
+  warmup: (signal: AbortSignal) => Promise<unknown>;
+  timeoutMs?: number;
+  openGate: () => void;
+  shutdownSignal?: AbortSignal;
+  warn?: (message: string) => void;
+  info?: (message: string) => void;
+}): Promise<StartupReadinessOutcome> {
+  const timeoutMs = options.timeoutMs ?? STARTUP_WARMUP_TIMEOUT_MS;
+  const warn = options.warn ?? ((message: string) => log.warn(message));
+  const info = options.info ?? ((message: string) => log.info(message));
+
+  try {
+    await options.deferredReady;
+  } catch (err) {
+    if (options.shutdownSignal?.aborted) return "cancelled";
+    warn(`Standalone deferred initialization failed; opening readiness gate: ${err}`);
+    options.openGate();
+    info("Standalone init gate opened after deferred initialization failure (fail-open)");
+    return "failed-open";
+  }
+  if (options.shutdownSignal?.aborted) return "cancelled";
+
+  const warmupAbort = new AbortController();
+  const onShutdown = () => warmupAbort.abort(options.shutdownSignal?.reason);
+  options.shutdownSignal?.addEventListener("abort", onShutdown, { once: true });
+  const timeout = (Promise as PromiseConstructorWithResolvers).withResolvers<never>();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    warmupAbort.abort();
+    timeout.reject(new Error(`startup warm-up timed out after ${timeoutMs}ms`));
+  }, timeoutMs);
+  timer.unref();
+
+  let outcome: StartupReadinessOutcome = "warmed";
+  try {
+    await Promise.race([options.warmup(warmupAbort.signal), timeout.promise]);
+  } catch (err) {
+    if (options.shutdownSignal?.aborted) {
+      outcome = "cancelled";
+    } else {
+      outcome = "failed-open";
+      warn(
+        timedOut
+          ? `Standalone startup warm-up timed out after ${timeoutMs}ms; opening readiness gate`
+          : `Standalone startup warm-up failed; opening readiness gate: ${err}`,
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+    options.shutdownSignal?.removeEventListener("abort", onShutdown);
+  }
+
+  if (outcome === "cancelled" || options.shutdownSignal?.aborted) return "cancelled";
+  options.openGate();
+  info(
+    outcome === "warmed"
+      ? "Standalone init gate opened (startup sync and search warm-up complete)"
+      : "Standalone init gate opened after warm-up failure (fail-open)",
+  );
+  return outcome;
 }
 
 async function cleanupFailedStartup(
@@ -755,6 +834,7 @@ export async function startServer(options?: {
   // Start the HTTP server immediately so health checks, MCP handshakes,
   // and liveness probes can connect while deferred init is still running.
   const service = new EngramAccessService(orchestrator);
+  let ready = false;
 
   const authToken = parsedServerConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";
 
@@ -770,6 +850,7 @@ export async function startServer(options?: {
     port: parsedServerConfig.port,
     authToken: authToken || undefined,
     authTokensGetter: () => getAllValidTokensCached(),
+    isReady: () => ready,
     principal: parsedServerConfig.principal,
     maxBodyBytes: parsedServerConfig.maxBodyBytes,
     adminConsoleEnabled: parsedServerConfig.adminConsoleEnabled,
@@ -799,6 +880,22 @@ export async function startServer(options?: {
   // block the server listener — connections are accepted immediately above.
   // An AbortController allows the shutdown handler to cancel pending retries.
   const startupSyncAbort = new AbortController();
+  void completeStartupReadiness({
+    deferredReady: orchestrator.deferredReady,
+    warmup: (signal) =>
+      orchestrator.qmd.search(
+        "remnic startup readiness",
+        config.defaultNamespace,
+        1,
+        undefined,
+        { signal },
+      ),
+    openGate: () => {
+      ready = true;
+    },
+    shutdownSignal: startupSyncAbort.signal,
+  });
+
 
   // Wrap httpServer.stop() so that existing callers also get full lifecycle
   // cleanup: retry timers, deferred init, HTTP listener, and orchestrator.

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -314,6 +314,26 @@ test("a backend that becomes no-op during sync opens readiness on the next retry
   assert.equal(readiness.ready, true);
 });
 
+test("shutdown cancels readiness while deferred initialization is pending", async () => {
+  const shutdown = new AbortController();
+  const pendingInit = Promise.withResolvers<void>();
+  let gateOpenCount = 0;
+  const readinessTask = completeStartupReadiness({
+    deferredReady: pendingInit.promise,
+    warmup: async () => undefined,
+    state: { ready: false, warmupAttempts: 0 },
+    openGate: () => {
+      gateOpenCount += 1;
+    },
+    shutdownSignal: shutdown.signal,
+  });
+
+  shutdown.abort();
+
+  assert.equal(await readinessTask, "cancelled");
+  assert.equal(gateOpenCount, 0);
+});
+
 test("the emergency override opens readiness at once and logs the exposure", async () => {
   const readiness = { ready: false, warmupAttempts: 0 };
   const errors: string[] = [];

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -5,6 +5,7 @@ import { type EngramAccessService, EngramAccessHttpServer } from "@remnic/core";
 import {
   completeStartupReadiness,
   parseServerConfig,
+  runStartupSearchWarmup,
 } from "../packages/remnic-server/src/index.js";
 
 async function fetchHealth(port: number, authorization?: string): Promise<Response> {
@@ -169,6 +170,36 @@ test("shutdown during retry delay never opens readiness", async () => {
   assert.equal(await readinessTask, "cancelled");
   assert.equal(gateOpenCount, 0);
   assert.equal(readiness.ready, false);
+});
+
+test("a fail-open degraded search result stays cold and retries", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  let searches = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async (signal) =>
+      runStartupSearchWarmup({
+        signal,
+        isAvailable: () => true,
+        search: async (onDegradation) => {
+          searches += 1;
+          if (searches === 1) onDegradation("daemon_loading");
+          return [];
+        },
+      }),
+    timeoutMs: 100,
+    retryIntervalMs: 1,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+  });
+
+  assert.equal(outcome, "warmed");
+  assert.equal(searches, 2);
+  assert.equal(readiness.warmupAttempts, 2);
+  assert.equal(readiness.ready, true);
 });
 
 test("the emergency override opens readiness at once and logs the exposure", async () => {

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -265,7 +265,7 @@ test("intentionally disabled search opens readiness without a warm-up", async ()
   let warmupCalls = 0;
 
   const outcome = await completeStartupReadiness({
-    deferredReady: Promise.resolve(),
+    deferredReady: Promise.withResolvers<void>().promise,
     warmup: async () => {
       warmupCalls += 1;
     },

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -285,6 +285,35 @@ test("intentionally disabled search opens readiness without a warm-up", async ()
   });
 });
 
+test("a backend that becomes no-op during sync opens readiness on the next retry", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  let searchDisabled = false;
+  let syncCalls = 0;
+  let warmupCalls = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    prepareWarmup: async () => {
+      syncCalls += 1;
+      searchDisabled = true;
+      return syncCalls >= 2;
+    },
+    warmup: async () => {
+      warmupCalls += 1;
+    },
+    skipWarmup: () => searchDisabled,
+    retryIntervalMs: 1,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+  });
+
+  assert.equal(outcome, "search-disabled");
+  assert.equal(warmupCalls, 0);
+  assert.equal(readiness.ready, true);
+});
+
 test("the emergency override opens readiness at once and logs the exposure", async () => {
   const readiness = { ready: false, warmupAttempts: 0 };
   const errors: string[] = [];

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { type EngramAccessService, EngramAccessHttpServer } from "@remnic/core";
+import { completeStartupReadiness } from "../packages/remnic-server/src/index.js";
+
+async function fetchHealth(port: number, authorization?: string): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/engram/v1/health`, {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+test("health stays at 503 until the startup warm-up completes, then resumes auth responses", async () => {
+  const warmup = Promise.withResolvers<void>();
+  let ready = false;
+  const service = {
+    health: async () => ({ ok: true }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    isReady: () => ready,
+  });
+  const status = await server.start();
+
+  const readinessTask = completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => warmup.promise,
+    timeoutMs: 1_000,
+    openGate: () => {
+      ready = true;
+    },
+  });
+
+  try {
+    const coldResponse = await fetchHealth(status.port);
+    assert.equal(coldResponse.status, 503);
+    assert.deepEqual(await coldResponse.json(), {
+      ok: false,
+      ready: false,
+      code: "not_ready",
+    });
+
+    warmup.resolve();
+    await readinessTask;
+
+    assert.equal((await fetchHealth(status.port)).status, 401);
+    assert.equal(
+      (await fetchHealth(status.port, "Bearer test-token")).status,
+      200,
+    );
+  } finally {
+    warmup.resolve();
+    await readinessTask;
+    await server.stop();
+  }
+});
+
+test("warm-up failure opens the readiness gate and logs the failure", async () => {
+  let gateOpenCount = 0;
+  const warnings: string[] = [];
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => {
+      throw new Error("search backend unavailable");
+    },
+    timeoutMs: 1_000,
+    openGate: () => {
+      gateOpenCount += 1;
+    },
+    warn: (message) => warnings.push(message),
+  });
+
+  assert.equal(outcome, "failed-open");
+  assert.equal(gateOpenCount, 1);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /warm-up failed.*search backend unavailable/i);
+});
+
+test("warm-up timeout aborts the query, opens the gate, and logs the timeout", async () => {
+  let receivedSignal: AbortSignal | undefined;
+  let gateOpenCount = 0;
+  const warnings: string[] = [];
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async (signal) => {
+      receivedSignal = signal;
+      return Promise.withResolvers<void>().promise;
+    },
+    timeoutMs: 10,
+    openGate: () => {
+      gateOpenCount += 1;
+    },
+    warn: (message) => warnings.push(message),
+  });
+
+  assert.equal(outcome, "failed-open");
+  assert.equal(gateOpenCount, 1);
+  assert.equal(receivedSignal?.aborted, true);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /warm-up timed out after 10ms/i);
+});

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -202,6 +202,31 @@ test("a fail-open degraded search result stays cold and retries", async () => {
   assert.equal(readiness.ready, true);
 });
 
+test("intentionally disabled search opens readiness without a warm-up", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  let warmupCalls = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => {
+      warmupCalls += 1;
+    },
+    skipWarmup: () => true,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+  });
+
+  assert.equal(outcome, "search-disabled");
+  assert.equal(warmupCalls, 0);
+  assert.deepEqual(readiness, {
+    ready: true,
+    warmupAttempts: 0,
+    lastError: null,
+  });
+});
+
 test("the emergency override opens readiness at once and logs the exposure", async () => {
   const readiness = { ready: false, warmupAttempts: 0 };
   const errors: string[] = [];

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { type EngramAccessService, EngramAccessHttpServer } from "@remnic/core";
-import { completeStartupReadiness } from "../packages/remnic-server/src/index.js";
+import {
+  completeStartupReadiness,
+  parseServerConfig,
+} from "../packages/remnic-server/src/index.js";
 
 async function fetchHealth(port: number, authorization?: string): Promise<Response> {
   return fetch(`http://127.0.0.1:${port}/engram/v1/health`, {
@@ -12,7 +15,7 @@ async function fetchHealth(port: number, authorization?: string): Promise<Respon
 
 test("health stays at 503 until the startup warm-up completes, then resumes auth responses", async () => {
   const warmup = Promise.withResolvers<void>();
-  let ready = false;
+  const readiness = { ready: false, warmupAttempts: 0 };
   const service = {
     health: async () => ({ ok: true }),
   } as unknown as EngramAccessService;
@@ -21,17 +24,20 @@ test("health stays at 503 until the startup warm-up completes, then resumes auth
     port: 0,
     authToken: "test-token",
     adminConsoleEnabled: false,
-    isReady: () => ready,
+    readiness: () => readiness,
   });
   const status = await server.start();
-
+  const shutdown = new AbortController();
   const readinessTask = completeStartupReadiness({
     deferredReady: Promise.resolve(),
     warmup: async () => warmup.promise,
     timeoutMs: 1_000,
+    retryIntervalMs: 10,
+    state: readiness,
     openGate: () => {
-      ready = true;
+      readiness.ready = true;
     },
+    shutdownSignal: shutdown.signal,
   });
 
   try {
@@ -40,6 +46,8 @@ test("health stays at 503 until the startup warm-up completes, then resumes auth
     assert.deepEqual(await coldResponse.json(), {
       ok: false,
       ready: false,
+      warmupAttempts: 1,
+      lastError: null,
       code: "not_ready",
     });
 
@@ -53,54 +61,145 @@ test("health stays at 503 until the startup warm-up completes, then resumes auth
     );
   } finally {
     warmup.resolve();
+    shutdown.abort();
     await readinessTask;
     await server.stop();
   }
 });
 
-test("warm-up failure opens the readiness gate and logs the failure", async () => {
-  let gateOpenCount = 0;
-  const warnings: string[] = [];
-
+test("a successful retry opens readiness on attempt N", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  let calls = 0;
   const outcome = await completeStartupReadiness({
     deferredReady: Promise.resolve(),
     warmup: async () => {
-      throw new Error("search backend unavailable");
+      calls += 1;
+      if (calls < 3) throw new TypeError("search backend unavailable");
     },
-    timeoutMs: 1_000,
+    timeoutMs: 100,
+    retryIntervalMs: 1,
+    state: readiness,
     openGate: () => {
-      gateOpenCount += 1;
+      readiness.ready = true;
     },
-    warn: (message) => warnings.push(message),
   });
 
-  assert.equal(outcome, "failed-open");
-  assert.equal(gateOpenCount, 1);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /warm-up failed.*search backend unavailable/i);
+  assert.equal(outcome, "warmed");
+  assert.deepEqual(readiness, {
+    ready: true,
+    warmupAttempts: 3,
+    lastError: null,
+  });
 });
 
-test("warm-up timeout aborts the query, opens the gate, and logs the timeout", async () => {
-  let receivedSignal: AbortSignal | undefined;
-  let gateOpenCount = 0;
-  const warnings: string[] = [];
+test("persistent warm-up failure keeps health at 503 and reports rising attempt state", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  const shutdown = new AbortController();
+  const service = {
+    health: async () => ({ ok: true }),
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    readiness: () => readiness,
+  });
+  const status = await server.start();
+  const twoAttempts = Promise.withResolvers<void>();
 
-  const outcome = await completeStartupReadiness({
+  const readinessTask = completeStartupReadiness({
     deferredReady: Promise.resolve(),
-    warmup: async (signal) => {
-      receivedSignal = signal;
-      return Promise.withResolvers<void>().promise;
+    warmup: async () => {
+      if (readiness.warmupAttempts >= 2) twoAttempts.resolve();
+      throw new TypeError("bad search path");
     },
-    timeoutMs: 10,
+    timeoutMs: 100,
+    retryIntervalMs: 5,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+    shutdownSignal: shutdown.signal,
+  });
+
+  try {
+    await twoAttempts.promise;
+    const response = await fetchHealth(status.port);
+    assert.equal(response.status, 503);
+    const body = await response.json() as {
+      ready: boolean;
+      warmupAttempts: number;
+      lastError: string;
+    };
+    assert.equal(body.ready, false);
+    assert.ok(body.warmupAttempts >= 2);
+    assert.equal(body.lastError, "TypeError");
+  } finally {
+    shutdown.abort();
+    assert.equal(await readinessTask, "cancelled");
+    await server.stop();
+  }
+});
+
+test("shutdown during retry delay never opens readiness", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  const shutdown = new AbortController();
+  let gateOpenCount = 0;
+  const firstFailure = Promise.withResolvers<void>();
+
+  const readinessTask = completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    warmup: async () => {
+      firstFailure.resolve();
+      throw new Error("still cold");
+    },
+    timeoutMs: 100,
+    retryIntervalMs: 1_000,
+    state: readiness,
     openGate: () => {
       gateOpenCount += 1;
     },
-    warn: (message) => warnings.push(message),
+    shutdownSignal: shutdown.signal,
   });
 
-  assert.equal(outcome, "failed-open");
-  assert.equal(gateOpenCount, 1);
-  assert.equal(receivedSignal?.aborted, true);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /warm-up timed out after 10ms/i);
+  await firstFailure.promise;
+  shutdown.abort();
+
+  assert.equal(await readinessTask, "cancelled");
+  assert.equal(gateOpenCount, 0);
+  assert.equal(readiness.ready, false);
+});
+
+test("the emergency override opens readiness at once and logs the exposure", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  const errors: string[] = [];
+  let warmupCalls = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.withResolvers<void>().promise,
+    warmup: async () => {
+      warmupCalls += 1;
+    },
+    override: true,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+    error: (message) => errors.push(message),
+  });
+
+  assert.equal(outcome, "overridden");
+  assert.equal(warmupCalls, 0);
+  assert.deepEqual(readiness, {
+    ready: true,
+    warmupAttempts: 0,
+    lastError: null,
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /emergency readiness override.*cold search backend.*traffic/i);
+});
+
+test("server config accepts the emergency readiness override", () => {
+  assert.equal(parseServerConfig({ readinessOverride: true }).readinessOverride, true);
 });

--- a/tests/cold-start-readiness.test.ts
+++ b/tests/cold-start-readiness.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { type EngramAccessService, EngramAccessHttpServer } from "@remnic/core";
+import { RemoteSearchBackend } from "@remnic/core/search/remote-backend";
 import {
   completeStartupReadiness,
   parseServerConfig,
@@ -200,6 +201,63 @@ test("a fail-open degraded search result stays cold and retries", async () => {
   assert.equal(searches, 2);
   assert.equal(readiness.warmupAttempts, 2);
   assert.equal(readiness.ready, true);
+});
+
+test("readiness waits for startup sync before running the warm-up", async () => {
+  const readiness = { ready: false, warmupAttempts: 0 };
+  let syncChecks = 0;
+  let warmupCalls = 0;
+
+  const outcome = await completeStartupReadiness({
+    deferredReady: Promise.resolve(),
+    prepareWarmup: async () => {
+      syncChecks += 1;
+      return syncChecks >= 3;
+    },
+    warmup: async () => {
+      warmupCalls += 1;
+    },
+    timeoutMs: 100,
+    retryIntervalMs: 1,
+    state: readiness,
+    openGate: () => {
+      readiness.ready = true;
+    },
+  });
+
+  assert.equal(outcome, "warmed");
+  assert.equal(syncChecks, 3);
+  assert.equal(warmupCalls, 1);
+  assert.equal(readiness.ready, true);
+});
+
+test("remote search failures report degradation instead of a healthy empty result", async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = async (input) =>
+    String(input).endsWith("/health")
+      ? new Response(null, { status: 200 })
+      : new Response(null, { status: 503 });
+
+  const backend = new RemoteSearchBackend({
+    baseUrl: "http://127.0.0.1:1",
+    timeoutMs: 100,
+  });
+  assert.equal(await backend.probe(), true);
+  const degradations: Array<{ backend: string; code: string }> = [];
+
+  const results = await backend.search("warm-up", undefined, 1, undefined, {
+    onDegradation: (degradation) => degradations.push(degradation),
+  });
+
+  assert.deepEqual(results, []);
+  assert.deepEqual(degradations, [{
+    backend: "remote",
+    code: "remote_error",
+    detail: "HTTP 503",
+  }]);
 });
 
 test("intentionally disabled search opens readiness without a warm-up", async () => {

--- a/tests/search-backend-degradation.test.ts
+++ b/tests/search-backend-degradation.test.ts
@@ -36,3 +36,30 @@ test("Meilisearch reports a final fail-open search error as degradation", async 
     },
   ]);
 });
+
+test("backend degradation observers cannot break fail-open search", async () => {
+  const backend = new MeilisearchBackend({
+    host: "http://127.0.0.1:7700",
+    collection: "memory",
+  });
+  const internal = backend as unknown as {
+    available: boolean;
+    client: { index: () => { search: () => Promise<never> } };
+  };
+  internal.available = true;
+  internal.client = {
+    index: () => ({
+      search: async () => {
+        throw new Error("query failed");
+      },
+    }),
+  };
+
+  const results = await backend.search("warmup", undefined, 1, undefined, {
+    onDegradation: () => {
+      throw new Error("observer failed");
+    },
+  });
+
+  assert.deepEqual(results, []);
+});

--- a/tests/search-backend-degradation.test.ts
+++ b/tests/search-backend-degradation.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MeilisearchBackend } from "../packages/remnic-core/src/search/meilisearch-backend.js";
+import type { SearchDegradation } from "../packages/remnic-core/src/search/port.js";
+
+test("Meilisearch reports a final fail-open search error as degradation", async () => {
+  const backend = new MeilisearchBackend({
+    host: "http://127.0.0.1:7700",
+    collection: "memory",
+  });
+  const internal = backend as unknown as {
+    available: boolean;
+    client: { index: () => { search: () => Promise<never> } };
+  };
+  internal.available = true;
+  internal.client = {
+    index: () => ({
+      search: async () => {
+        throw new Error("query failed");
+      },
+    }),
+  };
+  const degradations: SearchDegradation[] = [];
+
+  const results = await backend.search("warmup", undefined, 1, undefined, {
+    onDegradation: (degradation) => degradations.push(degradation),
+  });
+
+  assert.deepEqual(results, []);
+  assert.deepEqual(degradations, [
+    {
+      backend: "meilisearch",
+      code: "backend_error",
+      detail: "Error",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

- Return 503 from the health route while the standalone server is cold.
- Run a small search after the QMD startup sync, then open the ready gate.
- Retry a failed warm-up every 30 seconds until one attempt works or the server stops.
- Report the attempt count and error class in each cold health response.

## Operator-visible change

HAProxy checks `/engram/v1/health`. A cold server now returns 503, so the HAProxy L7 check marks it down. When the gate opens, a request with no token returns 401 as it did before. A request with a valid token returns 200.

The health response does not wait for startup work. It returns at once. The 503 body includes `warmupAttempts` and `lastError` for checks that need more detail. Process liveness stays with the service supervisor.

If all backends stay cold, fix the search fault and let the next retry open the gate. For an emergency only, set `REMNIC_READY_OVERRIDE=1` or set `server.readinessOverride` to `true`, then restart. The server writes a critical log because this sends traffic to a cold backend.

## Tests

- `pnpm exec tsx --test tests/cold-start-readiness.test.ts packages/remnic-core/src/access-http.test.ts tests/access-http.test.ts`
- `npm run preflight:quick`

Fixes #1828

<!-- voice-guard v1.2.0 | lint pass exit 0 (report mode) | rubric 10/10 | fingerprint v1.2 | model rewrite not run -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HAProxy/L7 routing behavior for cold servers and adds startup gating on search availability; emergency override can expose traffic to a cold backend.
> 
> **Overview**
> Standalone deployments now treat **`/engram/v1/health`** as a **readiness** probe: while search is still warming, the route returns **503** immediately with `ready: false`, `warmupAttempts`, `lastError`, and `code: not_ready`—**before** auth—so load balancers can keep cold instances out of rotation. Embedded HTTP hosts keep prior behavior via an optional `readiness` callback that defaults to always ready.
> 
> The **remnic-server** startup path adds **`completeStartupReadiness`**: wait for deferred init, ensure startup search sync, run a probe search via **`runStartupSearchWarmup`** (fails if `onDegradation` fires or the backend is unavailable), then open the gate. Failed or timed-out warm-ups retry on a 30s cadence until success or shutdown. Intentionally disabled search (`backend=noop`) skips warm-up; **`REMNIC_READY_OVERRIDE`** / **`server.readinessOverride`** force-ready with a critical log.
> 
> Search backends no longer look like “no matches” when they fail: **`reportSearchDegradation`** in `port.ts` notifies `onDegradation` safely, with expanded **`SearchDegradation`** types for remote/meilisearch/orama/lancedb. LanceDB, Meilisearch, Orama, and remote adapters call it on errors (not on abort). Shutdown now aborts the readiness loop and awaits it during HTTP stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516e9c5b55bb1c9fa929cbffbe09fe27d6cd3093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->