### PR TITLE
feat: ChatGPT developer-mode support — streamable-HTTP conformance + OAuth 2.1 facade

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,16 @@
 - [Identity Continuity](identity-continuity.md) — Continuity artifacts, templates, and rollout safety model (v8.4)
 - [Graph Dashboard](graph-dashboard.md) — Optional live graph observability server + patch stream (v8.8)
 
+## Integrations
+
+- [ChatGPT (developer mode)](integration/chatgpt.md) — Public-internet MCP + OAuth 2.1 flow: Tailscale Funnel / Cloudflare Tunnel, `server.oauth` config, local operator approval, troubleshooting
+- [Connector Setup Guide](integration/connector-setup.md) — Wire Remnic memory to Claude Code, Codex, Cursor, Copilot, Cline, Roo Code, Windsurf, Amp, Replit, Hermes, and any generic MCP client
+- [Pi Coding Agent](integration/pi.md) — Native Pi extension (`@remnic/plugin-pi`) for hooks, slash commands, and compaction coordination
+- [Oh My Pi (omp)](integration/omp.md) — omp rules, MCP server config, and the native omp extension
+- [Hermes Setup](integration/hermes-setup.md) — Hermes Agent via `remnic-hermes` Python package or `X-Hermes-Session-Id` auto-detection
+- [Deployment Topologies](integration/deployment-topologies.md) — Localhost, LAN, remote, containerized, standalone
+- [Plugin ID and Memory Namespaces](integration/plugin-id-and-memory-namespaces.md) — OpenClaw plugin id `openclaw-remnic`, memory namespace isolation
+
 ## Plans / Roadmaps
 
 - [Remnic Feature Roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1) — Current priority order, blockers, and next work

--- a/docs/chatgpt-apps-demo.md
+++ b/docs/chatgpt-apps-demo.md
@@ -6,6 +6,12 @@ submission package.
 
 Archetype: `vanilla-widget`.
 
+For the public ChatGPT-developer-mode MCP + OAuth flow (the path you use
+to actually connect chatgpt.com to a Remnic server over the public
+internet), see [integration/chatgpt.md](./integration/chatgpt.md). This
+demo is the local bearer-token flow against the same `/mcp` endpoint; the
+integration guide is the OAuth-funnel flow ChatGPT itself drives.
+
 ## What It Adds
 
 - MCP widget resource: `ui://remnic/memory-inspector.v1.html`

--- a/docs/integration/chatgpt.md
+++ b/docs/integration/chatgpt.md
@@ -138,8 +138,8 @@ Field-by-field:
 | `enabled` | yes | Master gate. Must be `true` for ChatGPT to discover the OAuth endpoints. Default `false`. |
 | `issuerUrl` | yes | **Public HTTPS base URL of the tunneled server.** Must match the URL ChatGPT sees exactly — this is the value the discovery documents are served from, and the value used in `WWW-Authenticate: Bearer resource_metadata=...` on `401` responses. |
 | `clientId` | yes | Operator-chosen identifier. You paste the same string into ChatGPT's app-creation UI. Pick anything memorable; the same value is the credential both sides trust. |
-| `clientSecret` | yes | High-entropy secret. Generate with `openssl rand -hex 32`. The same value is pasted into ChatGPT as the OAuth client secret. |
-| `tokenEndpointAuthMethod` | yes | Exactly one of `client_secret_post`, `client_secret_basic`, or `none`. This single method is both **advertised** in the discovery document and **enforced** at the token endpoint. Pick one and stick with it. |
+| `clientSecret` | when method is `client_secret_post` | High-entropy secret. Generate with `openssl rand -hex 32`. The same value is pasted into ChatGPT as the OAuth client secret. Not consulted (and not required) when `tokenEndpointAuthMethod` is `none`. |
+| `tokenEndpointAuthMethod` | no (default `client_secret_post`) | Exactly one of `client_secret_post` or `none`. The single configured method is both **advertised** in the discovery document and **enforced** at the token endpoint. `none` makes the client public — the token exchange is protected only by PKCE plus the local operator approval; prefer the default unless you understand that tradeoff. |
 | `redirectUris` | yes | Exact byte-for-byte allowlist of allowed ChatGPT redirect URIs. No prefixes, no patterns. You will add the value ChatGPT shows you after the app is created (see Step 3). Empty array = nothing can link. |
 | `approvalTtlSeconds` | no | How long a pending authorization transaction lives while waiting for the local operator to approve. Default `600` (10 minutes). |
 
@@ -366,7 +366,7 @@ re-runs the OAuth approval flow.
 | "Expired approval" in the browser tab on the server machine | `approvalTtlSeconds` elapsed (default 600 s) before the operator ran `remnic oauth approve`. | Run `remnic oauth approve <new-ref>` from the new pending transaction; the old ref is gone. Raise `approvalTtlSeconds` in the OAuth config if your operator is regularly slower. |
 | ChatGPT says "service unavailable" or the tool list is empty after the tunnel is working | The tunnel went offline (Tailscale node disconnected, `cloudflared` lost the connection). | Check the tunnel's status (`tailscale status`, `cloudflared tunnel info ...`) and re-establish. The server itself does not need a restart once the tunnel is back. |
 | ChatGPT keeps showing the **old** tool list after Remnic added or renamed a tool | ChatGPT caches the discovered tool list per app. | Use the **Refresh** action on the app's settings page in ChatGPT; it forces a re-fetch of the discovery document and tool list. Server-side changes do not invalidate ChatGPT's cache. |
-| `remnic oauth pending` says "No pending requests" while the browser is on the approval page | The page is polling the wrong server, or the server is bound to a different port than `issuerUrl` points at. | Check the URL in the browser tab — it should be `<issuerUrl>/oauth/authorize/poll?...`. If it is `127.0.0.1`, the tunnel is not routing correctly. |
+| `remnic oauth pending` says "No pending requests" while the browser is on the approval page | The page is polling the wrong server, or the server is bound to a different port than `issuerUrl` points at. | Check the URL in the browser tab — it should be `<issuerUrl>/authorize?...`, and the page polls `<issuerUrl>/oauth/authorize/poll`. If it shows `127.0.0.1`, the tunnel is not routing correctly. |
 | ChatGPT returns "Invalid client" or "Invalid client_secret" at the token endpoint | `clientId` / `clientSecret` pasted into ChatGPT does not match `server.oauth.clientId` / `server.oauth.clientSecret`. | Remnic enforces the single `tokenEndpointAuthMethod` from your config. Re-copy the values from your config file (no surrounding whitespace, no shell-expanded placeholders) and re-paste into the ChatGPT app. |
 | Operator `remnic oauth approve` returns 401 | The CLI is talking to a Remnic daemon that does not have the same operator bearer token. | The CLI uses the same operator auth as the rest of the daemon-backed commands (`REMNIC_AUTH_TOKEN` / config). Re-check the config / env on the server machine. |
 
@@ -421,11 +421,12 @@ re-runs the OAuth approval flow.
 
 ---
 
-## Endpoint reference (authoritative from contract)
+## Endpoint reference
 
-The following paths are mounted by Remnic's OAuth facade and are
-authoritative from the integration contract. If a future SDK change moves
-any of them, this doc will be updated to match.
+The following paths are mounted by Remnic's OAuth facade. The
+authorization and token endpoints follow the MCP TypeScript SDK's auth
+router layout (root-level `/authorize` and `/token`); the exact values
+are always discoverable from `/.well-known/oauth-authorization-server`.
 
 - `GET /.well-known/oauth-protected-resource` — RFC 9728 protected-resource
   metadata.
@@ -435,10 +436,10 @@ any of them, this doc will be updated to match.
   server metadata. ChatGPT fetches this during discovery; the
   `authorization_endpoint` and `token_endpoint` values are derived from
   `server.oauth.issuerUrl`.
-- `GET /oauth/authorize` — start of the authorization-code + PKCE (S256)
+- `GET /authorize` — start of the authorization-code + PKCE (S256)
   flow. Validates `client_id`, exact `redirect_uri` match, `response_type=code`,
   and PKCE S256 challenge. Renders the approval-instructions page.
-- `POST /oauth/token` — authorization-code grant only. Enforces the
+- `POST /token` — authorization-code grant only. Enforces the
   single configured `tokenEndpointAuthMethod`, verifies the PKCE verifier,
   and returns a long-lived bearer token. Re-linking rotates the token.
 - `POST /oauth/authorize/poll` — used by the approval page to wait for

--- a/docs/integration/chatgpt.md
+++ b/docs/integration/chatgpt.md
@@ -1,0 +1,471 @@
+# Using Remnic from chatgpt.com (developer mode)
+
+This guide walks through connecting a local Remnic server to ChatGPT on the
+web via ChatGPT's developer mode. The flow uses ChatGPT's streamable-HTTP MCP
+transport and OAuth 2.1 with a local operator-approval step.
+
+The chatgpt.com developer-mode flow is a **public-internet** MCP flow:
+ChatGPT's backend has to reach your server. You do not point ChatGPT at
+`http://localhost:4318`. You expose the server over HTTPS (Tailscale Funnel or
+a Cloudflare Tunnel), put a real `client_id` / `client_secret` you control
+into Remnic's config, and ChatGPT runs the OAuth dance against that public
+URL. The local operator approves every link request on the server machine.
+
+> **Not the ChatGPT Apps widget.** This guide is the OAuth + streamable-HTTP
+> MCP integration, not the SDK-style widget resource documented in
+> [`../chatgpt-apps-demo.md`](../chatgpt-apps-demo.md). The widget there works
+> locally against `/mcp` with a bearer token; this guide covers the public
+> flow ChatGPT itself uses.
+
+---
+
+## Prerequisites
+
+- **ChatGPT plan:** Pro, Plus, Business, Enterprise, or Edu on the web. The
+  developer-mode MCP flow is a ChatGPT-side feature and is not available on
+  the mobile or desktop ChatGPT clients.
+- **ChatGPT developer mode enabled:** ChatGPT web → **Settings** → **Security
+  and login** → **Developer mode** → turn on. ChatGPT will not show the
+  developer-mode app option at `chatgpt.com/plugins` until this is on.
+- **Remnic server running locally.** Start the standalone daemon:
+  ```bash
+  export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
+  remnic daemon start
+  remnic status
+  ```
+  See [Connector Setup Guide](./connector-setup.md) and
+  [Deployment Topologies](./deployment-topologies.md) for full setup,
+  including the OpenClaw plugin-mode alternative. The default port is
+  `4318`; substitute your own port everywhere if you change it.
+- **A `client_id` and `client_secret` you generate yourself.** Remnic is the
+  authorization server in this flow — there is no third-party IdP. You mint
+  the credentials in Remnic's config and paste the same values into ChatGPT's
+  app-creation UI. Generate a strong secret with:
+  ```bash
+  openssl rand -hex 32
+  ```
+
+---
+
+## Step 1: Expose the server over public HTTPS
+
+ChatGPT's backend only speaks to public HTTPS URLs. You need a tunnel that
+gives your local server a stable `https://...` URL and terminates TLS
+outside the tunnel. **Do not bind Remnic to `0.0.0.0` on the public
+internet and skip the tunnel** — ChatGPT requires HTTPS and the bearer-token
++ OAuth model in this guide assumes the tunnel, not raw exposure.
+
+> **Authentication is mandatory.** Remnic's OAuth facade is the gatekeeper,
+> but treat the public URL as untrusted: never expose the server over HTTPS
+> without `server.oauth.enabled: true` and a strong `clientSecret`. A bare
+> `/mcp` with the operator bearer token behind a tunnel is an instant memory
+> exfiltration path.
+
+### Option A: Tailscale Funnel (recommended)
+
+Tailscale Funnel is the simplest path: one command, no account setup, and the
+resulting URL (`https://<node>.<tailnet>.ts.net`) is stable for the lifetime
+of the node.
+
+1. Install and log in to Tailscale on the machine running Remnic:
+   ```bash
+   # See https://tailscale.com/download for your platform
+   tailscale up
+   ```
+2. Enable Funnel for the Remnic port (substitute the port you started on):
+   ```bash
+   sudo tailscale funnel 4318
+   ```
+3. Tailscale prints the public URL. It will look like:
+   ```
+   https://<node>.<tailnet>.ts.net/
+   ```
+   Copy that — this is the value you will paste into `server.oauth.issuerUrl`
+   below. Tailscale Funnel terminates TLS at the edge, so Remnic only needs
+   to bind to `127.0.0.1` on the plain HTTP port; you do **not** need
+   certificates or a reverse proxy.
+
+> **Note:** Tailscale Funnel proxies through Tailscale's edge and terminates
+> TLS before forwarding to your daemon. This means mTLS client-certificate
+> verification is **not possible** behind Funnel — see [Security
+> notes](#security-notes) below.
+
+### Option B: Cloudflare Tunnel (alternative)
+
+`cloudflared tunnel` also works as a generic TLS-terminating front. Run
+`cloudflared tunnel` against the same Remnic port; use whatever hostname
+Cloudflare assigns as your `issuerUrl`. This guide is intentionally
+account-agnostic; see the `cloudflared` docs for the one-time login and DNS
+routing on your account.
+
+Whatever tunnel you use, the rule is: the URL ChatGPT sees (the value of
+`server.oauth.issuerUrl` below) must match the URL the tunnel fronts —
+discovery, redirects, and the `WWW-Authenticate` resource-metadata pointer
+all key off it.
+
+---
+
+## Step 2: Configure OAuth in Remnic
+
+Remnic is the **authorization server** in this flow. You define the
+`client_id`, the `client_secret`, the redirect allowlist, and the public
+issuer URL in Remnic's config; you paste the same `client_id` /
+`client_secret` into ChatGPT's app-creation UI.
+
+Add the following to your Remnic server config (e.g. `~/.config/remnic/config.json`
+or wherever you keep the server config; env overrides are listed below):
+
+```jsonc
+{
+  "server": {
+    "oauth": {
+      "enabled": true,
+      "issuerUrl": "https://<node>.<tailnet>.ts.net",
+      "clientId": "remnic-chatgpt",
+      "clientSecret": "<openssl rand -hex 32 output>",
+      "tokenEndpointAuthMethod": "client_secret_post",
+      "redirectUris": [],
+      "approvalTtlSeconds": 600
+    }
+  }
+}
+```
+
+Field-by-field:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `enabled` | yes | Master gate. Must be `true` for ChatGPT to discover the OAuth endpoints. Default `false`. |
+| `issuerUrl` | yes | **Public HTTPS base URL of the tunneled server.** Must match the URL ChatGPT sees exactly — this is the value the discovery documents are served from, and the value used in `WWW-Authenticate: Bearer resource_metadata=...` on `401` responses. |
+| `clientId` | yes | Operator-chosen identifier. You paste the same string into ChatGPT's app-creation UI. Pick anything memorable; the same value is the credential both sides trust. |
+| `clientSecret` | yes | High-entropy secret. Generate with `openssl rand -hex 32`. The same value is pasted into ChatGPT as the OAuth client secret. |
+| `tokenEndpointAuthMethod` | yes | Exactly one of `client_secret_post`, `client_secret_basic`, or `none`. This single method is both **advertised** in the discovery document and **enforced** at the token endpoint. Pick one and stick with it. |
+| `redirectUris` | yes | Exact byte-for-byte allowlist of allowed ChatGPT redirect URIs. No prefixes, no patterns. You will add the value ChatGPT shows you after the app is created (see Step 3). Empty array = nothing can link. |
+| `approvalTtlSeconds` | no | How long a pending authorization transaction lives while waiting for the local operator to approve. Default `600` (10 minutes). |
+
+Environment overrides (all `REMNIC_OAUTH_*`):
+
+| Variable | Maps to |
+|----------|---------|
+| `REMNIC_OAUTH_ENABLED` | `server.oauth.enabled` (booleans: `true`/`1`/`yes`/`on`; anything else is falsy) |
+| `REMNIC_OAUTH_ISSUER_URL` | `server.oauth.issuerUrl` |
+| `REMNIC_OAUTH_CLIENT_ID` | `server.oauth.clientId` |
+| `REMNIC_OAUTH_CLIENT_SECRET` | `server.oauth.clientSecret` |
+| `REMNIC_OAUTH_TOKEN_AUTH_METHOD` | `server.oauth.tokenEndpointAuthMethod` |
+| `REMNIC_OAUTH_REDIRECT_URIS` | `server.oauth.redirectUris` (comma-separated) |
+| `REMNIC_OAUTH_APPROVAL_TTL_SECONDS` | `server.oauth.approvalTtlSeconds` |
+
+Restart the Remnic server so the OAuth facade mounts:
+
+```bash
+remnic daemon restart
+remnic status
+```
+
+Verify discovery is reachable on the public URL:
+
+```bash
+curl https://<node>.<tailnet>.ts.net/.well-known/oauth-authorization-server
+# Expect JSON with authorization_endpoint, token_endpoint, and the single
+# token_endpoint_auth_methods_supported value matching your config.
+```
+
+If discovery returns a connection error or the wrong JSON, the tunnel or
+`issuerUrl` is misconfigured — fix that before continuing, because every
+later step depends on it.
+
+---
+
+## Step 3: Create the app in ChatGPT
+
+1. In a browser, go to <https://chatgpt.com/plugins>.
+2. Click the **+** (add) button, choose **developer-mode app**.
+3. Fill in the form:
+   - **MCP server URL:** `<issuerUrl>/mcp` — for example,
+     `https://<node>.<tailnet>.ts.net/mcp`.
+   - **Authentication:** **OAuth**.
+   - **Client ID:** the same `clientId` you put in `server.oauth.clientId`
+     (e.g. `remnic-chatgpt`).
+   - **Client Secret:** the same `clientSecret` you put in
+     `server.oauth.clientSecret` (the `openssl rand -hex 32` output).
+4. Save the app. ChatGPT will run an initial discovery check; if it
+   succeeds, the app is created and its management page shows the
+   per-app **redirect/callback URL** — it looks like
+   `https://chatgpt.com/connector/oauth/{callback_id}`. **Copy that exact
+   value.** ChatGPT appends this URL to the authorization request and
+   Remnic's allowlist must match it byte-for-byte.
+5. Edit your Remnic config to add the copied URL to `redirectUris`:
+   ```jsonc
+   {
+     "server": {
+       "oauth": {
+         "redirectUris": [
+           "https://chatgpt.com/connector/oauth/<callback_id>"
+         ]
+       }
+     }
+   }
+   ```
+   Restart the server:
+   ```bash
+   remnic daemon restart
+   ```
+6. Back in ChatGPT, link / connect the app. ChatGPT will start the
+   authorization-code + PKCE (S256) flow against the discovery
+   `authorization_endpoint`; the operator-approval step happens on the
+   server machine (next section).
+
+> **If ChatGPT errors before you can copy the redirect URL:** the app is
+> still created, but ChatGPT's app management page may not display it
+> until the first link attempt succeeds. Re-open the app's settings;
+> the redirect URL is on the app's detail page.
+
+---
+
+## Step 4: Approve the link request locally
+
+When ChatGPT starts the authorization flow, Remnic's OAuth facade
+generates a pending transaction and serves an approval-instructions page in
+the user's browser. The page does **not** ask for any credential — it shows
+the approval ref and instructions to run the CLI on the server machine.
+
+On the **server machine** (the one running Remnic), in another terminal:
+
+```bash
+remnic oauth pending
+```
+
+Expected output (text):
+
+```
+Pending OAuth authorization requests (1):
+
+  ref:        a8f3-91d2-4e07
+  client:     remnic-chatgpt
+  redirect:   https://chatgpt.com/connector/oauth/<callback_id>
+  scopes:     (none requested)
+  resource:   https://<node>.<tailnet>.ts.net/mcp
+  created:    2026-07-11T09:42:13.117Z
+  expires:    2026-07-11T09:52:13.117Z
+```
+
+**Verify the `client`, `redirect`, `scopes`, and `resource` match what you
+expect before approving.** This is the only place you can refuse a request
+that, e.g., is asking for the wrong redirect URI or a different MCP resource.
+
+Approve (add `--yes` to skip the interactive prompt):
+
+```bash
+remnic oauth approve a8f3-91d2-4e07 --yes
+```
+
+Or, for the interactive form:
+
+```bash
+remnic oauth approve a8f3-91d2-4e07
+```
+
+Expected output (text):
+
+```
+Approving authorization request a8f3-91d2-4e07
+
+  client:     remnic-chatgpt
+  redirect:   https://chatgpt.com/connector/oauth/<callback_id>
+  scopes:     (none requested)
+  resource:   https://<node>.<tailnet>.ts.net/mcp
+
+Approved. ChatGPT will complete the browser flow automatically.
+```
+
+The browser tab on the ChatGPT side will then automatically complete the
+flow and ChatGPT will mark the app as linked. If the transaction has
+expired (`approvalTtlSeconds` elapsed, default 10 minutes) the page will
+show an "expired approval" message and ChatGPT will retry from the
+beginning — re-run `remnic oauth pending` to see the new ref.
+
+To refuse a request:
+
+```bash
+remnic oauth deny a8f3-91d2-4e07 --yes
+```
+
+---
+
+## Step 5: Use the app in the ChatGPT composer
+
+Once linked, ChatGPT treats the app's MCP tools as developer-mode tools in
+the composer. The MCP tools exposed by Remnic are the same tools the
+standalone server exposes to every other MCP client (see [Connector Setup
+Guide](./connector-setup.md) for the full tool list). Common ones to try:
+
+- `remnic.recall` — pull relevant memories into the conversation.
+- `remnic.memory_store` — explicitly save a memory.
+- `remnic.briefing` — session-start context load.
+- `remnic.observe` — observe a turn for later extraction.
+- `remnic.search` — direct search over the memory store.
+- `remnic.chatgpt_memory_inspector` — the read-only widget-backed inspector
+  (see [`../chatgpt-apps-demo.md`](../chatgpt-apps-demo.md)).
+
+Example prompts (paste into the ChatGPT composer):
+
+```
+Use remnic.recall to find my preferences about TypeScript project
+layout, then summarize the top three.
+
+Use remnic.briefing to load relevant context from last week about
+the Acme migration, then list the open questions.
+
+Use remnic.memory_store to remember: "I prefer Bun over pnpm for
+new TypeScript projects in 2026."
+```
+
+> **Write tools require per-conversation confirmation.** Remnic's tool
+> annotations mark tools without a `readOnlyHint` annotation as
+> write/mutate tools. ChatGPT will prompt the user to confirm any such
+> tool call before invoking it. The same is true in the admin console; see
+> [Connector Setup Guide](./connector-setup.md) for the read/write split
+> per tool.
+
+> **Tighten the tool surface.** If you do not want every tool exposed
+> (for example, if you only want `remnic.recall` in ChatGPT), open the
+> app's settings page in ChatGPT and disable the tools you do not need.
+> Remnic's server returns the same tool list to every OAuth-authenticated
+> ChatGPT session; per-app tool filtering is on ChatGPT's side.
+
+### Token rotation on re-link
+
+When you re-link the app (or ChatGPT rotates its tokens for any other
+reason), Remnic issues a new access token under the connector id `chatgpt`
+and revokes the old one. You can see the current token with:
+
+```bash
+remnic token list
+```
+
+Expected output (excerpt):
+
+```
+Connector tokens:
+  chatgpt          remnic_cg_…           (created 2026-07-11T09:55:01.221Z)
+  ...
+```
+
+The connector id is `chatgpt` and the token prefix is `remnic_cg_`. This
+rotation is expected: re-linking is the only ChatGPT-side mechanism that
+re-runs the OAuth approval flow.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| ChatGPT loops on a 401 from `/mcp` and never reaches the approval page | `redirectUris` allowlist does not match the per-app redirect URL ChatGPT shows. | Open the app in ChatGPT, copy the **exact** `https://chatgpt.com/connector/oauth/{callback_id}` URL, paste it into `server.oauth.redirectUris`, restart `remnic-server`. The match is byte-exact — trailing slash, query string, or `www.` vs no `www.` all break it. |
+| `/.well-known/oauth-authorization-server` returns a connection error from ChatGPT, but works locally | `issuerUrl` does not match the public URL the tunnel fronts. | Set `issuerUrl` to the same `https://...` URL ChatGPT sees (e.g. `https://<node>.<tailnet>.ts.net`), not `http://127.0.0.1:4318`. Restart the server. |
+| "Expired approval" in the browser tab on the server machine | `approvalTtlSeconds` elapsed (default 600 s) before the operator ran `remnic oauth approve`. | Run `remnic oauth approve <new-ref>` from the new pending transaction; the old ref is gone. Raise `approvalTtlSeconds` in the OAuth config if your operator is regularly slower. |
+| ChatGPT says "service unavailable" or the tool list is empty after the tunnel is working | The tunnel went offline (Tailscale node disconnected, `cloudflared` lost the connection). | Check the tunnel's status (`tailscale status`, `cloudflared tunnel info ...`) and re-establish. The server itself does not need a restart once the tunnel is back. |
+| ChatGPT keeps showing the **old** tool list after Remnic added or renamed a tool | ChatGPT caches the discovered tool list per app. | Use the **Refresh** action on the app's settings page in ChatGPT; it forces a re-fetch of the discovery document and tool list. Server-side changes do not invalidate ChatGPT's cache. |
+| `remnic oauth pending` says "No pending requests" while the browser is on the approval page | The page is polling the wrong server, or the server is bound to a different port than `issuerUrl` points at. | Check the URL in the browser tab — it should be `<issuerUrl>/oauth/authorize/poll?...`. If it is `127.0.0.1`, the tunnel is not routing correctly. |
+| ChatGPT returns "Invalid client" or "Invalid client_secret" at the token endpoint | `clientId` / `clientSecret` pasted into ChatGPT does not match `server.oauth.clientId` / `server.oauth.clientSecret`. | Remnic enforces the single `tokenEndpointAuthMethod` from your config. Re-copy the values from your config file (no surrounding whitespace, no shell-expanded placeholders) and re-paste into the ChatGPT app. |
+| Operator `remnic oauth approve` returns 401 | The CLI is talking to a Remnic daemon that does not have the same operator bearer token. | The CLI uses the same operator auth as the rest of the daemon-backed commands (`REMNIC_AUTH_TOKEN` / config). Re-check the config / env on the server machine. |
+
+---
+
+## Security notes
+
+- **Exact-redirect allowlist, not prefix.** `server.oauth.redirectUris` is
+  compared byte-for-byte against the `redirect_uri` parameter ChatGPT sends.
+  No patterns, no wildcards, no path prefixes. The reason is that any
+  prefix/pattern scheme becomes an open redirect in the face of path
+  normalization differences between OAuth clients and authorization
+  servers. The cost is one config edit per app; the benefit is that
+  ChatGPT can only ever bounce the authorization code back to the exact
+  URL Remnic expects.
+
+- **Single token-endpoint auth method.** The `tokenEndpointAuthMethod`
+  config value is the **only** method Remnic advertises in the discovery
+  document and the **only** method Remnic will accept at the token
+  endpoint. There is no fallback. Pick one (`client_secret_post` is the
+  ChatGPT-compatible default), keep the same value in the config, and
+  paste the same `client_id` / `client_secret` into ChatGPT.
+
+- **Approval requires the local operator token.** Knowing the approval
+  ref alone is not enough to authorize a request: the CLI's `approve`
+  command authenticates against the local Remnic daemon with the operator
+  bearer token. The web approval page never accepts a credential — it only
+  shows the ref and polls for status. This is by design: the public
+  tunnel is untrusted territory; only the operator on the server machine
+  can complete the link.
+
+- **`memoryDir` exposure is full memory access.** Anyone who can present a
+  valid ChatGPT-issued access token to your `/mcp` endpoint can read
+  everything in your memory directory and (for tools without
+  `readOnlyHint`) write to it. Treat the public URL as if it were your
+  memory directory itself. Use Tailscale ACLs / Cloudflare Access rules
+  to restrict what else can hit the URL if your account supports it.
+
+- **Optional hardening: OpenAI published egress IP allowlist.** OpenAI
+  publishes the IPs ChatGPT's backend uses. If your account / tunnel
+  supports source-IP allowlisting, restrict the funnel to those IPs. See
+  the OpenAI docs for the current list — it changes.
+
+- **mTLS is not possible behind Funnel / Cloudflare Tunnel.** Tailscale
+  Funnel and `cloudflared tunnel` terminate TLS at the edge and forward
+  plain HTTP to your daemon. Remnic therefore cannot verify a client
+  certificate in this configuration; the OAuth bearer token is the entire
+  authentication story at the MCP layer. If you need mTLS, run Remnic
+  behind a reverse proxy that preserves the client-cert handshake end to
+  end (nginx with `ssl_verify_client on`, Caddy with `tls` client auth,
+  etc.) — and accept that you are giving up the zero-config tunnel.
+
+---
+
+## Endpoint reference (authoritative from contract)
+
+The following paths are mounted by Remnic's OAuth facade and are
+authoritative from the integration contract. If a future SDK change moves
+any of them, this doc will be updated to match.
+
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 protected-resource
+  metadata.
+- `GET /.well-known/oauth-protected-resource/mcp` — same shape, scoped to
+  the `/mcp` resource.
+- `GET /.well-known/oauth-authorization-server` — RFC 8414 authorization-
+  server metadata. ChatGPT fetches this during discovery; the
+  `authorization_endpoint` and `token_endpoint` values are derived from
+  `server.oauth.issuerUrl`.
+- `GET /oauth/authorize` — start of the authorization-code + PKCE (S256)
+  flow. Validates `client_id`, exact `redirect_uri` match, `response_type=code`,
+  and PKCE S256 challenge. Renders the approval-instructions page.
+- `POST /oauth/token` — authorization-code grant only. Enforces the
+  single configured `tokenEndpointAuthMethod`, verifies the PKCE verifier,
+  and returns a long-lived bearer token. Re-linking rotates the token.
+- `POST /oauth/authorize/poll` — used by the approval page to wait for
+  operator approval. Body is `{ txn, pollSecret }`; response is
+  `{ status: "pending" }`, `{ status: "approved", redirect: "..." }`, or
+  `{ status: "denied" | "expired" }`.
+- `GET /oauth/pending` (operator-only) — list pending transactions.
+- `POST /oauth/pending/:ref/approve` (operator-only) — approve.
+- `POST /oauth/pending/:ref/deny` (operator-only) — deny.
+- `POST /mcp` — the streamable-HTTP MCP endpoint. The
+  `401 Unauthorized` response from `/mcp` carries
+  `WWW-Authenticate: Bearer resource_metadata="<issuerUrl>/.well-known/oauth-protected-resource/mcp"`
+  (RFC 9728), which is what tells ChatGPT where to start discovery.
+
+---
+
+## See also
+
+- [`../chatgpt-apps-demo.md`](../chatgpt-apps-demo.md) — the SDK-style
+  widget inspector (separate flow, runs locally with a bearer token).
+- [`./connector-setup.md`](./connector-setup.md) — MCP clients, the
+  generic `/mcp` bearer-token setup, and the full tool list.
+- [`./deployment-topologies.md`](./deployment-topologies.md) — Remnic
+  server deployment shapes (localhost, LAN, container, reverse proxy).
+- [`../connectors.md`](../connectors.md) — `remnic connectors` CLI
+  reference (live connectors; the OAuth flow here is not a "connector"
+  in that sense).
+- [`../operations.md`](../operations.md) — server lifecycle,
+  `REMNIC_AUTH_TOKEN`, and how to read daemon logs (useful when
+  troubleshooting discovery or `WWW-Authenticate`).

--- a/llms.txt
+++ b/llms.txt
@@ -309,3 +309,12 @@ CONNECTING OTHER AGENTS
   remnic connectors install codex-cli
   remnic connectors install replit
   pip install remnic-hermes
+
+CHATGPT DEVELOPER MODE (public OAuth + MCP flow):
+  docs/integration/chatgpt.md     chatgpt.com developer mode -> Remnic via
+                                  Tailscale Funnel or Cloudflare Tunnel, with
+                                  server.oauth config and local operator
+                                  approval (`remnic oauth pending|approve|deny`).
+                                  The OAuth facade in @remnic/server is the
+                                  authorization server; the connector id is
+                                  `chatgpt` (token prefix remnic_cg_).

--- a/packages/remnic-cli/src/cli-command-surface.test.ts
+++ b/packages/remnic-cli/src/cli-command-surface.test.ts
@@ -108,7 +108,8 @@ const DOCUMENTED_COMMANDS = [
   "wearables",
   "capsule",
   "offline",
-] as const;
+  "oauth",
+ ] as const;
 
 /**
  * The full set of top-level command names handled by `main()`'s switch
@@ -191,7 +192,8 @@ test("every recognised command dispatches to its own handler, not the banner", a
     "action-confidence": ["action-confidence"],
     capsule: ["capsule"],
     offline: ["offline", "status"],
-  };
+    oauth: ["oauth", "--help"],
+   };
 
   for (const command of ALL_COMMAND_NAMES) {
     const argv = fast[command];
@@ -364,4 +366,47 @@ test("capsule lineage without --fork-id is rejected with an error", async () => 
   const result = await runCli(["capsule", "lineage", "--root", "/tmp"]);
   assert.notEqual(result.exitCode, 0);
   assert.match(result.stderr, /--fork-id/);
+});
+
+test("oauth --help renders the oauth usage block (no banner)", async () => {
+  // Same pattern as `tree` / `capsule` no-subaction tests: --help is a
+  // deterministic in-process branch and should never fall through to the
+  // catch-all banner.
+  const result = await runCli(["oauth", "--help"]);
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /Usage: remnic oauth/);
+  assert.match(result.stdout, /oauth pending/);
+  assert.match(result.stdout, /oauth approve/);
+  assert.match(result.stdout, /oauth deny/);
+  assert.equal(result.stdout.includes(BANNER_MARKER), false);
+});
+
+test("oauth with an unknown subcommand prints usage and exits non-zero", async () => {
+  // Reaches the dispatcher (operator token gate runs first) and rejects
+  // the bogus subcommand. With no REMNIC_AUTH_TOKEN in the test env
+  // (the file-level isolation strips it) the token-gate fires before the
+  // subcommand switch — but the contract we care about is "non-zero exit
+  // + clear error", which both paths satisfy. Accept either message.
+  const result = await runCli(["oauth", "__bogus__"]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(
+    result.stderr + result.stdout,
+    /no operator token configured|Unknown oauth subcommand/,
+  );
+});
+
+test("oauth pending --format rejects an invalid value", async () => {
+  // Bad --format values are rejected before the operator-token check,
+  // so this is deterministic regardless of env state.
+  const result = await runCli(["oauth", "pending", "--format", "xml"]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /Invalid --format/);
+});
+
+test("oauth pending --format rejects a bare flag with no value", async () => {
+  // `--format` requires a value; a bare flag must error rather than
+  // silently default to "text" (CLAUDE.md rule 51 / cursor review #611).
+  const result = await runCli(["oauth", "pending", "--format"]);
+  assert.notEqual(result.exitCode, 0);
+  assert.match(result.stderr, /--format requires a value/);
 });

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4592,8 +4592,11 @@ function oauthFormatPendingText(pending: readonly OAuthPendingEntry[]): string {
   }
   const lines: string[] = [`Pending OAuth authorizations (${pending.length}):`];
   for (const txn of pending) {
+    const scopes = txn.scopes.length === 0 ? "(none)" : txn.scopes.join(" ");
+    const resource = txn.resource === null || txn.resource.length === 0 ? "(none)" : txn.resource;
     lines.push(
-      `  ref=${txn.ref}  client=${txn.clientId}  redirect=${txn.redirectUri}  expires=${txn.expiresAt}`,
+      `  ref=${txn.ref}  client=${txn.clientId}  redirect=${txn.redirectUri}`,
+      `      scopes=${scopes}  resource=${resource}  expires=${txn.expiresAt}`,
     );
   }
   return lines.join("\n");

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4439,6 +4439,26 @@ function oauthResolveBaseUrl(): string {
       }
     }
   }
+  // Env overrides win over the file, matching the daemon: startServer()
+  // merges REMNIC_HOST/REMNIC_PORT (ENGRAM_* legacy) over server.host/port,
+  // so the CLI must resolve the same endpoint or it targets the wrong port.
+  const envHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
+  if (typeof envHost === "string" && envHost.length > 0) {
+    host = envHost;
+  }
+  const envPortRaw = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
+  if (typeof envPortRaw === "string" && envPortRaw.length > 0) {
+    const envPort = Number(envPortRaw);
+    // Reject an explicitly-set-but-invalid port instead of silently
+    // falling back (the daemon rejects it too, so a bad value is a
+    // misconfiguration the operator must see, not paper over).
+    if (!Number.isInteger(envPort) || envPort < 1 || envPort > 65535) {
+      throw new Error(
+        `Invalid REMNIC_PORT/ENGRAM_PORT "${envPortRaw}": expected an integer in [1, 65535].`,
+      );
+    }
+    port = envPort;
+  }
   return `http://${host}:${port}`;
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4443,13 +4443,18 @@ function oauthResolveBaseUrl(): string {
 }
 
 /**
- * Resolve the operator bearer token. Priority matches the offline-sync
- * path: explicit `server.authToken` in the config, then
- * `REMNIC_AUTH_TOKEN` (with `ENGRAM_AUTH_TOKEN` as legacy alias). Returns
- * `undefined` when no token is configured; callers should fail loudly
- * rather than auto-pick a default.
+ * Resolve the operator bearer token, matching the daemon's precedence
+ * exactly. `startServer()` merges `REMNIC_AUTH_TOKEN` (env) OVER
+ * `server.authToken` (file), so the running daemon accepts the env token
+ * when both are set. This resolver therefore checks env FIRST, then the
+ * file value (with `ENGRAM_AUTH_TOKEN` as the legacy env alias). A file
+ * that still holds the literal `${REMNIC_AUTH_TOKEN}` placeholder no
+ * longer shadows the real env token. Returns `undefined` when no token is
+ * configured; callers fail loudly rather than auto-pick a default.
  */
 function oauthResolveOperatorToken(): string | undefined {
+  const envToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
+  if (typeof envToken === "string" && envToken.length > 0) return envToken;
   const raw = oauthReadConfigRecord(resolveConfigPath());
   if (raw && "server" in raw) {
     const server = raw.server;
@@ -4460,8 +4465,6 @@ function oauthResolveOperatorToken(): string | undefined {
       }
     }
   }
