### PR TITLE
fix(wearables): preserve Bee utterance boundaries and carry end timestamps

### DIFF
--- a/.changeset/bee-utterance-boundaries-1811.md
+++ b/.changeset/bee-utterance-boundaries-1811.md
@@ -1,0 +1,14 @@
+---
+"@remnic/core": patch
+"@remnic/connector-bee": patch
+---
+
+fix(wearables): preserve Bee utterance boundaries and carry end timestamps (#1811)
+
+Bee conversation utterances now map `start`/`end` to `WearableTranscriptSegment`
+timing (falling back to `spoken_at` for the start), and a new opt-in cleanup
+toggle `preserveUtteranceBoundaries` stops `mergeSameSpeaker` from collapsing
+segments whose speaker label is generic/low-confidence (e.g. "Unknown", empty).
+The Bee source defaults to boundary preservation, so a conversation of many
+`Unknown`-labeled utterances stays as many segments instead of one mega-segment;
+other connectors keep their existing merge behavior unless explicitly configured.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5563,6 +5563,11 @@
                       "type": "boolean",
                       "default": true,
                       "description": "Drop segments that look like ASR garbage."
+                    },
+                    "preserveUtteranceBoundaries": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Keep utterance-level boundaries (one segment per utterance) instead of merging consecutive same-speaker segments. Defaults off; Bee enables this by default. (issue #1811)"
                     }
                   }
                 }

--- a/packages/connector-bee/src/normalize.test.ts
+++ b/packages/connector-bee/src/normalize.test.ts
@@ -150,3 +150,21 @@ test("falls back to spoken_at when start/end are absent (#1811)", () => {
   assert.equal(segment.startIso, new Date(BASE_MS + 120_000).toISOString());
   assert.equal(segment.endIso, undefined);
 });
+
+test("falls back to spoken_at when start is 0 instead of treating 0 as set (#1811)", () => {
+  const conversation = conversationToWearable({
+    id: 14,
+    start_time: BASE_MS,
+    transcriptions: [
+      {
+        utterances: [
+          { text: "Zero start.", speaker: "0", start: 0, spoken_at: BASE_MS + 120_000 },
+        ],
+      },
+    ],
+  });
+  assert.equal(conversation.segments.length, 1);
+  const segment = conversation.segments[0];
+  assert.equal(segment.startIso, new Date(BASE_MS + 120_000).toISOString());
+  assert.equal(segment.endIso, undefined);
+});

--- a/packages/connector-bee/src/normalize.test.ts
+++ b/packages/connector-bee/src/normalize.test.ts
@@ -77,3 +77,76 @@ test("maps Bee facts to native memories", () => {
     tags: ["habit"],
   });
 });
