### PR TITLE
feat(core): prefix log lines with ISO 8601 timestamps

### DIFF
--- a/.changeset/1840-log-timestamps.md
+++ b/.changeset/1840-log-timestamps.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Prefix log lines with an ISO 8601 timestamp by default so daemon log events can be correlated with external facts (client disconnects, deploys, proxy changes) during incident triage. Opt out with `REMNIC_LOG_TIMESTAMPS=false` (also accepts `0`/`no`/`off`) or `initLogger(backend, debug, { timestamps: false })`; unrecognized env values fall through to the default (on). Closes #1840.

--- a/packages/remnic-core/src/logger.test.ts
+++ b/packages/remnic-core/src/logger.test.ts
@@ -108,3 +108,13 @@ test("unrecognized REMNIC_LOG_TIMESTAMPS falls through to the default (on)", () 
   log.info("hello");
   assert.equal(lines[0], `info|${FIXED} remnic: hello`);
 });
+
+test("empty or whitespace-only REMNIC_LOG_TIMESTAMPS reads as unset (default on)", () => {
+  for (const raw of ["", "   "]) {
+    const { lines, backend } = capture();
+    process.env.REMNIC_LOG_TIMESTAMPS = raw;
+    initLogger(backend, false, { clock: () => FIXED });
+    log.info("hello");
+    assert.equal(lines[0], `info|${FIXED} remnic: hello`, `raw=${JSON.stringify(raw)}`);
+  }
+});

--- a/packages/remnic-core/src/logger.test.ts
+++ b/packages/remnic-core/src/logger.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { type LoggerBackend, initLogger, log } from "./logger.js";
+
+const FIXED = "2026-07-11T20:00:00.000Z";
+
+function capture(): { lines: string[]; backend: LoggerBackend } {
+  const lines: string[] = [];
+  const push =
+    (level: string) =>
+    (msg: string, ...args: unknown[]) => {
+      lines.push(args.length ? `${level}|${msg}|${JSON.stringify(args)}` : `${level}|${msg}`);
+    };
+  return {
+    lines,
+    backend: {
+      info: push("info"),
+      warn: push("warn"),
+      error: push("error"),
+      debug: push("debug"),
+    },
+  };
+}
+
+const savedEnv = process.env.REMNIC_LOG_TIMESTAMPS;
+test.afterEach(() => {
+  if (savedEnv === undefined) Reflect.deleteProperty(process.env, "REMNIC_LOG_TIMESTAMPS");
+  else process.env.REMNIC_LOG_TIMESTAMPS = savedEnv;
+  // Reset to a silent backend (module default is NOOP) so this suite never
+  // leaks console output or timestamp state into sibling suites in-process.
+  initLogger({ info() {}, warn() {}, error() {}, debug() {} }, false, { timestamps: true });
+});
+
+test("prefixes each level with an ISO 8601 timestamp by default", () => {
+  const { lines, backend } = capture();
+  Reflect.deleteProperty(process.env, "REMNIC_LOG_TIMESTAMPS");
+  initLogger(backend, true, { clock: () => FIXED });
+
+  log.info("hello");
+  log.warn("careful");
+  log.error("boom", new Error("bad"));
+  log.debug("trace");
+
+  assert.deepEqual(lines, [
+    `info|${FIXED} remnic: hello`,
+    `warn|${FIXED} remnic: careful`,
+    `error|${FIXED} remnic: boom — bad`,
+    `debug|${FIXED} remnic [debug]: trace`,
+  ]);
+});
+
+test("timestamps: false restores the legacy 'remnic: ' format", () => {
+  const { lines, backend } = capture();
+  initLogger(backend, false, { timestamps: false, clock: () => FIXED });
+
+  log.info("hello");
+  assert.equal(lines[0], "info|remnic: hello");
+  assert.ok(!lines[0].includes(FIXED));
+});
+
+test("REMNIC_LOG_TIMESTAMPS=false disables the prefix", () => {
+  const { lines, backend } = capture();
+  process.env.REMNIC_LOG_TIMESTAMPS = "false";
+  initLogger(backend, false, { clock: () => FIXED });
+
+  log.info("hello");
+  assert.equal(lines[0], "info|remnic: hello");
+});
+
+test("explicit option overrides the env var", () => {
+  const { lines, backend } = capture();
+  process.env.REMNIC_LOG_TIMESTAMPS = "false";
+  initLogger(backend, false, { timestamps: true, clock: () => FIXED });
+
+  log.info("hello");
+  assert.equal(lines[0], `info|${FIXED} remnic: hello`);
+});
+
+test("emits a real ISO 8601 timestamp when no clock is injected", () => {
+  const { lines, backend } = capture();
+  Reflect.deleteProperty(process.env, "REMNIC_LOG_TIMESTAMPS");
+  initLogger(backend, false);
+
+  log.info("hello");
+  const m = /^info\|(\S+) remnic: hello$/.exec(lines[0]);
+  assert.ok(m, `unexpected line: ${lines[0]}`);
+  assert.ok(!Number.isNaN(Date.parse(m[1])));
+  assert.equal(new Date(m[1]).toISOString(), m[1]);
+});
+
+test("preserves variadic args and gates debug on the debug flag", () => {
+  const { lines, backend } = capture();
+  initLogger(backend, false, { clock: () => FIXED });
+  log.debug("suppressed");
+  assert.equal(lines.length, 0, "debug must be gated when debug=false");
+
+  initLogger(backend, true, { clock: () => FIXED });
+  log.info("withargs", { a: 1 });
+  assert.equal(lines.at(-1), `info|${FIXED} remnic: withargs|[{"a":1}]`);
+});
+
+test("unrecognized REMNIC_LOG_TIMESTAMPS falls through to the default (on)", () => {
+  const { lines, backend } = capture();
+  process.env.REMNIC_LOG_TIMESTAMPS = "maybe";
+  initLogger(backend, false, { clock: () => FIXED });
+
+  log.info("hello");
+  assert.equal(lines[0], `info|${FIXED} remnic: hello`);
+});

