### PR TITLE
refactor(core): expose recall introspection surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Exposed recall introspection through the typed `Orchestrator.recallIntrospection`
+  coordinator and removed the duplicate intent, QMD, and graph-recall forwarding
+  methods from the oversized composition root.
+
 ## [v9.3.652] — 2026-06-30
 
 ### Added

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2121,8 +2121,8 @@ export class EngramAccessService {
     if (!includeDebug) return undefined;
     if (!sessionKey?.trim()) return undefined;
     const [intent, graph] = await Promise.all([
-      this.orchestrator.getLastIntentSnapshot(namespace),
-      this.orchestrator.getLastGraphRecallSnapshot(namespace),
+      this.orchestrator.recallIntrospection.getLastIntentSnapshot(namespace),
+      this.orchestrator.recallIntrospection.getLastGraphRecallSnapshot(namespace),
     ]);
     return snapshot || intent || graph
       ? {
@@ -2831,8 +2831,8 @@ export class EngramAccessService {
     })();
     if (!namespace) return { found: false };
     const [intent, graph] = await Promise.all([
-      this.orchestrator.getLastIntentSnapshot(namespace),
-      this.orchestrator.getLastGraphRecallSnapshot(namespace),
+      this.orchestrator.recallIntrospection.getLastIntentSnapshot(namespace),
+      this.orchestrator.recallIntrospection.getLastGraphRecallSnapshot(namespace),
     ]);
     if (!readableSnapshot && !intent && !graph) return { found: false };
     return { found: true, snapshot: readableSnapshot ?? undefined, intent, graph };
@@ -4817,17 +4817,17 @@ export class EngramAccessService {
   }
 
   async intentDebug(namespace?: string): Promise<unknown> {
-    const snapshot = await this.orchestrator.getLastIntentSnapshot(namespace);
+    const snapshot = await this.orchestrator.recallIntrospection.getLastIntentSnapshot(namespace);
     return snapshot ?? { message: "No intent debug snapshot available" };
   }
 
   async qmdDebug(namespace?: string): Promise<unknown> {
-    const snapshot = await this.orchestrator.getLastQmdRecallSnapshot(namespace);
+    const snapshot = await this.orchestrator.recallIntrospection.getLastQmdRecallSnapshot(namespace);
     return snapshot ?? { message: "No QMD debug snapshot available" };
   }
 
   async graphExplainLastRecall(namespace?: string): Promise<unknown> {
-    const explanation = await this.orchestrator.explainLastGraphRecall({ namespace });
+    const explanation = await this.orchestrator.recallIntrospection.explainLastGraphRecall({ namespace });
     return { explanation };
   }
 

--- a/packages/remnic-core/src/orchestration/recall-introspection.ts
+++ b/packages/remnic-core/src/orchestration/recall-introspection.ts
@@ -54,15 +54,6 @@ export interface RecallIntrospectionDeps {
   effectiveCronRecallInstructionHeavyTokenCap(): number;
   readonly faithfulnessCounters: FaithfulnessGateCounters;
   getCodingContextForSession(sessionKey: string | undefined): CodingContext | null;
-  getLastGraphRecallSnapshot(
-    namespace?: string,
-  ): Promise<GraphRecallSnapshot | null>;
-  getLastIntentSnapshot(
-    namespace?: string,
-  ): Promise<IntentDebugSnapshot | null>;
-  getLastQmdRecallSnapshot(
-    namespace?: string,
-  ): Promise<QmdRecallSnapshot | null>;
   getStorage(namespace?: string): Promise<StorageManager>;
   readonly graphRecallCoordinator: GraphRecallCoordinator;
   readonly lastRecall: LastRecallStore;
@@ -299,7 +290,7 @@ export class RecallIntrospectionCoordinator {
     namespace?: string;
     maxExpanded?: number;
   }): Promise<string> {
-    const snapshot = await this.deps.getLastGraphRecallSnapshot(options?.namespace);
+    const snapshot = await this.getLastGraphRecallSnapshot(options?.namespace);
     if (!snapshot) return "No graph-recall snapshot found yet.";
     const maxExpanded = Math.max(1, Math.min(50, options?.maxExpanded ?? 10));
     const expanded = snapshot.expanded.slice(0, maxExpanded);
@@ -353,7 +344,7 @@ export class RecallIntrospectionCoordinator {
   }
 
   async explainLastIntent(options?: { namespace?: string }): Promise<string> {
-    const snapshot = await this.deps.getLastIntentSnapshot(options?.namespace);
+    const snapshot = await this.getLastIntentSnapshot(options?.namespace);
     if (!snapshot) return "No intent-debug snapshot found yet.";
     return [
       "## Last Intent Debug",
@@ -375,7 +366,7 @@ export class RecallIntrospectionCoordinator {
     namespace?: string;
     maxResults?: number;
   }): Promise<string> {
-    const snapshot = await this.deps.getLastQmdRecallSnapshot(options?.namespace);
+    const snapshot = await this.getLastQmdRecallSnapshot(options?.namespace);
     if (!snapshot) return "No QMD recall snapshot found yet.";
     const maxResults = Math.max(1, Math.min(25, options?.maxResults ?? 10));
     const shown = snapshot.results.slice(0, maxResults);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -611,7 +611,7 @@ export class Orchestrator {
   }
 
   getConsoleFaithfulnessDistribution(): FaithfulnessGateCounters | undefined {
-    return this.recallIntrospectionCoordinator.getConsoleFaithfulnessDistribution(
+    return this.recallIntrospection.getConsoleFaithfulnessDistribution(
     );
   }
   readonly modelRegistry: ModelRegistry;
@@ -2158,54 +2158,6 @@ export class Orchestrator {
     }
   }
 
-  async getLastGraphRecallSnapshot(
-    namespace?: string,
-  ): Promise<GraphRecallSnapshot | null> {
-    return this.recallIntrospectionCoordinator.getLastGraphRecallSnapshot(
-      namespace,
-    );
-  }
-
-  async getLastIntentSnapshot(
-    namespace?: string,
-  ): Promise<IntentDebugSnapshot | null> {
-    return this.recallIntrospectionCoordinator.getLastIntentSnapshot(
-      namespace,
-    );
-  }
-
-  async getLastQmdRecallSnapshot(
-    namespace?: string,
-  ): Promise<QmdRecallSnapshot | null> {
-    return this.recallIntrospectionCoordinator.getLastQmdRecallSnapshot(
-      namespace,
-    );
-  }
-
-  async explainLastGraphRecall(options?: {
-    namespace?: string;
-    maxExpanded?: number;
-  }): Promise<string> {
-    return this.recallIntrospectionCoordinator.explainLastGraphRecall(
-      options,
-    );
-  }
-
-  async explainLastIntent(options?: { namespace?: string }): Promise<string> {
-    return this.recallIntrospectionCoordinator.explainLastIntent(
-      options,
-    );
-  }
-
-  async explainLastQmdRecall(options?: {
-    namespace?: string;
-    maxResults?: number;
-  }): Promise<string> {
-    return this.recallIntrospectionCoordinator.explainLastQmdRecall(
-      options,
-    );
-  }
-
   private async searchConversationRecallResults(
     retrievalQuery: string,
     topK: number,
@@ -2341,7 +2293,7 @@ export class Orchestrator {
   async waitForDirectAnswerObservationIdle(
     timeoutMs: number = 60_000,
   ): Promise<boolean> {
-    return this.recallIntrospectionCoordinator.waitForDirectAnswerObservationIdle(
+    return this.recallIntrospection.waitForDirectAnswerObservationIdle(
       timeoutMs,
     );
   }
@@ -2354,7 +2306,7 @@ export class Orchestrator {
     caps: CapabilitySet,
     namespacesEnabled: boolean,
   ): void {
-    return this.recallIntrospectionCoordinator.enqueueDirectAnswerObservation(
+    return this.recallIntrospection.enqueueDirectAnswerObservation(
       prompt,
       sessionKey,
       namespaceOverride,
@@ -2374,7 +2326,7 @@ export class Orchestrator {
     caps: CapabilitySet,
     _parentAbortSignal?: AbortSignal,
   ): Promise<void> {
-    return this.recallIntrospectionCoordinator.annotateDirectAnswerTier(
+    return this.recallIntrospection.annotateDirectAnswerTier(
       prompt,
       sessionKey,
       namespaces,
@@ -2540,7 +2492,7 @@ export class Orchestrator {
     finalResults?: GraphRecallRankedResult[];
     shadowComparison?: GraphRecallShadowComparison;
   }): Promise<void> {
-    return this.recallIntrospectionCoordinator.recordLastGraphRecallSnapshot(
+    return this.recallIntrospection.recordLastGraphRecallSnapshot(
       options,
     );
   }
@@ -2548,7 +2500,7 @@ export class Orchestrator {
     storage: StorageManager;
     snapshot: IntentDebugSnapshot;
   }): Promise<void> {
-    return this.recallIntrospectionCoordinator.recordLastIntentSnapshot(
+    return this.recallIntrospection.recordLastIntentSnapshot(
       options,
     );
   }
@@ -2557,7 +2509,7 @@ export class Orchestrator {
     storage: StorageManager;
     snapshot: QmdRecallSnapshot;
   }): Promise<void> {
-    return this.recallIntrospectionCoordinator.recordLastQmdRecallSnapshot(
+    return this.recallIntrospection.recordLastQmdRecallSnapshot(
       options,
     );
   }
@@ -2566,7 +2518,7 @@ export class Orchestrator {
     namespace: string;
     snapshot: IntentDebugSnapshot;
   }): Promise<void> {
-    return this.recallIntrospectionCoordinator.recordLastIntentSnapshotForNamespace(
+    return this.recallIntrospection.recordLastIntentSnapshotForNamespace(
       options,
     );
   }
@@ -2746,7 +2698,7 @@ export class Orchestrator {
    */
   private _recallIntrospectionCoordinator: RecallIntrospectionCoordinator | undefined;
 
-  private get recallIntrospectionCoordinator(): RecallIntrospectionCoordinator {
+  get recallIntrospection(): RecallIntrospectionCoordinator {
     if (!this._recallIntrospectionCoordinator) {
       this._recallIntrospectionCoordinator = new RecallIntrospectionCoordinator(
         selfDeps<ConstructorParameters<typeof RecallIntrospectionCoordinator>[0]>(this),

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -4,7 +4,7 @@
   "oversizeThresholdLoc": 3000,
   "metrics": {
     "watchlistLoc": {
-      "packages/remnic-core/src/orchestrator.ts": 4020,
+      "packages/remnic-core/src/orchestrator.ts": 3972,
       "packages/remnic-core/src/cli.ts": 9395,
       "packages/remnic-core/src/access-service.ts": 5902,
       "packages/remnic-core/src/storage.ts": 6549,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -135,7 +135,7 @@ tests/access-http.test.ts(351,43): TS7031
 tests/access-http.test.ts(397,29): TS7031
 tests/access-http.test.ts(427,29): TS7031
 tests/access-http.test.ts(427,42): TS7031
-tests/access-http.test.ts(2295,3): TS2322
+tests/access-http.test.ts(2297,3): TS2322
 tests/access-idempotency.test.ts(40,68): TS2339
 tests/access-idempotency.test.ts(113,7): TS2349
 tests/access-idempotency.test.ts(170,7): TS2349
@@ -163,7 +163,7 @@ tests/access-mcp.test.ts(184,29): TS7031
 tests/access-mcp.test.ts(184,42): TS7031
 tests/access-service.test.ts(432,35): TS2339
 tests/access-service.test.ts(433,35): TS2339
-tests/access-service.test.ts(2061,5): TS2349
+tests/access-service.test.ts(2081,5): TS2349
 tests/amb-bridge.test.ts(20,8): TS7016
 tests/amb-bridge.test.ts(477,9): TS7034
 tests/amb-bridge.test.ts(482,20): TS7006

--- a/src/index.ts
+++ b/src/index.ts
@@ -1929,7 +1929,7 @@ const pluginDefinition = {
         explainLastRecall:
           cfg.activeRecallAttachRecallExplain === true
             ? async () =>
-                await orchestrator
+                await orchestrator.recallIntrospection
                   .explainLastQmdRecall()
                   .catch(() => null)
             : undefined,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1104,7 +1104,7 @@ Best for:
         const { namespace } = params as {
           namespace?: string;
         };
-        const text = await orchestrator.explainLastIntent({
+        const text = await orchestrator.recallIntrospection.explainLastIntent({
           namespace,
         });
         return toolResult(text);
@@ -1139,7 +1139,7 @@ Best for:
           namespace?: string;
           maxResults?: number;
         };
-        const text = await orchestrator.explainLastQmdRecall({
+        const text = await orchestrator.recallIntrospection.explainLastQmdRecall({
           namespace,
           maxResults,
         });
@@ -1175,7 +1175,7 @@ Best for:
           namespace?: string;
           maxExpanded?: number;
         };
-        const text = await orchestrator.explainLastGraphRecall({
+        const text = await orchestrator.recallIntrospection.explainLastGraphRecall({
           namespace,
           maxExpanded,
         });

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -2029,8 +2029,10 @@ test("access HTTP server binds namespace write authorization to its configured p
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
 
   const headers = {
@@ -2547,8 +2549,10 @@ test("access HTTP server returns 400 for explicit-capture validation errors", as
     recall: async () => "ctx",
     lastRecall: { get: () => null, getMostRecent: () => null },
     getStorage: async () => storage,
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
   const server = new EngramAccessHttpServer({
     service,

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -1237,6 +1237,7 @@ test("access service recall forwards overrides and returns explainable metadata"
       },
       lastRecall: { get: () => snapshot, getMostRecent: () => snapshot },
       getStorage: async () => storage,
+      recallIntrospection: {
       getLastIntentSnapshot: async () => ({
         recordedAt: "2026-03-08T00:00:00.000Z",
         promptHash: "prompt",
@@ -1258,6 +1259,7 @@ test("access service recall forwards overrides and returns explainable metadata"
         },
       }),
       getLastGraphRecallSnapshot: async () => null,
+      },
     } as any);
 
     const response = await service.recall({
@@ -1329,6 +1331,7 @@ test("access service recall reports the effective snapshot namespace in response
         getMostRecent: () => null,
       },
       getStorage: async () => storage,
+      recallIntrospection: {
       getLastIntentSnapshot: async (namespace: string) => {
         intentNamespace = namespace;
         return null;
@@ -1336,6 +1339,7 @@ test("access service recall reports the effective snapshot namespace in response
       getLastGraphRecallSnapshot: async (namespace: string) => {
         graphNamespace = namespace;
         return null;
+      },
       },
     } as any);
 
@@ -1410,8 +1414,10 @@ test("access service serializes result paths from the snapshot namespace", async
       recall: async () => "ctx",
       lastRecall: { get: () => snapshot, getMostRecent: () => snapshot },
       getStorage: async (namespace?: string) => (namespace === "project-x" ? namespaceStorage : globalStorage),
+      recallIntrospection: {
       getLastIntentSnapshot: async () => null,
       getLastGraphRecallSnapshot: async () => null,
+      },
     } as any);
 
     const response = await service.recall({
@@ -1469,8 +1475,10 @@ test("access service recall count stays aligned with snapshot memory ids when so
       recall: async () => "ctx",
       lastRecall: { get: () => snapshot, getMostRecent: () => snapshot },
       getStorage: async () => storage,
+      recallIntrospection: {
       getLastIntentSnapshot: async () => null,
       getLastGraphRecallSnapshot: async () => null,
+      },
     } as any);
 
     const response = await service.recall({
@@ -1531,6 +1539,7 @@ test("access service recall without a session key does not reuse another session
         },
       },
       getStorage: async () => storage,
+      recallIntrospection: {
       getLastIntentSnapshot: async () => ({
         recordedAt: "2026-03-10T00:00:00.000Z",
         promptHash: "prompt",
@@ -1548,6 +1557,7 @@ test("access service recall without a session key does not reuse another session
         nodes: [],
         edges: [],
       }),
+      },
     } as any);
 
     const response = await service.recall({
@@ -1609,8 +1619,10 @@ test("access service recallExplain omits mismatched most-recent snapshot when na
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
 
   const response = await service.recallExplain({
@@ -1659,8 +1671,10 @@ test("access service recallExplain omits most-recent snapshots without a namespa
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
 
   const response = await service.recallExplain({
@@ -1710,8 +1724,10 @@ test("access service recallExplain requires identity before exposing the most re
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
 
   const response = await service.recallExplain();
@@ -1768,6 +1784,7 @@ test("access service recallExplain does not fall back to unreadable default name
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async (namespace: string) => {
       intentSnapshotCalls += 1;
       assert.equal(namespace, "global");
@@ -1777,6 +1794,7 @@ test("access service recallExplain does not fall back to unreadable default name
       graphSnapshotCalls += 1;
       assert.equal(namespace, "global");
       return { namespace, graph: "debug-default" };
+    },
     },
   } as any);
 
@@ -1836,8 +1854,10 @@ test("access service recallExplain filters session snapshots by the requested na
       getMemoryById: async () => null,
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   } as any);
 
   const response = await service.recallExplain({

--- a/tests/graph-recall-integration.test.ts
+++ b/tests/graph-recall-integration.test.ts
@@ -312,7 +312,8 @@ test("getLastGraphRecallSnapshot reads persisted snapshot", async () => {
     "utf-8",
   );
 
-  const snapshot = await orchestrator.getLastGraphRecallSnapshot();
+  const snapshot =
+    await orchestrator.recallIntrospection.getLastGraphRecallSnapshot();
   assert.ok(snapshot);
   assert.equal(snapshot!.mode, "graph_mode");
   assert.equal(snapshot!.seedCount, 1);
@@ -358,7 +359,8 @@ test("getLastGraphRecallSnapshot preserves richer fallback and ranking fields wh
     "utf-8",
   );
 
-  const snapshot = (await orchestrator.getLastGraphRecallSnapshot()) as
+  const snapshot =
+    (await orchestrator.recallIntrospection.getLastGraphRecallSnapshot()) as
     | ({
         status?: string;
         reason?: string;
@@ -406,7 +408,10 @@ test("explainLastGraphRecall returns human-readable graph explanation", async ()
     "utf-8",
   );
 
-  const explanation = await orchestrator.explainLastGraphRecall({ maxExpanded: 1 });
+  const explanation =
+    await orchestrator.recallIntrospection.explainLastGraphRecall({
+      maxExpanded: 1,
+    });
   assert.match(explanation, /Last Graph Recall/);
   assert.match(explanation, /Mode: graph_mode/);
   assert.match(explanation, /showing 1/);
@@ -451,7 +456,10 @@ test("explainLastGraphRecall tolerates richer fallback snapshots and surfaces th
     "utf-8",
   );
 
-  const explanation = await orchestrator.explainLastGraphRecall({ maxExpanded: 5 });
+  const explanation =
+    await orchestrator.recallIntrospection.explainLastGraphRecall({
+      maxExpanded: 5,
+    });
   assert.match(explanation, /Last Graph Recall/);
   assert.match(explanation, /Mode: full/);
   if (explanation.includes("fallback")) {

--- a/tests/intent-debug.test.ts
+++ b/tests/intent-debug.test.ts
@@ -7,14 +7,30 @@ import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { registerTools } from "../src/tools.ts";
 
-const hasGetLastIntentSnapshot =
-  typeof (Orchestrator.prototype as any).getLastIntentSnapshot === "function";
-const hasExplainLastIntent =
-  typeof (Orchestrator.prototype as any).explainLastIntent === "function";
+
+test("Orchestrator exposes a stable recall-introspection surface", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-introspection-surface-"));
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      qmdEnabled: false,
+    }),
+  );
+
+  try {
+    const surface = orchestrator.recallIntrospection;
+    assert.equal(surface, orchestrator.recallIntrospection);
+    assert.equal(typeof surface.getLastIntentSnapshot, "function");
+    assert.equal(typeof surface.explainLastIntent, "function");
+  } finally {
+    await orchestrator.destroy();
+  }
+});
 
 test(
   "recallInternal persists last_intent.json when intent debugging is available",
-  { skip: !hasGetLastIntentSnapshot },
   async (t) => {
     const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-intent-debug-write-"));
     const cfg = parseConfig({
@@ -51,7 +67,6 @@ test(
 
 test(
   "getLastIntentSnapshot reads persisted intent snapshots when available",
-  { skip: !hasGetLastIntentSnapshot },
   async () => {
     const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-intent-debug-read-"));
     const cfg = parseConfig({
@@ -95,7 +110,8 @@ test(
       "utf-8",
     );
 
-    const snapshot = (await (orchestrator as any).getLastIntentSnapshot()) as
+    const snapshot =
+      (await orchestrator.recallIntrospection.getLastIntentSnapshot()) as
       | {
           promptHash?: string;
           plannedMode?: string;
@@ -118,7 +134,6 @@ test(
 
 test(
   "explainLastIntent returns a tool-facing summary when available",
-  { skip: !hasExplainLastIntent },
   async () => {
     const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-intent-debug-explain-"));
     const cfg = parseConfig({
@@ -162,7 +177,8 @@ test(
       "utf-8",
     );
 
-    const explanation = await (orchestrator as any).explainLastIntent();
+    const explanation =
+      await orchestrator.recallIntrospection.explainLastIntent();
     assert.equal(typeof explanation, "string");
     assert.match(explanation, /intent/i);
     assert.match(explanation, /graph_mode/i);
@@ -201,8 +217,10 @@ test("registerTools exposes memory_intent_debug when explainLastIntent is availa
       compoundingEnabled: false,
       identityContinuityEnabled: false,
     },
-    explainLastIntent: async () => "## Last Intent Debug\n\nPlanned mode: graph_mode",
-    explainLastGraphRecall: async () => "noop",
+    recallIntrospection: {
+      explainLastIntent: async () => "## Last Intent Debug\n\nPlanned mode: graph_mode",
+      explainLastGraphRecall: async () => "noop",
+    },
     qmd: {
       search: async () => [],
       searchGlobal: async () => [],

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -881,11 +881,13 @@ test("QMD recall snapshot helpers read persisted snapshots and memory_qmd_debug 
     "utf-8",
   );
 
-  const snapshot = await (orchestrator as any).getLastQmdRecallSnapshot();
+  const snapshot =
+    await orchestrator.recallIntrospection.getLastQmdRecallSnapshot();
   assert.ok(snapshot);
   assert.equal(snapshot.intentHint, "goal:review action:review");
 
-  const explanation = await (orchestrator as any).explainLastQmdRecall();
+  const explanation =
+    await orchestrator.recallIntrospection.explainLastQmdRecall();
   assert.match(explanation, /Last QMD Recall/);
   assert.match(explanation, /intent hint/i);
   assert.match(explanation, /hybrid top-up skipped reason/i);
@@ -918,9 +920,11 @@ test("QMD recall snapshot helpers read persisted snapshots and memory_qmd_debug 
       compoundingEnabled: false,
       identityContinuityEnabled: false,
     },
-    explainLastIntent: async () => "noop",
-    explainLastQmdRecall: async () => "## Last QMD Recall\n\nIntent hint: goal:review",
-    explainLastGraphRecall: async () => "noop",
+    recallIntrospection: {
+      explainLastIntent: async () => "noop",
+      explainLastQmdRecall: async () => "## Last QMD Recall\n\nIntent hint: goal:review",
+      explainLastGraphRecall: async () => "noop",
+    },
     qmd: {
       search: async () => [],
       searchGlobal: async () => [],

--- a/tests/recall-tag-filter.test.ts
+++ b/tests/recall-tag-filter.test.ts
@@ -114,8 +114,10 @@ function buildService(memories: FakeMemory[]) {
       },
       getMemoryTimeline: async () => [],
     }),
+    recallIntrospection: {
     getLastIntentSnapshot: async () => null,
     getLastGraphRecallSnapshot: async () => null,
+    },
   };
   return new EngramAccessService(orchestrator as never);
 }


### PR DESCRIPTION
## What changed

Recall debug reads now have one owner. `Orchestrator.recallIntrospection` exposes a typed API for intent, QMD, and graph snapshots. It also owns the matching explain methods.

All callers now use that API. This includes core code, access code, host hooks, tools, tests, and test doubles. The six old forwarding methods are gone. No alias or fallback remains.

The change cuts `orchestrator.ts` from 4,020 lines to 3,972 lines. The lower limit is now enforced by the structural ratchet. The changelog and shifted test type records are also current.

## Why

Issue #1800 aims to shrink large composition roots through small ownership seams. The recall coordinator already held this behavior. The root class only passed calls through. This change makes the real owner public and removes the duplicate path.

## Tests

- Focused intent, graph, QMD, access, HTTP, and tag tests: 159 passed.
- Core type check: passed.
- Root type check: passed.
- Entity hardening: 246 passed.
- Quick preflight: passed.
- Docs parity: passed.
- Structural ratchets: passed.

This closes part of #1800.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API relocation with no recall logic changes; risk is limited to missed call sites, which tests and grep suggest are fully migrated.
> 
> **Overview**
> **Recall introspection** is now a single public seam: `Orchestrator.recallIntrospection` (public getter on the lazy `RecallIntrospectionCoordinator`). Intent, QMD, and graph **snapshot getters** and **explain** helpers are no longer forwarded through `Orchestrator` itself.
> 
> **Call sites** (`access-service`, plugin `tools.ts` / `index.ts`, and tests) now call `orchestrator.recallIntrospection.*` instead of top-level orchestrator methods. `RecallIntrospectionCoordinator` explain paths call their own snapshot methods directly instead of depending on those methods on the orchestrator deps interface.
> 
> **Housekeeping:** `orchestrator.ts` LOC ratchet lowered (4020 → 3972), changelog updated, and test mocks extended with a `recallIntrospection` stub where orchestrators are faked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98a8941e525cd4881c3eebe43f71c3ca483a7105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->