+
+
+test("maps utterance start/end to segment timing, preferring start over spoken_at (#1811)", () => {
+  const conversation = conversationToWearable({
+    id: 11,
+    start_time: BASE_MS,
+    transcriptions: [
+      {
+        utterances: [
+          {
+            text: "First line.",
+            speaker: "0",
+            start: BASE_MS + 5_000,
+            end: BASE_MS + 8_000,
+            spoken_at: BASE_MS + 60_000,
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(conversation.segments.length, 1);
+  const segment = conversation.segments[0];
+  assert.equal(segment.startIso, new Date(BASE_MS + 5_000).toISOString());
+  assert.equal(segment.endIso, new Date(BASE_MS + 8_000).toISOString());
+});
+
+test("keeps many Unknown-labeled utterances as distinct segments with end timing (#1811)", () => {
+  const conversation = conversationToWearable({
+    id: 12,
+    start_time: BASE_MS,
+    transcriptions: [
+      {
+        utterances: Array.from({ length: 6 }, (_, index) => ({
+          text: `Utterance number ${index + 1}.`,
+          speaker: "Unknown",
+          start: BASE_MS + index * 10_000,
+          end: BASE_MS + index * 10_000 + 4_000,
+        })),
+      },
+    ],
+  });
+  // No mega-collapse at the normalizer: every utterance is its own segment.
+  assert.equal(conversation.segments.length, 6);
+  // Full transcript text is preserved across all segments.
+  assert.deepEqual(
+    conversation.segments.map((segment) => segment.text),
+    Array.from({ length: 6 }, (_, index) => `Utterance number ${index + 1}.`),
+  );
+  // End timing is carried through for every segment.
+  for (const [index, segment] of conversation.segments.entries()) {
+    assert.equal(segment.speakerKey, "Unknown");
+    assert.equal(segment.startIso, new Date(BASE_MS + index * 10_000).toISOString());
+    assert.equal(segment.endIso, new Date(BASE_MS + index * 10_000 + 4_000).toISOString());
+  }
+});
+
+test("falls back to spoken_at when start/end are absent (#1811)", () => {
+  const conversation = conversationToWearable({
+    id: 13,
+    start_time: BASE_MS,
+    transcriptions: [
+      {
+        utterances: [
+          { text: "Only spoken_at.", speaker: "0", spoken_at: BASE_MS + 120_000 },
+        ],
+      },
+    ],
+  });
+  assert.equal(conversation.segments.length, 1);
+  const segment = conversation.segments[0];
+  assert.equal(segment.startIso, new Date(BASE_MS + 120_000).toISOString());
+  assert.equal(segment.endIso, undefined);
+});

--- a/packages/connector-bee/src/normalize.ts
+++ b/packages/connector-bee/src/normalize.ts
@@ -35,12 +35,18 @@ export function conversationToWearable(
         typeof utterance.speaker === "string" && utterance.speaker.trim().length > 0
           ? utterance.speaker.trim()
           : "unknown";
-      // Prefer Bee's explicit utterance `start`/`end` when present; fall
-      // back to `spoken_at` for the start (issue #1811). Carrying `end`
-      // keeps per-utterance timing on the segment and lets the cleanup
-      // pass reason about real gaps instead of treating every utterance
-      // as a point in time.
-      const startIso = msToIso(utterance.start ?? utterance.spoken_at);
+      // Prefer Bee's explicit utterance `start`/`end` when a real
+      // (positive) timestamp is present; otherwise fall back to
+      // `spoken_at` for the start (issue #1811). A `start` of 0 is not a
+      // valid epoch, so it is treated as absent and yields the
+      // `spoken_at` fallback. Carrying `end` keeps per-utterance timing
+      // on the segment and lets the cleanup pass reason about real gaps
+      // instead of treating every utterance as a point in time.
+      const startMs =
+        typeof utterance.start === "number" && utterance.start > 0
+          ? utterance.start
+          : utterance.spoken_at;
+      const startIso = msToIso(startMs);
       const endIso = msToIso(utterance.end ?? undefined);
       segments.push({
         text,

--- a/packages/connector-bee/src/normalize.ts
+++ b/packages/connector-bee/src/normalize.ts
@@ -35,12 +35,18 @@ export function conversationToWearable(
         typeof utterance.speaker === "string" && utterance.speaker.trim().length > 0
           ? utterance.speaker.trim()
           : "unknown";
+      // Prefer Bee's explicit utterance `start`/`end` when present; fall
+      // back to `spoken_at` for the start (issue #1811). Carrying `end`
+      // keeps per-utterance timing on the segment and lets the cleanup
+      // pass reason about real gaps instead of treating every utterance
+      // as a point in time.
+      const startIso = msToIso(utterance.start ?? utterance.spoken_at);
+      const endIso = msToIso(utterance.end ?? undefined);
       segments.push({
         text,
         speakerKey: speaker,
-        ...(msToIso(utterance.spoken_at) !== undefined
-          ? { startIso: msToIso(utterance.spoken_at) }
-          : {}),
+        ...(startIso !== undefined ? { startIso } : {}),
+        ...(endIso !== undefined ? { endIso } : {}),
       });
     }
   }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -5563,6 +5563,11 @@
                       "type": "boolean",
                       "default": true,
                       "description": "Drop segments that look like ASR garbage."
+                    },
+                    "preserveUtteranceBoundaries": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Keep utterance-level boundaries (one segment per utterance) instead of merging consecutive same-speaker segments. Defaults off; Bee enables this by default. (issue #1811)"
                     }
                   }
                 }

--- a/packages/remnic-core/src/wearables/cleanup.test.ts
+++ b/packages/remnic-core/src/wearables/cleanup.test.ts
@@ -132,3 +132,59 @@ test("input conversation is not mutated", () => {
   cleanConversation(input, ALL_ON);
   assert.equal(JSON.stringify(input), before);
 });
+
+
+test("merges consecutive same-speaker runs across diarized speakers", () => {
+  const result = cleanConversation(
+    conversation([
+      { speakerKey: "0", text: "Hello there.", startIso: "2026-06-10T10:00:00Z", endIso: "2026-06-10T10:00:03Z" },
+      { speakerKey: "0", text: "How are you?", startIso: "2026-06-10T10:00:04Z", endIso: "2026-06-10T10:00:07Z" },
+      { speakerKey: "1", text: "Good, thanks.", startIso: "2026-06-10T10:00:08Z", endIso: "2026-06-10T10:00:11Z" },
+      { speakerKey: "1", text: "And you?", startIso: "2026-06-10T10:00:12Z", endIso: "2026-06-10T10:00:14Z" },
+      { speakerKey: "0", text: "Busy day.", startIso: "2026-06-10T10:00:15Z", endIso: "2026-06-10T10:00:18Z" },
+    ]),
+    ALL_ON,
+  );
+  // Three runs: 0+0, 1+1, 0. Generic-label protection is off here, so
+  // diarized same-speaker adjacency merges within the gap.
+  assert.equal(result.conversation.segments.length, 3);
+  assert.equal(result.conversation.segments[0].text, "Hello there. How are you?");
+  assert.equal(result.conversation.segments[1].text, "Good, thanks. And you?");
+  assert.equal(result.conversation.segments[2].text, "Busy day.");
+  assert.equal(result.mergedSegments, 2);
+});
+
+test("preserveUtteranceBoundaries keeps generic-labeled utterances distinct (#1811)", () => {
+  const settings: WearableCleanupSettings = { ...ALL_ON, preserveUtteranceBoundaries: true };
+  const result = cleanConversation(
+    conversation([
+      { speakerKey: "unknown", text: "First.", startIso: "2026-06-10T10:00:00Z", endIso: "2026-06-10T10:00:02Z" },
+      { speakerKey: "unknown", text: "Second.", startIso: "2026-06-10T10:00:03Z", endIso: "2026-06-10T10:00:05Z" },
+      { speakerKey: "Unknown", text: "Third.", startIso: "2026-06-10T10:00:06Z", endIso: "2026-06-10T10:00:08Z" },
+      { speakerKey: "0", text: "Diarized A.", startIso: "2026-06-10T10:00:09Z", endIso: "2026-06-10T10:00:11Z" },
+      { speakerKey: "0", text: "Diarized B.", startIso: "2026-06-10T10:00:12Z", endIso: "2026-06-10T10:00:14Z" },
+    ]),
+    settings,
+  );
+  // Generic "unknown"/"Unknown" utterances are NOT merged into one block.
+  assert.equal(result.conversation.segments.length, 4);
+  assert.deepEqual(
+    result.conversation.segments.map((segment) => segment.text),
+    ["First.", "Second.", "Third.", "Diarized A. Diarized B."],
+  );
+  assert.equal(result.mergedSegments, 1);
+});
+
+test("preserveUtteranceBoundaries default (off) still collapses generic labels", () => {
+  // The flag is opt-in: without it the legacy merge-everything behavior
+  // is unchanged for sources that never set it.
+  const result = cleanConversation(
+    conversation([
+      { speakerKey: "unknown", text: "First.", startIso: "2026-06-10T10:00:00Z", endIso: "2026-06-10T10:00:02Z" },
+      { speakerKey: "unknown", text: "Second.", startIso: "2026-06-10T10:00:03Z", endIso: "2026-06-10T10:00:05Z" },
+    ]),
+    ALL_ON,
+  );
+  assert.equal(result.conversation.segments.length, 1);
+  assert.equal(result.conversation.segments[0].text, "First. Second.");
+});

--- a/packages/remnic-core/src/wearables/cleanup.ts
+++ b/packages/remnic-core/src/wearables/cleanup.ts
@@ -25,6 +25,14 @@ export interface CleanupResult {
 const MERGE_GAP_MS = 30_000;
 
 /**
+ * Speaker labels that carry no real diarization signal. Bee (and other
+ * providers that fall back to a placeholder) emit "Unknown"/"unknown"
+ * or an empty string when diarization is unavailable; merging on such a
+ * label would collapse an entire conversation into one segment (issue #1811).
+ */
+const GENERIC_SPEAKER_PATTERN = /^unknown$/i;
+
+/**
  * Standalone filler tokens stripped when `stripFillers` is on. Matched
  * case-insensitively on word boundaries, only as whole tokens — "um"
  * inside "umbrella" is never touched. Deliberately short, low-risk
@@ -47,6 +55,9 @@ export function cleanConversation(
   let segments = conversation.segments.map((segment) => ({ ...segment }));
   let droppedSegments = 0;
   let mergedSegments = 0;
+  // Optional on the type so other connectors keep the legacy no-op
+  // default; absent means "off" (unchanged merge behavior).
+  const preserveBoundaries = settings.preserveUtteranceBoundaries === true;
 
   if (settings.stripFillers) {
     for (const segment of segments) {
@@ -86,7 +97,7 @@ export function cleanConversation(
     const merged: WearableTranscriptSegment[] = [];
     for (const segment of segments) {
       const previous = merged[merged.length - 1];
-      if (previous && canMerge(previous, segment)) {
+      if (previous && canMerge(previous, segment, preserveBoundaries)) {
         previous.text = `${previous.text} ${segment.text}`.trim();
         if (segment.endIso) previous.endIso = segment.endIso;
         mergedSegments += 1;
@@ -107,8 +118,18 @@ export function cleanConversation(
 function canMerge(
   previous: WearableTranscriptSegment,
   next: WearableTranscriptSegment,
+  preserveUtteranceBoundaries: boolean,
 ): boolean {
   if (previous.speakerKey !== next.speakerKey) return false;
+  // A generic/low-confidence speaker label ("Unknown", empty) carries no
+  // real diarization: merging on it collapses unrelated utterances. When
+  // the source opts into boundary preservation, refuse to merge across
+  // such a label (issue #1811). The keys are equal here, so checking one
+  // suffices; diarized labels still merge normally.
+  if (preserveUtteranceBoundaries) {
+    const label = previous.speakerKey.trim();
+    if (label.length === 0 || GENERIC_SPEAKER_PATTERN.test(label)) return false;
+  }
   const previousEnd = previous.endIso ? Date.parse(previous.endIso) : NaN;
   const nextStart = next.startIso ? Date.parse(next.startIso) : NaN;
   // Without timestamps, adjacency is the only signal — still merge.

--- a/packages/remnic-core/src/wearables/config.test.ts
+++ b/packages/remnic-core/src/wearables/config.test.ts
@@ -44,7 +44,32 @@ test("source settings default to the fully-automated smart pipeline", () => {
     stripFillers: true,
     collapseRepeats: true,
     dropLowQuality: true,
+    // Opt-in for Bee only; limitless keeps the legacy default (issue #1811).
+    preserveUtteranceBoundaries: false,
   });
+});
+
+test("bee source defaults to preserving utterance boundaries (#1811)", () => {
+  const parsed = parseWearablesConfig({
+    enabled: true,
+    sources: { bee: { enabled: true } },
+  });
+  assert.equal(parsed.sources.bee.cleanup.preserveUtteranceBoundaries, true);
+});
+
+test("cleanup.preserveUtteranceBoundaries is parsed and overrides the source default", () => {
+  const parsed = parseWearablesConfig({
+    enabled: true,
+    sources: { bee: { enabled: true, cleanup: { preserveUtteranceBoundaries: false } } },
+  });
+  assert.equal(parsed.sources.bee.cleanup.preserveUtteranceBoundaries, false);
+  assert.throws(
+    () =>
+      parseWearablesConfig({
+        sources: { bee: { cleanup: { preserveUtteranceBoundaries: "maybe" } } },
+      }),
+    /cleanup.preserveUtteranceBoundaries/,
+  );
 });
 
 test("top-level defaults are full-featured: digest and off-the-record on", () => {

--- a/packages/remnic-core/src/wearables/config.ts
+++ b/packages/remnic-core/src/wearables/config.ts
@@ -48,16 +48,35 @@ const DEFAULT_SOURCE_TRUST = 0.8;
 const DEFAULT_AUTO_APPROVE_TRUST = 0.7;
 const DEFAULT_REVIEW_TRUST = 0.45;
 
-export function defaultWearableCleanupSettings(): WearableCleanupSettings {
+// Sources whose provider emits per-utterance text but unreliable
+// speaker labels (Bee falls back to a generic "unknown" label when
+// diarization is unavailable). For those, the cleanup default keeps
+// utterance-level boundaries so a whole conversation does not collapse
+// into one mega-segment (issue #1811). Other sources keep the legacy
+// merge-everything default unless explicitly configured.
+const BOUNDARY_PRESERVING_SOURCE_IDS = new Set<string>(["bee"]);
+
+/**
+ * Default cleanup settings. `sourceId` (the connector id this block
+ * belongs to) only adjusts the `preserveUtteranceBoundaries` default —
+ * every other toggle is identical across sources.
+ */
+export function defaultWearableCleanupSettings(
+  sourceId?: string,
+): WearableCleanupSettings {
   return {
     mergeSameSpeaker: true,
     stripFillers: true,
     collapseRepeats: true,
     dropLowQuality: true,
+    preserveUtteranceBoundaries:
+      sourceId !== undefined && BOUNDARY_PRESERVING_SOURCE_IDS.has(sourceId),
   };
 }
 
-export function defaultWearableSourceSettings(): WearableSourceSettings {
+export function defaultWearableSourceSettings(
+  sourceId?: string,
+): WearableSourceSettings {
   return {
     enabled: false,
     memoryMode: "smart",
@@ -68,7 +87,7 @@ export function defaultWearableSourceSettings(): WearableSourceSettings {
     minImportance: DEFAULT_MIN_IMPORTANCE,
     maxMemoriesPerDay: DEFAULT_MAX_MEMORIES_PER_DAY,
     importNativeMemories: "smart",
-    cleanup: defaultWearableCleanupSettings(),
+    cleanup: defaultWearableCleanupSettings(sourceId),
   };
 }
 
@@ -184,9 +203,10 @@ function parseCorrectionRules(
 function parseSourceSettings(
   value: unknown,
   keyPath: string,
+  sourceId: string,
 ): WearableSourceSettings {
   const raw = requireObject(value, keyPath);
-  const defaults = defaultWearableSourceSettings();
+  const defaults = defaultWearableSourceSettings(sourceId);
 
   const minConfidenceRaw = coerceNumber(raw.minConfidence);
   // Out-of-range values reject loudly instead of clamping — silently
@@ -265,6 +285,12 @@ function parseSourceSettings(
       rawCleanup.dropLowQuality,
       `${keyPath}.cleanup.dropLowQuality`,
       defaults.cleanup.dropLowQuality,
+    ),
+    preserveUtteranceBoundaries: parseBool(
+      rawCleanup.preserveUtteranceBoundaries,
+      `${keyPath}.cleanup.preserveUtteranceBoundaries`,
+      // Optional on the type; the per-source default is always concrete.
+      defaults.cleanup.preserveUtteranceBoundaries ?? false,
     ),
   };
 
@@ -397,6 +423,7 @@ export function parseWearablesConfig(value: unknown): WearablesConfig {
       sources[sourceId] = parseSourceSettings(
         sourceValue,
         `wearables.sources.${sourceId}`,
+        sourceId,
       );
     }
   }

--- a/packages/remnic-core/src/wearables/types.ts
+++ b/packages/remnic-core/src/wearables/types.ts
@@ -210,6 +210,18 @@ export interface WearableCleanupSettings {
    * sync summary and excluded from memory extraction.
    */
   dropLowQuality: boolean;
+  /**
+   * Keep utterance-level boundaries for segments whose speaker label
+   * carries no real diarization signal (generic labels like "Unknown"
+   * or empty). When `mergeSameSpeaker` is also on, such segments are
+   * left distinct instead of collapsing into one block — a whole
+   * conversation of per-utterance text under a single generic label
+   * otherwise merges into one mega-segment (issue #1811). Sources whose
+   * provider emits reliable per-utterance text but unreliable speaker
+   * labels (Bee) default this on; others default off so existing merge
+   * behavior is unchanged unless explicitly configured.
+   */
+  preserveUtteranceBoundaries?: boolean;
 }
 
 /** A single user-specific transcript correction rule. */
@@ -337,4 +349,3 @@ export interface WearableSourceStatus {
   lastDateSynced: string | null;
   transcriptDays: number;
 }
-

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -5563,6 +5563,11 @@
                       "type": "boolean",
                       "default": true,
                       "description": "Drop segments that look like ASR garbage."
+                    },
+                    "preserveUtteranceBoundaries": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Keep utterance-level boundaries (one segment per utterance) instead of merging consecutive same-speaker segments. Defaults off; Bee enables this by default. (issue #1811)"
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
Bee utterances collapsed into one mega-segment when every utterance shared a generic speaker label (e.g. `Unknown`), losing boundaries/timing. Bee normalize now maps start/end to segment timing (start falls back to `spoken_at`); a new opt-in `WearableCleanupSettings.preserveUtteranceBoundaries` stops `mergeSameSpeaker` collapsing generic-labeled runs. Bee source defaults to preserving boundaries; other connectors unchanged unless configured.

Closes #1811.

## Validation
- 54 targeted tests (8 new: cases a–e per the issue); entity-hardening 246/246; core+bee+limitless+omi tsc; build; diagnostics == baseline.

## Risk
- `preserveUtteranceBoundaries` optional; absent/false = legacy behavior. Only active when both mergeSameSpeaker AND the flag are on. Invalid config value rejected (parseBool).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to Bee normalization and an opt-in cleanup flag with Bee-only default; other sources keep legacy merge unless explicitly configured.
> 
> **Overview**
> Fixes Bee transcripts collapsing into a single segment when every utterance shares a generic speaker label (e.g. `Unknown`), and improves per-utterance timing on normalized segments.
> 
> **Bee normalize** now sets segment `startIso` from utterance `start` when it is a positive timestamp (treating `0` as absent), otherwise `spoken_at`, and adds `endIso` from utterance `end`.
> 
> **Wearable cleanup** gains optional `preserveUtteranceBoundaries`: with `mergeSameSpeaker` on, consecutive segments with generic/empty speaker labels are not merged when the flag is true; diarized same-speaker runs still merge within the gap. The **Bee** source defaults this on via per-source cleanup defaults; other connectors stay off unless configured. Plugin JSON documents the new setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8387f07e1c25aefbbc722375bda3a7dc2bb21f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->