-  const envToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
-  if (typeof envToken === "string" && envToken.length > 0) return envToken;
   return undefined;
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4623,9 +4623,11 @@ function oauthPrintApprovalDetails(txn: OAuthPendingEntry): void {
   );
 }
 
-const OAUTH_USAGE = `remnic oauth — Manage pending OAuth authorizations (ChatGPT MCP)
+const OAUTH_USAGE = `Usage: remnic oauth <pending|approve|deny> [options]
 
-Usage:
+Manage pending OAuth authorizations (ChatGPT MCP).
+
+Subcommands:
   remnic oauth pending [--format json|text]            List pending authorization requests
   remnic oauth approve <ref> [--yes]                   Approve a pending request
   remnic oauth deny <ref>                              Deny a pending request
@@ -4639,13 +4641,12 @@ Server endpoints (operator bearer auth):
   POST /oauth/pending/<ref>/approve
   POST /oauth/pending/<ref>/deny`;
 
-async function cmdOAuth(rest: string[]): Promise<void> {
-  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") {
-    console.log(OAUTH_USAGE);
-    return;
-  }
-  const subcommand = rest[0];
-  const subRest = rest.slice(1);
+/**
+ * Resolve the operator token or exit. Called AFTER input validation in
+ * each subcommand branch — invalid input must be reported regardless of
+ * env/config state (rule: validate inputs first, deterministically).
+ */
+function oauthRequireOperatorToken(): string {
   const token = oauthResolveOperatorToken();
   if (!token) {
     console.error(
@@ -4653,15 +4654,70 @@ async function cmdOAuth(rest: string[]): Promise<void> {
     );
     process.exit(1);
   }
+  return token;
+}
+
+/**
+ * Strict argument validation for `remnic oauth` subcommands (rule: reject
+ * invalid CLI input explicitly; never silently ignore it). Walks the args
+ * once, rejects unknown options, and enforces the positional arity.
+ * Returns the positional args in order.
+ */
+function oauthValidateArgs(
+  args: string[],
+  spec: { flags: Record<string, "value" | "boolean">; maxPositionals: number; usage: string },
+): string[] {
+  const positionals: string[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg !== undefined && arg.startsWith("-")) {
+      if (seen.has(arg)) {
+        console.error(`Duplicate option "${arg}". ${spec.usage}`);
+        process.exit(1);
+      }
+      seen.add(arg);
+      const kind = spec.flags[arg];
+      if (kind === undefined) {
+        console.error(`Unknown option "${arg}". ${spec.usage}`);
+        process.exit(1);
+      }
+      if (kind === "value") {
+        const next = args[i + 1];
+        if (next === undefined || next.startsWith("-")) {
+          console.error(`${arg} requires a value. ${spec.usage}`);
+          process.exit(1);
+        }
+        i++; // skip the flag's value slot
+      }
+      continue;
+    }
+    if (arg !== undefined) positionals.push(arg);
+  }
+  if (positionals.length > spec.maxPositionals) {
+    console.error(`Unexpected argument "${positionals[spec.maxPositionals]}". ${spec.usage}`);
+    process.exit(1);
+  }
+  return positionals;
+}
+
+async function cmdOAuth(rest: string[]): Promise<void> {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") {
+    console.log(OAUTH_USAGE);
+    return;
+  }
+  const subcommand = rest[0];
+  const subRest = rest.slice(1);
 
   switch (subcommand) {
     case "pending": {
-      const formatPresent = hasFlag(subRest, "--format");
+      oauthValidateArgs(subRest, {
+        flags: { "--format": "value" },
+        maxPositionals: 0,
+        usage: "Usage: remnic oauth pending [--format json|text]",
+      });
       const formatRaw = resolveFlag(subRest, "--format");
-      if (formatPresent && (formatRaw === undefined || formatRaw === null)) {
-        console.error("--format requires a value. Use `--format json` or `--format text`.");
-        process.exit(1);
-      }
+      const formatPresent = hasFlag(subRest, "--format");
       const format = (() => {
         if (!formatPresent || formatRaw === undefined || formatRaw === null) return "text";
         const normalized = String(formatRaw).trim().toLowerCase();
@@ -4671,6 +4727,7 @@ async function cmdOAuth(rest: string[]): Promise<void> {
         }
         return normalized;
       })();
+      const token = oauthRequireOperatorToken();
       try {
         const payload = (await oauthFetch("GET", "/oauth/pending", token, undefined)) as
           | { pending?: OAuthPendingEntry[] }
@@ -4689,12 +4746,18 @@ async function cmdOAuth(rest: string[]): Promise<void> {
     }
 
     case "approve": {
-      const ref = subRest.find((arg) => !arg.startsWith("--"));
+      const positionals = oauthValidateArgs(subRest, {
+        flags: { "--yes": "boolean", "-y": "boolean" },
+        maxPositionals: 1,
+        usage: "Usage: remnic oauth approve <ref> [--yes]",
+      });
+      const ref = positionals[0];
       if (!ref) {
         console.error("Usage: remnic oauth approve <ref> [--yes]");
         process.exit(1);
       }
       const yes = hasFlag(subRest, "--yes") || hasFlag(subRest, "-y");
+      const token = oauthRequireOperatorToken();
       try {
         const payload = (await oauthFetch("GET", "/oauth/pending", token, undefined)) as
           | { pending?: OAuthPendingEntry[] }
@@ -4742,11 +4805,17 @@ async function cmdOAuth(rest: string[]): Promise<void> {
     }
 
     case "deny": {
-      const ref = subRest.find((arg) => !arg.startsWith("--"));
+      const positionals = oauthValidateArgs(subRest, {
+        flags: {},
+        maxPositionals: 1,
+        usage: "Usage: remnic oauth deny <ref>",
+      });
+      const ref = positionals[0];
       if (!ref) {
         console.error("Usage: remnic oauth deny <ref>");
         process.exit(1);
       }
+      const token = oauthRequireOperatorToken();
       try {
         const result = (await oauthFetch(
           "POST",

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -31,6 +31,7 @@
  *   sync              Diff-aware sync
  *   dedup             Find duplicate memories
  *   connectors        Manage host adapters
+ *   oauth <cmd>       Manage pending OAuth authorizations (ChatGPT MCP)
  */
 
 import fs from "node:fs";
@@ -399,7 +400,8 @@ type CommandName =
   | "xray"
   | "wearables"
   | "capsule"
-  | "offline";
+  | "offline"
+  | "oauth";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -4362,6 +4364,411 @@ async function cmdStatus(json: boolean): Promise<void> {
     console.log("Health: unable to reach server");
   } finally {
     clearTimeout(timeoutId);
+  }
+}
+// ── OAuth operator commands ─────────────────────────────────────────────────
+//
+// `remnic oauth <pending|approve|deny>` lets the operator manage pending
+// authorization requests served by `@remnic/server`'s OAuth 2.1 facade
+// (issue #1963 / ChatGPT developer-mode MCP). The daemon exposes three
+// bearer-protected endpoints (operator token is the same `server.authToken`
+// the rest of the access server accepts); this CLI is the only path the
+// human operator uses to approve or deny the requests those endpoints
+// represent.
+//
+// Reuses the same patterns as `cmdStatus` (host/port via
+// `resolveConfigPath` + the `server.port` default, bearer token from
+// `server.authToken` with the `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN`
+// env fallback already used by the offline token resolver) and the
+// `--format json|text` flag pattern from `cmdProcedural`.
+
+/** Shape of one entry in `GET /oauth/pending`. Mirrors the server response. */
+interface OAuthPendingEntry {
+  ref: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  resource: string | null;
+  createdAt: string;
+  expiresAt: string;
+}
+
+/** Result of a `POST /oauth/pending/<ref>/{approve,deny}` decision. */
+interface OAuthDecisionResponse {
+  ref: string;
+  status: "approved" | "denied";
+  redirect?: string;
+}
+
+/**
+ * Read + parse the remnic config file, returning a `Record<string, unknown>`
+ * view of its top level. Returns `undefined` on any IO / parse error so
+ * the caller can fall through to the env / default path. The cast is
+ * unavoidable here — `JSON.parse` returns `any` and the on-disk shape is
+ * user-authored — so this helper is the single point that materialises
+ * the unsafe boundary. Callers narrow with `typeof` / `in` at every
+ * access (rule: `ts-no-inline-cast-access`).
+ */
+function oauthReadConfigRecord(configPath: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function oauthResolveBaseUrl(): string {
+  const configPath = resolveConfigPath();
+  let port = 4318;
+  let host = "127.0.0.1";
+  const raw = oauthReadConfigRecord(configPath);
+  if (raw && "server" in raw) {
+    const server = raw.server;
+    if (server && typeof server === "object") {
+      const hostCandidate = (server as Record<string, unknown>).host;
+      if (typeof hostCandidate === "string" && hostCandidate.length > 0) {
+        host = hostCandidate;
+      }
+      const portCandidate = (server as Record<string, unknown>).port;
+      if (typeof portCandidate === "number" && Number.isInteger(portCandidate)) {
+        port = portCandidate;
+      }
+    }
+  }
+  return `http://${host}:${port}`;
+}
+
+/**
+ * Resolve the operator bearer token. Priority matches the offline-sync
+ * path: explicit `server.authToken` in the config, then
+ * `REMNIC_AUTH_TOKEN` (with `ENGRAM_AUTH_TOKEN` as legacy alias). Returns
+ * `undefined` when no token is configured; callers should fail loudly
+ * rather than auto-pick a default.
+ */
+function oauthResolveOperatorToken(): string | undefined {
+  const raw = oauthReadConfigRecord(resolveConfigPath());
+  if (raw && "server" in raw) {
+    const server = raw.server;
+    if (server && typeof server === "object" && "authToken" in server) {
+      const candidate = (server as Record<string, unknown>).authToken;
+      if (typeof candidate === "string" && candidate.length > 0) {
+        return candidate;
+      }
+    }
+  }
+  const envToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
+  if (typeof envToken === "string" && envToken.length > 0) return envToken;
+  return undefined;
+}
+
+/**
+ * Hit one of the operator OAuth endpoints. Centralises the auth header,
+ * the timeout, and the user-facing error mapping (401 → "operator token
+ * rejected"; connection refused → "is remnic-server running?"). The
+ * `JSON.parse` body is the result; status 204 / 200 with no body returns
+ * `null`. Throws on transport / status errors so the caller can
+ * translate the message into a CLI exit code.
+ */
+async function oauthFetch(
+  method: "GET" | "POST",
+  path: string,
+  token: string,
+  body: unknown | undefined,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${token}`,
+      accept: "application/json",
+    };
+    if (body !== undefined) {
+      headers["content-type"] = "application/json";
+    }
+    const init: RequestInit = {
+      method,
+      signal: controller.signal,
+      headers,
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+    const response = await fetch(`${oauthResolveBaseUrl()}${path}`, init);
+    if (response.status === 401) {
+      throw new Error(
+        "operator token rejected by remnic-server (HTTP 401). Update `server.authToken` or `REMNIC_AUTH_TOKEN` to match the running daemon.",
+      );
+    }
+    if (response.status === 404) {
+      throw new Error("unknown or expired ref");
+    }
+    if (response.status === 409) {
+      let description = "request conflicts with current state";
+      try {
+        const payload: unknown = await response.json();
+        if (
+          payload &&
+          typeof payload === "object" &&
+          "error_description" in payload
+        ) {
+          const candidate = (payload as Record<string, unknown>).error_description;
+          if (typeof candidate === "string" && candidate.length > 0) {
+            description = candidate;
+          }
+        }
+      } catch {
+        // Body wasn't JSON; keep the default description.
+      }
+      throw new Error(description);
+    }
+    if (!response.ok) {
+      throw new Error(`remnic-server returned HTTP ${response.status} ${response.statusText}`);
+    }
+    const text = await response.text();
+    if (text.length === 0) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error("remnic-server returned a non-JSON response");
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      const msg = err.message;
+      if (
+        msg.includes("ECONNREFUSED") ||
+        msg.includes("ECONNRESET") ||
+        msg.includes("fetch failed") ||
+        msg.includes("aborted") ||
+        msg.includes("ENOTFOUND")
+      ) {
+        throw new Error(
+          `cannot reach remnic-server at ${oauthResolveBaseUrl()} — is remnic-server running? Start it with \`remnic daemon start\`.`,
+        );
+      }
+      throw err;
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Render the pending list as a human-readable table. One line per entry:
+ *   ref <id>  client=<id>  redirect=<uri>  expires=<iso>
+ * Empty arrays produce the "No pending OAuth authorizations." line; the
+ * caller decides whether to add a trailing newline.
+ */
+function oauthFormatPendingText(pending: readonly OAuthPendingEntry[]): string {
+  if (pending.length === 0) {
+    return "No pending OAuth authorizations.";
+  }
+  const lines: string[] = [`Pending OAuth authorizations (${pending.length}):`];
+  for (const txn of pending) {
+    lines.push(
+      `  ref=${txn.ref}  client=${txn.clientId}  redirect=${txn.redirectUri}  expires=${txn.expiresAt}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Prompt the operator on a TTY. Returns true on `y` / `yes` (case
+ * insensitive), false on `n` / `no` / empty / EOF. Non-TTY callers MUST
+ * use `--yes` (or a similar explicit flag) — the `cmdOAuth` approve
+ * branch enforces that at the dispatch site.
+ */
+async function oauthPromptYesNo(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return false;
+  }
+  process.stdout.write(`${question} [y/N] `);
+  return new Promise<boolean>((resolve) => {
+    let buffer = "";
+    const onData = (chunk: Buffer | string): void => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      buffer += text;
+      if (text.includes("\n")) {
+        process.stdin.removeListener("data", onData);
+        process.stdin.pause();
+        const answer = buffer.trim().toLowerCase();
+        resolve(answer === "y" || answer === "yes");
+      }
+    };
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+  });
+}
+
+/** Print the full request details + warning before approval. */
+function oauthPrintApprovalDetails(txn: OAuthPendingEntry): void {
+  const scopeList = txn.scopes.length === 0 ? "(none)" : txn.scopes.join(" ");
+  const resource = txn.resource === null || txn.resource === undefined
+    ? "(none)"
+    : txn.resource;
+  console.log("Pending OAuth authorization request:");
+  console.log(`  ref:         ${txn.ref}`);
+  console.log(`  client:      ${txn.clientId}`);
+  console.log(`  redirect:    ${txn.redirectUri}`);
+  console.log(`  scopes:      ${scopeList}`);
+  console.log(`  resource:    ${resource}`);
+  console.log(`  created:     ${txn.createdAt}`);
+  console.log(`  expires:     ${txn.expiresAt}`);
+  console.log(
+    "WARNING: approval grants the requesting application an MCP access token tied to this Remnic instance.",
+  );
+}
+
+const OAUTH_USAGE = `remnic oauth — Manage pending OAuth authorizations (ChatGPT MCP)
+
+Usage:
+  remnic oauth pending [--format json|text]            List pending authorization requests
+  remnic oauth approve <ref> [--yes]                   Approve a pending request
+  remnic oauth deny <ref>                              Deny a pending request
+
+Options:
+  --format <name>   Output format for \`pending\`: "text" (default) or "json"
+  --yes             Required for \`approve\` when stdin is not a TTY
+
+Server endpoints (operator bearer auth):
+  GET  /oauth/pending
+  POST /oauth/pending/<ref>/approve
+  POST /oauth/pending/<ref>/deny`;
+
+async function cmdOAuth(rest: string[]): Promise<void> {
+  if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") {
+    console.log(OAUTH_USAGE);
+    return;
+  }
+  const subcommand = rest[0];
+  const subRest = rest.slice(1);
+  const token = oauthResolveOperatorToken();
+  if (!token) {
+    console.error(
+      "remnic oauth: no operator token configured. Set `server.authToken` in remnic.config.json or export REMNIC_AUTH_TOKEN.",
+    );
+    process.exit(1);
+  }
+
+  switch (subcommand) {
+    case "pending": {
+      const formatPresent = hasFlag(subRest, "--format");
+      const formatRaw = resolveFlag(subRest, "--format");
+      if (formatPresent && (formatRaw === undefined || formatRaw === null)) {
+        console.error("--format requires a value. Use `--format json` or `--format text`.");
+        process.exit(1);
+      }
+      const format = (() => {
+        if (!formatPresent || formatRaw === undefined || formatRaw === null) return "text";
+        const normalized = String(formatRaw).trim().toLowerCase();
+        if (normalized !== "text" && normalized !== "json") {
+          console.error(`Invalid --format "${formatRaw}". Allowed: text, json.`);
+          process.exit(1);
+        }
+        return normalized;
+      })();
+      try {
+        const payload = (await oauthFetch("GET", "/oauth/pending", token, undefined)) as
+          | { pending?: OAuthPendingEntry[] }
+          | null;
+        const pending = Array.isArray(payload?.pending) ? payload.pending : [];
+        if (format === "json") {
+          process.stdout.write(JSON.stringify(payload ?? { pending: [] }, null, 2) + "\n");
+          return;
+        }
+        console.log(oauthFormatPendingText(pending));
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      return;
+    }
+
+    case "approve": {
+      const ref = subRest.find((arg) => !arg.startsWith("--"));
+      if (!ref) {
+        console.error("Usage: remnic oauth approve <ref> [--yes]");
+        process.exit(1);
+      }
+      const yes = hasFlag(subRest, "--yes") || hasFlag(subRest, "-y");
+      try {
+        const payload = (await oauthFetch("GET", "/oauth/pending", token, undefined)) as
+          | { pending?: OAuthPendingEntry[] }
+          | null;
+        const pending = Array.isArray(payload?.pending) ? payload.pending : [];
+        const txn = pending.find((entry) => entry.ref === ref);
+        if (!txn) {
+          console.error(
+            `remnic oauth approve: no pending authorization with ref "${ref}". Run \`remnic oauth pending\` to see active requests.`,
+          );
+          process.exit(1);
+        }
+        oauthPrintApprovalDetails(txn);
+        let confirmed = yes;
+        if (!confirmed) {
+          if (!process.stdin.isTTY) {
+            console.error(
+              "remnic oauth approve: refusing to send the approval without an explicit --yes flag (stdin is not a TTY). Re-run with --yes to confirm.",
+            );
+            process.exit(1);
+          }
+          confirmed = await oauthPromptYesNo("Approve this request?");
+          if (!confirmed) {
+            console.log("Approval cancelled.");
+            return;
+          }
+        }
+        const result = (await oauthFetch(
+          "POST",
+          `/oauth/pending/${encodeURIComponent(ref)}/approve`,
+          token,
+          {},
+        )) as OAuthDecisionResponse | null;
+        const status = result?.status ?? "approved";
+        const redirect = result?.redirect;
+        console.log(`Approved ref=${ref} (status: ${status}).`);
+        if (typeof redirect === "string" && redirect.length > 0) {
+          console.log(`Client redirect: ${redirect}`);
+        }
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      return;
+    }
+
+    case "deny": {
+      const ref = subRest.find((arg) => !arg.startsWith("--"));
+      if (!ref) {
+        console.error("Usage: remnic oauth deny <ref>");
+        process.exit(1);
+      }
+      try {
+        const result = (await oauthFetch(
+          "POST",
+          `/oauth/pending/${encodeURIComponent(ref)}/deny`,
+          token,
+          {},
+        )) as OAuthDecisionResponse | null;
+        const status = result?.status ?? "denied";
+        console.log(`Denied ref=${ref} (status: ${status}).`);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      return;
+    }
+
+    default: {
+      console.error(
+        `Unknown oauth subcommand "${String(subcommand)}". Run \`remnic oauth --help\` for usage.`,
+      );
+      process.exit(1);
+    }
   }
 }
 
@@ -12044,6 +12451,15 @@ Options:
       break;
     }
 
+    case "oauth": {
+      // `remnic oauth <pending|approve|deny> [...]` — operator-side
+      // management of pending ChatGPT-MCP authorization requests. All
+      // network and rendering logic lives in cmdOAuth; the dispatcher
+      // just routes the slice.
+      await cmdOAuth(rest);
+      break;
+    }
+
     case "dedup": {
       const json = rest.includes("--json");
       cmdDedup(json);
@@ -12476,6 +12892,7 @@ Usage:
   remnic review <list|approve|dismiss|flag> [id]  Review inbox
   remnic sync <run|watch> [--source <dir>] Diff-aware sync
   remnic offline <prepare|sync|status|watch> Remote/offline memory sync
+  remnic oauth <pending|approve|deny> Manage pending OAuth authorizations (ChatGPT MCP)
   remnic dedup [--json]             Find duplicate memories
   remnic connectors <list|install|remove|doctor|marketplace> [id]  Manage connectors
     marketplace generate    Generate marketplace.json for Codex

--- a/packages/remnic-cli/src/oauth.test.ts
+++ b/packages/remnic-cli/src/oauth.test.ts
@@ -95,10 +95,13 @@ beforeEach(async () => {
  */
 function installFetchMock(handler: FetchHandler): { requests: CapturedRequest[] } {
   const requests: CapturedRequest[] = [];
+  // Structural param types (no DOM lib names): check-test-types runs
+  // without the browser lib, where `RequestInfo` does not resolve. The
+  // trailing `as typeof fetch` cast bridges to the real global signature.
   globalThis.fetch = (async (
-    input: RequestInfo | URL,
-    init: RequestInit = {},
-  ): Promise<Response> => {
+    input: string | URL | { url?: string },
+    init: { method?: string; headers?: Record<string, string>; body?: unknown } = {},
+  ) => {
     const url = typeof input === "string"
       ? input
       : input instanceof URL
@@ -515,6 +518,38 @@ test("oauth pending surfaces a clear error when the daemon returns non-JSON", as
     const result = await runCli(["oauth", "pending"]);
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /non-JSON response/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending rejects unknown options, duplicates, flag-as-value, and stray positionals", async () => {
+  const { requests } = installFetchMock(() => {
+    throw new Error("must not be called");
+  });
+  try {
+    const unknown = await runCli(["oauth", "pending", "--verbose"]);
+    assert.notEqual(unknown.exitCode, 0);
+    assert.match(unknown.stderr, /Unknown option "--verbose"/);
+
+    const duplicate = await runCli(["oauth", "pending", "--format", "json", "--format", "text"]);
+    assert.notEqual(duplicate.exitCode, 0);
+    assert.match(duplicate.stderr, /Duplicate option "--format"/);
+
+    // A flag in the value slot is a missing value, not a value.
+    const flagAsValue = await runCli(["oauth", "pending", "--format", "--yes"]);
+    assert.notEqual(flagAsValue.exitCode, 0);
+    assert.match(flagAsValue.stderr, /--format requires a value/);
+
+    const strayPositional = await runCli(["oauth", "pending", "extra"]);
+    assert.notEqual(strayPositional.exitCode, 0);
+    assert.match(strayPositional.stderr, /Unexpected argument "extra"/);
+
+    const strayApprove = await runCli(["oauth", "approve", "ref1", "ref2", "--yes"]);
+    assert.notEqual(strayApprove.exitCode, 0);
+    assert.match(strayApprove.stderr, /Unexpected argument "ref2"/);
+
+    assert.equal(requests.length, 0, "invalid input must never reach the daemon");
   } finally {
     restoreFetch();
   }

--- a/packages/remnic-cli/src/oauth.test.ts
+++ b/packages/remnic-cli/src/oauth.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Behaviour tests for `remnic oauth <pending|approve|deny>`.
+ *
+ * These tests mock `globalThis.fetch` (the only process-wide seam the
+ * dispatcher touches) and run the CLI in-process via `runCli` so the
+ * full switch + handler path is exercised. The mock records every
+ * request the CLI sends and serves canned responses, so the tests can
+ * assert both the auth header the CLI builds and the user-facing text it
+ * emits on the various error paths.
+ *
+ * `migrateFromEngram()` runs at the top of every non-migrate command and
+ * reads/writes ~/.remnic + ~/.engram, so the file-level HOME isolation
+ * (temp HOME) keeps that a no-op against an empty directory.
+ *
+ * `runCli` swaps `process.stdout` and `process.stderr` (not just their
+ * `.write` methods) and intercepts `process.exit`; tests rely on
+ * `RunCliResult.{stdout, stderr, exitCode}` for assertions. HOME and the
+ * `REMNIC_AUTH_TOKEN` / `ENGRAM_AUTH_TOKEN` env vars are isolated per
+ * test (no cross-test leakage).
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { after, before, beforeEach, test } from "node:test";
+
+import { runCli } from "./run-cli.js";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  authorization: string | null;
+  body: string;
+}
+
+interface FetchHandler {
+  (req: { url: string; method: string; body: string }):
+    | { status: number; body?: unknown }
+    | Promise<{ status: number; body?: unknown }>;
+}
+
+let tempHome = "";
+let originalHome: string | undefined;
+let originalFetch: typeof globalThis.fetch;
+let tempConfigDir = "";
+let originalFetchIsTTY: boolean | undefined;
+let originalStdinIsTTY: boolean | undefined;
+
+before(async () => {
+  originalHome = process.env.HOME;
+  tempHome = await mkdtemp(path.join(os.tmpdir(), "remnic-oauth-test-home-"));
+  process.env.HOME = tempHome;
+  originalFetch = globalThis.fetch;
+  // The TTY check in cmdOAuth matters for the approve flow: when stdin is
+  // not a TTY, --yes is required; when it IS a TTY, the prompt is shown.
+  // We force non-TTY for every test so the prompt path is never entered
+  // (which would block waiting for input). Tests that need to exercise
+  // the TTY path can flip the property on the fly.
+  originalStdinIsTTY = (process.stdin as { isTTY?: boolean }).isTTY;
+  (process.stdin as { isTTY?: boolean }).isTTY = false;
+  originalFetchIsTTY = (process.stdout as { isTTY?: boolean }).isTTY;
+  (process.stdout as { isTTY?: boolean }).isTTY = false;
+});
+
+after(async () => {
+  globalThis.fetch = originalFetch;
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  (process.stdin as { isTTY?: boolean }).isTTY = originalStdinIsTTY;
+  (process.stdout as { isTTY?: boolean }).isTTY = originalFetchIsTTY;
+  await rm(tempHome, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  // Each test gets a fresh temp config dir so resolveConfigPath() returns
+  // a path the dispatcher cannot accidentally read from a previous test.
+  // (resolveConfigPath() also walks ~/.config/remnic/config.json under
+  // HOME; HOME isolation already covers that.)
+  tempConfigDir = await mkdtemp(path.join(os.tmpdir(), "remnic-oauth-cfg-"));
+  // Default operator token for the suite. Individual tests can override
+  // by writing a config file with server.authToken.
+  process.env.REMNIC_AUTH_TOKEN = "test-operator-token";
+  // Pointer the dispatcher at the empty temp dir so it does not pick up
+  // a stray remnic.config.json the test runner dropped somewhere.
+  process.env.REMNIC_CONFIG_PATH = path.join(tempConfigDir, "remnic.config.json");
+});
+
+/**
+ * Install a fetch stub for the duration of a test. The stub records every
+ * request and routes through the supplied `handler`. The caller is
+ * responsible for the mock's response shape (status + optional JSON body).
+ */
+function installFetchMock(handler: FetchHandler): { requests: CapturedRequest[] } {
+  const requests: CapturedRequest[] = [];
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : (input as { url?: string }).url ?? String(input);
+    const method = (init.method ?? "GET").toUpperCase();
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    const body = typeof init.body === "string"
+      ? init.body
+      : init.body instanceof Uint8Array
+        ? Buffer.from(init.body).toString("utf8")
+        : "";
+    requests.push({
+      url,
+      method,
+      authorization: headers.authorization ?? headers.Authorization ?? null,
+      body,
+    });
+    const result = await handler({ url, method, body });
+    const responseBody = result.body === undefined
+      ? ""
+      : typeof result.body === "string"
+        ? result.body
+        : JSON.stringify(result.body);
+    return new Response(responseBody, {
+      status: result.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { requests };
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = originalFetch;
+}
+
+const SAMPLE_PENDING = {
+  pending: [
+    {
+      ref: "abc123",
+      clientId: "chatgpt-demo",
+      redirectUri: "https://chatgpt.com/oauth/callback",
+      scopes: ["mcp:read", "mcp:write"],
+      resource: "https://mcp.example.com",
+      createdAt: "2026-07-11T05:30:00.000Z",
+      expiresAt: "2026-07-11T05:40:00.000Z",
+    },
+  ],
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// `oauth pending` — list pending requests
+// ════════════════════════════════════════════════════════════════════════════
+
+test("oauth pending (text) renders the list and sends the bearer token", async () => {
+  const { requests } = installFetchMock(({ url, method }) => {
+    assert.match(url, /\/oauth\/pending$/);
+    assert.equal(method, "GET");
+    return { status: 200, body: SAMPLE_PENDING };
+  });
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].authorization, "Bearer test-operator-token");
+    assert.match(result.stdout, /Pending OAuth authorizations \(1\):/);
+    assert.match(result.stdout, /ref=abc123/);
+    assert.match(result.stdout, /client=chatgpt-demo/);
+    assert.match(result.stdout, /redirect=https:\/\/chatgpt\.com\/oauth\/callback/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending (text) reports the empty-state message when the list is empty", async () => {
+  installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stdout, /No pending OAuth authorizations\./);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending --format json emits the raw response body verbatim", async () => {
+  installFetchMock(() => ({ status: 200, body: SAMPLE_PENDING }));
+  try {
+    const result = await runCli(["oauth", "pending", "--format", "json"]);
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout.trim()) as { pending: unknown[] };
+    assert.equal(parsed.pending.length, 1);
+    const first = parsed.pending[0] as { ref: string; clientId: string };
+    assert.equal(first.ref, "abc123");
+    assert.equal(first.clientId, "chatgpt-demo");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending --format json falls back to an empty envelope on a null body", async () => {
+  installFetchMock(() => ({ status: 200, body: "" }));
+  try {
+    const result = await runCli(["oauth", "pending", "--format", "json"]);
+    assert.equal(result.exitCode, 0);
+    const parsed = JSON.parse(result.stdout.trim()) as { pending: unknown[] };
+    assert.deepEqual(parsed.pending, []);
+  } finally {
+    restoreFetch();
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// `oauth approve` — confirm + POST
+// ════════════════════════════════════════════════════════════════════════════
+
+test("oauth approve with --yes prints the request details and POSTs the decision", async () => {
+  const { requests } = installFetchMock(({ url, method }) => {
+    if (method === "GET" && /\/oauth\/pending$/.test(url)) {
+      return { status: 200, body: SAMPLE_PENDING };
+    }
+    if (method === "POST" && /\/oauth\/pending\/abc123\/approve$/.test(url)) {
+      return {
+        status: 200,
+        body: {
+          ref: "abc123",
+          status: "approved",
+          redirect: "https://chatgpt.com/oauth/callback?code=xyz",
+        },
+      };
+    }
+    return { status: 500, body: { error: "unexpected" } };
+  });
+  try {
+    const result = await runCli(["oauth", "approve", "abc123", "--yes"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    // Two requests: one GET to look up the ref, one POST to approve.
+    assert.equal(requests.length, 2);
+    const post = requests[1];
+    assert.equal(post.method, "POST");
+    assert.match(post.url, /\/oauth\/pending\/abc123\/approve$/);
+    assert.equal(post.authorization, "Bearer test-operator-token");
+    // Confirm the operator sees the details + the warning + the outcome.
+    assert.match(result.stdout, /ref:         abc123/);
+    assert.match(result.stdout, /client:      chatgpt-demo/);
+    assert.match(result.stdout, /redirect:    https:\/\/chatgpt\.com\/oauth\/callback/);
+    assert.match(result.stdout, /scopes:      mcp:read mcp:write/);
+    assert.match(result.stdout, /resource:    https:\/\/mcp\.example\.com/);
+    assert.match(
+      result.stdout,
+      /WARNING: approval grants the requesting application an MCP access token/,
+    );
+    assert.match(result.stdout, /Approved ref=abc123 \(status: approved\)\./);
+    assert.match(result.stdout, /Client redirect: https:\/\/chatgpt\.com\/oauth\/callback\?code=xyz/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth approve without --yes in a non-TTY refuses to POST the approval", async () => {
+  const { requests } = installFetchMock(({ url, method }) => {
+    if (method === "GET" && /\/oauth\/pending$/.test(url)) {
+      return { status: 200, body: SAMPLE_PENDING };
+    }
+    return { status: 500, body: { error: "should not be called" } };
+  });
+  try {
+    const result = await runCli(["oauth", "approve", "abc123"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(
+      result.stderr,
+      /refusing to send the approval without an explicit --yes flag/,
+    );
+    // The lookup GET may run (it does in the current implementation so
+    // the operator can see WHAT they would be approving), but the
+    // decision POST must NEVER happen — the no-TTY gate fires before it.
+    const decisions = requests.filter((req) => req.method === "POST");
+    assert.equal(
+      decisions.length,
+      0,
+      "approve without --yes must never POST to the decision endpoint",
+    );
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth approve with an unknown ref prints a clear error without POSTing", async () => {
+  const { requests } = installFetchMock(({ url, method }) => {
+    if (method === "GET" && /\/oauth\/pending$/.test(url)) {
+      return { status: 200, body: SAMPLE_PENDING };
+    }
+    return { status: 500, body: { error: "should not be called" } };
+  });
+  try {
+    const result = await runCli(["oauth", "approve", "nope", "--yes"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(
+      result.stderr,
+      /no pending authorization with ref "nope"/,
+    );
+    const decisions = requests.filter((req) => req.method === "POST");
+    assert.equal(
+      decisions.length,
+      0,
+      "approve with unknown ref must never POST to the decision endpoint",
+    );
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth approve without a ref prints usage and exits non-zero without any HTTP call", async () => {
+  const { requests } = installFetchMock(() => {
+    throw new Error("fetch must not be called when ref is missing");
+  });
+  try {
+    const result = await runCli(["oauth", "approve"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /Usage: remnic oauth approve <ref>/);
+    assert.equal(requests.length, 0);
+  } finally {
+    restoreFetch();
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// `oauth deny` — POST deny
+// ════════════════════════════════════════════════════════════════════════════
+
+test("oauth deny POSTs the deny decision and prints the outcome", async () => {
+  const { requests } = installFetchMock(({ url, method }) => {
+    if (method === "POST" && /\/oauth\/pending\/abc123\/deny$/.test(url)) {
+      return { status: 200, body: { ref: "abc123", status: "denied" } };
+    }
+    return { status: 500, body: { error: "unexpected" } };
+  });
+  try {
+    const result = await runCli(["oauth", "deny", "abc123"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].method, "POST");
+    assert.match(requests[0].url, /\/oauth\/pending\/abc123\/deny$/);
+    assert.equal(requests[0].authorization, "Bearer test-operator-token");
+    assert.match(result.stdout, /Denied ref=abc123 \(status: denied\)\./);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth deny without a ref prints usage and exits non-zero without any HTTP call", async () => {
+  const { requests } = installFetchMock(() => {
+    throw new Error("fetch must not be called when ref is missing");
+  });
+  try {
+    const result = await runCli(["oauth", "deny"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /Usage: remnic oauth deny <ref>/);
+    assert.equal(requests.length, 0);
+  } finally {
+    restoreFetch();
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Error mapping — 401 / connection refused / 404 / 409
+// ════════════════════════════════════════════════════════════════════════════
+
+test("oauth pending surfaces a clear 401 message when the daemon rejects the token", async () => {
+  installFetchMock(() => ({ status: 401, body: { error: "unauthorized" } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /operator token rejected/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending surfaces a clear 'is remnic-server running?' message on connection refused", async () => {
+  installFetchMock(() => {
+    // The Node undici fetch failure mode is an aggregate TypeError whose
+    // message contains "fetch failed" + a nested cause with ECONNREFUSED.
+    const cause = new Error("connect ECONNREFUSED 127.0.0.1:4318");
+    const err = new TypeError("fetch failed");
+    (err as Error & { cause?: unknown }).cause = cause;
+    throw err;
+  });
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /cannot reach remnic-server/);
+    assert.match(result.stderr, /is remnic-server running\?/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth approve maps 404 from the daemon to a clear 'unknown or expired ref' message", async () => {
+  // First GET (list) returns a pending entry; the POST to approve
+  // returns 404 (the daemon GCed the entry between the two requests).
+  installFetchMock(({ url, method }) => {
+    if (method === "GET") return { status: 200, body: SAMPLE_PENDING };
+    if (method === "POST") return { status: 404, body: { error: "invalid_request" } };
+    return { status: 500 };
+  });
+  try {
+    const result = await runCli(["oauth", "approve", "abc123", "--yes"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /unknown or expired ref/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth deny maps 409 with an error_description to a clear message", async () => {
+  installFetchMock(() => ({
+    status: 409,
+    body: { error: "invalid_request", error_description: "denied" },
+  }));
+  try {
+    const result = await runCli(["oauth", "deny", "abc123"]);
+    assert.notEqual(result.exitCode, 0);
+    // The server's error_description must reach the operator verbatim.
+    assert.match(result.stderr, /denied/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Operator token resolution
+// ════════════════════════════════════════════════════════════════════════════
+
+test("oauth with no operator token configured exits 1 with a clear error", async () => {
+  delete process.env.REMNIC_AUTH_TOKEN;
+  delete process.env.ENGRAM_AUTH_TOKEN;
+  // No server.authToken in the config file either (REMNIC_CONFIG_PATH
+  // points at a non-existent file). cmdOAuth must reject the call loudly
+  // instead of attempting the request.
+  let fetchCalled = false;
+  installFetchMock(() => {
+    fetchCalled = true;
+    return { status: 200, body: { pending: [] } };
+  });
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /no operator token configured/);
+    assert.equal(
+      fetchCalled,
+      false,
+      "must not hit the daemon when the operator token is missing",
+    );
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth prefers server.authToken from the config over REMNIC_AUTH_TOKEN", async () => {
+  // Write a config with server.authToken = "config-token" and confirm the
+  // CLI uses it (and not REMNIC_AUTH_TOKEN = "test-operator-token").
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH ?? "",
+    JSON.stringify({ server: { authToken: "config-token", port: 4318 } }),
+    "utf8",
+  );
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].authorization, "Bearer config-token");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth honours server.host and server.port from the config", async () => {
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH ?? "",
+    JSON.stringify({ server: { host: "10.0.0.42", port: 9999, authToken: "tok" } }),
+    "utf8",
+  );
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests.length, 1);
+    assert.match(requests[0].url, /^http:\/\/10\.0\.0\.42:9999\/oauth\/pending/);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth rejects an unknown subcommand with usage guidance and no HTTP call", async () => {
+  const { requests } = installFetchMock(() => {
+    throw new Error("must not be called");
+  });
+  try {
+    const result = await runCli(["oauth", "revoke-everything"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /Unknown oauth subcommand "revoke-everything"/);
+    assert.match(result.stderr, /remnic oauth --help/);
+    assert.equal(requests.length, 0, "invalid subcommands must never reach the daemon");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth pending surfaces a clear error when the daemon returns non-JSON", async () => {
+  installFetchMock(() => ({ status: 200, body: "<html>gateway error</html>" }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /non-JSON response/);
+  } finally {
+    restoreFetch();
+  }
+});

--- a/packages/remnic-cli/src/oauth.test.ts
+++ b/packages/remnic-cli/src/oauth.test.ts
@@ -549,6 +549,62 @@ test("oauth honours server.host and server.port from the config", async () => {
   }
 });
 
+test("oauth honours REMNIC_HOST/REMNIC_PORT env over server.host/port (matches daemon)", async () => {
+  // The daemon merges REMNIC_HOST/REMNIC_PORT over the file, so the CLI
+  // must target the same endpoint or it hits the wrong port.
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH ?? "",
+    JSON.stringify({ server: { host: "10.0.0.42", port: 9999, authToken: "tok" } }),
+    "utf8",
+  );
+  process.env.REMNIC_HOST = "192.168.5.5";
+  process.env.REMNIC_PORT = "7777";
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.match(requests[0].url, /^http:\/\/192\.168\.5\.5:7777\/oauth\/pending/);
+  } finally {
+    delete process.env.REMNIC_HOST;
+    delete process.env.REMNIC_PORT;
+    restoreFetch();
+  }
+});
+
+test("oauth rejects an invalid REMNIC_PORT instead of silently defaulting", async () => {
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  process.env.REMNIC_PORT = "abc";
+  try {
+    for (const bad of ["abc", "0", "70000", "42.5"]) {
+      process.env.REMNIC_PORT = bad;
+      const result = await runCli(["oauth", "pending"]);
+      assert.notEqual(result.exitCode, 0, `port "${bad}" must be rejected`);
+      assert.match(result.stderr, /Invalid REMNIC_PORT/);
+    }
+    assert.equal(requests.length, 0, "invalid port must never reach the daemon");
+  } finally {
+    delete process.env.REMNIC_PORT;
+    restoreFetch();
+  }
+});
+
+test("oauth honours legacy ENGRAM_HOST/ENGRAM_PORT when REMNIC_* are absent", async () => {
+  delete process.env.REMNIC_HOST;
+  delete process.env.REMNIC_PORT;
+  process.env.ENGRAM_HOST = "172.16.0.9";
+  process.env.ENGRAM_PORT = "5150";
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.match(requests[0].url, /^http:\/\/172\.16\.0\.9:5150\/oauth\/pending/);
+  } finally {
+    delete process.env.ENGRAM_HOST;
+    delete process.env.ENGRAM_PORT;
+    restoreFetch();
+  }
+});
+
 test("oauth rejects an unknown subcommand with usage guidance and no HTTP call", async () => {
   const { requests } = installFetchMock(() => {
     throw new Error("must not be called");

--- a/packages/remnic-cli/src/oauth.test.ts
+++ b/packages/remnic-cli/src/oauth.test.ts
@@ -171,6 +171,10 @@ test("oauth pending (text) renders the list and sends the bearer token", async (
     assert.match(result.stdout, /ref=abc123/);
     assert.match(result.stdout, /client=chatgpt-demo/);
     assert.match(result.stdout, /redirect=https:\/\/chatgpt\.com\/oauth\/callback/);
+    // Scopes + resource must be visible so an operator using `approve --yes`
+    // can vet the request from the listing (Codex review).
+    assert.match(result.stdout, /scopes=mcp:read mcp:write/);
+    assert.match(result.stdout, /resource=https:\/\/mcp\.example\.com/);
   } finally {
     restoreFetch();
   }

--- a/packages/remnic-cli/src/oauth.test.ts
+++ b/packages/remnic-cli/src/oauth.test.ts
@@ -461,9 +461,11 @@ test("oauth with no operator token configured exits 1 with a clear error", async
   }
 });
 
-test("oauth prefers server.authToken from the config over REMNIC_AUTH_TOKEN", async () => {
-  // Write a config with server.authToken = "config-token" and confirm the
-  // CLI uses it (and not REMNIC_AUTH_TOKEN = "test-operator-token").
+test("oauth uses REMNIC_AUTH_TOKEN over server.authToken (matches daemon env-over-file)", async () => {
+  // beforeEach sets REMNIC_AUTH_TOKEN = "test-operator-token". Even with a
+  // file token present, the daemon accepts the env token, so the CLI must
+  // too — otherwise approve/deny 401s against a daemon that merged env
+  // over file.
   await writeFile(
     process.env.REMNIC_CONFIG_PATH ?? "",
     JSON.stringify({ server: { authToken: "config-token", port: 4318 } }),
@@ -474,7 +476,57 @@ test("oauth prefers server.authToken from the config over REMNIC_AUTH_TOKEN", as
     const result = await runCli(["oauth", "pending"]);
     assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
     assert.equal(requests.length, 1);
+    assert.equal(requests[0].authorization, "Bearer test-operator-token");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth falls back to server.authToken when no env token is set", async () => {
+  delete process.env.REMNIC_AUTH_TOKEN;
+  delete process.env.ENGRAM_AUTH_TOKEN;
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH ?? "",
+    JSON.stringify({ server: { authToken: "config-token", port: 4318 } }),
+    "utf8",
+  );
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
     assert.equal(requests[0].authorization, "Bearer config-token");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("oauth uses ENGRAM_AUTH_TOKEN legacy alias only when REMNIC_AUTH_TOKEN is absent", async () => {
+  delete process.env.REMNIC_AUTH_TOKEN;
+  process.env.ENGRAM_AUTH_TOKEN = "legacy-token";
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests[0].authorization, "Bearer legacy-token");
+  } finally {
+    delete process.env.ENGRAM_AUTH_TOKEN;
+    restoreFetch();
+  }
+});
+
+test("oauth env token wins over a config still holding the ${REMNIC_AUTH_TOKEN} placeholder", async () => {
+  // A config initialized before the env was exported can hold the literal
+  // placeholder; the real env token must not be shadowed by it.
+  await writeFile(
+    process.env.REMNIC_CONFIG_PATH ?? "",
+    JSON.stringify({ server: { authToken: "${REMNIC_AUTH_TOKEN}", port: 4318 } }),
+    "utf8",
+  );
+  const { requests } = installFetchMock(() => ({ status: 200, body: { pending: [] } }));
+  try {
+    const result = await runCli(["oauth", "pending"]);
+    assert.equal(result.exitCode, 0, `unexpected stderr: ${result.stderr}`);
+    assert.equal(requests[0].authorization, "Bearer test-operator-token");
   } finally {
     restoreFetch();
   }

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -1454,3 +1454,268 @@ test("HTTP offline apply requires a changeset", async () => {
     await server.stop();
   }
 });
+
+test("HTTP server rejects invalid resourceMetadataUrl at construction", () => {
+  const service = {} as EngramAccessService;
+  for (const bad of ["not a url", "ftp://example.com/oauth", "//relative/path", ""]) {
+    assert.throws(
+      () =>
+        new EngramAccessHttpServer({
+          service,
+          port: 0,
+          authToken: "test-token",
+          adminConsoleEnabled: false,
+          resourceMetadataUrl: bad,
+        }),
+      /access HTTP resourceMetadataUrl/,
+      `resourceMetadataUrl=${JSON.stringify(bad)} must be rejected`,
+    );
+  }
+  // http and https are accepted.
+  for (const ok of [
+    "https://example.com/.well-known/oauth-protected-resource",
+    "http://127.0.0.1:8787/.well-known/oauth-protected-resource",
+  ]) {
+    const server = new EngramAccessHttpServer({
+      service,
+      port: 0,
+      authToken: "test-token",
+      adminConsoleEnabled: false,
+      resourceMetadataUrl: ok,
+    });
+    assert.ok(server, `resourceMetadataUrl=${ok} should be accepted`);
+  }
+});
+
+test("HTTP 401 www-authenticate carries resource_metadata exactly when configured", async () => {
+  const service = {} as EngramAccessService;
+  const metadataUrl = "https://example.test/.well-known/oauth-protected-resource";
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    resourceMetadataUrl: metadataUrl,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/health`);
+    assert.equal(response.status, 401);
+    assert.equal(
+      response.headers.get("www-authenticate"),
+      `Bearer resource_metadata="${metadataUrl}"`,
+    );
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP 401 www-authenticate is the bare Bearer challenge when resourceMetadataUrl is unset", async () => {
+  const service = {} as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/health`);
+    assert.equal(response.status, 401);
+    assert.equal(response.headers.get("www-authenticate"), "Bearer");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /mcp returns 405 with Allow: POST for GET and DELETE (authorized requests)", async () => {
+  const service = {} as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    for (const method of ["GET", "DELETE"]) {
+      const response = await fetch(`http://127.0.0.1:${status.port}/mcp`, {
+        method,
+        headers: { authorization: "Bearer test-token" },
+      });
+      assert.equal(response.status, 405, `${method} /mcp must be 405`);
+      assert.equal(response.headers.get("allow"), "POST", `${method} /mcp must advertise Allow: POST`);
+      const body = await response.json() as { code?: string };
+      assert.equal(body.code, "method_not_allowed");
+    }
+    // Unauthenticated GET /mcp still gets 401 first (auth gate beats method-conformance).
+    const unauth = await fetch(`http://127.0.0.1:${status.port}/mcp`, { method: "GET" });
+    assert.equal(unauth.status, 401);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /mcp rejects unknown MCP-Protocol-Version header with 400 JSON-RPC error", async () => {
+  const service = {} as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/mcp`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+        "mcp-protocol-version": "1999-01-01",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    assert.equal(response.status, 400);
+    const body = await response.json() as { jsonrpc?: string; error?: { message?: string } };
+    assert.equal(body.jsonrpc, "2.0");
+    assert.match(body.error?.message ?? "", /unsupported MCP-Protocol-Version/);
+
+    // A supported header is accepted (and a valid request proceeds normally).
+    for (const v of ["2025-06-18", "2025-03-26", "2024-11-05"]) {
+      const ok = await fetch(`http://127.0.0.1:${status.port}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+          "mcp-protocol-version": v,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+      assert.equal(ok.status, 200, `version ${v} should be accepted`);
+    }
+
+    // Absent header is also fine.
+    const absent = await fetch(`http://127.0.0.1:${status.port}/mcp`, {
+      method: "POST",
+      headers: { authorization: "Bearer test-token", "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    assert.equal(absent.status, 200);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP externalRequestHandler runs pre-auth, can end responses, and falls through on false", async () => {
+  // Minimal service stub: the fall-through leg hits /engram/v1/health, which
+  // calls service.health(). The stub is signature-faithful (full
+  // EngramAccessHealthResponse via `satisfies`) so interface drift fails here
+  // instead of passing vacuously; everything else in this test bypasses the
+  // service.
+  const healthStub = {
+    health: async () => ({
+      ok: true as const,
+      memoryDir: "/tmp/engram-test",
+      namespacesEnabled: false,
+      defaultNamespace: "default",
+      searchBackend: "recent",
+      qmdEnabled: false,
+      qmd: {
+        enabled: false,
+        active: false,
+        degraded: false,
+        mode: "disabled" as const,
+        collection: "",
+        collectionState: "skipped" as const,
+        installedVersion: null,
+        supportedVersion: null,
+        supported: null,
+        upgradeAvailable: null,
+        doctorAvailable: null,
+        debugStatus: "disabled",
+      },
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: false,
+    }),
+  } satisfies Pick<EngramAccessService, "health">;
+  const service = healthStub as EngramAccessService;
+  const seen: Array<{ path: string; method: string; authorized: boolean }> = [];
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    externalRequestHandler: async (_req, res, ctx) => {
+      seen.push({
+        path: new URL(_req.url ?? "/", "http://placeholder").pathname,
+        method: _req.method ?? "",
+        authorized: ctx.authorized,
+      });
+      if (new URL(_req.url ?? "/", "http://placeholder").pathname === "/probe/handled") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ handled: true, authorized: ctx.authorized }));
+        return true;
+      }
+      return false; // fall through to the normal pipeline
+    },
+  });
+  const status = await server.start();
+  try {
+    // Pre-auth, the handler sees authorized=false (no token sent).
+    const handled = await fetch(`http://127.0.0.1:${status.port}/probe/handled`);
+    assert.equal(handled.status, 200);
+    const handledBody = await handled.json() as { handled?: boolean; authorized?: boolean };
+    assert.equal(handledBody.handled, true);
+    assert.equal(handledBody.authorized, false, "handler must observe authorized=false pre-token");
+
+    // Fall-through path: same handler returns false, request continues to normal
+    // routing. Hit a real endpoint so we know the request reached it.
+    const passthrough = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/health`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(passthrough.status, 200, "fall-through should reach the normal health route");
+    const passthroughBody = await passthrough.json() as { ok?: boolean; memoryDir?: string };
+    assert.equal(passthroughBody.ok, true, "fall-through must return the stubbed health payload");
+    assert.equal(passthroughBody.memoryDir, "/tmp/engram-test");
+
+    // Authorized request: handler sees ctx.authorized=true.
+    const authed = await fetch(
+      `http://127.0.0.1:${status.port}/probe/handled`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    assert.equal(authed.status, 200);
+    const authedBody = await authed.json() as { authorized?: boolean };
+    assert.equal(authedBody.authorized, true, "handler must observe authorized=true with valid token");
+
+    assert.deepEqual(seen, [
+      { path: "/probe/handled", method: "GET", authorized: false },
+      { path: "/engram/v1/health", method: "GET", authorized: true },
+      { path: "/probe/handled", method: "GET", authorized: true },
+    ]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP externalRequestHandler errors flow through the existing error handler", async () => {
+  const service = {} as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    adminConsoleEnabled: false,
+    externalRequestHandler: async () => {
+      throw new Error("external-handler-explosion");
+    },
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/health`);
+    assert.equal(response.status, 500, "thrown errors must produce a 500 via the existing error handler");
+    const body = await response.json() as { code?: string };
+    assert.equal(body.code, "internal_error");
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -1615,7 +1615,7 @@ test("HTTP externalRequestHandler runs pre-auth, can end responses, and falls th
   const healthStub = {
     health: async () => ({
       ok: true as const,
-      memoryDir: "/tmp/engram-test",
+      memoryDir: "/tmp/remnic-test",
       namespacesEnabled: false,
       defaultNamespace: "default",
       searchBackend: "recent",
@@ -1677,7 +1677,7 @@ test("HTTP externalRequestHandler runs pre-auth, can end responses, and falls th
     assert.equal(passthrough.status, 200, "fall-through should reach the normal health route");
     const passthroughBody = await passthrough.json() as { ok?: boolean; memoryDir?: string };
     assert.equal(passthroughBody.ok, true, "fall-through must return the stubbed health payload");
-    assert.equal(passthroughBody.memoryDir, "/tmp/engram-test");
+    assert.equal(passthroughBody.memoryDir, "/tmp/remnic-test");
 
     // Authorized request: handler sees ctx.authorized=true.
     const authed = await fetch(
@@ -1715,6 +1715,91 @@ test("HTTP externalRequestHandler errors flow through the existing error handler
     assert.equal(response.status, 500, "thrown errors must produce a 500 via the existing error handler");
     const body = await response.json() as { code?: string };
     assert.equal(body.code, "internal_error");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP authTokenEntriesGetter is authoritative: scope policy binds connectors and never falls through", async () => {
+  // Signature-faithful health stub so non-MCP authorization outcomes are
+  // observable as 200-with-body (a bare `{}` service would 500 and mask
+  // accidental policy application).
+  const healthStub = {
+    health: async () => ({
+      ok: true as const,
+      memoryDir: "/tmp/remnic-scope-test",
+      namespacesEnabled: false,
+      defaultNamespace: "default",
+      searchBackend: "recent",
+      qmdEnabled: false,
+      qmd: {
+        enabled: false,
+        active: false,
+        degraded: false,
+        mode: "disabled" as const,
+        collection: "",
+        collectionState: "skipped" as const,
+        installedVersion: null,
+        supportedVersion: null,
+        supported: null,
+        upgradeAvailable: null,
+        doctorAvailable: null,
+        debugStatus: "disabled",
+      },
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: false,
+    }),
+  } satisfies Pick<EngramAccessService, "health">;
+  const entries = [
+    { token: "remnic_cg_scoped", connector: "chatgpt" },
+    { token: "remnic_cx_free", connector: "codex" },
+    { token: "remnic_xx_anon" }, // no connector — must fail closed under a policy
+  ];
+  const server = new EngramAccessHttpServer({
+    service: healthStub as EngramAccessService,
+    port: 0,
+    authToken: "operator-token",
+    // Dangerous shape on purpose: BOTH getters configured, and the string
+    // getter is a superset (extra "string_only_token"). The entries getter
+    // must decide alone; nothing may leak into the string getter.
+    authTokensGetter: () => [...entries.map((entry) => entry.token), "string_only_token"],
+    authTokenEntriesGetter: () => entries,
+    tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  const request = (token: string, path: string, method = "GET") =>
+    fetch(`http://127.0.0.1:${status.port}${path}`, {
+      method,
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      ...(method === "POST" ? { body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }) } : {}),
+    });
+  try {
+    // Scoped chatgpt token: /mcp only; health denied.
+    assert.equal((await request("remnic_cg_scoped", "/mcp", "POST")).status, 200);
+    assert.equal(
+      (await request("remnic_cg_scoped", "/engram/v1/health")).status,
+      401,
+      "chatgpt token must be denied off /mcp even with a permissive string getter present",
+    );
+    // Other connector tokens are unrestricted by this policy: /mcp AND health.
+    assert.equal((await request("remnic_cx_free", "/mcp", "POST")).status, 200);
+    const codexHealth = await request("remnic_cx_free", "/engram/v1/health");
+    assert.equal(codexHealth.status, 200);
+    assert.equal(((await codexHealth.json()) as { ok?: boolean }).ok, true);
+    // Entry without connector fails closed when a policy is configured.
+    assert.equal((await request("remnic_xx_anon", "/mcp", "POST")).status, 401);
+    // A token present ONLY in the string getter is NOT honored: the entries
+    // getter is authoritative and there is no fall-through.
+    assert.equal((await request("string_only_token", "/mcp", "POST")).status, 401);
+    assert.equal((await request("string_only_token", "/engram/v1/health")).status, 401);
+    // Unknown tokens are rejected everywhere.
+    assert.equal((await request("remnic_zz_unknown", "/mcp", "POST")).status, 401);
+    // Static operator token bypasses the policy entirely: /mcp AND health.
+    assert.equal((await request("operator-token", "/mcp", "POST")).status, 200);
+    const operatorHealth = await request("operator-token", "/engram/v1/health");
+    assert.equal(operatorHealth.status, 200);
+    assert.equal(((await operatorHealth.json()) as { ok?: boolean }).ok, true);
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -11,7 +11,7 @@ import { abortError, isAbortError } from "./abort-error.js";
 import { EngramAccessInputError, type EngramAccessService, type EngramAccessMemoryResponse, type EngramAccessWriteResponse } from "./access-service.js";
 import { CorrectionContractError } from "./correction/correction-contract.js";
 import { WearablesInputError } from "./wearables/errors.js";
-import { EngramMcpServer } from "./access-mcp.js";
+import { EngramMcpServer, MCP_SUPPORTED_PROTOCOL_VERSIONS } from "./access-mcp.js";
 import { validateRequest, type SchemaName, type SchemaTypeFor } from "./access-schema.js";
 import {
   OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
@@ -78,6 +78,28 @@ export interface EngramAccessHttpServerOptions {
    * existing health behavior.
    */
   readiness?: () => AccessHttpReadinessState;
+  /**
+   * When set, every 401 response includes
+   * `WWW-Authenticate: Bearer resource_metadata="<value>"` so MCP clients
+   * can discover the OAuth 2.0 protected-resource metadata document
+   * (RFC 9728). Must be an absolute http(s) URL; constructor throws on
+   * anything else. Unset → bare `Bearer`.
+   */
+  resourceMetadataUrl?: string;
+  /**
+   * Optional pre-auth request handler (e.g. OAuth facade mounted by
+   * `@remnic/server`). Runs after the admin-console handler and BEFORE
+   * bearer authorization. Return true if the request was fully handled
+   * (response ended). `ctx.authorized` reports whether the request
+   * carries a valid operator bearer token, so the handler can gate
+   * operator-only endpoints without owning token validation.
+   * Errors thrown by the handler flow into the existing error handling.
+   */
+  externalRequestHandler?: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    ctx: { authorized: boolean },
+  ) => Promise<boolean>;
 }
 
 export interface EngramAccessHttpServerStatus {
@@ -182,6 +204,23 @@ function parseHttpServerPort(port: number | undefined): number {
     throw new Error("access HTTP port must be an integer from 0 to 65535");
   }
   return port;
+}
+function assertResourceMetadataUrl(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(
+      `access HTTP resourceMetadataUrl must be an absolute http(s) URL, got: ${value}`,
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `access HTTP resourceMetadataUrl must use http or https, got: ${parsed.protocol}`,
+    );
+  }
+  return value;
 }
 
 function parseTrustZoneKindFilter(raw: string | null): TrustZoneRecordKind | undefined {
@@ -292,6 +331,12 @@ export class EngramAccessHttpServer {
   private readonly trustPrincipalHeader: boolean;
   private readonly adapterRegistry: AdapterRegistry | null;
   private readonly readiness: () => AccessHttpReadinessState;
+  private readonly resourceMetadataUrl?: string;
+  private readonly externalRequestHandler?: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    ctx: { authorized: boolean },
+  ) => Promise<boolean>;
   private readonly writeRequestTimestamps: number[] = [];
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
@@ -333,6 +378,8 @@ export class EngramAccessHttpServer {
     this.adminControls = options.adminControls;
     this.trustPrincipalHeader = options.trustPrincipalHeader === true;
     this.readiness = options.readiness ?? (() => ({ ready: true, warmupAttempts: 0 }));
+    this.resourceMetadataUrl = assertResourceMetadataUrl(options.resourceMetadataUrl);
+    this.externalRequestHandler = options.externalRequestHandler;
     this.adapterRegistry = options.enableAdapters !== false
       ? (options.adapterRegistry ?? new AdapterRegistry())
       : null;
@@ -642,11 +689,40 @@ export class EngramAccessHttpServer {
 
     }
 
+    // Run any host-supplied pre-auth request handler. It runs AFTER the
+    // admin-console branch (admin assets are public) and BEFORE the
+    // operator bearer gate. The handler decides whether it has fully
+    // owned the response (return true) or wants the request to fall
+    // through to the normal pipeline. `ctx.authorized` is computed
+    // here so the handler can implement operator-only endpoints
+    // (e.g. /oauth/pending) without owning token validation.
+    if (this.externalRequestHandler) {
+      const authorized = this.isAuthorized(req, pathname);
+      if (await this.externalRequestHandler(req, res, { authorized })) {
+        return;
+      }
+    }
+
     if (!this.isAuthorized(req, pathname)) {
       const body = JSON.stringify({ error: "unauthorized", code: "unauthorized" });
       res.writeHead(401, {
         "content-type": "application/json; charset=utf-8",
-        "www-authenticate": "Bearer",
+        "www-authenticate": this.bearerChallenge(),
+        "x-request-id": correlationId,
+      });
+      res.end(body);
+      return;
+    }
+
+    // Method-conformance for the streamable-HTTP MCP endpoint:
+    // GET/DELETE on /mcp must return 405 + Allow: POST instead of
+    // silently falling through to the generic 404. POST continues
+    // to the normal handler below.
+    if (pathname === "/mcp" && (req.method === "GET" || req.method === "DELETE")) {
+      const body = JSON.stringify({ error: "method_not_allowed", code: "method_not_allowed" });
+      res.writeHead(405, {
+        "content-type": "application/json; charset=utf-8",
+        allow: "POST",
         "x-request-id": correlationId,
       });
       res.end(body);
@@ -2682,7 +2758,28 @@ export class EngramAccessHttpServer {
   }
 
   private async handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // Reject requests that advertise an unknown MCP protocol version in
+    // the streamable-HTTP `MCP-Protocol-Version` header. Absent or
+    // valid → proceed. Unknown → 400 with a JSON-RPC-shaped error so
+    // the client surfaces a clear message. The supported set is
+    // exported by @remnic/core's access-mcp module to keep the
+    // version policy in a single place.
+    const headerVersion = req.headers["mcp-protocol-version"];
+    if (typeof headerVersion === "string" && headerVersion.length > 0) {
+      if (!(MCP_SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(headerVersion)) {
+        this.respondJson(res, 400, {
+          jsonrpc: "2.0",
+          id: null,
+          error: {
+            code: -32000,
+            message: `unsupported MCP-Protocol-Version: ${headerVersion}; supported: ${MCP_SUPPORTED_PROTOCOL_VERSIONS.join(", ")}`,
+          },
+        });
+        return;
+      }
+    }
     const body = await this.readJsonBody(req);
+
     const request = body as {
       jsonrpc?: string;
       id?: string | number | null;
@@ -3118,7 +3215,21 @@ export class EngramAccessHttpServer {
     return result.data as SchemaTypeFor<S>;
   }
 
-  private isAuthorized(req: IncomingMessage, pathname?: string): boolean {
+  /**
+   * Build the WWW-Authenticate challenge string for 401 responses.
+   * When `resourceMetadataUrl` is configured, includes the RFC 9728
+   * `resource_metadata` parameter so MCP clients (e.g. ChatGPT) can
+   * discover the OAuth 2.0 protected-resource metadata document.
+   * Otherwise the bare `Bearer` challenge is returned (unchanged).
+   */
+  private bearerChallenge(): string {
+    if (this.resourceMetadataUrl) {
+      return `Bearer resource_metadata="${this.resourceMetadataUrl}"`;
+    }
+    return "Bearer";
+  }
+
+   private isAuthorized(req: IncomingMessage, pathname?: string): boolean {
     if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter) return false;
     // Primary path: Authorization: Bearer <token> header.
     const raw = req.headers.authorization;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -54,6 +54,21 @@ export interface EngramAccessHttpServerOptions {
   authTokens?: string[];
   /** Dynamic token loader — called on each auth check so new/revoked tokens take effect without restart. */
   authTokensGetter?: () => string[];
+  /**
+   * Dynamic token-ENTRY loader ({token, connector} pairs from one coherent
+   * snapshot). Preferred over `authTokensGetter` when a `tokenPathPolicy`
+   * is set: the connector used for the policy decision comes from the SAME
+   * entry that validated, so identity can never lag validation.
+   */
+  authTokenEntriesGetter?: () => ReadonlyArray<{ token: string; connector?: string }>;
+  /**
+   * Optional per-request scope policy for tokens sourced from
+   * `authTokenEntriesGetter`. Return false to deny the (validated) token
+   * for this pathname. Static `authToken`/`authTokens` (operator-supplied)
+   * bypass the policy. Entries whose connector is missing FAIL CLOSED when
+   * a policy is configured.
+   */
+  tokenPathPolicy?: (connector: string, pathname: string | undefined) => boolean;
   principal?: string;
   maxBodyBytes?: number;
   adminConsoleEnabled?: boolean;
@@ -322,6 +337,8 @@ export class EngramAccessHttpServer {
   private readonly authToken?: string;
   private readonly authTokens: string[];
   private readonly authTokensGetter?: () => string[];
+  private readonly authTokenEntriesGetter?: () => ReadonlyArray<{ token: string; connector?: string }>;
+  private readonly tokenPathPolicy?: (connector: string, pathname: string | undefined) => boolean;
   private readonly authenticatedPrincipal?: string;
   private readonly maxBodyBytes: number;
   private readonly adminConsoleEnabled: boolean;
@@ -368,6 +385,8 @@ export class EngramAccessHttpServer {
     this.authToken = options.authToken?.trim() || undefined;
     this.authTokens = (options.authTokens ?? []).map((t) => t.trim()).filter(Boolean);
     this.authTokensGetter = options.authTokensGetter;
+    this.authTokenEntriesGetter = options.authTokenEntriesGetter;
+    this.tokenPathPolicy = options.tokenPathPolicy;
     this.authenticatedPrincipal = options.principal?.trim() || undefined;
     this.maxBodyBytes = Number.isFinite(options.maxBodyBytes)
       ? Math.max(1, Math.floor(options.maxBodyBytes ?? 131072))
@@ -398,7 +417,7 @@ export class EngramAccessHttpServer {
   }
 
   async start(): Promise<EngramAccessHttpServerStatus> {
-    if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter) {
+    if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter && !this.authTokenEntriesGetter) {
       throw new Error("engram access HTTP requires authToken or authTokens");
     }
     if (this.server) return this.status();
@@ -3230,7 +3249,14 @@ export class EngramAccessHttpServer {
   }
 
    private isAuthorized(req: IncomingMessage, pathname?: string): boolean {
-    if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter) return false;
+    if (
+      !this.authToken &&
+      this.authTokens.length === 0 &&
+      !this.authTokensGetter &&
+      !this.authTokenEntriesGetter
+    ) {
+      return false;
+    }
     // Primary path: Authorization: Bearer <token> header.
     const raw = req.headers.authorization;
     let candidate: string | null = null;
@@ -3270,7 +3296,24 @@ export class EngramAccessHttpServer {
     for (const valid of this.authTokens) {
       if (this.timingSafeStringEqual(token, valid)) return true;
     }
-    // Check dynamic tokens (reloaded per request for generate/revoke without restart)
+    // Entry-based dynamic tokens are AUTHORITATIVE when configured: the
+    // dynamic-token decision ends here (no fall-through to the string
+    // getter, which carries no identity and would bypass the policy).
+    // Validation and connector identity come from the same snapshot entry,
+    // so a scope policy can never observe a token fresher than the
+    // identity it scopes (mint/revoke coherence).
+    if (this.authTokenEntriesGetter) {
+      for (const entry of this.authTokenEntriesGetter()) {
+        if (!this.timingSafeStringEqual(token, entry.token)) continue;
+        if (!this.tokenPathPolicy) return true;
+        // Fail closed: a policy without a connector identity denies.
+        if (typeof entry.connector !== "string" || entry.connector.length === 0) return false;
+        return this.tokenPathPolicy(entry.connector, pathname);
+      }
+      return false;
+    }
+    // String-token getter (no identity, no policy) — only consulted when
+    // no entry getter is configured.
     if (this.authTokensGetter) {
       for (const valid of this.authTokensGetter()) {
         if (this.timingSafeStringEqual(token, valid)) return true;

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -109,7 +109,6 @@ const MCP_READ_ONLY_TOOL_SUFFIXES: Readonly<Record<string, true>> = {
   entity_get: true,
   review_queue_list: true,
   lcm_search: true,
-  continuity_audit_generate: true,
   continuity_incident_list: true,
   identity_anchor_get: true,
   memory_identity: true,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -78,7 +78,80 @@ type McpResource = {
   _meta?: Record<string, unknown>;
 };
 
-const MCP_PROTOCOL_VERSION = "2024-11-05";
+/**
+ * Conservative allowlist of canonical MCP tool suffixes that are
+ * unambiguously read-only. Tools in this set are tagged with
+ * `annotations: { readOnlyHint: true }` so ChatGPT (and other MCP
+ * clients that honor the hint) can skip per-call confirmation.
+ *
+ * The list is suffix-based so it covers both the `remnic.*` and
+ * `engram.*` naming forms. Anything not on it stays unannotated:
+ * uncertainty is resolved as "might mutate".
+ *
+ * Excluded by construction: anything that writes, runs a pipeline,
+ * flushes, applies, records, imports, or destructively deletes.
+ */
+const MCP_READ_ONLY_TOOL_SUFFIXES: Readonly<Record<string, true>> = {
+  recall: true,
+  recall_explain: true,
+  recall_tier_explain: true,
+  recall_xray: true,
+  briefing: true,
+  wearables_status: true,
+  transcript_day: true,
+  transcript_search: true,
+  transcript_memories: true,
+  action_confidence: true,
+  capsule_list: true,
+  procedural_stats: true,
+  memory_get: true,
+  memory_timeline: true,
+  entity_get: true,
+  review_queue_list: true,
+  lcm_search: true,
+  continuity_audit_generate: true,
+  continuity_incident_list: true,
+  identity_anchor_get: true,
+  memory_identity: true,
+  memory_search: true,
+  memory_profile: true,
+  memory_entities_list: true,
+  memory_questions: true,
+  memory_last_recall: true,
+  memory_intent_debug: true,
+  memory_qmd_debug: true,
+  memory_graph_explain: true,
+  graph_snapshot: true,
+  review_list: true,
+  profiling_report: true,
+  peer_list: true,
+  peer_get: true,
+  peer_profile_get: true,
+  console_state: true,
+  dreams_status: true,
+  codegraph_list_projects: true,
+  codegraph_index_status: true,
+  codegraph_search_graph: true,
+  codegraph_trace_path: true,
+  codegraph_detect_changes: true,
+  codegraph_query_graph: true,
+  codegraph_get_schema: true,
+  codegraph_get_snippet: true,
+  codegraph_get_architecture: true,
+  codegraph_search_code: true,
+};
+
+/**
+ * MCP protocol versions this server understands, ordered newest → oldest.
+ * Exported so the HTTP transport can validate the `MCP-Protocol-Version`
+ * header and reject requests advertising an unknown version.
+ */
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+];
+const MCP_DEFAULT_PROTOCOL_VERSION: string = MCP_SUPPORTED_PROTOCOL_VERSIONS[0] ?? "2025-06-18";
 const LEGACY_MCP_PREFIX = "engram.";
 const CANONICAL_MCP_PREFIX = "remnic.";
 
@@ -87,11 +160,25 @@ function toCanonicalToolName(name: string): string {
     ? `${CANONICAL_MCP_PREFIX}${name.slice(LEGACY_MCP_PREFIX.length)}`
     : name;
 }
-
 function toLegacyToolName(name: string): string {
   return name.startsWith(CANONICAL_MCP_PREFIX)
     ? `${LEGACY_MCP_PREFIX}${name.slice(CANONICAL_MCP_PREFIX.length)}`
     : name;
+}
+
+/**
+ * Suffix-based allowlist matcher. Returns true for tools whose canonical
+ * suffix (after stripping `remnic.` or `engram.`) is in
+ * {@link MCP_READ_ONLY_TOOL_SUFFIXES}. Unprefixed names are treated as
+ * unannotated.
+ */
+function isReadOnlyToolName(name: string): boolean {
+  for (const prefix of [CANONICAL_MCP_PREFIX, LEGACY_MCP_PREFIX]) {
+    if (name.startsWith(prefix)) {
+      return MCP_READ_ONLY_TOOL_SUFFIXES[name.slice(prefix.length)] === true;
+    }
+  }
+  return false;
 }
 
 function withToolAliases(tool: McpTool, emitLegacyTools = true): McpTool[] {
@@ -2342,6 +2429,17 @@ export class EngramMcpServer {
       );
       this.tools = [...this.tools, ...chatTools];
     }
+    // Apply `readOnlyHint` annotations to the conservative read-only
+    // allowlist. Done as a final pass so every spread (chat, codegraph,
+    // coding_*, correction, etc.) inherits the annotation without
+    // scattering the same logic across every `withToolAliases` call site.
+    // Suffix-based matching covers both the `remnic.*` and `engram.*`
+    // naming forms emitted by `withToolAliases`.
+    this.tools = this.tools.map((tool) =>
+      isReadOnlyToolName(tool.name) && tool.annotations?.readOnlyHint !== true
+        ? { ...tool, annotations: { ...(tool.annotations ?? {}), readOnlyHint: true } }
+        : tool,
+    );
   }
 
   /** Get clientInfo for a specific MCP session. Returns undefined for non-MCP requests. */
@@ -2369,6 +2467,24 @@ export class EngramMcpServer {
     }
     if (method === "initialize") {
       const params = request.params ?? {};
+      // MCP initialize REQUIRES params.protocolVersion (string). Reject a
+      // missing/mistyped field with JSON-RPC invalid params instead of
+      // silently negotiating (repo rule: never reinterpret invalid input).
+      // An unsupported-but-well-formed version gets the spec-mandated
+      // counter-offer below instead: the server answers with the newest
+      // version it supports and the client decides whether to proceed.
+      if (typeof params.protocolVersion !== "string" || params.protocolVersion.length === 0) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32602,
+            message:
+              "initialize requires params.protocolVersion (string); " +
+              `supported versions: ${MCP_SUPPORTED_PROTOCOL_VERSIONS.join(", ")}`,
+          },
+        };
+      }
       const rawClientInfo = params.clientInfo as { name?: string; version?: string } | undefined;
       // Generate a server-side session ID for this MCP session.
       // The caller should send this back as Mcp-Session-Id on subsequent requests.
@@ -2391,7 +2507,9 @@ export class EngramMcpServer {
         jsonrpc: "2.0",
         id,
         result: {
-          protocolVersion: MCP_PROTOCOL_VERSION,
+          protocolVersion: MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(params.protocolVersion)
+            ? params.protocolVersion
+            : MCP_DEFAULT_PROTOCOL_VERSION,
           capabilities: {
             tools: {},
             resources: {},

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -977,11 +977,14 @@ export {
 // ---------------------------------------------------------------------------
 
 export {
+  buildTokenEntry,
+  commitTokenEntry,
   generateToken,
   listTokens,
   revokeToken,
   getAllValidTokens,
   getAllValidTokensCached,
+  getAllValidTokenEntriesCached,
   resolveConnectorFromToken,
   loadTokenStore,
   saveTokenStore,

--- a/packages/remnic-core/src/tokens.test.ts
+++ b/packages/remnic-core/src/tokens.test.ts
@@ -8,6 +8,7 @@ import {
   buildTokenEntry,
   commitTokenEntry,
   generateToken,
+  getAllValidTokenEntriesCached,
   getAllValidTokensCached,
   loadTokenStore,
   revokeToken,
@@ -235,6 +236,32 @@ test("commitTokenEntry replaces the prior chatgpt entry so re-linking rotates th
     const chatgptEntries = store.tokens.filter((t) => t.connector === "chatgpt");
     assert.equal(chatgptEntries.length, 1, "only one chatgpt entry survives the rotate");
     assert.equal(chatgptEntries[0]?.token, second.token, "the new token is the surviving one");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("entries snapshot is coherent with validation: mint and revoke take effect immediately", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    // Warm the cache so a stale snapshot WOULD be observable if mutation
+    // failed to invalidate it.
+    assert.deepEqual([...getAllValidTokenEntriesCached(tokensPath)], []);
+
+    // Mint-then-use: the fresh token resolves with its connector in the
+    // SAME snapshot call that validates it — no window where the token is
+    // valid but its identity is unknown.
+    const minted = generateToken("chatgpt", tokensPath);
+    const afterMint = getAllValidTokenEntriesCached(tokensPath);
+    const found = afterMint.find((entry) => entry.token === minted.token);
+    assert.ok(found, "freshly minted token must appear immediately");
+    assert.equal(found.connector, "chatgpt");
+    assert.deepEqual(getAllValidTokensCached(tokensPath), [minted.token]);
+
+    // Revoke-then-use: the token disappears from the snapshot immediately.
+    assert.equal(revokeToken("chatgpt", tokensPath), true);
+    assert.deepEqual([...getAllValidTokenEntriesCached(tokensPath)], []);
+    assert.deepEqual(getAllValidTokensCached(tokensPath), []);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/tokens.test.ts
+++ b/packages/remnic-core/src/tokens.test.ts
@@ -208,3 +208,34 @@ test("generateToken uses a recognizable prefix for the omp connector", async () 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("generateToken uses a recognizable prefix for the chatgpt connector", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    const entry = generateToken("chatgpt", tokensPath);
+    assert.equal(entry.connector, "chatgpt");
+    assert.ok(
+      entry.token.startsWith("remnic_cg_"),
+      `expected remnic_cg_ prefix, got ${entry.token}`,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("commitTokenEntry replaces the prior chatgpt entry so re-linking rotates the token", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    const first = generateToken("chatgpt", tokensPath);
+    commitTokenEntry(first, tokensPath);
+    const second = generateToken("chatgpt", tokensPath);
+    commitTokenEntry(second, tokensPath);
+    assert.notEqual(first.token, second.token, "re-linking must mint a new token");
+    const store = loadTokenStore(tokensPath);
+    const chatgptEntries = store.tokens.filter((t) => t.connector === "chatgpt");
+    assert.equal(chatgptEntries.length, 1, "only one chatgpt entry survives the rotate");
+    assert.equal(chatgptEntries[0]?.token, second.token, "the new token is the surviving one");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/tokens.ts
+++ b/packages/remnic-core/src/tokens.ts
@@ -261,26 +261,36 @@ export function getAllValidTokens(tokensPath?: string): string[] {
   return loadTokenStore(tokensPath).tokens.map((t) => t.token);
 }
 
-// Cached token loader to avoid synchronous disk I/O on every HTTP request.
-// Re-reads tokens.json at most once per TTL interval (default 5s).
+// Cached token-entry snapshot to avoid synchronous disk I/O on every HTTP
+// request. Re-reads tokens.json at most once per TTL interval (default 5s).
+// There is deliberately exactly ONE cache: validation (token strings) and
+// identity (connector ids) are derived from the SAME snapshot, so a token
+// can never validate against a fresher snapshot than the one that resolves
+// its connector. saveTokenStore() invalidates on every mutation, so a
+// freshly minted or revoked token is coherent immediately.
 const TOKEN_CACHE_TTL_MS = 5_000;
-let _cachedTokens: string[] = [];
+let _cachedEntries: TokenEntry[] = [];
 let _cachedAt = 0;
 let _cachedPath: string | undefined;
 
 function invalidateTokenCache(): void {
-  _cachedTokens = [];
+  _cachedEntries = [];
   _cachedAt = 0;
   _cachedPath = undefined;
 }
 
-export function getAllValidTokensCached(tokensPath?: string): string[] {
+/** Cached token-entry snapshot ({token, connector} pairs). */
+export function getAllValidTokenEntriesCached(tokensPath?: string): readonly TokenEntry[] {
   const now = Date.now();
-  if (now - _cachedAt < TOKEN_CACHE_TTL_MS && tokensPath === _cachedPath) return _cachedTokens;
-  _cachedTokens = getAllValidTokens(tokensPath);
+  if (now - _cachedAt < TOKEN_CACHE_TTL_MS && tokensPath === _cachedPath) return _cachedEntries;
+  _cachedEntries = loadTokenStore(tokensPath).tokens;
   _cachedAt = now;
   _cachedPath = tokensPath;
-  return _cachedTokens;
+  return _cachedEntries;
+}
+
+export function getAllValidTokensCached(tokensPath?: string): string[] {
+  return getAllValidTokenEntriesCached(tokensPath).map((entry) => entry.token);
 }
 
 export function resolveConnectorFromToken(token: string, tokensPath?: string): string | undefined {

--- a/packages/remnic-core/src/tokens.ts
+++ b/packages/remnic-core/src/tokens.ts
@@ -36,6 +36,7 @@ const TOKEN_PREFIXES: Record<string, string> = {
   "windsurf": "remnic_ws_",
   "amp": "remnic_am_",
   "generic-mcp": "remnic_gm_",
+  "chatgpt": "remnic_cg_",
 };
 
 function defaultTokensPath(): string {

--- a/packages/remnic-server/README.md
+++ b/packages/remnic-server/README.md
@@ -45,6 +45,8 @@ enables the admin console explicitly and serves it at `/engram/ui/`. Package
 installs keep the console disabled unless `server.adminConsoleEnabled` or
 `REMNIC_ADMIN_CONSOLE_ENABLED=true` is set with a public asset directory.
 
+For the public ChatGPT developer-mode flow (Tailscale Funnel / Cloudflare Tunnel + OAuth 2.1 with local operator approval), see [docs/integration/chatgpt.md](../../docs/integration/chatgpt.md).
+
 The package also ships the legacy `engram-server` binary for compatibility.
 The bin wrappers are source-controlled so package managers can link them during
 workspace installs; release builds verify that both targets have Node shebangs

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -31,10 +31,13 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:^"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@remnic/core": "workspace:^",
+    "express": "^4.21.2"
   },
   "devDependencies": {
     "@remnic/core": "workspace:^",
+    "@types/express": "^4.17.21",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@remnic/core": "workspace:^",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.5.2"
   },
   "devDependencies": {
     "@remnic/core": "workspace:^",

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -14,7 +14,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
+import { parseConfig, isOpenaiApiKeyDisabled, resolveRemnicConfigRecord, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, getAllValidTokenEntriesCached, expandTildePath, type PluginConfig, type RemnicAdminControls, type RemnicAdminDashboardStatus, type RemnicAdminModelOption, type RemnicAdminConfigPatch } from "@remnic/core";
+import { applyOAuthEnvOverrides, buildOAuthRequestHandler } from "./oauth.js";
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -30,6 +31,8 @@ export interface ServerConfig {
     adminConsolePublicDir?: string;
     adminConsolePrefillToken?: boolean;
     readinessOverride?: boolean;
+    /** OAuth authorization-server facade for ChatGPT dev-mode apps (parsed by oauth.ts). */
+    oauth?: unknown;
   };
 }
 
@@ -951,13 +954,24 @@ export async function startServer(options?: {
   if (!authToken && getAllValidTokens().length === 0) {
     log.warn("No auth token set — server will reject all requests. Set REMNIC_AUTH_TOKEN, server.authToken in config, or generate tokens with 'remnic token generate'.");
   }
+  // OAuth facade (ChatGPT developer-mode apps): file block < REMNIC_OAUTH_* env.
+  // Parsed strictly — invalid values abort startup with a precise message.
+  const oauthConfig = applyOAuthEnvOverrides((serverConfig as { oauth?: unknown }).oauth);
+  const oauthRequestHandler = buildOAuthRequestHandler(oauthConfig);
+
 
   const httpServer = new EngramAccessHttpServer({
     service,
     host: parsedServerConfig.host,
     port: parsedServerConfig.port,
     authToken: authToken || undefined,
-    authTokensGetter: () => getAllValidTokensCached(),
+    // Entry-based getter: validation + connector identity from ONE cached
+    // snapshot (see tokens.ts). The path policy pins ChatGPT-minted OAuth
+    // tokens (connector "chatgpt") to the MCP endpoint only — they never
+    // authorize REST/admin routes. All other connector tokens keep full
+    // access, matching pre-OAuth behavior.
+    authTokenEntriesGetter: () => getAllValidTokenEntriesCached(),
+    tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
     readiness: () => readiness,
     principal: parsedServerConfig.principal,
     maxBodyBytes: parsedServerConfig.maxBodyBytes,
@@ -972,6 +986,15 @@ export async function startServer(options?: {
     citationsEnabled: config.citationsEnabled,
     citationsAutoDetect: config.citationsAutoDetect,
     emitLegacyTools: config.emitLegacyTools,
+    ...(oauthConfig.enabled
+      ? {
+          externalRequestHandler: oauthRequestHandler,
+          resourceMetadataUrl: new URL(
+            "/.well-known/oauth-protected-resource/mcp",
+            oauthConfig.issuerUrl,
+          ).href,
+        }
+      : {}),
   });
 
   let host: string;

--- a/packages/remnic-server/src/oauth.test.ts
+++ b/packages/remnic-server/src/oauth.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash, randomBytes } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +13,13 @@ import {
   getAllValidTokenEntriesCached,
   revokeToken,
 } from "@remnic/core";
-import { buildOAuthRequestHandler, parseOAuthConfig, applyOAuthEnvOverrides, type ParsedOAuthConfig } from "./oauth.js";
+import {
+  buildOAuthRequestHandler,
+  OAuthState,
+  parseOAuthConfig,
+  applyOAuthEnvOverrides,
+  type ParsedOAuthConfig,
+} from "./oauth.js";
 
 const OPERATOR_TOKEN = "operator-test-token";
 const CLIENT_ID = "remnic-chatgpt-test";
@@ -739,5 +745,139 @@ test("rate limiting: decision bucket returns JSON 429 when exhausted; poll bucke
     assert.notEqual(poll.status, 429, "poll bucket must not be consumed by decision traffic");
   } finally {
     await h.cleanup();
+  }
+});
+
+test("OAuthState.reviveCode: a persist failure can un-burn the code so the exchange retries", () => {
+  const config = parseOAuthConfig({
+    enabled: true,
+    issuerUrl: "http://127.0.0.1:4318",
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUris: [REDIRECT_URI],
+  });
+  const state = new OAuthState(config);
+  const txn = state.createPending({
+    clientId: CLIENT_ID,
+    redirectUri: REDIRECT_URI,
+    scopes: [],
+    resource: undefined,
+    state: undefined,
+    codeChallenge: "x".repeat(43),
+  });
+  const { code } = state.approveByRef(txn.ref);
+
+  // First exchange consumes the code.
+  const first = state.takeCode({ code, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, resource: undefined });
+  assert.ok(first, "first takeCode must succeed");
+  // Single-use: a second attempt is rejected while consumed.
+  assert.equal(
+    state.takeCode({ code, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, resource: undefined }),
+    undefined,
+    "a consumed code must not be reusable",
+  );
+  // Simulating a token-persist failure: revive, then the retry succeeds.
+  state.reviveCode(code);
+  const retry = state.takeCode({ code, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, resource: undefined });
+  assert.ok(retry, "revived code must be exchangeable again");
+
+  // A binding mismatch is NOT revived by reviveCode (only un-burns; the
+  // wrong-client attempt below still fails on its own merits).
+  state.reviveCode(code);
+  assert.equal(
+    state.takeCode({ code, clientId: "someone-else", redirectUri: REDIRECT_URI, resource: undefined }),
+    undefined,
+    "wrong client_id must still be rejected after revive",
+  );
+});
+
+test("token exchange: persist failure returns 500 and preserves the code; retry after recovery succeeds once", async () => {
+  // tokensPath lives in a read-only directory, so token-store LOAD (file
+  // absent → empty) works but the WRITE fails with EACCES — forcing the
+  // real catch in exchangeAuthorizationCode without breaking reads.
+  // Restoring write permission lets a retry of the SAME code succeed,
+  // proving the code was not burned by the failed persist.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-oauth-persistfail-"));
+  const roDir = path.join(dir, "ro");
+  await mkdir(roDir, { recursive: true });
+  await chmod(roDir, 0o555);
+  const tokensPath = path.join(roDir, "tokens.json"); // parent is read-only → EACCES on write
+  const port = await reserveFreePort();
+  const issuer = `http://127.0.0.1:${port}`;
+  const config = parseOAuthConfig({
+    enabled: true,
+    issuerUrl: issuer,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUris: [REDIRECT_URI],
+  });
+  const server = new EngramAccessHttpServer({
+    service: serviceStub as EngramAccessService,
+    host: "127.0.0.1",
+    port,
+    authToken: OPERATOR_TOKEN,
+    authTokenEntriesGetter: () => getAllValidTokenEntriesCached(tokensPath),
+    tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
+    adminConsoleEnabled: false,
+    externalRequestHandler: buildOAuthRequestHandler(config, { tokensPath }),
+  });
+  await server.start();
+  try {
+    const { verifier, challenge } = pkcePair();
+    const authorizeUrl = new URL("/authorize", issuer);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("client_id", CLIENT_ID);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    assert.equal((await fetch(authorizeUrl)).status, 200);
+    const pending = (await (
+      await fetch(`${issuer}/oauth/pending`, { headers: { authorization: `Bearer ${OPERATOR_TOKEN}` } })
+    ).json()) as { pending: Array<{ ref: string }> };
+    const ref = pending.pending[0]?.ref;
+    assert.ok(ref);
+    const approve = (await (
+      await fetch(`${issuer}/oauth/pending/${ref}/approve`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+      })
+    ).json()) as { redirect: string };
+    const code = new URL(approve.redirect).searchParams.get("code");
+    assert.ok(code);
+
+    const exchange = () =>
+      fetch(`${issuer}/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: verifier,
+          redirect_uri: REDIRECT_URI,
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+        }),
+      });
+
+    // Persist fails → 500 server_error, no token minted.
+    const failed = await exchange();
+    assert.equal(failed.status, 500);
+    assert.equal(((await failed.json()) as { error?: string }).error, "server_error");
+    assert.deepEqual([...getAllValidTokenEntriesCached(tokensPath)], [], "no token may be persisted on failure");
+
+    // Recover: restore write permission so the token store can persist.
+    await chmod(roDir, 0o755);
+    const ok = await exchange();
+    assert.equal(ok.status, 200, `retry must succeed after recovery: ${await ok.clone().text()}`);
+    assert.match(((await ok.json()) as { access_token: string }).access_token, /^remnic_cg_/);
+
+    // Single-use preserved: a third attempt with the now-spent code fails.
+    const replay = await exchange();
+    assert.equal(replay.status, 400);
+    assert.equal(((await replay.json()) as { error?: string }).error, "invalid_grant");
+  } finally {
+    await server.stop();
+    await chmod(roDir, 0o755).catch(() => {});
+    await rm(dir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-server/src/oauth.test.ts
+++ b/packages/remnic-server/src/oauth.test.ts
@@ -705,3 +705,39 @@ test("oauth config parsing rejects invalid input and applies env overrides", asy
     "https://chatgpt.com/connector/oauth/b",
   ]);
 });
+
+test("rate limiting: decision bucket returns JSON 429 when exhausted; poll bucket stays independent", async () => {
+  const h = await startHarness();
+  try {
+    // The decision limiter is 30/min. Fire 31 approve attempts against a
+    // non-existent ref (each would otherwise be a 404) — the 31st must be
+    // a 429 from the limiter, proving the operator mutation route is
+    // rate-limited.
+    let sawRateLimit = false;
+    let rateLimitBody: { error?: string } | undefined;
+    for (let i = 0; i < 31; i++) {
+      const resp = await fetch(`${h.issuer}/oauth/pending/no-such-ref/approve`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+      });
+      if (resp.status === 429) {
+        sawRateLimit = true;
+        rateLimitBody = (await resp.json()) as { error?: string };
+        break;
+      }
+    }
+    assert.equal(sawRateLimit, true, "decision route must 429 once its bucket is exhausted");
+    assert.equal(rateLimitBody?.error, "rate_limited", "429 body must be deterministic JSON");
+
+    // The poll bucket is independent: even after the decision limiter
+    // tripped, a poll still gets a normal (non-429) response.
+    const poll = await fetch(`${h.issuer}/oauth/authorize/poll`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ txn: "f".repeat(32), pollSecret: "0".repeat(32) }),
+    });
+    assert.notEqual(poll.status, 429, "poll bucket must not be consumed by decision traffic");
+  } finally {
+    await h.cleanup();
+  }
+});

--- a/packages/remnic-server/src/oauth.test.ts
+++ b/packages/remnic-server/src/oauth.test.ts
@@ -923,3 +923,37 @@ test("poll reports expired (not approved) once the authorization code is gone", 
   const afterConsume = state.poll(txn.txn, txn.pollSecret);
   assert.equal(afterConsume?.status, "expired", "poll must not redirect with a spent/expired code");
 });
+
+test("approved transactions survive the pending TTL while the authorization code is still live", (t) => {
+  t.mock.timers.enable({ apis: ["Date"] });
+  try {
+    const config = parseOAuthConfig({
+      enabled: true,
+      issuerUrl: "http://127.0.0.1:4318",
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      redirectUris: [REDIRECT_URI],
+      approvalTtlSeconds: 1, // 1 s pending TTL vs 120 s code TTL
+    });
+    const state = new OAuthState(config);
+    const txn = state.createPending({
+      clientId: CLIENT_ID,
+      redirectUri: REDIRECT_URI,
+      scopes: [],
+      resource: undefined,
+      state: undefined,
+      codeChallenge: "x".repeat(43),
+    });
+    state.approveByRef(txn.ref);
+    // Advance PAST the 1 s pending TTL but well within the 120 s code TTL.
+    t.mock.timers.tick(1_500);
+    const stillApproved = state.poll(txn.txn, txn.pollSecret);
+    assert.equal(stillApproved?.status, "approved", "approval before the deadline must remain redeemable");
+    // Advance past the code TTL: now both code and txn are gone.
+    t.mock.timers.tick(120_000);
+    const afterCode = state.poll(txn.txn, txn.pollSecret);
+    assert.equal(afterCode?.status, "expired");
+  } finally {
+    t.mock.timers.reset();
+  }
+});

--- a/packages/remnic-server/src/oauth.test.ts
+++ b/packages/remnic-server/src/oauth.test.ts
@@ -1,0 +1,707 @@
+import assert from "node:assert/strict";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  EngramAccessHttpServer,
+  type EngramAccessService,
+  generateToken,
+  getAllValidTokenEntriesCached,
+  revokeToken,
+} from "@remnic/core";
+import { buildOAuthRequestHandler, parseOAuthConfig, applyOAuthEnvOverrides, type ParsedOAuthConfig } from "./oauth.js";
+
+const OPERATOR_TOKEN = "operator-test-token";
+const CLIENT_ID = "remnic-chatgpt-test";
+const CLIENT_SECRET = "s3cret-e2e-value";
+const REDIRECT_URI = "https://chatgpt.com/connector/oauth/cb_test123";
+
+/** Reserve a free TCP port so the issuer URL can be fixed before start. */
+async function reserveFreePort(): Promise<number> {
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const probe = net.createServer();
+  probe.once("error", reject);
+  probe.listen(0, "127.0.0.1", () => {
+    const address = probe.address();
+    if (address && typeof address === "object") {
+      const { port } = address;
+      probe.close(() => resolve(port));
+    } else {
+      probe.close(() => reject(new Error("no address")));
+    }
+  });
+  return promise;
+}
+
+function pkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(48).toString("base64url");
+  const challenge = createHash("sha256").update(verifier, "ascii").digest("base64url");
+  return { verifier, challenge };
+}
+
+// Signature-faithful minimal service stub: only health() is exercised by
+// these tests (scope-policy checks against a REST route).
+const serviceStub = {
+  health: async () => ({
+    ok: true as const,
+    memoryDir: "/tmp/remnic-oauth-test",
+    namespacesEnabled: false,
+    defaultNamespace: "default",
+    searchBackend: "recent",
+    qmdEnabled: false,
+    qmd: {
+      enabled: false,
+      active: false,
+      degraded: false,
+      mode: "disabled" as const,
+      collection: "",
+      collectionState: "skipped" as const,
+      installedVersion: null,
+      supportedVersion: null,
+      supported: null,
+      upgradeAvailable: null,
+      doctorAvailable: null,
+      debugStatus: "disabled",
+    },
+    nativeKnowledgeEnabled: false,
+    projectionAvailable: false,
+  }),
+} satisfies Pick<EngramAccessService, "health">;
+
+interface Harness {
+  issuer: string;
+  tokensPath: string;
+  server: EngramAccessHttpServer;
+  config: ParsedOAuthConfig;
+  cleanup: () => Promise<void>;
+}
+
+/** Boot the access server with the OAuth facade wired exactly like startServer(). */
+async function startHarness(overrides?: Partial<Record<string, unknown>>): Promise<Harness> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-oauth-"));
+  const tokensPath = path.join(dir, "tokens.json");
+  const port = await reserveFreePort();
+  const issuer = `http://127.0.0.1:${port}`;
+  const config = parseOAuthConfig({
+    enabled: true,
+    issuerUrl: issuer,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    tokenEndpointAuthMethod: "client_secret_post",
+    redirectUris: [REDIRECT_URI],
+    ...overrides,
+  });
+  const server = new EngramAccessHttpServer({
+    service: serviceStub as EngramAccessService,
+    host: "127.0.0.1",
+    port,
+    authToken: OPERATOR_TOKEN,
+    // Production wiring (startServer): one coherent entries snapshot +
+    // chatgpt-connector tokens pinned to /mcp.
+    authTokenEntriesGetter: () => getAllValidTokenEntriesCached(tokensPath),
+    tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
+    adminConsoleEnabled: false,
+    externalRequestHandler: buildOAuthRequestHandler(config, { tokensPath }),
+    resourceMetadataUrl: `${issuer}/.well-known/oauth-protected-resource/mcp`,
+  });
+  await server.start();
+  return {
+    issuer,
+    tokensPath,
+    server,
+    config,
+    cleanup: async () => {
+      await server.stop();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Run the authorize → approve → token exchange flow, returning the access token. */
+async function completeOAuthFlow(h: Harness, opts?: { resource?: string }): Promise<string> {
+  const { verifier, challenge } = pkcePair();
+  const authorizeUrl = new URL("/authorize", h.issuer);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", CLIENT_ID);
+  authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+  authorizeUrl.searchParams.set("code_challenge", challenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("state", "state-xyz");
+  if (opts?.resource) authorizeUrl.searchParams.set("resource", opts.resource);
+
+  const page = await fetch(authorizeUrl);
+  assert.equal(page.status, 200, "authorize must render the approval page");
+  const html = await page.text();
+  assert.match(html, /remnic oauth approve/, "page must show the CLI approval command");
+  assert.doesNotMatch(html, /password|client_secret|bearer/i, "page must never ask for credentials");
+
+  // Operator lists pending and approves via the operator-only endpoint.
+  const pendingResp = await fetch(`${h.issuer}/oauth/pending`, {
+    headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+  });
+  assert.equal(pendingResp.status, 200);
+  const pendingBody = (await pendingResp.json()) as {
+    pending: Array<{ ref: string; clientId: string; redirectUri: string }>;
+  };
+  assert.equal(pendingBody.pending.length >= 1, true, "authorize must create a pending txn");
+  const txn = pendingBody.pending[pendingBody.pending.length - 1];
+  assert.ok(txn);
+  assert.equal(txn.clientId, CLIENT_ID);
+  assert.equal(txn.redirectUri, REDIRECT_URI);
+
+  const approveResp = await fetch(`${h.issuer}/oauth/pending/${txn.ref}/approve`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+  });
+  assert.equal(approveResp.status, 200);
+  const approveBody = (await approveResp.json()) as { status: string; redirect: string };
+  assert.equal(approveBody.status, "approved");
+  const redirect = new URL(approveBody.redirect);
+  assert.equal(`${redirect.origin}${redirect.pathname}`, REDIRECT_URI);
+  assert.equal(redirect.searchParams.get("state"), "state-xyz");
+  const code = redirect.searchParams.get("code");
+  assert.ok(code, "redirect must carry the authorization code");
+
+  // Token exchange (client_secret_post + PKCE verifier), form-encoded like
+  // a real OAuth client.
+  const tokenResp = await fetch(`${h.issuer}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      ...(opts?.resource ? { resource: opts.resource } : {}),
+    }),
+  });
+  assert.equal(tokenResp.status, 200, `token exchange must succeed: ${await tokenResp.clone().text()}`);
+  const tokens = (await tokenResp.json()) as { access_token: string; token_type: string };
+  assert.equal(tokens.token_type, "Bearer");
+  assert.match(tokens.access_token, /^remnic_cg_/, "access token must be a chatgpt-connector token");
+  return tokens.access_token;
+}
+
+async function mcpInitialize(h: Harness, accessToken: string): Promise<Response> {
+  return fetch(`${h.issuer}/mcp`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18", clientInfo: { name: "oauth-test", version: "1.0" } },
+    }),
+  });
+}
+
+test("OAuth discovery documents are served unauthenticated and truthful", async () => {
+  const h = await startHarness();
+  try {
+    for (const wellKnown of [
+      "/.well-known/oauth-protected-resource/mcp",
+      "/.well-known/oauth-protected-resource",
+    ]) {
+      const resp = await fetch(`${h.issuer}${wellKnown}`);
+      assert.equal(resp.status, 200, `${wellKnown} must be public`);
+      const body = (await resp.json()) as { resource: string; authorization_servers: string[] };
+      assert.equal(body.resource, `${h.issuer}/mcp`);
+      assert.deepEqual(body.authorization_servers, [`${h.issuer}/`]);
+    }
+    const asResp = await fetch(`${h.issuer}/.well-known/oauth-authorization-server`);
+    assert.equal(asResp.status, 200);
+    const asBody = (await asResp.json()) as Record<string, unknown>;
+    assert.equal(asBody.authorization_endpoint, `${h.issuer}/authorize`);
+    assert.equal(asBody.token_endpoint, `${h.issuer}/token`);
+    assert.deepEqual(asBody.code_challenge_methods_supported, ["S256"]);
+    // Truthfully narrowed: only the single configured method + grant.
+    assert.deepEqual(asBody.token_endpoint_auth_methods_supported, ["client_secret_post"]);
+    assert.deepEqual(asBody.grant_types_supported, ["authorization_code"]);
+    assert.equal(asBody.registration_endpoint, undefined, "DCR must not be advertised");
+
+    // 401 challenge advertises the resource metadata URL (RFC 9728).
+    const unauth = await fetch(`${h.issuer}/mcp`, { method: "POST" });
+    assert.equal(unauth.status, 401);
+    assert.equal(
+      unauth.headers.get("www-authenticate"),
+      `Bearer resource_metadata="${h.issuer}/.well-known/oauth-protected-resource/mcp"`,
+    );
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("full OAuth flow: authorize → CLI-style approve → token → authenticated /mcp", async () => {
+  const h = await startHarness();
+  try {
+    const accessToken = await completeOAuthFlow(h, { resource: `${h.issuer}/mcp` });
+
+    // Minted token works on /mcp immediately (mint-then-use coherence).
+    const init = await mcpInitialize(h, accessToken);
+    assert.equal(init.status, 200);
+    assert.ok(init.headers.get("mcp-session-id"), "initialize must assign an MCP session id");
+    const initBody = (await init.json()) as { result: { protocolVersion: string; serverInfo: { name: string } } };
+    assert.equal(initBody.result.protocolVersion, "2025-06-18");
+    assert.equal(initBody.result.serverInfo.name, "remnic");
+
+    // tools/list with the same token also works.
+    const tools = await fetch(`${h.issuer}/mcp`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+    });
+    assert.equal(tools.status, 200);
+    const toolsBody = (await tools.json()) as { result: { tools: Array<{ name: string }> } };
+    assert.equal(toolsBody.result.tools.length > 0, true);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("scope policy: chatgpt token is /mcp-only; operator and other connectors keep access", async () => {
+  const h = await startHarness();
+  try {
+    const accessToken = await completeOAuthFlow(h);
+
+    // ChatGPT token: /mcp works, everything else is denied.
+    assert.equal((await mcpInitialize(h, accessToken)).status, 200);
+    for (const denied of ["/engram/v1/health", "/engram/v1/adapters"]) {
+      const resp = await fetch(`${h.issuer}${denied}`, {
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+      assert.equal(resp.status, 401, `chatgpt token must be denied on ${denied}`);
+    }
+    // Including the OAuth operator endpoints — it cannot approve its own pendings.
+    const pendingWithChatGpt = await fetch(`${h.issuer}/oauth/pending`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    assert.equal(pendingWithChatGpt.status, 401);
+
+    // Static operator token: full REST access.
+    const opHealth = await fetch(`${h.issuer}/engram/v1/health`, {
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    assert.equal(opHealth.status, 200);
+    const opHealthBody = (await opHealth.json()) as { ok?: boolean };
+    assert.equal(opHealthBody.ok, true);
+
+    // Ordinary connector token (same store): unrestricted, as before OAuth.
+    const codexEntry = generateToken("codex", h.tokensPath);
+    const codexHealth = await fetch(`${h.issuer}/engram/v1/health`, {
+      headers: { authorization: `Bearer ${codexEntry.token}` },
+    });
+    assert.equal(codexHealth.status, 200, "non-chatgpt connector tokens keep full access");
+
+    // Revoke-immediately-use: revoking the chatgpt connector kills the token.
+    assert.equal(revokeToken("chatgpt", h.tokensPath), true);
+    assert.equal((await mcpInitialize(h, accessToken)).status, 401, "revoked token must be rejected");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("re-linking rotates the chatgpt token: old token stops working", async () => {
+  const h = await startHarness();
+  try {
+    const first = await completeOAuthFlow(h);
+    assert.equal((await mcpInitialize(h, first)).status, 200);
+    const second = await completeOAuthFlow(h);
+    assert.notEqual(second, first);
+    assert.equal((await mcpInitialize(h, second)).status, 200);
+    assert.equal((await mcpInitialize(h, first)).status, 401, "rotation must invalidate the old token");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("authorize rejections: bad client, unregistered redirect, missing PKCE, setup mode", async () => {
+  const h = await startHarness();
+  try {
+    const { challenge } = pkcePair();
+    const base = new URL("/authorize", h.issuer);
+    base.searchParams.set("response_type", "code");
+    base.searchParams.set("client_id", CLIENT_ID);
+    base.searchParams.set("redirect_uri", REDIRECT_URI);
+    base.searchParams.set("code_challenge", challenge);
+    base.searchParams.set("code_challenge_method", "S256");
+
+    // Unknown client_id → direct 400, no redirect.
+    const badClient = new URL(base);
+    badClient.searchParams.set("client_id", "someone-else");
+    const badClientResp = await fetch(badClient);
+    assert.equal(badClientResp.status, 400);
+
+    // Redirect URI not byte-exact in the allowlist → direct 400.
+    const badRedirect = new URL(base);
+    badRedirect.searchParams.set("redirect_uri", `${REDIRECT_URI}/extra`);
+    const badRedirectResp = await fetch(badRedirect);
+    assert.equal(badRedirectResp.status, 400);
+    const badRedirectBody = (await badRedirectResp.json()) as { error_description?: string };
+    assert.match(badRedirectBody.error_description ?? "", /redirect_uri/i);
+
+    // Missing code_challenge → post-redirect error (302 back to the client
+    // with ?error=, per OAuth error routing — redirect target is validated).
+    const noPkce = new URL(base);
+    noPkce.searchParams.delete("code_challenge");
+    const noPkceResp = await fetch(noPkce, { redirect: "manual" });
+    assert.equal(noPkceResp.status, 302);
+    const errRedirect = new URL(noPkceResp.headers.get("location") ?? "");
+    assert.equal(`${errRedirect.origin}${errRedirect.pathname}`, REDIRECT_URI);
+    assert.equal(errRedirect.searchParams.get("error"), "invalid_request");
+
+    // No pending txns were created by any rejected request.
+    const pending = await fetch(`${h.issuer}/oauth/pending`, {
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    const pendingBody = (await pending.json()) as { pending: unknown[] };
+    assert.equal(pendingBody.pending.length, 0);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("setup mode (empty redirectUris): discovery live, every authorization refused", async () => {
+  const h = await startHarness({ redirectUris: [] });
+  try {
+    const discovery = await fetch(`${h.issuer}/.well-known/oauth-authorization-server`);
+    assert.equal(discovery.status, 200);
+
+    const { challenge } = pkcePair();
+    const url = new URL("/authorize", h.issuer);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", CLIENT_ID);
+    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const resp = await fetch(url);
+    assert.equal(resp.status, 400, "no redirect URI is registered, so authorization must refuse");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("token endpoint rejections: wrong secret, wrong verifier, code reuse, refresh grant", async () => {
+  const h = await startHarness();
+  try {
+    // Set up an approved code via the normal flow, but do the exchange manually.
+    const { verifier, challenge } = pkcePair();
+    const url = new URL("/authorize", h.issuer);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", CLIENT_ID);
+    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    assert.equal((await fetch(url)).status, 200);
+    const pendingBody = (await (
+      await fetch(`${h.issuer}/oauth/pending`, { headers: { authorization: `Bearer ${OPERATOR_TOKEN}` } })
+    ).json()) as { pending: Array<{ ref: string }> };
+    const ref = pendingBody.pending[0]?.ref;
+    assert.ok(ref);
+    const approveBody = (await (
+      await fetch(`${h.issuer}/oauth/pending/${ref}/approve`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+      })
+    ).json()) as { redirect: string };
+    const code = new URL(approveBody.redirect).searchParams.get("code");
+    assert.ok(code);
+
+    const exchange = (body: Record<string, string>) =>
+      fetch(`${h.issuer}/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(body),
+      });
+
+    // Wrong client secret → 400 invalid_client (token untouched, code intact).
+    const wrongSecret = await exchange({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: "wrong",
+    });
+    assert.equal(wrongSecret.status, 400);
+    assert.equal(((await wrongSecret.json()) as { error?: string }).error, "invalid_client");
+
+    // Wrong PKCE verifier → 400 invalid_grant.
+    const wrongVerifier = await exchange({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: randomBytes(48).toString("base64url"),
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+    assert.equal(wrongVerifier.status, 400);
+    assert.equal(((await wrongVerifier.json()) as { error?: string }).error, "invalid_grant");
+
+    // Correct exchange succeeds…
+    const good = await exchange({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+    assert.equal(good.status, 200);
+
+    // …and the code is single-use: replay fails.
+    const replay = await exchange({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+    assert.equal(replay.status, 400);
+    assert.equal(((await replay.json()) as { error?: string }).error, "invalid_grant");
+
+    // Refresh grant is not supported.
+    const refresh = await exchange({
+      grant_type: "refresh_token",
+      refresh_token: "whatever",
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+    assert.equal(refresh.status, 400);
+    assert.equal(((await refresh.json()) as { error?: string }).error, "unsupported_grant_type");
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("poll endpoint: wrong secret rejected, approved poll returns the callback redirect", async () => {
+  const h = await startHarness();
+  try {
+    const { challenge } = pkcePair();
+    const url = new URL("/authorize", h.issuer);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", CLIENT_ID);
+    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("state", "poll-state");
+    const html = await (await fetch(url)).text();
+    const txnMatch = html.match(/var txn = "([0-9a-f]{32})"/);
+    const secretMatch = html.match(/var secret = "([0-9a-f]{32})"/);
+    assert.ok(txnMatch?.[1] && secretMatch?.[1], "page must embed txn id and poll secret");
+    const txn = txnMatch[1];
+    const pollSecret = secretMatch[1];
+
+    const poll = (body: unknown) =>
+      fetch(`${h.issuer}/oauth/authorize/poll`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    // Wrong secret → 401; missing fields → 400.
+    assert.equal((await poll({ txn, pollSecret: "0".repeat(32) })).status, 401);
+    assert.equal((await poll({ txn })).status, 400);
+
+    // Pending before decision.
+    const pendingPoll = await poll({ txn, pollSecret });
+    assert.equal(pendingPoll.status, 200);
+    assert.deepEqual(await pendingPoll.json(), { status: "pending" });
+
+    // Approve, then the poll returns the redirect with code + state.
+    const pendingList = (await (
+      await fetch(`${h.issuer}/oauth/pending`, { headers: { authorization: `Bearer ${OPERATOR_TOKEN}` } })
+    ).json()) as { pending: Array<{ ref: string }> };
+    const ref = pendingList.pending[0]?.ref;
+    assert.ok(ref);
+    await fetch(`${h.issuer}/oauth/pending/${ref}/approve`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    const approvedPoll = (await (await poll({ txn, pollSecret })).json()) as {
+      status: string;
+      redirect: string;
+    };
+    assert.equal(approvedPoll.status, "approved");
+    const redirect = new URL(approvedPoll.redirect);
+    assert.equal(`${redirect.origin}${redirect.pathname}`, REDIRECT_URI);
+    assert.equal(redirect.searchParams.get("state"), "poll-state");
+    assert.ok(redirect.searchParams.get("code"));
+
+    // Unknown txn reads as expired (no oracle for txn existence).
+    const unknown = await poll({ txn: "f".repeat(32), pollSecret });
+    assert.equal(unknown.status, 200);
+    assert.deepEqual(await unknown.json(), { status: "expired" });
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("operator endpoints require the operator token; deny flow reaches the poller", async () => {
+  const h = await startHarness();
+  try {
+    const { challenge } = pkcePair();
+    const url = new URL("/authorize", h.issuer);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", CLIENT_ID);
+    url.searchParams.set("redirect_uri", REDIRECT_URI);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const html = await (await fetch(url)).text();
+    const txn = html.match(/var txn = "([0-9a-f]{32})"/)?.[1];
+    const pollSecret = html.match(/var secret = "([0-9a-f]{32})"/)?.[1];
+    assert.ok(txn && pollSecret);
+
+    // No token / bad token → 401 for pending list and decisions.
+    assert.equal((await fetch(`${h.issuer}/oauth/pending`)).status, 401);
+    const pendingList = (await (
+      await fetch(`${h.issuer}/oauth/pending`, { headers: { authorization: `Bearer ${OPERATOR_TOKEN}` } })
+    ).json()) as { pending: Array<{ ref: string }> };
+    const ref = pendingList.pending[0]?.ref;
+    assert.ok(ref);
+    assert.equal((await fetch(`${h.issuer}/oauth/pending/${ref}/deny`, { method: "POST" })).status, 401);
+
+    // Deny with the operator token; the poller sees "denied".
+    const deny = await fetch(`${h.issuer}/oauth/pending/${ref}/deny`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    assert.equal(deny.status, 200);
+    const denied = await fetch(`${h.issuer}/oauth/authorize/poll`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ txn, pollSecret }),
+    });
+    assert.deepEqual(await denied.json(), { status: "denied" });
+
+    // Approving a denied txn conflicts.
+    const approveDenied = await fetch(`${h.issuer}/oauth/pending/${ref}/approve`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    assert.equal(approveDenied.status, 409);
+
+    // Unknown ref → 404.
+    const missing = await fetch(`${h.issuer}/oauth/pending/nope/approve`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    });
+    assert.equal(missing.status, 404);
+  } finally {
+    await h.cleanup();
+  }
+});
+
+test("disabled OAuth serves no facade endpoints and keeps the bare Bearer challenge", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-oauth-off-"));
+  const tokensPath = path.join(dir, "tokens.json");
+  const config = parseOAuthConfig({ enabled: false });
+  const server = new EngramAccessHttpServer({
+    service: serviceStub as EngramAccessService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: OPERATOR_TOKEN,
+    authTokenEntriesGetter: () => getAllValidTokenEntriesCached(tokensPath),
+    tokenPathPolicy: (connector, pathname) => connector !== "chatgpt" || pathname === "/mcp",
+    adminConsoleEnabled: false,
+    externalRequestHandler: buildOAuthRequestHandler(config, { tokensPath }),
+  });
+  const status = await server.start();
+  try {
+    const base = `http://127.0.0.1:${status.port}`;
+    for (const p of ["/.well-known/oauth-authorization-server", "/authorize", "/oauth/pending"]) {
+      const resp = await fetch(`${base}${p}`);
+      assert.notEqual(resp.status, 200, `${p} must not be served when OAuth is disabled`);
+    }
+    const unauth = await fetch(`${base}/mcp`, { method: "POST" });
+    assert.equal(unauth.status, 401);
+    assert.equal(unauth.headers.get("www-authenticate"), "Bearer");
+  } finally {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("oauth config parsing rejects invalid input and applies env overrides", async (t) => {
+  // Invalid enum / URL / boolean values throw with precise messages.
+  assert.throws(() => parseOAuthConfig({ enabled: true }), /issuerUrl/);
+  assert.throws(
+    () => parseOAuthConfig({ enabled: true, issuerUrl: "https://x.example", clientId: "c" }),
+    /clientSecret/,
+  );
+  assert.throws(
+    () =>
+      parseOAuthConfig({
+        enabled: true,
+        issuerUrl: "http://not-localhost.example",
+        clientId: "c",
+        clientSecret: "s",
+      }),
+    /https/,
+  );
+  assert.throws(
+    () =>
+      parseOAuthConfig({
+        enabled: true,
+        issuerUrl: "https://x.example",
+        clientId: "c",
+        clientSecret: "s",
+        tokenEndpointAuthMethod: "client_secret_basic",
+      }),
+    /tokenEndpointAuthMethod/,
+  );
+  assert.throws(
+    () =>
+      parseOAuthConfig({
+        enabled: true,
+        issuerUrl: "https://x.example",
+        clientId: "c",
+        clientSecret: "s",
+        redirectUris: ["not-a-url"],
+      }),
+    /redirectUris\[0\]/,
+  );
+  assert.throws(() => parseOAuthConfig({ enabled: "maybe" }), /boolean/);
+
+  // String booleans coerce ("false"/"0" are falsy — repo rule 24).
+  assert.equal(parseOAuthConfig({ enabled: "false" }).enabled, false);
+  assert.equal(parseOAuthConfig({ enabled: "0" }).enabled, false);
+
+  // Env overrides win over the file block.
+  const envKeys = [
+    "REMNIC_OAUTH_ENABLED",
+    "REMNIC_OAUTH_ISSUER_URL",
+    "REMNIC_OAUTH_CLIENT_ID",
+    "REMNIC_OAUTH_CLIENT_SECRET",
+    "REMNIC_OAUTH_REDIRECT_URIS",
+  ] as const;
+  const saved = new Map(envKeys.map((key) => [key, process.env[key]]));
+  t.after(() => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  process.env.REMNIC_OAUTH_ENABLED = "true";
+  process.env.REMNIC_OAUTH_ISSUER_URL = "https://env.example";
+  process.env.REMNIC_OAUTH_CLIENT_ID = "env-client";
+  process.env.REMNIC_OAUTH_CLIENT_SECRET = "env-secret";
+  process.env.REMNIC_OAUTH_REDIRECT_URIS = "https://chatgpt.com/connector/oauth/a, https://chatgpt.com/connector/oauth/b";
+  const parsed = applyOAuthEnvOverrides({ enabled: false, clientId: "file-client" });
+  assert.equal(parsed.enabled, true);
+  assert.equal(parsed.issuerUrl, "https://env.example");
+  assert.equal(parsed.clientId, "env-client");
+  assert.deepEqual(parsed.redirectUris, [
+    "https://chatgpt.com/connector/oauth/a",
+    "https://chatgpt.com/connector/oauth/b",
+  ]);
+});

--- a/packages/remnic-server/src/oauth.test.ts
+++ b/packages/remnic-server/src/oauth.test.ts
@@ -881,3 +881,45 @@ test("token exchange: persist failure returns 500 and preserves the code; retry 
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("applyOAuthEnvOverrides rejects a present-but-non-object server.oauth block", () => {
+  // `"oauth": true` / a string is invalid config, not "disabled" — it must
+  // throw rather than silently coerce to {} and turn OAuth off.
+  for (const bad of [true, "on", 42, ["x"]]) {
+    assert.throws(() => applyOAuthEnvOverrides(bad), /server\.oauth/);
+  }
+  // undefined (absent) is legal → disabled.
+  assert.equal(applyOAuthEnvOverrides(undefined).enabled, false);
+});
+
+test("poll reports expired (not approved) once the authorization code is gone", () => {
+  const config = parseOAuthConfig({
+    enabled: true,
+    issuerUrl: "http://127.0.0.1:4318",
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    redirectUris: [REDIRECT_URI],
+  });
+  const state = new OAuthState(config);
+  const txn = state.createPending({
+    clientId: CLIENT_ID,
+    redirectUri: REDIRECT_URI,
+    scopes: [],
+    resource: undefined,
+    state: undefined,
+    codeChallenge: "x".repeat(43),
+  });
+  state.approveByRef(txn.ref);
+  // While the code is live, poll hands back the redirect.
+  const approved = state.poll(txn.txn, txn.pollSecret);
+  assert.equal(approved?.status, "approved");
+  // Consume the code (as the token exchange does). The pending txn still
+  // reads "approved" (600 s TTL) but the code (120 s TTL) is gone, so poll
+  // must NOT redirect the browser to a dead code — it reports expired.
+  const code = new URL((approved as { redirect: string }).redirect).searchParams.get("code");
+  assert.ok(code, "approved poll must carry a code in the redirect");
+  const taken = state.takeCode({ code, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, resource: undefined });
+  assert.ok(taken, "sanity: code was consumable");
+  const afterConsume = state.poll(txn.txn, txn.pollSecret);
+  assert.equal(afterConsume?.status, "expired", "poll must not redirect with a spent/expired code");
+});

--- a/packages/remnic-server/src/oauth.ts
+++ b/packages/remnic-server/src/oauth.ts
@@ -394,11 +394,19 @@ export class OAuthState {
 
   /** Delete expired entries. Run before each lookup. */
   private gc(now: number): void {
-    for (const [key, txn] of this.pending) {
-      if (txn.expiresAt < now) this.pending.delete(key);
-    }
+    // Expire codes first so the pending check below sees the post-GC code
+    // set.
     for (const [key, code] of this.codes) {
       if (code.expiresAt < now) this.codes.delete(key);
+    }
+    for (const [key, txn] of this.pending) {
+      if (txn.expiresAt >= now) continue;
+      // Keep an APPROVED transaction alive while its authorization code is
+      // still live, even past the pending TTL: an approval made just
+      // before the deadline (or under a short approvalTtlSeconds) must
+      // still be pollable+redirectable until the code itself expires.
+      if (txn.outcome?.kind === "approved" && this.codes.has(txn.outcome.code)) continue;
+      this.pending.delete(key);
     }
   }
 

--- a/packages/remnic-server/src/oauth.ts
+++ b/packages/remnic-server/src/oauth.ts
@@ -55,6 +55,7 @@ import { createOAuthMetadata, mcpAuthMetadataRouter } from "@modelcontextprotoco
 import {
   InvalidGrantError,
   InvalidTokenError,
+  ServerError,
   UnsupportedGrantTypeError,
 } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
@@ -549,6 +550,21 @@ export class OAuthState {
     }
     return entry;
   }
+
+  /**
+   * Un-burn a code consumed by takeCode when the downstream token persist
+   * fails (disk full, permissions). Lets the client retry the exchange
+   * instead of being forced through a fresh authorize+approve. Only
+   * revives an entry still present and within TTL; a binding/PKCE
+   * mismatch is NOT revived (that is a genuine client error, and OAuth
+   * 2.1 revokes a code presented incorrectly).
+   */
+  reviveCode(code: string): void {
+    const entry = this.codes.get(code);
+    if (entry && entry.expiresAt >= Date.now()) {
+      entry.consumed = false;
+    }
+  }
 }
 
 // ── HTML approval page (auto-polling) ────────────────────────────────────────
@@ -749,9 +765,23 @@ class RemnicOAuthProvider implements OAuthServerProvider {
     }
     // Mint a fresh Remnic connector token as the OAuth access token.
     // commitTokenEntry replaces the previous `chatgpt` entry, so
-    // re-linking rotates the token — documented behavior.
+    // re-linking rotates the token — documented behavior. If the
+    // token-store write fails (disk full, permissions), revive the code
+    // so the client can retry the exchange instead of being forced
+    // through a fresh authorize+approve (AGENTS.md #14 — don't burn old
+    // state before the replacement is confirmed).
     const tokenEntry = buildTokenEntry(CHATGPT_CONNECTOR_ID);
-    commitTokenEntry(tokenEntry, this.tokensPath);
+    try {
+      commitTokenEntry(tokenEntry, this.tokensPath);
+    } catch (err) {
+      this.state.reviveCode(authorizationCode);
+      log.warn(
+        `OAuth token persist failed; authorization code revived for retry: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      throw new ServerError("failed to persist the issued token; retry the exchange");
+    }
     log.info(`OAuth token issued for connector "${CHATGPT_CONNECTOR_ID}" (client=${client.client_id})`);
     return {
       access_token: tokenEntry.token,

--- a/packages/remnic-server/src/oauth.ts
+++ b/packages/remnic-server/src/oauth.ts
@@ -48,6 +48,7 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import express, { type Express, type Request, type Response } from "express";
+import { rateLimit } from "express-rate-limit";
 import { authorizationHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/authorize.js";
 import { tokenHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/token.js";
 import { createOAuthMetadata, mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
@@ -848,9 +849,34 @@ export function buildOAuthApp(
 
   // Remnic-specific endpoints below parse JSON bodies.
   app.use(express.json({ limit: "32kb" }));
+  // Rate limiters for the Remnic-owned endpoints (the SDK already
+  // rate-limits /authorize and /token). Two policies:
+  //  - pollLimiter: generous. The approval page polls every ~3 s for up
+  //    to approvalTtlSeconds, so a full flow is ~200 polls; 120/min per IP
+  //    leaves headroom for several concurrent flows without locking the
+  //    browser out of its own approval.
+  //  - operatorReadLimiter / operatorDecisionLimiter: operator list vs
+  //    approve/deny. Both are low-frequency, so tight bounds blunt
+  //    brute-forcing an approval ref while never impeding a human
+  //    operator; separate buckets keep listing from starving decisions.
+  // Shared limiter shape: deterministic JSON 429 (stable `error` code) so
+  // ChatGPT and the CLI get a machine-parseable body, never default HTML.
+  const makeLimiter = (max: number) =>
+    rateLimit({
+      windowMs: 60_000,
+      max,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: { error: "rate_limited", error_description: "too many requests; retry later" },
+    });
+  const pollLimiter = makeLimiter(120);
+  // Read listing gets its own bucket so polling `pending` can never
+  // exhaust the decision (approve/deny) capacity below.
+  const operatorReadLimiter = makeLimiter(60);
+  const operatorDecisionLimiter = makeLimiter(30);
 
   // ── Poll endpoint (public; gated by txn id + pollSecret) ──────────────
-  app.post("/oauth/authorize/poll", (req: Request, res: Response) => {
+  app.post("/oauth/authorize/poll", pollLimiter, (req: Request, res: Response) => {
     const body: unknown = req.body;
     if (
       !isPlainObject(body) ||
@@ -877,7 +903,7 @@ export function buildOAuthApp(
     return false;
   }
 
-  app.get("/oauth/pending", (req: Request, res: Response) => {
+  app.get("/oauth/pending", operatorReadLimiter, (req: Request, res: Response) => {
     if (!operatorGuard(req, res)) return;
     const pending = state.listPending().map((txn) => ({
       ref: txn.ref,
@@ -923,8 +949,8 @@ export function buildOAuthApp(
     };
   }
 
-  app.post("/oauth/pending/:ref/approve", decisionHandler("approve"));
-  app.post("/oauth/pending/:ref/deny", decisionHandler("deny"));
+  app.post("/oauth/pending/:ref/approve", operatorDecisionLimiter, decisionHandler("approve"));
+  app.post("/oauth/pending/:ref/deny", operatorDecisionLimiter, decisionHandler("deny"));
 
   return {
     app,

--- a/packages/remnic-server/src/oauth.ts
+++ b/packages/remnic-server/src/oauth.ts
@@ -1,0 +1,1000 @@
+/**
+ * OAuth 2.1 authorization-server facade for the standalone Remnic server.
+ *
+ * Why this exists: ChatGPT developer-mode apps (chatgpt.com) can only talk
+ * to remote MCP servers with OAuth, "No Authentication", or Mixed auth —
+ * there is no static API-key/bearer option in the ChatGPT UI. Remnic's MCP
+ * endpoint (`POST /mcp`) is bearer-token protected, so this module lets
+ * Remnic act as its OWN authorization server: ChatGPT runs a standard
+ * authorization-code + PKCE flow against these endpoints and receives a
+ * regular Remnic connector token (connector id `chatgpt`) as the OAuth
+ * access token. The existing bearer validation on `/mcp` then works
+ * unchanged.
+ *
+ * Protocol layer: the security-critical endpoints are NOT hand-rolled.
+ * `authorizationHandler`, `tokenHandler` (PKCE S256 verification, client
+ * authentication, param validation, rate limiting) and the RFC 8414 /
+ * RFC 9728 metadata router all come from `@modelcontextprotocol/sdk`.
+ * This module contributes only the Remnic-specific pieces:
+ *
+ *  - config parsing (`server.oauth` block + `REMNIC_OAUTH_*` env overrides),
+ *  - the static single-client store (Remnic pre-registers ChatGPT; the
+ *    operator pastes the same client id/secret into ChatGPT's app UI),
+ *  - the pending-approval interaction: `/authorize` renders a page that
+ *    instructs the operator to run `remnic oauth approve <ref>` locally;
+ *    the page polls with a per-transaction secret and redirects to the
+ *    ChatGPT callback once the operator approves,
+ *  - operator-only pending/approve/deny endpoints (gated by the core
+ *    bearer authorization passed in from the access server), and
+ *  - access-token minting into the Remnic token store.
+ *
+ * Security model (do not weaken):
+ *  - The approval page NEVER asks for credentials. Approval happens
+ *    out-of-band via the CLI, which authenticates with the operator
+ *    bearer token against the local daemon.
+ *  - `txn` id and `pollSecret` are independent 128-bit random values;
+ *    the human-readable `ref` shown on the page cannot authorize
+ *    anything by itself.
+ *  - Authorization codes are 128-bit, single-use, TTL-capped at 120 s,
+ *    and bound to client_id + redirect_uri + PKCE challenge + resource.
+ *  - Redirect URIs are validated by the SDK against the exact
+ *    pre-registered allowlist (`server.oauth.redirectUris`); an empty
+ *    allowlist refuses every authorization (setup mode: discovery works,
+ *    authorization does not).
+ *  - Secret comparisons go through SHA-256 digests + `timingSafeEqual`,
+ *    which is constant-time and never throws on length mismatch.
+ */
+
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import express, { type Express, type Request, type Response } from "express";
+import { authorizationHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/authorize.js";
+import { tokenHandler } from "@modelcontextprotocol/sdk/server/auth/handlers/token.js";
+import { createOAuthMetadata, mcpAuthMetadataRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+  UnsupportedGrantTypeError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { buildTokenEntry, commitTokenEntry, getAllValidTokensCached, log } from "@remnic/core";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Token-endpoint client auth methods this facade supports. The SDK's
+ * client-auth middleware reads credentials from the request body only,
+ * so `client_secret_basic` is intentionally NOT offered: advertising a
+ * method the token endpoint would reject is worse than not offering it.
+ * ChatGPT supports `client_secret_post` and `none` for predefined
+ * clients.
+ */
+const ALLOWED_TOKEN_AUTH_METHODS = ["client_secret_post", "none"] as const;
+export type OAuthTokenEndpointAuthMethod = (typeof ALLOWED_TOKEN_AUTH_METHODS)[number];
+
+/** Default TTL for pending authorizations (10 minutes). */
+const DEFAULT_APPROVAL_TTL_SECONDS = 600;
+
+/** Authorization-code TTL (OAuth 2.1 recommends short single-use codes). */
+const AUTHORIZATION_CODE_TTL_MS = 120_000;
+
+/** 128 bits of entropy in hex = 32 chars. */
+const HIGH_ENTROPY_HEX_BYTES = 16;
+
+/** Connector id under which OAuth access tokens are minted. */
+const CHATGPT_CONNECTOR_ID = "chatgpt";
+
+// ── Config schema + parser ──────────────────────────────────────────────────
+
+/**
+ * Raw config block as it appears in `server.oauth`. All fields optional at
+ * the type level; the parser enforces requirements when `enabled: true`.
+ */
+export interface OAuthConfigInput {
+  enabled?: unknown;
+  issuerUrl?: unknown;
+  clientId?: unknown;
+  clientSecret?: unknown;
+  tokenEndpointAuthMethod?: unknown;
+  redirectUris?: unknown;
+  approvalTtlSeconds?: unknown;
+}
+
+export interface ParsedOAuthConfig {
+  enabled: boolean;
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string;
+  tokenEndpointAuthMethod: OAuthTokenEndpointAuthMethod;
+  redirectUris: string[];
+  approvalTtlSeconds: number;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Coerce a boolean coming from JSON (any) or env (string). Mirrors the
+ * repo's canonical boolean coercion (rules 17, 24): "true"/"1"/"yes"/"on"
+ * are truthy, "false"/"0"/"no"/"off" are falsy. Anything else throws.
+ */
+function coerceBoolean(value: unknown, source: string): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+  }
+  throw new Error(`Invalid ${source}: expected a boolean (got: ${JSON.stringify(value)})`);
+}
+
+function coerceNonEmptyString(value: unknown, source: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${source}: expected a non-empty string`);
+  }
+  return value.trim();
+}
+
+function coercePositiveInteger(value: unknown, source: string): number {
+  const num = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
+  if (typeof num !== "number" || !Number.isInteger(num) || num <= 0) {
+    throw new Error(`Invalid ${source}: expected a positive integer (got: ${JSON.stringify(value)})`);
+  }
+  return num;
+}
+
+function coerceAbsoluteHttpsUrl(
+  value: unknown,
+  source: string,
+  opts: { allowHttpForLocalhost: boolean },
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${source}: expected a non-empty URL string`);
+  }
+  const trimmed = value.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid ${source}: "${trimmed}" is not a valid URL`);
+  }
+  if (parsed.hash || parsed.search) {
+    throw new Error(`Invalid ${source}: URL must not include a query string or fragment`);
+  }
+  const isHttps = parsed.protocol === "https:";
+  const isLocalhostHttp =
+    opts.allowHttpForLocalhost &&
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost");
+  if (!isHttps && !isLocalhostHttp) {
+    throw new Error(
+      `Invalid ${source}: must be an absolute https:// URL (http:// allowed only for 127.0.0.1/localhost)`,
+    );
+  }
+  return trimmed;
+}
+
+function coerceTokenAuthMethod(value: unknown, source: string): OAuthTokenEndpointAuthMethod {
+  if (typeof value !== "string") {
+    throw new Error(`Invalid ${source}: expected one of ${ALLOWED_TOKEN_AUTH_METHODS.join(", ")}`);
+  }
+  const trimmed = value.trim();
+  const match = ALLOWED_TOKEN_AUTH_METHODS.find((method) => method === trimmed);
+  if (!match) {
+    throw new Error(
+      `Invalid ${source}: "${trimmed}" is not allowed. Use one of ${ALLOWED_TOKEN_AUTH_METHODS.join(", ")}.`,
+    );
+  }
+  return match;
+}
+
+function coerceRedirectUris(value: unknown, source: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Invalid ${source}: expected an array of exact redirect URI strings`);
+  }
+  return value.map((entry, index) =>
+    coerceAbsoluteHttpsUrl(entry, `${source}[${index}]`, { allowHttpForLocalhost: true }),
+  );
+}
+
+const DISABLED_OAUTH_CONFIG: ParsedOAuthConfig = {
+  enabled: false,
+  issuerUrl: "",
+  clientId: "",
+  clientSecret: "",
+  tokenEndpointAuthMethod: "client_secret_post",
+  redirectUris: [],
+  approvalTtlSeconds: DEFAULT_APPROVAL_TTL_SECONDS,
+};
+
+/**
+ * Parse the `server.oauth` config block. Throws on invalid input.
+ *
+ * When disabled (or absent), only `enabled` is consulted — a
+ * partially-filled disabled block is legal. When enabled, `issuerUrl`,
+ * `clientId`, and (unless auth method is `none`) `clientSecret` are
+ * required. `redirectUris` MAY be empty: that is "setup mode" — the
+ * discovery documents are served so ChatGPT can create the app, but every
+ * authorization attempt is refused until the exact per-app callback URL
+ * (shown in ChatGPT's app management page) is added to the allowlist.
+ */
+export function parseOAuthConfig(raw: unknown): ParsedOAuthConfig {
+  if (raw === undefined) return { ...DISABLED_OAUTH_CONFIG };
+  if (!isPlainObject(raw)) {
+    throw new Error("Invalid server.oauth: expected a JSON object");
+  }
+  const input = raw as OAuthConfigInput;
+  const enabled = input.enabled === undefined ? false : coerceBoolean(input.enabled, "server.oauth.enabled");
+  if (!enabled) return { ...DISABLED_OAUTH_CONFIG };
+
+  const issuerUrl =
+    input.issuerUrl === undefined
+      ? ""
+      : coerceAbsoluteHttpsUrl(input.issuerUrl, "server.oauth.issuerUrl", { allowHttpForLocalhost: true });
+  const clientId =
+    input.clientId === undefined ? "" : coerceNonEmptyString(input.clientId, "server.oauth.clientId");
+  const clientSecret =
+    input.clientSecret === undefined ? "" : coerceNonEmptyString(input.clientSecret, "server.oauth.clientSecret");
+  const tokenEndpointAuthMethod =
+    input.tokenEndpointAuthMethod === undefined
+      ? "client_secret_post"
+      : coerceTokenAuthMethod(input.tokenEndpointAuthMethod, "server.oauth.tokenEndpointAuthMethod");
+  const redirectUris =
+    input.redirectUris === undefined ? [] : coerceRedirectUris(input.redirectUris, "server.oauth.redirectUris");
+  const approvalTtlSeconds =
+    input.approvalTtlSeconds === undefined
+      ? DEFAULT_APPROVAL_TTL_SECONDS
+      : coercePositiveInteger(input.approvalTtlSeconds, "server.oauth.approvalTtlSeconds");
+
+  if (issuerUrl === "") {
+    throw new Error("Invalid server.oauth.issuerUrl: required when enabled (absolute https URL)");
+  }
+  if (clientId === "") {
+    throw new Error("Invalid server.oauth.clientId: required when enabled (non-empty string)");
+  }
+  if (tokenEndpointAuthMethod !== "none" && clientSecret === "") {
+    throw new Error(
+      `Invalid server.oauth.clientSecret: required when enabled and tokenEndpointAuthMethod is "${tokenEndpointAuthMethod}"`,
+    );
+  }
+
+  return {
+    enabled: true,
+    issuerUrl,
+    clientId,
+    clientSecret,
+    tokenEndpointAuthMethod,
+    redirectUris,
+    approvalTtlSeconds,
+  };
+}
+
+// ── Env overrides (REMNIC_OAUTH_*) ───────────────────────────────────────────
+
+/**
+ * Build the OAuth config overrides from env vars (REMNIC_OAUTH_*). The
+ * merged result goes back through `parseOAuthConfig`, so invalid values
+ * throw the same precise messages.
+ */
+export function readOAuthEnvOverrides(): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {};
+  if (process.env.REMNIC_OAUTH_ENABLED !== undefined) overrides.enabled = process.env.REMNIC_OAUTH_ENABLED;
+  if (process.env.REMNIC_OAUTH_ISSUER_URL !== undefined) overrides.issuerUrl = process.env.REMNIC_OAUTH_ISSUER_URL;
+  if (process.env.REMNIC_OAUTH_CLIENT_ID !== undefined) overrides.clientId = process.env.REMNIC_OAUTH_CLIENT_ID;
+  if (process.env.REMNIC_OAUTH_CLIENT_SECRET !== undefined) {
+    overrides.clientSecret = process.env.REMNIC_OAUTH_CLIENT_SECRET;
+  }
+  if (process.env.REMNIC_OAUTH_TOKEN_AUTH_METHOD !== undefined) {
+    overrides.tokenEndpointAuthMethod = process.env.REMNIC_OAUTH_TOKEN_AUTH_METHOD;
+  }
+  if (process.env.REMNIC_OAUTH_REDIRECT_URIS !== undefined) {
+    overrides.redirectUris = process.env.REMNIC_OAUTH_REDIRECT_URIS.split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+  if (process.env.REMNIC_OAUTH_APPROVAL_TTL_SECONDS !== undefined) {
+    overrides.approvalTtlSeconds = process.env.REMNIC_OAUTH_APPROVAL_TTL_SECONDS;
+  }
+  return overrides;
+}
+
+/** Merge env overrides over the file block and parse the result. */
+export function applyOAuthEnvOverrides(fileBlock: unknown): ParsedOAuthConfig {
+  const overrides = readOAuthEnvOverrides();
+  const merged: Record<string, unknown> = isPlainObject(fileBlock) ? { ...fileBlock } : {};
+  for (const [key, value] of Object.entries(overrides)) {
+    merged[key] = value;
+  }
+  return parseOAuthConfig(merged);
+}
+
+// ── Small crypto helpers ─────────────────────────────────────────────────────
+
+/**
+ * Constant-time string equality via fixed-size SHA-256 digests. Digest
+ * comparison never throws on length mismatch and does not leak length
+ * or content timing. Hash equality implies content equality.
+ */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  const digestA = createHash("sha256").update(a, "utf8").digest();
+  const digestB = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+/**
+ * Human-readable approval ref: 8 random bytes rendered in base36
+ * (~62 bits, 13 chars max). Unguessable in practice, but knowing the ref
+ * alone never authorizes anything — approval additionally requires the
+ * operator bearer token.
+ */
+function newApprovalRef(): string {
+  return BigInt(`0x${randomHex(8)}`).toString(36);
+}
+
+// ── Pending-transaction store ────────────────────────────────────────────────
+
+export interface PendingTransaction {
+  /** High-entropy public id; key for the poll endpoint. */
+  txn: string;
+  /** Separate high-entropy secret required alongside `txn` to poll. */
+  pollSecret: string;
+  /** Human-visible approval ref for the CLI. */
+  ref: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  resource: string | undefined;
+  state: string | undefined;
+  codeChallenge: string;
+  createdAt: number;
+  expiresAt: number;
+  outcome?: { kind: "approved"; code: string } | { kind: "denied" };
+}
+
+interface AuthorizationCodeEntry {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  resource: string | undefined;
+  expiresAt: number;
+  consumed: boolean;
+}
+
+export class OAuthState {
+  private readonly pending = new Map<string, PendingTransaction>();
+  private readonly codes = new Map<string, AuthorizationCodeEntry>();
+  private readonly config: ParsedOAuthConfig;
+
+  constructor(config: ParsedOAuthConfig) {
+    this.config = config;
+  }
+
+  get approvalTtlMs(): number {
+    return this.config.approvalTtlSeconds * 1000;
+  }
+
+  /** Delete expired entries. Run before each lookup. */
+  private gc(now: number): void {
+    for (const [key, txn] of this.pending) {
+      if (txn.expiresAt < now) this.pending.delete(key);
+    }
+    for (const [key, code] of this.codes) {
+      if (code.expiresAt < now) this.codes.delete(key);
+    }
+  }
+
+  createPending(args: {
+    clientId: string;
+    redirectUri: string;
+    scopes: string[];
+    resource: string | undefined;
+    state: string | undefined;
+    codeChallenge: string;
+  }): PendingTransaction {
+    const now = Date.now();
+    this.gc(now);
+    const txn: PendingTransaction = {
+      txn: randomHex(HIGH_ENTROPY_HEX_BYTES),
+      pollSecret: randomHex(HIGH_ENTROPY_HEX_BYTES),
+      ref: newApprovalRef(),
+      clientId: args.clientId,
+      redirectUri: args.redirectUri,
+      scopes: args.scopes,
+      resource: args.resource,
+      state: args.state,
+      codeChallenge: args.codeChallenge,
+      createdAt: now,
+      expiresAt: now + this.approvalTtlMs,
+    };
+    this.pending.set(txn.txn, txn);
+    return txn;
+  }
+
+  listPending(): PendingTransaction[] {
+    const now = Date.now();
+    this.gc(now);
+    return Array.from(this.pending.values())
+      .filter((txn) => !txn.outcome)
+      .sort((a, b) => (a.createdAt === b.createdAt ? a.txn.localeCompare(b.txn) : a.createdAt - b.createdAt));
+  }
+
+  findByRef(ref: string): PendingTransaction | undefined {
+    const now = Date.now();
+    this.gc(now);
+    for (const txn of this.pending.values()) {
+      if (txn.ref === ref) return txn;
+    }
+    return undefined;
+  }
+
+  /**
+   * Approve a pending transaction by ref. Returns the authorization code.
+   * Re-approval of an already-approved txn returns the same code so the
+   * operator can recover from a client-side miss. Throws on
+   * missing/expired/denied.
+   */
+  approveByRef(ref: string): { code: string; txn: PendingTransaction } {
+    const now = Date.now();
+    this.gc(now);
+    const txn = this.findByRef(ref);
+    if (!txn) throw new Error("unknown or expired ref");
+    if (txn.outcome) {
+      if (txn.outcome.kind === "approved") return { code: txn.outcome.code, txn };
+      throw new Error("denied");
+    }
+    const code = randomHex(HIGH_ENTROPY_HEX_BYTES);
+    this.codes.set(code, {
+      code,
+      clientId: txn.clientId,
+      redirectUri: txn.redirectUri,
+      codeChallenge: txn.codeChallenge,
+      resource: txn.resource,
+      expiresAt: now + AUTHORIZATION_CODE_TTL_MS,
+      consumed: false,
+    });
+    txn.outcome = { kind: "approved", code };
+    return { code, txn };
+  }
+
+  denyByRef(ref: string): void {
+    const now = Date.now();
+    this.gc(now);
+    const txn = this.findByRef(ref);
+    if (!txn) throw new Error("unknown or expired ref");
+    if (txn.outcome) {
+      if (txn.outcome.kind === "denied") return; // idempotent
+      throw new Error("already approved");
+    }
+    txn.outcome = { kind: "denied" };
+  }
+
+  /** Redirect target carrying the code (+ state) back to the client. */
+  buildRedirect(txn: PendingTransaction, code: string): string {
+    const url = new URL(txn.redirectUri);
+    url.searchParams.set("code", code);
+    if (txn.state) url.searchParams.set("state", txn.state);
+    return url.toString();
+  }
+
+  /** Poll status; `undefined` on wrong pollSecret. */
+  poll(
+    txnId: string,
+    pollSecret: string,
+  ):
+    | { status: "pending" }
+    | { status: "approved"; redirect: string }
+    | { status: "denied" }
+    | { status: "expired" }
+    | undefined {
+    const now = Date.now();
+    this.gc(now);
+    const txn = this.pending.get(txnId);
+    if (!txn) return { status: "expired" };
+    if (!timingSafeStringEqual(txn.pollSecret, pollSecret)) return undefined;
+    if (!txn.outcome) {
+      if (txn.expiresAt < now) return { status: "expired" };
+      return { status: "pending" };
+    }
+    if (txn.outcome.kind === "denied") return { status: "denied" };
+    return { status: "approved", redirect: this.buildRedirect(txn, txn.outcome.code) };
+  }
+
+  /**
+   * Read a code entry without consuming it (SDK PKCE verification path).
+   * Returns undefined on unknown/expired/consumed.
+   */
+  peekCode(code: string): AuthorizationCodeEntry | undefined {
+    const now = Date.now();
+    this.gc(now);
+    const entry = this.codes.get(code);
+    if (!entry || entry.consumed || entry.expiresAt < now) return undefined;
+    return entry;
+  }
+
+  /**
+   * Consume a code after the SDK verified PKCE. Enforces single use and
+   * the client/redirect/resource bindings. Returns the entry on success,
+   * undefined on any mismatch.
+   */
+  takeCode(args: {
+    code: string;
+    clientId: string;
+    redirectUri: string | undefined;
+    resource: string | undefined;
+  }): AuthorizationCodeEntry | undefined {
+    const entry = this.peekCode(args.code);
+    if (!entry) return undefined;
+    // Burn the code before the binding checks: a code that reaches the
+    // exchange step is spent regardless of outcome (OAuth 2.1 single use).
+    entry.consumed = true;
+    if (!timingSafeStringEqual(entry.clientId, args.clientId)) return undefined;
+    // The token request MAY omit redirect_uri only when the authorization
+    // request used the client's single registered URI; when provided it
+    // must match the bound value exactly.
+    if (args.redirectUri !== undefined && entry.redirectUri !== args.redirectUri) return undefined;
+    if (entry.resource !== undefined) {
+      if (args.resource === undefined) return undefined;
+      if (entry.resource !== args.resource) return undefined;
+    }
+    return entry;
+  }
+}
+
+// ── HTML approval page (auto-polling) ────────────────────────────────────────
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderApprovalPage(args: { txn: PendingTransaction; issuerUrl: string; command: string }): string {
+  const { txn, issuerUrl, command } = args;
+  // The page NEVER asks for credentials. It displays the approval ref and
+  // CLI instructions, then polls /oauth/authorize/poll with the
+  // per-transaction pollSecret. On approval the browser follows the
+  // redirect to the client's callback.
+  const safeRef = escapeHtml(txn.ref);
+  const safeClientId = escapeHtml(txn.clientId);
+  const safeRedirect = escapeHtml(txn.redirectUri);
+  const safeResource = txn.resource ? escapeHtml(txn.resource) : "";
+  const safeCommand = escapeHtml(command);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Remnic MCP authorization</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; color: #1a1a1a; }
+  h1 { font-size: 1.4rem; }
+  .ref { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 1.1rem; background: #f4f4f5; padding: 0.25rem 0.5rem; border-radius: 4px; }
+  details { margin: 1rem 0; padding: 0.75rem 1rem; background: #fafafa; border: 1px solid #e4e4e7; border-radius: 6px; }
+  summary { cursor: pointer; font-weight: 600; }
+  code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9rem; }
+  pre { background: #f4f4f5; padding: 0.75rem; border-radius: 4px; overflow-x: auto; }
+  #status { margin-top: 1.5rem; padding: 0.75rem 1rem; border-radius: 6px; font-weight: 600; }
+  .pending { background: #fef9c3; color: #713f12; }
+  .approved { background: #dcfce7; color: #14532d; }
+  .denied { background: #fee2e2; color: #7f1d1d; }
+  .expired { background: #f3f4f6; color: #374151; }
+</style>
+</head>
+<body>
+<h1>Remnic MCP authorization pending</h1>
+<p>An external application has requested access to your Remnic MCP server.
+Open a terminal on the Remnic host and run:</p>
+<pre>${safeCommand}</pre>
+<p>Approval ref: <span class="ref">${safeRef}</span></p>
+<details>
+  <summary>Request details</summary>
+  <ul>
+    <li>Client ID: <code>${safeClientId}</code></li>
+    <li>Redirect URI: <code>${safeRedirect}</code></li>
+    ${safeResource ? `<li>Resource: <code>${safeResource}</code></li>` : ""}
+    <li>Scopes: <code>${escapeHtml(txn.scopes.join(" ")) || "(none requested)"}</code></li>
+  </ul>
+</details>
+<div id="status" class="pending">Waiting for operator approval&hellip;</div>
+<script>
+(function () {
+  var statusEl = document.getElementById("status");
+  var txn = ${JSON.stringify(txn.txn)};
+  var secret = ${JSON.stringify(txn.pollSecret)};
+  var issuer = ${JSON.stringify(issuerUrl)};
+  var done = false;
+  function render(result) {
+    if (result.status === "pending") return;
+    done = true;
+    if (result.status === "approved") {
+      statusEl.className = "approved";
+      statusEl.textContent = "Approved — redirecting\\u2026";
+      window.location.replace(result.redirect);
+    } else if (result.status === "denied") {
+      statusEl.className = "denied";
+      statusEl.textContent = "Denied by operator. Return to the calling app to retry or cancel.";
+    } else {
+      statusEl.className = "expired";
+      statusEl.textContent = "This request expired. Return to the calling app to retry.";
+    }
+  }
+  function poll() {
+    if (done) return;
+    fetch(issuer + "/oauth/authorize/poll", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ txn: txn, pollSecret: secret }),
+    })
+      .then(function (res) {
+        if (!res.ok) throw new Error("poll failed");
+        return res.json();
+      })
+      .then(render)
+      .catch(function () { /* transient; next interval retries */ });
+  }
+  poll();
+  setInterval(poll, 3000);
+})();
+</script>
+</body>
+</html>`;
+}
+
+// ── Provider (SDK OAuthServerProvider implementation) ────────────────────────
+
+/**
+ * Static single-client provider backed by the pending-approval store and
+ * the Remnic token store. All protocol validation (PKCE, client auth,
+ * redirect membership, param shapes) happens in the SDK handlers; this
+ * provider only implements the Remnic-specific decisions.
+ */
+class RemnicOAuthProvider implements OAuthServerProvider {
+  private readonly config: ParsedOAuthConfig;
+  private readonly state: OAuthState;
+  private readonly staticClient: OAuthClientInformationFull;
+  /** Token-store override for tests; production uses the default path. */
+  private readonly tokensPath?: string;
+
+  constructor(config: ParsedOAuthConfig, state: OAuthState, tokensPath?: string) {
+    this.config = config;
+    this.state = state;
+    this.tokensPath = tokensPath;
+    this.staticClient = {
+      client_id: config.clientId,
+      // With `none`, the client is public: no secret is stored, so the
+      // SDK's client-auth middleware will not demand one. Otherwise the
+      // secret is REQUIRED on every token request.
+      ...(config.tokenEndpointAuthMethod === "none" ? {} : { client_secret: config.clientSecret }),
+      redirect_uris: config.redirectUris,
+      token_endpoint_auth_method: config.tokenEndpointAuthMethod,
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+    };
+  }
+
+  get clientsStore(): OAuthRegisteredClientsStore {
+    const client = this.staticClient;
+    return {
+      getClient: (clientId: string) => (clientId === client.client_id ? client : undefined),
+      // No registerClient: dynamic client registration is deliberately
+      // NOT supported — the single client is pre-registered via config.
+    };
+  }
+
+  async authorize(client: OAuthClientInformationFull, params: AuthorizationParams, res: Response): Promise<void> {
+    const txn = this.state.createPending({
+      clientId: client.client_id,
+      redirectUri: params.redirectUri,
+      scopes: params.scopes ?? [],
+      resource: params.resource?.href,
+      state: params.state,
+      codeChallenge: params.codeChallenge,
+    });
+    log.info(
+      `OAuth authorization pending: ref=${txn.ref} client=${txn.clientId} redirect=${txn.redirectUri} — ` +
+        `run \`remnic oauth approve ${txn.ref}\` to approve`,
+    );
+    res
+      .status(200)
+      .type("html")
+      .send(
+        renderApprovalPage({
+          txn,
+          issuerUrl: this.config.issuerUrl.replace(/\/+$/, ""),
+          command: `remnic oauth approve ${txn.ref}`,
+        }),
+      );
+  }
+
+  async challengeForAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+  ): Promise<string> {
+    const entry = this.state.peekCode(authorizationCode);
+    if (!entry || !timingSafeStringEqual(entry.clientId, client.client_id)) {
+      throw new InvalidGrantError("authorization code is invalid, expired, or already used");
+    }
+    return entry.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    redirectUri?: string,
+    resource?: URL,
+  ): Promise<OAuthTokens> {
+    const entry = this.state.takeCode({
+      code: authorizationCode,
+      clientId: client.client_id,
+      redirectUri,
+      resource: resource?.href,
+    });
+    if (!entry) {
+      throw new InvalidGrantError("authorization code is invalid, expired, or already used");
+    }
+    // Mint a fresh Remnic connector token as the OAuth access token.
+    // commitTokenEntry replaces the previous `chatgpt` entry, so
+    // re-linking rotates the token — documented behavior.
+    const tokenEntry = buildTokenEntry(CHATGPT_CONNECTOR_ID);
+    commitTokenEntry(tokenEntry, this.tokensPath);
+    log.info(`OAuth token issued for connector "${CHATGPT_CONNECTOR_ID}" (client=${client.client_id})`);
+    return {
+      access_token: tokenEntry.token,
+      token_type: "Bearer",
+    };
+  }
+
+  async exchangeRefreshToken(): Promise<OAuthTokens> {
+    throw new UnsupportedGrantTypeError(
+      "refresh_token grant is not supported; re-link the app to rotate the token",
+    );
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const valid = getAllValidTokensCached(this.tokensPath).some((candidate) =>
+      timingSafeStringEqual(candidate, token),
+    );
+    if (!valid) {
+      throw new InvalidTokenError("unknown or revoked token");
+    }
+    return {
+      token,
+      clientId: this.config.clientId,
+      scopes: [],
+    };
+  }
+}
+
+// ── Express app builder ─────────────────────────────────────────────────────
+
+export interface OAuthAppBundle {
+  app: Express;
+  state: OAuthState;
+  /** Paths owned by the OAuth facade (exact matches). */
+  ownedExactPaths: string[];
+  /** Path prefixes owned by the OAuth facade. */
+  ownedPathPrefixes: string[];
+}
+
+/**
+ * Build the express app hosting all OAuth endpoints.
+ *
+ * SDK-owned: `/authorize`, `/token`,
+ * `/.well-known/oauth-authorization-server`,
+ * `/.well-known/oauth-protected-resource/mcp`.
+ * Remnic-owned: `/oauth/authorize/poll` (public, secret-gated),
+ * `/oauth/pending[...]` (operator-only), plus a bare
+ * `/.well-known/oauth-protected-resource` alias for clients that do not
+ * implement RFC 9728 path insertion.
+ *
+ * @param authCtxLookup returns the operator-authorization context the core
+ * access server computed for this request; the facade never validates
+ * bearer tokens itself.
+ */
+export function buildOAuthApp(
+  config: ParsedOAuthConfig,
+  authCtxLookup: (req: IncomingMessage) => { authorized: boolean },
+  deps?: { tokensPath?: string },
+): OAuthAppBundle {
+  const state = new OAuthState(config);
+  const provider = new RemnicOAuthProvider(config, state, deps?.tokensPath);
+  const issuer = new URL(config.issuerUrl);
+  const resourceServerUrl = new URL("/mcp", issuer);
+
+  if (config.redirectUris.length === 0) {
+    log.warn(
+      "server.oauth.redirectUris is empty — OAuth discovery is live but every authorization will be refused " +
+        "until the exact callback URL from ChatGPT's app management page is added (setup mode).",
+    );
+  }
+
+  const app = express();
+  app.disable("x-powered-by");
+
+  // SDK metadata, truthfully narrowed to what this server actually
+  // accepts: a single client-auth method and the authorization_code grant.
+  const oauthMetadata = createOAuthMetadata({ provider, issuerUrl: issuer });
+  oauthMetadata.token_endpoint_auth_methods_supported = [config.tokenEndpointAuthMethod];
+  oauthMetadata.grant_types_supported = ["authorization_code"];
+
+  // SDK handlers own the protocol-critical endpoints.
+  app.use("/authorize", authorizationHandler({ provider }));
+  app.use("/token", tokenHandler({ provider }));
+  app.use(mcpAuthMetadataRouter({ oauthMetadata, resourceServerUrl, resourceName: "Remnic" }));
+
+  // Alias: serve the protected-resource document at the bare well-known
+  // path too (the SDK mounts only the RFC 9728 path-inserted variant).
+  app.get("/.well-known/oauth-protected-resource", (_req: Request, res: Response) => {
+    res.status(200).json({
+      resource: resourceServerUrl.href,
+      authorization_servers: [oauthMetadata.issuer],
+      resource_name: "Remnic",
+    });
+  });
+
+  // Remnic-specific endpoints below parse JSON bodies.
+  app.use(express.json({ limit: "32kb" }));
+
+  // ── Poll endpoint (public; gated by txn id + pollSecret) ──────────────
+  app.post("/oauth/authorize/poll", (req: Request, res: Response) => {
+    const body: unknown = req.body;
+    if (
+      !isPlainObject(body) ||
+      typeof body.txn !== "string" ||
+      typeof body.pollSecret !== "string" ||
+      body.txn.length === 0 ||
+      body.pollSecret.length === 0
+    ) {
+      res.status(400).json({ error: "invalid_request", error_description: "txn and pollSecret are required" });
+      return;
+    }
+    const result = state.poll(body.txn, body.pollSecret);
+    if (result === undefined) {
+      res.status(401).json({ error: "invalid_request", error_description: "unknown txn or wrong pollSecret" });
+      return;
+    }
+    res.status(200).json(result);
+  });
+
+  // ── Operator-only endpoints ────────────────────────────────────────────
+  function operatorGuard(req: Request, res: Response): boolean {
+    if (authCtxLookup(req).authorized === true) return true;
+    res.status(401).json({ error: "unauthorized", error_description: "operator authentication required" });
+    return false;
+  }
+
+  app.get("/oauth/pending", (req: Request, res: Response) => {
+    if (!operatorGuard(req, res)) return;
+    const pending = state.listPending().map((txn) => ({
+      ref: txn.ref,
+      clientId: txn.clientId,
+      redirectUri: txn.redirectUri,
+      scopes: txn.scopes,
+      resource: txn.resource ?? null,
+      createdAt: new Date(txn.createdAt).toISOString(),
+      expiresAt: new Date(txn.expiresAt).toISOString(),
+    }));
+    res.status(200).json({ pending });
+  });
+
+  function decisionHandler(action: "approve" | "deny") {
+    return (req: Request, res: Response) => {
+      if (!operatorGuard(req, res)) return;
+      const ref = req.params.ref;
+      if (!ref) {
+        res.status(400).json({ error: "invalid_request", error_description: "ref is required" });
+        return;
+      }
+      try {
+        if (action === "approve") {
+          const { txn, code } = state.approveByRef(ref);
+          res.status(200).json({ ref, status: "approved", redirect: state.buildRedirect(txn, code) });
+        } else {
+          state.denyByRef(ref);
+          res.status(200).json({ ref, status: "denied" });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === "unknown or expired ref") {
+          res.status(404).json({ error: "invalid_request", error_description: message });
+          return;
+        }
+        if (message === "denied" || message === "already approved") {
+          res.status(409).json({ error: "invalid_request", error_description: message });
+          return;
+        }
+        log.warn(`OAuth ${action} endpoint unexpected error: ${message}`);
+        res.status(500).json({ error: "server_error", error_description: "internal error" });
+      }
+    };
+  }
+
+  app.post("/oauth/pending/:ref/approve", decisionHandler("approve"));
+  app.post("/oauth/pending/:ref/deny", decisionHandler("deny"));
+
+  return {
+    app,
+    state,
+    ownedExactPaths: [
+      "/authorize",
+      "/token",
+      "/.well-known/oauth-authorization-server",
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-protected-resource/mcp",
+    ],
+    ownedPathPrefixes: ["/oauth/"],
+  };
+}
+
+// ── External request handler (mount point) ──────────────────────────────────
+
+/**
+ * Adapt the OAuth express app to the core access server's
+ * `externalRequestHandler` hook. Ownership is decided by pathname BEFORE
+ * delegating to express (deterministic — never inferred from express
+ * fallthrough), so non-OAuth requests always continue down the normal
+ * core pipeline.
+ */
+export function buildOAuthRequestHandler(
+  config: ParsedOAuthConfig,
+  deps?: { tokensPath?: string },
+): (req: IncomingMessage, res: ServerResponse, ctx: { authorized: boolean }) => Promise<boolean> {
+  if (!config.enabled) {
+    return async () => false;
+  }
+  // Core computes the operator-authorization ctx per request and hands it
+  // to the hook; stash it per-request so express handlers can read it
+  // without ever re-validating headers themselves.
+  const ctxByRequest = new WeakMap<IncomingMessage, { authorized: boolean }>();
+  const bundle = buildOAuthApp(config, (req) => ctxByRequest.get(req) ?? { authorized: false }, deps);
+  const exactPaths = new Set(bundle.ownedExactPaths);
+
+  return (req, res, ctx) => {
+    let pathname: string;
+    try {
+      pathname = new URL(req.url ?? "/", "http://placeholder").pathname;
+    } catch {
+      return Promise.resolve(false);
+    }
+    const owned = exactPaths.has(pathname) || bundle.ownedPathPrefixes.some((prefix) => pathname.startsWith(prefix));
+    if (!owned) return Promise.resolve(false);
+
+    ctxByRequest.set(req, ctx);
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    const finish = () => resolve(true);
+    res.on("finish", finish);
+    res.on("close", finish);
+    // An express app instance is a Node request listener; the third
+    // argument runs when no route matched or a handler errored.
+    bundle.app(req as Request, res as Response, (err: unknown) => {
+      if (!res.headersSent) {
+        if (err) {
+          log.warn(`OAuth facade error: ${err instanceof Error ? err.message : String(err)}`);
+          res.statusCode = 500;
+          res.setHeader("content-type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: "server_error", error_description: "internal error" }));
+        } else {
+          res.statusCode = 404;
+          res.setHeader("content-type", "application/json; charset=utf-8");
+          res.end(JSON.stringify({ error: "not_found", error_description: "unknown OAuth endpoint" }));
+        }
+      }
+      resolve(true);
+    });
+    return promise;
+  };
+}

--- a/packages/remnic-server/src/oauth.ts
+++ b/packages/remnic-server/src/oauth.ts
@@ -306,6 +306,13 @@ export function readOAuthEnvOverrides(): Record<string, unknown> {
 
 /** Merge env overrides over the file block and parse the result. */
 export function applyOAuthEnvOverrides(fileBlock: unknown): ParsedOAuthConfig {
+  // A present-but-non-object `server.oauth` (e.g. `true` or a string) is
+  // invalid config, not "disabled". Hand it straight to parseOAuthConfig,
+  // which throws a precise error, instead of silently coercing it to `{}`
+  // and treating OAuth as off (repo rule: reject invalid input).
+  if (fileBlock !== undefined && !isPlainObject(fileBlock)) {
+    return parseOAuthConfig(fileBlock);
+  }
   const overrides = readOAuthEnvOverrides();
   const merged: Record<string, unknown> = isPlainObject(fileBlock) ? { ...fileBlock } : {};
   for (const [key, value] of Object.entries(overrides)) {
@@ -508,6 +515,13 @@ export class OAuthState {
       return { status: "pending" };
     }
     if (txn.outcome.kind === "denied") return { status: "denied" };
+    // Approved, but only hand back the redirect while the authorization
+    // code is still live. The code TTL (120 s) is shorter than the txn TTL
+    // (approvalTtlSeconds, default 600 s), so a slow browser poll could
+    // otherwise be redirected with a code that has already expired,
+    // failing the token exchange. Once the code is gone (expired or
+    // already exchanged), report expired so the client restarts cleanly.
+    if (!this.peekCode(txn.outcome.code)) return { status: "expired" };
     return { status: "approved", redirect: this.buildRedirect(txn, txn.outcome.code) };
   }
 

--- a/packages/remnic-server/tsconfig.json
+++ b/packages/remnic-server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "ES2024.Promise"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.22.2
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@4.22.2)
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -3412,6 +3415,11 @@ snapshots:
   expand-template@2.0.3: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@4.22.2):
+    dependencies:
+      express: 4.22.2
+      ip-address: 10.2.0
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,10 +561,19 @@ importers:
 
   packages/remnic-server:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
+      express:
+        specifier: ^4.21.2
+        version: 4.22.2
     devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.25
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -898,6 +907,12 @@ packages:
   '@honcho-ai/sdk@2.2.0':
     resolution: {integrity: sha512-SyygN+BrpUB2fRjhwcYmT+tcEhHrKmbj9nOZLVUFY7M5YBswJ+mZb/CeLpNbRh+QQTU8F8JWY3lQat95c6nwmA==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -971,6 +986,15 @@ packages:
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpack/msgpack@3.1.3':
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
@@ -1277,11 +1301,17 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/command-line-args@5.2.3':
     resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
 
   '@types/command-line-usage@5.0.4':
     resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
@@ -1289,11 +1319,29 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@4.19.9':
+    resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
+
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1302,6 +1350,15 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -1313,10 +1370,24 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1337,6 +1408,9 @@ packages:
     resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
     engines: {node: '>=12.17'}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1355,6 +1429,14 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1369,9 +1451,21 @@ packages:
     peerDependencies:
       esbuild: ~0.28.1
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001802:
     resolution: {integrity: sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==}
@@ -1421,12 +1515,43 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1434,6 +1559,14 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1452,6 +1585,14 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1459,8 +1600,19 @@ packages:
   dpack@0.6.22:
     resolution: {integrity: sha512-WGPNlW2OAE7Bj0eODMpAHUcEqxrlg01e9OFZDxQodminIgC194/cRHT7K04Z1j7AUEWTeeplYGrIv/xRdwU9Hg==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.387:
     resolution: {integrity: sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1468,6 +1620,18 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1478,12 +1642,47 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+    engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1497,6 +1696,14 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-replace@3.0.0:
     resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
     engines: {node: '>=4.0.0'}
@@ -1507,6 +1714,18 @@ packages:
   flatbuffers@24.12.23:
     resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1515,12 +1734,27 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1529,8 +1763,32 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.29:
+    resolution: {integrity: sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   hyparquet@1.26.2:
     resolution: {integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1541,12 +1799,26 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1563,6 +1835,12 @@ packages:
   json-bignum@0.0.3:
     resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
     engines: {node: '>=0.8'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1589,8 +1867,52 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   meilisearch@0.46.0:
     resolution: {integrity: sha512-bx0tei1B+Ke0Y02pCoqmcwfpkwuDf+/ZkQDVDvb+ZfGDpWaxq9Z7sE5kc3o8zWvP6wJE7e3PoU3Oy6WINqq5bw==}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1613,6 +1935,9 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1626,6 +1951,14 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   node-abi@3.94.0:
     resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
@@ -1648,6 +1981,14 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1672,9 +2013,19 @@ packages:
       zod:
         optional: true
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1689,6 +2040,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -1725,8 +2080,32 @@ packages:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1773,6 +2152,10 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -1782,8 +2165,15 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1797,12 +2187,31 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   seqproto@0.2.3:
     resolution: {integrity: sha512-HpNyPYl7DJa2a6XQJ+MJAc6ft6Y9ZU+zRiuvTHFpLPeqvapcTAGFJyhMEIN7Y7VXhWT6NEdNVhbXFHwtaCOfCw==}
     engines: {node: '>= 20.0.0'}
 
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1811,6 +2220,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -1825,6 +2250,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1871,6 +2300,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -1912,6 +2345,14 @@ packages:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1935,6 +2376,10 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1943,6 +2388,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
@@ -2020,6 +2473,11 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2274,6 +2732,10 @@ snapshots:
     dependencies:
       zod: 4.0.0
 
+  '@hono/node-server@1.19.14(hono@4.12.29)':
+    dependencies:
+      hono: 4.12.29
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -2330,6 +2792,28 @@ snapshots:
       '@lancedb/lancedb-linux-x64-musl': 0.26.2
       '@lancedb/lancedb-win32-arm64-msvc': 0.26.2
       '@lancedb/lancedb-win32-x64-msvc': 0.26.2
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.29)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.29
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpack/msgpack@3.1.3': {}
 
@@ -2543,15 +3027,42 @@ snapshots:
     dependencies:
       '@types/node': 22.20.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.20.0
+
   '@types/command-line-args@5.2.3': {}
 
   '@types/command-line-usage@5.0.4': {}
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@types/cross-spawn@6.0.6':
     dependencies:
       '@types/node': 22.20.0
 
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@4.19.9':
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.25':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.9
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/node@20.19.43':
     dependencies:
@@ -2561,6 +3072,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -2568,6 +3083,21 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 22.20.0
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.20.0
+
+  '@types/serve-static@1.15.10':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.20.0
+      '@types/send': 0.17.6
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -2583,7 +3113,28 @@ snapshots:
 
   abbrev@4.0.0: {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.17.0: {}
+
+  ajv-formats@3.0.1:
+    dependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2607,6 +3158,8 @@ snapshots:
 
   array-back@6.2.3: {}
 
+  array-flatten@1.1.1: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.42: {}
@@ -2626,6 +3179,37 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@1.20.6:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.42
@@ -2644,7 +3228,19 @@ snapshots:
       esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001802: {}
 
@@ -2691,9 +3287,30 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2702,6 +3319,10 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -2713,17 +3334,39 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
   detect-libc@2.1.2: {}
 
   dpack@0.6.22: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.387: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
   env-paths@2.2.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -2756,15 +3399,126 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expand-template@2.0.3: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@4.22.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.6
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.3: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
 
   file-uri-to-path@1.0.0: {}
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-replace@3.0.0:
     dependencies:
@@ -2778,20 +3532,72 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
   github-from-package@0.0.0: {}
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.29: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   hyparquet@1.26.2: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2799,9 +3605,17 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
   isexe@2.0.0: {}
 
   isexe@4.0.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -2810,6 +3624,10 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-bignum@0.0.3: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -2829,7 +3647,33 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  media-typer@1.1.0: {}
+
   meilisearch@0.46.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime@1.6.0: {}
 
   mimic-response@3.1.0: {}
 
@@ -2850,6 +3694,8 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -2861,6 +3707,10 @@ snapshots:
   nanoid@3.3.15: {}
 
   napi-build-utils@2.0.0: {}
+
+  negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   node-abi@3.94.0:
     dependencies:
@@ -2887,6 +3737,12 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -2899,7 +3755,13 @@ snapshots:
     optionalDependencies:
       zod: 4.0.0
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
+
+  path-to-regexp@0.1.13: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -2908,6 +3770,8 @@ snapshots:
   picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -2946,10 +3810,38 @@ snapshots:
 
   proc-log@6.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2991,6 +3883,8 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   rollup@4.62.2:
@@ -3024,7 +3918,19 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -3032,15 +3938,97 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   seqproto@0.2.3: {}
 
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   simple-concat@1.0.1: {}
 
@@ -3053,6 +4041,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  statuses@2.0.2: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -3117,6 +4107,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  toidentifier@1.0.1: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -3170,6 +4162,17 @@ snapshots:
       '@turbo/windows-64': 2.9.14
       '@turbo/windows-arm64': 2.9.14
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   typical@4.0.0: {}
@@ -3182,6 +4185,8 @@ snapshots:
 
   undici@6.27.0: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
       browserslist: 4.28.4
@@ -3189,6 +4194,10 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
+  vary@1.1.2: {}
 
   vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
@@ -3223,6 +4232,10 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/tests/access-mcp-action-confidence.test.ts
+++ b/tests/access-mcp-action-confidence.test.ts
@@ -31,7 +31,7 @@ function fakeService(capture: { calls: unknown[] }): EngramAccessService {
 
 test("MCP advertises action_confidence under engram and remnic names", async () => {
   const server = new EngramMcpServer(fakeService({ calls: [] }));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
 
   const tools = await server.handleRequest({
     jsonrpc: "2.0",
@@ -48,7 +48,7 @@ test("MCP advertises action_confidence under engram and remnic names", async () 
 test("MCP action_confidence validates and dispatches to service", async () => {
   const capture = { calls: [] as unknown[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
 
   const response = await server.handleRequest({
     jsonrpc: "2.0",
@@ -85,7 +85,7 @@ test("MCP action_confidence validates and dispatches to service", async () => {
 test("MCP action_confidence rejects unknown risk values before service dispatch", async () => {
   const capture = { calls: [] as unknown[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
 
   const response = await server.handleRequest({
     jsonrpc: "2.0",

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -144,12 +144,7 @@ function resultText(response: unknown): string {
 
 test("ChatGPT Apps inspector advertises app-compatible tool metadata and aliases", async () => {
   const server = new EngramMcpServer(fakeService({ recalls: [], xrays: [], actionRequests: [] }));
-  const init = await server.handleRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {},
-  });
+  const init = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   assert.deepEqual((init?.result as { capabilities: Record<string, unknown> }).capabilities.resources, {});
 
   const toolsResponse = await server.handleRequest({

--- a/tests/access-mcp-recall-xray.test.ts
+++ b/tests/access-mcp-recall-xray.test.ts
@@ -50,7 +50,7 @@ function fakeService(capture: {
 
 test("MCP advertises both engram.recall_xray and remnic.recall_xray", async () => {
   const server = new EngramMcpServer(fakeService({ calls: [] }));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   const tools = await server.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -67,7 +67,7 @@ test("MCP advertises both engram.recall_xray and remnic.recall_xray", async () =
 test("MCP engram.recall_xray dispatches to recallXray with threaded params", async () => {
   const capture = { calls: [] as any[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
 
   const response = await server.handleRequest({
     jsonrpc: "2.0",
@@ -99,7 +99,7 @@ test("MCP engram.recall_xray dispatches to recallXray with threaded params", asy
 test("MCP remnic.recall_xray alias dispatches identically", async () => {
   const capture = { calls: [] as any[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   await server.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -116,7 +116,7 @@ test("MCP remnic.recall_xray alias dispatches identically", async () => {
 test("MCP engram.recall_xray coerces string budget to integer", async () => {
   const capture = { calls: [] as any[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   await server.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -132,7 +132,7 @@ test("MCP engram.recall_xray coerces string budget to integer", async () => {
 test("MCP engram.recall_xray rejects invalid budget with a listed-options error", async () => {
   const capture = { calls: [] as any[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   const response = await server.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -163,7 +163,7 @@ test("MCP engram.recall_xray rejects non-string non-number budgets (e.g., boolea
   // of coercing them.  This exercises the boolean and object cases.
   const capture = { calls: [] as any[] };
   const server = new EngramMcpServer(fakeService(capture));
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   for (const badBudget of [true, false, { v: 1 }, [4096]]) {
     const response = await server.handleRequest({
       jsonrpc: "2.0",

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -298,17 +298,80 @@ function toolCallErrorMessage(resp: unknown): string {
   return r.result.content?.[0]?.text ?? "";
 }
 
+test("MCP initialize negotiates the protocol version per spec", async () => {
+  const server = new EngramMcpServer(createFakeService());
+
+  // Every supported version is echoed back verbatim.
+  for (const version of ["2025-06-18", "2025-03-26", "2024-11-05"]) {
+    const init = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: version },
+    });
+    const result = init?.result;
+    assert.ok(result && typeof result === "object" && "protocolVersion" in result);
+    assert.equal(result.protocolVersion, version, `supported version ${version} must be echoed`);
+  }
+
+  // A well-formed but unsupported version gets the spec counter-offer:
+  // the newest version the server supports.
+  const future = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "initialize",
+    params: { protocolVersion: "2099-01-01" },
+  });
+  const futureResult = future?.result;
+  assert.ok(futureResult && typeof futureResult === "object" && "protocolVersion" in futureResult);
+  assert.equal(futureResult.protocolVersion, "2025-06-18");
+
+  // Missing / mistyped / empty protocolVersion is invalid params, not a
+  // silent default (rule: reject invalid inputs explicitly).
+  for (const params of [{}, { protocolVersion: 42 }, { protocolVersion: "" }]) {
+    const bad = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "initialize",
+      params: params as Record<string, unknown>,
+    });
+    const error = bad?.error;
+    assert.ok(error && typeof error === "object" && "code" in error, "expected JSON-RPC error");
+    assert.equal(error.code, -32602);
+    assert.match(String((error as { message?: unknown }).message ?? ""), /protocolVersion/);
+  }
+});
+
+test("MCP tools/list marks read-only tools with readOnlyHint and leaves write tools unmarked", async () => {
+  const server = new EngramMcpServer(createFakeService());
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
+  const listed = await server.handleRequest({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  const result = listed?.result as { tools: Array<{ name: string; annotations?: { readOnlyHint?: boolean } }> };
+  const byName = new Map(result.tools.map((tool) => [tool.name, tool]));
+
+  // Pure reads carry the hint in both naming forms.
+  for (const name of ["remnic.recall", "engram.recall", "remnic.memory_get", "engram.memory_search"]) {
+    const tool = byName.get(name);
+    assert.ok(tool, `${name} must be listed`);
+    assert.equal(tool.annotations?.readOnlyHint, true, `${name} must carry readOnlyHint`);
+  }
+
+  // Mutating tools must NOT carry it — ChatGPT treats unannotated tools as
+  // write actions requiring confirmation, which is the safe default.
+  for (const name of ["remnic.memory_store", "engram.memory_store", "remnic.wearables_sync", "engram.observe"]) {
+    const tool = byName.get(name);
+    assert.ok(tool, `${name} must be listed`);
+    assert.notEqual(tool.annotations?.readOnlyHint, true, `${name} must not be marked read-only`);
+  }
+});
+
 test("MCP server advertises tools and dispatches recall", async () => {
   const server = new EngramMcpServer(createFakeService());
 
-  const init = await server.handleRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {},
-  });
+  const init = await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   assert.equal(init?.jsonrpc, "2.0");
-  assert.equal((init?.result as { protocolVersion: string }).protocolVersion, "2024-11-05");
+  // Requested version is supported → server echoes it back.
+  assert.equal((init?.result as { protocolVersion: string }).protocolVersion, "2025-06-18");
 
   const tools = await server.handleRequest({
     jsonrpc: "2.0",
@@ -897,7 +960,7 @@ test("engram.peer_set rejects non-string kind/displayName/notes (Codex P2 PR #75
 
 test("engram.console_state and remnic.console_state return a ConsoleStateSnapshot", async () => {
   const server = new EngramMcpServer(createFakeService());
-  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
 
   for (const toolName of ["engram.console_state", "remnic.console_state"]) {
     const resp = await server.handleRequest({
@@ -925,22 +988,12 @@ test("MCP initialize re-reads the server version for each server instance", asyn
   try {
     process.env.OPENCLAW_ENGRAM_VERSION = "9.9.1";
     const firstServer = new EngramMcpServer(createFakeService());
-    const firstInit = await firstServer.handleRequest({
-      jsonrpc: "2.0",
-      id: 1,
-      method: "initialize",
-      params: {},
-    });
+    const firstInit = await firstServer.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
     assert.equal((firstInit?.result as { serverInfo: { version: string } }).serverInfo.version, "9.9.1");
 
     process.env.OPENCLAW_ENGRAM_VERSION = "9.9.2";
     const secondServer = new EngramMcpServer(createFakeService());
-    const secondInit = await secondServer.handleRequest({
-      jsonrpc: "2.0",
-      id: 2,
-      method: "initialize",
-      params: {},
-    });
+    const secondInit = await secondServer.handleRequest({ jsonrpc: "2.0", id: 2, method: "initialize", params: { protocolVersion: "2025-06-18" } });
     assert.equal((secondInit?.result as { serverInfo: { version: string } }).serverInfo.version, "9.9.2");
   } finally {
     if (originalVersion === undefined) {

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -620,12 +620,7 @@ test("HTTP /engram/v1/graph/snapshot forwards filters to the service", async () 
 test("MCP graph_snapshot tool is exposed under both prefixes", async () => {
   const service = createFakeService();
   const mcp = new EngramMcpServer(service);
-  const init = await mcp.handleRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {},
-  });
+  const init = await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   assert.ok(init);
   const tools = await mcp.handleRequest({
     jsonrpc: "2.0",
@@ -659,12 +654,7 @@ test("MCP graph_snapshot tool dispatches to the service", async () => {
     },
   } as unknown as Partial<EngramAccessService>);
   const mcp = new EngramMcpServer(service);
-  await mcp.handleRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {},
-  });
+  await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   const result = await mcp.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -688,12 +678,7 @@ test("MCP graph_snapshot tool dispatches to the service", async () => {
 test("MCP graph_snapshot rejects non-numeric limit at the boundary", async () => {
   const service = createFakeService();
   const mcp = new EngramMcpServer(service);
-  await mcp.handleRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {},
-  });
+  await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
   const result = await mcp.handleRequest({
     jsonrpc: "2.0",
     id: 2,

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -620,7 +620,12 @@ test("HTTP /engram/v1/graph/snapshot forwards filters to the service", async () 
 test("MCP graph_snapshot tool is exposed under both prefixes", async () => {
   const service = createFakeService();
   const mcp = new EngramMcpServer(service);
-  const init = await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
+  const init = await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18" },
+  });
   assert.ok(init);
   const tools = await mcp.handleRequest({
     jsonrpc: "2.0",
@@ -654,7 +659,12 @@ test("MCP graph_snapshot tool dispatches to the service", async () => {
     },
   } as unknown as Partial<EngramAccessService>);
   const mcp = new EngramMcpServer(service);
-  await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
+  await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18" },
+  });
   const result = await mcp.handleRequest({
     jsonrpc: "2.0",
     id: 2,
@@ -678,7 +688,12 @@ test("MCP graph_snapshot tool dispatches to the service", async () => {
 test("MCP graph_snapshot rejects non-numeric limit at the boundary", async () => {
   const service = createFakeService();
   const mcp = new EngramMcpServer(service);
-  await mcp.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18" } });
+  await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18" },
+  });
   const result = await mcp.handleRequest({
     jsonrpc: "2.0",
     id: 2,


### PR DESCRIPTION
## What

Makes a standalone `remnic-server` connectable from **chatgpt.com developer-mode apps**. ChatGPT dev-mode supports only OAuth / No Auth / Mixed (no static bearer header), so Remnic now acts as its own OAuth 2.1 authorization server, minting its regular connector tokens as OAuth access tokens.

### Transport (`@remnic/core`)
- MCP protocol-version negotiation (`2025-06-18` / `2025-03-26` / `2024-11-05`): echo supported client versions, counter-offer newest on unknown, JSON-RPC `-32602` on missing/mistyped `protocolVersion`.
- Validate the `MCP-Protocol-Version` header on `POST /mcp` (400 on unknown); `405 + Allow: POST` for GET/DELETE `/mcp`.
- `resourceMetadataUrl` option → RFC 9728 `WWW-Authenticate: Bearer resource_metadata="…"` on 401s.
- `externalRequestHandler` pre-auth hook so hosts can mount public endpoints without core learning host specifics.
- Conservative `readOnlyHint` annotations on unambiguously read-only tools (ChatGPT skips per-call confirmation for them).
- Scoped auth: `authTokenEntriesGetter` + `tokenPathPolicy` — validation and connector identity come from ONE coherent token-store snapshot; fail closed; no fall-through to the unscoped string getter.

### OAuth facade (`@remnic/server`)
- Protocol endpoints (`/authorize`, `/token`, RFC 8414 + RFC 9728 discovery) are **`@modelcontextprotocol/sdk` auth handlers** — PKCE S256, client auth, param validation, redirect-URI membership, and rate limiting are SDK-owned, not hand-rolled.
- Remnic glue: `server.oauth` config (+`REMNIC_OAUTH_*` env, strict validation, `enabled: false` default), static pre-registered client, **exact byte-for-byte redirect allowlist** (empty = setup mode: discovery live, every authorization refused), pending-approval interaction (the authorize page never asks for credentials — it shows `remnic oauth approve <ref>` instructions and polls with a per-transaction secret).
- Codes: 128-bit, single-use, 120 s TTL, bound to client_id + redirect_uri + PKCE challenge + resource.
- Access token = connector token (`chatgpt`, `remnic_cg_` prefix); re-linking rotates it; the token-path policy pins it to `POST /mcp` only (401 on all REST/admin routes — tested).

### CLI (`@remnic/cli`)
- `remnic oauth pending|approve <ref>|deny <ref>` with strict input validation (validate-first, unknown/duplicate/missing-value flags rejected), TTY confirmation, `--yes` for non-TTY, clear 401/404/409/unreachable errors.

### Docs
- `docs/integration/chatgpt.md`: full walkthrough (dev mode, Tailscale Funnel / Cloudflare Tunnel, config, app creation, callback registration, approval flow, troubleshooting, security notes). Cross-refs in docs/README, remnic-server README, llms.txt.

## Verification

- **Full-flow integration tests** (`packages/remnic-server/src/oauth.test.ts`, 11 tests): discovery → authorize → approve → PKCE token exchange → authenticated `/mcp` initialize + tools/list; scope-policy matrix (chatgpt token /mcp-only; operator + other connectors unaffected); rotation; revoke-immediately; negative paths (bad client, unregistered redirect, missing PKCE, wrong verifier, code replay, refresh grant, wrong poll secret, unauthorized operator endpoints, disabled-OAuth 404s).
- **Official MCP SDK client smoke** against a real `startServer` boot behind a live Tailscale Funnel (scratch instance, disposable creds, torn down after): 401-challenge discovery chain → OAuth flow → `StreamableHTTPClientTransport` connect → tools/list (85 tools, readOnlyHint verified) → `remnic.recall` call. All green.
- Core: `access-http` 33/33, `access-mcp` + version-negotiation suites 67/67 + 106-test batch, tokens coherence tests; CLI: 20/20 behavioral + 26/26 command-surface.
- `lint`, `check-config-contract`, `check-docs-parity`, `check-ratchets`, `check-review-patterns`, `plugin:inspect`, and every quick-preflight test step: **exit 0 individually**.

## Known gate caveats (inherited, receipts in hand)

- `check-test-types` (inside `preflight:quick`) is **red on clean origin/main** in this environment (~535 pre-existing error classes). Normalized (file+code) diff vs. clean main: **zero branch-only error classes** (bench-file deltas reproduce on main once `@remnic/bench` is built).
- Full offline suite (13 124 tests): 13 111–13 113 pass. `tier migration updates the projected memory path` fails **identically on clean origin/main in isolation** (inherited, deterministic). Remaining deltas are load flakes / local-tree artifact contamination — all pass in isolation and in a clean detached worktree at this exact HEAD.
- Live chatgpt.com UI linking was **not** browser-automated (no logged-in ChatGPT session available in the automatable browser); protocol interop was validated with the official SDK streamable-HTTP client over the public Funnel URL instead. docs/integration/chatgpt.md documents the manual UI steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Exposes memory over the public internet via OAuth and tunnels; scoped `/mcp`-only tokens and operator approval mitigate but misconfiguration (weak secrets, wrong redirect allowlist, tunnel without OAuth) could enable full memory read/write.
> 
> **Overview**
> Adds **chatgpt.com developer-mode** support: a public HTTPS OAuth 2.1 flow (Tailscale Funnel / Cloudflare Tunnel) where Remnic is the authorization server, mints `chatgpt` connector tokens (`remnic_cg_`), and requires **local operator approval** before linking.
> 
> **`@remnic/core`** tightens streamable-HTTP MCP: multi-version `initialize` negotiation, `MCP-Protocol-Version` validation on `POST /mcp`, `405` for GET/DELETE on `/mcp`, optional RFC 9728 `resource_metadata` on 401s, a pre-auth `externalRequestHandler` hook, scoped auth via `authTokenEntriesGetter` + `tokenPathPolicy` (ChatGPT tokens limited to `/mcp`), and conservative `readOnlyHint` on read-only tools.
> 
> **`@remnic/server`** wires `server.oauth` / `REMNIC_OAUTH_*` into an OAuth facade (discovery, authorize, token, poll, operator pending endpoints) and pins OAuth-issued tokens to MCP only.
> 
> **`@remnic/cli`** adds `remnic oauth pending|approve|deny` against operator-protected daemon routes.
> 
> Docs: new `docs/integration/chatgpt.md` plus index cross-links; extensive integration and CLI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b954a092e81b05fc55afadbb3de54e3f6345a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->