### PR TITLE
Make the regression-gate variance test deterministic

### DIFF
--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -207,35 +207,48 @@ test("regression gate: passes when metrics match the baseline", async () => {
   assert.equal(result.regressions.length, 0);
 });
 
-test("regression gate: passes within 30% tolerance on natural variance", async () => {
-  const report1 = await runCodingGraphBenchmark({
-    fixture: { fileCount: 10, symbolsPerFile: 5 },
-    iterations: 20,
-  });
-  // Run again — natural timing variance should stay within 30%.
-  const report2 = await runCodingGraphBenchmark({
+test("regression gate: tolerates a slowdown strictly below the tolerance bound", async () => {
+  const report = await runCodingGraphBenchmark({
     fixture: { fileCount: 10, symbolsPerFile: 5 },
     iterations: 20,
   });
 
-  const baseline = buildBaselineFromReport(report1, "run 1");
-  const result = checkCodingGraphRegression(report2, baseline, 30);
-  // Natural back-to-back variance must not trip the gate as a GROSS
-  // regression. The sub-ms p95 metrics (incrementalUpdate /
-  // incrementalModifiedUpdate / tracePath / searchGraph) are excluded from
-  // this check: their p95 over ~20 sub-ms samples is outlier-dominated — a
-  // single GC/scheduler spike swings a 0.2 ms p95 by 10×+ — so a relative
-  // bound is meaningless there (a known property of micro-benchmark p95, not
-  // a gate defect). Only metrics with a baseline ≥ 2 ms (fullIndexMs) are
-  // stable enough for a relative-variance comparison. dbBytesPerKloc is
-  // deterministic on the same machine and never regresses. A REAL regression
-  // on the stable metrics is ~10× (see the prove-fail test), well above the
-  // 50% bound used here (#1688).
-  const stableRegressions = result.regressions.filter((r) => r.baseline >= 2);
-  assert.ok(
-    result.passed || stableRegressions.every((r) => r.percentChange < 50),
-    "natural variance should not trigger gross regression on stable (≥2ms) metrics",
+  // History (#1688, #1838): this test used to run the benchmark TWICE and
+  // assert the two wall-clock reports stayed within tolerance. That asserts
+  // a statistical property of a shared CI runner, not a property of the
+  // gate, and it flaked on untouched branches AND blocked two release runs
+  // on 2026-07-11 even after the #1688 hardening. The tolerance contract is
+  // deterministic when tested like the prove-fail test below: perturb the
+  // BASELINE by a known factor and assert the gate's verdict. Scaling every
+  // baseline metric by 1/1.2 makes each measured metric read as exactly a
+  // +20% change - ratio math, independent of absolute wall-clock values -
+  // which sits strictly below the 30% tolerance, so the gate MUST pass
+  // outright. No stable-metric filtering, no waiver.
+  const realMetrics = extractMetrics(report);
+  const scaled = Object.fromEntries(
+    Object.entries(realMetrics).map(([key, value]) => [
+      key,
+      typeof value === "number" ? Math.max(0.001, value / 1.2) : value,
+    ]),
+  ) as typeof realMetrics;
+  const moderateBaseline: CodingGraphBaseline = {
+    schemaVersion: report.schemaVersion,
+    machine: report.machine,
+    fixtureConfig: report.fixture.config,
+    metrics: scaled,
+    createdAt: report.timestamp,
+    note: "synthetic: every metric 1.2x faster than measured (+20% apparent change)",
+  };
+
+  const result = checkCodingGraphRegression(report, moderateBaseline, 30);
+  assert.equal(
+    result.passed,
+    true,
+    "a uniform +20% change must pass a 30% tolerance gate",
   );
+  assert.equal(result.regressions.length, 0, "no metric may be flagged");
+  // The bracket around this middle case: identical metrics pass at any
+  // tolerance (smoke test above); a 10x slowdown fails (prove-fail below).
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/bench/src/coding-graph/harness.test.ts
+++ b/packages/bench/src/coding-graph/harness.test.ts
@@ -23,6 +23,7 @@ import {
   checkCodingGraphRegression,
   buildBaselineFromReport,
   extractMetrics,
+  METRIC_DIRECTION,
   compareMachineFingerprints,
   createSeededRng,
   DEFAULT_SMOKE_FIXTURE,
@@ -219,17 +220,23 @@ test("regression gate: tolerates a slowdown strictly below the tolerance bound",
   // gate, and it flaked on untouched branches AND blocked two release runs
   // on 2026-07-11 even after the #1688 hardening. The tolerance contract is
   // deterministic when tested like the prove-fail test below: perturb the
-  // BASELINE by a known factor and assert the gate's verdict. Scaling every
-  // baseline metric by 1/1.2 makes each measured metric read as exactly a
-  // +20% change - ratio math, independent of absolute wall-clock values -
-  // which sits strictly below the 30% tolerance, so the gate MUST pass
-  // outright. No stable-metric filtering, no waiver.
+  // BASELINE by a known factor and assert the gate's verdict. Each metric is
+  // moved 20% into ITS OWN regressing direction: lower-is-better (ms, bytes)
+  // baselines sit below the measured value so the measurement reads as a
+  // +20% slowdown; higher-is-better (LOC/s) baselines sit ABOVE the measured
+  // value so the measurement reads as a 20% throughput drop
+  // (chatgpt-codex-connector #1843 P2). Both are 20% in the regressing
+  // direction - ratio math, no wall-clock coupling - strictly below the 30%
+  // tolerance, so the gate MUST pass outright. No stable-metric waiver.
   const realMetrics = extractMetrics(report);
   const scaled = Object.fromEntries(
-    Object.entries(realMetrics).map(([key, value]) => [
-      key,
-      typeof value === "number" ? Math.max(0.001, value / 1.2) : value,
-    ]),
+    Object.entries(realMetrics).map(([key, value]) => {
+      if (typeof value !== "number") return [key, value];
+      const higherIsBetter =
+        METRIC_DIRECTION[key as keyof typeof METRIC_DIRECTION] === "higher-is-better";
+      const scaledValue = higherIsBetter ? value * 1.2 : value / 1.2;
+      return [key, Math.max(0.001, scaledValue)];
+    }),
   ) as typeof realMetrics;
   const moderateBaseline: CodingGraphBaseline = {
     schemaVersion: report.schemaVersion,
@@ -237,7 +244,7 @@ test("regression gate: tolerates a slowdown strictly below the tolerance bound",
     fixtureConfig: report.fixture.config,
     metrics: scaled,
     createdAt: report.timestamp,
-    note: "synthetic: every metric 1.2x faster than measured (+20% apparent change)",
+    note: "synthetic: every metric 20% into its regressing direction vs measured",
   };
 
   const result = checkCodingGraphRegression(report, moderateBaseline, 30);

--- a/packages/bench/src/coding-graph/index.ts
+++ b/packages/bench/src/coding-graph/index.ts
@@ -22,6 +22,7 @@ export {
   extractMetrics,
   buildBaselineFromReport,
   compareMachineFingerprints,
+  METRIC_DIRECTION,
 } from "./regression.js";
 export type { RegressionMetricKey } from "./regression.js";
 

--- a/packages/bench/src/coding-graph/regression.ts
+++ b/packages/bench/src/coding-graph/regression.ts
@@ -27,7 +27,7 @@ import { DEFAULT_TOLERANCE_PERCENT } from "./types.js";
 // higherIsBetter keys: throughput (LOC/s).
 // ---------------------------------------------------------------------------
 
-const METRIC_DIRECTION = {
+export const METRIC_DIRECTION = {
   fullIndexMs: "lower-is-better" as const,
   fullIndexLocsPerSecond: "higher-is-better" as const,
   incrementalUpdateP95Ms: "lower-is-better" as const,


### PR DESCRIPTION
Fixes #1838. The variance gate test ran the benchmark twice and asserted the two wall-clock reports stayed within tolerance. That checks the CI runner's scheduling noise, not the gate. It flaked on three untouched branches in one day and blocked two release runs on 2026-07-11, even after the #1688 hardening.

The replacement tests the same contract the deterministic way the prove-fail test next to it already does: scale every baseline metric by a known factor and assert the verdict. A uniform +20% change against a 30% tolerance must pass outright - ratio math, no wall-clock coupling, no stable-metric waiver. The bracket: identical metrics pass at any tolerance (smoke test), +20% passes 30% (this test), 10x fails (prove-fail test).

Ran the suite three times back to back locally: 37/37 each time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and public export of an existing constant; no change to production regression gate behavior in CI.
> 
> **Overview**
> Replaces the **regression gate variance** test that ran `runCodingGraphBenchmark` twice and compared two wall-clock reports within a 30% tolerance. That asserted CI scheduling noise, not gate logic, and flaked (#1838); the old **stable-metric waiver** (only metrics with baseline ≥ 2 ms) is removed with it.
> 
> The new test runs the benchmark once, builds a synthetic baseline by moving **every** metric **20%** in its regressing direction using **`METRIC_DIRECTION`** (÷1.2 for lower-is-better, ×1.2 for higher-is-better throughput), then asserts `checkCodingGraphRegression` **passes** at 30% with zero regressions—same deterministic pattern as the adjacent prove-fail test.
> 
> **`METRIC_DIRECTION`** is **exported** from `regression.ts` and re-exported via `index.ts` so the harness test can scale baselines directionally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d30ce42f710333d328a3f5f1f75234a1aa967f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->