--- a/packages/remnic-core/src/logger.ts
+++ b/packages/remnic-core/src/logger.ts
@@ -12,8 +12,27 @@ const NOOP_LOGGER: LoggerBackend = {
   debug() {},
 };
 
+export interface LoggerOptions {
+  /** Prefix each emitted line with an ISO 8601 timestamp. Defaults to true. */
+  timestamps?: boolean;
+  /** Clock source for the timestamp prefix; injectable for tests. */
+  clock?: () => string;
+}
+
 let _backend: LoggerBackend = NOOP_LOGGER;
 let _debug = false;
+let _timestamps = true;
+let _clock: () => string = () => new Date().toISOString();
+
+// Coerce a boolean-like env string. Unrecognized values return undefined so
+// callers fall through to the default rather than silently disabling.
+function coerceBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const s = value.trim().toLowerCase();
+  if (s === "0" || s === "false" || s === "no" || s === "off" || s === "") return false;
+  if (s === "1" || s === "true" || s === "yes" || s === "on") return true;
+  return undefined;
+}
 
 // Late-bind console.* rather than capturing references at module import
 // time. In production this is behaviour-identical to the pre-bound
@@ -31,28 +50,35 @@ const CONSOLE_LOGGER: LoggerBackend = {
   debug: (msg, ...args) => console.debug(msg, ...args),
 };
 
-export function initLogger(backend?: LoggerBackend, debug?: boolean): void {
+export function initLogger(backend?: LoggerBackend, debug?: boolean, options?: LoggerOptions): void {
   _backend = backend ?? CONSOLE_LOGGER;
   _debug = debug ?? false;
+  // Precedence: explicit option > REMNIC_LOG_TIMESTAMPS env > default (on).
+  _timestamps = options?.timestamps ?? coerceBool(process.env.REMNIC_LOG_TIMESTAMPS) ?? true;
+  _clock = options?.clock ?? (() => new Date().toISOString());
+}
+
+// Format one log line: "<iso> remnic: <msg>" when timestamps are enabled,
+// otherwise the legacy "remnic: <msg>". Timestamp is per-call.
+function fmt(msg: string, label = "remnic"): string {
+  const ts = _timestamps ? `${_clock()} ` : "";
+  return `${ts}${label}: ${msg}`;
 }
 
 export const log = {
   info(msg: string, ...args: unknown[]): void {
-    _backend.info(`remnic: ${msg}`, ...args);
+    _backend.info(fmt(msg), ...args);
   },
   warn(msg: string, ...args: unknown[]): void {
-    _backend.warn(`remnic: ${msg}`, ...args);
+    _backend.warn(fmt(msg), ...args);
   },
   error(msg: string, err?: unknown): void {
-    const detail =
-      err instanceof Error ? err.message : err ? String(err) : "";
-    _backend.error(
-      `remnic: ${msg}${detail ? ` — ${detail}` : ""}`,
-    );
+    const detail = err instanceof Error ? err.message : err ? String(err) : "";
+    _backend.error(fmt(`${msg}${detail ? ` — ${detail}` : ""}`));
   },
   debug(msg: string, ...args: unknown[]): void {
     if (!_debug) return;
     const fn = _backend.debug ?? _backend.info;
-    fn(`remnic [debug]: ${msg}`, ...args);
+    fn(fmt(msg, "remnic [debug]"), ...args);
   },
 };

--- a/packages/remnic-core/src/logger.ts
+++ b/packages/remnic-core/src/logger.ts
@@ -24,12 +24,14 @@ let _debug = false;
 let _timestamps = true;
 let _clock: () => string = () => new Date().toISOString();
 
-// Coerce a boolean-like env string. Unrecognized values return undefined so
-// callers fall through to the default rather than silently disabling.
+// Coerce a boolean-like env string. Empty/whitespace-only and unrecognized
+// values return undefined so callers fall through to the default (timestamps
+// on) rather than silently disabling — an empty env var reads as "unset".
 function coerceBool(value: string | undefined): boolean | undefined {
   if (value === undefined) return undefined;
   const s = value.trim().toLowerCase();
-  if (s === "0" || s === "false" || s === "no" || s === "off" || s === "") return false;
+  if (s === "") return undefined;
+  if (s === "0" || s === "false" || s === "no" || s === "off") return false;
   if (s === "1" || s === "true" || s === "yes" || s === "on") return true;
   return undefined;
 }


### PR DESCRIPTION
## Summary

Daemon log lines carried no timestamps, so log events could not be correlated with external facts (client disconnects, deploys, proxy changes) during incident triage. This prefixes every log line with an ISO 8601 timestamp by default.

- `log.info/warn/error/debug` now emit `<iso> remnic: <msg>` (and `<iso> remnic [debug]: <msg>`).
- Opt out via `REMNIC_LOG_TIMESTAMPS=false` (also accepts `0`/`no`/`off`) or `initLogger(backend, debug, { timestamps: false })`.
- Precedence: explicit option → env var → default (on). Unrecognized env values fall through to the default rather than silently disabling (coerceBool convention).
- Timestamp source is injectable (`clock` option) for deterministic tests. `initLogger`'s new third argument is optional — all existing call sites are unaffected.

Closes #1840.

## Type of change

- [x] Feature

## Validation

- [x] `npm run check-types` (diagnostics identical to baseline; only local delta is the pnpm-field deprecation WARN, which CI does not surface)
- [x] Focused test: `packages/remnic-core/src/logger.test.ts` — 7/7 pass
- [x] `pnpm --filter @remnic/core build`
- [x] `biome check` clean on changed files
- [x] Added tests for behavior changes

## Changelog

- [x] Changeset added (`.changeset/1840-log-timestamps.md`, `@remnic/core` patch)

## Risk assessment

- [x] No secrets/tokens added
- [x] Backwards compatibility considered — legacy format preserved behind opt-out; `initLogger` signature is additively optional
- [x] Zero/flag semantics: `REMNIC_LOG_TIMESTAMPS` boolean-like coercion validated (`false`/`0`/`no`/`off`); unrecognized → default-on
- [x] No new config schema surface (env + init option only; no `openclaw.plugin.json` change)

## Notes for reviewers

Timestamp is applied per logger call (each call emits one line). No high-risk retrieval/cache/orchestrator paths touched, so `test:entity-hardening` is not triggered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only formatting in the core logger; backward-compatible optional API and legacy format behind opt-out.
> 
> **Overview**
> **Default log output now includes an ISO 8601 timestamp** on every `log.info/warn/error/debug` line (`<iso> remnic: …`), so daemon logs can be aligned with external events during incidents. The previous `remnic: …` shape is unchanged when timestamps are off.
> 
> **Configuration:** optional third argument `initLogger(…, { timestamps?, clock? })`; `REMNIC_LOG_TIMESTAMPS` with boolean-like coercion (`false`/`0`/`no`/`off` disable; empty or unknown values default to timestamps **on**). Explicit `timestamps` wins over the env var. Injectable `clock` supports deterministic tests.
> 
> Adds `logger.test.ts` and a `@remnic/core` patch changeset (closes #1840).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bad65448489f162adbdbf08115cad90d92a0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->