### PR TITLE
feat(wearables): deterministic cross-source transcript fusion (foundation)

### DIFF
--- a/.changeset/wearable-fusion-master-gate-algo-version-1849.md
+++ b/.changeset/wearable-fusion-master-gate-algo-version-1849.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Address two Codex review findings on the wearable cross-source fusion (PR #1849 / issue #1810): (1) `fuseDay` now calls `assertEnabled()` — the same master-gate check the sync/check paths use — before the fusion-specific enabled check, so a globally-disabled wearables setup can no longer read sources or write/delete `_fusion/<date>.md` artifacts; (2) the fusion algorithm/schema version (`FUSION_ALGO_VERSION`) is folded into the day content hash (idempotency key) so a change to the clustering/reconciliation/reconstruction algorithm invalidates cached artifacts even when raw inputs and fusion config are byte-identical — pre-existing `_fusion/` files are regenerated rather than served stale.

--- a/.changeset/wearable-fusion-reconstruct-clock-1849.md
+++ b/.changeset/wearable-fusion-reconstruct-clock-1849.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Close the reconstruct-clock finding class on the wearable cross-source fusion foundation (PR #1849 / issue #1810): when a stored transcript renders a missing conversation end as `--:--`, `reconstructFusionInputs` rebuilds segments carrying only a `startIso`, so the cluster interval fallback previously collapsed to a zero-length point at the conversation start and mis-clustered later conversations. The cluster `effectiveInterval` now derives the conversation window end from each segment's own extent (`endIso ?? startIso`) — reaching the latest segment start when no end is known — and clamps it to `>= start`, so a missing-end conversation clusters by its actual segments (including cross-midnight-rolled ones) instead of its start. Prior clock fixes (24:xx normalization, heading + segment cross-midnight roll) are unchanged.

--- a/.changeset/wearable-fusion-review-fixes-1849.md
+++ b/.changeset/wearable-fusion-review-fixes-1849.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Address second-round reviewer findings on the wearable cross-source fusion foundation (PR #1849 / issue #1810): normalize renderer `24:xx` midnight clocks to valid `00:xx` ISO and roll cross-midnight conversation windows when reconstructing fusion inputs; prefer a longer corroborating transcript over a truncated high-trust clip; keep distinct cross-source untimestamped utterances from collapsing on speaker key; treat raw diarization keys (`SPEAKER_00`) as generic speakers; and relocate the fused-day file IO out of the root `storage.ts` watchlist file (LOC ratchet) into a new `FusionArtifactStore` under `wearables/fusion/store.ts`.

--- a/.changeset/wearable-fusion-shared-decode-wrap-plausibility-1849.md
+++ b/.changeset/wearable-fusion-shared-decode-wrap-plausibility-1849.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+---
+
+Address the two second-round reviewer findings on the wearable cross-source fusion foundation (PR #1849 / issue #1810):
+
+1. `reconstruct`: only roll an earlier heading end clock into the next calendar day when the implied wrap duration (start -> midnight -> end) is within a plausible single-conversation bound (12h). A near-24h implied span (e.g. 14:00 -> 13:00) is almost certainly a malformed/ordinary earlier clock rather than a midnight crossing, so it stays on the same date with endIso < startIso and the existing cluster clamp collapses it to the start instead of spanning the day and broadly clustering unrelated neighbors. Valid cross-midnight wraps (short or long-but-plausible) still roll forward.
+
+2. Escaped segment text is an internal serialization detail. A shared decode primitive (`unescapeSegmentText`) and `decodeTranscriptBody` now live in `day-store` and are used by the fusion reconstruct path AND every user-facing view/search/index surface (`dayTranscript`, `searchTranscripts` scan + indexed snippet), so escaped newlines/backslashes never leak into transcript display or search. The fusion reader still decodes each segment exactly once during parse and legacy transcripts keep round-tripping their original text.

--- a/.changeset/wearables-fusion-foundation.md
+++ b/.changeset/wearables-fusion-foundation.md
@@ -1,0 +1,16 @@
+---
+"@remnic/core": minor
+---
+
+Add deterministic, config-gated cross-source wearable transcript fusion
+(issue #1810). Introduces a `wearables/fusion/` module that clusters
+same-day conversations from multiple enabled sources by time
+overlap/proximity, reconciles text (preferring higher source trust and
+more-complete transcripts) and speakers deterministically, surfaces
+unresolved conflicts as `disagreements[]`, and writes a derived
+`FusedWearableConversation` artifact alongside raw transcripts with a
+stable content-hash id (idempotent re-runs). Gated behind
+`wearables.fusion.enabled` (default false) — no behavior change when
+disabled. LLM-assisted reconciliation, memory extraction over fused
+artifacts, full segment-level alignment, and search-index integration
+are deferred follow-ups.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5377,6 +5377,31 @@
             "default": true,
             "description": "Write one compact daily-digest memory per synced source/day."
           },
+          "fusion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
+              },
+              "proximityGapMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 300000,
+                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
+              },
+              "windowToleranceMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 30000,
+                "description": "Max drift (ms) for two segments to align across sources."
+              }
+            }
+          },
           "autoSyncEnabled": {
             "type": "boolean",
             "default": true,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5377,31 +5377,6 @@
             "default": true,
             "description": "Write one compact daily-digest memory per synced source/day."
           },
-          "fusion": {
-            "type": "object",
-            "additionalProperties": false,
-            "default": {},
-            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "default": false,
-                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
-              },
-              "proximityGapMs": {
-                "type": "integer",
-                "minimum": 1,
-                "default": 300000,
-                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
-              },
-              "windowToleranceMs": {
-                "type": "integer",
-                "minimum": 1,
-                "default": 30000,
-                "description": "Max drift (ms) for two segments to align across sources."
-              }
-            }
-          },
           "autoSyncEnabled": {
             "type": "boolean",
             "default": true,
@@ -5596,6 +5571,31 @@
                     }
                   }
                 }
+              }
+            }
+          },
+          "fusion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
+              },
+              "proximityGapMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 300000,
+                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
+              },
+              "windowToleranceMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 30000,
+                "description": "Max drift (ms) for two segments to align across sources."
               }
             }
           }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -5573,6 +5573,31 @@
                 }
               }
             }
+          },
+          "fusion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
+              },
+              "proximityGapMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 300000,
+                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
+              },
+              "windowToleranceMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 30000,
+                "description": "Max drift (ms) for two segments to align across sources."
+              }
+            }
           }
         }
       },

--- a/packages/remnic-core/src/cli-wearables-fuse.test.ts
+++ b/packages/remnic-core/src/cli-wearables-fuse.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  registerCli,
+  type CliApi,
+  type CliCommand,
+  type CliProgram,
+} from "./cli.js";
+import type { WearablesService } from "./wearables/service.js";
+
+/**
+ * Host-CLI registration test for the wearables `fuse`/`fused` subcommands.
+ *
+ * The shared runner (`runWearablesCliCommand`) already handles fuse/fused, but
+ * the host CLI must ALSO register forwarders under `wearablesCmd` — otherwise
+ * commander rejects `remnic wearables fuse <date>` / `remnic wearables fused
+ * <date>` as unknown subcommands before the runner is ever reached (issue
+ * #1849). This drives `registerCli` with a recording program mock plus a stub
+ * orchestrator and asserts both that the subcommands are registered and that
+ * their actions dispatch into the runner (which calls the wearables service).
+ */
+
+/** Recording commander stand-in: records the command tree + action callbacks. */
+class RecCmd implements CliCommand {
+  readonly children = new Map<string, RecCmd>();
+  readonly options: string[] = [];
+  readonly args: string[] = [];
+  actionFn?: (...args: unknown[]) => unknown;
+  constructor(readonly rawName: string) {}
+  description(): CliCommand {
+    return this;
+  }
+  option(flags: string): CliCommand {
+    this.options.push(flags);
+    return this;
+  }
+  requiredOption(flags: string): CliCommand {
+    this.options.push(flags);
+    return this;
+  }
+  argument(name: string): CliCommand {
+    this.args.push(name);
+    return this;
+  }
+  action(fn: (...args: unknown[]) => Promise<void> | void): CliCommand {
+    this.actionFn = fn;
+    return this;
+  }
+  command(name: string): CliCommand {
+    const key = name.split(/\s+/)[0]!;
+    const child = new RecCmd(name);
+    this.children.set(key, child);
+    return child;
+  }
+}
+
+class RecProgram implements CliProgram {
+  readonly root = new RecCmd("__program__");
+  command(name: string): CliCommand {
+    return this.root.command(name);
+  }
+}
+
+/**
+ * Deterministic orchestrator stub. registerCli only reads `config.*` while
+ * building the command tree (feature flags gate subcommand registration;
+ * memoryDir is an option default), so every accessed field returns a real
+ * primitive — no Proxy ever reaches a string/number call site. The wearables
+ * forwarder is the only action that touches the stub, via getWearablesService.
+ */
+function makeOrchestratorStub(
+  service: WearablesService,
+): Parameters<typeof registerCli>[1] {
+  const config = new Proxy(
+    { memoryDir: "/tmp/cli-wearables-fuse-test" } as Record<string, unknown>,
+    {
+      get(target, prop) {
+        if (typeof prop === "symbol") return undefined;
+        if (prop in target) return target[prop as string];
+        const key = prop as string;
+        if (
+          key.endsWith("WindowMs") ||
+          key.endsWith("SoftLimit") ||
+          key.endsWith("HardLimit")
+        ) {
+          return 0;
+        }
+        return true; // feature flags -> enabled (every subcommand registers)
+      },
+    },
+  );
+  return { config, getWearablesService: () => service } as unknown as Parameters<
+    typeof registerCli
+  >[1];
+}
+
+/** Spy service recording fuseDay/fusedConversations dispatch. */
+function spyService(): WearablesService & {
+  calls: Array<[string, string]>;
+} {
+  const calls: Array<[string, string]> = [];
+  const svc = {
+    fuseDay: async (date: string) => {
+      calls.push(["fuseDay", date]);
+      return {
+        date,
+        sources: ["limitless", "bee"],
+        conversationCount: 2,
+        contentHash: "h",
+        written: true,
+      };
+    },
+    fusedConversations: async (date: string) => {
+      calls.push(["fusedConversations", date]);
+      return [];
+    },
+  };
+  return { ...svc, calls } as unknown as WearablesService & {
+    calls: Array<[string, string]>;
+  };
+}
+
+function buildRegisteredTree(): {
+  program: RecProgram;
+  wearables: RecCmd;
+  service: WearablesService & { calls: Array<[string, string]> };
+} {
+  const program = new RecProgram();
+  const service = spyService();
+  const api: CliApi = {
+    registerCli: (handler) => handler({ program }),
+  };
+  registerCli(api, makeOrchestratorStub(service));
+  const wearables = program.root.children.get("engram")?.children.get("wearables");
+  assert.ok(wearables, "wearables command registered under engram");
+  return { program, wearables: wearables!, service };
+}
+
+test("wearablesCmd registers fuse and fused subcommands (#1849)", () => {
+  const { wearables } = buildRegisteredTree();
+  // fuse/fused must be present alongside the previously-registered forwarders.
+  const subcommands = [...wearables.children.keys()];
+  for (const expected of [
+    "status",
+    "check",
+    "sync",
+    "transcript",
+    "search",
+    "memories",
+    "speakers",
+    "corrections",
+    "fuse",
+    "fused",
+  ]) {
+    assert.ok(
+      subcommands.includes(expected),
+      `wearables ${expected} subcommand registered`,
+    );
+  }
+
+  const fuse = wearables.children.get("fuse")!;
+  assert.ok(
+    fuse.rawName.includes("<date>"),
+    "fuse declares a <date> argument",
+  );
+  assert.ok(fuse.options.includes("--json"), "fuse forwards --json");
+
+  const fused = wearables.children.get("fused")!;
+  assert.ok(
+    fused.rawName.includes("<date>"),
+    "fused declares a <date> argument",
+  );
+  assert.ok(fused.options.includes("--json"), "fused forwards --json");
+});
+
+test("wearables fuse/fused forwarders dispatch to the runner, not rejected (#1849)", async () => {
+  const { wearables, service } = buildRegisteredTree();
+  const fuse = wearables.children.get("fuse")!;
+  const fused = wearables.children.get("fused")!;
+
+  // commander passes the <date> positional as arg[0] and the options object
+  // as the trailing arg — the same shape the `search <query>` forwarder uses.
+  await fuse.actionFn!("2026-06-10", { json: false });
+  assert.deepEqual(
+    service.calls[0],
+    ["fuseDay", "2026-06-10"],
+    "wearables fuse <date> dispatches into the runner -> service.fuseDay",
+  );
+
+  await fused.actionFn!("2026-06-10", { json: true });
+  assert.deepEqual(
+    service.calls[1],
+    ["fusedConversations", "2026-06-10"],
+    "wearables fused <date> dispatches into the runner -> service.fusedConversations",
+  );
+});

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -5376,6 +5376,31 @@ export function registerCli(
           .action(async (...args: unknown[]) =>
             forwardWearables(["corrections", "remove", String(args[0] ?? "")]),
           );
+        wearablesCmd
+          .command("fuse <date>")
+          .description("Fuse (cross-source merge) wearable transcripts for a day")
+          .option("--json", "JSON output")
+          .action(async (...args: unknown[]) => {
+            const options = (args[1] ?? {}) as Record<string, unknown>;
+            await forwardWearables([
+              "fuse",
+              String(args[0] ?? ""),
+              ...(options.json === true ? ["--json"] : []),
+            ]);
+          });
+
+        wearablesCmd
+          .command("fused <date>")
+          .description("List fused conversations for a day")
+          .option("--json", "JSON output")
+          .action(async (...args: unknown[]) => {
+            const options = (args[1] ?? {}) as Record<string, unknown>;
+            await forwardWearables([
+              "fused",
+              String(args[0] ?? ""),
+              ...(options.json === true ? ["--json"] : []),
+            ]);
+          });
       }
 
       cmd

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2721,6 +2721,7 @@ export class StorageManager {
       readDir: (d) => readdir(d),
       deleteFile: (p) => unlink(p),
       realpath: (p) => realpath(p),
+      lstat: (p) => lstat(p).then((st) => ({ isSymbolicLink: st.isSymbolicLink() })),
     }));
   }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -23,6 +23,7 @@ import { serializeProvenanceFields, parseProvenanceSources, parseProvenanceTag, 
 import { serializeFaithfulnessFields, parseFaithfulnessField } from "./extraction-faithfulness.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import { isValidTranscriptDate, WEARABLES_DIR_NAME } from "./wearables/day-store.js";
+import { FusionArtifactStore } from "./wearables/fusion/index.js";
 import {
   SecureStoreLockedError,
   MAGIC_HEADER_SIZE,
@@ -2709,71 +2710,16 @@ export class StorageManager {
     );
   }
 
-  // Wearable cross-source fusion derived artifacts (#1810) -----------------
-  //
-  // Stored under `<baseDir>/wearables/_fusion/<YYYY-MM-DD>.md` — a reserved
-  // underscore-prefixed subdir that the per-source listing regex skips, so
-  // fused artifacts sit alongside raw transcripts without polluting source
-  // listings or transcript-search hit mapping. IO lives here so the derived
-  // files inherit the same encrypted-at-rest + atomic-write semantics as
-  // raw day transcripts.
-  // -------------------------------------------------------------------------
+  private _fusionStore?: FusionArtifactStore;
 
-  private static readonly FUSION_DIR_NAME = "_fusion";
-
-  wearableFusedDayPath(date: string): string {
-    if (!isValidTranscriptDate(date)) {
-      throw new Error(
-        `invalid wearable fusion date '${String(date)}' — expected YYYY-MM-DD`,
-      );
-    }
-    return path.join(
-      this.wearablesDir,
-      StorageManager.FUSION_DIR_NAME,
-      `${date}.md`,
-    );
-  }
-
-  async writeWearableFusedDay(date: string, serialized: string): Promise<void> {
-    const targetPath = this.wearableFusedDayPath(date);
-    // writeMaybeEncryptedFile handles mkdir + atomic temp→rename.
-    await this.writeStorageSecureFile(targetPath, serialized);
-  }
-
-  /** Read a stored fused-day artifact; null when absent. */
-  async readWearableFusedDay(date: string): Promise<string | null> {
-    const targetPath = this.wearableFusedDayPath(date);
-    try {
-      return await readMaybeEncryptedFile(
-        targetPath,
-        this._secureStoreKey,
-        this.baseDir,
-      );
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-      throw err;
-    }
-  }
-
-  /** List dates with stored fused artifacts, newest first. */
-  async listWearableFusedDays(): Promise<string[]> {
-    const dir = path.join(this.wearablesDir, StorageManager.FUSION_DIR_NAME);
-    let entries: string[];
-    try {
-      entries = await readdir(dir);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-      throw err;
-    }
-    const days: string[] = [];
-    for (const entry of entries) {
-      if (!entry.endsWith(".md")) continue;
-      const date = entry.slice(0, -3);
-      if (!isValidTranscriptDate(date)) continue;
-      days.push(date);
-    }
-    days.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
-    return days;
+  /** Derived fusion-day IO; file IO lives in wearables/fusion (#1810). */
+  fusionArtifactStore(): FusionArtifactStore {
+    if (this._fusionStore) return this._fusionStore;
+    return (this._fusionStore = new FusionArtifactStore(this.wearablesDir, {
+      writeFile: (p, c) => this.writeStorageSecureFile(p, c),
+      readFile: (p) => readMaybeEncryptedFile(p, this._secureStoreKey, this.baseDir),
+      readDir: (d) => readdir(d),
+    }));
   }
 
   /**

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2709,6 +2709,73 @@ export class StorageManager {
     );
   }
 
+  // Wearable cross-source fusion derived artifacts (#1810) -----------------
+  //
+  // Stored under `<baseDir>/wearables/_fusion/<YYYY-MM-DD>.md` — a reserved
+  // underscore-prefixed subdir that the per-source listing regex skips, so
+  // fused artifacts sit alongside raw transcripts without polluting source
+  // listings or transcript-search hit mapping. IO lives here so the derived
+  // files inherit the same encrypted-at-rest + atomic-write semantics as
+  // raw day transcripts.
+  // -------------------------------------------------------------------------
+
+  private static readonly FUSION_DIR_NAME = "_fusion";
+
+  wearableFusedDayPath(date: string): string {
+    if (!isValidTranscriptDate(date)) {
+      throw new Error(
+        `invalid wearable fusion date '${String(date)}' — expected YYYY-MM-DD`,
+      );
+    }
+    return path.join(
+      this.wearablesDir,
+      StorageManager.FUSION_DIR_NAME,
+      `${date}.md`,
+    );
+  }
+
+  async writeWearableFusedDay(date: string, serialized: string): Promise<void> {
+    const targetPath = this.wearableFusedDayPath(date);
+    // writeMaybeEncryptedFile handles mkdir + atomic temp→rename.
+    await this.writeStorageSecureFile(targetPath, serialized);
+  }
+
+  /** Read a stored fused-day artifact; null when absent. */
+  async readWearableFusedDay(date: string): Promise<string | null> {
+    const targetPath = this.wearableFusedDayPath(date);
+    try {
+      return await readMaybeEncryptedFile(
+        targetPath,
+        this._secureStoreKey,
+        this.baseDir,
+      );
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  /** List dates with stored fused artifacts, newest first. */
+  async listWearableFusedDays(): Promise<string[]> {
+    const dir = path.join(this.wearablesDir, StorageManager.FUSION_DIR_NAME);
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const days: string[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const date = entry.slice(0, -3);
+      if (!isValidTranscriptDate(date)) continue;
+      days.push(date);
+    }
+    days.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
+    return days;
+  }
+
   /**
    * Locate a wearable-sourced memory by exact (trimmed) content,
    * ignoring the "[Attributes: ...]" suffix writeMemory appends for

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2715,10 +2715,11 @@ export class StorageManager {
   /** Derived fusion-day IO; file IO lives in wearables/fusion (#1810). */
   fusionArtifactStore(): FusionArtifactStore {
     if (this._fusionStore) return this._fusionStore;
-    return (this._fusionStore = new FusionArtifactStore(this.wearablesDir, {
+    return (this._fusionStore = new FusionArtifactStore(this.wearablesDir, this.baseDir, {
       writeFile: (p, c) => this.writeStorageSecureFile(p, c),
       readFile: (p) => readMaybeEncryptedFile(p, this._secureStoreKey, this.baseDir),
       readDir: (d) => readdir(d),
+      deleteFile: (p) => unlink(p),
       realpath: (p) => realpath(p),
     }));
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2719,6 +2719,7 @@ export class StorageManager {
       writeFile: (p, c) => this.writeStorageSecureFile(p, c),
       readFile: (p) => readMaybeEncryptedFile(p, this._secureStoreKey, this.baseDir),
       readDir: (d) => readdir(d),
+      realpath: (p) => realpath(p),
     }));
   }
 

--- a/packages/remnic-core/src/wearables/cli.test.ts
+++ b/packages/remnic-core/src/wearables/cli.test.ts
@@ -198,3 +198,68 @@ test("backend faults propagate instead of being swallowed as exit codes", async 
     /disk exploded/,
   );
 });
+
+test("fuse command requires a date and renders the fuseDay result", async () => {
+  const { io, out, err } = makeIo();
+  const service = stubService({
+    fuseDay: async () => ({
+      date: "2026-06-10",
+      sources: ["bee", "limitless"],
+      conversationCount: 2,
+      contentHash: "abc123",
+      written: true,
+    }),
+  });
+  assert.equal(await runWearablesCliCommand(service, ["fuse"], io), 1);
+  assert.match(err.join(""), /fuse requires a date/);
+
+  // Success path needs its own captured stdout.
+  const okIo = makeIo();
+  assert.equal(
+    await runWearablesCliCommand(service, ["fuse", "2026-06-10"], okIo.io),
+    0,
+  );
+  assert.match(
+    okIo.out.join(""),
+    /Fused 2026-06-10: 2 conversations from 2 sources/,
+  );
+});
+
+test("fused command lists conversations and surfaces disagreements (--json)", async () => {
+  const { io, out } = makeIo();
+  const service = stubService({
+    fusedConversations: async () => [
+      {
+        id: "fusion-1",
+        date: "2026-06-10",
+        startIso: "2026-06-10T09:00:00.000Z",
+        sources: ["bee", "limitless"],
+        speakers: [],
+        segments: [
+          { speaker: "Me (you)", isSelf: true, text: "hi", confidence: 0.8, provenance: { source: "limitless", conversationId: "c1", sourceTrust: 0.8, reason: "only-source", alternatives: [] } },
+        ],
+        disagreements: [
+          { kind: "asr-text", subject: "2026-06-10T09:00:00.000Z", candidates: [{ source: "bee", value: "x" }, { source: "limitless", value: "y" }] },
+        ],
+        provenance: { contributions: [], proximityGapMs: 300000, windowToleranceMs: 30000, method: "time-proximity" },
+      },
+    ],
+  });
+  assert.equal(await runWearablesCliCommand(service, ["fused", "2026-06-10", "--json"], io), 0);
+  const parsed = JSON.parse(out.join(""));
+  assert.equal(parsed.date, "2026-06-10");
+  assert.equal(parsed.conversations.length, 1);
+  assert.equal(parsed.conversations[0].disagreements.length, 1);
+
+  // Plain-text path surfaces the disagreement count.
+  const text = makeIo();
+  assert.equal(await runWearablesCliCommand(service, ["fused", "2026-06-10"], text.io), 0);
+  assert.match(text.out.join(""), /disagreement \[asr-text\]/);
+});
+
+test("fused command reports nothing-fused gracefully", async () => {
+  const { io, out } = makeIo();
+  const service = stubService({ fusedConversations: async () => [] });
+  assert.equal(await runWearablesCliCommand(service, ["fused", "2026-06-10"], io), 0);
+  assert.match(out.join(""), /No fused conversations for 2026-06-10/);
+});

--- a/packages/remnic-core/src/wearables/cli.test.ts
+++ b/packages/remnic-core/src/wearables/cli.test.ts
@@ -225,6 +225,43 @@ test("fuse command requires a date and renders the fuseDay result", async () => 
   );
 });
 
+test("fuse command prints a distinct skip line when fusion is skipped, not '(unchanged)'", async () => {
+  // written:false has two meanings (issue #1849): a skip (e.g. conflicting
+  // source timezones, which also clears any existing fused artifact) must
+  // NOT be mislabeled as an idempotent "(unchanged)" no-op.
+  const { io, out } = makeIo();
+  const service = stubService({
+    fuseDay: async () => ({
+      date: "2026-06-10",
+      sources: [],
+      conversationCount: 0,
+      contentHash: "",
+      written: false,
+      skipped: { reason: "conflicting-timezones" },
+    }),
+  });
+  assert.equal(await runWearablesCliCommand(service, ["fuse", "2026-06-10"], io), 0);
+  const text = out.join("");
+  assert.match(text, /Skipped fusing 2026-06-10: conflicting-timezones/);
+  assert.match(text, /cleared/);
+  assert.doesNotMatch(text, /unchanged/, "a skip must not look idempotent");
+});
+
+test("fuse command keeps '(unchanged)' for written:false without a skip reason", async () => {
+  const { io, out } = makeIo();
+  const service = stubService({
+    fuseDay: async () => ({
+      date: "2026-06-10",
+      sources: ["bee", "limitless"],
+      conversationCount: 2,
+      contentHash: "abc123",
+      written: false,
+    }),
+  });
+  assert.equal(await runWearablesCliCommand(service, ["fuse", "2026-06-10"], io), 0);
+  assert.match(out.join(""), /\(unchanged\)/);
+});
+
 test("fused command lists conversations and surfaces disagreements (--json)", async () => {
   const { io, out } = makeIo();
   const service = stubService({

--- a/packages/remnic-core/src/wearables/cli.ts
+++ b/packages/remnic-core/src/wearables/cli.ts
@@ -434,9 +434,25 @@ export async function runWearablesCliCommand(
           io.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
           return 0;
         }
-        io.stdout.write(
-          `Fused ${date}: ${result.conversationCount} conversation${result.conversationCount === 1 ? "" : "s"} from ${result.sources.length} source${result.sources.length === 1 ? "" : "s"}.${result.written ? "" : " (unchanged)"}\n`,
-        );
+        // `written:false` has two distinct meanings (issue #1849): a genuine
+        // idempotent no-op (inputs unchanged) OR a deliberate SKIP — e.g.
+        // mixed source timezones — where fusion was refused and any
+        // previously-fused artifact for the day was cleared. The JSON path
+        // carries `skipped`, but the text path collapsed both into
+        // "(unchanged)", hiding a skip (and a possible artifact deletion)
+        // behind an idempotent-looking label. Check `skipped` first and emit
+        // a distinct skip line; reserve "(unchanged)" for written:false
+        // WITHOUT a skip reason. Mirrors the `skipped` field the JSON path
+        // serializes.
+        if (result.skipped) {
+          io.stdout.write(
+            `Skipped fusing ${date}: ${result.skipped.reason} — no fused artifact written; any existing fused artifact for the day was cleared.\n`,
+          );
+        } else {
+          io.stdout.write(
+            `Fused ${date}: ${result.conversationCount} conversation${result.conversationCount === 1 ? "" : "s"} from ${result.sources.length} source${result.sources.length === 1 ? "" : "s"}.${result.written ? "" : " (unchanged)"}\n`,
+          );
+        }
         return 0;
       }
       case "fused": {

--- a/packages/remnic-core/src/wearables/cli.ts
+++ b/packages/remnic-core/src/wearables/cli.ts
@@ -33,6 +33,8 @@ Commands:
     --source <id>  --from <date>  --to <date>  --limit <n>
   memories [options]             List memories created from transcripts
     --source <id>  --date <date>  --limit <n>
+  fuse <YYYY-MM-DD>              Fuse enabled sources' transcripts for a day
+  fused <YYYY-MM-DD>             List fused conversations for a day
   speakers list                  Show the speaker registry
   speakers self <name>           Set the wearer's display name
   speakers set <source> <key> <name> [--self]
@@ -418,6 +420,53 @@ export async function runWearablesCliCommand(
         throw new WearablesInputError(
           `unknown corrections action '${action}' — expected list, add, or remove`,
         );
+      }
+      case "fuse": {
+        const parsed = parseFlags(rest);
+        const date = flagString(parsed, "--date") ?? parsed.positional[0];
+        if (!date) {
+          throw new WearablesInputError(
+            "fuse requires a date (e.g. wearables fuse 2026-06-10)",
+          );
+        }
+        const result = await service.fuseDay(date);
+        if (parsed.flags.has("--json")) {
+          io.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+          return 0;
+        }
+        io.stdout.write(
+          `Fused ${date}: ${result.conversationCount} conversation${result.conversationCount === 1 ? "" : "s"} from ${result.sources.length} source${result.sources.length === 1 ? "" : "s"}.${result.written ? "" : " (unchanged)"}\n`,
+        );
+        return 0;
+      }
+      case "fused": {
+        const parsed = parseFlags(rest);
+        const date = flagString(parsed, "--date") ?? parsed.positional[0];
+        if (!date) {
+          throw new WearablesInputError(
+            "fused requires a date (e.g. wearables fused 2026-06-10)",
+          );
+        }
+        const conversations = await service.fusedConversations(date);
+        if (parsed.flags.has("--json")) {
+          io.stdout.write(`${JSON.stringify({ date, conversations }, null, 2)}\n`);
+          return 0;
+        }
+        if (conversations.length === 0) {
+          io.stdout.write(`No fused conversations for ${date}.\n`);
+          return 0;
+        }
+        for (const conv of conversations) {
+          io.stdout.write(
+            `${conv.id} ${conv.startIso}${conv.endIso ? ` \u2013 ${conv.endIso}` : ""} (${conv.sources.join(", ")}, ${conv.segments.length} segment${conv.segments.length === 1 ? "" : "s"})\n`,
+          );
+          for (const disagreement of conv.disagreements) {
+            io.stdout.write(
+              `  disagreement [${disagreement.kind}] @ ${disagreement.subject}: ${disagreement.candidates.length} candidate${disagreement.candidates.length === 1 ? "" : "s"}\n`,
+            );
+          }
+        }
+        return 0;
       }
       default:
         throw new WearablesInputError(

--- a/packages/remnic-core/src/wearables/config.test.ts
+++ b/packages/remnic-core/src/wearables/config.test.ts
@@ -245,3 +245,35 @@ test("a deep window narrower than the tick window is rejected, 0 disables", () =
     5,
   );
 });
+
+
+test("fusion defaults to disabled with documented knobs", () => {
+  const parsed = parseWearablesConfig({});
+  assert.equal(parsed.fusion.enabled, false);
+  assert.equal(parsed.fusion.proximityGapMs, 300_000);
+  assert.equal(parsed.fusion.windowToleranceMs, 30_000);
+});
+
+test("fusion enabled flag and knobs parse and validate", () => {
+  const parsed = parseWearablesConfig({
+    fusion: { enabled: true, proximityGapMs: 120_000, windowToleranceMs: 15_000 },
+  });
+  assert.equal(parsed.fusion.enabled, true);
+  assert.equal(parsed.fusion.proximityGapMs, 120_000);
+  assert.equal(parsed.fusion.windowToleranceMs, 15_000);
+});
+
+test("fusion knobs reject non-positive integers", () => {
+  assert.throws(
+    () => parseWearablesConfig({ fusion: { proximityGapMs: 0 } }),
+    /proximityGapMs must be a positive integer/,
+  );
+  assert.throws(
+    () => parseWearablesConfig({ fusion: { windowToleranceMs: -5 } }),
+    /windowToleranceMs must be a positive integer/,
+  );
+});
+
+test("fusion block must be an object when present", () => {
+  assert.throws(() => parseWearablesConfig({ fusion: "on" }), /must be an object/);
+});

--- a/packages/remnic-core/src/wearables/config.ts
+++ b/packages/remnic-core/src/wearables/config.ts
@@ -16,6 +16,7 @@ import type {
   WearableCleanupSettings,
   WearableCorrectionRule,
   WearableMemoryMode,
+  WearableFusionConfig,
   WearableSourceSettings,
   WearablesConfig,
 } from "./types.js";
@@ -47,6 +48,11 @@ const MAX_AUTO_SYNC_WINDOW_DAYS = 90;
 const DEFAULT_SOURCE_TRUST = 0.8;
 const DEFAULT_AUTO_APPROVE_TRUST = 0.7;
 const DEFAULT_REVIEW_TRUST = 0.45;
+// Cross-source fusion (#1810) — disabled by default; enabling is the
+// only behavior change fusion introduces.
+const DEFAULT_FUSION_ENABLED = false;
+const DEFAULT_FUSION_PROXIMITY_GAP_MS = 300_000;
+const DEFAULT_FUSION_WINDOW_TOLERANCE_MS = 30_000;
 
 // Sources whose provider emits per-utterance text but unreliable
 // speaker labels (Bee falls back to a generic "unknown" label when
@@ -91,6 +97,14 @@ export function defaultWearableSourceSettings(
   };
 }
 
+export function defaultWearableFusionConfig(): WearableFusionConfig {
+  return {
+    enabled: DEFAULT_FUSION_ENABLED,
+    proximityGapMs: DEFAULT_FUSION_PROXIMITY_GAP_MS,
+    windowToleranceMs: DEFAULT_FUSION_WINDOW_TOLERANCE_MS,
+  };
+}
+
 export function defaultWearablesConfig(): WearablesConfig {
   return {
     enabled: false,
@@ -104,6 +118,7 @@ export function defaultWearablesConfig(): WearablesConfig {
     autoSyncDeepDays: DEFAULT_AUTO_SYNC_DEEP_DAYS,
     corrections: [],
     sources: {},
+    fusion: defaultWearableFusionConfig(),
   };
 }
 
@@ -331,6 +346,42 @@ function parseSourceSettings(
  * Parse the `wearables` config block. `undefined` yields the disabled
  * default config; any present-but-malformed value throws.
  */
+function parseFusionSettings(
+  value: unknown,
+  keyPath: string,
+): WearableFusionConfig {
+  if (value === undefined) return defaultWearableFusionConfig();
+  const raw = requireObject(value, keyPath);
+  const defaults = defaultWearableFusionConfig();
+  const parsePositiveInt = (
+    value: unknown,
+    name: string,
+    fallback: number,
+  ): number => {
+    if (value === undefined) return fallback;
+    const coerced = coerceNumber(value);
+    if (coerced === undefined || !Number.isInteger(coerced) || coerced <= 0) {
+      throw new Error(
+        `${keyPath}.${name} must be a positive integer (got ${JSON.stringify(value)})`,
+      );
+    }
+    return coerced;
+  };
+  return {
+    enabled: parseBool(raw.enabled, `${keyPath}.enabled`, defaults.enabled),
+    proximityGapMs: parsePositiveInt(
+      raw.proximityGapMs,
+      "proximityGapMs",
+      defaults.proximityGapMs,
+    ),
+    windowToleranceMs: parsePositiveInt(
+      raw.windowToleranceMs,
+      "windowToleranceMs",
+      defaults.windowToleranceMs,
+    ),
+  };
+}
+
 export function parseWearablesConfig(value: unknown): WearablesConfig {
   if (value === undefined) return defaultWearablesConfig();
   const raw = requireObject(value, "wearables");
@@ -455,6 +506,7 @@ export function parseWearablesConfig(value: unknown): WearablesConfig {
     autoSyncIntervalMinutes,
     autoSyncDays,
     autoSyncDeepDays,
+    fusion: parseFusionSettings(raw.fusion, "wearables.fusion"),
     corrections: parseCorrectionRules(raw.corrections, "wearables.corrections"),
     sources,
   };

--- a/packages/remnic-core/src/wearables/day-store.test.ts
+++ b/packages/remnic-core/src/wearables/day-store.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  bodyIsEscaped,
   composeDayTranscriptBody,
   composeDayTranscriptMeta,
   decodeTranscriptBody,
@@ -9,6 +10,7 @@ import {
   isValidTranscriptDate,
   parseDayTranscript,
   serializeDayTranscript,
+  TRANSCRIPT_FORMAT_VERSION,
 } from "./day-store.js";
 import { emptySpeakerRegistry } from "./speakers.js";
 import type { WearableConversation } from "./types.js";
@@ -156,7 +158,7 @@ test("decodeTranscriptBody decodes segment text but leaves headings/locations un
     "*Location: D:\\data*\n" +
     "\n" +
     '**Me (you)** [09:00]: Line one.\\nLine two.\n';
-  const decoded = decodeTranscriptBody(body);
+  const decoded = decodeTranscriptBody(body, true);
   // Segment text IS decoded: backslash-n -> real newline.
   assert.ok(decoded.includes("Line one.\nLine two."), "segment newline decoded");
   assert.ok(!decoded.includes("Line one.\\nLine two."), "no escaped-newline leak in segment");
@@ -182,7 +184,7 @@ test("decodeTranscriptBody recovers original segment text from a composed body (
   assert.ok(body.includes("First line.\\nSecond line"), "stored body has the escaped newline");
   // ...and decoding recovers the original utterance verbatim.
   assert.ok(
-    decodeTranscriptBody(body).includes(original),
+    decodeTranscriptBody(body, true).includes(original),
     "decoded body recovers the original segment text",
   );
 });
@@ -218,7 +220,7 @@ test("speaker label with markdown delimiters round-trips through compose → par
     "label delimiters are escaped in the stored body: " + body,
   );
   // Display decoding recovers the ORIGINAL label for view/search surfaces.
-  const decoded = decodeTranscriptBody(body);
+  const decoded = decodeTranscriptBody(body, true);
   assert.ok(
     decoded.includes("**A**B** [09:01]: Delimited label."),
     "decoded body shows the original unescaped label: " + decoded,
@@ -246,4 +248,85 @@ test("legacy raw label without escape sequences parses and decodes verbatim (#18
     "**Guest** [09:01]: Good morning.\n";
   const decoded = decodeTranscriptBody(body);
   assert.equal(decoded, body, "legacy body with no escapes decodes verbatim");
+});
+
+test("legacy body with literal backslash-n/backslash-r is never decoded (#1849)", () => {
+  // A pre-escaper transcript whose segment text contains the LITERAL
+  // two-character sequences \n and \r (not escape sequences). The
+  // format-aware decoder MUST leave them byte-for-byte unchanged so the
+  // original content is never corrupted.
+  const legacyBody =
+    "# bee transcript — 2026-06-10\n" +
+    "\n" +
+    "## 09:00–09:10 (conversation c1)\n" +
+    "\n" +
+    "**Guest** [09:00]: A literal backslash-n \\n and backslash-r \\r here.\n";
+  // Default (escaped=false): legacy body is a no-op.
+  assert.equal(
+    decodeTranscriptBody(legacyBody),
+    legacyBody,
+    "legacy body must not be decoded without an explicit format marker",
+  );
+  // Even when explicitly told the body IS escaped, the literal sequences
+  // \n / \r WOULD be decoded — but only NEW-format bodies (meta carries
+  // formatVersion >= 2) are ever passed escaped=true by the service.
+  // Here we verify the SAFETY of the default: callers that forget the
+  // flag never corrupt legacy content.
+  assert.equal(
+    decodeTranscriptBody(legacyBody, false),
+    legacyBody,
+    "escaped=false leaves legacy literal escapes unchanged",
+  );
+});
+
+test("new-format body with formatVersion marker decodes correctly (#1849)", () => {
+  const conversations: WearableConversation[] = [
+    {
+      id: "c1",
+      source: "bee",
+      startIso: "2026-06-10T09:00:00Z",
+      segments: [{ speakerKey: "user", isWearer: true, text: "Line one.\nLine two." }],
+    },
+  ];
+  const body = composeDayTranscriptBody("bee", "2026-06-10", "UTC", conversations, REGISTRY);
+  const meta = composeDayTranscriptMeta(
+    "bee", "2026-06-10", "UTC", conversations, REGISTRY, body, "2026-06-11T01:00:00.000Z",
+  );
+  // The meta carries the format version marker.
+  assert.equal(meta.formatVersion, TRANSCRIPT_FORMAT_VERSION);
+  assert.ok(bodyIsEscaped(meta), "new-format meta is recognized as escaped");
+  // bodyIsEscaped returns false for legacy (no marker) and null.
+  assert.equal(bodyIsEscaped(null), false);
+  assert.equal(bodyIsEscaped(undefined), false);
+  assert.equal(bodyIsEscaped({}), false);
+  assert.equal(bodyIsEscaped({ formatVersion: 1 }), false);
+  // Decoding with the escaped flag recovers the original newline.
+  const decoded = decodeTranscriptBody(body, bodyIsEscaped(meta));
+  assert.ok(decoded.includes("Line one.\nLine two."), "new-format body decodes the newline");
+});
+
+test("composeDayTranscriptMeta stamps formatVersion and serialize/parse round-trips it (#1849)", () => {
+  const body = composeDayTranscriptBody(
+    "limitless", "2026-06-10", "UTC", CONVERSATIONS, REGISTRY,
+  );
+  const meta = composeDayTranscriptMeta(
+    "limitless", "2026-06-10", "UTC", CONVERSATIONS, REGISTRY, body, "2026-06-11T01:00:00.000Z",
+  );
+  assert.equal(meta.formatVersion, TRANSCRIPT_FORMAT_VERSION);
+  const serialized = serializeDayTranscript(meta, body);
+  assert.ok(serialized.includes("formatVersion: 2"), "serialized file carries the marker");
+  const parsed = parseDayTranscript(serialized);
+  assert.ok(parsed);
+  assert.equal(parsed!.meta.formatVersion, TRANSCRIPT_FORMAT_VERSION);
+  // A legacy file (hand-written, no formatVersion line) parses with
+  // formatVersion undefined so bodyIsEscaped returns false.
+  const legacyFile =
+    "---\nkind: wearable-transcript\nsource: \"bee\"\ndate: \"2026-06-10\"\n" +
+    "timezone: \"UTC\"\nconversationCount: 1\nsegmentCount: 1\n" +
+    "speakers: []\ndurationMinutes: 0\ncontentHash: \"x\"\nsyncedAt: \"y\"\n" +
+    "---\n\n# bee transcript — 2026-06-10\n";
+  const legacyParsed = parseDayTranscript(legacyFile);
+  assert.ok(legacyParsed);
+  assert.equal(legacyParsed!.meta.formatVersion, undefined);
+  assert.equal(bodyIsEscaped(legacyParsed!.meta), false);
 });

--- a/packages/remnic-core/src/wearables/day-store.test.ts
+++ b/packages/remnic-core/src/wearables/day-store.test.ts
@@ -186,3 +186,64 @@ test("decodeTranscriptBody recovers original segment text from a composed body (
     "decoded body recovers the original segment text",
   );
 });
+
+
+test("speaker label with markdown delimiters round-trips through compose → parse and decodeTranscriptBody (#1849)", () => {
+  // A speaker label containing `**`, `[`, `]` — the exact characters that
+  // delimit a segment line. Without safe serialization the label breaks
+  // TRANSCRIPT_SEGMENT_LINE parsing; with escape/unescape it round-trips
+  // losslessly through composition, parsing, and display decoding.
+  const registry = emptySpeakerRegistry();
+  registry.selfName = "Me";
+  registry.speakers["bee:SPEAKER_01"] = {
+    name: "A**B",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  const conversations: WearableConversation[] = [
+    {
+      id: "c1",
+      source: "bee",
+      startIso: "2026-06-10T09:00:00Z",
+      segments: [
+        { speakerKey: "user", isWearer: true, text: "Hi there.", startIso: "2026-06-10T09:00:00Z" },
+        { speakerKey: "SPEAKER_01", text: "Delimited label.", startIso: "2026-06-10T09:01:00Z" },
+      ],
+    },
+  ];
+  const body = composeDayTranscriptBody("bee", "2026-06-10", "UTC", conversations, registry);
+  // The raw stored body escapes the delimiters so the parser never sees
+  // a forged `**` or `[` boundary inside the label.
+  assert.ok(
+    body.includes("**A\\*\\*B**"),
+    "label delimiters are escaped in the stored body: " + body,
+  );
+  // Display decoding recovers the ORIGINAL label for view/search surfaces.
+  const decoded = decodeTranscriptBody(body);
+  assert.ok(
+    decoded.includes("**A**B** [09:01]: Delimited label."),
+    "decoded body shows the original unescaped label: " + decoded,
+  );
+  // parseDayTranscript preserves the body bytes verbatim.
+  const serialized = serializeDayTranscript(
+    composeDayTranscriptMeta("bee", "2026-06-10", "UTC", conversations, registry, body, "2026-06-11T01:00:00.000Z"),
+    body,
+  );
+  const parsed = parseDayTranscript(serialized);
+  assert.ok(parsed);
+  assert.equal(parsed!.body, body, "body survives serialization round-trip");
+});
+
+test("legacy raw label without escape sequences parses and decodes verbatim (#1849)", () => {
+  // A hand-written stored body whose label was NEVER escaped (a pre-
+  // escaper transcript). decodeTranscriptBody and the segment-line parser
+  // must treat it as a no-op: no backslash sequences => unchanged label.
+  const body =
+    "# bee transcript — 2026-06-10\n" +
+    "\n" +
+    "## 09:00–09:10 (conversation c1)\n" +
+    "\n" +
+    "**Me (you)** [09:00]: Hello world.\n" +
+    "**Guest** [09:01]: Good morning.\n";
+  const decoded = decodeTranscriptBody(body);
+  assert.equal(decoded, body, "legacy body with no escapes decodes verbatim");
+});

--- a/packages/remnic-core/src/wearables/day-store.test.ts
+++ b/packages/remnic-core/src/wearables/day-store.test.ts
@@ -9,6 +9,7 @@ import {
   hashTranscriptBody,
   isValidTranscriptDate,
   parseDayTranscript,
+  parseTranscriptSegmentLine,
   serializeDayTranscript,
   TRANSCRIPT_FORMAT_VERSION,
 } from "./day-store.js";
@@ -193,7 +194,7 @@ test("decodeTranscriptBody recovers original segment text from a composed body (
 test("speaker label with markdown delimiters round-trips through compose → parse and decodeTranscriptBody (#1849)", () => {
   // A speaker label containing `**`, `[`, `]` — the exact characters that
   // delimit a segment line. Without safe serialization the label breaks
-  // TRANSCRIPT_SEGMENT_LINE parsing; with escape/unescape it round-trips
+  // parseTranscriptSegmentLine parsing; with escape/unescape it round-trips
   // losslessly through composition, parsing, and display decoding.
   const registry = emptySpeakerRegistry();
   registry.selfName = "Me";
@@ -329,4 +330,60 @@ test("composeDayTranscriptMeta stamps formatVersion and serialize/parse round-tr
   assert.ok(legacyParsed);
   assert.equal(legacyParsed!.meta.formatVersion, undefined);
   assert.equal(bodyIsEscaped(legacyParsed!.meta), false);
+});
+
+test("parseTranscriptSegmentLine extracts label, clock, and text (#1849)", () => {
+  const m = parseTranscriptSegmentLine("**Pat** [09:30]: Hello world.");
+  assert.deepEqual(m, { label: "Pat", clock: "09:30", text: "Hello world." });
+});
+
+test("parseTranscriptSegmentLine handles single-char label and empty text", () => {
+  const m = parseTranscriptSegmentLine("**X** [00:00]: ");
+  assert.deepEqual(m, { label: "X", clock: "00:00", text: "" });
+});
+
+test("parseTranscriptSegmentLine preserves backslash escape sequences in label/text", () => {
+  // Escaped labels/text from the escape-aware serializer carry literal
+  // backslash sequences that must survive the linear parser unchanged.
+  const m = parseTranscriptSegmentLine("**Pat \\*Smith\\*** [09:00]: Hello \\n world.");
+  assert.ok(m);
+  assert.equal(m!.label, "Pat \\*Smith\\*");
+  assert.equal(m!.clock, "09:00");
+  assert.equal(m!.text, "Hello \\n world.");
+});
+
+test("parseTranscriptSegmentLine returns null for non-segment lines", () => {
+  assert.equal(parseTranscriptSegmentLine(""), null);
+  assert.equal(parseTranscriptSegmentLine("not a segment"), null);
+  assert.equal(parseTranscriptSegmentLine("**no close"), null);
+  assert.equal(parseTranscriptSegmentLine("**label** no bracket"), null);
+  assert.equal(parseTranscriptSegmentLine("**label** [clock] no colon-space"), null);
+  assert.equal(parseTranscriptSegmentLine("**label** [clock]:no space"), null);
+  assert.equal(parseTranscriptSegmentLine("**label** []: text"), null);
+});
+
+test("parseTranscriptSegmentLine is linear-safe on adversarial repeated delimiters (#1849)", () => {
+  // A line with many '*' chars must not cause polynomial backtracking.
+  // The linear scan finds the first '**' followed by \s[ — or returns
+  // null — without exploring exponential alternatives.
+  const longLabel = "a".repeat(10_000);
+  const adversarial = `**${longLabel}** [09:00]: text`;
+  const m = parseTranscriptSegmentLine(adversarial);
+  assert.ok(m, "long label with valid delimiters must parse");
+  assert.equal(m!.label, longLabel);
+  assert.equal(m!.clock, "09:00");
+  assert.equal(m!.text, "text");
+
+  // All stars, no closing \s[ — must return null quickly.
+  const noClose = "**" + "*".repeat(10_000);
+  assert.equal(parseTranscriptSegmentLine(noClose), null);
+
+  // All stars followed by valid suffix — the first '**' positions are
+  // all stars (not followed by \s), so the scan walks the entire run
+  // in O(n) and finds the '** ' before '['.
+  const allStars = "**" + "*".repeat(10_000) + "** [09:00]: text";
+  const m2 = parseTranscriptSegmentLine(allStars);
+  assert.ok(m2, "star-prefixed line with valid delimiters must parse");
+  assert.equal(m2!.clock, "09:00");
+  assert.equal(m2!.text, "text");
 });

--- a/packages/remnic-core/src/wearables/day-store.test.ts
+++ b/packages/remnic-core/src/wearables/day-store.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   composeDayTranscriptBody,
   composeDayTranscriptMeta,
+  decodeTranscriptBody,
   hashTranscriptBody,
   isValidTranscriptDate,
   parseDayTranscript,
@@ -140,4 +141,48 @@ test("invalid timezone falls back to UTC clock rendering instead of crashing", (
     REGISTRY,
   );
   assert.match(body, /## \d{2}:\d{2}–\d{2}:\d{2} · Morning coffee/);
+});
+
+
+test("decodeTranscriptBody decodes segment text but leaves headings/locations untouched (#1849)", () => {
+  // Hand-written stored body: segment text carries the escaped forms
+  // (backslash-n for a newline) exactly as composeDayTranscriptBody
+  // serializes them, while the title/location are NOT escaped on write.
+  const body =
+    "# bee transcript — 2026-06-10\n" +
+    "\n" +
+    "## 09:00–09:10 · C:\\roadmap (conversation c1)\n" +
+    "\n" +
+    "*Location: D:\\data*\n" +
+    "\n" +
+    '**Me (you)** [09:00]: Line one.\\nLine two.\n';
+  const decoded = decodeTranscriptBody(body);
+  // Segment text IS decoded: backslash-n -> real newline.
+  assert.ok(decoded.includes("Line one.\nLine two."), "segment newline decoded");
+  assert.ok(!decoded.includes("Line one.\\nLine two."), "no escaped-newline leak in segment");
+  // Title and location are NOT escaped on write, so a literal backslash
+  // there must pass through verbatim (only segment text is decoded).
+  assert.ok(decoded.includes("· C:\\roadmap (conversation c1)"), "title backslash untouched");
+  assert.ok(decoded.includes("*Location: D:\\data*"), "location backslash untouched");
+});
+
+test("decodeTranscriptBody recovers original segment text from a composed body (#1849)", () => {
+  const original = "First line.\nSecond line with a backslash \\ here.";
+  const conversations: WearableConversation[] = [
+    {
+      id: "c1",
+      source: "bee",
+      startIso: "2026-06-10T09:00:00Z",
+      segments: [{ speakerKey: "user", isWearer: true, text: original }],
+    },
+  ];
+  const body = composeDayTranscriptBody("bee", "2026-06-10", "UTC", conversations, REGISTRY);
+  // The stored body carries the ESCAPED form, not the original...
+  assert.ok(!body.includes(original), "stored body is escaped, not the raw original");
+  assert.ok(body.includes("First line.\\nSecond line"), "stored body has the escaped newline");
+  // ...and decoding recovers the original utterance verbatim.
+  assert.ok(
+    decodeTranscriptBody(body).includes(original),
+    "decoded body recovers the original segment text",
+  );
 });

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -44,54 +44,6 @@ export function hashTranscriptBody(body: string): string {
   return createHash("sha256").update(body, "utf-8").digest("hex");
 }
 
-/**
- * UTC offset (minutes east of UTC) for `timeZone` on the given calendar
- * date, or null when the zone is not a recognized IANA identifier. Evaluated
- * at local noon to stay clear of DST transition boundaries near midnight;
- * the wearable fusion path only needs date-level, minute-precision offsets.
- *
- * Used by the fusion path to detect sources rendered under conflicting
- * timezones (codex P2): reconstructFusionInputs rebuilds every clock as
- * `${date}T${HH}:${MM}:00Z` assuming all sources share one timezone, so
- * mixed-offset sources must be detected and refused rather than silently
- * misaligned on the fused timeline.
- */
-export function utcOffsetMinutesForDate(date: string, timeZone: string): number | null {
-  const noonUtcMs = Date.parse(`${date}T12:00:00Z`);
-  if (Number.isNaN(noonUtcMs)) return null;
-  let parts: Intl.DateTimeFormatPart[];
-  try {
-    parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour12: false,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    }).formatToParts(new Date(noonUtcMs));
-  } catch {
-    return null;
-  }
-  const part = (type: string): string | undefined =>
-    parts.find((entry) => entry.type === type)?.value;
-  const hourRaw = part("hour");
-  if (hourRaw === undefined) return null;
-  // ICU en-US hour12:false renders the zeroth hour as 24 on some builds.
-  const hour = Number.parseInt(hourRaw === "24" ? "0" : hourRaw, 10);
-  const zonedUtcMs = Date.UTC(
-    Number.parseInt(part("year") ?? "", 10),
-    Number.parseInt(part("month") ?? "", 10) - 1,
-    Number.parseInt(part("day") ?? "", 10),
-    hour,
-    Number.parseInt(part("minute") ?? "", 10),
-    Number.parseInt(part("second") ?? "", 10),
-  );
-  if (Number.isNaN(zonedUtcMs)) return null;
-  return Math.round((zonedUtcMs - noonUtcMs) / 60_000);
-}
-
 function formatClockTime(iso: string | undefined, timezone: string): string {
   if (!iso) return "--:--";
   const ms = Date.parse(iso);
@@ -254,7 +206,10 @@ export function parseDayTranscript(raw: string): WearableDayTranscript | null {
     kind: "wearable-transcript",
     source,
     date,
-    timezone: scalars.get("timezone") ?? "UTC",
+    // Preserve a missing timezone field as "" rather than coercing to a
+    // default: the fusion identity guard must see "no resolvable tz id"
+    // and skip, never silently match a known zone.
+    timezone: scalars.get("timezone") ?? "",
     conversationCount: parseNonNegativeInt(scalars.get("conversationCount")),
     segmentCount: parseNonNegativeInt(scalars.get("segmentCount")),
     speakers,

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -69,6 +69,24 @@ function conversationDurationMinutes(conversation: WearableConversation): number
   return (end - start) / 60_000;
 }
 
+/**
+ * Escape segment text for the line-based markdown format so that embedded
+ * newlines, carriage returns, and backslashes survive the serialize →
+ * reconstruct round-trip losslessly.  Reversed by `unescapeSegmentText`
+ * in `fusion/reconstruct.ts`.
+ *
+ * Without this, a segment whose text contains a newline is split across
+ * multiple physical lines; the reconstruct path treats each line
+ * independently and the continuation is silently dropped (or worse, a
+ * continuation line that looks like a heading/clock is mis-parsed).
+ */
+function escapeSegmentText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
 /** Compose the markdown body (no frontmatter) for one source/day. */
 export function composeDayTranscriptBody(
   sourceId: string,
@@ -101,7 +119,7 @@ export function composeDayTranscriptBody(
     for (const segment of conversation.segments) {
       const { label } = resolveSpeaker(sourceId, segment, registry);
       const at = formatClockTime(segment.startIso, timezone);
-      lines.push(`**${label}** [${at}]: ${segment.text}`);
+      lines.push(`**${label}** [${at}]: ${escapeSegmentText(segment.text)}`);
     }
     lines.push("");
   }

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -35,6 +35,17 @@ export const WEARABLES_DIR_NAME = "wearables";
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
+ * Day-transcript body serialization format version. Folded into
+ * `hashTranscriptBody` so a version bump invalidates files written by an
+ * older serializer and forces an idempotent rewrite. Decoders gate on this:
+ * only bodies whose parsed meta carries >= this version have escape
+ * sequences decoded; legacy bodies (absent / older) are left byte-for-byte
+ * unchanged so a literal two-character `\n`/`\r` in a pre-escaper
+ * transcript is never altered (issue #1849).
+ */
+export const TRANSCRIPT_FORMAT_VERSION = 2;
+
+/**
  * A rendered transcript segment line: `**label** [clock]: text`. Shared
  * by the composer (escape), the display/search decoder
  * (`decodeTranscriptBody`), and the fusion reconstruct parser so all
@@ -50,7 +61,14 @@ export function isValidTranscriptDate(date: string): boolean {
 }
 
 export function hashTranscriptBody(body: string): string {
-  return createHash("sha256").update(body, "utf-8").digest("hex");
+  // The version prefix makes the hash an idempotency key for the body AS
+  // SERIALIZED under the current format: when the escape encoding changes
+  // (version bump) every existing file's stored hash no longer matches and
+  // the pipeline rewrites it with the new marker — no separate migration
+  // pass needed (issue #1849).
+  return createHash("sha256")
+    .update(`v${TRANSCRIPT_FORMAT_VERSION}\n${body}`, "utf-8")
+    .digest("hex");
 }
 
 function formatClockTime(iso: string | undefined, timezone: string): string {
@@ -156,6 +174,24 @@ export function unescapeSpeakerLabel(label: string): string {
 }
 
 /**
+ * Whether a parsed day-transcript's body was written by the escape-aware
+ * serializer (meta carries `formatVersion` >= `TRANSCRIPT_FORMAT_VERSION`).
+ * Legacy bodies (no marker, or an older version) must NOT be decoded: their
+ * literal two-character `\n`, `\r`, and lone backslashes are original
+ * content, not escape sequences (issue #1849).
+ */
+export function bodyIsEscaped(
+  meta: { formatVersion?: number } | null | undefined,
+): boolean {
+  return (
+    meta !== null &&
+    meta !== undefined &&
+    typeof meta.formatVersion === "number" &&
+    meta.formatVersion >= TRANSCRIPT_FORMAT_VERSION
+  );
+}
+
+/**
  * Decode the escaped segment text AND speaker label of a stored
  * transcript body into the ORIGINAL forms for user-facing
  * view/search/index surfaces. Only segment lines are touched: the text
@@ -166,8 +202,16 @@ export function unescapeSpeakerLabel(label: string): string {
  * reconstruct path does NOT use this — it decodes each segment once
  * during parse — so callers feeding bodies back into reconstruct must
  * pass the RAW stored body, not a decoded one, to avoid double-decoding.
+ *
+ * FORMAT-AWARE (issue #1849): when `escaped` is falsy (the default) the
+ * body is returned byte-for-byte unchanged. Only bodies written by the
+ * escape-aware serializer (`escaped = true`, derived from
+ * `bodyIsEscaped(meta)`) are decoded, so a legacy transcript's literal
+ * two-character `\n`/`\r` or lone backslash is never altered. Callers
+ * that have the parsed meta should pass `bodyIsEscaped(meta)`.
  */
-export function decodeTranscriptBody(body: string): string {
+export function decodeTranscriptBody(body: string, escaped = false): string {
+  if (!escaped) return body;
   const lines = body.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const match = TRANSCRIPT_SEGMENT_LINE.exec(lines[i]);
@@ -246,6 +290,7 @@ export function composeDayTranscriptMeta(
     durationMinutes,
     contentHash: hashTranscriptBody(body),
     syncedAt,
+    formatVersion: TRANSCRIPT_FORMAT_VERSION,
   };
 }
 
@@ -256,6 +301,9 @@ export function serializeDayTranscript(
 ): string {
   const lines: string[] = ["---"];
   lines.push(`kind: ${meta.kind}`);
+  if (typeof meta.formatVersion === "number") {
+    lines.push(`formatVersion: ${meta.formatVersion}`);
+  }
   lines.push(`source: ${JSON.stringify(meta.source)}`);
   lines.push(`date: ${JSON.stringify(meta.date)}`);
   lines.push(`timezone: ${JSON.stringify(meta.timezone)}`);
@@ -318,6 +366,9 @@ export function parseDayTranscript(raw: string): WearableDayTranscript | null {
 
   const meta: WearableDayTranscriptMeta = {
     kind: "wearable-transcript",
+    ...(scalars.has("formatVersion")
+      ? { formatVersion: parseNonNegativeInt(scalars.get("formatVersion")) }
+      : {}),
     source,
     date,
     // Preserve a missing timezone field as "" rather than coercing to a

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -44,6 +44,54 @@ export function hashTranscriptBody(body: string): string {
   return createHash("sha256").update(body, "utf-8").digest("hex");
 }
 
+/**
+ * UTC offset (minutes east of UTC) for `timeZone` on the given calendar
+ * date, or null when the zone is not a recognized IANA identifier. Evaluated
+ * at local noon to stay clear of DST transition boundaries near midnight;
+ * the wearable fusion path only needs date-level, minute-precision offsets.
+ *
+ * Used by the fusion path to detect sources rendered under conflicting
+ * timezones (codex P2): reconstructFusionInputs rebuilds every clock as
+ * `${date}T${HH}:${MM}:00Z` assuming all sources share one timezone, so
+ * mixed-offset sources must be detected and refused rather than silently
+ * misaligned on the fused timeline.
+ */
+export function utcOffsetMinutesForDate(date: string, timeZone: string): number | null {
+  const noonUtcMs = Date.parse(`${date}T12:00:00Z`);
+  if (Number.isNaN(noonUtcMs)) return null;
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(new Date(noonUtcMs));
+  } catch {
+    return null;
+  }
+  const part = (type: string): string | undefined =>
+    parts.find((entry) => entry.type === type)?.value;
+  const hourRaw = part("hour");
+  if (hourRaw === undefined) return null;
+  // ICU en-US hour12:false renders the zeroth hour as 24 on some builds.
+  const hour = Number.parseInt(hourRaw === "24" ? "0" : hourRaw, 10);
+  const zonedUtcMs = Date.UTC(
+    Number.parseInt(part("year") ?? "", 10),
+    Number.parseInt(part("month") ?? "", 10) - 1,
+    Number.parseInt(part("day") ?? "", 10),
+    hour,
+    Number.parseInt(part("minute") ?? "", 10),
+    Number.parseInt(part("second") ?? "", 10),
+  );
+  if (Number.isNaN(zonedUtcMs)) return null;
+  return Math.round((zonedUtcMs - noonUtcMs) / 60_000);
+}
+
 function formatClockTime(iso: string | undefined, timezone: string): string {
   if (!iso) return "--:--";
   const ms = Date.parse(iso);

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -116,15 +116,56 @@ export function unescapeSegmentText(text: string): string {
 }
 
 /**
- * Decode the escaped segment text of a stored transcript body into the
- * ORIGINAL text for user-facing view/search/index surfaces. Only the
- * text portion of segment lines is decoded; headings, locations, and
- * the H1 header are NOT escaped on write and pass through unchanged, so
- * a title or location containing a literal backslash is never altered.
- * The fusion reconstruct path does NOT use this — it decodes each
- * segment once during parse — so callers feeding bodies back into
- * reconstruct must pass the RAW stored body, not a decoded one, to
- * avoid double-decoding.
+ * Escape a speaker label for the line-based markdown format so that
+ * markdown-delimiter characters in an arbitrary user/provider label
+ * (`**`, `[`, `]`), the escape character (`\`), and embedded newlines/
+ * carriage returns cannot break `TRANSCRIPT_SEGMENT_LINE` parsing.
+ * Without this, a label containing `**` (or `** [clock]:`) can make the
+ * non-greedy delimiter match land on the wrong `**` and mis-parse the
+ * clock/text — or fail to parse the line at all. Reversed by
+ * `unescapeSpeakerLabel` (this module). Legacy transcripts whose labels
+ * were never escaped still parse: `unescapeSpeakerLabel` is a no-op on
+ * any label without a backslash escape sequence (#1849).
+ */
+export function escapeSpeakerLabel(label: string): string {
+  return label
+    .replace(/\\/g, "\\\\")
+    .replace(/\*/g, "\\*")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
+}
+
+/**
+ * Reverse `escapeSpeakerLabel`. Unknown escape sequences (a backslash
+ * followed by a character the escaper never emits) are passed through
+ * literally so legacy transcripts with raw labels still round-trip
+ * their original text, mirroring `unescapeSegmentText` for segment text.
+ */
+export function unescapeSpeakerLabel(label: string): string {
+  return label.replace(/\\(.)/g, (_match, ch: string) => {
+    if (ch === "\\") return "\\";
+    if (ch === "*") return "*";
+    if (ch === "[") return "[";
+    if (ch === "]") return "]";
+    if (ch === "n") return "\n";
+    if (ch === "r") return "\r";
+    return "\\" + ch;
+  });
+}
+
+/**
+ * Decode the escaped segment text AND speaker label of a stored
+ * transcript body into the ORIGINAL forms for user-facing
+ * view/search/index surfaces. Only segment lines are touched: the text
+ * is decoded via `unescapeSegmentText` and the label via
+ * `unescapeSpeakerLabel`; headings, locations, and the H1 header are
+ * NOT escaped on write and pass through unchanged, so a title or
+ * location containing a literal backslash is never altered. The fusion
+ * reconstruct path does NOT use this — it decodes each segment once
+ * during parse — so callers feeding bodies back into reconstruct must
+ * pass the RAW stored body, not a decoded one, to avoid double-decoding.
  */
 export function decodeTranscriptBody(body: string): string {
   const lines = body.split("\n");
@@ -132,9 +173,10 @@ export function decodeTranscriptBody(body: string): string {
     const match = TRANSCRIPT_SEGMENT_LINE.exec(lines[i]);
     if (match === null) continue;
     const [, label, clock, rawText] = match;
-    const decoded = unescapeSegmentText(rawText);
-    if (decoded === rawText) continue;
-    lines[i] = `**${label}** [${clock}]: ${decoded}`;
+    const decodedText = unescapeSegmentText(rawText);
+    const decodedLabel = unescapeSpeakerLabel(label);
+    if (decodedText === rawText && decodedLabel === label) continue;
+    lines[i] = `**${decodedLabel}** [${clock}]: ${decodedText}`;
   }
   return lines.join("\n");
 }
@@ -171,7 +213,9 @@ export function composeDayTranscriptBody(
     for (const segment of conversation.segments) {
       const { label } = resolveSpeaker(sourceId, segment, registry);
       const at = formatClockTime(segment.startIso, timezone);
-      lines.push(`**${label}** [${at}]: ${escapeSegmentText(segment.text)}`);
+      lines.push(
+        `**${escapeSpeakerLabel(label)}** [${at}]: ${escapeSegmentText(segment.text)}`,
+      );
     }
     lines.push("");
   }

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -34,6 +34,15 @@ export const WEARABLES_DIR_NAME = "wearables";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * A rendered transcript segment line: `**label** [clock]: text`. Shared
+ * by the composer (escape), the display/search decoder
+ * (`decodeTranscriptBody`), and the fusion reconstruct parser so all
+ * three agree on what a segment line is — no divergent parsing across
+ * the view/search/index surfaces (#1849).
+ */
+export const TRANSCRIPT_SEGMENT_LINE = /^\*\*(.+?)\*\*\s\[(.+?)\]:\s(.*)$/;
+
 export function isValidTranscriptDate(date: string): boolean {
   if (!DATE_PATTERN.test(date)) return false;
   const parsed = new Date(`${date}T00:00:00Z`);
@@ -73,7 +82,8 @@ function conversationDurationMinutes(conversation: WearableConversation): number
  * Escape segment text for the line-based markdown format so that embedded
  * newlines, carriage returns, and backslashes survive the serialize →
  * reconstruct round-trip losslessly.  Reversed by `unescapeSegmentText`
- * in `fusion/reconstruct.ts`.
+ * (this module — the single decode primitive shared with the fusion
+ * reconstruct path and every view/search/index surface).
  *
  * Without this, a segment whose text contains a newline is split across
  * multiple physical lines; the reconstruct path treats each line
@@ -85,6 +95,48 @@ function escapeSegmentText(text: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/\n/g, "\\n")
     .replace(/\r/g, "\\r");
+}
+
+/**
+ * Reverse `escapeSegmentText`. Unknown escape sequences (a lone
+ * backslash followed by a character the escaper never emits) are passed
+ * through literally so legacy transcripts that never went through the
+ * escaper still round-trip their original text. This is the SINGLE
+ * decode primitive: the fusion reconstruct path and every user-facing
+ * view/search/index surface call it so escaped storage never leaks to
+ * display (#1849).
+ */
+export function unescapeSegmentText(text: string): string {
+  return text.replace(/\\(.)/g, (_match, ch: string) => {
+    if (ch === "n") return "\n";
+    if (ch === "r") return "\r";
+    if (ch === "\\") return "\\";
+    return "\\" + ch;
+  });
+}
+
+/**
+ * Decode the escaped segment text of a stored transcript body into the
+ * ORIGINAL text for user-facing view/search/index surfaces. Only the
+ * text portion of segment lines is decoded; headings, locations, and
+ * the H1 header are NOT escaped on write and pass through unchanged, so
+ * a title or location containing a literal backslash is never altered.
+ * The fusion reconstruct path does NOT use this — it decodes each
+ * segment once during parse — so callers feeding bodies back into
+ * reconstruct must pass the RAW stored body, not a decoded one, to
+ * avoid double-decoding.
+ */
+export function decodeTranscriptBody(body: string): string {
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const match = TRANSCRIPT_SEGMENT_LINE.exec(lines[i]);
+    if (match === null) continue;
+    const [, label, clock, rawText] = match;
+    const decoded = unescapeSegmentText(rawText);
+    if (decoded === rawText) continue;
+    lines[i] = `**${label}** [${clock}]: ${decoded}`;
+  }
+  return lines.join("\n");
 }
 
 /** Compose the markdown body (no frontmatter) for one source/day. */

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -46,13 +46,114 @@ const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 export const TRANSCRIPT_FORMAT_VERSION = 2;
 
 /**
- * A rendered transcript segment line: `**label** [clock]: text`. Shared
- * by the composer (escape), the display/search decoder
- * (`decodeTranscriptBody`), and the fusion reconstruct parser so all
- * three agree on what a segment line is — no divergent parsing across
- * the view/search/index surfaces (#1849).
+ * Result of parsing a rendered transcript segment line.
  */
-export const TRANSCRIPT_SEGMENT_LINE = /^\*\*(.+?)\*\*\s\[(.+?)\]:\s(.*)$/;
+export interface TranscriptSegmentMatch {
+  /** Speaker label text between the `**` delimiters. */
+  label: string;
+  /** Clock text between the `[` `]` delimiters. */
+  clock: string;
+  /** Segment text after the colon. */
+  text: string;
+}
+
+/**
+ * Test a single character code point against the JavaScript regex `\s`
+ * whitespace class without invoking a regex. Used by the linear segment
+ * line parser so no quantified pattern is ever evaluated on untrusted
+ * transcript content (CodeQL polynomial-redos, issue #1849).
+ */
+function isRegexWhitespace(code: number): boolean {
+  return (
+    (code >= 0x09 && code <= 0x0d) ||
+    code === 0x20 ||
+    code === 0xa0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000 ||
+    code === 0xfeff
+  );
+}
+
+/**
+ * Parse a rendered transcript segment line (`**label** [clock]: text`)
+ * into its three components using a linear, bounded scan — a CodeQL-safe
+ * replacement for the polynomial-risk regex that previously matched this
+ * format. Returns null when the line is not a segment line.
+ *
+ * The scan finds the FIRST occurrence of each structural delimiter
+ * (`**` after the label, `]` after the clock) exactly as the original
+ * non-greedy regex did, and verifies the fixed separator characters
+ * (`\s`, `[`, `:`, `\s`) by single-character code-point comparison.
+ * No quantified regex is evaluated on the line (#1849).
+ *
+ * Escaped labels (formatVersion >= 2) never contain an unescaped `**`,
+ * `[`, or `]`, and rendered clocks are always `HH:MM` / `--:--`, so the
+ * first delimiter is always the correct one for every well-formed
+ * transcript. Legacy unescaped labels are used verbatim by the caller
+ * and parsed identically here.
+ */
+export function parseTranscriptSegmentLine(
+  line: string,
+): TranscriptSegmentMatch | null {
+  // Must start with '**'.
+  if (!line.startsWith("**")) return null;
+
+  // Find the closing '**' of the label: the first '**' at index >= 3
+  // (label is at least 1 char) that is immediately followed by \s and
+  // then '['. This mirrors the non-greedy regex: the engine tries the
+  // shortest label first and extends only when the subsequent fixed
+  // delimiters do not line up. An escaped label ending with '\*' is
+  // correctly handled because the spurious '**' (escape-star + close-
+  // star) is not followed by \s and the scan continues.
+  let labelEnd = -1;
+  for (let i = 3; i < line.length; i++) {
+    if (
+      line.charCodeAt(i) !== 0x2a /* '*' */ ||
+      i + 3 >= line.length ||
+      line.charCodeAt(i + 1) !== 0x2a /* '*' */ ||
+      !isRegexWhitespace(line.charCodeAt(i + 2)) ||
+      line.charCodeAt(i + 3) !== 0x5b /* '[' */
+    ) {
+      continue;
+    }
+    labelEnd = i;
+    break;
+  }
+  if (labelEnd === -1) return null;
+
+  const label = line.slice(2, labelEnd);
+  // Clock content starts after the closing '**', the \s, and the '['.
+  const clockStart = labelEnd + 4;
+
+  // Find the closing ']' of the clock: the first ']' at index >=
+  // clockStart + 1 (clock is at least 1 char) that is immediately
+  // followed by ':' and \s — matching the non-greedy regex.
+  let clockEnd = -1;
+  for (let i = clockStart + 1; i < line.length; i++) {
+    if (
+      line.charCodeAt(i) !== 0x5d /* ']' */ ||
+      i + 2 >= line.length ||
+      line.charCodeAt(i + 1) !== 0x3a /* ':' */ ||
+      !isRegexWhitespace(line.charCodeAt(i + 2))
+    ) {
+      continue;
+    }
+    clockEnd = i;
+    break;
+  }
+  if (clockEnd === -1) return null;
+
+  return {
+    label,
+    clock: line.slice(clockStart, clockEnd),
+    text: line.slice(clockEnd + 3),
+  };
+}
 
 export function isValidTranscriptDate(date: string): boolean {
   if (!DATE_PATTERN.test(date)) return false;
@@ -137,7 +238,7 @@ export function unescapeSegmentText(text: string): string {
  * Escape a speaker label for the line-based markdown format so that
  * markdown-delimiter characters in an arbitrary user/provider label
  * (`**`, `[`, `]`), the escape character (`\`), and embedded newlines/
- * carriage returns cannot break `TRANSCRIPT_SEGMENT_LINE` parsing.
+ * carriage returns cannot break `parseTranscriptSegmentLine` parsing.
  * Without this, a label containing `**` (or `** [clock]:`) can make the
  * non-greedy delimiter match land on the wrong `**` and mis-parse the
  * clock/text — or fail to parse the line at all. Reversed by
@@ -214,9 +315,9 @@ export function decodeTranscriptBody(body: string, escaped = false): string {
   if (!escaped) return body;
   const lines = body.split("\n");
   for (let i = 0; i < lines.length; i++) {
-    const match = TRANSCRIPT_SEGMENT_LINE.exec(lines[i]);
+    const match = parseTranscriptSegmentLine(lines[i]);
     if (match === null) continue;
-    const [, label, clock, rawText] = match;
+    const { label, clock, text: rawText } = match;
     const decodedText = unescapeSegmentText(rawText);
     const decodedLabel = unescapeSpeakerLabel(label);
     if (decodedText === rawText && decodedLabel === label) continue;

--- a/packages/remnic-core/src/wearables/day-store.ts
+++ b/packages/remnic-core/src/wearables/day-store.ts
@@ -90,7 +90,7 @@ function conversationDurationMinutes(conversation: WearableConversation): number
  * independently and the continuation is silently dropped (or worse, a
  * continuation line that looks like a heading/clock is mis-parsed).
  */
-function escapeSegmentText(text: string): string {
+export function escapeSegmentText(text: string): string {
   return text
     .replace(/\\/g, "\\\\")
     .replace(/\n/g, "\\n")

--- a/packages/remnic-core/src/wearables/fusion/cluster.ts
+++ b/packages/remnic-core/src/wearables/fusion/cluster.ts
@@ -46,24 +46,30 @@ function effectiveInterval(conversation: FusionConversationInput): Interval {
   const start = Date.parse(conversation.startIso);
   const endRaw =
     conversation.endIso !== undefined ? Date.parse(conversation.endIso) : NaN;
+  let end: number;
   if (Number.isFinite(endRaw)) {
-    return { start, end: endRaw as number };
-  }
-  // No conversation-level end: derive the window from each segment's own
-  // extent (its end when known, otherwise its start). The latest extent
-  // spans the actual segments; falling back only to `start` would produce a
-  // zero/negative-length window that drops or mis-clusters the conversation.
-  let maxExtent = NaN;
-  for (const segment of conversation.segments) {
-    const iso = segment.endIso ?? segment.startIso;
-    if (iso === undefined) continue;
-    const ms = Date.parse(iso);
-    if (Number.isFinite(ms) && (Number.isNaN(maxExtent) || ms > maxExtent)) {
-      maxExtent = ms;
+    end = endRaw as number;
+  } else {
+    // No conversation-level end: derive the window from each segment's own
+    // extent (its end when known, otherwise its start). The latest extent
+    // spans the actual segments; falling back only to `start` would produce a
+    // zero/negative-length window that drops or mis-clusters the conversation.
+    let maxExtent = NaN;
+    for (const segment of conversation.segments) {
+      const iso = segment.endIso ?? segment.startIso;
+      if (iso === undefined) continue;
+      const ms = Date.parse(iso);
+      if (Number.isFinite(ms) && (Number.isNaN(maxExtent) || ms > maxExtent)) {
+        maxExtent = ms;
+      }
     }
+    end = Number.isFinite(maxExtent) ? (maxExtent as number) : start;
   }
-  const derivedEnd = Number.isFinite(maxExtent) ? (maxExtent as number) : start;
-  return { start, end: Math.max(derivedEnd, start) };
+  // Clamp universally so the window is always non-negative. An explicit
+  // conversation end that precedes the start (malformed/cross-day input)
+  // would otherwise yield a negative-length window that shrinks the merge
+  // horizon and can split a within-gap cluster.
+  return { start, end: Math.max(end, start) };
 }
 
 function compareConversation(

--- a/packages/remnic-core/src/wearables/fusion/cluster.ts
+++ b/packages/remnic-core/src/wearables/fusion/cluster.ts
@@ -1,0 +1,131 @@
+/**
+ * Wearable cross-source fusion — deterministic conversation clustering.
+ *
+ * Conversations from multiple sources recording the same real-world
+ * event overlap or sit within a proximity gap. This module groups them
+ * into clusters using a classic interval-merge-with-gap sweep, which is
+ * fully deterministic: the only inputs are start/end times, source ids,
+ * and conversation ids (no randomness, no LLM).
+ *
+ * Partial overlap is tolerated: a conversation that begins before the
+ * current cluster's end (+ gap) joins it even if it extends well past.
+ */
+
+import type { FusionConversationInput } from "./types.js";
+
+/** Default max gap (ms) between two conversations to merge into one cluster. */
+export const DEFAULT_PROXIMITY_GAP_MS = 5 * 60_000;
+
+interface Interval {
+  start: number;
+  end: number;
+}
+
+/**
+ * Resolve a conversation's effective [start, end] window in epoch ms.
+ * Falls back to the latest segment end, then to the start, so a
+ * conversation with no end still contributes a (possibly point) interval
+ * rather than being dropped.
+ */
+function effectiveInterval(conversation: FusionConversationInput): Interval {
+  const start = Date.parse(conversation.startIso);
+  const endRaw =
+    conversation.endIso !== undefined ? Date.parse(conversation.endIso) : NaN;
+  if (Number.isFinite(endRaw)) {
+    return { start, end: endRaw as number };
+  }
+  let maxSegEnd = NaN;
+  for (const segment of conversation.segments) {
+    if (segment.endIso !== undefined) {
+      const ms = Date.parse(segment.endIso);
+      if (Number.isFinite(ms) && (Number.isNaN(maxSegEnd) || ms > maxSegEnd)) {
+        maxSegEnd = ms;
+      }
+    }
+  }
+  return { start, end: Number.isFinite(maxSegEnd) ? (maxSegEnd as number) : start };
+}
+
+function compareConversation(
+  a: FusionConversationInput,
+  b: FusionConversationInput,
+): number {
+  if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+  if (a.conversationId !== b.conversationId) {
+    return a.conversationId < b.conversationId ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Cluster conversations across sources for one day. Returns clusters in
+ * chronological order; each cluster is sorted by (start, source, id).
+ * Conversations whose start time is unparseable are emitted as
+ * single-element clusters at the tail (sorted by source then id) so no
+ * data is lost.
+ */
+export function clusterConversations(
+  inputs: readonly FusionConversationInput[],
+  proximityGapMs: number = DEFAULT_PROXIMITY_GAP_MS,
+): FusionConversationInput[][] {
+  const finite: Array<{ conv: FusionConversationInput; interval: Interval }> = [];
+  const noStart: FusionConversationInput[] = [];
+  for (const conv of inputs) {
+    const interval = effectiveInterval(conv);
+    if (Number.isFinite(interval.start)) {
+      finite.push({ conv, interval });
+    } else {
+      noStart.push(conv);
+    }
+  }
+
+  finite.sort((a, b) => {
+    if (a.interval.start !== b.interval.start) {
+      return a.interval.start - b.interval.start;
+    }
+    return compareConversation(a.conv, b.conv);
+  });
+
+  const clusters: FusionConversationInput[][] = [];
+  let current: FusionConversationInput[] = [];
+  let currentEnd = NaN;
+  const flush = () => {
+    if (current.length > 0) {
+      clusters.push(current);
+      current = [];
+    }
+  };
+
+  for (const { conv, interval } of finite) {
+    if (current.length === 0) {
+      current = [conv];
+      currentEnd = interval.end;
+      continue;
+    }
+    // Overlap or within-gap adjacency -> join the cluster.
+    const joins =
+      interval.start <= currentEnd + proximityGapMs ||
+      Number.isNaN(currentEnd);
+    if (joins) {
+      current.push(conv);
+      if (Number.isNaN(currentEnd) || interval.end > currentEnd) {
+        currentEnd = interval.end;
+      }
+    } else {
+      flush();
+      current = [conv];
+      currentEnd = interval.end;
+    }
+  }
+  flush();
+
+  // Conversations with no parseable start can't be ordered in time, so
+  // each becomes its own cluster, appended after the time-ordered ones.
+  // Sort for determinism (source, id).
+  noStart.sort(compareConversation);
+  for (const conv of noStart) {
+    clusters.push([conv]);
+  }
+
+  return clusters;
+}

--- a/packages/remnic-core/src/wearables/fusion/cluster.ts
+++ b/packages/remnic-core/src/wearables/fusion/cluster.ts
@@ -23,9 +23,24 @@ interface Interval {
 
 /**
  * Resolve a conversation's effective [start, end] window in epoch ms.
- * Falls back to the latest segment end, then to the start, so a
- * conversation with no end still contributes a (possibly point) interval
- * rather than being dropped.
+ *
+ * When the conversation carries no explicit end (`endIso` undefined — the
+ * reconstructed form of a stored transcript whose heading end renders as
+ * `--:--`), the window is derived from the segments so it spans the actual
+ * utterances instead of collapsing to a zero-length point at the start:
+ *
+ *   1. conversation `endIso`, when known;
+ *   2. the latest segment END (`segment.endIso`);
+ *   3. the latest segment START (`segment.startIso`) — reconstructed
+ *      transcripts rebuild segments with only a start, so the window must
+ *      reach the last segment start;
+ *   4. the conversation start itself (no segments at all).
+ *
+ * Each segment contributes its own extent (end when known, otherwise its
+ * start); the window end is the maximum extent. Segment ISOs are already
+ * rolled for cross-midnight by the reconstruct layer, so the derived end is
+ * consistent with the segment timeline. The end is clamped to `>= start` so
+ * the window is always valid regardless of input anomalies.
  */
 function effectiveInterval(conversation: FusionConversationInput): Interval {
   const start = Date.parse(conversation.startIso);
@@ -34,16 +49,21 @@ function effectiveInterval(conversation: FusionConversationInput): Interval {
   if (Number.isFinite(endRaw)) {
     return { start, end: endRaw as number };
   }
-  let maxSegEnd = NaN;
+  // No conversation-level end: derive the window from each segment's own
+  // extent (its end when known, otherwise its start). The latest extent
+  // spans the actual segments; falling back only to `start` would produce a
+  // zero/negative-length window that drops or mis-clusters the conversation.
+  let maxExtent = NaN;
   for (const segment of conversation.segments) {
-    if (segment.endIso !== undefined) {
-      const ms = Date.parse(segment.endIso);
-      if (Number.isFinite(ms) && (Number.isNaN(maxSegEnd) || ms > maxSegEnd)) {
-        maxSegEnd = ms;
-      }
+    const iso = segment.endIso ?? segment.startIso;
+    if (iso === undefined) continue;
+    const ms = Date.parse(iso);
+    if (Number.isFinite(ms) && (Number.isNaN(maxExtent) || ms > maxExtent)) {
+      maxExtent = ms;
     }
   }
-  return { start, end: Number.isFinite(maxSegEnd) ? (maxSegEnd as number) : start };
+  const derivedEnd = Number.isFinite(maxExtent) ? (maxExtent as number) : start;
+  return { start, end: Math.max(derivedEnd, start) };
 }
 
 function compareConversation(

--- a/packages/remnic-core/src/wearables/fusion/cluster.ts
+++ b/packages/remnic-core/src/wearables/fusion/cluster.ts
@@ -21,6 +21,42 @@ interface Interval {
   end: number;
 }
 
+/** The latest extent of a set of segments as an epoch-ms value + its ISO.
+ * Each segment contributes its OWN extent — its `endIso` when known,
+ * otherwise its `startIso` — and the result is the maximum. Reconstructed
+ * `--:--` transcripts rebuild segments with only a start, so this reaches
+ * the last segment start; segment ISOs are already cross-midnight-rolled by
+ * the reconstruct layer, so the derived end is consistent with the segment
+ * timeline. Returns undefined when no segment carries a parseable extent.
+ *
+ * This is the SINGLE shared primitive behind every end/interval derivation
+ * in the fusion pipeline (cluster interval, fused conversation end): when a
+ * conversation-level end is missing, the window falls back to the latest
+ * segment extent instead of collapsing to a zero-length point at the start.
+ */
+export interface SegmentExtent {
+  /** Epoch ms of the latest extent. */
+  ms: number;
+  /** ISO string that produced `ms` (a segment endIso, else its startIso). */
+  iso: string;
+}
+
+export function maxSegmentExtent(
+  segments: readonly { endIso?: string; startIso?: string }[],
+): SegmentExtent | undefined {
+  let best: SegmentExtent | undefined;
+  for (const seg of segments) {
+    const iso = seg.endIso ?? seg.startIso;
+    if (iso === undefined) continue;
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) continue;
+    if (best === undefined || ms > best.ms) {
+      best = { ms, iso };
+    }
+  }
+  return best;
+}
+
 /**
  * Resolve a conversation's effective [start, end] window in epoch ms.
  *
@@ -46,25 +82,14 @@ function effectiveInterval(conversation: FusionConversationInput): Interval {
   const start = Date.parse(conversation.startIso);
   const endRaw =
     conversation.endIso !== undefined ? Date.parse(conversation.endIso) : NaN;
-  let end: number;
-  if (Number.isFinite(endRaw)) {
-    end = endRaw as number;
-  } else {
-    // No conversation-level end: derive the window from each segment's own
-    // extent (its end when known, otherwise its start). The latest extent
-    // spans the actual segments; falling back only to `start` would produce a
-    // zero/negative-length window that drops or mis-clusters the conversation.
-    let maxExtent = NaN;
-    for (const segment of conversation.segments) {
-      const iso = segment.endIso ?? segment.startIso;
-      if (iso === undefined) continue;
-      const ms = Date.parse(iso);
-      if (Number.isFinite(ms) && (Number.isNaN(maxExtent) || ms > maxExtent)) {
-        maxExtent = ms;
-      }
-    }
-    end = Number.isFinite(maxExtent) ? (maxExtent as number) : start;
-  }
+  // No conversation-level end ("--:--"): derive the window from the latest
+  // SEGMENT extent via the shared primitive, so every end/interval derivation
+  // in the pipeline uses ONE coherent implementation. Falling back only to
+  // `start` would produce a zero/negative-length window that drops or
+  // mis-clusters the conversation (issue #1810).
+  const end = Number.isFinite(endRaw)
+    ? (endRaw as number)
+    : (maxSegmentExtent(conversation.segments)?.ms ?? start);
   // Clamp universally so the window is always non-negative. An explicit
   // conversation end that precedes the start (malformed/cross-day input)
   // would otherwise yield a negative-length window that shrinks the merge

--- a/packages/remnic-core/src/wearables/fusion/cluster.ts
+++ b/packages/remnic-core/src/wearables/fusion/cluster.ts
@@ -1,14 +1,18 @@
 /**
  * Wearable cross-source fusion — deterministic conversation clustering.
  *
- * Conversations from multiple sources recording the same real-world
- * event overlap or sit within a proximity gap. This module groups them
- * into clusters using a classic interval-merge-with-gap sweep, which is
- * fully deterministic: the only inputs are start/end times, source ids,
- * and conversation ids (no randomness, no LLM).
+ * Conversations from multiple sources recording the same real-world event
+ * overlap or sit within a proximity gap. This module groups them into
+ * clusters that are fully deterministic: the only inputs are start/end
+ * times, source ids, and conversation ids (no randomness, no LLM).
  *
- * Partial overlap is tolerated: a conversation that begins before the
- * current cluster's end (+ gap) joins it even if it extends well past.
+ * Cross-source time proximity BRIDGES the same real-world conversation
+ * recorded by DIFFERENT sources. A single source's own distinct
+ * conversations are never merged by time proximity alone — that would
+ * collapse the source's conversation boundaries. Two same-source
+ * conversations may end up in one cluster only when a different-source
+ * conversation within the gap corroborates that they are part of the same
+ * real-world event (a cross-source chain/bridge).
  */
 
 import type { FusionConversationInput } from "./types.js";
@@ -114,6 +118,25 @@ function compareConversation(
  * Conversations whose start time is unparseable are emitted as
  * single-element clusters at the tail (sorted by source then id) so no
  * data is lost.
+ *
+ * ## Cross-source bridging rule (issue #1849)
+ *
+ * Time proximity is meant to bridge the SAME real-world conversation
+ * recorded by DIFFERENT sources — not to merge one source's own distinct
+ * conversations. Two conversations from the SAME source are therefore
+ * never directly joined by time proximity alone; they may end up in the
+ * same cluster only through a cross-source chain where a different-source
+ * conversation within the gap corroborates the bridge. This preserves the
+ * source's own conversation boundaries when no other source corroborates
+ * a merge.
+ *
+ * Concretely, a union-find pass links every pair of conversations that
+ * (a) come from DIFFERENT sources and (b) sit within the proximity gap
+ * (the later start ≤ the earlier end + gap). The transitive closure then
+ * groups same-source conversations that are bridged by at least one
+ * intervening different-source conversation. A single source with two
+ * near-back-to-back conversations and no other source recording the same
+ * window stays in two separate clusters.
  */
 export function clusterConversations(
   inputs: readonly FusionConversationInput[],
@@ -130,6 +153,7 @@ export function clusterConversations(
     }
   }
 
+  // Deterministic processing + output ordering: (start, source, id).
   finite.sort((a, b) => {
     if (a.interval.start !== b.interval.start) {
       return a.interval.start - b.interval.start;
@@ -137,38 +161,62 @@ export function clusterConversations(
     return compareConversation(a.conv, b.conv);
   });
 
-  const clusters: FusionConversationInput[][] = [];
-  let current: FusionConversationInput[] = [];
-  let currentEnd = NaN;
-  const flush = () => {
-    if (current.length > 0) {
-      clusters.push(current);
-      current = [];
+  const n = finite.length;
+
+  // Union-find so that same-source pairs are never directly joined by time
+  // proximity alone; they may share a cluster only through a cross-source
+  // bridge (transitive closure over different-source proximity edges).
+  const parent = new Array<number>(n);
+  for (let i = 0; i < n; i++) parent[i] = i;
+
+  const find = (x: number): number => {
+    let root = x;
+    while (parent[root] !== root) root = parent[root];
+    // Path compression.
+    let cur = x;
+    while (parent[cur] !== root) {
+      const next = parent[cur]!;
+      parent[cur] = root;
+      cur = next;
     }
+    return root;
   };
 
-  for (const { conv, interval } of finite) {
-    if (current.length === 0) {
-      current = [conv];
-      currentEnd = interval.end;
-      continue;
-    }
-    // Overlap or within-gap adjacency -> join the cluster.
-    const joins =
-      interval.start <= currentEnd + proximityGapMs ||
-      Number.isNaN(currentEnd);
-    if (joins) {
-      current.push(conv);
-      if (Number.isNaN(currentEnd) || interval.end > currentEnd) {
-        currentEnd = interval.end;
-      }
-    } else {
-      flush();
-      current = [conv];
-      currentEnd = interval.end;
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
+
+  // Link every cross-source pair within the proximity gap. `finite` is
+  // sorted by start, so once j's start exceeds i's end + gap, every later
+  // j is also out of reach — break early.
+  for (let i = 0; i < n; i++) {
+    const endGap = finite[i]!.interval.end + proximityGapMs;
+    for (let j = i + 1; j < n; j++) {
+      if (finite[j]!.interval.start > endGap) break;
+      // Only DIFFERENT sources may be directly joined by proximity.
+      if (finite[i]!.conv.source === finite[j]!.conv.source) continue;
+      union(i, j);
     }
   }
-  flush();
+
+  // Group conversations by union-find root. Because `finite` is sorted and
+  // we iterate in index order, each group's conversations stay in (start,
+  // source, id) order, and groups are discovered in chronological order
+  // (the first root seen belongs to the earliest-starting conversation).
+  const clusters: FusionConversationInput[][] = [];
+  const rootToCluster = new Map<number, number>();
+  for (let i = 0; i < n; i++) {
+    const root = find(i);
+    let idx = rootToCluster.get(root);
+    if (idx === undefined) {
+      idx = clusters.length;
+      rootToCluster.set(root, idx);
+      clusters.push([]);
+    }
+    clusters[idx]!.push(finite[i]!.conv);
+  }
 
   // Conversations with no parseable start can't be ordered in time, so
   // each becomes its own cluster, appended after the time-ordered ones.

--- a/packages/remnic-core/src/wearables/fusion/fuse.ts
+++ b/packages/remnic-core/src/wearables/fusion/fuse.ts
@@ -14,6 +14,7 @@
 import { createHash } from "node:crypto";
 import { clusterConversations } from "./cluster.js";
 import {
+  DEFAULT_SOURCE_TRUST,
   DEFAULT_WINDOW_TOLERANCE_MS,
   fuseCluster,
   type FuseClusterResult,
@@ -30,9 +31,11 @@ import type {
 const FUSION_ID_PREFIX = "fusion";
 
 /**
- * Canonical, stable serialization of a set of fusion inputs. Used both
- * for the per-conversation id and the day content hash — so identical
- * inputs always produce identical hashes regardless of input order.
+ * Canonical, stable serialization of a set of fusion inputs — the base
+ * for the per-conversation id. Input-only so a conversation keeps a
+ * stable identity across re-runs regardless of input order. The day
+ * content hash additionally folds the effective fusion config (see
+ * `canonicalDayKey`) so a config change invalidates the cached artifact.
  */
 function canonicalInputsKey(
   date: string,
@@ -57,6 +60,56 @@ function canonicalInputsKey(
     }
   }
   return createHash("sha256").update(lines.join("\n"), "utf-8").digest("hex");
+}
+
+/**
+ * Effective-config fingerprint folded into the day content hash so a
+ * change to any clustering/reconciliation knob (proximity gap, window
+ * tolerance, or per-source trust) invalidates the cached artifact.
+ * Defaults are resolved so an explicit default hashes identically to an
+ * omission, keeping the skip-unchanged path deterministic. Only sources
+ * that actually contribute to the day are included, so a trust change
+ * for an absent source cannot spuriously trigger a rebuild.
+ */
+function configFingerprint(
+  options: FusionOptions,
+  sources: readonly string[],
+): string {
+  const proximityGapMs = options.proximityGapMs ?? DEFAULT_PROXIMITY_GAP_MS;
+  const windowToleranceMs =
+    options.windowToleranceMs ?? DEFAULT_WINDOW_TOLERANCE_MS;
+  const lines: string[] = [
+    `gap:${proximityGapMs}`,
+    `tol:${windowToleranceMs}`,
+  ];
+  const trustMap = options.sourceTrust ?? {};
+  for (const source of [...new Set(sources)].sort()) {
+    const trust = trustMap[source] ?? DEFAULT_SOURCE_TRUST;
+    lines.push(`trust|${source}|${trust}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Day idempotency key: the input-only hash combined with the effective
+ * fusion-config fingerprint. Same inputs + same config => same hash
+ * (no duplicate rewrite); a config change => new hash => rebuild.
+ */
+function canonicalDayKey(
+  date: string,
+  inputs: readonly FusionConversationInput[],
+  options: FusionOptions,
+): string {
+  const inputsKey = canonicalInputsKey(date, inputs);
+  const fingerprint = configFingerprint(
+    options,
+    inputs.map((conv) => conv.source),
+  );
+  return createHash("sha256")
+    .update(inputsKey)
+    .update("\n")
+    .update(fingerprint)
+    .digest("hex");
 }
 
 function buildProvenance(
@@ -130,6 +183,6 @@ export function fuseDay(
     date,
     conversations,
     sources,
-    contentHash: canonicalInputsKey(date, inputs),
+    contentHash: canonicalDayKey(date, inputs, options),
   };
 }

--- a/packages/remnic-core/src/wearables/fusion/fuse.ts
+++ b/packages/remnic-core/src/wearables/fusion/fuse.ts
@@ -1,0 +1,135 @@
+/**
+ * Wearable cross-source fusion — day-level orchestrator.
+ *
+ * Takes every enabled source's normalized conversations for one day,
+ * clusters them across sources, reconciles each cluster, and attaches a
+ * stable content-hash id so re-running over unchanged inputs produces a
+ * byte-identical artifact (idempotent — no duplicate files).
+ *
+ * Deterministic end to end: no timestamps from "now", no LLM, no
+ * randomness. The only time-derived value is the `fusedAt` frontmatter
+ * field added at storage time (excluded from the content hash).
+ */
+
+import { createHash } from "node:crypto";
+import { clusterConversations } from "./cluster.js";
+import {
+  DEFAULT_WINDOW_TOLERANCE_MS,
+  fuseCluster,
+  type FuseClusterResult,
+} from "./reconcile.js";
+import { DEFAULT_PROXIMITY_GAP_MS } from "./cluster.js";
+import type {
+  FusionConversationInput,
+  FusionDayResult,
+  FusionOptions,
+  FusedConversationProvenance,
+  FusedWearableConversation,
+} from "./types.js";
+
+const FUSION_ID_PREFIX = "fusion";
+
+/**
+ * Canonical, stable serialization of a set of fusion inputs. Used both
+ * for the per-conversation id and the day content hash — so identical
+ * inputs always produce identical hashes regardless of input order.
+ */
+function canonicalInputsKey(
+  date: string,
+  inputs: readonly FusionConversationInput[],
+): string {
+  const sorted = [...inputs].sort((a, b) => {
+    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+    if (a.conversationId !== b.conversationId) {
+      return a.conversationId < b.conversationId ? -1 : 1;
+    }
+    return 0;
+  });
+  const lines: string[] = [`date:${date}`];
+  for (const conv of sorted) {
+    lines.push(
+      `conv|${conv.source}|${conv.conversationId}|${conv.startIso}|${conv.endIso ?? ""}|${conv.title ?? ""}|${conv.summary ?? ""}`,
+    );
+    for (const segment of conv.segments) {
+      lines.push(
+        `seg|${segment.speaker}|${segment.isSelf ? "self" : "other"}|${segment.startIso ?? ""}|${segment.endIso ?? ""}|${segment.text}`,
+      );
+    }
+  }
+  return createHash("sha256").update(lines.join("\n"), "utf-8").digest("hex");
+}
+
+function buildProvenance(
+  cluster: readonly FusionConversationInput[],
+  proximityGapMs: number,
+  windowToleranceMs: number,
+): FusedConversationProvenance {
+  return {
+    contributions: cluster.map((conv) => ({
+      source: conv.source,
+      conversationId: conv.conversationId,
+      startIso: conv.startIso,
+      ...(conv.endIso !== undefined ? { endIso: conv.endIso } : {}),
+      segmentCount: conv.segments.length,
+    })),
+    proximityGapMs,
+    windowToleranceMs,
+    method: "time-proximity",
+  };
+}
+
+/**
+ * Fuse every source's conversations for one day into a stable result.
+ * Empty input yields an empty (but well-formed) result so callers can
+ * treat "nothing to fuse" uniformly.
+ */
+export function fuseDay(
+  date: string,
+  inputs: readonly FusionConversationInput[],
+  options: FusionOptions = {},
+): FusionDayResult {
+  const proximityGapMs = options.proximityGapMs ?? DEFAULT_PROXIMITY_GAP_MS;
+  const windowToleranceMs =
+    options.windowToleranceMs ?? DEFAULT_WINDOW_TOLERANCE_MS;
+
+  const clusters = clusterConversations(inputs, proximityGapMs);
+  const conversations: FusedWearableConversation[] = clusters.map((cluster) => {
+    const fused: FuseClusterResult = fuseCluster(cluster, {
+      ...options,
+      windowToleranceMs,
+    });
+    const id = `${FUSION_ID_PREFIX}-${canonicalInputsKey(date, cluster).slice(0, 24)}`;
+    const result: FusedWearableConversation = {
+      id,
+      date,
+      startIso: fused.startIso,
+      sources: fused.sources,
+      speakers: fused.speakers,
+      segments: fused.segments,
+      disagreements: fused.disagreements,
+      provenance: buildProvenance(cluster, proximityGapMs, windowToleranceMs),
+    };
+    if (fused.endIso !== undefined) result.endIso = fused.endIso;
+    if (fused.title !== undefined) result.title = fused.title;
+    if (fused.summary !== undefined) result.summary = fused.summary;
+    return result;
+  });
+
+  const sourcesSeen = new Set<string>();
+  const sources: string[] = [];
+  for (const conv of conversations) {
+    for (const source of conv.sources) {
+      if (!sourcesSeen.has(source)) {
+        sourcesSeen.add(source);
+        sources.push(source);
+      }
+    }
+  }
+
+  return {
+    date,
+    conversations,
+    sources,
+    contentHash: canonicalInputsKey(date, inputs),
+  };
+}

--- a/packages/remnic-core/src/wearables/fusion/fuse.ts
+++ b/packages/remnic-core/src/wearables/fusion/fuse.ts
@@ -48,18 +48,33 @@ function canonicalInputsKey(
     }
     return 0;
   });
-  const lines: string[] = [`date:${date}`];
-  for (const conv of sorted) {
-    lines.push(
-      `conv|${conv.source}|${conv.conversationId}|${conv.startIso}|${conv.endIso ?? ""}|${conv.title ?? ""}|${conv.summary ?? ""}`,
-    );
-    for (const segment of conv.segments) {
-      lines.push(
-        `seg|${segment.speaker}|${segment.isSelf ? "self" : "other"}|${segment.startIso ?? ""}|${segment.endIso ?? ""}|${segment.text}`,
-      );
-    }
-  }
-  return createHash("sha256").update(lines.join("\n"), "utf-8").digest("hex");
+  // Serialize the structured tuples UNAMBIGUOUSLY before hashing. The old
+  // `|`/newline-delimited form could collide: a speaker label or segment
+  // text containing `|` (or a newline plus a forged `seg|…`/`conv|…`
+  // prefix) could make two DISTINCT inputs serialize to identical bytes,
+  // hashing alike — so fuseDay wrongly took the idempotent-skip path and
+  // kept serving a stale artifact. JSON string quoting makes every field
+  // boundary unforgeable, and the positional array order is the
+  // deterministic key order (no object keys to sort).
+  const record = [
+    date,
+    sorted.map((conv) => [
+      conv.source,
+      conv.conversationId,
+      conv.startIso,
+      conv.endIso ?? "",
+      conv.title ?? "",
+      conv.summary ?? "",
+      conv.segments.map((segment) => [
+        segment.speaker,
+        segment.isSelf ? "self" : "other",
+        segment.startIso ?? "",
+        segment.endIso ?? "",
+        segment.text,
+      ]),
+    ]),
+  ];
+  return createHash("sha256").update(JSON.stringify(record), "utf-8").digest("hex");
 }
 
 /**
@@ -78,16 +93,14 @@ function configFingerprint(
   const proximityGapMs = options.proximityGapMs ?? DEFAULT_PROXIMITY_GAP_MS;
   const windowToleranceMs =
     options.windowToleranceMs ?? DEFAULT_WINDOW_TOLERANCE_MS;
-  const lines: string[] = [
-    `gap:${proximityGapMs}`,
-    `tol:${windowToleranceMs}`,
-  ];
   const trustMap = options.sourceTrust ?? {};
-  for (const source of [...new Set(sources)].sort()) {
-    const trust = trustMap[source] ?? DEFAULT_SOURCE_TRUST;
-    lines.push(`trust|${source}|${trust}`);
-  }
-  return lines.join("\n");
+  // JSON form so a source id (or future field) containing `|` cannot forge
+  // a trust-entry boundary and collide two distinct effective configs into
+  // one day hash.
+  const trustEntries = [...new Set(sources)]
+    .sort()
+    .map((source) => [source, trustMap[source] ?? DEFAULT_SOURCE_TRUST]);
+  return JSON.stringify([proximityGapMs, windowToleranceMs, trustEntries]);
 }
 
 /**

--- a/packages/remnic-core/src/wearables/fusion/fuse.ts
+++ b/packages/remnic-core/src/wearables/fusion/fuse.ts
@@ -29,6 +29,17 @@ import type {
 } from "./types.js";
 
 const FUSION_ID_PREFIX = "fusion";
+/**
+ * Fusion algorithm/schema version. Folded into the day content hash (the
+ * idempotency key) so a change to the clustering, reconciliation, or
+ * reconstruction algorithm invalidates cached artifacts even when the raw
+ * inputs and fusion config are byte-identical — pre-existing `_fusion/`
+ * files are regenerated rather than served stale. Bump this whenever the
+ * fusion algorithm meaningfully changes (this PR changed it repeatedly).
+ * The per-conversation id (`canonicalInputsKey`) is intentionally NOT
+ * folded with the version, so a conversation keeps a stable identity.
+ */
+export const FUSION_ALGO_VERSION = "2026-07-12-1";
 
 /**
  * Canonical, stable serialization of a set of fusion inputs — the base
@@ -105,13 +116,17 @@ function configFingerprint(
 
 /**
  * Day idempotency key: the input-only hash combined with the effective
- * fusion-config fingerprint. Same inputs + same config => same hash
- * (no duplicate rewrite); a config change => new hash => rebuild.
+ * fusion-config fingerprint AND the fusion algorithm version. Same inputs +
+ * same config + same version => same hash (no duplicate rewrite); a config
+ * change OR an algorithm-version bump => new hash => rebuild. The version
+ * is what forces regeneration when the ALGORITHM itself changes but the
+ * inputs and config are byte-identical (issue #1849).
  */
-function canonicalDayKey(
+export function canonicalDayKey(
   date: string,
   inputs: readonly FusionConversationInput[],
   options: FusionOptions,
+  algoVersion: string = FUSION_ALGO_VERSION,
 ): string {
   const inputsKey = canonicalInputsKey(date, inputs);
   const fingerprint = configFingerprint(
@@ -122,6 +137,8 @@ function canonicalDayKey(
     .update(inputsKey)
     .update("\n")
     .update(fingerprint)
+    .update("\n")
+    .update(algoVersion)
     .digest("hex");
 }
 

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -8,8 +8,10 @@ import {
   DEFAULT_PROXIMITY_GAP_MS,
   DEFAULT_WINDOW_TOLERANCE_MS,
   clusterConversations,
+  composeFusionDayMeta,
   fuseDay,
   fusionInputsFromConversations,
+  hashFusionBody,
   reconstructFusionInputs,
   serializeFusionDay,
   parseFusionDay,
@@ -446,21 +448,20 @@ test("serialize/parse round-trips a fused day file", () => {
       ],
     }),
   );
-  const serialized = serializeFusionDay(
-    {
-      kind: "wearable-fusion",
-      date: DATE,
-      sourceCount: fused.sources.length,
-      conversationCount: fused.conversations.length,
-      contentHash: fused.contentHash,
-      fusedAt: "2026-06-11T00:00:00.000Z",
-    },
+  const meta = composeFusionDayMeta(
+    DATE,
     fused.conversations,
+    fused.sources,
+    fused.contentHash,
+    "2026-06-11T00:00:00.000Z",
   );
+  const serialized = serializeFusionDay(meta, fused.conversations);
   const parsed = parseFusionDay(serialized);
   assert.ok(parsed);
   assert.equal(parsed!.meta.kind, "wearable-fusion");
   assert.equal(parsed!.meta.date, DATE);
+  assert.equal(parsed!.meta.bodyHash, hashFusionBody(fused.conversations));
+  assert.equal(parsed!.parseOk, true);
   assert.equal(parsed!.conversations.length, 1);
   assert.equal(parsed!.conversations[0]!.segments[0]!.text, "Round trip.");
 });
@@ -468,6 +469,77 @@ test("serialize/parse round-trips a fused day file", () => {
 test("parseFusionDay returns null for non-fusion content", () => {
   assert.equal(parseFusionDay("---\nkind: wearable-transcript\n---\n\nbody\n"), null);
   assert.equal(parseFusionDay("not a transcript at all"), null);
+});
+
+test("parseFusionDay accepts a well-formed conversation array", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs({
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Well formed.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    }),
+  );
+  const serialized = serializeFusionDay(
+    composeFusionDayMeta(DATE, fused.conversations, fused.sources, fused.contentHash, "2026-06-11T00:00:00.000Z"),
+    fused.conversations,
+  );
+  const parsed = parseFusionDay(serialized);
+  assert.ok(parsed);
+  assert.equal(parsed!.parseOk, true);
+  assert.equal(parsed!.conversations.length, fused.conversations.length);
+});
+
+test("parseFusionDay accepts a legitimately-empty body", () => {
+  const serialized = serializeFusionDay(
+    composeFusionDayMeta(DATE, [], [], "abc", "2026-06-11T00:00:00.000Z"),
+    [],
+  );
+  const parsed = parseFusionDay(serialized);
+  assert.ok(parsed);
+  assert.equal(parsed!.parseOk, true);
+  assert.equal(parsed!.conversations.length, 0);
+});
+
+test("parseFusionDay rejects corrupt bodies even with matching hash + count", () => {
+  // Frontmatter carries a hash + count that would otherwise "match"; the
+  // body itself must drive parseOk:false so fuseDay force-rewrites.
+  const header = [
+    "---",
+    "kind: wearable-fusion",
+    `date: ${JSON.stringify(DATE)}`,
+    "sourceCount: 1",
+    "conversationCount: 1",
+    'contentHash: "matches"',
+    'bodyHash: "matches"',
+    'fusedAt: "2026-06-11T00:00:00.000Z"',
+    "---",
+    "",
+  ].join("\n");
+  // Non-array JSON, empty object, null, wrong-typed, and partial elements
+  // are all rejected; a legitimately-empty [] is accepted.
+  for (const [body, expectOk] of [
+    ['{"not":"array"}', false],
+    ["[{}]", false],
+    ["[null]", false],
+    ['[{"id":1}]', false],
+    ['[{"id":"x"}]', false],
+    ["[]", true],
+  ] as const) {
+    const parsed = parseFusionDay(`${header}${body}\n`);
+    assert.ok(parsed, `expected a non-null parse for body ${body}`);
+    assert.equal(
+      parsed!.parseOk,
+      expectOk,
+      `expected parseOk:${expectOk} for body ${body}`,
+    );
+    if (!expectOk) {
+      assert.equal(parsed!.conversations.length, 0, `expected empty convs for body ${body}`);
+    }
+  }
 });
 
 test("reconstructFusionInputs parses a rendered transcript body", () => {

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -2322,3 +2322,44 @@ test("implausible earlier end does not span the day: cluster clamps it to the st
     "clamped point-window keeps the within-gap neighbor in one cluster (no broad clustering)",
   );
 });
+
+test("reconstruct never attributes a non-self speaker whose name ends in (you) as self (issue #1849)", () => {
+  // A non-self override stored with a name that already ends in the
+  // reserved `(you)` marker. The renderer (resolveSpeaker) reserves the
+  // marker, so the stored transcript line carries NO marker for Pat, and
+  // reconstruct reads self status only from the authoritative marker.
+  const registry = emptySpeakerRegistry();
+  registry.selfName = "Jordan";
+  registry.speakers["bee:SPEAKER_01"] = {
+    name: "Pat (you)",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [
+        { text: "I am the wearer.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        { text: "I am Pat.", speakerKey: "SPEAKER_01", startIso: "2026-06-10T09:01:00.000Z" },
+      ],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, registry);
+
+  // The rendered body must NOT place a `(you)` marker on the non-self
+  // Pat line — the marker is reserved for the wearer only.
+  assert.ok(/\*\*Pat\*\* \[09:01\]: I am Pat\./.test(body), "Pat's label has no (you) marker: " + body);
+
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed.length, 1);
+  const segs = parsed[0]!.segments;
+  assert.equal(segs.length, 2);
+  // Wearer keeps the authoritative marker -> self.
+  assert.equal(segs[0]!.speaker, "Jordan (you)");
+  assert.equal(segs[0]!.isSelf, true);
+  // Pat is NOT attributed as self despite the stored name ending in (you).
+  assert.equal(segs[1]!.speaker, "Pat");
+  assert.equal(segs[1]!.isSelf, false);
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { composeDayTranscriptBody } from "../day-store.js";
 import { emptySpeakerRegistry } from "../speakers.js";
 import type { WearableConversation } from "../types.js";
 import {
@@ -487,4 +488,196 @@ test("reconstructFusionInputs parses a rendered transcript body", () => {
   assert.equal(conv.segments[0]!.isSelf, true);
   assert.equal(conv.segments[1]!.speaker, "Jane");
   assert.equal(conv.segments[1]!.isSelf, false);
+});
+
+test("reconstruct normalizes renderer 24:xx midnight clocks to valid 00:xx ISO", () => {
+  // en-US hour12:false renders the first wall-clock hour as 24:xx on some
+  // ICU builds; reconstruct must never emit an invalid/next-day timestamp.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 24:00–24:30 · Late night (conversation c1)",
+    "",
+    "**Me (you)** [24:05]: Hello world.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  // 24:00 -> 00:00 on the SAME date (not the next day); valid + parseable.
+  assert.equal(conv.startIso, "2026-06-10T00:00:00.000Z");
+  assert.equal(conv.endIso, "2026-06-10T00:30:00.000Z");
+  assert.ok(Number.isFinite(Date.parse(conv.startIso!)), "startIso is a valid timestamp");
+  assert.equal(conv.segments.length, 1);
+  const segIso = conv.segments[0]!.startIso!;
+  assert.equal(segIso, "2026-06-10T00:05:00.000Z");
+  assert.ok(Number.isFinite(Date.parse(segIso)), "24:05 -> valid 00:05 ISO");
+});
+
+test("reconstruct rolls a cross-midnight conversation end into the next day", () => {
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 23:55–00:10 · Late call (conversation c1)",
+    "",
+    "**Me (you)** [23:58]: Still talking.",
+    "**Jane** [00:05]: After midnight.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T23:55:00.000Z");
+  // end clock 00:10 < start clock 23:55 -> rolled to the next calendar day.
+  assert.equal(conv.endIso, "2026-06-11T00:10:00.000Z");
+  assert.ok(conv.endIso! >= conv.startIso!, "endIso must not precede startIso");
+  const isos = conv.segments.map((s) => s.startIso);
+  assert.ok(
+    isos.includes("2026-06-10T23:58:00.000Z"),
+    "pre-midnight segment stays on the rendered date",
+  );
+  assert.ok(
+    isos.includes("2026-06-11T00:05:00.000Z"),
+    "post-midnight segment rolls to the next day",
+  );
+});
+
+test("truncated high-trust text yields to a longer corroborating transcript", () => {
+  // bee is the MORE trusted source but its text is a clipped prefix of
+  // omi's full wording; the more-complete wording must win (not the trust).
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "The deploy window opens at",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+      {
+        source: "omi",
+        conversations: [
+          conversation("omi", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "The deploy window opens at three and closes at five.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+    { sourceTrust: { bee: 0.95, omi: 0.6 } },
+  );
+  const conv = fused.conversations[0]!;
+  const segment = conv.segments[0]!;
+  assert.equal(
+    segment.text,
+    "The deploy window opens at three and closes at five.",
+  );
+  assert.equal(segment.provenance.reason, "more-complete");
+  assert.equal(segment.provenance.source, "omi");
+  assert.equal(conv.disagreements.length, 0, "a truncation is not a disagreement");
+});
+
+test("distinct untimestamped same-speaker utterances do not collapse across sources", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "First distinct untimestamped thought.", isWearer: true },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "Second distinct untimestamped thought.", isWearer: true },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  assert.equal(
+    conv.segments.length,
+    2,
+    "distinct untimestamped utterances stay separate, not collapsed",
+  );
+  const texts = conv.segments.map((s) => s.text).sort();
+  assert.deepEqual(texts, [
+    "First distinct untimestamped thought.",
+    "Second distinct untimestamped thought.",
+  ]);
+});
+
+test("raw diarization keys like SPEAKER_00 are treated as generic speakers", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "omi",
+        conversations: [
+          conversation("omi", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Hello there.",
+              speakerKey: "SPEAKER_00",
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  const speaker = conv.speakers.find((s) => !s.isSelf);
+  assert.ok(speaker, "a non-self speaker is present");
+  assert.equal(speaker!.label, "SPEAKER_00");
+  assert.ok(
+    speaker!.confidence <= 0.5,
+    "raw diarization key is generic (<=0.5), not a confident attribution",
+  );
+});
+
+test("reconstruct round-trips through the real composeDayTranscriptBody renderer", () => {
+  // Feed the actual renderer's output through reconstruct (not a hand-
+  // written body) so renderer/parser drift is caught. The renderer emits
+  // minute-precision clocks, so reconstructed ISOs zero the seconds.
+  const conversations = [
+    conversation(
+      "limitless",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [
+        { text: "Hello world.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        { text: "Good to see you.", startIso: "2026-06-10T09:01:00.000Z" },
+      ],
+      { title: "Morning sync", endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.conversationId, "c1");
+  assert.equal(conv.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(conv.endIso, "2026-06-10T09:10:00.000Z");
+  assert.equal(conv.title, "Morning sync");
+  assert.equal(conv.segments.length, 2);
+  assert.equal(conv.segments[0]!.text, "Hello world.");
+  assert.equal(conv.segments[0]!.isSelf, true);
+  assert.equal(conv.segments[0]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(conv.segments[1]!.text, "Good to see you.");
+  assert.equal(conv.segments[1]!.isSelf, false);
+  assert.equal(conv.segments[1]!.startIso, "2026-06-10T09:01:00.000Z");
 });

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1415,7 +1415,7 @@ test("reconstruct round-trips through the real composeDayTranscriptBody renderer
     ),
   ];
   const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body, escaped: true }]);
   assert.equal(parsed.length, 1);
   const conv = parsed[0]!;
   assert.equal(conv.conversationId, "c1");
@@ -2117,7 +2117,7 @@ test("multiline segment text round-trips losslessly through the real renderer", 
     ),
   ];
   const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body, escaped: true }]);
   assert.equal(parsed.length, 1);
   const segs = parsed[0]!.segments;
   assert.equal(segs.length, 2);
@@ -2137,7 +2137,7 @@ test("segment text with backslashes round-trips losslessly", () => {
     ),
   ];
   const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed[0]!.segments[0]!.text, tricky);
 });
 
@@ -2156,7 +2156,7 @@ test("multiline segment with continuation that resembles heading syntax is not m
     ),
   ];
   const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body, escaped: true }]);
   assert.equal(parsed.length, 1, "adversarial heading must not create a second conversation");
   assert.equal(parsed[0]!.segments.length, 1);
   assert.equal(parsed[0]!.segments[0]!.text, adversarial);
@@ -2174,7 +2174,7 @@ test("segment text with continuation resembling a segment clock line stays in on
     ),
   ];
   const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed[0]!.segments.length, 1, "injected segment line must not be parsed separately");
   assert.equal(parsed[0]!.segments[0]!.text, adversarial);
 });
@@ -2211,7 +2211,7 @@ test("carriage returns in segment text round-trip losslessly", () => {
     ),
   ];
   const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body, escaped: true }]);
   assert.equal(parsed[0]!.segments[0]!.text, crText);
 });
 
@@ -2227,7 +2227,7 @@ test("unicode and mixed special characters in segment text round-trip losslessly
     ),
   ];
   const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed[0]!.segments[0]!.text, unicode);
 });
 
@@ -2352,7 +2352,7 @@ test("reconstruct never attributes a non-self speaker whose name ends in (you) a
   // Pat line — the marker is reserved for the wearer only.
   assert.ok(/\*\*Pat\*\* \[09:01\]: I am Pat\./.test(body), "Pat's label has no (you) marker: " + body);
 
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed.length, 1);
   const segs = parsed[0]!.segments;
   assert.equal(segs.length, 2);
@@ -2508,7 +2508,7 @@ test("speaker label containing markdown delimiters round-trips through compose �
     "label delimiters are escaped in the stored body: " + body,
   );
   // Reconstruct decodes the label back to the original form.
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed.length, 1);
   const segs = parsed[0]!.segments;
   assert.equal(segs.length, 2);
@@ -2535,6 +2535,6 @@ test("speaker label A**B alone round-trips through compose → reconstruct (#184
     ),
   ];
   const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, registry);
-  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body, escaped: true }]);
   assert.equal(parsed[0]!.segments[0]!.speaker, "A**B");
 });

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -2247,3 +2247,78 @@ test("legacy transcript with unknown backslash sequences preserves them lossless
   assert.equal(parsed[0]!.segments[0]!.text, "Path is C:\\Users\\josh and config at D:\\data");
   assert.equal(parsed[0]!.segments[1]!.text, "Regex \\d+ matches digits, \\w+ matches words");
 });
+
+
+test("reconstruct rolls a long-but-plausible cross-midnight wrap into the next day (#1849)", () => {
+  // start 22:00 -> end 02:00 wraps 4h (240 min) — well within the
+  // plausible-conversation bound, so the end still rolls to the next day.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 22:00–02:00 · Overnight (conversation c1)",
+    "",
+    "**Me (you)** [23:30]: Still awake.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T22:00:00.000Z");
+  assert.equal(conv.endIso, "2026-06-11T02:00:00.000Z");
+  assert.ok(conv.endIso! >= conv.startIso!, "plausible wrap rolls end forward");
+});
+
+test("reconstruct does NOT roll an implausible near-24h earlier end clock (#1849)", () => {
+  // start 14:00 -> end 13:00 implies a ~23h wrap, almost certainly a
+  // malformed/ordinary earlier clock, not a midnight crossing. The end must
+  // STAY on the same date (earlier than the start) so the downstream cluster
+  // clamp collapses it to the start instead of spanning the whole day and
+  // broadly clustering unrelated neighbors.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 14:00–13:00 · Sync (conversation c1)",
+    "",
+    "**Me (you)** [14:05]: Discussed the roadmap.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T14:00:00.000Z");
+  // NOT rolled: end stays on the same date, preceding the start.
+  assert.equal(conv.endIso, "2026-06-10T13:00:00.000Z");
+  assert.ok(conv.endIso! < conv.startIso!, "implausible earlier end is left for the clamp");
+  // The segment clock (14:05 >= start 14:00) is unaffected and stays put.
+  assert.equal(conv.segments[0]!.startIso, "2026-06-10T14:05:00.000Z");
+});
+
+test("implausible earlier end does not span the day: cluster clamps it to the start (#1849)", () => {
+  // Reconstructed from a 14:00->13:00 heading (implausible wrap, not rolled),
+  // the conversation end precedes its start exactly like a direct malformed
+  // input, so effectiveInterval clamps it to [14:00, 14:00] instead of a
+  // ~23h window. A different-source neighbor at 14:03 (within the 5-min gap)
+  // therefore clusters with it rather than being swallowed by a day-long span.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 14:00–13:00 · Sync (conversation c1)",
+    "",
+    "**Me (you)** [14:00]: Roadmap.",
+    "",
+  ].join("\n");
+  const limitless = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T14:03:00.000Z",
+    endIso: "2026-06-10T14:08:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Neighbor." }],
+  };
+  const clusters = clusterConversations([...limitless, bee]);
+  assert.equal(
+    clusters.length,
+    1,
+    "clamped point-window keeps the within-gap neighbor in one cluster (no broad clustering)",
+  );
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -831,6 +831,41 @@ test("parseFusionDay rejects corrupt bodies even with matching hash + count", ()
   }
 });
 
+test("parseFusionDay rejects a blank or whitespace-only body as corrupt (#1849)", () => {
+  // An existing artifact whose body is blank/whitespace-only (frontmatter
+  // present but no JSON) is corrupt — NOT a valid empty `[]`. The
+  // serializer always writes JSON.stringify(conversations, null, 2) which
+  // produces "[]" for zero conversations, so a blank body means the file
+  // was truncated, partially written, or manually emptied.
+  const header = [
+    "---",
+    "kind: wearable-fusion",
+    `date: ${JSON.stringify(DATE)}`,
+    "sourceCount: 0",
+    "conversationCount: 0",
+    'contentHash: "abc"',
+    'bodyHash: "def"',
+    'fusedAt: "2026-06-11T00:00:00.000Z"',
+    "---",
+    "",
+  ].join("\n");
+  for (const body of ["", "   ", "\n\n", "\t"]) {
+    const parsed = parseFusionDay(`${header}${body}\n`);
+    assert.ok(parsed, `expected non-null parse for blank body`);
+    assert.equal(
+      parsed!.parseOk,
+      false,
+      `blank/whitespace body must be corrupt: ${JSON.stringify(body)}`,
+    );
+    assert.equal(parsed!.conversations.length, 0);
+  }
+  // A valid serialized [] remains accepted with parseOk true.
+  const validParsed = parseFusionDay(`${header}[]\n`);
+  assert.ok(validParsed);
+  assert.equal(validParsed!.parseOk, true);
+  assert.equal(validParsed!.conversations.length, 0);
+});
+
 test("reconstructFusionInputs parses a rendered transcript body", () => {
   const body = [
     "# limitless transcript — 2026-06-10",
@@ -2482,7 +2517,7 @@ test("implausible earlier segment does not span the day: neighbor clusters, not 
 test("speaker label containing markdown delimiters round-trips through compose → reconstruct (#1849)", () => {
   // A user-defined speaker label with `**`, `[`, and `]` — the exact
   // characters that delimit a segment line. Without safe serialization the
-  // `**` (or `[clock]`) inside the label can break TRANSCRIPT_SEGMENT_LINE
+  // `**` (or `[clock]`) inside the label can break parseTranscriptSegmentLine
   // parsing; with escape/unescape the label survives losslessly.
   const registry = emptySpeakerRegistry();
   registry.speakers["bee:SPEAKER_01"] = {

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -482,6 +482,93 @@ test("content hash folds fusion config: same inputs, changed knob => new hash", 
   );
 });
 
+test("hash encoding is delimiter-injection-safe: distinct inputs differing only by where a `|`/newline falls never collide (issue #1849)", () => {
+  // The conversation id + day contentHash are computed from a serialization
+  // of the structured fusion inputs. That serialization must be UNAMBIGUOUS:
+  // a user-defined speaker label or segment text containing `|` (or a
+  // newline plus a forged `seg|…` line) must not be able to forge a
+  // field/record boundary — otherwise two DISTINCT inputs would serialize to
+  // identical bytes, hash alike, and fuseDay would wrongly take the
+  // idempotent-skip path, keeping a stale artifact.
+  const startIso = "2026-06-10T09:00:00.000Z";
+
+  // Collision pair over the OLD `|`/newline-delimited form:
+  //  - "split": ONE segment whose text embeds a newline plus a forged
+  //    `seg|…` line, so its serialized bytes looked like two segment lines.
+  //  - "two": TWO real segments whose serialized lines are byte-identical
+  //    to "split" once the old delimiter joins ran.
+  const split: FusionConversationInput[] = [
+    {
+      source: "limitless",
+      conversationId: "c1",
+      startIso,
+      segments: [
+        { speaker: "Alice", isSelf: false, text: "Bob\nseg|Carol|other|||Dave" },
+      ],
+    },
+  ];
+  const two: FusionConversationInput[] = [
+    {
+      source: "limitless",
+      conversationId: "c1",
+      startIso,
+      segments: [
+        { speaker: "Alice", isSelf: false, text: "Bob" },
+        { speaker: "Carol", isSelf: false, text: "Dave" },
+      ],
+    },
+  ];
+
+  const fusedSplit = fuseDay(DATE, split);
+  const fusedTwo = fuseDay(DATE, two);
+
+  // The two distinct inputs must NOT collide.
+  assert.notEqual(
+    fusedSplit.contentHash,
+    fusedTwo.contentHash,
+    "a segment text containing a forged delimiter must not collide with two real segments",
+  );
+  assert.notEqual(
+    fusedSplit.conversations[0]!.id,
+    fusedTwo.conversations[0]!.id,
+    "the per-conversation id must also be collision-safe",
+  );
+
+  // A `|` inside a speaker label must not be confused with one inside the
+  // text field (field-boundary forgery).
+  const labelPipe: FusionConversationInput[] = [
+    {
+      source: "limitless",
+      conversationId: "c1",
+      startIso,
+      segments: [{ speaker: "Alice|Bob", isSelf: false, text: "Carol" }],
+    },
+  ];
+  const textPipe: FusionConversationInput[] = [
+    {
+      source: "limitless",
+      conversationId: "c1",
+      startIso,
+      segments: [{ speaker: "Alice", isSelf: false, text: "Bob|Carol" }],
+    },
+  ];
+  assert.notEqual(
+    fuseDay(DATE, labelPipe).contentHash,
+    fuseDay(DATE, textPipe).contentHash,
+    "a `|` in a speaker label vs in the text must hash differently",
+  );
+
+  // Idempotency is preserved for genuine no-ops: the same logical input
+  // (built twice, independently) still produces the SAME hash, so the
+  // idempotent-skip path keeps working for unchanged inputs.
+  assert.equal(
+    fuseDay(DATE, split).contentHash,
+    fuseDay(DATE, JSON.parse(JSON.stringify(split))).contentHash,
+    "identical logical inputs must hash identically (idempotent skip still works)",
+  );
+});
+
+
 test("serialize/parse round-trips a fused day file", () => {
   const fused = fuseDay(
     DATE,

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1610,6 +1610,147 @@ test("derived interval is clamped to end >= start for a missing-end conversation
   assert.equal(clusters[0]!.length, 1);
 });
 
+test("fused conversation end spans a missing-end source's later segments, not the short explicit end (issue #1849)", () => {
+  // Source A (bee) carries an explicit SHORT end (09:05); source B
+  // (limitless) is a stored transcript whose heading end renders as
+  // "--:--" (no endIso) with later utterances — its last segment starts at
+  // 09:30. Reconstructed segments carry only a startIso, so a fused end
+  // derived from conversation-level ends ALONE would stop at A's 09:05,
+  // clipping the conversation before B's later segments. The fused end must
+  // span B's last segment start (issue #1849: segment-extent derivation).
+  const bBody = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 09:00–--:-- · Sync (conversation c1)",
+    "",
+    "**Me (you)** [09:00]: Plan A.",
+    "**Jane** [09:30]: Later topic.",
+    "",
+  ].join("\n");
+  const bInputs = reconstructFusionInputs(DATE, [{ source: "limitless", body: bBody }]);
+  assert.equal(bInputs.length, 1);
+  assert.equal(bInputs[0]!.endIso, undefined, "B has no heading end");
+  const a: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    endIso: "2026-06-10T09:05:00.000Z",
+    segments: [
+      { speaker: "Me (you)", isSelf: true, text: "Plan A.", startIso: "2026-06-10T09:00:00.000Z" },
+    ],
+  };
+  const fused = fuseDay(DATE, [...bInputs, a]);
+  assert.equal(fused.conversations.length, 1, "A + B cluster into one conversation");
+  // B's "Later topic." (09:30) is B-only and must survive as a segment.
+  assert.ok(
+    fused.conversations[0]!.segments.some((s) => s.text === "Later topic."),
+    "B's later segment is preserved",
+  );
+  assert.equal(
+    fused.conversations[0]!.endIso,
+    "2026-06-10T09:30:00.000Z",
+    "fused end spans B's last segment start, not A's short explicit end",
+  );
+});
+
+test("fused conversation end keeps the latest explicit conversation end when no missing-end source extends past it (issue #1849)", () => {
+  // No over-extension: when every source carries an explicit conversation
+  // end and all segments sit within those ends, the segment-extent fallback
+  // must NOT override the latest explicit conversation end. Here A ends at
+  // 09:40 and B at 09:35; segment ends are far earlier (09:00:30 / 09:05:30),
+  // so the fused end stays 09:40.
+  const a: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    endIso: "2026-06-10T09:40:00.000Z",
+    segments: [
+      {
+        speaker: "Me (you)",
+        isSelf: true,
+        text: "Hello.",
+        startIso: "2026-06-10T09:00:00.000Z",
+        endIso: "2026-06-10T09:00:30.000Z",
+      },
+    ],
+  };
+  const b: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:05:00.000Z",
+    endIso: "2026-06-10T09:35:00.000Z",
+    segments: [
+      {
+        speaker: "Jane",
+        isSelf: false,
+        text: "Hi back.",
+        startIso: "2026-06-10T09:05:00.000Z",
+        endIso: "2026-06-10T09:05:30.000Z",
+      },
+    ],
+  };
+  const fused = fuseDay(DATE, [a, b]);
+  assert.equal(fused.conversations.length, 1);
+  assert.equal(
+    fused.conversations[0]!.endIso,
+    "2026-06-10T09:40:00.000Z",
+    "latest explicit conversation end wins; segment extents do not shrink it",
+  );
+});
+
+test("fused conversation end is clamped to >= start when a missing-end source's segments precede the start (issue #1849)", () => {
+  // Mirrors the cluster interval clamp (cluster.ts): a missing-end
+  // conversation whose only segment parses BEFORE the conversation start
+  // must still yield a fused end >= start — never a negative-length window.
+  const anomalous: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    segments: [
+      { speaker: "Jane", isSelf: false, text: "Early.", startIso: "2026-06-10T08:30:00.000Z" },
+    ],
+  };
+  const fused = fuseDay(DATE, [anomalous]);
+  assert.equal(fused.conversations.length, 1);
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.endIso, "2026-06-10T09:00:00.000Z", "end clamped to the cluster start");
+  assert.ok(Date.parse(conv.endIso!) >= Date.parse(conv.startIso!));
+});
+
+test("fused conversation end spans rolled cross-midnight segments of a missing-end source (issue #1849)", () => {
+  // A missing-end ("--:--") conversation whose segments wrap past midnight
+  // are rolled to the next calendar day by reconstruct. The fused end must
+  // reach the rolled last segment (2026-06-11T00:05), not a short explicit
+  // end from a corroborating source (bee ends at 00:00).
+  const bBody = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 23:55–--:-- · Late call (conversation c1)",
+    "",
+    "**Me (you)** [23:58]: Still talking.",
+    "**Jane** [00:05]: After midnight.",
+    "",
+  ].join("\n");
+  const bInputs = reconstructFusionInputs(DATE, [{ source: "limitless", body: bBody }]);
+  assert.equal(bInputs[0]!.endIso, undefined);
+  const a: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T23:55:00.000Z",
+    endIso: "2026-06-11T00:00:00.000Z",
+    segments: [
+      { speaker: "Me (you)", isSelf: true, text: "Still talking.", startIso: "2026-06-10T23:58:00.000Z" },
+    ],
+  };
+  const fused = fuseDay(DATE, [...bInputs, a]);
+  assert.equal(fused.conversations.length, 1);
+  assert.equal(
+    fused.conversations[0]!.endIso,
+    "2026-06-11T00:05:00.000Z",
+    "fused end spans B's rolled post-midnight segment start",
+  );
+});
+
 /** True when every timestamped segment precedes any later-timestamped one
  * and untimestamped segments trail (non-decreasing startIso). The fused
  * output must always satisfy this — the group-anchor emission + defensive

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -781,6 +781,108 @@ test("distinct untimestamped same-speaker utterances do not collapse across sour
   ]);
 });
 
+test("repeated short utterance attaches to the closest matching group, not the first (issue #1849)", () => {
+  // Source A (limitless) says "yes" twice — at 09:00:00 and 09:00:20.
+  // Source B (bee) says "yes" once at 09:00:21, which is within
+  // windowToleranceMs (30s) of BOTH of A's utterances. First-match would
+  // attach B to the 09:00:00 group (found first); closest-match must attach
+  // it to 09:00:20 (nearest), so B corroborates the utterance it actually
+  // overlaps and provenance stays correct.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:20.000Z" },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c2", "2026-06-10T09:00:00.000Z", [
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:21.000Z" },
+          ]),
+        ],
+      },
+    ),
+    { sourceTrust: { limitless: 0.9, bee: 0.7 } },
+  );
+
+  assert.equal(fused.conversations.length, 1);
+  const conv = fused.conversations[0]!;
+  // Two distinct utterances stay separate (same source never collapses).
+  assert.equal(conv.segments.length, 2);
+
+  const byStart = [...conv.segments].sort((a, b) =>
+    (a.startIso ?? "").localeCompare(b.startIso ?? ""),
+  );
+  // The early "yes" carries ONLY limitless — B did not corroborate it.
+  assert.equal(byStart[0]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(
+    byStart[0]!.provenance.alternatives.length,
+    0,
+    "B must not corroborate the 09:00:00 utterance under closest-match",
+  );
+  // The later "yes" carries BOTH sources — B corroborated the nearest group.
+  assert.equal(byStart[1]!.startIso, "2026-06-10T09:00:20.000Z");
+  assert.ok(
+    byStart[1]!.provenance.alternatives.some((a) => a.source === "bee"),
+    "B must corroborate the 09:00:20 utterance (closest match)",
+  );
+});
+
+test("equal-distance candidate groups tie-break to the earlier anchor (issue #1849)", () => {
+  // B's "yes" at 09:00:15 is 15s from A's 09:00:00 and 15s from A's
+  // 09:00:30 — an exact tie. The documented tie-break prefers the smaller
+  // anchor, so B corroborates the earlier (09:00:00) utterance.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c2", "2026-06-10T09:00:00.000Z", [
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:15.000Z" },
+          ]),
+        ],
+      },
+    ),
+    { sourceTrust: { limitless: 0.9, bee: 0.7 } },
+  );
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 2);
+  const byStart = [...conv.segments].sort((a, b) =>
+    (a.startIso ?? "").localeCompare(b.startIso ?? ""),
+  );
+  // The 09:00:00 utterance gets B's corroboration (smaller anchor wins tie).
+  assert.equal(byStart[0]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.ok(
+    byStart[0]!.provenance.alternatives.some((a) => a.source === "bee"),
+    "tie-break must attach B to the earlier anchor (09:00:00)",
+  );
+  // The 09:00:30 utterance stays limitless-only.
+  assert.equal(byStart[1]!.startIso, "2026-06-10T09:00:30.000Z");
+  assert.equal(
+    byStart[1]!.provenance.alternatives.length,
+    0,
+    "B must not corroborate the 09:00:30 utterance",
+  );
+});
+
 test("distinct timestamped same-window utterances stay separate, not collapsed", () => {
   // Two sources capture genuinely different utterances inside the same
   // time window (within the alignment tolerance). They must NOT merge into

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1042,3 +1042,160 @@ test("same window + same text + different speaker fuses to one segment with a re
     "both speaker labels are retained",
   );
 });
+
+test("cluster interval spans to the latest segment start when the conversation end is missing", () => {
+  // A stored transcript renders a missing conversation end as "--:--".
+  // reconstructFusionInputs rebuilds segments with only a startIso, so the
+  // cluster interval must DERIVE its end from the latest segment start —
+  // not collapse to a zero-length point at the conversation start. A later
+  // conversation that sits within the proximity gap of the LAST segment
+  // (but far past the start) must join the same cluster.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 09:00–--:-- · Morning (conversation c1)",
+    "",
+    "**Me (you)** [09:00]: First.",
+    "**Jane** [09:15]: Second.",
+    "**Jane** [09:30]: Third.",
+    "",
+  ].join("\n");
+  const reconstructed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(reconstructed.length, 1);
+  assert.equal(reconstructed[0]!.endIso, undefined, "no end clock -> no endIso");
+  // bee starts 3 min after the last limitless segment (09:33) — within the
+  // 5-minute gap of 09:30, so it clusters. The old zero-length bug measured
+  // the gap from 09:00 (33 min) and split them into two clusters.
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:33:00.000Z",
+    endIso: "2026-06-10T09:40:00.000Z",
+    segments: [
+      { speaker: "Bee", isSelf: false, text: "Follow up.", startIso: "2026-06-10T09:33:00.000Z" },
+    ],
+  };
+  const clusters = clusterConversations([...reconstructed, bee]);
+  assert.equal(
+    clusters.length,
+    1,
+    "missing-end conversation clusters by its last segment start, not its conversation start",
+  );
+});
+
+test("missing-end interval does not over-extend: a neighbor past the gap of the last segment stays separate", () => {
+  // The derived interval must be exactly [start, last segment start], not
+  // unbounded. A neighbor 10 min past the last segment (> 5 min gap) must
+  // NOT cluster with the missing-end conversation.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 09:00–--:-- · Morning (conversation c1)",
+    "",
+    "**Me (you)** [09:00]: First.",
+    "**Jane** [09:30]: Last segment.",
+    "",
+  ].join("\n");
+  const reconstructed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:40:00.000Z",
+    endIso: "2026-06-10T09:50:00.000Z",
+    segments: [
+      { speaker: "Bee", isSelf: false, text: "Later.", startIso: "2026-06-10T09:40:00.000Z" },
+    ],
+  };
+  const clusters = clusterConversations([...reconstructed, bee]);
+  assert.equal(clusters.length, 2, "10 min past the last segment is outside the gap");
+});
+
+test("cluster interval spans rolled cross-midnight segments when the conversation end is missing", () => {
+  // Cross-midnight segments in a missing-end conversation are rolled to the
+  // next calendar day by reconstruct; the cluster interval end must reach
+  // the rolled last segment so a post-midnight neighbor clusters correctly.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 23:55–--:-- · Late call (conversation c1)",
+    "",
+    "**Me (you)** [23:58]: Still talking.",
+    "**Jane** [00:05]: After midnight.",
+    "",
+  ].join("\n");
+  const reconstructed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(reconstructed.length, 1);
+  assert.equal(reconstructed[0]!.endIso, undefined);
+  // The latest segment rolled to 2026-06-11T00:05; a bee conversation at
+  // 00:08 (3 min later) must cluster with it.
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-11T00:08:00.000Z",
+    endIso: "2026-06-11T00:15:00.000Z",
+    segments: [
+      { speaker: "Bee", isSelf: false, text: "Late.", startIso: "2026-06-11T00:08:00.000Z" },
+    ],
+  };
+  const clusters = clusterConversations([...reconstructed, bee]);
+  assert.equal(
+    clusters.length,
+    1,
+    "cross-midnight missing-end conversation clusters by its rolled last segment",
+  );
+});
+
+test("derived interval uses max(segment ends or segment starts) for mixed-segment inputs", () => {
+  // Directly constructed input proving the coherent model: when the
+  // conversation end is absent and segments carry a MIX of endIso and
+  // startIso, the window end is the maximum segment EXTENT (each segment's
+  // end when known, else its start). Here the second segment's start
+  // (09:20) must beat the first segment's end (09:10).
+  const mixed: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    segments: [
+      {
+        speaker: "Jane",
+        isSelf: false,
+        text: "First.",
+        startIso: "2026-06-10T09:00:00.000Z",
+        endIso: "2026-06-10T09:10:00.000Z",
+      },
+      { speaker: "Jane", isSelf: false, text: "Second.", startIso: "2026-06-10T09:20:00.000Z" },
+    ],
+  };
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:23:00.000Z",
+    endIso: "2026-06-10T09:30:00.000Z",
+    segments: [
+      { speaker: "Bee", isSelf: false, text: "After.", startIso: "2026-06-10T09:23:00.000Z" },
+    ],
+  };
+  // bee at 09:23 is within the 5-min gap of the derived end 09:20 -> one
+  // cluster. If the interval had stopped at the first segment's END (09:10)
+  // the gap would be 13 min and they would split.
+  const clusters = clusterConversations([mixed, bee]);
+  assert.equal(clusters.length, 1, "max segment extent (start beats earlier end) spans the window");
+});
+
+test("derived interval is clamped to end >= start for a missing-end conversation", () => {
+  // Guarantee the [start, end] window is always valid: a conversation with
+  // no end and only segments that somehow parse before the start still
+  // yields end >= start (a point interval), never a negative-length window.
+  const anomalous: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    segments: [
+      { speaker: "Jane", isSelf: false, text: "Early.", startIso: "2026-06-10T08:30:00.000Z" },
+    ],
+  };
+  const clusters = clusterConversations([anomalous]);
+  assert.equal(clusters.length, 1);
+  // The conversation is emitted (not dropped) and forms a valid cluster.
+  assert.equal(clusters[0]!.length, 1);
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -916,3 +916,129 @@ test("reconstruct round-trips through the real composeDayTranscriptBody renderer
   assert.equal(conv.segments[1]!.isSelf, false);
   assert.equal(conv.segments[1]!.startIso, "2026-06-10T09:01:00.000Z");
 });
+
+test("equal-key comparator inputs keep stable input order (deterministic across runs)", () => {
+  // Two cross-source conflicts where the bee source contributes TWO same-
+  // speaker, same-length cands. bee1 and bee2 tie on every comparator key
+  // (trust, text length, source) — only a STABLE secondary key keeps them
+  // in input order. A comparator that returns nonzero for equal items (the
+  // `a < b ? -1 : 1` antipattern) leaves their order undefined.
+  const textSeed = "Limitless seed text.";
+  const textBee1 = "Bee conflict one xyz.";
+  const textBee2 = "Bee conflict two xyz.";
+  const build = () =>
+    fuseDay(
+      DATE,
+      inputs(
+        {
+          source: "limitless",
+          conversations: [
+            conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+              {
+                text: textSeed,
+                speakerName: "Jane",
+                startIso: "2026-06-10T09:00:30.000Z",
+              },
+            ]),
+          ],
+        },
+        {
+          source: "bee",
+          conversations: [
+            conversation("bee", "c1", "2026-06-10T09:00:05.000Z", [
+              {
+                text: textBee1,
+                speakerName: "Jane",
+                startIso: "2026-06-10T09:00:30.000Z",
+              },
+              {
+                text: textBee2,
+                speakerName: "Jane",
+                startIso: "2026-06-10T09:00:30.000Z",
+              },
+            ]),
+          ],
+        },
+      ),
+    );
+
+  const fused = build();
+  // Deterministic: re-running produces identical output.
+  assert.deepEqual(build(), fused);
+
+  const conv = fused.conversations[0]!;
+  // The three distinct same-window utterances stay separate and surface one
+  // cross-segment ASR conflict.
+  assert.equal(conv.segments.length, 3);
+  const disagreement = conv.disagreements.find((d) => d.kind === "asr-text");
+  assert.ok(disagreement, "a cross-segment asr-text disagreement is recorded");
+  const values = disagreement!.candidates.map((c) => c.value);
+  assert.equal(values.length, 3);
+  // Stable: the two equal-key bee cands keep input order (bee1 before bee2),
+  // never swapped by an unstable comparator.
+  assert.ok(
+    values.indexOf(textBee1) < values.indexOf(textBee2),
+    "equal-key cands keep stable input order",
+  );
+});
+
+test("same window + same text + different speaker fuses to one segment with a recorded speaker conflict", () => {
+  // Two sources capture the same utterance in the same window but DISAGREE
+  // on the speaker (Jane vs John). The same-speaker gate must not split
+  // these into two segments: they corroborate on time+text, so they fuse
+  // into ONE utterance and the speaker disagreement is recorded with
+  // provenance for each label. (The r2 separation is about DIFFERENT text;
+  // this is SAME text, different speaker.)
+  const text = "Let's ship the launch on Friday.";
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            { text, speakerName: "Jane", startIso: "2026-06-10T09:00:30.000Z" },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text, speakerName: "John", startIso: "2026-06-10T09:00:30.000Z" },
+          ]),
+        ],
+      },
+    ),
+    { sourceTrust: { limitless: 0.9 } },
+  );
+  const conv = fused.conversations[0]!;
+  // ONE fused segment — not two separate ones.
+  assert.equal(conv.segments.length, 1);
+  const segment = conv.segments[0]!;
+  assert.equal(segment.text, text);
+  // The higher-trust source's attribution wins provisionally.
+  assert.equal(segment.speaker, "Jane");
+  assert.equal(segment.isSelf, false);
+  // A speaker conflict is recorded (not silently dropped).
+  const speakerDisagreement = conv.disagreements.find(
+    (d) => d.kind === "speaker",
+  );
+  assert.ok(speakerDisagreement, "a speaker disagreement is recorded");
+  const labeled = speakerDisagreement!.candidates.map(
+    (c) => `${c.source}=${c.value}`,
+  );
+  assert.deepEqual([...labeled].sort(), ["bee=John", "limitless=Jane"]);
+  assert.deepEqual(speakerDisagreement!.provisional, {
+    source: "limitless",
+    value: "Jane",
+  });
+  // Confidence is lowered by the unresolved speaker conflict.
+  assert.ok(segment.confidence < 0.8);
+  // No attribution is lost: both labels still appear in the speaker list.
+  const labels = conv.speakers.filter((s) => !s.isSelf).map((s) => s.label);
+  assert.ok(
+    labels.includes("Jane") && labels.includes("John"),
+    "both speaker labels are retained",
+  );
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -7,6 +7,8 @@ import type { WearableConversation } from "../types.js";
 import {
   DEFAULT_PROXIMITY_GAP_MS,
   DEFAULT_WINDOW_TOLERANCE_MS,
+  FUSION_ALGO_VERSION,
+  canonicalDayKey,
   clusterConversations,
   composeFusionDayMeta,
   fuseDay,
@@ -479,6 +481,56 @@ test("content hash folds fusion config: same inputs, changed knob => new hash", 
     base.conversations[0]!.id,
     widerGap.conversations[0]!.id,
     "conversation id is input-only and stable across a config change",
+  );
+});
+
+test("content hash folds the fusion algorithm version (issue #1849)", () => {
+  // The day contentHash is the idempotency key. When the fusion ALGORITHM
+  // changes (clustering/reconciliation/reconstruction fixes) with byte-
+  // identical inputs and config, the hash must still differ so a stale
+  // artifact is regenerated rather than skipped — contentHash + bodyHash
+  // alone only prove the stored body is self-consistent, not that it was
+  // produced by the current algorithm.
+  const day = inputs(
+    {
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Algorithm-sensitive hash.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    },
+    {
+      source: "bee",
+      conversations: [
+        conversation("bee", "c2", "2026-06-10T09:00:20.000Z", [
+          { text: "Second source.", isWearer: false, startIso: "2026-06-10T09:00:40.000Z" },
+        ]),
+      ],
+    },
+  );
+
+  const current = fuseDay(DATE, day);
+
+  // A stale algorithm version must produce a DIFFERENT day hash.
+  const staleHash = canonicalDayKey(DATE, day, {}, "2000-01-01-stale");
+  assert.notEqual(
+    current.contentHash,
+    staleHash,
+    "a different algorithm version must invalidate the content hash",
+  );
+
+  // Same version => identical hash (idempotency preserved).
+  assert.equal(
+    current.contentHash,
+    canonicalDayKey(DATE, day, {}, FUSION_ALGO_VERSION),
+    "same version must produce the same hash",
+  );
+
+  // The per-conversation id is input-only and unaffected by the version.
+  assert.ok(
+    current.conversations[0]!.id.startsWith("fusion-"),
+    "conversation id is unaffected by the algorithm version",
   );
 });
 

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -197,6 +197,110 @@ test("explicit end earlier than start is clamped to start so a within-gap neighb
   );
 });
 
+test("same-source conversations within the proximity gap stay separate without a cross-source bridge (issue #1849)", () => {
+  // The proximity gap bridges the SAME real-world conversation recorded by
+  // DIFFERENT sources. Two conversations from the SAME source within the
+  // gap must NOT merge: no other source corroborates that they are the
+  // same event, so the source's own conversation boundaries are preserved.
+  const a: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    endIso: "2026-06-10T09:10:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "First meeting." }],
+  };
+  const b: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c2",
+    startIso: "2026-06-10T09:12:00.000Z",
+    endIso: "2026-06-10T09:20:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Second meeting." }],
+  };
+  // 2-minute gap < 5-minute default, but SAME source => two clusters.
+  const clusters = clusterConversations([a, b]);
+  assert.equal(
+    clusters.length,
+    2,
+    "same-source conversations stay separate without a cross-source bridge",
+  );
+  assert.deepEqual(
+    clusters.map((c) => c[0]!.conversationId),
+    ["c1", "c2"],
+    "each conversation is its own cluster, in chronological order",
+  );
+});
+
+test("different-source conversations within the proximity gap still merge (cross-source bridge)", () => {
+  // Cross-source proximity bridging is the INTENDED use of the gap —
+  // verify it is preserved by the cross-source bridge rule.
+  const a: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    endIso: "2026-06-10T09:10:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "First meeting." }],
+  };
+  const b: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:12:00.000Z",
+    endIso: "2026-06-10T09:20:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "First meeting." }],
+  };
+  // 2-minute gap < 5-minute default, DIFFERENT sources => one cluster.
+  const clusters = clusterConversations([a, b]);
+  assert.equal(clusters.length, 1, "different-source conversations within the gap merge");
+  assert.deepEqual(clusters[0]!.map((c) => c.source).sort(), ["bee", "limitless"]);
+});
+
+test("same-source conversations bridged by a different-source chain merge into one cluster (issue #1849)", () => {
+  // A(src1) and C(src1) are the SAME source. B(src2) sits within the gap
+  // of both and bridges them: A→B→C is a valid cross-source chain. Without
+  // B, A and C would stay separate (same source, no bridge).
+  //
+  // Chosen behavior: a same-source pair that would NOT merge on its own
+  // MAY share a cluster when a different-source conversation within the gap
+  // corroborates the bridge — the union-find transitive closure links them
+  // through B. This preserves source boundaries when no bridge exists while
+  // still fusing corroborated chains.
+  const a: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:00:00.000Z",
+    endIso: "2026-06-10T09:03:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Topic one." }],
+  };
+  const b: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T09:06:00.000Z",
+    endIso: "2026-06-10T09:10:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Topic one." }],
+  };
+  const c: FusionConversationInput = {
+    source: "limitless",
+    conversationId: "c2",
+    startIso: "2026-06-10T09:09:00.000Z",
+    endIso: "2026-06-10T09:20:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Topic two." }],
+  };
+  // A-B: diff source, 3-min gap (< 5 min) => bridge.
+  // A-C: same source, and C is 6 min past A.end (outside the gap) anyway.
+  // B-C: diff source, C overlaps B => bridge.
+  // => one cluster {A, B, C}, sorted by (start, source, id).
+  const clusters = clusterConversations([a, b, c]);
+  assert.equal(
+    clusters.length,
+    1,
+    "the bee conversation bridges the two limitless conversations into one cluster",
+  );
+  assert.deepEqual(
+    clusters[0]!.map((conv) => conv.conversationId),
+    ["c1", "c1", "c2"],
+    "cluster is sorted by (start, source, id): limitless c1, bee c1, limitless c2",
+  );
+});
+
 test("conflicting ASR text for the same window is recorded as a disagreement", () => {
   const fused = fuseDay(
     DATE,

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -4,6 +4,8 @@ import { test } from "node:test";
 import { emptySpeakerRegistry } from "../speakers.js";
 import type { WearableConversation } from "../types.js";
 import {
+  DEFAULT_PROXIMITY_GAP_MS,
+  DEFAULT_WINDOW_TOLERANCE_MS,
   clusterConversations,
   fuseDay,
   fusionInputsFromConversations,
@@ -366,6 +368,67 @@ test("idempotency: identical inputs produce a stable id and content hash", () =>
 
   assert.equal(a.conversations[0]!.id, b.conversations[0]!.id);
   assert.equal(a.contentHash, b.contentHash);
+});
+
+test("content hash folds fusion config: same inputs, changed knob => new hash", () => {
+  // Two contributing sources so per-source trust is part of the fingerprint.
+  const day = inputs(
+    {
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Config-sensitive hash.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    },
+    {
+      source: "bee",
+      conversations: [
+        conversation("bee", "c2", "2026-06-10T09:00:20.000Z", [
+          { text: "Second source.", isWearer: false, startIso: "2026-06-10T09:00:40.000Z" },
+        ]),
+      ],
+    },
+  );
+
+  const base = fuseDay(DATE, day);
+
+  // A change to any clustering/reconciliation knob must invalidate the hash.
+  const widerGap = fuseDay(DATE, day, { proximityGapMs: 600_000 });
+  assert.notEqual(
+    base.contentHash,
+    widerGap.contentHash,
+    "proximityGapMs change must invalidate the content hash",
+  );
+  const tighterTol = fuseDay(DATE, day, { windowToleranceMs: 5_000 });
+  assert.notEqual(
+    base.contentHash,
+    tighterTol.contentHash,
+    "windowToleranceMs change must invalidate the content hash",
+  );
+  const reweighted = fuseDay(DATE, day, { sourceTrust: { limitless: 0.95 } });
+  assert.notEqual(
+    base.contentHash,
+    reweighted.contentHash,
+    "per-source trust change must invalidate the content hash",
+  );
+
+  // Idempotency is preserved: explicit defaults hash identically to omission,
+  // and the per-conversation id stays stable across a config change.
+  const withDefaults = fuseDay(DATE, day, {
+    proximityGapMs: DEFAULT_PROXIMITY_GAP_MS,
+    windowToleranceMs: DEFAULT_WINDOW_TOLERANCE_MS,
+  });
+  assert.equal(
+    base.contentHash,
+    withDefaults.contentHash,
+    "explicit defaults must hash identically to omission",
+  );
+  assert.equal(
+    base.conversations[0]!.id,
+    widerGap.conversations[0]!.id,
+    "conversation id is input-only and stable across a config change",
+  );
 });
 
 test("serialize/parse round-trips a fused day file", () => {

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1027,6 +1027,129 @@ test("distinct timestamped same-window utterances stay separate, not collapsed",
   assert.equal(conv.disagreements[0]!.candidates.length, 2);
 });
 
+test("cross-segment ASR disagreement detected for differently-labeled self speakers (#1849)", () => {
+  // Two sources both record the WEARER but label them differently:
+  // limitless uses the default "Me (you)" while bee has an override
+  // naming the wearer "Alex" -> "Alex (you)". Both normalize to the SAME
+  // speakerKey ("self"), so grouping treats them as one identity. The
+  // cross-segment ASR-disagreement pass MUST use that same identity — not
+  // the raw display label — or a real same-window ASR conflict between
+  // them is silently missed and both confidences wrongly stay high.
+  const beeRegistry = {
+    ...REGISTRY,
+    speakers: {
+      "bee:user": {
+        name: "Alex",
+        isSelf: true,
+        updatedAt: "2026-06-10T00:00:00.000Z",
+      },
+    },
+  };
+  const limitless = fusionInputsFromConversations(
+    "limitless",
+    [
+      conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+        {
+          text: "Meeting with Sarah at noon.",
+          isWearer: true,
+          startIso: "2026-06-10T09:00:30.000Z",
+        },
+      ]),
+    ],
+    REGISTRY,
+  );
+  const bee = fusionInputsFromConversations(
+    "bee",
+    [
+      conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+        {
+          text: "Lunch with the design team.",
+          isWearer: true,
+          startIso: "2026-06-10T09:00:31.000Z",
+        },
+      ]),
+    ],
+    beeRegistry,
+  );
+  const fused = fuseDay(DATE, [...limitless, ...bee]);
+  const conv = fused.conversations[0]!;
+  // The two utterances disagree on text, so they stay separate segments.
+  assert.equal(conv.segments.length, 2);
+  // Precondition: different display labels but the same self identity.
+  assert.ok(conv.segments.every((s) => s.isSelf), "both are the wearer");
+  assert.notEqual(
+    conv.segments[0]!.speaker,
+    conv.segments[1]!.speaker,
+    "the wearer is labeled differently across the two sources",
+  );
+  // The cross-segment ASR-text disagreement IS recorded (was skipped).
+  const disagreement = conv.disagreements.find((d) => d.kind === "asr-text");
+  assert.ok(
+    disagreement,
+    "a same-self different-label ASR disagreement is recorded, not skipped",
+  );
+  assert.equal(disagreement!.candidates.length, 2);
+  // Both involved segments carry lowered confidence.
+  assert.ok(
+    conv.segments.every((s) => s.confidence < 0.8),
+    "both disagreeing segments carry lowered confidence",
+  );
+});
+
+test("differently-labeled self speakers that agree still merge into one segment (#1849)", () => {
+  // Same two-source setup as above, but the text AGREES. Since both
+  // normalize to speakerKey "self" and the text corroborates, they merge
+  // into ONE segment (no cross-segment disagreement) — the fix must not
+  // over-trigger and split an agreeing utterance.
+  const beeRegistry = {
+    ...REGISTRY,
+    speakers: {
+      "bee:user": {
+        name: "Alex",
+        isSelf: true,
+        updatedAt: "2026-06-10T00:00:00.000Z",
+      },
+    },
+  };
+  const text = "Let's ship the launch on Friday.";
+  const limitless = fusionInputsFromConversations(
+    "limitless",
+    [
+      conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+        { text, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+      ]),
+    ],
+    REGISTRY,
+  );
+  const bee = fusionInputsFromConversations(
+    "bee",
+    [
+      conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+        { text, isWearer: true, startIso: "2026-06-10T09:00:31.000Z" },
+      ]),
+    ],
+    beeRegistry,
+  );
+  const fused = fuseDay(DATE, [...limitless, ...bee]);
+  const conv = fused.conversations[0]!;
+  // The agreeing utterances merge into ONE segment, not two.
+  assert.equal(conv.segments.length, 1);
+  assert.equal(conv.segments[0]!.text, text);
+  assert.equal(conv.segments[0]!.isSelf, true);
+  // No cross-segment ASR disagreement for corroborating text.
+  const asrDisagreement = conv.disagreements.find((d) => d.kind === "asr-text");
+  assert.equal(
+    asrDisagreement,
+    undefined,
+    "agreeing utterances produce no cross-segment ASR disagreement",
+  );
+  // Corroboration BOOSTS confidence — it is not lowered.
+  assert.ok(
+    conv.segments[0]!.confidence > 0.8,
+    "corroborated utterance keeps boosted confidence",
+  );
+});
+
 test("equal-time same-source utterances keep original transcript order, not label order", () => {
   // From stored transcripts, segment times are minute-precision, so several
   // utterances from one source can share an identical anchorMs. The

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -27,6 +27,7 @@ function conversation(
   segments: Array<{
     text: string;
     speakerKey?: string;
+    speakerName?: string;
     isWearer?: boolean;
     startIso?: string;
     endIso?: string;
@@ -40,6 +41,7 @@ function conversation(
     segments: segments.map((segment) => ({
       text: segment.text,
       speakerKey: segment.speakerKey ?? "user",
+      ...(segment.speakerName !== undefined ? { speakerName: segment.speakerName } : {}),
       ...(segment.isWearer !== undefined ? { isWearer: segment.isWearer } : {}),
       ...(segment.startIso !== undefined ? { startIso: segment.startIso } : {}),
       ...(segment.endIso !== undefined ? { endIso: segment.endIso } : {}),
@@ -716,6 +718,70 @@ test("distinct timestamped same-window utterances stay separate, not collapsed",
   // The cross-source conflict is surfaced for review (not silently dropped).
   assert.equal(conv.disagreements.length, 1);
   assert.equal(conv.disagreements[0]!.candidates.length, 2);
+});
+
+test("equal-time same-source utterances keep original transcript order, not label order", () => {
+  // From stored transcripts, segment times are minute-precision, so several
+  // utterances from one source can share an identical anchorMs. The
+  // alignment tie-break must preserve the ORIGINAL transcript sequence:
+  // sorting equal-time segments by speaker label would scramble them
+  // ("Amy" before "Zoe" even though Zoe spoke first).
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Zoe spoke first.",
+              speakerName: "Zoe",
+              startIso: "2026-06-10T09:00:00.000Z",
+            },
+            {
+              text: "Amy spoke second.",
+              speakerName: "Amy",
+              startIso: "2026-06-10T09:00:00.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 2);
+  assert.deepEqual(
+    conv.segments.map((s) => s.text),
+    ["Zoe spoke first.", "Amy spoke second."],
+    "equal-time utterances keep original transcript order, not label order",
+  );
+  assert.deepEqual(conv.segments.map((s) => s.speaker), ["Zoe", "Amy"]);
+});
+
+test("untimestamped same-source utterances keep original transcript order", () => {
+  // Missing times all share the missing-anchor group; the tie-break must
+  // still preserve original transcript sequence rather than speaker label.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "Zoe untimestamped first.", speakerName: "Zoe" },
+            { text: "Amy untimestamped second.", speakerName: "Amy" },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 2);
+  assert.deepEqual(
+    conv.segments.map((s) => s.text),
+    ["Zoe untimestamped first.", "Amy untimestamped second."],
+  );
+  assert.deepEqual(conv.segments.map((s) => s.speaker), ["Zoe", "Amy"]);
 });
 
 test("raw diarization keys like SPEAKER_00 are treated as generic speakers", () => {

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1347,3 +1347,248 @@ test("derived interval is clamped to end >= start for a missing-end conversation
   // The conversation is emitted (not dropped) and forms a valid cluster.
   assert.equal(clusters[0]!.length, 1);
 });
+
+/** True when every timestamped segment precedes any later-timestamped one
+ * and untimestamped segments trail (non-decreasing startIso). The fused
+ * output must always satisfy this — the group-anchor emission + defensive
+ * final sort guarantee it. */
+function isChronologicallySorted(
+  segments: { startIso?: string }[],
+): boolean {
+  let last = -Infinity;
+  for (const seg of segments) {
+    const ms = seg.startIso !== undefined ? Date.parse(seg.startIso) : NaN;
+    if (!Number.isFinite(ms)) continue; // untimestamped trails; checked elsewhere
+    if (ms < last) return false;
+    last = ms;
+  }
+  return true;
+}
+
+test("fused segment keeps the group anchor clock, not the higher-trust source's later clock (issue #1849 chronology)", () => {
+  // bee (low-trust) captures "yes" at 09:00:00; limitless (high-trust)
+  // captures a DIFFERENT utterance "standup notes" at 09:00:10, then
+  // corroborates "yes" at 09:00:25 (within the 30s tolerance of 09:00:00).
+  // The fused "yes" group's anchor is 09:00:00; the high-trust chosen
+  // member's clock is 09:00:25. Emitting chosen.startIso would place the
+  // "yes" segment at 09:00:25 — AFTER the 09:00:10 "standup notes" segment
+  // — yet the group sorts at the 09:00:00 anchor (first), so the printed
+  // timeline would read 09:00:25 before 09:00:10: corrupted chronology.
+  // The fix emits the anchor clock for the timeline position while the
+  // high-trust source still provides the text; its original clock is kept
+  // in provenance for traceability.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+          ]),
+        ],
+      },
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c2", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "standup notes",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:10.000Z",
+            },
+            { text: "yes", isWearer: true, startIso: "2026-06-10T09:00:25.000Z" },
+          ]),
+        ],
+      },
+    ),
+    { sourceTrust: { bee: 0.6, limitless: 0.9 } },
+  );
+
+  const conv = fused.conversations[0]!;
+  // The two "yes" utterances fuse; "standup notes" stays separate.
+  assert.equal(conv.segments.length, 2);
+
+  const yes = conv.segments.find((s) => s.text === "yes")!;
+  const notes = conv.segments.find((s) => s.text === "standup notes")!;
+  assert.ok(yes, "the fused yes segment is present");
+  assert.ok(notes, "the standup notes segment is present");
+
+  // Timeline position is the GROUP ANCHOR (09:00:00), not the chosen
+  // source's 09:00:25 clock.
+  assert.equal(yes.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(notes.startIso, "2026-06-10T09:00:10.000Z");
+
+  // The higher-trust source (limitless) still provides the TEXT — provenance
+  // records it — but the emitted chronology uses the anchor, so the
+  // high-trust "yes" does NOT jump ahead of the 09:00:10 segment.
+  assert.equal(yes.provenance.source, "limitless");
+  assert.equal(yes.provenance.reason, "higher-trust");
+  // The source's ORIGINAL recording clock is preserved in provenance.
+  assert.equal(
+    yes.provenance.sourceStartIso,
+    "2026-06-10T09:00:25.000Z",
+    "provenance keeps the higher-trust source's original time",
+  );
+
+  // The fused "yes" sits at the anchor (09:00:00) which is BEFORE the
+  // 09:00:10 "standup notes" — chronologically correct. Before the fix the
+  // high-trust segment's 09:00:25 clock would have printed it after 09:10.
+  assert.ok(
+    conv.segments.indexOf(yes) < conv.segments.indexOf(notes),
+    "the anchor-clock fused segment precedes the later intervening segment",
+  );
+  assert.ok(
+    Date.parse(yes.startIso!) <= Date.parse(notes.startIso!),
+    "emitted timestamps are non-decreasing across the two segments",
+  );
+
+  // Final-output-sorted assertion: the whole fused conversation is
+  // chronologically ordered by startIso.
+  assert.ok(
+    isChronologicallySorted(conv.segments),
+    "the fused output is sorted by timestamp (non-decreasing startIso)",
+  );
+});
+
+test("equal-anchor fused segments keep their source/cluster sequence, not trust order (final sort stability)", () => {
+  // Two distinct utterances from two sources at the SAME timestamp land at
+  // the same anchor. Clustering orders conversations by (start, source, id),
+  // so bee precedes limitless here regardless of the inputs() call order.
+  // The defensive final sort must keep that deterministic sequence via the
+  // pre-sort index tie-break — NOT reorder by trust. bee is the LOWER-trust
+  // source, so a trust-based tie-break would put limitless first; the test
+  // asserts bee stays first, proving the tie-break is sequence, not trust.
+  const build = () =>
+    fuseDay(
+      DATE,
+      inputs(
+        {
+          source: "limitless",
+          conversations: [
+            conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+              {
+                text: "Limitless same-anchor utterance.",
+                isWearer: true,
+                startIso: "2026-06-10T09:00:00.000Z",
+              },
+            ]),
+          ],
+        },
+        {
+          source: "bee",
+          conversations: [
+            conversation("bee", "c2", "2026-06-10T09:00:00.000Z", [
+              {
+                text: "Bee same-anchor utterance.",
+                isWearer: true,
+                startIso: "2026-06-10T09:00:00.000Z",
+              },
+            ]),
+          ],
+        },
+      ),
+      { sourceTrust: { bee: 0.6, limitless: 0.9 } },
+    );
+
+  const fused = build();
+  // Deterministic: re-running produces identical output.
+  assert.deepEqual(build(), fused);
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 2);
+  // bee precedes limitless by the (start, source) cluster sequence — NOT by
+  // trust, which would put the higher-trust limitless first.
+  assert.deepEqual(
+    conv.segments.map((s) => s.text),
+    ["Bee same-anchor utterance.", "Limitless same-anchor utterance."],
+    "equal-anchor segments keep source/cluster sequence, not trust order",
+  );
+  assert.deepEqual(
+    conv.segments.map((s) => s.provenance.source),
+    ["bee", "limitless"],
+    "bee (lower-trust) precedes limitless (higher-trust) — sequence wins",
+  );
+  // Both share the anchor; equal timestamps did not reorder them.
+  assert.equal(conv.segments[0]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(conv.segments[1]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.ok(isChronologicallySorted(conv.segments));
+});
+
+test("missing-timestamp segments keep their position after the timed ones (final sort)", () => {
+  // A MIX of timestamped and untimestamped utterances. The defensive final
+  // sort must place timed segments first (in time order) and let
+  // untimestamped ones trail in their original relative order — never
+  // interspersing or scrambling the missing-time entries.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "Timed one.", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+            { text: "Untimed one.", isWearer: true },
+            { text: "Untimed two.", isWearer: true },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 3);
+  // The timed segment leads; the two untimestamped segments follow in
+  // their original transcript order (one before two).
+  assert.equal(conv.segments[0]!.text, "Timed one.");
+  assert.notEqual(conv.segments[0]!.startIso, undefined);
+  assert.equal(conv.segments[1]!.text, "Untimed one.");
+  assert.equal(conv.segments[1]!.startIso, undefined);
+  assert.equal(conv.segments[2]!.text, "Untimed two.");
+  assert.equal(conv.segments[2]!.startIso, undefined);
+  assert.ok(isChronologicallySorted(conv.segments));
+});
+
+test("cross-source clock skew does not scramble same-anchor utterances (final sort)", () => {
+  // Two distinct utterances, each corroborated across two sources whose
+  // clocks are skewed (bee at 09:00:00, limitless +4s at 09:00:04). Each
+  // utterance fuses to one segment at the bee anchor (09:00:00). The
+  // defensive final sort sees two segments sharing the anchor timestamp;
+  // it must keep their input order (first topic before second topic), not
+  // let the skew or any source key reorder them.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "First topic.", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+            { text: "Second topic.", isWearer: true, startIso: "2026-06-10T09:00:00.000Z" },
+          ]),
+        ],
+      },
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c2", "2026-06-10T09:00:00.000Z", [
+            { text: "First topic.", isWearer: true, startIso: "2026-06-10T09:00:04.000Z" },
+            { text: "Second topic.", isWearer: true, startIso: "2026-06-10T09:00:04.000Z" },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  // Two distinct utterances, each corroborated -> two fused segments.
+  assert.equal(conv.segments.length, 2);
+  // Both emitted at the bee anchor (earliest); the +4s skew is absorbed.
+  assert.equal(conv.segments[0]!.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(conv.segments[1]!.startIso, "2026-06-10T09:00:00.000Z");
+  // Input order preserved across the shared anchor — not scrambled by skew.
+  assert.deepEqual(
+    conv.segments.map((s) => s.text),
+    ["First topic.", "Second topic."],
+    "same-anchor utterances keep input order despite cross-source skew",
+  );
+  assert.ok(isChronologicallySorted(conv.segments));
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -2363,3 +2363,178 @@ test("reconstruct never attributes a non-self speaker whose name ends in (you) a
   assert.equal(segs[1]!.speaker, "Pat");
   assert.equal(segs[1]!.isSelf, false);
 });
+
+test("reconstruct does NOT roll an implausible earlier SEGMENT clock into the next day (#1849)", () => {
+  // start 14:00, a segment clocked at 13:00 (provider skew / a clock that
+  // ran backwards). The implied wrap (14:00 -> midnight -> 13:00) is ~23h,
+  // far past the plausible-conversation bound. The segment must STAY on the
+  // same date so it precedes the start and the downstream cluster clamp
+  // collapses it — NOT roll to the next day and stretch a ~23h interval
+  // that broadly clusters unrelated neighbors.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 14:00–15:00 · Sync (conversation c1)",
+    "",
+    "**Me (you)** [14:00]: Opening remark.",
+    "**Jane** [13:00]: Provider-skewed earlier clock.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T14:00:00.000Z");
+  // The 13:00 segment is NOT rolled to 2026-06-11; it stays on 2026-06-10.
+  const skewed = conv.segments.find((s) => s.text === "Provider-skewed earlier clock.");
+  assert.ok(skewed, "provider-skewed segment present");
+  assert.equal(
+    skewed!.startIso,
+    "2026-06-10T13:00:00.000Z",
+    "implausible earlier segment stays on the same date",
+  );
+  // It precedes the conversation start, leaving it for the cluster clamp.
+  assert.ok(
+    Date.parse(skewed!.startIso!) < Date.parse(conv.startIso!),
+    "same-date earlier segment precedes the start (ready for clamping)",
+  );
+});
+
+test("reconstruct still rolls a plausible post-midnight SEGMENT clock into the next day (#1849)", () => {
+  // start 23:55, a segment at 00:05 wraps only 10 min — well within the
+  // plausible bound. The segment MUST roll forward despite the heading end
+  // clock also being plausible; the segment-vs-start plausibility gate must
+  // not over-tighten and suppress genuine midnight wraps.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 23:55–00:10 · Late (conversation c1)",
+    "",
+    "**Me (you)** [23:58]: Still talking.",
+    "**Jane** [00:05]: After midnight.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T23:55:00.000Z");
+  assert.equal(conv.endIso, "2026-06-11T00:10:00.000Z");
+  const isos = conv.segments.map((s) => s.startIso);
+  assert.ok(
+    isos.includes("2026-06-10T23:58:00.000Z"),
+    "pre-midnight segment stays on the rendered date",
+  );
+  assert.ok(
+    isos.includes("2026-06-11T00:05:00.000Z"),
+    "plausible post-midnight segment rolls to the next day",
+  );
+});
+
+test("reconstruct rolls a long-but-plausible post-midnight segment (boundary of the wrap bound) (#1849)", () => {
+  // start 20:00, segment 01:00: implied wrap = 240 + 60 = 300 min, well
+  // within the 12h bound. Must still roll.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 20:00–--:-- · Evening (conversation c1)",
+    "",
+    "**Jane** [01:00]: Past midnight, long evening.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T20:00:00.000Z");
+  assert.equal(
+    conv.segments[0]!.startIso,
+    "2026-06-11T01:00:00.000Z",
+    "long-but-plausible wrap (5h) still rolls to the next day",
+  );
+});
+
+test("implausible earlier segment does not span the day: neighbor clusters, not swallows (#1849)", () => {
+  // A 14:00-start conversation with a 13:00 provider-skewed segment. The
+  // segment stays same-date (13:00 < start 14:00) and is clamped by the
+  // interval to [14:00, 14:00]. A different-source neighbor at 14:03 (within
+  // the 5-min gap) clusters with it. If the segment had wrongly rolled to
+  // 2026-06-11T13:00 the window would span ~23h and swallow far-flung
+  // neighbors instead of clustering only nearby ones.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 14:00–15:00 · Sync (conversation c1)",
+    "",
+    "**Me (you)** [14:00]: Roadmap.",
+    "**Jane** [13:00]: Skew.",
+    "",
+  ].join("\n");
+  const limitless = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  const bee: FusionConversationInput = {
+    source: "bee",
+    conversationId: "c1",
+    startIso: "2026-06-10T14:03:00.000Z",
+    endIso: "2026-06-10T14:08:00.000Z",
+    segments: [{ speaker: "Me (you)", isSelf: true, text: "Neighbor." }],
+  };
+  const clusters = clusterConversations([...limitless, bee]);
+  assert.equal(clusters.length, 1, "clamped window clusters the nearby neighbor");
+});
+
+test("speaker label containing markdown delimiters round-trips through compose → reconstruct (#1849)", () => {
+  // A user-defined speaker label with `**`, `[`, and `]` — the exact
+  // characters that delimit a segment line. Without safe serialization the
+  // `**` (or `[clock]`) inside the label can break TRANSCRIPT_SEGMENT_LINE
+  // parsing; with escape/unescape the label survives losslessly.
+  const registry = emptySpeakerRegistry();
+  registry.speakers["bee:SPEAKER_01"] = {
+    name: 'A**B [weird]: label',
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [
+        { text: "I am the wearer.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        { text: "I am tricky.", speakerKey: "SPEAKER_01", startIso: "2026-06-10T09:01:00.000Z" },
+      ],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, registry);
+  // The stored body MUST serialize the delimiters safely (no raw ** [ ]: ).
+  assert.ok(
+    !/\*\*A\*\*B/.test(body),
+    "label delimiters are escaped in the stored body: " + body,
+  );
+  // Reconstruct decodes the label back to the original form.
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed.length, 1);
+  const segs = parsed[0]!.segments;
+  assert.equal(segs.length, 2);
+  assert.equal(segs[0]!.speaker, "Me (you)");
+  assert.equal(segs[0]!.isSelf, true);
+  assert.equal(segs[1]!.speaker, 'A**B [weird]: label', "delimited label round-trips losslessly");
+  assert.equal(segs[1]!.isSelf, false);
+});
+
+test("speaker label A**B alone round-trips through compose → reconstruct (#1849)", () => {
+  // Minimal repro from the contract: a label that is exactly `A**B`.
+  const registry = emptySpeakerRegistry();
+  registry.speakers["bee:SPEAKER_01"] = {
+    name: "A**B",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: "Hello.", speakerKey: "SPEAKER_01", startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, registry);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed[0]!.segments[0]!.speaker, "A**B");
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -1,0 +1,427 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { emptySpeakerRegistry } from "../speakers.js";
+import type { WearableConversation } from "../types.js";
+import {
+  clusterConversations,
+  fuseDay,
+  fusionInputsFromConversations,
+  reconstructFusionInputs,
+  serializeFusionDay,
+  parseFusionDay,
+} from "./index.js";
+import type { FusionConversationInput } from "./index.js";
+
+const DATE = "2026-06-10";
+const REGISTRY = emptySpeakerRegistry();
+
+/** Build a minimal wearable conversation with resolved self/others. */
+function conversation(
+  source: string,
+  id: string,
+  startIso: string,
+  segments: Array<{
+    text: string;
+    speakerKey?: string;
+    isWearer?: boolean;
+    startIso?: string;
+    endIso?: string;
+  }>,
+  extra: Partial<WearableConversation> = {},
+): WearableConversation {
+  return {
+    id,
+    source,
+    startIso,
+    segments: segments.map((segment) => ({
+      text: segment.text,
+      speakerKey: segment.speakerKey ?? "user",
+      ...(segment.isWearer !== undefined ? { isWearer: segment.isWearer } : {}),
+      ...(segment.startIso !== undefined ? { startIso: segment.startIso } : {}),
+      ...(segment.endIso !== undefined ? { endIso: segment.endIso } : {}),
+    })),
+    ...extra,
+  };
+}
+
+function inputs(
+  ...perSource: Array<{ source: string; conversations: WearableConversation[] }>
+): FusionConversationInput[] {
+  return perSource.flatMap(({ source, conversations }) =>
+    fusionInputsFromConversations(source, conversations, REGISTRY),
+  );
+}
+
+test("exact overlap: two sources, same time/text fuse to one segment, no disagreement", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation(
+            "limitless",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [
+              {
+                text: "Let's ship the launch on Friday.",
+                isWearer: true,
+                startIso: "2026-06-10T09:00:30.000Z",
+              },
+            ],
+            { endIso: "2026-06-10T09:01:00.000Z" },
+          ),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation(
+            "bee",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [
+              {
+                text: "Let's ship the launch on Friday.",
+                isWearer: true,
+                startIso: "2026-06-10T09:00:31.000Z",
+              },
+            ],
+            { endIso: "2026-06-10T09:01:00.000Z" },
+          ),
+        ],
+      },
+    ),
+    { sourceTrust: { limitless: 0.9, bee: 0.7 } },
+  );
+
+  assert.equal(fused.conversations.length, 1);
+  const conv = fused.conversations[0]!;
+  assert.deepEqual(conv.sources.sort(), ["bee", "limitless"]);
+  assert.equal(conv.segments.length, 1, "overlapping identical text collapses to one segment");
+  const segment = conv.segments[0]!;
+  assert.equal(segment.text, "Let's ship the launch on Friday.");
+  assert.equal(segment.provenance.source, "limitless");
+  assert.equal(segment.provenance.reason, "higher-trust");
+  assert.equal(segment.provenance.alternatives.length, 1);
+  assert.equal(conv.disagreements.length, 0, "identical text is not a disagreement");
+});
+
+test("partial overlap: adjacent conversations still cluster into one fused conversation", () => {
+  const clusters = clusterConversations(
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation(
+            "limitless",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [{ text: "First topic.", isWearer: true }],
+            { endIso: "2026-06-10T09:20:00.000Z" },
+          ),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation(
+            "bee",
+            "c1",
+            "2026-06-10T09:22:00.000Z",
+            [{ text: "Second topic.", isWearer: true }],
+            { endIso: "2026-06-10T09:40:00.000Z" },
+          ),
+        ],
+      },
+    ),
+  );
+  // 2-minute gap < 5-minute default proximity -> one cluster.
+  assert.equal(clusters.length, 1);
+});
+
+test("conflicting ASR text for the same window is recorded as a disagreement", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Let's ship the launch on Friday.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Let's skip the launch entirely.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:31.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.disagreements.length, 1);
+  const disagreement = conv.disagreements[0]!;
+  assert.equal(disagreement.kind, "asr-text");
+  assert.equal(disagreement.candidates.length, 2);
+  assert.ok(disagreement.provisional, "a provisional winner is kept, never silently dropped");
+  // The fused segment carries lowered confidence when a conflict exists.
+  assert.ok(conv.segments[0]!.confidence < 0.8);
+});
+
+test("truncation is more-complete, not a disagreement: verbatim beats clipped", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "The deploy window opens at three and closes at five.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "The deploy window opens at three and closes at",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:31.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.disagreements.length, 0, "a clipped transcript is not a conflict");
+  const segment = conv.segments[0]!;
+  assert.equal(
+    segment.text,
+    "The deploy window opens at three and closes at five.",
+  );
+  assert.equal(segment.provenance.reason, "more-complete");
+});
+
+test("summary-style + verbatim-style source: summary preserved, verbatim segments win", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "omi",
+        conversations: [
+          conversation(
+            "omi",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [{ text: "Discussed the launch.", isWearer: true }],
+            {
+              endIso: "2026-06-10T09:10:00.000Z",
+              title: "Launch sync",
+              summary: "A short summary of the launch discussion.",
+            },
+          ),
+        ],
+      },
+      {
+        source: "limitless",
+        conversations: [
+          conversation(
+            "limitless",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [
+              {
+                text: "We agreed to launch on Friday at noon.",
+                isWearer: true,
+                startIso: "2026-06-10T09:00:30.000Z",
+              },
+              {
+                text: "I will send the checklist.",
+                isWearer: true,
+                startIso: "2026-06-10T09:01:00.000Z",
+              },
+            ],
+            { endIso: "2026-06-10T09:10:00.000Z" },
+          ),
+        ],
+      },
+    ),
+  );
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.title, "Launch sync");
+  assert.equal(conv.summary, "A short summary of the launch discussion.");
+  // Verbatim source contributes more complete, on-the-record segments.
+  assert.ok(
+    conv.segments.some((segment) =>
+      segment.text.startsWith("We agreed to launch"),
+    ),
+    "verbatim segment is retained",
+  );
+});
+
+test("missing timestamps: segments without start are preserved and still fused", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "No timestamp on this utterance.", isWearer: true },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            { text: "No timestamp on this utterance.", isWearer: true },
+          ]),
+        ],
+      },
+    ),
+  );
+
+  const conv = fused.conversations[0]!;
+  assert.equal(conv.segments.length, 1);
+  assert.equal(conv.segments[0]!.text, "No timestamp on this utterance.");
+  assert.equal(conv.segments[0]!.startIso, undefined);
+});
+
+test("speaker-label uncertainty: generic single-source label carries lowered confidence", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Hello there.",
+              speakerKey: "0",
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+
+  const conv = fused.conversations[0]!;
+  const generic = conv.speakers.find((speaker) => !speaker.isSelf);
+  assert.ok(generic, "a non-self speaker is present");
+  assert.ok(
+    generic!.confidence <= 0.5,
+    "a generic label seen in one source is marked uncertain",
+  );
+});
+
+test("idempotency: identical inputs produce a stable id and content hash", () => {
+  const a = fuseDay(
+    DATE,
+    inputs({
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Stable input.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    }),
+  );
+  // Re-run with a different source ORDER — must hash identically.
+  const b = fuseDay(
+    DATE,
+    inputs({
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Stable input.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    }),
+  );
+
+  assert.equal(a.conversations[0]!.id, b.conversations[0]!.id);
+  assert.equal(a.contentHash, b.contentHash);
+});
+
+test("serialize/parse round-trips a fused day file", () => {
+  const fused = fuseDay(
+    DATE,
+    inputs({
+      source: "limitless",
+      conversations: [
+        conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+          { text: "Round trip.", isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        ]),
+      ],
+    }),
+  );
+  const serialized = serializeFusionDay(
+    {
+      kind: "wearable-fusion",
+      date: DATE,
+      sourceCount: fused.sources.length,
+      conversationCount: fused.conversations.length,
+      contentHash: fused.contentHash,
+      fusedAt: "2026-06-11T00:00:00.000Z",
+    },
+    fused.conversations,
+  );
+  const parsed = parseFusionDay(serialized);
+  assert.ok(parsed);
+  assert.equal(parsed!.meta.kind, "wearable-fusion");
+  assert.equal(parsed!.meta.date, DATE);
+  assert.equal(parsed!.conversations.length, 1);
+  assert.equal(parsed!.conversations[0]!.segments[0]!.text, "Round trip.");
+});
+
+test("parseFusionDay returns null for non-fusion content", () => {
+  assert.equal(parseFusionDay("---\nkind: wearable-transcript\n---\n\nbody\n"), null);
+  assert.equal(parseFusionDay("not a transcript at all"), null);
+});
+
+test("reconstructFusionInputs parses a rendered transcript body", () => {
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 09:00–09:20 · Morning coffee (conversation conv-1)",
+    "",
+    "**Me (you)** [09:00]: Hello world.",
+    "**Jane** [09:01]: Hi there.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.conversationId, "conv-1");
+  assert.equal(conv.startIso, "2026-06-10T09:00:00.000Z");
+  assert.equal(conv.segments.length, 2);
+  assert.equal(conv.segments[0]!.speaker, "Me (you)");
+  assert.equal(conv.segments[0]!.isSelf, true);
+  assert.equal(conv.segments[1]!.speaker, "Jane");
+  assert.equal(conv.segments[1]!.isSelf, false);
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -2230,3 +2230,20 @@ test("unicode and mixed special characters in segment text round-trip losslessly
   const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
   assert.equal(parsed[0]!.segments[0]!.text, unicode);
 });
+
+test("legacy transcript with unknown backslash sequences preserves them losslessly", () => {
+  // Pre-escaper transcripts may contain arbitrary backslash sequences
+  // (Windows paths, regex) that the escaper would never emit.  These
+  // must round-trip: unescapeSegmentText keeps the backslash for any
+  // escape it does not recognise, while \n / \r / \\ still decode.
+  const legacyBody =
+    "# bee transcript — 2026-06-10\n" +
+    "\n" +
+    "## 09:00–09:10 (conversation c1)\n" +
+    "\n" +
+    '**Me (you)** [09:00]: Path is C:\\Users\\josh and config at D:\\data\n' +
+    "**Guest** [09:01]: Regex \\d+ matches digits, \\w+ matches words\n";
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body: legacyBody }]);
+  assert.equal(parsed[0]!.segments[0]!.text, "Path is C:\\Users\\josh and config at D:\\data");
+  assert.equal(parsed[0]!.segments[1]!.text, "Regex \\d+ matches digits, \\w+ matches words");
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -149,6 +149,52 @@ test("partial overlap: adjacent conversations still cluster into one fused conve
   assert.equal(clusters.length, 1);
 });
 
+test("explicit end earlier than start is clamped to start so a within-gap neighbor still clusters (#1849)", () => {
+  // A parseable endIso that precedes the start (malformed/cross-day input)
+  // must collapse to the start: effectiveInterval returns [09:00, 09:00]
+  // instead of the negative-length [09:00, 08:55]. Without the clamp the
+  // malformed end (08:55) sits 8 min before the neighbor's 09:03 start —
+  // outside the 5-min gap — and the two split; with the clamp the 09:00 end
+  // keeps the 09:03 neighbor within the gap so they merge into one cluster.
+  const clusters = clusterConversations(
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation(
+            "limitless",
+            "c1",
+            "2026-06-10T09:00:00.000Z",
+            [{ text: "Clamped window topic.", isWearer: true }],
+            { endIso: "2026-06-10T08:55:00.000Z" },
+          ),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation(
+            "bee",
+            "c1",
+            "2026-06-10T09:03:00.000Z",
+            [{ text: "Neighbor topic.", isWearer: true }],
+            { endIso: "2026-06-10T09:10:00.000Z" },
+          ),
+        ],
+      },
+    ),
+  );
+  assert.equal(
+    clusters.length,
+    1,
+    "clamped-to-start end keeps the within-gap neighbor in one cluster",
+  );
+  assert.deepEqual(
+    clusters[0]!.map((c) => c.source).sort(),
+    ["bee", "limitless"],
+  );
+});
+
 test("conflicting ASR text for the same window is recorded as a disagreement", () => {
   const fused = fuseDay(
     DATE,

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -621,6 +621,63 @@ test("distinct untimestamped same-speaker utterances do not collapse across sour
   ]);
 });
 
+test("distinct timestamped same-window utterances stay separate, not collapsed", () => {
+  // Two sources capture genuinely different utterances inside the same
+  // time window (within the alignment tolerance). They must NOT merge into
+  // one segment — that would silently drop one source's content. Each
+  // stays its own segment with its own provenance (consistent with the
+  // untimestamped-collapse guard); the cross-source conflict is still
+  // surfaced for review rather than silently resolved.
+  const fused = fuseDay(
+    DATE,
+    inputs(
+      {
+        source: "limitless",
+        conversations: [
+          conversation("limitless", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Meeting with Sarah at noon.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:30.000Z",
+            },
+          ]),
+        ],
+      },
+      {
+        source: "bee",
+        conversations: [
+          conversation("bee", "c1", "2026-06-10T09:00:00.000Z", [
+            {
+              text: "Lunch with the design team.",
+              isWearer: true,
+              startIso: "2026-06-10T09:00:31.000Z",
+            },
+          ]),
+        ],
+      },
+    ),
+  );
+  const conv = fused.conversations[0]!;
+  assert.equal(
+    conv.segments.length,
+    2,
+    "distinct same-window utterances stay separate, not collapsed",
+  );
+  const texts = conv.segments.map((s) => s.text).sort();
+  assert.deepEqual(texts, [
+    "Lunch with the design team.",
+    "Meeting with Sarah at noon.",
+  ]);
+  // Provenance is preserved per segment — no source's content is lost.
+  assert.deepEqual(
+    conv.segments.map((s) => s.provenance.source).sort(),
+    ["bee", "limitless"],
+  );
+  // The cross-source conflict is surfaced for review (not silently dropped).
+  assert.equal(conv.disagreements.length, 1);
+  assert.equal(conv.disagreements[0]!.candidates.length, 2);
+});
+
 test("raw diarization keys like SPEAKER_00 are treated as generic speakers", () => {
   const fused = fuseDay(
     DATE,

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -2099,3 +2099,134 @@ test("cross-source clock skew does not scramble same-anchor utterances (final so
   );
   assert.ok(isChronologicallySorted(conv.segments));
 });
+
+// ─── Multiline segment round-trip regression (#1810) ────────────────────
+
+test("multiline segment text round-trips losslessly through the real renderer", () => {
+  const multi = "First line.\nSecond line.\nThird line.";
+  const conversations = [
+    conversation(
+      "limitless",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [
+        { text: multi, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" },
+        { text: "After.", startIso: "2026-06-10T09:01:00.000Z" },
+      ],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const segs = parsed[0]!.segments;
+  assert.equal(segs.length, 2);
+  assert.equal(segs[0]!.text, multi, "multiline text must round-trip exactly");
+  assert.equal(segs[1]!.text, "After.");
+});
+
+test("segment text with backslashes round-trips losslessly", () => {
+  const tricky = "Path C:\\Users\\test and tab\\there";
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: tricky, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed[0]!.segments[0]!.text, tricky);
+});
+
+test("multiline segment with continuation that resembles heading syntax is not mis-parsed", () => {
+  // The second line looks exactly like a conversation heading. Without
+  // escaping, reconstructFusionInputs would split this into two
+  // conversations. With escaping, the whole thing is one segment.
+  const adversarial = "Normal text.\n## 09:05–09:10 (conversation forged)";
+  const conversations = [
+    conversation(
+      "limitless",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: adversarial, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1, "adversarial heading must not create a second conversation");
+  assert.equal(parsed[0]!.segments.length, 1);
+  assert.equal(parsed[0]!.segments[0]!.text, adversarial);
+});
+
+test("segment text with continuation resembling a segment clock line stays in one segment", () => {
+  const adversarial = "Start.\n**Speaker** [10:00]: injected segment";
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: adversarial, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed[0]!.segments.length, 1, "injected segment line must not be parsed separately");
+  assert.equal(parsed[0]!.segments[0]!.text, adversarial);
+});
+
+test("legacy single-line transcript without escape sequences still parses correctly", () => {
+  // Hand-written body mimicking a pre-escaping transcript. No escape
+  // sequences present, so unescapeSegmentText is a no-op.
+  const legacyBody =
+    "# bee transcript — 2026-06-10\n" +
+    "\n" +
+    "## 09:00–09:10 (conversation c1)\n" +
+    "\n" +
+    "**Me (you)** [09:00]: Hello world.\n" +
+    "**Guest** [09:01]: Good morning.\n";
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body: legacyBody }]);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0]!.conversationId, "c1");
+  assert.equal(parsed[0]!.segments.length, 2);
+  assert.equal(parsed[0]!.segments[0]!.text, "Hello world.");
+  assert.equal(parsed[0]!.segments[0]!.isSelf, true);
+  assert.equal(parsed[0]!.segments[1]!.text, "Good morning.");
+  assert.equal(parsed[0]!.segments[1]!.isSelf, false);
+});
+
+test("carriage returns in segment text round-trip losslessly", () => {
+  const crText = "Line one.\r\nLine two.";
+  const conversations = [
+    conversation(
+      "limitless",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: crText, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("limitless", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed[0]!.segments[0]!.text, crText);
+});
+
+test("unicode and mixed special characters in segment text round-trip losslessly", () => {
+  const unicode = "日本語テスト emoji 🎉 and newline\nplus backslash \\ and more";
+  const conversations = [
+    conversation(
+      "bee",
+      "c1",
+      "2026-06-10T09:00:00.000Z",
+      [{ text: unicode, isWearer: true, startIso: "2026-06-10T09:00:30.000Z" }],
+      { endIso: "2026-06-10T09:10:00.000Z" },
+    ),
+  ];
+  const body = composeDayTranscriptBody("bee", DATE, "UTC", conversations, REGISTRY);
+  const parsed = reconstructFusionInputs(DATE, [{ source: "bee", body }]);
+  assert.equal(parsed[0]!.segments[0]!.text, unicode);
+});

--- a/packages/remnic-core/src/wearables/fusion/fusion.test.ts
+++ b/packages/remnic-core/src/wearables/fusion/fusion.test.ts
@@ -542,6 +542,46 @@ test("reconstruct rolls a cross-midnight conversation end into the next day", ()
   );
 });
 
+test("reconstruct rolls a post-midnight segment even when the heading end clock is missing", () => {
+  // A stored transcript whose heading end is unparseable (e.g. "--:--",
+  // the rendered form of a missing endIso) must still roll a subsequent
+  // segment whose clock precedes the start clock into the next calendar
+  // day. The roll decision is driven by the segment-vs-start comparison,
+  // not gated on a parseable heading end clock.
+  const body = [
+    "# limitless transcript — 2026-06-10",
+    "",
+    "## 23:55–--:-- · Late call (conversation c1)",
+    "",
+    "**Me (you)** [23:58]: Still talking.",
+    "**Jane** [00:05]: After midnight.",
+    "",
+  ].join("\n");
+  const parsed = reconstructFusionInputs(DATE, [{ source: "limitless", body }]);
+  assert.equal(parsed.length, 1);
+  const conv = parsed[0]!;
+  assert.equal(conv.startIso, "2026-06-10T23:55:00.000Z");
+  // No parseable end clock -> no endIso is reconstructed.
+  assert.equal(conv.endIso, undefined);
+  const isos = conv.segments.map((s) => s.startIso);
+  assert.ok(
+    isos.includes("2026-06-10T23:58:00.000Z"),
+    "pre-midnight segment stays on the rendered date",
+  );
+  assert.ok(
+    isos.includes("2026-06-11T00:05:00.000Z"),
+    "post-midnight segment rolls to the next day despite a missing heading end",
+  );
+  // The rolled segment must sort AFTER the conversation start so the
+  // timeline ordering stays correct.
+  const rolled = conv.segments.find((s) => s.startIso === "2026-06-11T00:05:00.000Z");
+  assert.ok(rolled, "rolled segment present");
+  assert.ok(
+    Date.parse(rolled!.startIso!) > Date.parse(conv.startIso!),
+    "segment ISO must sort after the start ISO",
+  );
+});
+
 test("truncated high-trust text yields to a longer corroborating transcript", () => {
   // bee is the MORE trusted source but its text is a clipped prefix of
   // omi's full wording; the more-complete wording must win (not the trust).

--- a/packages/remnic-core/src/wearables/fusion/index.ts
+++ b/packages/remnic-core/src/wearables/fusion/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Wearable cross-source fusion — public surface (issue #1810).
+ *
+ * Deterministic, config-gated fusion of multi-source wearable
+ * transcripts into `FusedWearableConversation` artifacts. No LLM calls
+ * in this module — see the PR body for the deferred follow-ups
+ * (LLM-assisted reconciliation, memory extraction over fused artifacts,
+ * full segment alignment, search-index integration).
+ */
+
+export type {
+  DisagreementKind,
+  FusionConversationInput,
+  FusionDayResult,
+  FusionOptions,
+  FusionSegmentInput,
+  FusedConversationProvenance,
+  FusedContribution,
+  FusedDayFile,
+  FusedDayMeta,
+  FusedDisagreement,
+  FusedSegment,
+  FusedSegmentProvenance,
+  FusedSpeaker,
+  FusedWearableConversation,
+  SegmentPickReason,
+} from "./types.js";
+export {
+  DEFAULT_PROXIMITY_GAP_MS,
+  clusterConversations,
+} from "./cluster.js";
+export {
+  DEFAULT_SOURCE_TRUST,
+  DEFAULT_WINDOW_TOLERANCE_MS,
+  fuseCluster,
+  fusionInputsFromConversations,
+  type FuseClusterResult,
+} from "./reconcile.js";
+export { fuseDay } from "./fuse.js";
+export {
+  FUSION_KIND,
+  composeFusionDayMeta,
+  hashFusionBody,
+  parseFusionDay,
+  serializeFusionDay,
+} from "./store.js";
+export { reconstructFusionInputs } from "./reconstruct.js";

--- a/packages/remnic-core/src/wearables/fusion/index.ts
+++ b/packages/remnic-core/src/wearables/fusion/index.ts
@@ -36,7 +36,7 @@ export {
   fusionInputsFromConversations,
   type FuseClusterResult,
 } from "./reconcile.js";
-export { fuseDay } from "./fuse.js";
+export { FUSION_ALGO_VERSION, canonicalDayKey, fuseDay } from "./fuse.js";
 export {
   FUSION_DIR_NAME,
   FUSION_KIND,

--- a/packages/remnic-core/src/wearables/fusion/index.ts
+++ b/packages/remnic-core/src/wearables/fusion/index.ts
@@ -38,7 +38,10 @@ export {
 } from "./reconcile.js";
 export { fuseDay } from "./fuse.js";
 export {
+  FUSION_DIR_NAME,
   FUSION_KIND,
+  FusionArtifactStore,
+  type FusionFileIo,
   composeFusionDayMeta,
   hashFusionBody,
   parseFusionDay,

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -678,7 +678,17 @@ function detectCrossSegmentDisagreements(
     for (let j = i + 1; j < n; j++) {
       if (claimed[j]) continue;
       const cand = segments[j]!;
-      if (cand.isSelf !== seed.isSelf || cand.speaker !== seed.speaker) {
+      // Speaker identity is matched via speakerKey() — the SAME
+      // normalization grouping uses (line 305) — not the raw display
+      // label. The wearer is often labeled differently per source (e.g.
+      // "Me (you)" vs an override "Alex (you)"); both normalize to
+      // "self". Matching on the raw label would skip them, leaving a real
+      // same-window ASR-text disagreement undetected and both confidences
+      // wrongly high. (Issue #1849.)
+      if (
+        speakerKey(cand.speaker, cand.isSelf) !==
+        speakerKey(seed.speaker, seed.isSelf)
+      ) {
         continue;
       }
       if (cand.provenance.source === seed.provenance.source) continue;

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -323,12 +323,52 @@ export function fuseCluster(
       );
     };
 
+    // Choose the CLOSEST corroborating group instead of the first match
+    // (issue #1849). Within windowToleranceMs several groups can corroborate
+    // the same short utterance — e.g. a speaker repeating "yes" at 10:00 and
+    // 10:20 with a 30s window — so a later source segment at 10:21
+    // corroborates BOTH. First-match would attach it to the earliest (10:00)
+    // group even though 10:20 is nearer, misattributing provenance and
+    // potentially reordering the fused timeline. Scan every candidate and
+    // keep the one whose anchor is nearest to this segment by
+    // |anchorMs - startMs|; ties break on the smaller anchor, then on the
+    // order the group was created (stable, never dependent on key order).
+    // Single-occurrence behavior is unchanged: the lone corroborating group
+    // is trivially the closest.
+    const closestCorroborating = (
+      wantSameSpeaker: boolean,
+    ): AlignGroup | undefined => {
+      let best: AlignGroup | undefined;
+      let bestDelta = Infinity;
+      for (const group of groups) {
+        if (
+          (group.key === key) !== wantSameSpeaker ||
+          !corroborates(group)
+        ) {
+          continue;
+        }
+        const delta =
+          !segMissing && Number.isFinite(group.anchorMs)
+            ? Math.abs(seg.startMs - group.anchorMs)
+            : 0;
+        if (
+          best === undefined ||
+          delta < bestDelta ||
+          (delta === bestDelta && group.anchorMs < best.anchorMs)
+        ) {
+          best = group;
+          bestDelta = delta;
+        }
+      }
+      return best;
+    };
+
     // Prefer an exact same-speaker corroborating group.
-    let chosen = groups.find((group) => group.key === key && corroborates(group));
+    let chosen = closestCorroborating(true);
     if (chosen === undefined) {
       // Fall back: same utterance (time+text corroborate) but a different
       // speaker label -> speaker conflict, aligned into one segment.
-      chosen = groups.find((group) => group.key !== key && corroborates(group));
+      chosen = closestCorroborating(false);
     }
 
     if (chosen !== undefined) {

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -1,0 +1,476 @@
+/**
+ * Wearable cross-source fusion — deterministic reconciliation.
+ *
+ * Given one cluster (conversations from N sources that overlapped in
+ * time), produce a single reconciled timeline where each utterance
+ * carries the best source's text plus per-segment provenance, and
+ * conflicts that could not be settled deterministically are recorded as
+ * disagreements.
+ *
+ * Reconciliation rules (all deterministic, no LLM):
+ *  - text: prefer higher source trust, then the more-complete (longer)
+ *    transcript over a truncated one; otherwise a stable tie-break.
+ *  - disagreement: when two sources offer genuinely different text for
+ *    the same window/speaker (neither contains the other), record every
+ *    candidate and keep a provisional winner marked uncertain — we never
+ *    silently pick.
+ *  - speaker: resolved labels unify the wearer across sources; generic
+ *    labels that cannot be cross-matched keep a lowered confidence.
+ *
+ * Full segment-level alignment beyond time windows is a deferred
+ * follow-up (see PR body). This pass aligns by (speaker, time window).
+ */
+
+import { resolveSpeaker, type SpeakerRegistry } from "../speakers.js";
+import type { WearableConversation } from "../types.js";
+import type {
+  FusionConversationInput,
+  FusionOptions,
+  FusionSegmentInput,
+  FusedDisagreement,
+  FusedSegment,
+  FusedSpeaker,
+  SegmentPickReason,
+} from "./types.js";
+
+/** Default max drift (ms) for two segments to align across sources. */
+export const DEFAULT_WINDOW_TOLERANCE_MS = 30_000;
+/** Default trust weight for a source with no configured prior. */
+export const DEFAULT_SOURCE_TRUST = 0.8;
+/** Trust prior at which a source is considered "more trusted" than another. */
+const TRUST_DECISION_EPSILON = 1e-9;
+/** Labels that cannot be confidently cross-matched between sources. */
+const GENERIC_LABEL_PATTERN = /^(Speaker \d+|Unknown speaker)$/;
+
+export interface FuseClusterResult {
+  sources: string[];
+  speakers: FusedSpeaker[];
+  title?: string;
+  summary?: string;
+  startIso: string;
+  endIso?: string;
+  segments: FusedSegment[];
+  disagreements: FusedDisagreement[];
+}
+
+interface TaggedSegment {
+  source: string;
+  conversationId: string;
+  speakerLabel: string;
+  isSelf: boolean;
+  text: string;
+  startMs: number;
+  startIso?: string;
+  endIso?: string;
+  sourceTrust: number;
+}
+
+interface AlignGroup {
+  /** Match key: "self" for the wearer, else the resolved label. */
+  key: string;
+  speakerLabel: string;
+  isSelf: boolean;
+  members: TaggedSegment[];
+  anchorMs: number;
+}
+
+/** Match key that unifies the wearer across sources. */
+function speakerKey(label: string, isSelf: boolean): string {
+  return isSelf ? "self" : label;
+}
+
+function resolveTrust(
+  source: string,
+  trustMap: Record<string, number> | undefined,
+): number {
+  const value = trustMap?.[source];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.min(1, Math.max(0, value));
+  }
+  return DEFAULT_SOURCE_TRUST;
+}
+
+/** Lowercased, punctuation-stripped word sequence — order-sensitive. */
+function normalizeWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .split(/\s+/)
+    .filter((word) => word.length > 0);
+}
+
+function wordsEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** True when `short` is an exact leading prefix of `long` (truncation). */
+function isWordPrefix(short: string[], long: string[]): boolean {
+  if (short.length === 0 || short.length > long.length) return false;
+  for (let i = 0; i < short.length; i++) {
+    if (short[i] !== long[i]) return false;
+  }
+  return true;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Build fusion inputs from raw provider conversations + the shared
+ * speaker registry. This is the precise connector path: full ISO
+ * timestamps and resolved speaker labels. (The on-demand service path
+ * instead reconstructs inputs from stored transcripts — see
+ * `reconstruct.ts`.)
+ */
+export function fusionInputsFromConversations(
+  sourceId: string,
+  conversations: readonly WearableConversation[],
+  registry: SpeakerRegistry,
+): FusionConversationInput[] {
+  return conversations.map((conversation) => {
+    const segments: FusionSegmentInput[] = conversation.segments.map((raw) => {
+      const resolved = resolveSpeaker(sourceId, raw, registry);
+      return {
+        speaker: resolved.label,
+        isSelf: resolved.isSelf,
+        text: raw.text,
+        ...(raw.startIso !== undefined ? { startIso: raw.startIso } : {}),
+        ...(raw.endIso !== undefined ? { endIso: raw.endIso } : {}),
+      };
+    });
+    return {
+      source: sourceId,
+      conversationId: conversation.id,
+      startIso: conversation.startIso,
+      ...(conversation.endIso !== undefined ? { endIso: conversation.endIso } : {}),
+      ...(conversation.title !== undefined ? { title: conversation.title } : {}),
+      ...(conversation.summary !== undefined ? { summary: conversation.summary } : {}),
+      segments,
+    };
+  });
+}
+
+/**
+ * Fuse one cluster into a reconciled conversation (without id/date).
+ */
+export function fuseCluster(
+  cluster: readonly FusionConversationInput[],
+  options: FusionOptions = {},
+): FuseClusterResult {
+  const trustMap = options.sourceTrust;
+  const toleranceMs = options.windowToleranceMs ?? DEFAULT_WINDOW_TOLERANCE_MS;
+
+  // Sources in first-appearance order.
+  const sources: string[] = [];
+  const sourcesSeen = new Set<string>();
+  for (const conv of cluster) {
+    if (!sourcesSeen.has(conv.source)) {
+      sourcesSeen.add(conv.source);
+      sources.push(conv.source);
+    }
+  }
+
+  // Earliest start / latest end across the cluster.
+  let startMs = Number.POSITIVE_INFINITY;
+  let endMs = Number.NEGATIVE_INFINITY;
+  let startIso: string | undefined;
+  let endIso: string | undefined;
+  for (const conv of cluster) {
+    const ms = Date.parse(conv.startIso);
+    if (Number.isFinite(ms) && ms < startMs) {
+      startMs = ms;
+      startIso = conv.startIso;
+    }
+    if (conv.endIso !== undefined) {
+      const endM = Date.parse(conv.endIso);
+      if (Number.isFinite(endM) && endM > endMs) {
+        endMs = endM;
+        endIso = conv.endIso;
+      }
+    }
+  }
+  if (startIso === undefined) {
+    // No parseable start in the cluster — fall back to the first conv's
+    // start string so the required field stays present downstream.
+    startIso = cluster[0]?.startIso ?? new Date(0).toISOString();
+  }
+
+  // Title / summary: first non-empty in cluster order.
+  let title: string | undefined;
+  let summary: string | undefined;
+  for (const conv of cluster) {
+    if (title === undefined && conv.title !== undefined && conv.title.trim().length > 0) {
+      title = conv.title.trim();
+    }
+    if (
+      summary === undefined &&
+      conv.summary !== undefined &&
+      conv.summary.trim().length > 0
+    ) {
+      summary = conv.summary.trim();
+    }
+    if (title !== undefined && summary !== undefined) break;
+  }
+
+  // Flatten + tag every segment with its source provenance and trust.
+  const tagged: TaggedSegment[] = [];
+  for (const conv of cluster) {
+    const sourceTrust = resolveTrust(conv.source, trustMap);
+    for (const segment of conv.segments) {
+      const startMsValue =
+        segment.startIso !== undefined ? Date.parse(segment.startIso) : NaN;
+      tagged.push({
+        source: conv.source,
+        conversationId: conv.conversationId,
+        speakerLabel: segment.speaker,
+        isSelf: segment.isSelf,
+        text: segment.text,
+        startMs: Number.isFinite(startMsValue)
+          ? (startMsValue as number)
+          : Number.POSITIVE_INFINITY,
+        ...(segment.startIso !== undefined ? { startIso: segment.startIso } : {}),
+        ...(segment.endIso !== undefined ? { endIso: segment.endIso } : {}),
+        sourceTrust,
+      });
+    }
+  }
+
+  // Deterministic order: time, then source, then speaker label.
+  tagged.sort((a, b) => {
+    const aFinite = Number.isFinite(a.startMs);
+    const bFinite = Number.isFinite(b.startMs);
+    if (aFinite && bFinite && a.startMs !== b.startMs) return a.startMs - b.startMs;
+    if (aFinite !== bFinite) return aFinite ? -1 : 1;
+    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+    if (a.speakerLabel !== b.speakerLabel) {
+      return a.speakerLabel < b.speakerLabel ? -1 : 1;
+    }
+    if (a.conversationId !== b.conversationId) {
+      return a.conversationId < b.conversationId ? -1 : 1;
+    }
+    return 0;
+  });
+
+  // Greedy cross-source alignment: a group holds at most one segment per
+  // source (so two sequential same-source utterances never collapse),
+  // and accepts a new segment only when speaker matches and the start is
+  // within the tolerance window of the group anchor.
+  const groups: AlignGroup[] = [];
+  for (const seg of tagged) {
+    const key = speakerKey(seg.speakerLabel, seg.isSelf);
+    const segMissing = !Number.isFinite(seg.startMs);
+    let chosen: AlignGroup | undefined;
+    for (const group of groups) {
+      if (group.key !== key) continue;
+      if (group.members.some((member) => member.source === seg.source)) continue;
+      // Missing-start segments only align with other missing-start groups.
+      const groupMissing = !Number.isFinite(group.anchorMs);
+      if (groupMissing !== segMissing) continue;
+      if (!groupMissing && Math.abs(seg.startMs - group.anchorMs) > toleranceMs) {
+        continue;
+      }
+      chosen = group;
+      break;
+    }
+    if (chosen !== undefined) {
+      chosen.members.push(seg);
+    } else {
+      groups.push({
+        key,
+        speakerLabel: seg.speakerLabel,
+        isSelf: seg.isSelf,
+        members: [seg],
+        anchorMs: seg.startMs,
+      });
+    }
+  }
+
+  // Output groups in time order (missing-start groups last, stable).
+  groups.sort((a, b) => {
+    const aMissing = !Number.isFinite(a.anchorMs);
+    const bMissing = !Number.isFinite(b.anchorMs);
+    if (aMissing !== bMissing) return aMissing ? 1 : -1;
+    if (!aMissing && a.anchorMs !== b.anchorMs) return a.anchorMs - b.anchorMs;
+    const am = a.members[0];
+    const bm = b.members[0];
+    if (am.source !== bm.source) return am.source < bm.source ? -1 : 1;
+    return am.speakerLabel < bm.speakerLabel ? -1 : am.speakerLabel > bm.speakerLabel ? 1 : 0;
+  });
+
+  const segments: FusedSegment[] = [];
+  const disagreements: FusedDisagreement[] = [];
+  for (const group of groups) {
+    const reconciled = reconcileGroup(group);
+    segments.push(reconciled.segment);
+    if (reconciled.disagreement !== undefined) {
+      disagreements.push(reconciled.disagreement);
+    }
+  }
+
+  const result: FuseClusterResult = {
+    sources,
+    speakers: collectSpeakers(tagged),
+    startIso,
+    segments,
+    disagreements,
+  };
+  if (endIso !== undefined) result.endIso = endIso;
+  if (title !== undefined) result.title = title;
+  if (summary !== undefined) result.summary = summary;
+  return result;
+}
+
+interface ReconciledGroup {
+  segment: FusedSegment;
+  disagreement?: FusedDisagreement;
+}
+
+function reconcileGroup(group: AlignGroup): ReconciledGroup {
+  const members = group.members;
+  // Rank: higher trust, then more-complete (longer), then stable source order.
+  const ranked = [...members].sort((a, b) => {
+    if (Math.abs(b.sourceTrust - a.sourceTrust) > TRUST_DECISION_EPSILON) {
+      return b.sourceTrust - a.sourceTrust;
+    }
+    if (b.text.length !== a.text.length) return b.text.length - a.text.length;
+    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+    return a.conversationId < b.conversationId ? -1 : 1;
+  });
+  const winner = ranked[0];
+  const rest = ranked.slice(1);
+
+  const reason: SegmentPickReason =
+    members.length === 1
+      ? "only-source"
+      : rest.some((r) => winner.sourceTrust - r.sourceTrust > TRUST_DECISION_EPSILON)
+        ? "higher-trust"
+        : rest.some((r) => winner.text.length - r.text.length > 0)
+          ? "more-complete"
+          : "tie-break";
+
+  // Conflict detection: a candidate whose word sequence differs from
+  // the winner AND is not a containment (one a prefix/truncation of the
+  // other). Containment is "more-complete wins" with no disagreement.
+  const winnerWords = normalizeWords(winner.text);
+  const disagree: Array<{ source: string; value: string }> = [];
+  let conflict = false;
+  for (const candidate of rest) {
+    const candidateWords = normalizeWords(candidate.text);
+    if (winnerWords.length === 0 && candidateWords.length === 0) continue;
+    if (wordsEqual(winnerWords, candidateWords)) continue;
+    if (
+      isWordPrefix(candidateWords, winnerWords) ||
+      isWordPrefix(winnerWords, candidateWords)
+    ) {
+      continue;
+    }
+    conflict = true;
+    disagree.push({ source: candidate.source, value: candidate.text });
+  }
+
+  const alternatives = rest.map((candidate) => ({
+    source: candidate.source,
+    text: candidate.text,
+  }));
+
+  // Confidence: single source -> its trust; corroboration boosts;
+  // a recorded conflict lowers it.
+  const confidence = conflict
+    ? clamp01(winner.sourceTrust * 0.7)
+    : members.length > 1
+      ? clamp01(winner.sourceTrust + 0.1 * (members.length - 1))
+      : clamp01(winner.sourceTrust);
+
+  const segment: FusedSegment = {
+    speaker: group.speakerLabel,
+    isSelf: group.isSelf,
+    text: winner.text,
+    confidence,
+    provenance: {
+      source: winner.source,
+      conversationId: winner.conversationId,
+      sourceTrust: winner.sourceTrust,
+      reason,
+      alternatives,
+    },
+    ...(winner.startIso !== undefined ? { startIso: winner.startIso } : {}),
+    ...(winner.endIso !== undefined ? { endIso: winner.endIso } : {}),
+  };
+
+  let disagreement: FusedDisagreement | undefined;
+  if (conflict) {
+    const anchorIso =
+      winner.startIso ??
+      (Number.isFinite(group.anchorMs)
+        ? new Date(group.anchorMs).toISOString()
+        : undefined);
+    disagreement = {
+      kind: "asr-text",
+      subject: anchorIso ?? "(no timestamp)",
+      candidates: [{ source: winner.source, value: winner.text }, ...disagree],
+      provisional: { source: winner.source, value: winner.text },
+    };
+  }
+
+  return { segment, disagreement };
+}
+
+/**
+ * Build the reconciled speaker list. The wearer unifies across all
+ * sources; generic labels (bare "Speaker N" or a raw key) seen in only
+ * one source get a lowered confidence since they could not be
+ * confidently matched across sources.
+ */
+function collectSpeakers(tagged: readonly TaggedSegment[]): FusedSpeaker[] {
+  interface Acc {
+    label: string;
+    isSelf: boolean;
+    sources: Set<string>;
+    generic: boolean;
+  }
+  const order: string[] = [];
+  const acc = new Map<string, Acc>();
+  for (const seg of tagged) {
+    const key = speakerKey(seg.speakerLabel, seg.isSelf);
+    let entry = acc.get(key);
+    if (entry === undefined) {
+      entry = {
+        label: seg.speakerLabel,
+        isSelf: seg.isSelf,
+        sources: new Set<string>(),
+        generic: GENERIC_LABEL_PATTERN.test(seg.speakerLabel),
+      };
+      acc.set(key, entry);
+      order.push(key);
+    }
+    entry.sources.add(seg.source);
+  }
+  return order.map((key) => {
+    const entry = acc.get(key);
+    if (entry === undefined) throw new Error("fusion speaker accumulator miss");
+    const sourceCount = entry.sources.size;
+    const confidence = entry.isSelf
+      ? sourceCount > 1
+        ? 0.95
+        : 0.85
+      : entry.generic
+        ? sourceCount > 1
+          ? 0.7
+          : 0.5
+        : sourceCount > 1
+          ? 0.9
+          : 0.7;
+    return {
+      label: entry.label,
+      isSelf: entry.isSelf,
+      confidence,
+      sources: [...entry.sources].sort(),
+    };
+  });
+}

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -22,6 +22,7 @@
  */
 
 import { resolveSpeaker, type SpeakerRegistry } from "../speakers.js";
+import { maxSegmentExtent } from "./cluster.js";
 import type { WearableConversation } from "../types.js";
 import type {
   FusionConversationInput,
@@ -210,7 +211,15 @@ export function fuseCluster(
     }
   }
 
-  // Earliest start / latest end across the cluster.
+  // Earliest start / latest end across the cluster. The fused END considers
+  // BOTH every conversation's explicit endIso AND every segment's own extent
+  // (endIso ?? startIso) across ALL members: a stored transcript whose
+  // heading end renders as "--:--" rebuilds segments with only a start, so
+  // its later segment starts must still extend the fused window — otherwise
+  // a source with an explicit SHORT end would clip the fused conversation
+  // before the missing-end source's last utterance (issue #1849). Segment
+  // extents use the SAME `maxSegmentExtent` primitive as the cluster
+  // interval, so there is one coherent end derivation in the pipeline.
   let startMs = Number.POSITIVE_INFINITY;
   let endMs = Number.NEGATIVE_INFINITY;
   let startIso: string | undefined;
@@ -228,6 +237,22 @@ export function fuseCluster(
         endIso = conv.endIso;
       }
     }
+  }
+  // Fall back to / extend with the latest segment extent across ALL members
+  // so a missing-end ("--:--") source's later segment starts are not lost.
+  const segmentExtent = maxSegmentExtent(
+    cluster.flatMap((conv) => conv.segments),
+  );
+  if (segmentExtent !== undefined && segmentExtent.ms > endMs) {
+    endMs = segmentExtent.ms;
+    endIso = segmentExtent.iso;
+  }
+  // Clamp the fused window end to >= start so it is always valid, mirroring
+  // cluster.ts. A malformed explicit/derived end preceding the cluster start
+  // would otherwise yield a negative-length window.
+  if (endIso !== undefined && Number.isFinite(startMs) && endMs < startMs) {
+    endIso = startIso;
+    endMs = startMs;
   }
   if (startIso === undefined) {
     // No parseable start in the cluster — fall back to the first conv's

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -281,40 +281,56 @@ export function fuseCluster(
   });
 
   // Greedy cross-source alignment: a group holds at most one segment per
-  // source (so two sequential same-source utterances never collapse),
-  // and accepts a new segment only when speaker matches and the start is
-  // within the tolerance window of the group anchor.
+  // source (so two sequential same-source utterances never collapse). A
+  // segment joins an existing group when their time windows match (or both
+  // are untimestamped) AND the text corroborates the SAME utterance.
+  // Speaker is matched in two tiers: first an exact same-speaker group;
+  // only when none exists does a segment join a group whose utterance
+  // corroborates but whose speaker label DISAGREES. That is a speaker
+  // conflict on the same utterance — fused into one segment and recorded
+  // as a disagreement (see reconcileGroup) rather than emitted as two
+  // separate segments. This does NOT collapse distinct utterances: the
+  // text must corroborate, so different-worded same-window segments
+  // (the r2 separation) still stay apart.
   const groups: AlignGroup[] = [];
   for (const seg of tagged) {
     const key = speakerKey(seg.speakerLabel, seg.isSelf);
     const segMissing = !Number.isFinite(seg.startMs);
-    let chosen: AlignGroup | undefined;
-    for (const group of groups) {
-      if (group.key !== key) continue;
-      if (group.members.some((member) => member.source === seg.source)) continue;
+    const segWords = normalizeWords(seg.text);
+
+    // True when `group` has room for `seg`'s source and corroborates the
+    // same utterance (matching time window + corroborating text). Speaker
+    // is intentionally NOT tested here — the caller decides whether a
+    // same-speaker match or a speaker-conflict match is acceptable.
+    const corroborates = (group: AlignGroup): boolean => {
+      if (group.members.some((member) => member.source === seg.source)) {
+        return false;
+      }
       // Missing-start segments only align with other missing-start groups.
       const groupMissing = !Number.isFinite(group.anchorMs);
-      if (groupMissing !== segMissing) continue;
+      if (groupMissing !== segMissing) return false;
       if (!groupMissing && Math.abs(seg.startMs - group.anchorMs) > toleranceMs) {
-        continue;
+        return false;
       }
-      // Cross-source corroboration gate. A segment only joins an existing
-      // group when it corroborates the SAME utterance as a member. Without
-      // this, distinct utterances that merely share a speaker and a time
-      // window (timestamped) — or a speaker key alone (untimed) — collapse
-      // into one segment and silently lose a source's content. Timestamped
-      // alignment accepts an exact word match OR a leading-word prefix
-      // (truncation) so the more-complete-wins override can still reunite a
-      // clipped transcript with its full wording; untimed alignment has no
-      // time anchor, so it requires an exact word match.
-      const segWords = normalizeWords(seg.text);
-      const corroborated = group.members.some((member) =>
+      // Cross-source corroboration gate: distinct utterances that merely
+      // share a speaker and a time window (timestamped) — or a speaker key
+      // alone (untimed) — must NOT collapse. Timestamped alignment accepts
+      // an exact word match OR a leading-word prefix (truncation) so the
+      // more-complete-wins override can reunite a clipped transcript with
+      // its full wording; untimed alignment has no anchor, so exact only.
+      return group.members.some((member) =>
         wordsCorroborate(normalizeWords(member.text), segWords, !groupMissing),
       );
-      if (!corroborated) continue;
-      chosen = group;
-      break;
+    };
+
+    // Prefer an exact same-speaker corroborating group.
+    let chosen = groups.find((group) => group.key === key && corroborates(group));
+    if (chosen === undefined) {
+      // Fall back: same utterance (time+text corroborate) but a different
+      // speaker label -> speaker conflict, aligned into one segment.
+      chosen = groups.find((group) => group.key !== key && corroborates(group));
     }
+
     if (chosen !== undefined) {
       chosen.members.push(seg);
       if (seg.originalIndex < chosen.originalIndex) {
@@ -349,9 +365,7 @@ export function fuseCluster(
   for (const group of groups) {
     const reconciled = reconcileGroup(group);
     segments.push(reconciled.segment);
-    if (reconciled.disagreement !== undefined) {
-      disagreements.push(reconciled.disagreement);
-    }
+    disagreements.push(...reconciled.disagreements);
   }
   // Cross-segment ASR disagreements: distinct utterances kept as separate
   // segments (never collapsed) yet sharing a speaker + time window and
@@ -376,19 +390,25 @@ export function fuseCluster(
 
 interface ReconciledGroup {
   segment: FusedSegment;
-  disagreement?: FusedDisagreement;
+  disagreements: FusedDisagreement[];
 }
 
 function reconcileGroup(group: AlignGroup): ReconciledGroup {
   const members = group.members;
-  // Rank: higher trust, then more-complete (longer), then stable source order.
+  // Rank: higher trust, then more-complete (longer), then stable source
+  // order, finally the original transcript index — a total order so the
+  // comparator returns 0 only for an identical item (never nonzero on a
+  // tie), keeping the sort stable and contract-compliant.
   const ranked = [...members].sort((a, b) => {
     if (Math.abs(b.sourceTrust - a.sourceTrust) > TRUST_DECISION_EPSILON) {
       return b.sourceTrust - a.sourceTrust;
     }
     if (b.text.length !== a.text.length) return b.text.length - a.text.length;
     if (a.source !== b.source) return a.source < b.source ? -1 : 1;
-    return a.conversationId < b.conversationId ? -1 : 1;
+    if (a.conversationId !== b.conversationId) {
+      return a.conversationId < b.conversationId ? -1 : 1;
+    }
+    return a.originalIndex - b.originalIndex;
   });
   const top = ranked[0];
   const topWords = normalizeWords(top.text);
@@ -454,22 +474,35 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
     disagree.push({ source: candidate.source, value: candidate.text });
   }
 
+  // Speaker-attribution conflict: members of the same utterance disagree
+  // on who spoke (same time window + corroborating text, different label).
+  // Detected from member labels — not the group key — so a group that
+  // absorbed a conflicting speaker is handled identically. The chosen
+  // (top-ranked) member's attribution wins the segment provisionally;
+  // every source's label is surfaced as a disagreement with full
+  // provenance so no attribution is silently lost.
+  const distinctSpeakerKeys = new Set(
+    members.map((m) => speakerKey(m.speakerLabel, m.isSelf)),
+  );
+  const speakerConflict = distinctSpeakerKeys.size > 1;
+
   const alternatives = others.map((candidate) => ({
     source: candidate.source,
     text: candidate.text,
   }));
 
-  // Confidence: single source -> its trust; corroboration boosts;
-  // a recorded conflict lowers it.
-  const confidence = conflict
-    ? clamp01(chosen.sourceTrust * 0.7)
-    : members.length > 1
-      ? clamp01(chosen.sourceTrust + 0.1 * (members.length - 1))
-      : clamp01(chosen.sourceTrust);
+  // Confidence: single source -> its trust; corroboration boosts; a
+  // recorded text OR speaker conflict lowers it.
+  const confidence =
+    conflict || speakerConflict
+      ? clamp01(chosen.sourceTrust * 0.7)
+      : members.length > 1
+        ? clamp01(chosen.sourceTrust + 0.1 * (members.length - 1))
+        : clamp01(chosen.sourceTrust);
 
   const segment: FusedSegment = {
-    speaker: group.speakerLabel,
-    isSelf: group.isSelf,
+    speaker: chosen.speakerLabel,
+    isSelf: chosen.isSelf,
     text: chosen.text,
     confidence,
     provenance: {
@@ -483,22 +516,37 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
     ...(chosen.endIso !== undefined ? { endIso: chosen.endIso } : {}),
   };
 
-  let disagreement: FusedDisagreement | undefined;
+  const disagreements: FusedDisagreement[] = [];
+  const anchorIso =
+    chosen.startIso ??
+    (Number.isFinite(group.anchorMs)
+      ? new Date(group.anchorMs).toISOString()
+      : undefined);
   if (conflict) {
-    const anchorIso =
-      chosen.startIso ??
-      (Number.isFinite(group.anchorMs)
-        ? new Date(group.anchorMs).toISOString()
-        : undefined);
-    disagreement = {
+    disagreements.push({
       kind: "asr-text",
       subject: anchorIso ?? "(no timestamp)",
       candidates: [{ source: chosen.source, value: chosen.text }, ...disagree],
       provisional: { source: chosen.source, value: chosen.text },
-    };
+    });
+  }
+  if (speakerConflict) {
+    // One candidate per source (a group holds one member per source),
+    // sorted by source for determinism; the chosen source is provisional.
+    const speakerCandidates = members
+      .map((m) => ({ source: m.source, value: m.speakerLabel }))
+      .sort((a, b) =>
+        a.source < b.source ? -1 : a.source > b.source ? 1 : 0,
+      );
+    disagreements.push({
+      kind: "speaker",
+      subject: anchorIso ?? "(no timestamp)",
+      candidates: speakerCandidates,
+      provisional: { source: chosen.source, value: chosen.speakerLabel },
+    });
   }
 
-  return { segment, disagreement };
+  return { segment, disagreements };
 }
 
 /**
@@ -549,8 +597,13 @@ function detectCrossSegmentDisagreements(
     for (const idx of clusterIdx) claimed[idx] = true;
 
     const involved = clusterIdx.map((idx) => segments[idx]!);
-    // Rank the provisional winner: higher trust, then longer text, then
-    // stable source order — mirrors reconcileGroup's member ranking.
+    // Stable secondary key: each involved segment's position in the
+    // reconciled segment array (clusterIdx is ascending). Two cands can
+    // share a source, so source alone is NOT a total order here; the
+    // position tie-break makes the comparator return 0 only for an
+    // identical item and keeps the ranking deterministic — mirroring
+    // reconcileGroup's originalIndex tie-break.
+    const involvedOrder = new Map(involved.map((seg, i) => [seg, i]));
     involved.sort((a, b) => {
       if (
         Math.abs(b.provenance.sourceTrust - a.provenance.sourceTrust) >
@@ -559,7 +612,10 @@ function detectCrossSegmentDisagreements(
         return b.provenance.sourceTrust - a.provenance.sourceTrust;
       }
       if (b.text.length !== a.text.length) return b.text.length - a.text.length;
-      return a.provenance.source < b.provenance.source ? -1 : 1;
+      if (a.provenance.source !== b.provenance.source) {
+        return a.provenance.source < b.provenance.source ? -1 : 1;
+      }
+      return involvedOrder.get(a)! - involvedOrder.get(b)!;
     });
     const provisional = involved[0]!;
     const anchorIso = involved

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -39,8 +39,11 @@ export const DEFAULT_WINDOW_TOLERANCE_MS = 30_000;
 export const DEFAULT_SOURCE_TRUST = 0.8;
 /** Trust prior at which a source is considered "more trusted" than another. */
 const TRUST_DECISION_EPSILON = 1e-9;
-/** Labels that cannot be confidently cross-matched between sources. */
-const GENERIC_LABEL_PATTERN = /^(Speaker \d+|Unknown speaker)$/;
+/** Labels that cannot be confidently cross-matched between sources.
+ * Raw provider diarization keys (e.g. Omi `SPEAKER_00`) are generic too:
+ * they carry no cross-source identity, so they get the same lowered
+ * confidence as bare "Speaker N". */
+const GENERIC_LABEL_PATTERN = /^(Speaker \d+|Unknown speaker|SPEAKER_\d+)$/i;
 
 export interface FuseClusterResult {
   sources: string[];
@@ -275,6 +278,17 @@ export function fuseCluster(
       if (!groupMissing && Math.abs(seg.startMs - group.anchorMs) > toleranceMs) {
         continue;
       }
+      // Untimestamped (missing-start) segments cannot be aligned by time,
+      // so merging two of them on speaker key alone would collapse two
+      // DISTINCT utterances into one and silently drop a source. Require
+      // text corroboration before such a cross-source merge.
+      if (groupMissing && segMissing) {
+        const segWords = normalizeWords(seg.text);
+        const corroborated = group.members.some((member) =>
+          wordsEqual(normalizeWords(member.text), segWords),
+        );
+        if (!corroborated) continue;
+      }
       chosen = group;
       break;
     }
@@ -342,31 +356,63 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
     if (a.source !== b.source) return a.source < b.source ? -1 : 1;
     return a.conversationId < b.conversationId ? -1 : 1;
   });
-  const winner = ranked[0];
-  const rest = ranked.slice(1);
+  const top = ranked[0];
+  const topWords = normalizeWords(top.text);
+
+  // Truncation override: the top-ranked (highest-trust) member may be a
+  // CLIPPED version of a corroborating candidate — e.g. a summary source
+  // clipped at "The deploy window opens at" while a verbatim source has
+  // the full sentence. Trust dominates the rank, so without this the
+  // truncated high-trust text would win despite the documented
+  // "more-complete wins" rule. When the top's words are a strict prefix of
+  // another member's words, adopt the LONGEST such more-complete member's
+  // text + provenance.
+  let chosen = top;
+  if (topWords.length > 0) {
+    let bestLen = -1;
+    for (const candidate of ranked) {
+      if (candidate === top) continue;
+      const candidateWords = normalizeWords(candidate.text);
+      if (
+        isWordPrefix(topWords, candidateWords) &&
+        candidateWords.length > topWords.length &&
+        candidateWords.length > bestLen
+      ) {
+        chosen = candidate;
+        bestLen = candidateWords.length;
+      }
+    }
+  }
+  const truncatedOverride = chosen !== top;
+  const others = ranked.filter((member) => member !== chosen);
+
+  const chosenWords = normalizeWords(chosen.text);
 
   const reason: SegmentPickReason =
     members.length === 1
       ? "only-source"
-      : rest.some((r) => winner.sourceTrust - r.sourceTrust > TRUST_DECISION_EPSILON)
-        ? "higher-trust"
-        : rest.some((r) => winner.text.length - r.text.length > 0)
-          ? "more-complete"
-          : "tie-break";
+      : truncatedOverride
+        ? "more-complete"
+        : others.some(
+            (r) => chosen.sourceTrust - r.sourceTrust > TRUST_DECISION_EPSILON,
+          )
+          ? "higher-trust"
+          : others.some((r) => chosen.text.length - r.text.length > 0)
+            ? "more-complete"
+            : "tie-break";
 
-  // Conflict detection: a candidate whose word sequence differs from
-  // the winner AND is not a containment (one a prefix/truncation of the
+  // Conflict detection: a candidate whose word sequence differs from the
+  // chosen text AND is not a containment (one a prefix/truncation of the
   // other). Containment is "more-complete wins" with no disagreement.
-  const winnerWords = normalizeWords(winner.text);
   const disagree: Array<{ source: string; value: string }> = [];
   let conflict = false;
-  for (const candidate of rest) {
+  for (const candidate of others) {
     const candidateWords = normalizeWords(candidate.text);
-    if (winnerWords.length === 0 && candidateWords.length === 0) continue;
-    if (wordsEqual(winnerWords, candidateWords)) continue;
+    if (chosenWords.length === 0 && candidateWords.length === 0) continue;
+    if (wordsEqual(chosenWords, candidateWords)) continue;
     if (
-      isWordPrefix(candidateWords, winnerWords) ||
-      isWordPrefix(winnerWords, candidateWords)
+      isWordPrefix(candidateWords, chosenWords) ||
+      isWordPrefix(chosenWords, candidateWords)
     ) {
       continue;
     }
@@ -374,7 +420,7 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
     disagree.push({ source: candidate.source, value: candidate.text });
   }
 
-  const alternatives = rest.map((candidate) => ({
+  const alternatives = others.map((candidate) => ({
     source: candidate.source,
     text: candidate.text,
   }));
@@ -382,39 +428,39 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
   // Confidence: single source -> its trust; corroboration boosts;
   // a recorded conflict lowers it.
   const confidence = conflict
-    ? clamp01(winner.sourceTrust * 0.7)
+    ? clamp01(chosen.sourceTrust * 0.7)
     : members.length > 1
-      ? clamp01(winner.sourceTrust + 0.1 * (members.length - 1))
-      : clamp01(winner.sourceTrust);
+      ? clamp01(chosen.sourceTrust + 0.1 * (members.length - 1))
+      : clamp01(chosen.sourceTrust);
 
   const segment: FusedSegment = {
     speaker: group.speakerLabel,
     isSelf: group.isSelf,
-    text: winner.text,
+    text: chosen.text,
     confidence,
     provenance: {
-      source: winner.source,
-      conversationId: winner.conversationId,
-      sourceTrust: winner.sourceTrust,
+      source: chosen.source,
+      conversationId: chosen.conversationId,
+      sourceTrust: chosen.sourceTrust,
       reason,
       alternatives,
     },
-    ...(winner.startIso !== undefined ? { startIso: winner.startIso } : {}),
-    ...(winner.endIso !== undefined ? { endIso: winner.endIso } : {}),
+    ...(chosen.startIso !== undefined ? { startIso: chosen.startIso } : {}),
+    ...(chosen.endIso !== undefined ? { endIso: chosen.endIso } : {}),
   };
 
   let disagreement: FusedDisagreement | undefined;
   if (conflict) {
     const anchorIso =
-      winner.startIso ??
+      chosen.startIso ??
       (Number.isFinite(group.anchorMs)
         ? new Date(group.anchorMs).toISOString()
         : undefined);
     disagreement = {
       kind: "asr-text",
       subject: anchorIso ?? "(no timestamp)",
-      candidates: [{ source: winner.source, value: winner.text }, ...disagree],
-      provisional: { source: winner.source, value: winner.text },
+      candidates: [{ source: chosen.source, value: chosen.text }, ...disagree],
+      provisional: { source: chosen.source, value: chosen.text },
     };
   }
 

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -66,6 +66,10 @@ interface TaggedSegment {
   startIso?: string;
   endIso?: string;
   sourceTrust: number;
+  /** Original position in the flattened input (sources in first-appearance
+   * order, then segment order within each source). Carried through
+   * alignment so equal-time segments keep their transcript sequence. */
+  originalIndex: number;
 }
 
 interface AlignGroup {
@@ -75,6 +79,9 @@ interface AlignGroup {
   isSelf: boolean;
   members: TaggedSegment[];
   anchorMs: number;
+  /** Earliest original sequence index among members — the secondary sort
+   * key so equal-anchorMs groups keep transcript/source order. */
+  originalIndex: number;
 }
 
 /** Match key that unifies the wearer across sources. */
@@ -256,24 +263,21 @@ export function fuseCluster(
         ...(segment.startIso !== undefined ? { startIso: segment.startIso } : {}),
         ...(segment.endIso !== undefined ? { endIso: segment.endIso } : {}),
         sourceTrust,
+        originalIndex: tagged.length,
       });
     }
   }
 
-  // Deterministic order: time, then source, then speaker label.
+  // Deterministic order: time first. Equal-time (and both-missing)
+  // segments keep their ORIGINAL transcript/source sequence instead of
+  // being scrambled by source or speaker label, so minute-precision and
+  // untimestamped utterances are not reordered relative to their input.
   tagged.sort((a, b) => {
     const aFinite = Number.isFinite(a.startMs);
     const bFinite = Number.isFinite(b.startMs);
     if (aFinite && bFinite && a.startMs !== b.startMs) return a.startMs - b.startMs;
     if (aFinite !== bFinite) return aFinite ? -1 : 1;
-    if (a.source !== b.source) return a.source < b.source ? -1 : 1;
-    if (a.speakerLabel !== b.speakerLabel) {
-      return a.speakerLabel < b.speakerLabel ? -1 : 1;
-    }
-    if (a.conversationId !== b.conversationId) {
-      return a.conversationId < b.conversationId ? -1 : 1;
-    }
-    return 0;
+    return a.originalIndex - b.originalIndex;
   });
 
   // Greedy cross-source alignment: a group holds at most one segment per
@@ -313,6 +317,9 @@ export function fuseCluster(
     }
     if (chosen !== undefined) {
       chosen.members.push(seg);
+      if (seg.originalIndex < chosen.originalIndex) {
+        chosen.originalIndex = seg.originalIndex;
+      }
     } else {
       groups.push({
         key,
@@ -320,20 +327,21 @@ export function fuseCluster(
         isSelf: seg.isSelf,
         members: [seg],
         anchorMs: seg.startMs,
+        originalIndex: seg.originalIndex,
       });
     }
   }
 
-  // Output groups in time order (missing-start groups last, stable).
+  // Output groups in time order; missing-start groups last. Equal-anchorMs
+  // (and all-missing) groups tie-break on original transcript/source
+  // sequence — not source/speaker label — so equal-time utterances keep
+  // the order they appeared in their input transcripts.
   groups.sort((a, b) => {
     const aMissing = !Number.isFinite(a.anchorMs);
     const bMissing = !Number.isFinite(b.anchorMs);
     if (aMissing !== bMissing) return aMissing ? 1 : -1;
     if (!aMissing && a.anchorMs !== b.anchorMs) return a.anchorMs - b.anchorMs;
-    const am = a.members[0];
-    const bm = b.members[0];
-    if (am.source !== bm.source) return am.source < bm.source ? -1 : 1;
-    return am.speakerLabel < bm.speakerLabel ? -1 : am.speakerLabel > bm.speakerLabel ? 1 : 0;
+    return a.originalIndex - b.originalIndex;
   });
 
   const segments: FusedSegment[] = [];

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -79,6 +79,14 @@ interface AlignGroup {
   isSelf: boolean;
   members: TaggedSegment[];
   anchorMs: number;
+  /** The anchor member's ORIGINAL start ISO — the canonical utterance
+   * time the fused segment is emitted at (groups are sorted by anchorMs,
+   * so the emitted startIso must come from here, not from the chosen
+   * higher-trust source's later clock, or pre-sorted chronology breaks).
+   * Undefined for untimestamped (missing-start) groups. */
+  anchorStartIso?: string;
+  /** The anchor member's ORIGINAL end ISO, when known. */
+  anchorEndIso?: string;
   /** Earliest original sequence index among members — the secondary sort
    * key so equal-anchorMs groups keep transcript/source order. */
   originalIndex: number;
@@ -383,6 +391,11 @@ export function fuseCluster(
         isSelf: seg.isSelf,
         members: [seg],
         anchorMs: seg.startMs,
+        // The creating segment is the EARLIEST member (tagged is
+        // time-sorted), so its clock IS the group anchor that groups are
+        // sorted by and that the fused segment must be emitted at.
+        anchorStartIso: seg.startIso,
+        anchorEndIso: seg.endIso,
         originalIndex: seg.originalIndex,
       });
     }
@@ -407,6 +420,33 @@ export function fuseCluster(
     segments.push(reconciled.segment);
     disagreements.push(...reconciled.disagreements);
   }
+  // Belt-and-suspenders: segments are built from anchor-sorted groups with
+  // each segment's startIso pinned to its group anchor, so the array is
+  // already chronological. This explicit, STABLE re-sort guarantees that
+  // invariant end to end — no trust-based text/content swap can ever
+  // reorder the timeline, even if a future change alters how a fused
+  // segment's timestamp is derived. Stability contract:
+  //   - timestamped segments sort by startMs ascending;
+  //   - missing/invalid timestamps keep their position (timestamped before
+  //     missing, preserving original relative order among missing ones);
+  //   - equal timestamps preserve prior order via a deterministic secondary
+  //     key (the pre-sort index), never reordering by source/speaker — so
+  //     cross-source clock skew does not scramble same-anchor utterances.
+  const preSortOrder = new Map(segments.map((seg, i) => [seg, i]));
+  segments.sort((a, b) => {
+    const aMs = a.startIso !== undefined ? Date.parse(a.startIso) : Number.NaN;
+    const bMs = b.startIso !== undefined ? Date.parse(b.startIso) : Number.NaN;
+    const aFinite = Number.isFinite(aMs);
+    const bFinite = Number.isFinite(bMs);
+    if (aFinite && bFinite) {
+      if (aMs !== bMs) return aMs - bMs;
+    } else if (aFinite !== bFinite) {
+      return aFinite ? -1 : 1;
+    }
+    // Equal timestamp (or both missing): preserve prior order — never let
+    // a naive ts-only comparator scramble equal/missing-time entries.
+    return (preSortOrder.get(a) ?? 0) - (preSortOrder.get(b) ?? 0);
+  });
   // Cross-segment ASR disagreements: distinct utterances kept as separate
   // segments (never collapsed) yet sharing a speaker + time window and
   // disagreeing on wording. Neither side's content is lost — both remain
@@ -540,6 +580,16 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
         ? clamp01(chosen.sourceTrust + 0.1 * (members.length - 1))
         : clamp01(chosen.sourceTrust);
 
+  // TIMELINE POSITION (startIso/endIso) comes from the group/window ANCHOR
+  // — the canonical utterance time the groups are sorted by — NOT from the
+  // chosen (higher-trust) source's clock. The chosen source may be LATER
+  // than the anchor (a low-trust utterance at 10:00 corroborated by a
+  // high-trust source at 10:25 within tolerance); emitting chosen.startIso
+  // would print the fused segment at 10:25 even though the group sits at
+  // the 10:00 anchor, jumping it past an intervening 10:10 utterance and
+  // corrupting the chronology. The chosen source still provides the TEXT;
+  // only the timeline position is anchored. Its original clock is kept in
+  // provenance so the source's recording time stays traceable.
   const segment: FusedSegment = {
     speaker: chosen.speakerLabel,
     isSelf: chosen.isSelf,
@@ -551,14 +601,23 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
       sourceTrust: chosen.sourceTrust,
       reason,
       alternatives,
+      ...(chosen.startIso !== undefined
+        ? { sourceStartIso: chosen.startIso }
+        : {}),
+      ...(chosen.endIso !== undefined ? { sourceEndIso: chosen.endIso } : {}),
     },
-    ...(chosen.startIso !== undefined ? { startIso: chosen.startIso } : {}),
-    ...(chosen.endIso !== undefined ? { endIso: chosen.endIso } : {}),
+    ...(group.anchorStartIso !== undefined
+      ? { startIso: group.anchorStartIso }
+      : {}),
+    ...(group.anchorEndIso !== undefined ? { endIso: group.anchorEndIso } : {}),
   };
 
   const disagreements: FusedDisagreement[] = [];
+  // The disagreement subject is the EMITTED timeline position (the group
+  // anchor), coherent with segment.startIso — not the chosen source's
+  // possibly-later clock.
   const anchorIso =
-    chosen.startIso ??
+    group.anchorStartIso ??
     (Number.isFinite(group.anchorMs)
       ? new Date(group.anchorMs).toISOString()
       : undefined);

--- a/packages/remnic-core/src/wearables/fusion/reconcile.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconcile.ts
@@ -119,6 +119,22 @@ function isWordPrefix(short: string[], long: string[]): boolean {
   return true;
 }
 
+/** Whether two normalized word sequences corroborate the SAME utterance.
+ * Exact match always corroborates; a leading-word-prefix (truncation)
+ * corroborates only when `allowPrefix` is set (timestamped alignment),
+ * so the more-complete-wins override can reunite a clipped transcript
+ * with its full wording. Untimed alignment passes `allowPrefix = false`
+ * and demands an exact word match. */
+function wordsCorroborate(
+  a: string[],
+  b: string[],
+  allowPrefix: boolean,
+): boolean {
+  if (wordsEqual(a, b)) return true;
+  if (!allowPrefix) return false;
+  return isWordPrefix(a, b) || isWordPrefix(b, a);
+}
+
 function clamp01(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.min(1, Math.max(0, value));
@@ -278,17 +294,20 @@ export function fuseCluster(
       if (!groupMissing && Math.abs(seg.startMs - group.anchorMs) > toleranceMs) {
         continue;
       }
-      // Untimestamped (missing-start) segments cannot be aligned by time,
-      // so merging two of them on speaker key alone would collapse two
-      // DISTINCT utterances into one and silently drop a source. Require
-      // text corroboration before such a cross-source merge.
-      if (groupMissing && segMissing) {
-        const segWords = normalizeWords(seg.text);
-        const corroborated = group.members.some((member) =>
-          wordsEqual(normalizeWords(member.text), segWords),
-        );
-        if (!corroborated) continue;
-      }
+      // Cross-source corroboration gate. A segment only joins an existing
+      // group when it corroborates the SAME utterance as a member. Without
+      // this, distinct utterances that merely share a speaker and a time
+      // window (timestamped) — or a speaker key alone (untimed) — collapse
+      // into one segment and silently lose a source's content. Timestamped
+      // alignment accepts an exact word match OR a leading-word prefix
+      // (truncation) so the more-complete-wins override can still reunite a
+      // clipped transcript with its full wording; untimed alignment has no
+      // time anchor, so it requires an exact word match.
+      const segWords = normalizeWords(seg.text);
+      const corroborated = group.members.some((member) =>
+        wordsCorroborate(normalizeWords(member.text), segWords, !groupMissing),
+      );
+      if (!corroborated) continue;
       chosen = group;
       break;
     }
@@ -326,6 +345,13 @@ export function fuseCluster(
       disagreements.push(reconciled.disagreement);
     }
   }
+  // Cross-segment ASR disagreements: distinct utterances kept as separate
+  // segments (never collapsed) yet sharing a speaker + time window and
+  // disagreeing on wording. Neither side's content is lost — both remain
+  // visible segments — but the unresolved conflict is still surfaced for
+  // review and each involved segment's confidence is lowered, matching
+  // how an in-group conflict is flagged.
+  detectCrossSegmentDisagreements(segments, toleranceMs, disagreements);
 
   const result: FuseClusterResult = {
     sources,
@@ -465,6 +491,91 @@ function reconcileGroup(group: AlignGroup): ReconciledGroup {
   }
 
   return { segment, disagreement };
+}
+
+/**
+ * Detect ASR-text disagreements BETWEEN segments that were intentionally
+ * kept separate (distinct utterances) yet share a speaker and a time
+ * window and disagree on wording. Unlike an in-group conflict (same
+ * utterance bridged by a truncation), these never merged — so neither
+ * side's content is lost — but the unresolved disagreement is still
+ * surfaced for review and each involved segment's confidence is lowered.
+ *
+ * Timestamped only: untimestamped segments have no window anchor to compare
+ * against. Mutates `confidence` on involved segments and appends to `out`.
+ */
+function detectCrossSegmentDisagreements(
+  segments: FusedSegment[],
+  toleranceMs: number,
+  out: FusedDisagreement[],
+): void {
+  const n = segments.length;
+  if (n < 2) return;
+  const claimed = new Array<boolean>(n).fill(false);
+  for (let i = 0; i < n; i++) {
+    if (claimed[i]) continue;
+    const seed = segments[i]!;
+    const seedMs =
+      seed.startIso !== undefined ? Date.parse(seed.startIso) : NaN;
+    if (!Number.isFinite(seedMs)) continue;
+    const seedWords = normalizeWords(seed.text);
+    const clusterIdx: number[] = [];
+    for (let j = i + 1; j < n; j++) {
+      if (claimed[j]) continue;
+      const cand = segments[j]!;
+      if (cand.isSelf !== seed.isSelf || cand.speaker !== seed.speaker) {
+        continue;
+      }
+      if (cand.provenance.source === seed.provenance.source) continue;
+      const candMs =
+        cand.startIso !== undefined ? Date.parse(cand.startIso) : NaN;
+      if (!Number.isFinite(candMs)) continue;
+      if (Math.abs(candMs - seedMs) > toleranceMs) continue;
+      if (wordsCorroborate(seedWords, normalizeWords(cand.text), true)) {
+        continue;
+      }
+      clusterIdx.push(j);
+    }
+    if (clusterIdx.length === 0) continue;
+    clusterIdx.unshift(i);
+    for (const idx of clusterIdx) claimed[idx] = true;
+
+    const involved = clusterIdx.map((idx) => segments[idx]!);
+    // Rank the provisional winner: higher trust, then longer text, then
+    // stable source order — mirrors reconcileGroup's member ranking.
+    involved.sort((a, b) => {
+      if (
+        Math.abs(b.provenance.sourceTrust - a.provenance.sourceTrust) >
+        TRUST_DECISION_EPSILON
+      ) {
+        return b.provenance.sourceTrust - a.provenance.sourceTrust;
+      }
+      if (b.text.length !== a.text.length) return b.text.length - a.text.length;
+      return a.provenance.source < b.provenance.source ? -1 : 1;
+    });
+    const provisional = involved[0]!;
+    const anchorIso = involved
+      .map((s) => s.startIso)
+      .filter((v): v is string => v !== undefined)
+      .sort()[0];
+
+    for (const seg of involved) {
+      seg.confidence = clamp01(seg.provenance.sourceTrust * 0.7);
+    }
+
+    out.push({
+      kind: "asr-text",
+      subject: anchorIso ?? "(no timestamp)",
+      candidates: involved.map((s) => ({
+        source: s.provenance.source,
+        value: s.text,
+      })),
+      provisional: {
+        source: provisional.provenance.source,
+        value: provisional.text,
+      },
+    });
+  }
 }
 
 /**

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -79,7 +79,7 @@ function unescapeSegmentText(text: string): string {
     if (ch === "n") return "\n";
     if (ch === "r") return "\r";
     if (ch === "\\") return "\\";
-    return ch;
+    return "\\" + ch;
   });
 }
 

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -93,12 +93,23 @@ function nextCalendarDay(date: string): string {
  */
 export function reconstructFusionInputs(
   date: string,
-  dayTranscripts: ReadonlyArray<{ source: string; body: string }>,
+  dayTranscripts: ReadonlyArray<{
+    source: string;
+    body: string;
+    /**
+     * Whether the body was written by the escape-aware serializer
+     * (`bodyIsEscaped(meta)`). When falsy (legacy) the segment text and
+     * speaker label are used verbatim — no escape decoding — so a legacy
+     * transcript's literal two-character `\n`/`\r` is never altered
+     * (issue #1849).
+     */
+    escaped?: boolean;
+  }>,
 ): FusionConversationInput[] {
   if (!isValidTranscriptDate(date)) return [];
   const inputs: FusionConversationInput[] = [];
 
-  for (const { source, body } of dayTranscripts) {
+  for (const { source, body, escaped } of dayTranscripts) {
     let current: {
       conversationId: string;
       title?: string;
@@ -185,7 +196,7 @@ export function reconstructFusionInputs(
       if (segmentMatch !== null) {
         if (current === null) continue; // segment outside any conversation
         const [, label, clock, rawText] = segmentMatch;
-        const text = unescapeSegmentText(rawText);
+        const text = escaped ? unescapeSegmentText(rawText) : rawText;
         const segMin = clockMinutesOfDay(clock);
         // A segment clock EARLIER than the conversation start clock MAY
         // have crossed midnight. Roll it to the next calendar day ONLY
@@ -214,9 +225,12 @@ export function reconstructFusionInputs(
         const segDate = plausibleSegWrap ? nextCalendarDay(date) : date;
         const startIso = clockToIso(clock, segDate);
         // Decode the safely-serialized speaker label back to its original
-        // form; legacy raw labels (no escape sequences) round-trip
-        // verbatim (#1849).
-        const speaker = unescapeSpeakerLabel(label.trim());
+        // form ONLY when the body is escape-aware; legacy raw labels are
+        // used verbatim so their literal characters are never altered
+        // (#1849).
+        const speaker = escaped
+          ? unescapeSpeakerLabel(label.trim())
+          : label.trim();
         const segment: FusionSegmentInput = {
           speaker,
           // Self status is read from the RESERVED `(you)` marker, which the

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -20,6 +20,7 @@ import {
   isValidTranscriptDate,
   TRANSCRIPT_SEGMENT_LINE,
   unescapeSegmentText,
+  unescapeSpeakerLabel,
 } from "../day-store.js";
 import { hasSelfMarker } from "../speakers.js";
 import type {
@@ -37,14 +38,14 @@ const MINUTES_PER_DAY = 24 * 60;
 
 /**
  * Upper bound on a plausible single-conversation duration, used to decide
- * whether an earlier heading end clock is a genuine midnight wrap (start
- * -> midnight -> end within this bound) versus a malformed/ordinary
- * earlier clock that should stay on the same date and be clamped
- * downstream. Generous enough that any legitimate overnight wrap a
- * wearable source would emit still rolls forward; tight enough that a
- * near-24h implied span (e.g. 14:00 -> 13:00) is treated as the error it
- * almost certainly is instead of producing a day-spanning window that
- * broadly clusters unrelated neighbors (#1849).
+ * whether an earlier heading end clock (or segment clock) is a genuine
+ * midnight wrap (start -> midnight -> end/segment within this bound)
+ * versus a malformed/ordinary earlier clock that should stay on the same
+ * date and be clamped downstream. Generous enough that any legitimate
+ * overnight wrap a wearable source would emit still rolls forward; tight
+ * enough that a near-24h implied span (e.g. 14:00 -> 13:00) is treated as
+ * the error it almost certainly is instead of producing a day-spanning
+ * window that broadly clusters unrelated neighbors (#1849).
  */
 const MAX_PLAUSIBLE_WRAP_MINUTES = 12 * 60;
 
@@ -149,9 +150,9 @@ export function reconstructFusionInputs(
         // endIso < startIso so the downstream cluster clamp collapses it
         // to the start instead of stretching the window across most of
         // the day and broadly clustering unrelated neighbors (#1849).
-        // Post-midnight SEGMENTS roll independently below: a segment whose
-        // clock precedes the start clock crossed midnight regardless of
-        // whether the heading end clock was parseable or rolled.
+        // Post-midnight SEGMENTS roll independently below under the SAME
+        // plausibility bound: a segment whose clock precedes the start
+        // clock is rolled only when the implied wrap is plausible.
         const wrapped =
           startMin !== undefined && endMin !== undefined && endMin < startMin;
         const wrapDuration =
@@ -186,24 +187,42 @@ export function reconstructFusionInputs(
         const [, label, clock, rawText] = segmentMatch;
         const text = unescapeSegmentText(rawText);
         const segMin = clockMinutesOfDay(clock);
-        // A segment clock EARLIER than the conversation start clock crossed
-        // midnight; roll it to the next calendar day. Driven by the
-        // segment-vs-start comparison directly — NOT gated on `wrapped` —
-        // so a heading whose end is missing/unparseable (e.g.
-        // `## 23:55–--:--`) still rolls its `[00:05]` segment forward.
-        const segDate =
+        // A segment clock EARLIER than the conversation start clock MAY
+        // have crossed midnight. Roll it to the next calendar day ONLY
+        // when the implied wrap duration (start -> midnight -> segment)
+        // is within the SAME plausible single-conversation bound as the
+        // heading end; a near-24h implied span (e.g. start 14:00,
+        // segment 13:00) is almost certainly a malformed/provider-skew
+        // earlier clock, not a midnight crossing. Leaving it on the SAME
+        // date keeps segIso < startIso so the downstream cluster clamp
+        // collapses it instead of stretching the interval across most of
+        // the day and broadly clustering unrelated neighbors (#1849).
+        // Driven by the segment-vs-start comparison directly — NOT gated
+        // on `wrapped` — so a heading whose end is missing/unparseable
+        // (e.g. `## 23:55–--:--`) still rolls a plausible `[00:05]`
+        // segment forward.
+        const segWrapDuration =
+          current.wrapStartMin !== undefined && segMin !== undefined
+            ? MINUTES_PER_DAY - current.wrapStartMin + segMin
+            : undefined;
+        const plausibleSegWrap =
           current.wrapStartMin !== undefined &&
           segMin !== undefined &&
-          segMin < current.wrapStartMin
-            ? nextCalendarDay(date)
-            : date;
+          segMin < current.wrapStartMin &&
+          segWrapDuration !== undefined &&
+          segWrapDuration <= MAX_PLAUSIBLE_WRAP_MINUTES;
+        const segDate = plausibleSegWrap ? nextCalendarDay(date) : date;
         const startIso = clockToIso(clock, segDate);
+        // Decode the safely-serialized speaker label back to its original
+        // form; legacy raw labels (no escape sequences) round-trip
+        // verbatim (#1849).
+        const speaker = unescapeSpeakerLabel(label.trim());
         const segment: FusionSegmentInput = {
-          speaker: label.trim(),
+          speaker,
           // Self status is read from the RESERVED `(you)` marker, which the
           // renderer guarantees can only appear on the wearer's label -
           // never on a non-self display name (issue #1849).
-          isSelf: hasSelfMarker(label),
+          isSelf: hasSelfMarker(speaker),
           text,
           ...(startIso !== undefined ? { startIso } : {}),
         };

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -88,8 +88,9 @@ export function reconstructFusionInputs(
       startIso?: string;
       endIso?: string;
       segments: FusionSegmentInput[];
-      /** True when this conversation's end clock precedes its start clock
-       * (it wraps past midnight); post-midnight clocks roll to next day. */
+      /** True when the heading end clock precedes the start clock (the
+       * conversation window wrapped past midnight); rolls `endIso` forward.
+       * Post-midnight SEGMENTS roll independently via `wrapStartMin`. */
       wrapped: boolean;
       wrapStartMin?: number;
     } | null = null;
@@ -123,9 +124,11 @@ export function reconstructFusionInputs(
         const startMin = clockMinutesOfDay(startClock);
         const endMin = clockMinutesOfDay(endClock);
         // A conversation whose end clock reads EARLIER than its start
-        // clock wrapped past midnight; roll its end (and any post-midnight
-        // segment) to the next calendar day so endIso >= startIso and the
-        // timeline sorts correctly.
+        // clock wrapped past midnight; roll its end to the next calendar
+        // day so endIso >= startIso and the timeline sorts correctly.
+        // Post-midnight SEGMENTS roll independently below: a segment whose
+        // clock precedes the start clock crossed midnight regardless of
+        // whether the heading end clock was parseable.
         const wrapped =
           startMin !== undefined && endMin !== undefined && endMin < startMin;
         const startIso = clockToIso(startClock, date);
@@ -151,8 +154,12 @@ export function reconstructFusionInputs(
         if (current === null) continue; // segment outside any conversation
         const [, label, clock, text] = segmentMatch;
         const segMin = clockMinutesOfDay(clock);
+        // A segment clock EARLIER than the conversation start clock crossed
+        // midnight; roll it to the next calendar day. Driven by the
+        // segment-vs-start comparison directly — NOT gated on `wrapped` —
+        // so a heading whose end is missing/unparseable (e.g.
+        // `## 23:55–--:--`) still rolls its `[00:05]` segment forward.
         const segDate =
-          current.wrapped &&
           current.wrapStartMin !== undefined &&
           segMin !== undefined &&
           segMin < current.wrapStartMin

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -32,7 +32,36 @@ const CLOCK_PATTERN = /^(\d{2}):(\d{2})$/;
 function clockToIso(clock: string, date: string): string | undefined {
   const match = CLOCK_PATTERN.exec(clock.trim());
   if (match === null) return undefined;
-  return `${date}T${match[1]}:${match[2]}:00.000Z`;
+  // en-US hour12:false renders the first wall-clock hour (00:xx) as 24:xx
+  // on some ICU builds. CLOCK_PATTERN matches "24", which would build an
+  // invalid ISO (24:01-24:59 => NaN) or a next-day instant (24:00 => start
+  // of next day). Normalize to 00:xx on the SAME rendered date; cross-
+  // midnight conversation windows are rolled forward by the caller.
+  const hour = match[1] === "24" ? "00" : match[1];
+  return `${date}T${hour}:${match[2]}:00.000Z`;
+}
+
+/**
+ * Minutes-of-day for a rendered clock (24:xx normalized to 0), or
+ * undefined when the clock is not parseable (e.g. "--:--"). Used to
+ * detect conversations that wrap past midnight.
+ */
+function clockMinutesOfDay(clock: string): number | undefined {
+  const match = CLOCK_PATTERN.exec(clock.trim());
+  if (match === null) return undefined;
+  const hour = match[1] === "24" ? 0 : Number.parseInt(match[1], 10);
+  return hour * 60 + Number.parseInt(match[2], 10);
+}
+
+/** Increment a YYYY-MM-DD date string by one calendar day (UTC arithmetic). */
+function nextCalendarDay(date: string): string {
+  const [y, m, d] = date.split("-").map((part) => Number.parseInt(part, 10));
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + 1);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
 }
 
 function isSelfLabel(label: string): boolean {
@@ -59,6 +88,10 @@ export function reconstructFusionInputs(
       startIso?: string;
       endIso?: string;
       segments: FusionSegmentInput[];
+      /** True when this conversation's end clock precedes its start clock
+       * (it wraps past midnight); post-midnight clocks roll to next day. */
+      wrapped: boolean;
+      wrapStartMin?: number;
     } | null = null;
 
     const flushCurrent = () => {
@@ -87,15 +120,25 @@ export function reconstructFusionInputs(
       if (heading !== null) {
         flushCurrent();
         const [, startClock, endClock, title, id] = heading;
+        const startMin = clockMinutesOfDay(startClock);
+        const endMin = clockMinutesOfDay(endClock);
+        // A conversation whose end clock reads EARLIER than its start
+        // clock wrapped past midnight; roll its end (and any post-midnight
+        // segment) to the next calendar day so endIso >= startIso and the
+        // timeline sorts correctly.
+        const wrapped =
+          startMin !== undefined && endMin !== undefined && endMin < startMin;
+        const startIso = clockToIso(startClock, date);
+        const endIso = wrapped
+          ? clockToIso(endClock, nextCalendarDay(date))
+          : clockToIso(endClock, date);
         current = {
           conversationId: id,
           segments: [],
-          ...(clockToIso(startClock, date) !== undefined
-            ? { startIso: clockToIso(startClock, date) }
-            : {}),
-          ...(clockToIso(endClock, date) !== undefined
-            ? { endIso: clockToIso(endClock, date) }
-            : {}),
+          wrapped,
+          ...(startMin !== undefined ? { wrapStartMin: startMin } : {}),
+          ...(startIso !== undefined ? { startIso } : {}),
+          ...(endIso !== undefined ? { endIso } : {}),
           ...(title !== undefined && title.length > 0 ? { title } : {}),
         };
         continue;
@@ -107,13 +150,20 @@ export function reconstructFusionInputs(
       if (segmentMatch !== null) {
         if (current === null) continue; // segment outside any conversation
         const [, label, clock, text] = segmentMatch;
+        const segMin = clockMinutesOfDay(clock);
+        const segDate =
+          current.wrapped &&
+          current.wrapStartMin !== undefined &&
+          segMin !== undefined &&
+          segMin < current.wrapStartMin
+            ? nextCalendarDay(date)
+            : date;
+        const startIso = clockToIso(clock, segDate);
         const segment: FusionSegmentInput = {
           speaker: label.trim(),
           isSelf: isSelfLabel(label),
           text,
-          ...(clockToIso(clock, date) !== undefined
-            ? { startIso: clockToIso(clock, date) }
-            : {}),
+          ...(startIso !== undefined ? { startIso } : {}),
         };
         current.segments.push(segment);
       }

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -69,6 +69,21 @@ function isSelfLabel(label: string): boolean {
 }
 
 /**
+ * Reverse `escapeSegmentText` (day-store.ts).  Unknown escape sequences
+ * (a lone backslash followed by a character we don't emit) are passed
+ * through literally so legacy transcripts that never went through the
+ * escaper still round-trip their original text.
+ */
+function unescapeSegmentText(text: string): string {
+  return text.replace(/\\(.)/g, (_match, ch: string) => {
+    if (ch === "n") return "\n";
+    if (ch === "r") return "\r";
+    if (ch === "\\") return "\\";
+    return ch;
+  });
+}
+
+/**
  * Reconstruct fusion inputs for a day from one or more sources' stored
  * transcript bodies. Each body is the markdown produced by
  * `composeDayTranscriptBody` (frontmatter already stripped by the
@@ -152,7 +167,8 @@ export function reconstructFusionInputs(
       const segmentMatch = SEGMENT_LINE.exec(line);
       if (segmentMatch !== null) {
         if (current === null) continue; // segment outside any conversation
-        const [, label, clock, text] = segmentMatch;
+        const [, label, clock, rawText] = segmentMatch;
+        const text = unescapeSegmentText(rawText);
         const segMin = clockMinutesOfDay(clock);
         // A segment clock EARLIER than the conversation start clock crossed
         // midnight; roll it to the next calendar day. Driven by the

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -1,0 +1,127 @@
+/**
+ * Wearable cross-source fusion — reconstruct inputs from stored transcripts.
+ *
+ * The on-demand service path fuses from already-synced day transcripts
+ * (offline, no connector calls). Those files store a human-readable
+ * markdown body, so this module parses it back into the normalized
+ * `FusionConversationInput[]` shape the fusion engine consumes.
+ *
+ * Precision caveat (documented, accepted for this foundational PR):
+ * the rendered body carries minute-precision clock times in the
+ * configured timezone. We reconstruct them as `${date}T${HH}:${MM}:00Z`
+ * — every source for a given day is rendered in the SAME timezone, so
+ * relative within-day comparisons and time-window alignment stay
+ * correct even though the absolute ISO is timezone-normalized. Full
+ * segment-level alignment with sub-minute precision is a deferred
+ * follow-up (see PR body).
+ */
+
+import { isValidTranscriptDate } from "../day-store.js";
+import type {
+  FusionConversationInput,
+  FusionSegmentInput,
+} from "./types.js";
+
+const CONVERSATION_HEADING =
+  /^## (.+?)\u2013(.+?)(?:\s\u00b7\s(.*))?\s\(conversation (.+)\)$/;
+const LOCATION_LINE = /^\*Location: (.+)\*$/;
+const SEGMENT_LINE = /^\*\*(.+?)\*\*\s\[(.+?)\]:\s(.*)$/;
+const CLOCK_PATTERN = /^(\d{2}):(\d{2})$/;
+
+/** Rendered clock ("HH:MM") -> timezone-normalized ISO; "--:--" -> undefined. */
+function clockToIso(clock: string, date: string): string | undefined {
+  const match = CLOCK_PATTERN.exec(clock.trim());
+  if (match === null) return undefined;
+  return `${date}T${match[1]}:${match[2]}:00.000Z`;
+}
+
+function isSelfLabel(label: string): boolean {
+  return /\(you\)\s*$/.test(label.trim());
+}
+
+/**
+ * Reconstruct fusion inputs for a day from one or more sources' stored
+ * transcript bodies. Each body is the markdown produced by
+ * `composeDayTranscriptBody` (frontmatter already stripped by the
+ * caller via `parseDayTranscript`).
+ */
+export function reconstructFusionInputs(
+  date: string,
+  dayTranscripts: ReadonlyArray<{ source: string; body: string }>,
+): FusionConversationInput[] {
+  if (!isValidTranscriptDate(date)) return [];
+  const inputs: FusionConversationInput[] = [];
+
+  for (const { source, body } of dayTranscripts) {
+    let current: {
+      conversationId: string;
+      title?: string;
+      startIso?: string;
+      endIso?: string;
+      segments: FusionSegmentInput[];
+    } | null = null;
+
+    const flushCurrent = () => {
+      if (current === null) return;
+      const startIso =
+        current.startIso ??
+        current.segments.find((segment) => segment.startIso !== undefined)?.startIso ??
+        `${date}T00:00:00.000Z`;
+      const input: FusionConversationInput = {
+        source,
+        conversationId: current.conversationId,
+        startIso,
+        segments: current.segments,
+      };
+      if (current.endIso !== undefined) input.endIso = current.endIso;
+      if (current.title !== undefined) input.title = current.title;
+      inputs.push(input);
+      current = null;
+    };
+
+    for (const rawLine of body.split("\n")) {
+      const line = rawLine.trimEnd();
+      if (line.length === 0) continue;
+
+      const heading = CONVERSATION_HEADING.exec(line);
+      if (heading !== null) {
+        flushCurrent();
+        const [, startClock, endClock, title, id] = heading;
+        current = {
+          conversationId: id,
+          segments: [],
+          ...(clockToIso(startClock, date) !== undefined
+            ? { startIso: clockToIso(startClock, date) }
+            : {}),
+          ...(clockToIso(endClock, date) !== undefined
+            ? { endIso: clockToIso(endClock, date) }
+            : {}),
+          ...(title !== undefined && title.length > 0 ? { title } : {}),
+        };
+        continue;
+      }
+
+      if (LOCATION_LINE.exec(line) !== null) continue;
+
+      const segmentMatch = SEGMENT_LINE.exec(line);
+      if (segmentMatch !== null) {
+        if (current === null) continue; // segment outside any conversation
+        const [, label, clock, text] = segmentMatch;
+        const segment: FusionSegmentInput = {
+          speaker: label.trim(),
+          isSelf: isSelfLabel(label),
+          text,
+          ...(clockToIso(clock, date) !== undefined
+            ? { startIso: clockToIso(clock, date) }
+            : {}),
+        };
+        current.segments.push(segment);
+        continue;
+      }
+      // Unrecognized lines (e.g. the H1 source header) are ignored.
+    }
+    flushCurrent();
+  }
+
+  return inputs;
+}

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -16,7 +16,11 @@
  * follow-up (see PR body).
  */
 
-import { isValidTranscriptDate } from "../day-store.js";
+import {
+  isValidTranscriptDate,
+  TRANSCRIPT_SEGMENT_LINE,
+  unescapeSegmentText,
+} from "../day-store.js";
 import type {
   FusionConversationInput,
   FusionSegmentInput,
@@ -25,8 +29,23 @@ import type {
 const CONVERSATION_HEADING =
   /^## (.+?)\u2013(.+?)(?:\s\u00b7\s(.*))?\s\(conversation (.+)\)$/;
 const LOCATION_LINE = /^\*Location: (.+)\*$/;
-const SEGMENT_LINE = /^\*\*(.+?)\*\*\s\[(.+?)\]:\s(.*)$/;
 const CLOCK_PATTERN = /^(\d{2}):(\d{2})$/;
+
+/** Minutes in a 24-hour day. */
+const MINUTES_PER_DAY = 24 * 60;
+
+/**
+ * Upper bound on a plausible single-conversation duration, used to decide
+ * whether an earlier heading end clock is a genuine midnight wrap (start
+ * -> midnight -> end within this bound) versus a malformed/ordinary
+ * earlier clock that should stay on the same date and be clamped
+ * downstream. Generous enough that any legitimate overnight wrap a
+ * wearable source would emit still rolls forward; tight enough that a
+ * near-24h implied span (e.g. 14:00 -> 13:00) is treated as the error it
+ * almost certainly is instead of producing a day-spanning window that
+ * broadly clusters unrelated neighbors (#1849).
+ */
+const MAX_PLAUSIBLE_WRAP_MINUTES = 12 * 60;
 
 /** Rendered clock ("HH:MM") -> timezone-normalized ISO; "--:--" -> undefined. */
 function clockToIso(clock: string, date: string): string | undefined {
@@ -66,21 +85,6 @@ function nextCalendarDay(date: string): string {
 
 function isSelfLabel(label: string): boolean {
   return /\(you\)\s*$/.test(label.trim());
-}
-
-/**
- * Reverse `escapeSegmentText` (day-store.ts).  Unknown escape sequences
- * (a lone backslash followed by a character we don't emit) are passed
- * through literally so legacy transcripts that never went through the
- * escaper still round-trip their original text.
- */
-function unescapeSegmentText(text: string): string {
-  return text.replace(/\\(.)/g, (_match, ch: string) => {
-    if (ch === "n") return "\n";
-    if (ch === "r") return "\r";
-    if (ch === "\\") return "\\";
-    return "\\" + ch;
-  });
 }
 
 /**
@@ -139,15 +143,30 @@ export function reconstructFusionInputs(
         const startMin = clockMinutesOfDay(startClock);
         const endMin = clockMinutesOfDay(endClock);
         // A conversation whose end clock reads EARLIER than its start
-        // clock wrapped past midnight; roll its end to the next calendar
-        // day so endIso >= startIso and the timeline sorts correctly.
+        // clock MAY have wrapped past midnight. Roll its end to the next
+        // calendar day ONLY when the implied wrap duration (start ->
+        // midnight -> end) is within a plausible single-conversation
+        // bound; a near-24h implied span (e.g. start 14:00, end 13:00)
+        // is almost certainly a malformed/ordinary earlier clock, not a
+        // midnight crossing. Leaving that end on the SAME date keeps
+        // endIso < startIso so the downstream cluster clamp collapses it
+        // to the start instead of stretching the window across most of
+        // the day and broadly clustering unrelated neighbors (#1849).
         // Post-midnight SEGMENTS roll independently below: a segment whose
         // clock precedes the start clock crossed midnight regardless of
-        // whether the heading end clock was parseable.
+        // whether the heading end clock was parseable or rolled.
         const wrapped =
           startMin !== undefined && endMin !== undefined && endMin < startMin;
+        const wrapDuration =
+          startMin !== undefined && endMin !== undefined
+            ? MINUTES_PER_DAY - startMin + endMin
+            : undefined;
+        const plausibleWrap =
+          wrapped &&
+          wrapDuration !== undefined &&
+          wrapDuration <= MAX_PLAUSIBLE_WRAP_MINUTES;
         const startIso = clockToIso(startClock, date);
-        const endIso = wrapped
+        const endIso = plausibleWrap
           ? clockToIso(endClock, nextCalendarDay(date))
           : clockToIso(endClock, date);
         current = {
@@ -164,7 +183,7 @@ export function reconstructFusionInputs(
 
       if (LOCATION_LINE.exec(line) !== null) continue;
 
-      const segmentMatch = SEGMENT_LINE.exec(line);
+      const segmentMatch = TRANSCRIPT_SEGMENT_LINE.exec(line);
       if (segmentMatch !== null) {
         if (current === null) continue; // segment outside any conversation
         const [, label, clock, rawText] = segmentMatch;

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -18,7 +18,7 @@
 
 import {
   isValidTranscriptDate,
-  TRANSCRIPT_SEGMENT_LINE,
+  parseTranscriptSegmentLine,
   unescapeSegmentText,
   unescapeSpeakerLabel,
 } from "../day-store.js";
@@ -192,10 +192,10 @@ export function reconstructFusionInputs(
 
       if (LOCATION_LINE.exec(line) !== null) continue;
 
-      const segmentMatch = TRANSCRIPT_SEGMENT_LINE.exec(line);
+      const segmentMatch = parseTranscriptSegmentLine(line);
       if (segmentMatch !== null) {
         if (current === null) continue; // segment outside any conversation
-        const [, label, clock, rawText] = segmentMatch;
+        const { label, clock, text: rawText } = segmentMatch;
         const text = escaped ? unescapeSegmentText(rawText) : rawText;
         const segMin = clockMinutesOfDay(clock);
         // A segment clock EARLIER than the conversation start clock MAY

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -21,6 +21,7 @@ import {
   TRANSCRIPT_SEGMENT_LINE,
   unescapeSegmentText,
 } from "../day-store.js";
+import { hasSelfMarker } from "../speakers.js";
 import type {
   FusionConversationInput,
   FusionSegmentInput,
@@ -81,10 +82,6 @@ function nextCalendarDay(date: string): string {
   const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
   const dd = String(dt.getUTCDate()).padStart(2, "0");
   return `${yy}-${mm}-${dd}`;
-}
-
-function isSelfLabel(label: string): boolean {
-  return /\(you\)\s*$/.test(label.trim());
 }
 
 /**
@@ -203,7 +200,10 @@ export function reconstructFusionInputs(
         const startIso = clockToIso(clock, segDate);
         const segment: FusionSegmentInput = {
           speaker: label.trim(),
-          isSelf: isSelfLabel(label),
+          // Self status is read from the RESERVED `(you)` marker, which the
+          // renderer guarantees can only appear on the wearer's label -
+          // never on a non-self display name (issue #1849).
+          isSelf: hasSelfMarker(label),
           text,
           ...(startIso !== undefined ? { startIso } : {}),
         };

--- a/packages/remnic-core/src/wearables/fusion/reconstruct.ts
+++ b/packages/remnic-core/src/wearables/fusion/reconstruct.ts
@@ -116,7 +116,6 @@ export function reconstructFusionInputs(
             : {}),
         };
         current.segments.push(segment);
-        continue;
       }
       // Unrecognized lines (e.g. the H1 source header) are ignored.
     }

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -12,6 +12,8 @@
  */
 
 import { createHash } from "node:crypto";
+import * as path from "node:path";
+import { isValidTranscriptDate } from "../day-store.js";
 import type {
   FusedDayFile,
   FusedDayMeta,
@@ -129,4 +131,81 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
     fusedAt: scalars.get("fusedAt") ?? "",
   };
   return { meta, conversations };
+}
+
+/** Reserved underscore-prefixed subdir for derived fusion artifacts. */
+export const FUSION_DIR_NAME = "_fusion";
+
+/**
+ * Encrypted-at-rest + atomic file IO the fusion artifact store needs.
+ * Satisfied by StorageManager (which owns the secure-store key + atomic
+ * write path) and injected so this module performs NO direct fs — the
+ * derived files inherit the same encrypted-at-rest + atomic-write
+ * semantics as raw day transcripts without this module knowing the key.
+ */
+export interface FusionFileIo {
+  writeFile(filePath: string, content: string): Promise<void>;
+  /** Read a file; rejects with ENOENT when it is absent. */
+  readFile(filePath: string): Promise<string>;
+  /** Directory entries; rejects with ENOENT when the directory is absent. */
+  readDir(dirPath: string): Promise<string[]>;
+}
+
+/**
+ * Owns the derived fused-day artifact files under
+ * `<wearablesDir>/_fusion/<YYYY-MM-DD>.md`. Path construction, date
+ * validation, and newest-first listing live here (relocated out of the
+ * root storage module — issue #1810 ratchet); the bytes flow through the
+ * injected secure IO.
+ */
+export class FusionArtifactStore {
+  constructor(
+    private readonly wearablesDir: string,
+    private readonly io: FusionFileIo,
+  ) {}
+
+  fusedDayPath(date: string): string {
+    if (!isValidTranscriptDate(date)) {
+      throw new Error(
+        `invalid wearable fusion date '${String(date)}' — expected YYYY-MM-DD`,
+      );
+    }
+    return path.join(this.wearablesDir, FUSION_DIR_NAME, `${date}.md`);
+  }
+
+  async writeFusedDay(date: string, serialized: string): Promise<void> {
+    await this.io.writeFile(this.fusedDayPath(date), serialized);
+  }
+
+  /** Read a stored fused-day artifact; null when absent. */
+  async readFusedDay(date: string): Promise<string | null> {
+    try {
+      return await this.io.readFile(this.fusedDayPath(date));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  /** List dates with stored fused artifacts, newest first. */
+  async listFusedDays(): Promise<string[]> {
+    let entries: string[];
+    try {
+      entries = await this.io.readDir(
+        path.join(this.wearablesDir, FUSION_DIR_NAME),
+      );
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const days: string[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const date = entry.slice(0, -3);
+      if (!isValidTranscriptDate(date)) continue;
+      days.push(date);
+    }
+    days.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
+    return days;
+  }
 }

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -13,6 +13,7 @@
 
 import { createHash } from "node:crypto";
 import * as path from "node:path";
+import { pathIsInside } from "../../utils/path-containment.js";
 import { isValidTranscriptDate } from "../day-store.js";
 import type {
   FusedDayFile,
@@ -280,6 +281,13 @@ export interface FusionFileIo {
   readFile(filePath: string): Promise<string>;
   /** Directory entries; rejects with ENOENT when the directory is absent. */
   readDir(dirPath: string): Promise<string[]>;
+  /**
+   * Resolve a path through symlinks (node:fs/promises realpath); rejects
+   * with ENOENT when the path is absent. Used by the symlink-containment
+   * guard so a symlinked `_fusion` dir (or parent) that resolves outside
+   * the wearables root is rejected before any read/write (AGENTS.md #3).
+   */
+  realpath(filePath: string): Promise<string>;
 }
 
 /**
@@ -305,13 +313,17 @@ export class FusionArtifactStore {
   }
 
   async writeFusedDay(date: string, serialized: string): Promise<void> {
-    await this.io.writeFile(this.fusedDayPath(date), serialized);
+    const filePath = this.fusedDayPath(date);
+    await this.assertPathContained(filePath);
+    await this.io.writeFile(filePath, serialized);
   }
 
   /** Read a stored fused-day artifact; null when absent. */
   async readFusedDay(date: string): Promise<string | null> {
+    const filePath = this.fusedDayPath(date);
+    await this.assertPathContained(filePath);
     try {
-      return await this.io.readFile(this.fusedDayPath(date));
+      return await this.io.readFile(filePath);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw err;
@@ -320,11 +332,11 @@ export class FusionArtifactStore {
 
   /** List dates with stored fused artifacts, newest first. */
   async listFusedDays(): Promise<string[]> {
+    const fusionDir = path.join(this.wearablesDir, FUSION_DIR_NAME);
+    await this.assertPathContained(fusionDir);
     let entries: string[];
     try {
-      entries = await this.io.readDir(
-        path.join(this.wearablesDir, FUSION_DIR_NAME),
-      );
+      entries = await this.io.readDir(fusionDir);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw err;
@@ -338,5 +350,42 @@ export class FusionArtifactStore {
     }
     days.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
     return days;
+  }
+
+  /**
+   * Reject a symlinked/traversing fusion artifact path before any IO. The
+   * fusion dir (`<wearablesDir>/_fusion`) and its parents are followed
+   * directly by the secure IO; a symlink placed there (attacker-writable
+   * or a malformed memory dir) would otherwise be followed and read/write
+   * outside the allowed root (AGENTS.md pattern #3). Resolve the candidate
+   * and the wearables root through realpath and refuse anything that
+   * escapes — mirroring `assertPathInsideRoot` in the storage walkers.
+   * Absent paths are allowed (the secure write creates them lexically
+   * under the root; a missing path cannot yet be a followable symlink).
+   */
+  private async assertPathContained(targetPath: string): Promise<void> {
+    let rootReal: string;
+    try {
+      rootReal = await this.io.realpath(this.wearablesDir);
+    } catch {
+      // Fresh dir not yet on disk — no symlink can resolve through a
+      // missing root, so fall back to a lexical resolve.
+      rootReal = path.resolve(this.wearablesDir);
+    }
+    // Guard both the fusion directory (the entry a writer controls) and,
+    // when present, the target file itself.
+    for (const candidate of [path.dirname(targetPath), targetPath]) {
+      let candidateReal: string;
+      try {
+        candidateReal = await this.io.realpath(candidate);
+      } catch {
+        continue; // absent — nothing to follow
+      }
+      if (!pathIsInside(rootReal, candidateReal)) {
+        throw new Error(
+          "wearable fusion artifact path resolves outside the wearables root — refusing to follow a symlink/traversal (AGENTS.md pattern #3)",
+        );
+      }
+    }
   }
 }

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -88,7 +88,11 @@ function parseNonNegativeInt(value: string | undefined): number {
 /**
  * Parse a persisted fused-day file. Returns null when the content does
  * not look like a fusion artifact (wrong kind / missing frontmatter) so
- * callers can distinguish "not fused" from a malformed file.
+ * callers can distinguish "not fused" from a malformed file. A non-null
+ * result carries `parseOk`: false when the JSON body was truncated/corrupt
+ * (conversations is empty in that case), true for a legitimately-empty
+ * `[]` body — so the skip-unchanged path can force a self-repair rewrite
+ * regardless of the recomputed conversation count.
  */
 export function parseFusionDay(raw: string): FusedDayFile | null {
   if (!raw.startsWith("---\n")) return null;
@@ -108,17 +112,23 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
   if (date === undefined) return null;
 
   let conversations: FusedWearableConversation[] = [];
+  let parseOk = true;
   const bodyTrimmed = body.trim();
   if (bodyTrimmed.length > 0) {
     try {
       const parsed: unknown = JSON.parse(bodyTrimmed);
       if (Array.isArray(parsed)) {
         conversations = parsed as FusedWearableConversation[];
+      } else {
+        // Valid JSON but not the expected array shape — flag as corrupt so
+        // callers recompute fusion rather than trusting an empty read.
+        parseOk = false;
       }
     } catch {
-      // A truncated/corrupt body parses to no conversations rather than
-      // throwing — callers recompute fusion rather than crashing reads.
-      conversations = [];
+      // A truncated/corrupt body fails to parse; flag parseOk:false so the
+      // skip-unchanged path forces a self-repair rewrite (even when the
+      // frontmatter hash matches and the recomputed count is also zero).
+      parseOk = false;
     }
   }
 
@@ -130,7 +140,7 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
     contentHash: scalars.get("contentHash") ?? "",
     fusedAt: scalars.get("fusedAt") ?? "",
   };
-  return { meta, conversations };
+  return { meta, conversations, parseOk };
 }
 
 /** Reserved underscore-prefixed subdir for derived fusion artifacts. */

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -281,11 +281,14 @@ export interface FusionFileIo {
   readFile(filePath: string): Promise<string>;
   /** Directory entries; rejects with ENOENT when the directory is absent. */
   readDir(dirPath: string): Promise<string[]>;
+  /** Remove a file; rejects with ENOENT when it is absent. */
+  deleteFile(filePath: string): Promise<void>;
   /**
    * Resolve a path through symlinks (node:fs/promises realpath); rejects
    * with ENOENT when the path is absent. Used by the symlink-containment
-   * guard so a symlinked `_fusion` dir (or parent) that resolves outside
-   * the wearables root is rejected before any read/write (AGENTS.md #3).
+   * guard so a symlinked `_fusion` dir (or a symlinked wearables root)
+   * that resolves outside the memory dir is rejected before any
+   * read/write/delete (AGENTS.md #3).
    */
   realpath(filePath: string): Promise<string>;
 }
@@ -300,6 +303,7 @@ export interface FusionFileIo {
 export class FusionArtifactStore {
   constructor(
     private readonly wearablesDir: string,
+    private readonly memoryDir: string,
     private readonly io: FusionFileIo,
   ) {}
 
@@ -330,6 +334,24 @@ export class FusionArtifactStore {
     }
   }
 
+  /**
+   * Remove a stored fused-day artifact. Idempotent: a no-op when the
+   * artifact is already absent. Used to clear a now-stale derived file
+   * before a fusion run that deliberately refuses to fuse (e.g. a day
+   * whose sources later conflict on timezone) so fusedConversations()
+   * does not keep serving a stale view (issue #1849).
+   */
+  async deleteFusedDay(date: string): Promise<void> {
+    const filePath = this.fusedDayPath(date);
+    await this.assertPathContained(filePath);
+    try {
+      await this.io.deleteFile(filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+  }
+
   /** List dates with stored fused artifacts, newest first. */
   async listFusedDays(): Promise<string[]> {
     const fusionDir = path.join(this.wearablesDir, FUSION_DIR_NAME);
@@ -356,36 +378,55 @@ export class FusionArtifactStore {
    * Reject a symlinked/traversing fusion artifact path before any IO. The
    * fusion dir (`<wearablesDir>/_fusion`) and its parents are followed
    * directly by the secure IO; a symlink placed there (attacker-writable
-   * or a malformed memory dir) would otherwise be followed and read/write
-   * outside the allowed root (AGENTS.md pattern #3). Resolve the candidate
-   * and the wearables root through realpath and refuse anything that
-   * escapes — mirroring `assertPathInsideRoot` in the storage walkers.
-   * Absent paths are allowed (the secure write creates them lexically
-   * under the root; a missing path cannot yet be a followable symlink).
+   * or a malformed memory dir) would otherwise be followed and
+   * read/write/delete outside the allowed root (AGENTS.md pattern #3).
+   *
+   * Containment is anchored to the real MEMORY-DIR root, not the
+   * wearables dir, AND the wearables root is checked explicitly: if
+   * `wearablesDir` itself is a symlink that resolves outside memoryDir, a
+   * leaf candidate like `<wearablesDir>/_fusion/<date>.md` may not yet
+   * exist (so its realpath ENOENT-skips) and the write would silently
+   * create the file inside the symlinked escape target. Checking
+   * `wearablesDir` itself — which resolves through the symlink when it
+   * exists — closes that gap, while the per-leaf checks catch a nested
+   * `_fusion` or per-file symlink. Absent paths are allowed (a fresh
+   * write creates them lexically under the root; only a path that
+   * resolves to an existing target can redirect IO). Mirrors
+   * `assertPathInsideRoot` in the storage walkers.
    */
   private async assertPathContained(targetPath: string): Promise<void> {
     let rootReal: string;
     try {
-      rootReal = await this.io.realpath(this.wearablesDir);
+      rootReal = await this.io.realpath(this.memoryDir);
     } catch {
-      // Fresh dir not yet on disk — no symlink can resolve through a
-      // missing root, so fall back to a lexical resolve.
-      rootReal = path.resolve(this.wearablesDir);
+      // Fresh memory dir not yet on disk — no symlink can resolve through
+      // a missing root, so fall back to a lexical resolve.
+      rootReal = path.resolve(this.memoryDir);
     }
-    // Guard both the fusion directory (the entry a writer controls) and,
-    // when present, the target file itself.
-    for (const candidate of [path.dirname(targetPath), targetPath]) {
-      let candidateReal: string;
-      try {
-        candidateReal = await this.io.realpath(candidate);
-      } catch {
-        continue; // absent — nothing to follow
-      }
-      if (!pathIsInside(rootReal, candidateReal)) {
-        throw new Error(
-          "wearable fusion artifact path resolves outside the wearables root — refusing to follow a symlink/traversal (AGENTS.md pattern #3)",
-        );
-      }
+    // The wearables root first (catches a symlinked wearables dir even
+    // when the leaf artifact does not yet exist), then the fusion dir and
+    // the target file itself.
+    await this.assertNoEscape(rootReal, this.wearablesDir);
+    await this.assertNoEscape(rootReal, path.dirname(targetPath));
+    await this.assertNoEscape(rootReal, targetPath);
+  }
+
+  /**
+   * Refuse a candidate whose realpath escapes the memory root. Absent
+   * candidates are allowed: a missing path cannot yet redirect IO, and
+   * the secure write creates it lexically under the root.
+   */
+  private async assertNoEscape(rootReal: string, candidate: string): Promise<void> {
+    let candidateReal: string;
+    try {
+      candidateReal = await this.io.realpath(candidate);
+    } catch {
+      return; // absent — nothing to follow
+    }
+    if (!pathIsInside(rootReal, candidateReal)) {
+      throw new Error(
+        "wearable fusion artifact path resolves outside the memory dir — refusing to follow a symlink/traversal (AGENTS.md pattern #3)",
+      );
     }
   }
 }

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -291,6 +291,14 @@ export interface FusionFileIo {
    * read/write/delete (AGENTS.md #3).
    */
   realpath(filePath: string): Promise<string>;
+  /**
+   * Stat a path WITHOUT following a trailing symlink
+   * (node:fs/promises lstat); rejects with ENOENT when the path is
+   * absent. Used to detect a pre-existing symlink at the fusion
+   * artifact directory itself, which is rejected even when its
+   * target resolves inside the memory dir (issue #1849).
+   */
+  lstat(filePath: string): Promise<{ isSymbolicLink: boolean }>;
 }
 
 /**
@@ -409,6 +417,37 @@ export class FusionArtifactStore {
     await this.assertNoEscape(rootReal, this.wearablesDir);
     await this.assertNoEscape(rootReal, path.dirname(targetPath));
     await this.assertNoEscape(rootReal, targetPath);
+    // Reject a symlinked `_fusion` dir outright — even when its
+    // target resolves INSIDE the memory dir. The managed fusion root
+    // is always a real directory created by the secure write; a
+    // pre-existing link there is tampering/aliasing and is refused
+    // before a single byte is written or read (issue #1849).
+    await this.assertFusionDirNotSymlinked();
+  }
+
+  /**
+   * Refuse a pre-existing symbolic link at the `<wearablesDir>/_fusion`
+   * directory. Unlike `assertNoEscape` (which follows the link and only
+   * rejects when the target lands outside the memory dir), this catches a
+   * fusion root that aliases an in-bounds path — e.g. a `_fusion` link
+   * pointed at a raw source transcript — so fusion IO never writes
+   * through it and overwrites the aliased file. Absent dirs are allowed
+   * (a fresh write creates a real directory lexically under the root).
+   */
+  private async assertFusionDirNotSymlinked(): Promise<void> {
+    const fusionDir = path.join(this.wearablesDir, FUSION_DIR_NAME);
+    let stat: { isSymbolicLink: boolean };
+    try {
+      stat = await this.io.lstat(fusionDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    if (stat.isSymbolicLink) {
+      throw new Error(
+        "wearable fusion dir '_fusion' is a symbolic link — refusing to follow it even when it resolves inside the memory dir (AGENTS.md pattern #3)",
+      );
+    }
   }
 
   /**

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -6,8 +6,9 @@
  * the day-transcript convention: YAML frontmatter (`kind:
  * wearable-fusion`) + a JSON body carrying the structured
  * `FusedWearableConversation[]`. The frontmatter `contentHash` is the
- * idempotency key derived purely from inputs, so an unchanged re-run
- * produces a byte-identical file.
+ * idempotency key derived from inputs plus the effective fusion config,
+ * so an unchanged re-run (same inputs AND config) produces a
+ * byte-identical file.
  */
 
 import { createHash } from "node:crypto";

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -44,6 +44,7 @@ export function composeFusionDayMeta(
     sourceCount: sources.length,
     conversationCount: conversations.length,
     contentHash,
+    bodyHash: hashFusionBody(conversations),
     fusedAt,
   };
 }
@@ -59,6 +60,7 @@ export function serializeFusionDay(
   lines.push(`sourceCount: ${meta.sourceCount}`);
   lines.push(`conversationCount: ${meta.conversationCount}`);
   lines.push(`contentHash: ${JSON.stringify(meta.contentHash)}`);
+  lines.push(`bodyHash: ${JSON.stringify(meta.bodyHash)}`);
   lines.push(`fusedAt: ${JSON.stringify(meta.fusedAt)}`);
   lines.push("---");
   lines.push("");
@@ -85,14 +87,129 @@ function parseNonNegativeInt(value: string | undefined): number {
   return Math.floor(parsed);
 }
 
+const FUSED_SEGMENT_PICK_REASONS: Record<string, true> = {
+  "only-source": true,
+  "higher-trust": true,
+  "more-complete": true,
+  "tie-break": true,
+};
+
+const FUSED_DISAGREEMENT_KINDS: Record<string, true> = {
+  "asr-text": true,
+  speaker: true,
+  timestamp: true,
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/** Structural guard for a parsed segment-provenance record. */
+function isFusedSegmentProvenance(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.source !== "string") return false;
+  if (typeof value.conversationId !== "string") return false;
+  if (typeof value.sourceTrust !== "number") return false;
+  if (typeof value.reason !== "string") return false;
+  if (!(value.reason in FUSED_SEGMENT_PICK_REASONS)) return false;
+  return (
+    Array.isArray(value.alternatives) &&
+    value.alternatives.every(
+      (alt) =>
+        isPlainObject(alt) && typeof alt.source === "string" && typeof alt.text === "string",
+    )
+  );
+}
+
+/** Structural guard for a parsed fused segment. */
+function isFusedSegment(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.speaker !== "string") return false;
+  if (typeof value.isSelf !== "boolean") return false;
+  if (typeof value.text !== "string") return false;
+  if (typeof value.confidence !== "number") return false;
+  return isFusedSegmentProvenance(value.provenance);
+}
+
+/** Structural guard for a parsed fused speaker. */
+function isFusedSpeaker(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.label !== "string") return false;
+  if (typeof value.isSelf !== "boolean") return false;
+  if (typeof value.confidence !== "number") return false;
+  return isStringArray(value.sources);
+}
+
+/** Structural guard for a parsed fused disagreement. */
+function isFusedDisagreement(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.kind !== "string") return false;
+  if (!(value.kind in FUSED_DISAGREEMENT_KINDS)) return false;
+  if (typeof value.subject !== "string") return false;
+  return (
+    Array.isArray(value.candidates) &&
+    value.candidates.every(
+      (cand) =>
+        isPlainObject(cand) && typeof cand.source === "string" && typeof cand.value === "string",
+    )
+  );
+}
+
+/** Structural guard for a parsed fused-conversation contribution record. */
+function isFusedContribution(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.source !== "string") return false;
+  if (typeof value.conversationId !== "string") return false;
+  if (typeof value.startIso !== "string") return false;
+  return typeof value.segmentCount === "number";
+}
+
+/** Structural guard for a parsed fused-conversation provenance record. */
+function isFusedConversationProvenance(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  if (!Array.isArray(value.contributions) || !value.contributions.every(isFusedContribution)) {
+    return false;
+  }
+  if (typeof value.proximityGapMs !== "number") return false;
+  if (typeof value.windowToleranceMs !== "number") return false;
+  return value.method === "time-proximity";
+}
+
+/**
+ * Structural guard for a parsed fused conversation. Every required field of
+ * `FusedWearableConversation` (and its nested segments / speakers /
+ * disagreements / provenance) must be present with the right shape, so a
+ * null, wrong-typed, or partial element (`[{}]`, `[null]`, `[{id:1}]`) is
+ * rejected and the caller treats the body as corrupt (parseOk:false →
+ * self-repair rewrite) rather than trusting it.
+ */
+function isFusedWearableConversation(value: unknown): value is FusedWearableConversation {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.id !== "string") return false;
+  if (typeof value.date !== "string") return false;
+  if (typeof value.startIso !== "string") return false;
+  if (!isStringArray(value.sources)) return false;
+  if (!Array.isArray(value.speakers) || !value.speakers.every(isFusedSpeaker)) return false;
+  if (!Array.isArray(value.segments) || !value.segments.every(isFusedSegment)) return false;
+  if (!Array.isArray(value.disagreements) || !value.disagreements.every(isFusedDisagreement)) {
+    return false;
+  }
+  return isFusedConversationProvenance(value.provenance);
+}
+
 /**
  * Parse a persisted fused-day file. Returns null when the content does
  * not look like a fusion artifact (wrong kind / missing frontmatter) so
  * callers can distinguish "not fused" from a malformed file. A non-null
- * result carries `parseOk`: false when the JSON body was truncated/corrupt
- * (conversations is empty in that case), true for a legitimately-empty
- * `[]` body — so the skip-unchanged path can force a self-repair rewrite
- * regardless of the recomputed conversation count.
+ * result carries `parseOk`: false when the JSON body failed to parse, was
+ * not an array, or held a malformed element (conversations is empty in
+ * that case), true for a well-formed (incl. legitimately-empty `[]`)
+ * body — so the skip-unchanged path can force a self-repair rewrite
+ * regardless of the recomputed conversation count or body hash.
  */
 export function parseFusionDay(raw: string): FusedDayFile | null {
   if (!raw.startsWith("---\n")) return null;
@@ -117,11 +234,14 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
   if (bodyTrimmed.length > 0) {
     try {
       const parsed: unknown = JSON.parse(bodyTrimmed);
-      if (Array.isArray(parsed)) {
-        conversations = parsed as FusedWearableConversation[];
+      if (Array.isArray(parsed) && parsed.every(isFusedWearableConversation)) {
+        conversations = parsed;
       } else {
-        // Valid JSON but not the expected array shape — flag as corrupt so
-        // callers recompute fusion rather than trusting an empty read.
+        // Valid JSON but not a well-formed FusedWearableConversation[]
+        // (non-array, or an array carrying a null / wrong-typed /
+        // missing-required-field element) — flag corrupt so callers
+        // recompute fusion rather than trusting a partial read. A
+        // legitimately-empty [] is accepted with parseOk left true.
         parseOk = false;
       }
     } catch {
@@ -138,6 +258,7 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
     sourceCount: parseNonNegativeInt(scalars.get("sourceCount")),
     conversationCount: parseNonNegativeInt(scalars.get("conversationCount")),
     contentHash: scalars.get("contentHash") ?? "",
+    bodyHash: scalars.get("bodyHash") ?? "",
     fusedAt: scalars.get("fusedAt") ?? "",
   };
   return { meta, conversations, parseOk };

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -1,0 +1,131 @@
+/**
+ * Wearable cross-source fusion — derived-day file serialization.
+ *
+ * One derived file per fused day, stored ALONGSIDE raw source transcripts
+ * (under the wearables tree) but never overwriting them. Format mirrors
+ * the day-transcript convention: YAML frontmatter (`kind:
+ * wearable-fusion`) + a JSON body carrying the structured
+ * `FusedWearableConversation[]`. The frontmatter `contentHash` is the
+ * idempotency key derived purely from inputs, so an unchanged re-run
+ * produces a byte-identical file.
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  FusedDayFile,
+  FusedDayMeta,
+  FusedWearableConversation,
+} from "./types.js";
+
+export const FUSION_KIND = "wearable-fusion" as const;
+
+/** Hash the canonical JSON body for idempotent skip-unchanged checks. */
+export function hashFusionBody(
+  conversations: readonly FusedWearableConversation[],
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify(conversations), "utf-8")
+    .digest("hex");
+}
+
+export function composeFusionDayMeta(
+  date: string,
+  conversations: readonly FusedWearableConversation[],
+  sources: readonly string[],
+  contentHash: string,
+  fusedAt: string,
+): FusedDayMeta {
+  return {
+    kind: FUSION_KIND,
+    date,
+    sourceCount: sources.length,
+    conversationCount: conversations.length,
+    contentHash,
+    fusedAt,
+  };
+}
+
+/** Serialize meta + conversations into the persisted file format. */
+export function serializeFusionDay(
+  meta: FusedDayMeta,
+  conversations: readonly FusedWearableConversation[],
+): string {
+  const lines: string[] = ["---"];
+  lines.push(`kind: ${meta.kind}`);
+  lines.push(`date: ${JSON.stringify(meta.date)}`);
+  lines.push(`sourceCount: ${meta.sourceCount}`);
+  lines.push(`conversationCount: ${meta.conversationCount}`);
+  lines.push(`contentHash: ${JSON.stringify(meta.contentHash)}`);
+  lines.push(`fusedAt: ${JSON.stringify(meta.fusedAt)}`);
+  lines.push("---");
+  lines.push("");
+  return `${lines.join("\n")}\n${JSON.stringify(conversations, null, 2)}\n`;
+}
+
+function parseScalar(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Fall through to the raw value below.
+    }
+  }
+  return trimmed;
+}
+
+function parseNonNegativeInt(value: string | undefined): number {
+  if (value === undefined) return 0;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+}
+
+/**
+ * Parse a persisted fused-day file. Returns null when the content does
+ * not look like a fusion artifact (wrong kind / missing frontmatter) so
+ * callers can distinguish "not fused" from a malformed file.
+ */
+export function parseFusionDay(raw: string): FusedDayFile | null {
+  if (!raw.startsWith("---\n")) return null;
+  const closeIndex = raw.indexOf("\n---\n", 4);
+  if (closeIndex === -1) return null;
+  const header = raw.slice(4, closeIndex);
+  const body = raw.slice(closeIndex + 5).replace(/^\n/, "");
+
+  const scalars = new Map<string, string>();
+  for (const line of header.split("\n")) {
+    const match = line.match(/^([A-Za-z][A-Za-z0-9]*): (.*)$/);
+    if (match) scalars.set(match[1], parseScalar(match[2]));
+  }
+
+  if (scalars.get("kind") !== FUSION_KIND) return null;
+  const date = scalars.get("date");
+  if (date === undefined) return null;
+
+  let conversations: FusedWearableConversation[] = [];
+  const bodyTrimmed = body.trim();
+  if (bodyTrimmed.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(bodyTrimmed);
+      if (Array.isArray(parsed)) {
+        conversations = parsed as FusedWearableConversation[];
+      }
+    } catch {
+      // A truncated/corrupt body parses to no conversations rather than
+      // throwing — callers recompute fusion rather than crashing reads.
+      conversations = [];
+    }
+  }
+
+  const meta: FusedDayMeta = {
+    kind: FUSION_KIND,
+    date,
+    sourceCount: parseNonNegativeInt(scalars.get("sourceCount")),
+    conversationCount: parseNonNegativeInt(scalars.get("conversationCount")),
+    contentHash: scalars.get("contentHash") ?? "",
+    fusedAt: scalars.get("fusedAt") ?? "",
+  };
+  return { meta, conversations };
+}

--- a/packages/remnic-core/src/wearables/fusion/store.ts
+++ b/packages/remnic-core/src/wearables/fusion/store.ts
@@ -232,7 +232,16 @@ export function parseFusionDay(raw: string): FusedDayFile | null {
   let conversations: FusedWearableConversation[] = [];
   let parseOk = true;
   const bodyTrimmed = body.trim();
-  if (bodyTrimmed.length > 0) {
+  if (bodyTrimmed.length === 0) {
+    // An existing artifact whose body is blank or whitespace-only (no
+    // JSON at all) is corrupt — it is NOT a valid empty `[]`. The
+    // serializer always writes `JSON.stringify(conversations, null, 2)`
+    // which produces `[]` for zero conversations, so a blank body means
+    // the file was truncated, partially written, or manually emptied.
+    // Flag parseOk:false so fusedConversations() surfaces the corruption
+    // and fuseDay() repairs it (issue #1849).
+    parseOk = false;
+  } else {
     try {
       const parsed: unknown = JSON.parse(bodyTrimmed);
       if (Array.isArray(parsed) && parsed.every(isFusedWearableConversation)) {

--- a/packages/remnic-core/src/wearables/fusion/types.ts
+++ b/packages/remnic-core/src/wearables/fusion/types.ts
@@ -202,4 +202,12 @@ export interface FusedDayMeta {
 export interface FusedDayFile {
   meta: FusedDayMeta;
   conversations: FusedWearableConversation[];
+  /**
+   * False when the JSON body failed to parse (truncated/corrupt). A
+   * legitimately empty (`[]`) body parses fine — parseOk stays true — so
+   * callers can distinguish "nothing to fuse" from a broken file and force
+   * a self-repair rewrite even when the frontmatter hash matches and the
+   * parsed conversation count is also zero.
+   */
+  parseOk: boolean;
 }

--- a/packages/remnic-core/src/wearables/fusion/types.ts
+++ b/packages/remnic-core/src/wearables/fusion/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Wearable cross-source fusion — shared types (issue #1810).
+ *
+ * Fusion merges same-day conversations from multiple enabled wearable
+ * sources into `FusedWearableConversation` artifacts: one reconciled
+ * timeline per real-world conversation, with per-segment source
+ * provenance and unresolved conflicts surfaced as `disagreements[]`.
+ *
+ * Everything in this module is DETERMINISTIC — no LLM calls. LLM-assisted
+ * reconciliation, memory-extraction over fused artifacts, and full
+ * segment-level alignment are deferred follow-ups (see PR body).
+ */
+
+/**
+ * One normalized segment fed into fusion. Speaker labels are already
+ * resolved through the speaker registry (`resolveSpeaker`), and text is
+ * post-cleanup + post-redaction — fusion consumes the same material day
+ * transcripts store, never raw provider output.
+ */
+export interface FusionSegmentInput {
+  /** Resolved speaker label (e.g. "Jane", "Me (you)", "Speaker 0"). */
+  speaker: string;
+  /** Whether this speaker is the wearer. */
+  isSelf: boolean;
+  /** Utterance text. */
+  text: string;
+  /** ISO 8601 start, when known. */
+  startIso?: string;
+  /** ISO 8601 end, when known. */
+  endIso?: string;
+}
+
+/** One normalized conversation fed into fusion. */
+export interface FusionConversationInput {
+  /** Source id this conversation came from. */
+  source: string;
+  /** Provider-stable conversation id within that source. */
+  conversationId: string;
+  /** Provider title, when available. */
+  title?: string;
+  /** Provider summary, when available. */
+  summary?: string;
+  /** ISO 8601 conversation start. */
+  startIso: string;
+  /** ISO 8601 conversation end, when known. */
+  endIso?: string;
+  /** Ordered normalized segments. */
+  segments: FusionSegmentInput[];
+}
+
+/** Why a particular source's text was chosen for a fused segment. */
+export type SegmentPickReason =
+  | "only-source"
+  | "higher-trust"
+  | "more-complete"
+  | "tie-break";
+
+/** Kind of unresolved conflict surfaced during reconciliation. */
+export type DisagreementKind = "asr-text" | "speaker" | "timestamp";
+
+/** Per-segment record of where the chosen text came from and what else was considered. */
+export interface FusedSegmentProvenance {
+  /** Source id the chosen text came from. */
+  source: string;
+  /** Conversation id within that source. */
+  conversationId: string;
+  /** Trust weight of the chosen source at reconciliation time (0..1). */
+  sourceTrust: number;
+  /** Why this source won the pick. */
+  reason: SegmentPickReason;
+  /** Other sources that offered a candidate text for this window/speaker. */
+  alternatives: Array<{ source: string; text: string }>;
+}
+
+/** One reconciled utterance in a fused conversation. */
+export interface FusedSegment {
+  /** Reconciled speaker label. */
+  speaker: string;
+  /** Whether this speaker is the wearer. */
+  isSelf: boolean;
+  /** Reconciled utterance text. */
+  text: string;
+  /** Window start (ISO), when known. */
+  startIso?: string;
+  /** Window end (ISO), when known. */
+  endIso?: string;
+  /** 0..1 confidence in this segment's text + attribution. */
+  confidence: number;
+  provenance: FusedSegmentProvenance;
+}
+
+/** An unresolved conflict that reconciliation could not settle deterministically. */
+export interface FusedDisagreement {
+  kind: DisagreementKind;
+  /**
+   * What the disagreement concerns — an ISO window anchor, a speaker
+   * label, or "(no timestamp)" for un-timestamped windows.
+   */
+  subject: string;
+  /** The conflicting candidates that could not be auto-resolved. */
+  candidates: Array<{ source: string; value: string }>;
+  /** Best-effort provisional winner; marked uncertain, NOT authoritative. */
+  provisional?: { source: string; value: string };
+}
+
+/** A reconciled speaker that appears in the fused conversation. */
+export interface FusedSpeaker {
+  /** Display label. */
+  label: string;
+  /** Whether this speaker is the wearer. */
+  isSelf: boolean;
+  /**
+   * 0..1 — lowered when a speaker could not be confidently matched
+   * across sources (e.g. a generic diarization label seen in one
+   * source only).
+   */
+  confidence: number;
+  /** Source ids that produced this speaker. */
+  sources: string[];
+}
+
+/** Record of one source conversation that fed a fused conversation. */
+export interface FusedContribution {
+  source: string;
+  conversationId: string;
+  startIso: string;
+  endIso?: string;
+  segmentCount: number;
+}
+
+/** How a fused conversation was assembled. */
+export interface FusedConversationProvenance {
+  /** Source conversations that fed this cluster. */
+  contributions: FusedContribution[];
+  /** Max gap (ms) two conversations could span and still merge. */
+  proximityGapMs: number;
+  /** Max drift (ms) for two segments to align across sources. */
+  windowToleranceMs: number;
+  /** Clustering method (deterministic, time-proximity based). */
+  method: "time-proximity";
+}
+
+/**
+ * A real-world conversation reconstructed from one or more wearable
+ * sources recording at the same time. The fused artifact.
+ */
+export interface FusedWearableConversation {
+  /** Stable content-hash id (deterministic from inputs; idempotent). */
+  id: string;
+  /** YYYY-MM-DD the conversation was recorded. */
+  date: string;
+  /** Earliest start across contributing sources. */
+  startIso: string;
+  /** Latest end across contributing sources, when known. */
+  endIso?: string;
+  /** Source ids that contributed at least one conversation. */
+  sources: string[];
+  /** Reconciled speakers (deduped across sources). */
+  speakers: FusedSpeaker[];
+  /** Provider title, when any source supplied one. */
+  title?: string;
+  /** Provider summary, when any source supplied one. */
+  summary?: string;
+  /** Aligned, reconciled segments in chronological order. */
+  segments: FusedSegment[];
+  /** Unresolved conflicts surfaced during reconciliation. */
+  disagreements: FusedDisagreement[];
+  provenance: FusedConversationProvenance;
+}
+
+/** Options for a fusion pass. */
+export interface FusionOptions {
+  /** Max gap (ms) between conversations to merge into one cluster. */
+  proximityGapMs?: number;
+  /** Max drift (ms) for two segments to align across sources. */
+  windowToleranceMs?: number;
+  /** Per-source trust weights (unknown sources default to 0.8). */
+  sourceTrust?: Record<string, number>;
+}
+
+/** Result of fusing one day across all sources. */
+export interface FusionDayResult {
+  date: string;
+  conversations: FusedWearableConversation[];
+  /** Distinct source ids that contributed any conversation. */
+  sources: string[];
+  /** SHA-256 of the canonical input serialization (idempotency key). */
+  contentHash: string;
+}
+
+/** Frontmatter persisted on a fused-day derived file. */
+export interface FusedDayMeta {
+  kind: "wearable-fusion";
+  date: string;
+  sourceCount: number;
+  conversationCount: number;
+  contentHash: string;
+  fusedAt: string;
+}
+
+/** A parsed fused-day derived file. */
+export interface FusedDayFile {
+  meta: FusedDayMeta;
+  conversations: FusedWearableConversation[];
+}

--- a/packages/remnic-core/src/wearables/fusion/types.ts
+++ b/packages/remnic-core/src/wearables/fusion/types.ts
@@ -195,6 +195,13 @@ export interface FusedDayMeta {
   sourceCount: number;
   conversationCount: number;
   contentHash: string;
+  /**
+   * SHA-256 over the canonical serialized body (`hashFusionBody`). Stored
+   * so the skip-unchanged path can detect a body whose bytes drifted from
+   * the recomputed artifact even when `contentHash` + conversation count
+   * still match — forcing a self-repair rewrite on body-level corruption.
+   */
+  bodyHash: string;
   fusedAt: string;
 }
 

--- a/packages/remnic-core/src/wearables/fusion/types.ts
+++ b/packages/remnic-core/src/wearables/fusion/types.ts
@@ -184,7 +184,7 @@ export interface FusionDayResult {
   conversations: FusedWearableConversation[];
   /** Distinct source ids that contributed any conversation. */
   sources: string[];
-  /** SHA-256 of the canonical input serialization (idempotency key). */
+  /** SHA-256 over the canonical input serialization + effective fusion config (idempotency key). */
   contentHash: string;
 }
 

--- a/packages/remnic-core/src/wearables/fusion/types.ts
+++ b/packages/remnic-core/src/wearables/fusion/types.ts
@@ -70,6 +70,14 @@ export interface FusedSegmentProvenance {
   reason: SegmentPickReason;
   /** Other sources that offered a candidate text for this window/speaker. */
   alternatives: Array<{ source: string; text: string }>;
+  /** The chosen source's ORIGINAL start time (ISO), when known. The fused
+   * segment is emitted on the group/window ANCHOR timeline position so
+   * pre-sorted chronology stays valid even when the higher-trust source's
+   * clock is later than the anchor; this preserves WHERE the chosen text
+   * was actually recorded for provenance/traceability. */
+  sourceStartIso?: string;
+  /** The chosen source's ORIGINAL end time (ISO), when known (see sourceStartIso). */
+  sourceEndIso?: string;
 }
 
 /** One reconciled utterance in a fused conversation. */

--- a/packages/remnic-core/src/wearables/index.ts
+++ b/packages/remnic-core/src/wearables/index.ts
@@ -61,12 +61,18 @@ export {
   type SpeakerRegistry,
 } from "./speakers.js";
 export {
+  bodyIsEscaped,
   composeDayTranscriptBody,
   composeDayTranscriptMeta,
+  decodeTranscriptBody,
+  escapeSegmentText,
   hashTranscriptBody,
   isValidTranscriptDate,
   parseDayTranscript,
   serializeDayTranscript,
+  TRANSCRIPT_FORMAT_VERSION,
+  unescapeSegmentText,
+  unescapeSpeakerLabel,
   WEARABLES_DIR_NAME,
 } from "./day-store.js";
 export {

--- a/packages/remnic-core/src/wearables/index.ts
+++ b/packages/remnic-core/src/wearables/index.ts
@@ -69,11 +69,13 @@ export {
   hashTranscriptBody,
   isValidTranscriptDate,
   parseDayTranscript,
+  parseTranscriptSegmentLine,
   serializeDayTranscript,
   TRANSCRIPT_FORMAT_VERSION,
   unescapeSegmentText,
   unescapeSpeakerLabel,
   WEARABLES_DIR_NAME,
+  type TranscriptSegmentMatch,
 } from "./day-store.js";
 export {
   emptySyncState,

--- a/packages/remnic-core/src/wearables/index.ts
+++ b/packages/remnic-core/src/wearables/index.ts
@@ -9,6 +9,7 @@ export * from "./types.js";
 export { describeErrorForOperator, WearablesInputError } from "./errors.js";
 export {
   defaultWearableCleanupSettings,
+  defaultWearableFusionConfig,
   defaultWearableSourceSettings,
   defaultWearablesConfig,
   KNOWN_WEARABLE_SOURCE_IDS,
@@ -112,3 +113,35 @@ export {
   type WearableTranscriptSearchResult,
   type WearablesServiceDeps,
 } from "./service.js";
+
+export {
+  clusterConversations,
+  composeFusionDayMeta,
+  DEFAULT_PROXIMITY_GAP_MS,
+  DEFAULT_SOURCE_TRUST,
+  DEFAULT_WINDOW_TOLERANCE_MS,
+  FUSION_KIND,
+  fuseCluster,
+  fuseDay,
+  fusionInputsFromConversations,
+  hashFusionBody,
+  parseFusionDay,
+  reconstructFusionInputs,
+  serializeFusionDay,
+  type FuseClusterResult,
+  type DisagreementKind,
+  type FusionConversationInput,
+  type FusionDayResult,
+  type FusionOptions,
+  type FusionSegmentInput,
+  type FusedConversationProvenance,
+  type FusedContribution,
+  type FusedDayFile,
+  type FusedDayMeta,
+  type FusedDisagreement,
+  type FusedSegment,
+  type FusedSegmentProvenance,
+  type FusedSpeaker,
+  type FusedWearableConversation,
+  type SegmentPickReason,
+} from "./fusion/index.js";

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -9,6 +9,7 @@ import {
   composeDayTranscriptMeta,
   serializeDayTranscript,
 } from "./day-store.js";
+import { FusionArtifactStore } from "./fusion/index.js";
 import { emptySpeakerRegistry } from "./speakers.js";
 import {
   createWearableMemoryWriter,
@@ -35,6 +36,23 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
   }>;
 } {
   const fusedFiles = new Map<string, string>();
+  const fusionStore = new FusionArtifactStore(path.join(memoryDir, "wearables"), {
+    writeFile: async (filePath, content) => {
+      fusedFiles.set(filePath, content);
+    },
+    readFile: async (filePath) => {
+      if (!fusedFiles.has(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`) as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return fusedFiles.get(filePath)!;
+    },
+    readDir: async (dirPath) =>
+      [...fusedFiles.keys()]
+        .filter((key) => path.dirname(key) === dirPath)
+        .map((key) => path.basename(key)),
+  });
   const files = new Map<string, string>();
   const storage = {
     dir: memoryDir,
@@ -66,14 +84,8 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
         .filter((entry) => sourceId === undefined || entry.source === sourceId)
         .sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
     },
-    async writeWearableFusedDay(date: string, serialized: string) {
-      fusedFiles.set(date, serialized);
-    },
-    async readWearableFusedDay(date: string) {
-      return fusedFiles.get(date) ?? null;
-    },
-    async listWearableFusedDays() {
-      return [...fusedFiles.keys()].sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
+    fusionArtifactStore() {
+      return fusionStore;
     },
     async readAllMemories() {
       return storage.memories;
@@ -636,7 +648,7 @@ test("fuseDay writes a derived artifact, is idempotent, and leaves raw transcrip
     });
 
     // No fused artifact yet.
-    assert.equal(await storage.readWearableFusedDay("2026-06-10"), null);
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
 
     const first = await service.fuseDay("2026-06-10");
     assert.equal(first.written, true);

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -807,3 +807,68 @@ test("fuseDay rewrites an artifact whose body is corrupt despite a matching cont
   }
 });
 
+test("fuseDay rewrites a corrupt body even when the expected conversation count is zero", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // No stored transcripts for this day -> fusion yields ZERO conversations.
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: {
+        enabled: true,
+        proximityGapMs: 300_000,
+        windowToleranceMs: 30_000,
+      },
+    });
+
+    // First fuse writes a valid (empty) artifact.
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.equal(first.conversationCount, 0);
+    const hash = first.contentHash;
+
+    // A legitimately-empty ([] body) artifact must SKIP on re-run: same
+    // inputs + config, clean parse, 0 == 0 -> not rewritten.
+    const idempotent = await service.fuseDay("2026-06-10");
+    assert.equal(idempotent.written, false, "a valid empty body must skip");
+    assert.equal(idempotent.contentHash, hash);
+
+    // Corrupt the stored body while leaving the frontmatter (incl.
+    // contentHash) intact: truncated JSON that the lenient read parser
+    // reduces to zero conversations.
+    const fusionStore = storage.fusionArtifactStore();
+    const validRaw = await fusionStore.readFusedDay("2026-06-10");
+    assert.ok(validRaw);
+    const closeIdx = validRaw!.indexOf("\n---\n", 4);
+    assert.ok(closeIdx !== -1, "fused artifact has a closing frontmatter delimiter");
+    const corruptRaw = `${validRaw!.slice(0, closeIdx + 5)}\n{ this is not valid JSON`;
+    await fusionStore.writeFusedDay("2026-06-10", corruptRaw);
+
+    // The corrupted body reads as zero conversations, and the recomputed
+    // result is ALSO zero — without the parseOk signal this 0 == 0 match
+    // plus a matching hash would silently skip and leave the bad file.
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+
+    // Re-fuse: matching hash + 0 == 0 but a corrupt body (parseOk:false)
+    // => self-repair (written: true), not a silent skip.
+    const repaired = await service.fuseDay("2026-06-10");
+    assert.equal(
+      repaired.written,
+      true,
+      "a corrupt body must be rewritten even when the expected count is zero",
+    );
+    assert.equal(repaired.contentHash, hash);
+    assert.equal(repaired.conversationCount, 0);
+
+    // A final re-run is idempotent again: the repaired body parses cleanly,
+    // so it skips (written: false), proving the rewrite was a one-off
+    // self-repair rather than a permanent forced write.
+    const final = await service.fuseDay("2026-06-10");
+    assert.equal(final.written, false, "a repaired artifact must skip on the next run");
+    assert.equal(final.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -673,3 +673,60 @@ test("fuseDay writes a derived artifact, is idempotent, and leaves raw transcrip
     rmSync(storage.dir, { recursive: true, force: true });
   }
 });
+
+test("fuseDay rebuilds the artifact when fusion config changes (not skipped)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Two enabled sources recorded the same overlapping window.
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+
+    const baseSources = {
+      limitless: { ...defaultWearableSourceSettings(), enabled: true },
+      bee: { ...defaultWearableSourceSettings(), enabled: true },
+    };
+
+    const serviceGap5m = makeService(storage, {
+      sources: baseSources,
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    // Initial fuse writes the artifact.
+    const first = await serviceGap5m.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    const firstHash = first.contentHash;
+
+    // Unchanged inputs + config => idempotent skip.
+    const rerun = await serviceGap5m.fuseDay("2026-06-10");
+    assert.equal(rerun.written, false, "unchanged inputs+config must not rewrite");
+    assert.equal(rerun.contentHash, firstHash);
+
+    // Tune proximityGapMs => new content hash => artifact rebuilt, not skipped.
+    const serviceGap10m = makeService(storage, {
+      sources: baseSources,
+      fusion: { enabled: true, proximityGapMs: 600_000, windowToleranceMs: 30_000 },
+    });
+    const afterGap = await serviceGap10m.fuseDay("2026-06-10");
+    assert.equal(afterGap.written, true, "proximityGapMs change must trigger a rebuild");
+    assert.notEqual(afterGap.contentHash, firstHash);
+
+    // Re-run under the new config => idempotent skip again.
+    const afterGapRerun = await serviceGap10m.fuseDay("2026-06-10");
+    assert.equal(afterGapRerun.written, false);
+    assert.equal(afterGapRerun.contentHash, afterGap.contentHash);
+
+    // Tune per-source trust => new content hash => artifact rebuilt.
+    const serviceTrust = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true, sourceTrust: 0.95 },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 600_000, windowToleranceMs: 30_000 },
+    });
+    const afterTrust = await serviceTrust.fuseDay("2026-06-10");
+    assert.equal(afterTrust.written, true, "per-source trust change must trigger a rebuild");
+    assert.notEqual(afterTrust.contentHash, afterGap.contentHash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -1239,3 +1239,96 @@ test("fuseDay skips when a source lacks a resolvable timezone id", async () => {
   }
 });
 
+test("fuseDay ignores a zero-conversation source when checking timezone identity (issue #1849)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // limitless CONTRIBUTES a real conversation under one timezone.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    // bee is an EMPTY (all-elided / zero-conversation) transcript — the
+    // sync path writes one explicitly for days whose segments were all
+    // dropped. It carries a DIFFERENT timezone, but contributes NO
+    // conversations/clocks, so it must not block the fusion.
+    const registry = emptySpeakerRegistry();
+    const beeBody = composeDayTranscriptBody(
+      "bee",
+      "2026-06-10",
+      "Asia/Tokyo",
+      [],
+      registry,
+    );
+    const beeMeta = composeDayTranscriptMeta(
+      "bee",
+      "2026-06-10",
+      "Asia/Tokyo",
+      [],
+      registry,
+      beeBody,
+      "2026-06-11T01:00:00.000Z",
+    );
+    storage.files.set("bee/2026-06-10", serializeDayTranscript(beeMeta, beeBody));
+
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-06-10");
+    // The zero-conversation source is ignored; the single contributing
+    // source fuses normally (NOT skipped).
+    assert.equal(result.written, true, "a zero-conversation source must not block fusion");
+    assert.equal(result.skipped, undefined);
+    assert.ok(result.conversationCount >= 1, "the contributing source still fuses");
+    assert.deepEqual([...result.sources].sort(), ["limitless"]);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay still skips when two CONTRIBUTING sources disagree on timezone (issue #1849)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Both sources CONTRIBUTE a real conversation but under DIFFERENT
+    // timezones — the guard must still skip. This is the contrasting case
+    // to ignoring zero-conversation sources: only sources that actually
+    // contribute clocks are compared, and two disagreeing contributors skip.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    storeDay(
+      storage,
+      "bee",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "Asia/Tokyo",
+    );
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-06-10");
+    assert.equal(result.written, false, "two disagreeing contributing sources must skip");
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(result.sources.length, 0);
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -742,3 +742,68 @@ test("fuseDay rebuilds the artifact when fusion config changes (not skipped)", a
     rmSync(storage.dir, { recursive: true, force: true });
   }
 });
+test("fuseDay rewrites an artifact whose body is corrupt despite a matching contentHash", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Two enabled sources recorded the same overlapping window.
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: {
+        enabled: true,
+        proximityGapMs: 300_000,
+        windowToleranceMs: 30_000,
+      },
+    });
+
+    // Initial fuse writes a valid artifact.
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.ok(first.conversationCount >= 1, "overlapping sources fuse into >=1 conversation");
+    const hash = first.contentHash;
+
+    // Corrupt the stored body while leaving the frontmatter (incl.
+    // contentHash) intact: a truncated/garbled JSON body that the lenient
+    // read parser reduces to zero conversations.
+    const fusionStore = storage.fusionArtifactStore();
+    const validRaw = await fusionStore.readFusedDay("2026-06-10");
+    assert.ok(validRaw);
+    const closeIdx = validRaw!.indexOf("\n---\n", 4);
+    assert.ok(closeIdx !== -1, "fused artifact has a closing frontmatter delimiter");
+    const corruptRaw = `${validRaw!.slice(0, closeIdx + 5)}\n{ this is not valid JSON`;
+    await fusionStore.writeFusedDay("2026-06-10", corruptRaw);
+
+    // The corrupted artifact now reads as zero conversations.
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+
+    // Re-fuse: matching contentHash but a corrupt body => self-repair
+    // (written: true), not a silent skip that leaves the bad file in place.
+    const repaired = await service.fuseDay("2026-06-10");
+    assert.equal(repaired.written, true, "a corrupt body must be rewritten despite a matching hash");
+    assert.equal(repaired.contentHash, hash, "inputs+config are unchanged so the hash is stable");
+    assert.equal(repaired.conversationCount, first.conversationCount);
+
+    // Subsequent read returns the correct conversations again.
+    const conversations = await service.fusedConversations("2026-06-10");
+    assert.equal(conversations.length, first.conversationCount);
+    assert.ok(conversations[0]!.id.startsWith("fusion-"));
+    assert.deepEqual(
+      [...conversations[0]!.sources].sort(),
+      ["bee", "limitless"],
+    );
+
+    // A final re-run is idempotent again: the repaired body is valid, so
+    // it is skipped (written: false), proving the rewrite was a one-off
+    // self-repair rather than a permanent forced write.
+    const idempotent = await service.fuseDay("2026-06-10");
+    assert.equal(idempotent.written, false, "a repaired artifact must skip on the next run");
+    assert.equal(idempotent.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -34,6 +34,7 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
     content: string;
   }>;
 } {
+  const fusedFiles = new Map<string, string>();
   const files = new Map<string, string>();
   const storage = {
     dir: memoryDir,
@@ -64,6 +65,15 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
         })
         .filter((entry) => sourceId === undefined || entry.source === sourceId)
         .sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
+    },
+    async writeWearableFusedDay(date: string, serialized: string) {
+      fusedFiles.set(date, serialized);
+    },
+    async readWearableFusedDay(date: string) {
+      return fusedFiles.get(date) ?? null;
+    },
+    async listWearableFusedDays() {
+      return [...fusedFiles.keys()].sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
     },
     async readAllMemories() {
       return storage.memories;
@@ -593,5 +603,73 @@ test("speaker and correction management round-trips through the service", async 
     await assert.rejects(service.removeCorrection(5), /out of range/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay is gated by wearables.fusion.enabled", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["Hello world."]);
+    const service = makeService(storage); // fusion defaults to disabled
+    await assert.rejects(() => service.fuseDay("2026-06-10"), /fusion is not enabled/);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay writes a derived artifact, is idempotent, and leaves raw transcripts untouched", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Two enabled sources recorded the same overlapping window.
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: {
+        enabled: true,
+        proximityGapMs: 300_000,
+        windowToleranceMs: 30_000,
+      },
+    });
+
+    // No fused artifact yet.
+    assert.equal(await storage.readWearableFusedDay("2026-06-10"), null);
+
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.ok(first.conversationCount >= 1, "overlapping sources fuse into >=1 conversation");
+    assert.deepEqual([...first.sources].sort(), ["bee", "limitless"]);
+
+    // The derived artifact is readable via the listing surface.
+    const conversations = await service.fusedConversations("2026-06-10");
+    assert.equal(conversations.length, first.conversationCount);
+    assert.ok(conversations[0]!.id.startsWith("fusion-"));
+    assert.deepEqual(
+      [...conversations[0]!.sources].sort(),
+      ["bee", "limitless"],
+    );
+
+    // Idempotent re-run: identical inputs -> not written again.
+    const second = await service.fuseDay("2026-06-10");
+    assert.equal(second.written, false, "unchanged inputs must not rewrite the artifact");
+    assert.equal(second.contentHash, first.contentHash);
+
+    // Raw per-source transcripts remain readable and untouched.
+    const limitlessRaw = await storage.readWearableDayTranscript("limitless", "2026-06-10");
+    const beeRaw = await storage.readWearableDayTranscript("bee", "2026-06-10");
+    assert.notEqual(limitlessRaw, null);
+    assert.notEqual(beeRaw, null);
+    // Raw transcripts are byte-identical to what was stored (fusion never
+    // overwrites source transcripts).
+    assert.ok(limitlessRaw?.includes("We agreed to ship Friday."));
+    assert.ok(beeRaw?.includes("We agreed to ship Friday."));
+
+    // listFusedDays surfaces the fused date.
+    assert.deepEqual(await service.listFusedDays(), ["2026-06-10"]);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -872,3 +872,118 @@ test("fuseDay rewrites a corrupt body even when the expected conversation count 
   }
 });
 
+test("fuseDay rewrites an artifact whose body has malformed elements despite matching hash + bodyHash + count", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.ok(first.conversationCount >= 1);
+    const hash = first.contentHash;
+
+    // Replace ONLY the body with a parseable-but-malformed array `[{}]`,
+    // leaving every frontmatter field (contentHash, bodyHash, count)
+    // intact. The body parses as JSON and is an array, but its element is
+    // not a well-formed FusedWearableConversation — element validation
+    // must drive parseOk:false so fuseDay rewrites rather than trusting
+    // the matching hashes + count.
+    const fusionStore = storage.fusionArtifactStore();
+    const validRaw = await fusionStore.readFusedDay("2026-06-10");
+    assert.ok(validRaw);
+    const closeIdx = validRaw!.indexOf("\n---\n", 4);
+    assert.ok(closeIdx !== -1);
+    await fusionStore.writeFusedDay("2026-06-10", `${validRaw!.slice(0, closeIdx + 5)}\n[{}]`);
+
+    // The malformed body reads as zero conversations.
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+
+    // Re-fuse: matching hash + bodyHash + count but parseOk:false => rewrite.
+    const repaired = await service.fuseDay("2026-06-10");
+    assert.equal(repaired.written, true, "a malformed-element body must be rewritten");
+    assert.equal(repaired.contentHash, hash);
+    assert.equal(repaired.conversationCount, first.conversationCount);
+
+    // Repaired body is valid again, so the next run skips idempotently.
+    const idempotent = await service.fuseDay("2026-06-10");
+    assert.equal(idempotent.written, false, "a repaired artifact must skip on the next run");
+    assert.equal(idempotent.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay rewrites an artifact whose body bytes drifted despite matching contentHash + count", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.ok(first.conversationCount >= 1);
+    const hash = first.contentHash;
+
+    // Tamper: keep the body structurally valid (parses, every element is a
+    // well-formed conversation, same conversation count) but ALTER its
+    // bytes, leaving the frontmatter (contentHash + bodyHash + count)
+    // untouched. parseOk stays true and contentHash still matches, so only
+    // the body-hash recompute over the stored body can catch the drift.
+    const fusionStore = storage.fusionArtifactStore();
+    const validRaw = await fusionStore.readFusedDay("2026-06-10");
+    assert.ok(validRaw);
+    const closeIdx = validRaw!.indexOf("\n---\n", 4);
+    assert.ok(closeIdx !== -1);
+    const header = validRaw!.slice(0, closeIdx + 5);
+    const bodyJson = validRaw!.slice(closeIdx + 5).replace(/^\n/, "").trimEnd();
+    const convs = JSON.parse(bodyJson) as Array<{ segments: Array<{ text: string }> }>;
+    convs[0]!.segments[0]!.text += " [tampered]";
+    await fusionStore.writeFusedDay(
+      "2026-06-10",
+      `${header}\n${JSON.stringify(convs, null, 2)}\n`,
+    );
+
+    // The tampered body still parses cleanly (valid structure + elements),
+    // so it is served until the next fuseDay repairs it.
+    const tampered = await service.fusedConversations("2026-06-10");
+    assert.equal(tampered.length, first.conversationCount);
+    assert.ok(tampered[0]!.segments[0]!.text.includes("[tampered]"));
+
+    // Re-fuse: contentHash matches + parseOk true, but the stored body
+    // hash no longer matches a recompute over the stored body => rewrite.
+    const repaired = await service.fuseDay("2026-06-10");
+    assert.equal(
+      repaired.written,
+      true,
+      "a byte-drifted body must be rewritten via the body-hash check",
+    );
+    assert.equal(repaired.contentHash, hash);
+    assert.equal(repaired.conversationCount, first.conversationCount);
+
+    // The repaired body no longer carries the tampered text.
+    const restored = await service.fusedConversations("2026-06-10");
+    assert.ok(!restored[0]!.segments[0]!.text.includes("[tampered]"));
+
+    const idempotent = await service.fuseDay("2026-06-10");
+    assert.equal(idempotent.written, false);
+    assert.equal(idempotent.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -8,9 +8,19 @@ import { test } from "node:test";
 import {
   composeDayTranscriptBody,
   composeDayTranscriptMeta,
+  parseDayTranscript,
   serializeDayTranscript,
 } from "./day-store.js";
-import { FusionArtifactStore } from "./fusion/index.js";
+import {
+  DEFAULT_SOURCE_TRUST,
+  FUSION_ALGO_VERSION,
+  FusionArtifactStore,
+  canonicalDayKey,
+  composeFusionDayMeta,
+  parseFusionDay,
+  reconstructFusionInputs,
+  serializeFusionDay,
+} from "./fusion/index.js";
 import { emptySpeakerRegistry } from "./speakers.js";
 import {
   createWearableMemoryWriter,
@@ -639,6 +649,35 @@ test("fuseDay is gated by wearables.fusion.enabled", async () => {
   }
 });
 
+test("fuseDay honors the wearables master gate before the fusion gate (issue #1849)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["Hello world."]);
+    // wearables.enabled=false but fusion.enabled=true — fuseDay must refuse
+    // at the master gate (the same assertEnabled() sync/checkAuth use),
+    // before reading any source or touching the derived artifact store.
+    const service = makeService(storage, {
+      enabled: false,
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+    await assert.rejects(
+      () => service.fuseDay("2026-06-10"),
+      /wearables are not enabled/,
+    );
+    // The master-gate refusal must not write or delete any fusion artifact.
+    assert.equal(
+      await storage.fusionArtifactStore().readFusedDay("2026-06-10"),
+      null,
+      "master-gate refusal must not mutate derived fusion state",
+    );
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
 test("fuseDay writes a derived artifact, is idempotent, and leaves raw transcripts untouched", async () => {
   const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
   try {
@@ -748,6 +787,95 @@ test("fuseDay rebuilds the artifact when fusion config changes (not skipped)", a
     const afterTrust = await serviceTrust.fuseDay("2026-06-10");
     assert.equal(afterTrust.written, true, "per-source trust change must trigger a rebuild");
     assert.notEqual(afterTrust.contentHash, afterGap.contentHash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay regenerates a stale artifact written under an older algorithm version (issue #1849)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const baseSources = {
+      limitless: { ...defaultWearableSourceSettings(), enabled: true },
+      bee: { ...defaultWearableSourceSettings(), enabled: true },
+    };
+    const fusionConfig = { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 };
+    const service = makeService(storage, { sources: baseSources, fusion: fusionConfig });
+
+    // Initial fuse writes the artifact under the current algorithm version.
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    const currentHash = first.contentHash;
+
+    // Unchanged inputs + same version => idempotent skip.
+    const rerun = await service.fuseDay("2026-06-10");
+    assert.equal(rerun.written, false, "same version must be idempotent");
+
+    // Simulate a pre-bump artifact: reconstruct the same inputs the service
+    // fuses and compute the day hash under a STALE algorithm version, then
+    // overwrite the stored artifact with the SAME body but that stale hash.
+    const bodies = await Promise.all(
+      ["limitless", "bee"].map(async (source) => {
+        const raw = await storage.readWearableDayTranscript(source, "2026-06-10");
+        const parsed = parseDayTranscript(raw ?? "");
+        return { source, body: parsed?.body ?? raw ?? "" };
+      }),
+    );
+    const reconstructed = reconstructFusionInputs("2026-06-10", bodies);
+    const staleHash = canonicalDayKey(
+      "2026-06-10",
+      reconstructed,
+      {
+        proximityGapMs: 300_000,
+        windowToleranceMs: 30_000,
+        sourceTrust: { limitless: DEFAULT_SOURCE_TRUST, bee: DEFAULT_SOURCE_TRUST },
+      },
+      "2000-01-01-stale",
+    );
+    assert.notEqual(staleHash, currentHash, "sanity: stale-version hash differs");
+    // Sanity: the current-version hash matches what the service produced —
+    // the only difference between staleHash and currentHash is the version.
+    assert.equal(
+      canonicalDayKey(
+        "2026-06-10",
+        reconstructed,
+        {
+          proximityGapMs: 300_000,
+          windowToleranceMs: 30_000,
+          sourceTrust: { limitless: DEFAULT_SOURCE_TRUST, bee: DEFAULT_SOURCE_TRUST },
+        },
+        FUSION_ALGO_VERSION,
+      ),
+      currentHash,
+      "sanity: canonicalDayKey with the current version matches fuseDay output",
+    );
+
+    // Overwrite the stored artifact with the SAME conversations but the stale
+    // contentHash (same body => same bodyHash; only the version-derived
+    // contentHash differs).
+    const store = storage.fusionArtifactStore();
+    const rawArtifact = await store.readFusedDay("2026-06-10");
+    const parsedArtifact = parseFusionDay(rawArtifact ?? "");
+    assert.ok(parsedArtifact, "artifact must exist after initial fuse");
+    const staleMeta = composeFusionDayMeta(
+      "2026-06-10",
+      parsedArtifact!.conversations,
+      [...first.sources].sort(),
+      staleHash,
+      parsedArtifact!.meta.fusedAt,
+    );
+    await store.writeFusedDay(
+      "2026-06-10",
+      serializeFusionDay(staleMeta, parsedArtifact!.conversations),
+    );
+
+    // Re-fuse: the recomputed hash (current version) != stale stored hash, so
+    // the artifact is regenerated rather than skipped.
+    const afterStale = await service.fuseDay("2026-06-10");
+    assert.equal(afterStale.written, true, "stale algo-version artifact must be regenerated");
+    assert.equal(afterStale.contentHash, currentHash, "regenerated hash matches the current algorithm");
   } finally {
     rmSync(storage.dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { realpath as fsRealpath } from "node:fs/promises";
 import { test } from "node:test";
 
 import {
@@ -52,6 +53,7 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
       [...fusedFiles.keys()]
         .filter((key) => path.dirname(key) === dirPath)
         .map((key) => path.basename(key)),
+    realpath: (filePath) => fsRealpath(filePath),
   });
   const files = new Map<string, string>();
   const storage = {

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -1508,3 +1508,46 @@ test("fuseDay still skips when two CONTRIBUTING sources disagree on timezone (is
     rmSync(storage.dir, { recursive: true, force: true });
   }
 });
+
+
+test("dayTranscript returns decoded segment text, not the escaped storage form (#1849)", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "remnic-service-"));
+  try {
+    const storage = makeStorage(dir);
+    // Segment text carries a real newline + a literal backslash. The stored
+    // file escapes both; the user-facing view must decode them back.
+    const original = "Line one.\nLine two with a backslash \\ path.";
+    storeDay(storage, "limitless", "2026-06-10", [original]);
+    const service = makeService(storage);
+    const views = await service.dayTranscript("2026-06-10");
+    assert.equal(views.length, 1);
+    assert.ok(views[0].body.includes(original), "view shows the original (decoded) text");
+    assert.ok(
+      views[0].body.includes("Line one.\\nLine two") === false,
+      "no escaped-newline leak in the user-facing view",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("searchTranscripts scan decodes segment text so snippets show the original (#1849)", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "remnic-service-"));
+  try {
+    const storage = makeStorage(dir);
+    // Segment text spans a newline; the escaped storage form would leak a
+    // literal backslash-n into the snippet unless the scan decodes first.
+    storeDay(storage, "limitless", "2026-06-10", ["Alpha part.\nBeta GAPWORD here."]);
+    const service = makeService(storage);
+    const results = await service.searchTranscripts("GAPWORD");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].backend, "scan");
+    assert.ok(results[0].snippet.includes("GAPWORD"));
+    assert.ok(
+      results[0].snippet.includes("Alpha part.\\nBeta") === false,
+      "snippet has no escaped-newline leak",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -71,6 +71,20 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
       }
     },
     realpath: (filePath) => fsRealpath(filePath),
+    lstat: async (filePath) => {
+      // The in-memory mock models no real symlinks: a `_fusion` dir
+      // "exists" when at least one fused file lives beneath it, and is
+      // never itself a symbolic link.
+      const hasChildren = [...fusedFiles.keys()].some(
+        (k) => path.dirname(k) === filePath,
+      );
+      if (!hasChildren) {
+        const err = new Error(`ENOENT: ${filePath}`) as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return { isSymbolicLink: false };
+    },
   });
   const files = new Map<string, string>();
   const storage = {

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -37,7 +37,7 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
   }>;
 } {
   const fusedFiles = new Map<string, string>();
-  const fusionStore = new FusionArtifactStore(path.join(memoryDir, "wearables"), {
+  const fusionStore = new FusionArtifactStore(path.join(memoryDir, "wearables"), memoryDir, {
     writeFile: async (filePath, content) => {
       fusedFiles.set(filePath, content);
     },
@@ -53,6 +53,13 @@ function makeStorage(memoryDir: string): WearableStorageIo & {
       [...fusedFiles.keys()]
         .filter((key) => path.dirname(key) === dirPath)
         .map((key) => path.basename(key)),
+    deleteFile: async (filePath) => {
+      if (!fusedFiles.delete(filePath)) {
+        const err = new Error(`ENOENT: ${filePath}`) as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+    },
     realpath: (filePath) => fsRealpath(filePath),
   });
   const files = new Map<string, string>();
@@ -1025,6 +1032,61 @@ test("fuseDay skips a day whose sources were rendered under conflicting timezone
     assert.equal(result.sources.length, 0);
     // No artifact is written for the conflicting day.
     assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay clears a stale fused artifact when a later run skips on conflicting timezones", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // First, both sources share one timezone -> the day fuses successfully.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    storeDay(
+      storage,
+      "bee",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const first = await service.fuseDay("2026-06-10");
+    assert.equal(first.written, true);
+    assert.ok(first.conversationCount >= 1, "same-timezone sources fuse");
+    // A fused artifact now exists and is served by the listing surface.
+    assert.notEqual(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    assert.ok((await service.fusedConversations("2026-06-10")).length >= 1);
+
+    // Later sync: bee's source is re-rendered under a DIFFERENT timezone
+    // (Asia/Tokyo, UTC+9), conflicting with limitless (UTC-7 in summer).
+    storeDay(
+      storage,
+      "bee",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "Asia/Tokyo",
+    );
+
+    // Re-fuse: the day is now skipped, and the stale artifact MUST be
+    // cleared so fusedConversations() stops serving it (issue #1849).
+    const result = await service.fuseDay("2026-06-10");
+    assert.equal(result.written, false);
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
   } finally {
     rmSync(storage.dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -329,6 +329,59 @@ test("zero in-scope indexed hits fall back to the bounded scan", async () => {
   }
 });
 
+test("indexed search escapes the query and decodes the snippet (#1849)", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "remnic-service-"));
+  try {
+    const storage = makeStorage(dir);
+    // Segment text carries a literal backslash. In the stored file the
+    // backslash is doubled, so the indexed text has C:\\GAPDIR while
+    // the original had C:\GAPDIR. The indexed backend must receive
+    // the escaped form to match the indexed representation.
+    storeDay(storage, "limitless", "2026-06-10", ["File at C:\\GAPDIR\\report.txt"]);
+
+    const receivedQueries: string[] = [];
+    const service = new WearablesService({
+      config: { ...defaultWearablesConfig(), enabled: true },
+      getStorage: async () => storage,
+      extract: null,
+      searchBackend: {
+        async search(query: string) {
+          receivedQueries.push(query);
+          // Simulate a hit whose preview carries the escaped form.
+          return [
+            {
+              path: "/memory/wearables/limitless/2026-06-10.md",
+              score: 0.9,
+              preview: "**Me (you)** [10:00]: File at C:\\\\GAPDIR\\\\report.txt",
+            },
+          ];
+        },
+      },
+    });
+
+    const results = await service.searchTranscripts("C:\\GAPDIR");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].backend, "indexed");
+    assert.equal(results[0].source, "limitless");
+    // The escaped query form (doubled backslash) must reach the backend.
+    assert.ok(
+      receivedQueries.some((q) => q === "C:\\\\GAPDIR"),
+      "indexed backend must receive escaped query for backslash content",
+    );
+    // The snippet must show the DECODED original (single backslash).
+    assert.ok(
+      results[0].snippet.includes("C:\\GAPDIR"),
+      "snippet shows decoded single backslash",
+    );
+    assert.ok(
+      !results[0].snippet.includes("C:\\\\GAPDIR"),
+      "no escaped-backslash leak in snippet",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("transcriptMemories filters by wearable source and day", async () => {
   const dir = mkdtempSync(path.join(tmpdir(), "remnic-service-"));
   try {

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -915,8 +915,9 @@ test("fuseDay rewrites an artifact whose body is corrupt despite a matching cont
     const corruptRaw = `${validRaw!.slice(0, closeIdx + 5)}\n{ this is not valid JSON`;
     await fusionStore.writeFusedDay("2026-06-10", corruptRaw);
 
-    // The corrupted artifact now reads as zero conversations.
-    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+    // The corrupted artifact surfaces as a corrupt-artifact error, not a
+    // clean empty list (issue #1849).
+    await assert.rejects(service.fusedConversations("2026-06-10"), /corrupt/);
 
     // Re-fuse: matching contentHash but a corrupt body => self-repair
     // (written: true), not a silent skip that leaves the bad file in place.
@@ -983,10 +984,11 @@ test("fuseDay rewrites a corrupt body even when the expected conversation count 
     const corruptRaw = `${validRaw!.slice(0, closeIdx + 5)}\n{ this is not valid JSON`;
     await fusionStore.writeFusedDay("2026-06-10", corruptRaw);
 
-    // The corrupted body reads as zero conversations, and the recomputed
-    // result is ALSO zero — without the parseOk signal this 0 == 0 match
-    // plus a matching hash would silently skip and leave the bad file.
-    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+    // The corrupted body surfaces as a corrupt-artifact error (not a clean
+    // empty), and the recomputed result is ALSO zero — without the parseOk
+    // signal this 0 == 0 match plus a matching hash would silently skip
+    // and leave the bad file.
+    await assert.rejects(service.fusedConversations("2026-06-10"), /corrupt/);
 
     // Re-fuse: matching hash + 0 == 0 but a corrupt body (parseOk:false)
     // => self-repair (written: true), not a silent skip.
@@ -1041,8 +1043,8 @@ test("fuseDay rewrites an artifact whose body has malformed elements despite mat
     assert.ok(closeIdx !== -1);
     await fusionStore.writeFusedDay("2026-06-10", `${validRaw!.slice(0, closeIdx + 5)}\n[{}]`);
 
-    // The malformed body reads as zero conversations.
-    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+    // The malformed body surfaces as a corrupt-artifact error (issue #1849).
+    await assert.rejects(service.fusedConversations("2026-06-10"), /corrupt/);
 
     // Re-fuse: matching hash + bodyHash + count but parseOk:false => rewrite.
     const repaired = await service.fuseDay("2026-06-10");
@@ -1054,6 +1056,52 @@ test("fuseDay rewrites an artifact whose body has malformed elements despite mat
     const idempotent = await service.fuseDay("2026-06-10");
     assert.equal(idempotent.written, false, "a repaired artifact must skip on the next run");
     assert.equal(idempotent.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fusedConversations surfaces a corrupt artifact distinctly, not as a clean empty (issue #1849)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    storeDay(storage, "limitless", "2026-06-10", ["We agreed to ship Friday."]);
+    storeDay(storage, "bee", "2026-06-10", ["We agreed to ship Friday."]);
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    // Initial fuse writes a valid artifact with >= 1 conversation.
+    const first = await service.fuseDay("2026-06-10");
+    assert.ok(first.conversationCount >= 1);
+
+    // A day that was never fused returns [] — the "no artifact" path.
+    assert.deepEqual(await service.fusedConversations("2026-07-01"), []);
+
+    // Corrupt the body: valid frontmatter, garbled JSON body.
+    const fusionStore = storage.fusionArtifactStore();
+    const validRaw = await fusionStore.readFusedDay("2026-06-10");
+    assert.ok(validRaw);
+    const closeIdx = validRaw!.indexOf("\n---\n", 4);
+    assert.ok(closeIdx !== -1);
+    await fusionStore.writeFusedDay(
+      "2026-06-10",
+      `${validRaw!.slice(0, closeIdx + 5)}\n{ this is not valid JSON`,
+    );
+
+    // The corrupt artifact must NOT look like "no conversations" — it must
+    // throw so the caller/CLI can distinguish corruption from absence and
+    // prompt a re-fuse, rather than silently returning an empty list.
+    await assert.rejects(
+      service.fusedConversations("2026-06-10"),
+      /corrupt/,
+    );
+
+    // The "never fused" path is unchanged — still returns [].
+    assert.deepEqual(await service.fusedConversations("2026-07-01"), []);
   } finally {
     rmSync(storage.dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -6,6 +6,7 @@ import { realpath as fsRealpath } from "node:fs/promises";
 import { test } from "node:test";
 
 import {
+  bodyIsEscaped,
   composeDayTranscriptBody,
   composeDayTranscriptMeta,
   parseDayTranscript,
@@ -887,7 +888,11 @@ test("fuseDay regenerates a stale artifact written under an older algorithm vers
       ["limitless", "bee"].map(async (source) => {
         const raw = await storage.readWearableDayTranscript(source, "2026-06-10");
         const parsed = parseDayTranscript(raw ?? "");
-        return { source, body: parsed?.body ?? raw ?? "" };
+        return {
+          source,
+          body: parsed?.body ?? raw ?? "",
+          escaped: bodyIsEscaped(parsed?.meta),
+        };
       }),
     );
     const reconstructed = reconstructFusionInputs("2026-06-10", bodies);

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -1092,12 +1092,14 @@ test("fuseDay clears a stale fused artifact when a later run skips on conflictin
   }
 });
 
-test("fuseDay still fuses sources whose timezones share one UTC offset", async () => {
+test("fuseDay skips sources that share a UTC offset but differ in timezone id", async () => {
   const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
   try {
-    // Two sources with DIFFERENT tz names but the SAME offset on this
-    // summer date (America/Los_Angeles and America/Tijuana are both
-    // UTC-7 on 2026-06-10) must still fuse — they sit on one timeline.
+    // America/Los_Angeles and America/Tijuana are both UTC-7 on this
+    // summer date, so the OLD noon-offset guard fused them. Under the
+    // tz-identity model their DIFFERENT IANA ids must skip instead:
+    // reconstructFusionInputs only compares local HH:MM clocks safely
+    // when every source carries one explicit, identical tz id.
     storeDay(
       storage,
       "limitless",
@@ -1121,9 +1123,117 @@ test("fuseDay still fuses sources whose timezones share one UTC offset", async (
     });
 
     const result = await service.fuseDay("2026-06-10");
-    assert.equal(result.written, true, "same-offset sources fuse normally");
-    assert.equal(result.skipped, undefined);
-    assert.ok(result.conversationCount >= 1);
+    assert.equal(result.written, false, "differing tz ids skip even at equal offset");
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(result.sources.length, 0);
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay skips a DST-date pair whose noon offsets coincide (LA vs Phoenix on 2026-03-08)", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Regression for the codex finding: on 2026-03-08 America/Los_Angeles
+    // springs forward (UTC-8 -> UTC-7) at 02:00 while America/Phoenix
+    // stays UTC-7 all day. Both zones are UTC-7 by local NOON, so the old
+    // single-offset guard fused the day — yet recordings before LA's
+    // switch sat an hour apart and were misaligned on the fused timeline.
+    // Exact tz-id identity now refuses this pair up front.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-03-08",
+      ["Morning standup before the DST switch."],
+      "America/Los_Angeles",
+    );
+    storeDay(
+      storage,
+      "bee",
+      "2026-03-08",
+      ["Morning standup before the DST switch."],
+      "America/Phoenix",
+    );
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-03-08");
+    assert.equal(result.written, false, "DST-date coincident-offset pair skips");
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(result.sources.length, 0);
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-03-08"), null);
+    assert.equal((await service.fusedConversations("2026-03-08")).length, 0);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay skips when a source lacks a resolvable timezone id", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // limitless carries an explicit tz id; bee's transcript is missing the
+    // timezone field entirely. The guard must NOT coerce the missing id to
+    // a default and silently match — any unresolvable tz fails safe.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    // Build bee's transcript the normal way, then strip the timezone line
+    // so the persisted frontmatter has no resolvable tz id.
+    const registry = emptySpeakerRegistry();
+    const conversations: WearableConversation[] = [
+      {
+        id: "bee-2026-06-10",
+        source: "bee",
+        title: "Stored conversation",
+        startIso: "2026-06-10T10:00:00.000Z",
+        endIso: "2026-06-10T10:30:00.000Z",
+        segments: [{ speakerKey: "user", isWearer: true, text: "We agreed to ship Friday." }],
+      },
+    ];
+    const beeBody = composeDayTranscriptBody(
+      "bee",
+      "2026-06-10",
+      "UTC",
+      conversations,
+      registry,
+    );
+    const beeMeta = composeDayTranscriptMeta(
+      "bee",
+      "2026-06-10",
+      "UTC",
+      conversations,
+      registry,
+      beeBody,
+      "2026-06-11T01:00:00.000Z",
+    );
+    const beeRaw = serializeDayTranscript(beeMeta, beeBody).replace(/^timezone: .*\n/m, "");
+    storage.files.set("bee/2026-06-10", beeRaw);
+
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-06-10");
+    assert.equal(result.written, false, "a missing tz id fails safe");
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(result.sources.length, 0);
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    assert.equal((await service.fusedConversations("2026-06-10")).length, 0);
   } finally {
     rmSync(storage.dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/service.test.ts
+++ b/packages/remnic-core/src/wearables/service.test.ts
@@ -134,6 +134,7 @@ function storeDay(
   sourceId: string,
   date: string,
   texts: string[],
+  timezone = "UTC",
 ): void {
   const registry = emptySpeakerRegistry();
   const conversations: WearableConversation[] = [
@@ -150,11 +151,11 @@ function storeDay(
       })),
     },
   ];
-  const body = composeDayTranscriptBody(sourceId, date, "UTC", conversations, registry);
+  const body = composeDayTranscriptBody(sourceId, date, timezone, conversations, registry);
   const meta = composeDayTranscriptMeta(
     sourceId,
     date,
-    "UTC",
+    timezone,
     conversations,
     registry,
     body,
@@ -984,6 +985,83 @@ test("fuseDay rewrites an artifact whose body bytes drifted despite matching con
     const idempotent = await service.fuseDay("2026-06-10");
     assert.equal(idempotent.written, false);
     assert.equal(idempotent.contentHash, hash);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay skips a day whose sources were rendered under conflicting timezones", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Two enabled sources recorded the same window but in DIFFERENT
+    // timezones whose UTC offsets genuinely differ on this date
+    // (America/Los_Angeles is UTC-7 in summer; Asia/Tokyo is UTC+9).
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    storeDay(
+      storage,
+      "bee",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "Asia/Tokyo",
+    );
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-06-10");
+    // Fail-safe: the day is skipped with a reason, not silently misaligned.
+    assert.equal(result.written, false);
+    assert.equal(result.skipped?.reason, "conflicting-timezones");
+    assert.equal(result.sources.length, 0);
+    // No artifact is written for the conflicting day.
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+  } finally {
+    rmSync(storage.dir, { recursive: true, force: true });
+  }
+});
+
+test("fuseDay still fuses sources whose timezones share one UTC offset", async () => {
+  const storage = makeStorage(mkdtempSync(path.join(tmpdir(), "remnic-fusion-")));
+  try {
+    // Two sources with DIFFERENT tz names but the SAME offset on this
+    // summer date (America/Los_Angeles and America/Tijuana are both
+    // UTC-7 on 2026-06-10) must still fuse — they sit on one timeline.
+    storeDay(
+      storage,
+      "limitless",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Los_Angeles",
+    );
+    storeDay(
+      storage,
+      "bee",
+      "2026-06-10",
+      ["We agreed to ship Friday."],
+      "America/Tijuana",
+    );
+    const service = makeService(storage, {
+      sources: {
+        limitless: { ...defaultWearableSourceSettings(), enabled: true },
+        bee: { ...defaultWearableSourceSettings(), enabled: true },
+      },
+      fusion: { enabled: true, proximityGapMs: 300_000, windowToleranceMs: 30_000 },
+    });
+
+    const result = await service.fuseDay("2026-06-10");
+    assert.equal(result.written, true, "same-offset sources fuse normally");
+    assert.equal(result.skipped, undefined);
+    assert.ok(result.conversationCount >= 1);
   } finally {
     rmSync(storage.dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -13,7 +13,7 @@ import {
 } from "./corrections.js";
 import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
-import { isValidTranscriptDate, parseDayTranscript } from "./day-store.js";
+import { isValidTranscriptDate, parseDayTranscript, utcOffsetMinutesForDate } from "./day-store.js";
 import {
   composeFusionDayMeta,
   type FusionArtifactStore,
@@ -25,6 +25,7 @@ import {
   type FusedWearableConversation,
 } from "./fusion/index.js";
 import { stripAttributesSuffix } from "../storage.js";
+import { log } from "../logger.js";
 import type { MemoryFrontmatter } from "../types.js";
 import type { WearableMemoryGenDeps } from "./memory-gen.js";
 import { WEARABLE_SOURCE_PREFIX, wearableSourceLabel } from "./memory-gen.js";
@@ -491,6 +492,7 @@ export class WearablesService {
     conversationCount: number;
     contentHash: string;
     written: boolean;
+    skipped?: { reason: string };
   }> {
     if (!this.deps.config.fusion.enabled) {
       throw new WearablesInputError(
@@ -503,10 +505,43 @@ export class WearablesService {
     const storage = await this.deps.getStorage();
     const enabled = this.enabledSources();
     const bodies: Array<{ source: string; body: string }> = [];
+    const sourceTimezones: string[] = [];
     for (const [source] of enabled) {
       const raw = await storage.readWearableDayTranscript(source, date);
       if (raw === null) continue;
-      bodies.push({ source, body: parseDayTranscript(raw)?.body ?? raw });
+      const parsed = parseDayTranscript(raw);
+      bodies.push({ source, body: parsed?.body ?? raw });
+      sourceTimezones.push(parsed?.meta.timezone ?? "UTC");
+    }
+    // Mixed-timezone guard (codex P2): reconstructFusionInputs rebuilds every
+    // clock as `${date}T${HH}:${MM}:00Z` assuming all sources share one tz.
+    // Sources rendered under DIFFERENT UTC offsets would misalign on the
+    // fused timeline; detect that and skip the day with a logged reason
+    // rather than silently producing misaligned ISO. Full cross-tz offset
+    // normalization is deferred (see the precision caveat in reconstruct.ts).
+    if (bodies.length > 1) {
+      const offsets = sourceTimezones.map((tz) => utcOffsetMinutesForDate(date, tz));
+      const allKnown = offsets.every((offset) => offset !== null);
+      const allEqual = allKnown && offsets.every((offset) => offset === offsets[0]);
+      if (!allEqual) {
+        const detail = bodies
+          .map(
+            (entry, i) =>
+              `${entry.source}=${sourceTimezones[i]}(${offsets[i] === null ? "?" : offsets[i]}m)`,
+          )
+          .join(", ");
+        log.warn(
+          `wearables fusion: skipping ${date} — sources were rendered under conflicting timezones (${detail}); full cross-tz normalization is deferred`,
+        );
+        return {
+          date,
+          sources: [],
+          conversationCount: 0,
+          contentHash: "",
+          written: false,
+          skipped: { reason: "conflicting-timezones" },
+        };
+      }
     }
     const sourceTrust: Record<string, number> = {};
     for (const [id, settings] of enabled) {

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -16,6 +16,7 @@ import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { isValidTranscriptDate, parseDayTranscript } from "./day-store.js";
 import {
   composeFusionDayMeta,
+  type FusionArtifactStore,
   fuseDay as fuseDayInputs,
   parseFusionDay,
   reconstructFusionInputs,
@@ -67,9 +68,7 @@ export interface WearableStorageIo {
   listWearableTranscriptDays(
     sourceId?: string,
   ): Promise<Array<{ source: string; date: string }>>;
-  writeWearableFusedDay(date: string, serialized: string): Promise<void>;
-  readWearableFusedDay(date: string): Promise<string | null>;
-  listWearableFusedDays(): Promise<string[]>;
+  fusionArtifactStore(): FusionArtifactStore;
   readAllMemories(): Promise<
     Array<{
       path: string;
@@ -519,7 +518,7 @@ export class WearablesService {
     });
     // Idempotent skip-unchanged: do not rewrite when the content hash
     // matches the stored artifact (mirrors the raw-transcript fast path).
-    const existingRaw = await storage.readWearableFusedDay(date);
+    const existingRaw = await storage.fusionArtifactStore().readFusedDay(date);
     const existingHash =
       parseFusionDay(existingRaw ?? "")?.meta.contentHash ?? null;
     const written = existingHash !== result.contentHash;
@@ -531,7 +530,7 @@ export class WearablesService {
         result.contentHash,
         new Date().toISOString(),
       );
-      await storage.writeWearableFusedDay(
+      await storage.fusionArtifactStore().writeFusedDay(
         date,
         serializeFusionDay(meta, result.conversations),
       );
@@ -557,7 +556,7 @@ export class WearablesService {
       throw new WearablesInputError(`invalid date '${date}' — expected YYYY-MM-DD`);
     }
     const storage = await this.deps.getStorage();
-    const raw = await storage.readWearableFusedDay(date);
+    const raw = await storage.fusionArtifactStore().readFusedDay(date);
     if (raw === null) return [];
     return parseFusionDay(raw)?.conversations ?? [];
   }
@@ -565,7 +564,7 @@ export class WearablesService {
   /** List dates with stored fused artifacts, newest first. */
   async listFusedDays(): Promise<string[]> {
     const storage = await this.deps.getStorage();
-    return storage.listWearableFusedDays();
+    return storage.fusionArtifactStore().listFusedDays();
   }
 
   /**

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -494,6 +494,7 @@ export class WearablesService {
     written: boolean;
     skipped?: { reason: string };
   }> {
+    this.assertEnabled();
     if (!this.deps.config.fusion.enabled) {
       throw new WearablesInputError(
         "wearables fusion is not enabled — set `wearables.fusion.enabled: true` in the plugin config",

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -480,8 +480,8 @@ export class WearablesService {
   /**
    * Fuse all enabled sources' stored transcripts for one day into a
    * derived `FusedWearableConversation[]` artifact. Deterministic and
-   * idempotent: unchanged inputs produce a stable content hash and the
-   * derived file is left untouched on re-run. Requires
+   * idempotent: unchanged inputs and fusion config produce a stable
+   * content hash and the derived file is left untouched on re-run. Requires
    * `wearables.fusion.enabled`; otherwise it throws. Raw per-source
    * transcripts are never modified.
    */

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -13,7 +13,11 @@ import {
 } from "./corrections.js";
 import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
-import { isValidTranscriptDate, parseDayTranscript } from "./day-store.js";
+import {
+  decodeTranscriptBody,
+  isValidTranscriptDate,
+  parseDayTranscript,
+} from "./day-store.js";
 import {
   composeFusionDayMeta,
   type FusionArtifactStore,
@@ -455,7 +459,13 @@ export class WearablesService {
         source,
         date,
         meta: parsed?.meta ?? null,
-        body: parsed?.body ?? raw,
+        // Decode escaped segment text for display: the stored body is an
+        // internal line-based serialization (newlines/backslashes escaped
+        // so segment text survives the serialize -> reconstruct round
+        // trip); user-facing view surfaces must show the original text.
+        // The fusion reconstruct path reads raw bodies separately and
+        // decodes once during parse, so this never double-decodes (#1849).
+        body: decodeTranscriptBody(parsed?.body ?? raw),
         overlapsWith: [],
       });
     }
@@ -714,7 +724,9 @@ export class WearablesService {
             source: located.source,
             date: located.date,
             score: hit.score,
-            snippet: hit.preview,
+            // Decode the escaped serialization so the snippet shows the
+            // original segment text (#1849).
+            snippet: decodeTranscriptBody(hit.preview),
             backend: "indexed",
           });
           if (results.length >= limit) break;
@@ -740,7 +752,10 @@ export class WearablesService {
       if (!matchesScope(source, date)) continue;
       const raw = await storage.readWearableDayTranscript(source, date);
       if (raw === null) continue;
-      const body = parseDayTranscript(raw)?.body ?? raw;
+      // Decode escaped segment text so searches match AND snippets show
+      // the ORIGINAL text (e.g. a real newline or backslash), not the
+      // internal escape serialization (#1849).
+      const body = decodeTranscriptBody(parseDayTranscript(raw)?.body ?? raw);
       const lower = body.toLowerCase();
       const index = lower.indexOf(needle);
       if (index === -1) continue;

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -18,6 +18,7 @@ import {
   composeFusionDayMeta,
   type FusionArtifactStore,
   fuseDay as fuseDayInputs,
+  hashFusionBody,
   parseFusionDay,
   reconstructFusionInputs,
   serializeFusionDay,
@@ -516,26 +517,28 @@ export class WearablesService {
       windowToleranceMs: this.deps.config.fusion.windowToleranceMs,
       sourceTrust,
     });
-    // Idempotent skip-unchanged: do not rewrite when the content hash
-    // matches the stored artifact AND the stored body parsed cleanly into
-    // the expected conversation set. A truncated/corrupt body fails to
-    // parse (parseOk:false) even when the frontmatter hash matches and the
-    // recomputed conversation count is also zero, so we rewrite to
-    // self-repair instead of trusting the hash alone (mirrors the
-    // raw-transcript fast path otherwise).
+    // Idempotent skip-unchanged: do not rewrite when the input content
+    // hash matches the stored artifact, the stored body parsed cleanly
+    // into a well-formed conversation set, AND the stored body hash still
+    // matches a recompute over the stored body itself. A
+    // truncated/corrupt/malformed-element body fails to parse
+    // (parseOk:false) even when the frontmatter hash matches, and a body
+    // whose bytes drifted fails the body-hash recompute even when the
+    // input hash + conversation count still match — so either forces a
+    // self-repair rewrite instead of trusting the hashes alone.
     const existingRaw = await storage.fusionArtifactStore().readFusedDay(date);
     const existing = parseFusionDay(existingRaw ?? "");
     // parseOk is bound to a local so the skip condition can keep the
-    // explicit `existing !== null` guard for the `.meta`/`.conversations`
-    // accesses below — an inline `existing.parseOk` member check there
-    // trips useOptionalChain (whose suggested fix would drop the guard and
-    // null-deref the later accesses), so we read it via optional chain.
+    // explicit `existing !== null` guard for the `.meta` access below —
+    // an inline `existing.parseOk` member check there trips
+    // useOptionalChain (whose suggested fix would drop the guard and
+    // null-deref the later access), so we read it via optional chain.
     const parsedCleanly = existing?.parseOk === true;
     const skipUnchanged =
       existing !== null &&
       parsedCleanly &&
       existing.meta.contentHash === result.contentHash &&
-      existing.conversations.length === result.conversations.length;
+      existing.meta.bodyHash === hashFusionBody(existing.conversations);
     const written = !skipUnchanged;
     if (written) {
       const meta = composeFusionDayMeta(

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -626,8 +626,12 @@ export class WearablesService {
 
   /**
    * List fused conversations for a date (the fusion listing surface).
-   * Returns the persisted derived artifact, or an empty array when no
-   * fused artifact has been written for that day.
+   * Returns the persisted derived artifact's conversations, or an empty
+   * array when no fused artifact has been written for that day. When a
+   * file EXISTS but its body is corrupt (parseOk:false), throws
+   * WearablesInputError so the caller can distinguish a broken artifact
+   * from a day that was never fused — never silently returns an empty
+   * list that looks identical to "no artifact" (issue #1849).
    */
   async fusedConversations(
     date: string,
@@ -638,7 +642,14 @@ export class WearablesService {
     const storage = await this.deps.getStorage();
     const raw = await storage.fusionArtifactStore().readFusedDay(date);
     if (raw === null) return [];
-    return parseFusionDay(raw)?.conversations ?? [];
+    const parsed = parseFusionDay(raw);
+    if (parsed === null) return [];
+    if (!parsed.parseOk) {
+      throw new WearablesInputError(
+        `fused artifact for ${date} is corrupt — re-run \`wearables fuse ${date}\` to repair`,
+      );
+    }
+    return parsed.conversations;
   }
 
   /** List dates with stored fused artifacts, newest first. */

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -533,6 +533,10 @@ export class WearablesService {
         log.warn(
           `wearables fusion: skipping ${date} — sources were rendered under conflicting timezones (${detail}); full cross-tz normalization is deferred`,
         );
+        // Clear any previously-fused artifact for this day: a day that
+        // fused successfully before must not keep serving a stale view
+        // now that this run explicitly refuses to fuse (issue #1849).
+        await storage.fusionArtifactStore().deleteFusedDay(date);
         return {
           date,
           sources: [],

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -517,15 +517,23 @@ export class WearablesService {
       sourceTrust,
     });
     // Idempotent skip-unchanged: do not rewrite when the content hash
-    // matches the stored artifact AND the stored body still parses into
-    // the expected conversation set. A truncated/corrupt body parses to
-    // an empty (or count-mismatched) list even when the frontmatter hash
-    // matches, so we rewrite to self-repair instead of trusting the hash
-    // alone (mirrors the raw-transcript fast path otherwise).
+    // matches the stored artifact AND the stored body parsed cleanly into
+    // the expected conversation set. A truncated/corrupt body fails to
+    // parse (parseOk:false) even when the frontmatter hash matches and the
+    // recomputed conversation count is also zero, so we rewrite to
+    // self-repair instead of trusting the hash alone (mirrors the
+    // raw-transcript fast path otherwise).
     const existingRaw = await storage.fusionArtifactStore().readFusedDay(date);
     const existing = parseFusionDay(existingRaw ?? "");
+    // parseOk is bound to a local so the skip condition can keep the
+    // explicit `existing !== null` guard for the `.meta`/`.conversations`
+    // accesses below — an inline `existing.parseOk` member check there
+    // trips useOptionalChain (whose suggested fix would drop the guard and
+    // null-deref the later accesses), so we read it via optional chain.
+    const parsedCleanly = existing?.parseOk === true;
     const skipUnchanged =
       existing !== null &&
+      parsedCleanly &&
       existing.meta.contentHash === result.contentHash &&
       existing.conversations.length === result.conversations.length;
     const written = !skipUnchanged;

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -517,11 +517,18 @@ export class WearablesService {
       sourceTrust,
     });
     // Idempotent skip-unchanged: do not rewrite when the content hash
-    // matches the stored artifact (mirrors the raw-transcript fast path).
+    // matches the stored artifact AND the stored body still parses into
+    // the expected conversation set. A truncated/corrupt body parses to
+    // an empty (or count-mismatched) list even when the frontmatter hash
+    // matches, so we rewrite to self-repair instead of trusting the hash
+    // alone (mirrors the raw-transcript fast path otherwise).
     const existingRaw = await storage.fusionArtifactStore().readFusedDay(date);
-    const existingHash =
-      parseFusionDay(existingRaw ?? "")?.meta.contentHash ?? null;
-    const written = existingHash !== result.contentHash;
+    const existing = parseFusionDay(existingRaw ?? "");
+    const skipUnchanged =
+      existing !== null &&
+      existing.meta.contentHash === result.contentHash &&
+      existing.conversations.length === result.conversations.length;
+    const written = !skipUnchanged;
     if (written) {
       const meta = composeFusionDayMeta(
         date,

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -513,25 +513,44 @@ export class WearablesService {
       bodies.push({ source, body: parsed?.body ?? raw });
       sourceTimezones.push(parsed?.meta.timezone ?? "");
     }
+    // Reconstruct the normalized inputs once and derive the sources that
+    // actually CONTRIBUTE conversations/clocks for the day. The sync path
+    // can persist an explicit EMPTY (all-elided / zero-conversation)
+    // transcript for days whose segments were all dropped; such a file
+    // contributes no clocks, so it must not influence the timezone guard
+    // below.
+    const reconstructed = reconstructFusionInputs(date, bodies);
+    const contributing = bodies
+      .map((entry, i) => ({
+        source: entry.source,
+        timezone: sourceTimezones[i] ?? "",
+      }))
+      .filter((entry) =>
+        reconstructed.some((input) => input.source === entry.source),
+      );
     // Mixed-timezone guard: reconstructFusionInputs rebuilds every clock as
     // `${date}T${HH}:${MM}:00Z` and compares local HH:MM clocks across sources
     // as if they shared one timezone. That comparison is ONLY valid when every
-    // source present for the day carries the SAME explicit IANA timezone id
-    // (meta.timezone). Sampling one UTC offset per source is insufficient: on
-    // DST-transition dates two different zones can share a noon offset yet
-    // differ during recorded hours (e.g. America/Los_Angeles vs America/Phoenix
-    // on 2026-03-08 — both UTC-7 by noon, an hour apart before LA's
-    // spring-forward). A source whose timezone id is missing/empty is treated
-    // as unresolvable rather than silently coerced to a default, so any unknown
-    // tz fails safe. Require exact tz-id identity across all present sources.
-    if (bodies.length > 1) {
-      const referenceTz = sourceTimezones[0]!;
+    // CONTRIBUTING source (one that reconstructs to >=1 conversation) carries
+    // the SAME explicit IANA timezone id (meta.timezone). Sources that
+    // reconstruct to zero conversations contribute no clocks and are ignored,
+    // so an empty/all-elided transcript rendered under a different (or
+    // missing) timezone cannot block a genuine same-zone fusion. Sampling one
+    // UTC offset per source is insufficient: on DST-transition dates two
+    // different zones can share a noon offset yet differ during recorded hours
+    // (e.g. America/Los_Angeles vs America/Phoenix on 2026-03-08 — both UTC-7
+    // by noon, an hour apart before LA's spring-forward). A source whose
+    // timezone id is missing/empty is treated as unresolvable rather than
+    // silently coerced to a default, so any unknown tz fails safe. Require
+    // exact tz-id identity across all contributing sources.
+    if (contributing.length > 1) {
+      const referenceTz = contributing[0]!.timezone;
       const allSameExplicitTz =
         referenceTz.trim().length > 0 &&
-        sourceTimezones.every((tz) => tz === referenceTz);
+        contributing.every((entry) => entry.timezone === referenceTz);
       if (!allSameExplicitTz) {
-        const detail = bodies
-          .map((entry, i) => `${entry.source}=${sourceTimezones[i] || "?"}`)
+        const detail = contributing
+          .map((entry) => `${entry.source}=${entry.timezone || "?"}`)
           .join(", ");
         log.warn(
           `wearables fusion: skipping ${date} — sources were rendered under differing timezones (${detail}); reconstructFusionInputs only compares local clocks correctly when every source shares one explicit IANA timezone id`,
@@ -554,7 +573,7 @@ export class WearablesService {
     for (const [id, settings] of enabled) {
       sourceTrust[id] = settings.sourceTrust;
     }
-    const result = fuseDayInputs(date, reconstructFusionInputs(date, bodies), {
+    const result = fuseDayInputs(date, reconstructed, {
       proximityGapMs: this.deps.config.fusion.proximityGapMs,
       windowToleranceMs: this.deps.config.fusion.windowToleranceMs,
       sourceTrust,

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -14,6 +14,7 @@ import {
 import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import {
+  bodyIsEscaped,
   decodeTranscriptBody,
   escapeSegmentText,
   isValidTranscriptDate,
@@ -466,7 +467,7 @@ export class WearablesService {
         // trip); user-facing view surfaces must show the original text.
         // The fusion reconstruct path reads raw bodies separately and
         // decodes once during parse, so this never double-decodes (#1849).
-        body: decodeTranscriptBody(parsed?.body ?? raw),
+        body: decodeTranscriptBody(parsed?.body ?? raw, bodyIsEscaped(parsed?.meta)),
         overlapsWith: [],
       });
     }
@@ -516,13 +517,17 @@ export class WearablesService {
     }
     const storage = await this.deps.getStorage();
     const enabled = this.enabledSources();
-    const bodies: Array<{ source: string; body: string }> = [];
+    const bodies: Array<{ source: string; body: string; escaped?: boolean }> = [];
     const sourceTimezones: string[] = [];
     for (const [source] of enabled) {
       const raw = await storage.readWearableDayTranscript(source, date);
       if (raw === null) continue;
       const parsed = parseDayTranscript(raw);
-      bodies.push({ source, body: parsed?.body ?? raw });
+      bodies.push({
+        source,
+        body: parsed?.body ?? raw,
+        escaped: bodyIsEscaped(parsed?.meta),
+      });
       sourceTimezones.push(parsed?.meta.timezone ?? "");
     }
     // Reconstruct the normalized inputs once and derive the sources that
@@ -725,6 +730,7 @@ export class WearablesService {
         escaped === trimmed ? [trimmed] : [trimmed, escaped];
       const seen = new Set<string>();
       const results: WearableTranscriptSearchResult[] = [];
+      const idxStorage = await this.deps.getStorage();
       for (const q of queries) {
         const hits = await this.deps.searchBackend.search(q, limit * 5);
         if (hits === null) break; // backend unavailable
@@ -735,13 +741,18 @@ export class WearablesService {
           const dedupeKey = `${located.source}:${located.date}`;
           if (seen.has(dedupeKey)) continue;
           seen.add(dedupeKey);
+          // The indexed snippet mirrors the stored body's escape encoding.
+          // Read the file once to learn whether it was written by the
+          // escape-aware serializer so a LEGACY file's literal two-character
+          // \n/\r is never decoded (#1849).
+          const idxRaw =
+            await idxStorage.readWearableDayTranscript(located.source, located.date);
+          const idxMeta = parseDayTranscript(idxRaw ?? "")?.meta ?? null;
           results.push({
             source: located.source,
             date: located.date,
             score: hit.score,
-            // Decode the escaped serialization so the snippet shows
-            // the original segment text (#1849).
-            snippet: decodeTranscriptBody(hit.preview),
+            snippet: decodeTranscriptBody(hit.preview, bodyIsEscaped(idxMeta)),
             backend: "indexed",
           });
           if (results.length >= limit) break;
@@ -768,10 +779,16 @@ export class WearablesService {
       if (!matchesScope(source, date)) continue;
       const raw = await storage.readWearableDayTranscript(source, date);
       if (raw === null) continue;
+      const scanParsed = parseDayTranscript(raw);
       // Decode escaped segment text so searches match AND snippets show
       // the ORIGINAL text (e.g. a real newline or backslash), not the
-      // internal escape serialization (#1849).
-      const body = decodeTranscriptBody(parseDayTranscript(raw)?.body ?? raw);
+      // internal escape serialization — but ONLY for bodies written by
+      // the escape-aware serializer; legacy bodies are searched verbatim
+      // (#1849).
+      const body = decodeTranscriptBody(
+        scanParsed?.body ?? raw,
+        bodyIsEscaped(scanParsed?.meta),
+      );
       const lower = body.toLowerCase();
       const index = lower.indexOf(needle);
       if (index === -1) continue;

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -13,7 +13,7 @@ import {
 } from "./corrections.js";
 import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
-import { isValidTranscriptDate, parseDayTranscript, utcOffsetMinutesForDate } from "./day-store.js";
+import { isValidTranscriptDate, parseDayTranscript } from "./day-store.js";
 import {
   composeFusionDayMeta,
   type FusionArtifactStore,
@@ -511,27 +511,30 @@ export class WearablesService {
       if (raw === null) continue;
       const parsed = parseDayTranscript(raw);
       bodies.push({ source, body: parsed?.body ?? raw });
-      sourceTimezones.push(parsed?.meta.timezone ?? "UTC");
+      sourceTimezones.push(parsed?.meta.timezone ?? "");
     }
-    // Mixed-timezone guard (codex P2): reconstructFusionInputs rebuilds every
-    // clock as `${date}T${HH}:${MM}:00Z` assuming all sources share one tz.
-    // Sources rendered under DIFFERENT UTC offsets would misalign on the
-    // fused timeline; detect that and skip the day with a logged reason
-    // rather than silently producing misaligned ISO. Full cross-tz offset
-    // normalization is deferred (see the precision caveat in reconstruct.ts).
+    // Mixed-timezone guard: reconstructFusionInputs rebuilds every clock as
+    // `${date}T${HH}:${MM}:00Z` and compares local HH:MM clocks across sources
+    // as if they shared one timezone. That comparison is ONLY valid when every
+    // source present for the day carries the SAME explicit IANA timezone id
+    // (meta.timezone). Sampling one UTC offset per source is insufficient: on
+    // DST-transition dates two different zones can share a noon offset yet
+    // differ during recorded hours (e.g. America/Los_Angeles vs America/Phoenix
+    // on 2026-03-08 — both UTC-7 by noon, an hour apart before LA's
+    // spring-forward). A source whose timezone id is missing/empty is treated
+    // as unresolvable rather than silently coerced to a default, so any unknown
+    // tz fails safe. Require exact tz-id identity across all present sources.
     if (bodies.length > 1) {
-      const offsets = sourceTimezones.map((tz) => utcOffsetMinutesForDate(date, tz));
-      const allKnown = offsets.every((offset) => offset !== null);
-      const allEqual = allKnown && offsets.every((offset) => offset === offsets[0]);
-      if (!allEqual) {
+      const referenceTz = sourceTimezones[0]!;
+      const allSameExplicitTz =
+        referenceTz.trim().length > 0 &&
+        sourceTimezones.every((tz) => tz === referenceTz);
+      if (!allSameExplicitTz) {
         const detail = bodies
-          .map(
-            (entry, i) =>
-              `${entry.source}=${sourceTimezones[i]}(${offsets[i] === null ? "?" : offsets[i]}m)`,
-          )
+          .map((entry, i) => `${entry.source}=${sourceTimezones[i] || "?"}`)
           .join(", ");
         log.warn(
-          `wearables fusion: skipping ${date} — sources were rendered under conflicting timezones (${detail}); full cross-tz normalization is deferred`,
+          `wearables fusion: skipping ${date} — sources were rendered under differing timezones (${detail}); reconstructFusionInputs only compares local clocks correctly when every source shares one explicit IANA timezone id`,
         );
         // Clear any previously-fused artifact for this day: a day that
         // fused successfully before must not keep serving a stale view

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -15,6 +15,7 @@ import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import {
   decodeTranscriptBody,
+  escapeSegmentText,
   isValidTranscriptDate,
   parseDayTranscript,
 } from "./day-store.js";
@@ -713,33 +714,48 @@ export class WearablesService {
     };
 
     if (this.deps.searchBackend) {
-      const hits = await this.deps.searchBackend.search(trimmed, limit * 5);
-      if (hits !== null) {
-        const results: WearableTranscriptSearchResult[] = [];
+      // The index stores escaped segment text (real newlines become
+      // the two characters \n, lone backslashes are doubled). A query
+      // containing those characters in their ORIGINAL decoded form will
+      // not match the indexed representation, so we ALSO search the
+      // escaped form. This keeps the indexed path at parity with the
+      // scan fallback, which decodes the body before searching (#1849).
+      const escaped = escapeSegmentText(trimmed);
+      const queries =
+        escaped === trimmed ? [trimmed] : [trimmed, escaped];
+      const seen = new Set<string>();
+      const results: WearableTranscriptSearchResult[] = [];
+      for (const q of queries) {
+        const hits = await this.deps.searchBackend.search(q, limit * 5);
+        if (hits === null) break; // backend unavailable
         for (const hit of hits) {
           const located = locateTranscriptPath(hit.path);
           if (!located) continue;
           if (!matchesScope(located.source, located.date)) continue;
+          const dedupeKey = `${located.source}:${located.date}`;
+          if (seen.has(dedupeKey)) continue;
+          seen.add(dedupeKey);
           results.push({
             source: located.source,
             date: located.date,
             score: hit.score,
-            // Decode the escaped serialization so the snippet shows the
-            // original segment text (#1849).
+            // Decode the escaped serialization so the snippet shows
+            // the original segment text (#1849).
             snippet: decodeTranscriptBody(hit.preview),
             backend: "indexed",
           });
           if (results.length >= limit) break;
         }
-        // The index spans the whole memory dir, so ordinary memory
-        // files can crowd transcripts out of the top hits entirely.
-        // Zero in-scope hits therefore doesn't mean "no transcript
-        // matches" — fall through to the bounded scan in that case
-        // (Codex P2 on PR #1458). Partial result sets stay indexed-only
-        // so the two backends never interleave in one response.
-        if (results.length > 0) {
-          return results;
-        }
+        if (results.length >= limit) break;
+      }
+      // The index spans the whole memory dir, so ordinary memory
+      // files can crowd transcripts out of the top hits entirely.
+      // Zero in-scope hits therefore doesn't mean "no transcript
+      // matches" — fall through to the bounded scan in that case
+      // (Codex P2 on PR #1458). Partial result sets stay indexed-only
+      // so the two backends never interleave in one response.
+      if (results.length > 0) {
+        return results;
       }
     }
 

--- a/packages/remnic-core/src/wearables/service.ts
+++ b/packages/remnic-core/src/wearables/service.ts
@@ -14,6 +14,14 @@ import {
 import { describeErrorForOperator, WearablesInputError } from "./errors.js";
 import { inferMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { isValidTranscriptDate, parseDayTranscript } from "./day-store.js";
+import {
+  composeFusionDayMeta,
+  fuseDay as fuseDayInputs,
+  parseFusionDay,
+  reconstructFusionInputs,
+  serializeFusionDay,
+  type FusedWearableConversation,
+} from "./fusion/index.js";
 import { stripAttributesSuffix } from "../storage.js";
 import type { MemoryFrontmatter } from "../types.js";
 import type { WearableMemoryGenDeps } from "./memory-gen.js";
@@ -59,6 +67,9 @@ export interface WearableStorageIo {
   listWearableTranscriptDays(
     sourceId?: string,
   ): Promise<Array<{ source: string; date: string }>>;
+  writeWearableFusedDay(date: string, serialized: string): Promise<void>;
+  readWearableFusedDay(date: string): Promise<string | null>;
+  listWearableFusedDays(): Promise<string[]>;
   readAllMemories(): Promise<
     Array<{
       path: string;
@@ -462,6 +473,99 @@ export class WearablesService {
     if (sourceId !== undefined) assertValidSourceId(sourceId);
     const storage = await this.deps.getStorage();
     return storage.listWearableTranscriptDays(sourceId);
+  }
+
+  // -- cross-source fusion (#1810) -----------------------------------------
+
+  /**
+   * Fuse all enabled sources' stored transcripts for one day into a
+   * derived `FusedWearableConversation[]` artifact. Deterministic and
+   * idempotent: unchanged inputs produce a stable content hash and the
+   * derived file is left untouched on re-run. Requires
+   * `wearables.fusion.enabled`; otherwise it throws. Raw per-source
+   * transcripts are never modified.
+   */
+  async fuseDay(date: string): Promise<{
+    date: string;
+    sources: string[];
+    conversationCount: number;
+    contentHash: string;
+    written: boolean;
+  }> {
+    if (!this.deps.config.fusion.enabled) {
+      throw new WearablesInputError(
+        "wearables fusion is not enabled — set `wearables.fusion.enabled: true` in the plugin config",
+      );
+    }
+    if (!isValidTranscriptDate(date)) {
+      throw new WearablesInputError(`invalid date '${date}' — expected YYYY-MM-DD`);
+    }
+    const storage = await this.deps.getStorage();
+    const enabled = this.enabledSources();
+    const bodies: Array<{ source: string; body: string }> = [];
+    for (const [source] of enabled) {
+      const raw = await storage.readWearableDayTranscript(source, date);
+      if (raw === null) continue;
+      bodies.push({ source, body: parseDayTranscript(raw)?.body ?? raw });
+    }
+    const sourceTrust: Record<string, number> = {};
+    for (const [id, settings] of enabled) {
+      sourceTrust[id] = settings.sourceTrust;
+    }
+    const result = fuseDayInputs(date, reconstructFusionInputs(date, bodies), {
+      proximityGapMs: this.deps.config.fusion.proximityGapMs,
+      windowToleranceMs: this.deps.config.fusion.windowToleranceMs,
+      sourceTrust,
+    });
+    // Idempotent skip-unchanged: do not rewrite when the content hash
+    // matches the stored artifact (mirrors the raw-transcript fast path).
+    const existingRaw = await storage.readWearableFusedDay(date);
+    const existingHash =
+      parseFusionDay(existingRaw ?? "")?.meta.contentHash ?? null;
+    const written = existingHash !== result.contentHash;
+    if (written) {
+      const meta = composeFusionDayMeta(
+        date,
+        result.conversations,
+        result.sources,
+        result.contentHash,
+        new Date().toISOString(),
+      );
+      await storage.writeWearableFusedDay(
+        date,
+        serializeFusionDay(meta, result.conversations),
+      );
+    }
+    return {
+      date: result.date,
+      sources: result.sources,
+      conversationCount: result.conversations.length,
+      contentHash: result.contentHash,
+      written,
+    };
+  }
+
+  /**
+   * List fused conversations for a date (the fusion listing surface).
+   * Returns the persisted derived artifact, or an empty array when no
+   * fused artifact has been written for that day.
+   */
+  async fusedConversations(
+    date: string,
+  ): Promise<FusedWearableConversation[]> {
+    if (!isValidTranscriptDate(date)) {
+      throw new WearablesInputError(`invalid date '${date}' — expected YYYY-MM-DD`);
+    }
+    const storage = await this.deps.getStorage();
+    const raw = await storage.readWearableFusedDay(date);
+    if (raw === null) return [];
+    return parseFusionDay(raw)?.conversations ?? [];
+  }
+
+  /** List dates with stored fused artifacts, newest first. */
+  async listFusedDays(): Promise<string[]> {
+    const storage = await this.deps.getStorage();
+    return storage.listWearableFusedDays();
   }
 
   /**

--- a/packages/remnic-core/src/wearables/speakers.test.ts
+++ b/packages/remnic-core/src/wearables/speakers.test.ts
@@ -8,10 +8,12 @@ import {
   DEFAULT_SELF_NAME,
   distinctSpeakerLabels,
   emptySpeakerRegistry,
+  hasSelfMarker,
   loadSpeakerRegistry,
   resolveSpeaker,
   saveSpeakerRegistry,
   speakerRegistryKey,
+  stripSelfMarker,
 } from "./speakers.js";
 
 test("resolution precedence: override > wearer flag > provider name > raw key", () => {
@@ -165,4 +167,34 @@ test("distinctSpeakerLabels never emits a non-self label ending in (you)", () =>
   );
   // The wearer keeps the marker; the non-self "Pat (you)" override does not.
   assert.deepEqual(labels, ["Me (you)", "Pat"]);
+});
+
+test("stripSelfMarker / hasSelfMarker use linear string ops (CodeQL #1849)", () => {
+  // Standard cases — marker present and absent.
+  assert.equal(stripSelfMarker("Jordan (you)"), "Jordan");
+  assert.equal(stripSelfMarker("Jordan"), "Jordan");
+  assert.equal(hasSelfMarker("Jordan (you)"), true);
+  assert.equal(hasSelfMarker("Jordan"), false);
+
+  // Trailing whitespace around the marker is absorbed.
+  assert.equal(stripSelfMarker("Jordan (you)  "), "Jordan");
+  assert.equal(hasSelfMarker("Jordan (you) \t"), true);
+
+  // Only the final marker is stripped — a second "(you)" survives.
+  assert.equal(stripSelfMarker("Jordan (you)(you)"), "Jordan (you)");
+
+  // Marker with leading whitespace but no name.
+  assert.equal(stripSelfMarker(" (you)"), "");
+  assert.equal(stripSelfMarker("(you)"), "");
+
+  // Empty / whitespace-only input — the case that caused O(n^2)
+  // backtracking with the old \s*\(you\)\s*$ regex.
+  assert.equal(stripSelfMarker(""), "");
+  assert.equal(stripSelfMarker("   "), "");
+  assert.equal(hasSelfMarker("   "), false);
+  assert.equal(hasSelfMarker(""), false);
+
+  // "(you)" not at the end is NOT a marker.
+  assert.equal(hasSelfMarker("(you) said hi"), false);
+  assert.equal(stripSelfMarker("(you) said hi"), "(you) said hi");
 });

--- a/packages/remnic-core/src/wearables/speakers.test.ts
+++ b/packages/remnic-core/src/wearables/speakers.test.ts
@@ -108,3 +108,61 @@ test("a malformed speakers file throws instead of silently resetting", async () 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("the reserved (you) self marker is stripped from non-self display names (issue #1849)", () => {
+  const registry = emptySpeakerRegistry();
+  registry.selfName = "Jordan";
+  // A non-self override whose stored name already ends with the reserved
+  // marker must NOT carry it into the rendered label — otherwise the
+  // fusion reconstructor would read the suffix as self metadata and
+  // attribute this speaker's words to the wearer.
+  registry.speakers[speakerRegistryKey("bee", "SPEAKER_01")] = {
+    name: "Pat (you)",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  assert.deepEqual(
+    resolveSpeaker("bee", { speakerKey: "SPEAKER_01" }, registry),
+    { label: "Pat", isSelf: false },
+  );
+
+  // A self override whose name ends with the marker renders exactly ONE
+  // marker (never "Pat (you) (you)").
+  registry.speakers[speakerRegistryKey("bee", "SPEAKER_02")] = {
+    name: "Pat (you)",
+    isSelf: true,
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  assert.deepEqual(
+    resolveSpeaker("bee", { speakerKey: "SPEAKER_02" }, registry),
+    { label: "Pat (you)", isSelf: true },
+  );
+
+  // A provider-supplied name carrying the marker is also stripped.
+  assert.deepEqual(
+    resolveSpeaker(
+      "omi",
+      { speakerKey: "SPEAKER_03", speakerName: "Sam (you)" },
+      registry,
+    ),
+    { label: "Sam", isSelf: false },
+  );
+
+});
+
+test("distinctSpeakerLabels never emits a non-self label ending in (you)", () => {
+  const registry = emptySpeakerRegistry();
+  registry.speakers[speakerRegistryKey("bee", "0")] = {
+    name: "Pat (you)",
+    updatedAt: "2026-06-10T00:00:00Z",
+  };
+  const labels = distinctSpeakerLabels(
+    "bee",
+    [
+      { speakerKey: "user", isWearer: true },
+      { speakerKey: "0" },
+    ],
+    registry,
+  );
+  // The wearer keeps the marker; the non-self "Pat (you)" override does not.
+  assert.deepEqual(labels, ["Me (you)", "Pat"]);
+});

--- a/packages/remnic-core/src/wearables/speakers.test.ts
+++ b/packages/remnic-core/src/wearables/speakers.test.ts
@@ -198,3 +198,41 @@ test("stripSelfMarker / hasSelfMarker use linear string ops (CodeQL #1849)", () 
   assert.equal(hasSelfMarker("(you) said hi"), false);
   assert.equal(stripSelfMarker("(you) said hi"), "(you) said hi");
 });
+
+test("raw speakerKey fallback strips the reserved (you) marker (issue #1849)", () => {
+  // A provider speakerKey that literally contains the reserved `(you)`
+  // suffix must NEVER carry it into a rendered non-self label. Without
+  // the strip, the fusion reconstructor would read the suffix as self
+  // metadata and misattribute the speaker as the wearer.
+  const registry = emptySpeakerRegistry();
+  registry.selfName = "Jordan";
+
+  // Raw key with a trailing (you) — non-self fallback path.
+  const resolved = resolveSpeaker(
+    "bee",
+    { speakerKey: "Pat (you)" },
+    registry,
+  );
+  assert.equal(resolved.isSelf, false, "raw key is never self");
+  assert.equal(resolved.label, "Pat", "(you) stripped from raw key label");
+  assert.equal(hasSelfMarker(resolved.label), false, "no marker leaks");
+
+  // Bare-digit key with a trailing (you) becomes "Speaker <digits>"
+  // after stripping, never carrying the marker.
+  const digitResolved = resolveSpeaker(
+    "omi",
+    { speakerKey: "5 (you)" },
+    registry,
+  );
+  assert.equal(digitResolved.isSelf, false);
+  assert.equal(digitResolved.label, "Speaker 5");
+
+  // A key that is ONLY "(you)" strips to empty -> "Unknown speaker".
+  const onlyMarker = resolveSpeaker(
+    "limitless",
+    { speakerKey: "(you)" },
+    registry,
+  );
+  assert.equal(onlyMarker.isSelf, false);
+  assert.equal(onlyMarker.label, "Unknown speaker");
+});

--- a/packages/remnic-core/src/wearables/speakers.ts
+++ b/packages/remnic-core/src/wearables/speakers.ts
@@ -45,16 +45,22 @@ export const DEFAULT_SELF_NAME = "Me";
  * (issue #1849).
  */
 export const SELF_MARKER_SUFFIX = " (you)";
-const SELF_MARKER_RE = /\s*\(you\)\s*$/;
+const SELF_MARKER = "(you)";
 
 /**
  * Remove a reserved `(you)` self marker from a display name. Applied to
  * every base name before it becomes a label so the marker can only ever
  * appear as the renderer-appended self flag, never as part of a stored
  * non-self display name.
+ *
+ * Implemented with plain string ops instead of a regex so the leading
+ * `\s*` (no anchor) cannot cause the O(n²) backtracking CodeQL flags
+ * on whitespace-only input (js/polynomial-redos).
  */
 export function stripSelfMarker(name: string): string {
-  return name.replace(SELF_MARKER_RE, "").trimEnd();
+  const trimmed = name.trimEnd();
+  if (!trimmed.endsWith(SELF_MARKER)) return trimmed;
+  return trimmed.slice(0, -SELF_MARKER.length).trimEnd();
 }
 
 /**
@@ -63,7 +69,7 @@ export function stripSelfMarker(name: string): string {
  * the fusion reconstructor (issue #1849).
  */
 export function hasSelfMarker(label: string): boolean {
-  return SELF_MARKER_RE.test(label);
+  return label.trimEnd().endsWith(SELF_MARKER);
 }
 
 export function emptySpeakerRegistry(): SpeakerRegistry {

--- a/packages/remnic-core/src/wearables/speakers.ts
+++ b/packages/remnic-core/src/wearables/speakers.ts
@@ -193,7 +193,12 @@ export function resolveSpeaker(
     // so a provider label cannot masquerade as the reserved self flag.
     return { label: stripSelfMarker(segment.speakerName.trim()), isSelf: false };
   }
-  const key = segment.speakerKey.trim();
+  // Strip the reserved `(you)` marker from the raw key so a provider
+  // speakerKey like "Pat (you)" can never leak the marker into a non-self
+  // rendered label — the fusion reconstructor reads the suffix as
+  // authoritative self metadata and would misattribute the speaker as the
+  // wearer (issue #1849).
+  const key = stripSelfMarker(segment.speakerKey.trim());
   // Bare diarization indexes read better with a prefix.
   if (/^\d+$/.test(key)) {
     return { label: `Speaker ${key}`, isSelf: false };

--- a/packages/remnic-core/src/wearables/speakers.ts
+++ b/packages/remnic-core/src/wearables/speakers.ts
@@ -35,6 +35,37 @@ export interface SpeakerRegistry {
 
 export const DEFAULT_SELF_NAME = "Me";
 
+/**
+ * Reserved self marker appended to a wearer's display label so the
+ * rendered transcript carries explicit, parseable self metadata. It is
+ * RESERVED: a non-self display label can never carry it (see
+ * `stripSelfMarker`), so when `reconstructFusionInputs` reads it back it
+ * is authoritative self metadata — never a coincidental display-name
+ * suffix that would misattribute another speaker as the wearer
+ * (issue #1849).
+ */
+export const SELF_MARKER_SUFFIX = " (you)";
+const SELF_MARKER_RE = /\s*\(you\)\s*$/;
+
+/**
+ * Remove a reserved `(you)` self marker from a display name. Applied to
+ * every base name before it becomes a label so the marker can only ever
+ * appear as the renderer-appended self flag, never as part of a stored
+ * non-self display name.
+ */
+export function stripSelfMarker(name: string): string {
+  return name.replace(SELF_MARKER_RE, "").trimEnd();
+}
+
+/**
+ * Whether a rendered label carries the reserved self marker. This is the
+ * single authoritative self-status detector shared by the renderer and
+ * the fusion reconstructor (issue #1849).
+ */
+export function hasSelfMarker(label: string): boolean {
+  return SELF_MARKER_RE.test(label);
+}
+
 export function emptySpeakerRegistry(): SpeakerRegistry {
   return { version: 1, selfName: DEFAULT_SELF_NAME, speakers: {} };
 }
@@ -130,19 +161,31 @@ export function resolveSpeaker(
   const override = registry.speakers[speakerRegistryKey(sourceId, segment.speakerKey)];
   if (override) {
     const isSelf = override.isSelf === true;
+    // Reserve the `(you)` marker: strip any pre-existing marker from the
+    // base name so a NON-self label can never carry it. Without this, a
+    // speaker override like "Pat (you)" set WITHOUT --self would render
+    // as "Pat (you)" and the fusion reconstructor would read the suffix
+    // as self metadata, attributing Pat's words to the wearer (issue
+    // #1849).
+    const base = stripSelfMarker(override.name);
     return {
-      label: isSelf ? `${override.name} (you)` : override.name,
+      label: isSelf ? `${base}${SELF_MARKER_SUFFIX}` : base,
       isSelf,
     };
   }
   if (segment.isWearer === true) {
-    return { label: `${registry.selfName} (you)`, isSelf: true };
+    return {
+      label: `${stripSelfMarker(registry.selfName)}${SELF_MARKER_SUFFIX}`,
+      isSelf: true,
+    };
   }
   if (
     typeof segment.speakerName === "string" &&
     segment.speakerName.trim().length > 0
   ) {
-    return { label: segment.speakerName.trim(), isSelf: false };
+    // Provider-supplied names are never self here; strip a stray marker
+    // so a provider label cannot masquerade as the reserved self flag.
+    return { label: stripSelfMarker(segment.speakerName.trim()), isSelf: false };
   }
   const key = segment.speakerKey.trim();
   // Bare diarization indexes read better with a prefix.

--- a/packages/remnic-core/src/wearables/storage-io.test.ts
+++ b/packages/remnic-core/src/wearables/storage-io.test.ts
@@ -235,20 +235,60 @@ test("a symlinked _fusion dir that escapes the memory dir is refused, not follow
     // Write must be refused — never followed into the escape dir.
     await assert.rejects(
       store.writeFusedDay("2026-06-10", "---\nkind: wearable-fusion\n---\n\n[]\n"),
-      /resolves outside the wearables root/,
+      /resolves outside the memory dir/,
     );
     // Read and list are refused for the same reason.
     await assert.rejects(
       store.readFusedDay("2026-06-10"),
-      /resolves outside the wearables root/,
+      /resolves outside the memory dir/,
     );
     await assert.rejects(
       store.listFusedDays(),
-      /resolves outside the wearables root/,
+      /resolves outside the memory dir/,
     );
     // Nothing was written into the escape target.
     const leaked = await readdir(escapeDir).catch(() => []);
     assert.equal(leaked.length, 0, "no fused artifact must leak into the symlink target");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(escapeDir, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked wearables root that escapes the memory dir is refused, not followed", async () => {
+  const { storage, dir } = makeStorage();
+  // Outside target: a sibling temp dir NOT under the memory dir root.
+  const escapeDir = mkdtempSync(path.join(tmpdir(), "remnic-wearables-escape-"));
+  try {
+    // The memory dir root exists (makeStorage created it); plant a
+    // wearables ROOT that is itself a symlink pointing outside memoryDir.
+    // Containment is anchored to realpath(memoryDir), so this must be
+    // rejected for every fusion IO — never followed (issue #1849).
+    await symlink(escapeDir, path.join(dir, "wearables"), "dir");
+
+    const store = storage.fusionArtifactStore();
+    // Write must be refused even though the leaf artifact does not yet
+    // exist — never followed into the symlinked escape root.
+    await assert.rejects(
+      store.writeFusedDay("2026-06-10", "---\nkind: wearable-fusion\n---\n\n[]\n"),
+      /resolves outside the memory dir/,
+    );
+    // Read, list, and delete are refused for the same reason.
+    await assert.rejects(
+      store.readFusedDay("2026-06-10"),
+      /resolves outside the memory dir/,
+    );
+    await assert.rejects(
+      store.listFusedDays(),
+      /resolves outside the memory dir/,
+    );
+    await assert.rejects(
+      store.deleteFusedDay("2026-06-10"),
+      /resolves outside the memory dir/,
+    );
+    // Nothing was written into the escape target.
+    const leaked = await readdir(escapeDir).catch(() => []);
+    assert.equal(leaked.length, 0, "no fused artifact must leak into the symlinked wearables root");
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(escapeDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/wearables/storage-io.test.ts
+++ b/packages/remnic-core/src/wearables/storage-io.test.ts
@@ -195,14 +195,14 @@ test("fused-day artifacts write/read/list and stay out of transcript listings", 
       "---\nkind: wearable-transcript\n---\n\nbody\n",
     );
     // Write a fused-day artifact.
-    assert.equal(await storage.readWearableFusedDay("2026-06-10"), null);
-    await storage.writeWearableFusedDay(
+    assert.equal(await storage.fusionArtifactStore().readFusedDay("2026-06-10"), null);
+    await storage.fusionArtifactStore().writeFusedDay(
       "2026-06-10",
       "---\nkind: wearable-fusion\n---\n\n[]\n",
     );
-    const raw = await storage.readWearableFusedDay("2026-06-10");
+    const raw = await storage.fusionArtifactStore().readFusedDay("2026-06-10");
     assert.ok(raw?.includes("wearable-fusion"));
-    assert.deepEqual(await storage.listWearableFusedDays(), ["2026-06-10"]);
+    assert.deepEqual(await storage.fusionArtifactStore().listFusedDays(), ["2026-06-10"]);
 
     // The reserved _fusion dir must NOT show up as a pseudo-source in
     // the per-source transcript listing.
@@ -212,7 +212,7 @@ test("fused-day artifacts write/read/list and stay out of transcript listings", 
 
     // Malformed dates are rejected before path math (no traversal).
     await assert.rejects(
-      storage.readWearableFusedDay("../../etc/passwd"),
+      storage.fusionArtifactStore().readFusedDay("../../etc/passwd"),
       /invalid wearable fusion date/,
     );
   } finally {

--- a/packages/remnic-core/src/wearables/storage-io.test.ts
+++ b/packages/remnic-core/src/wearables/storage-io.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, readdir, symlink } from "node:fs/promises";
+import { mkdir, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
@@ -292,5 +292,41 @@ test("a symlinked wearables root that escapes the memory dir is refused, not fol
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(escapeDir, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked _fusion dir that resolves INSIDE the memory dir is refused, not followed (issue #1849)", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    // A real raw source transcript living under the wearables tree, and
+    // a `_fusion` symlink that aliases the SAME directory (resolves
+    // inside the memory dir, so the escape guard alone would allow it).
+    // Without the explicit symlink rejection, writeFusedDay("2026-06-10")
+    // would follow the link and OVERWRITE the raw source file.
+    const rawDir = path.join(dir, "wearables", "limitless");
+    const rawFile = path.join(rawDir, "2026-06-10.md");
+    await mkdir(rawDir, { recursive: true });
+    await writeFile(rawFile, "RAW SOURCE TRANSCRIPT\n", "utf-8");
+    await mkdir(path.join(dir, "wearables"), { recursive: true });
+    await symlink(rawDir, path.join(dir, "wearables", "_fusion"), "dir");
+
+    const store = storage.fusionArtifactStore();
+    // Write must be refused because `_fusion` is a symlink — even though
+    // its target resolves inside the memory dir.
+    await assert.rejects(
+      store.writeFusedDay("2026-06-10", "---\nkind: wearable-fusion\n---\n\n[]\n"),
+      /is a symbolic link/,
+    );
+    // Read, list, and delete are refused for the same reason.
+    await assert.rejects(store.readFusedDay("2026-06-10"), /is a symbolic link/);
+    await assert.rejects(store.listFusedDays(), /is a symbolic link/);
+    await assert.rejects(store.deleteFusedDay("2026-06-10"), /is a symbolic link/);
+
+    // The raw source file must be untouched — the fused artifact was
+    // never written through the symlink.
+    const after = await readFile(rawFile, "utf-8");
+    assert.equal(after, "RAW SOURCE TRANSCRIPT\n", "raw source file must not be overwritten");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/wearables/storage-io.test.ts
+++ b/packages/remnic-core/src/wearables/storage-io.test.ts
@@ -184,3 +184,38 @@ test("non-transcript files in the wearables tree are ignored by listing", async 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("fused-day artifacts write/read/list and stay out of transcript listings", async () => {
+  const { storage, dir } = makeStorage();
+  try {
+    // Seed a raw transcript so the listing is non-empty.
+    await storage.writeWearableDayTranscript(
+      "limitless",
+      "2026-06-10",
+      "---\nkind: wearable-transcript\n---\n\nbody\n",
+    );
+    // Write a fused-day artifact.
+    assert.equal(await storage.readWearableFusedDay("2026-06-10"), null);
+    await storage.writeWearableFusedDay(
+      "2026-06-10",
+      "---\nkind: wearable-fusion\n---\n\n[]\n",
+    );
+    const raw = await storage.readWearableFusedDay("2026-06-10");
+    assert.ok(raw?.includes("wearable-fusion"));
+    assert.deepEqual(await storage.listWearableFusedDays(), ["2026-06-10"]);
+
+    // The reserved _fusion dir must NOT show up as a pseudo-source in
+    // the per-source transcript listing.
+    const transcriptDays = await storage.listWearableTranscriptDays();
+    assert.ok(transcriptDays.every((entry) => entry.source !== "_fusion"));
+    assert.equal(transcriptDays.length, 1);
+
+    // Malformed dates are rejected before path math (no traversal).
+    await assert.rejects(
+      storage.readWearableFusedDay("../../etc/passwd"),
+      /invalid wearable fusion date/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/wearables/storage-io.test.ts
+++ b/packages/remnic-core/src/wearables/storage-io.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readdir, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { test } from "node:test";
@@ -217,5 +218,39 @@ test("fused-day artifacts write/read/list and stay out of transcript listings", 
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked _fusion dir that escapes the memory dir is refused, not followed", async () => {
+  const { storage, dir } = makeStorage();
+  // Outside target: a sibling temp dir NOT under the memory dir root.
+  const escapeDir = mkdtempSync(path.join(tmpdir(), "remnic-fusion-escape-"));
+  try {
+    // Ensure the wearables parent exists, then plant a symlinked _fusion
+    // dir that points outside the allowed root (AGENTS.md pattern #3).
+    await mkdir(path.join(dir, "wearables"), { recursive: true });
+    await symlink(escapeDir, path.join(dir, "wearables", "_fusion"), "dir");
+
+    const store = storage.fusionArtifactStore();
+    // Write must be refused — never followed into the escape dir.
+    await assert.rejects(
+      store.writeFusedDay("2026-06-10", "---\nkind: wearable-fusion\n---\n\n[]\n"),
+      /resolves outside the wearables root/,
+    );
+    // Read and list are refused for the same reason.
+    await assert.rejects(
+      store.readFusedDay("2026-06-10"),
+      /resolves outside the wearables root/,
+    );
+    await assert.rejects(
+      store.listFusedDays(),
+      /resolves outside the wearables root/,
+    );
+    // Nothing was written into the escape target.
+    const leaked = await readdir(escapeDir).catch(() => []);
+    assert.equal(leaked.length, 0, "no fused artifact must leak into the symlink target");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(escapeDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/wearables/types.ts
+++ b/packages/remnic-core/src/wearables/types.ts
@@ -354,6 +354,13 @@ export interface WearableDayTranscriptMeta {
   /** SHA-256 of the body — used to skip unchanged rewrites. */
   contentHash: string;
   syncedAt: string;
+  /**
+   * Body serialization format version. Present (>= 2) only on bodies written
+   * by the escape-aware serializer; absent on legacy transcripts. Decoders
+   * gate on this so a legacy body's literal two-character `\n`/`\r` is never
+   * altered (issue #1849).
+   */
+  formatVersion?: number;
 }
 
 /** A parsed day-transcript file. */

--- a/packages/remnic-core/src/wearables/types.ts
+++ b/packages/remnic-core/src/wearables/types.ts
@@ -285,6 +285,30 @@ export interface WearablesConfig {
   corrections: WearableCorrectionRule[];
   /** Per-source settings, keyed by connector id. */
   sources: Record<string, WearableSourceSettings>;
+  /**
+   * Cross-source fusion settings (issue #1810). Default disabled —
+   * enabling it is the only behavior change fusion introduces.
+   */
+  fusion: WearableFusionConfig;
+}
+
+/**
+ * Cross-source fusion configuration (issue #1810). When disabled (the
+ * default), no fusion artifacts are written and no behavior changes.
+ */
+export interface WearableFusionConfig {
+  /** Master gate for fusion. Default false. */
+  enabled: boolean;
+  /**
+   * Max gap (ms) between two conversations to merge into one fused
+   * cluster. Default 300000 (5 minutes).
+   */
+  proximityGapMs: number;
+  /**
+   * Max drift (ms) for two segments to align across sources. Default
+   * 30000 (30 seconds).
+   */
+  windowToleranceMs: number;
 }
 
 /** Summary returned by a sync run (one source). */

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -5573,6 +5573,31 @@
                 }
               }
             }
+          },
+          "fusion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Cross-source fusion of multi-source wearable transcripts into one reconciled artifact per real-world conversation (issue #1810). Deterministic and disabled by default.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate for cross-source fusion. When false, no fusion artifacts are written and no behavior changes."
+              },
+              "proximityGapMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 300000,
+                "description": "Max gap (ms) between two conversations to merge into one fused cluster."
+              },
+              "windowToleranceMs": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 30000,
+                "description": "Max drift (ms) for two segments to align across sources."
+              }
+            }
           }
         }
       },

--- a/scripts/ratchet-baseline.json
+++ b/scripts/ratchet-baseline.json
@@ -5,7 +5,7 @@
   "metrics": {
     "watchlistLoc": {
       "packages/remnic-core/src/orchestrator.ts": 3972,
-      "packages/remnic-core/src/cli.ts": 9395,
+      "packages/remnic-core/src/cli.ts": 9420,
       "packages/remnic-core/src/access-service.ts": 5902,
       "packages/remnic-core/src/storage.ts": 6549,
       "packages/remnic-core/src/config.ts": 4438


### PR DESCRIPTION
## Summary
Foundational multi-source wearable transcript fusion (PR 1 of the #1810 epic). Config-gated (`wearables.fusion.enabled`, default false). Adds a `FusedWearableConversation` derived artifact: deterministic conversation clustering across enabled sources (time overlap + secondary similarity), deterministic text/speaker reconciliation (higher trust/completeness; unresolved conflicts recorded in `disagreements[]`, never silently chosen), full source provenance, idempotent content-hashed artifact stored alongside (never overwriting) raw transcripts, and a listing surface.

Explicitly DEFERRED to follow-up PRs: LLM-assisted reconciliation, memory-extraction over fused artifacts + fusion structuredAttributes, full segment-level alignment, search-index integration, late-source re-scoring beyond idempotent rebuild.

Closes #1810 partially (foundation); follow-ups tracked for the deferred scope.

## Validation
- 64 targeted tests (exact/partial overlap, conflicting ASR, summary+verbatim, missing timestamps, speaker uncertainty, idempotency); entity-hardening 246/246; build; diagnostics == baseline; config mirrored in openclaw.plugin.json.

## Risk
- Gated off by default (enabling is the only behavior change). Raw transcripts untouched. Idempotent (stable id). Respects redaction before writing fusion artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new fusion and day-store serialization path touches stored transcripts and display/search when enabled or on rewrite; default-off gating limits production exposure but algorithm/hash bumps can regenerate fusion artifacts.
> 
> **Overview**
> Adds **config-gated cross-source wearable transcript fusion** (`wearables.fusion.enabled`, default off): a new `wearables/fusion/` pipeline clusters same-day conversations across enabled sources by time proximity (cross-source bridging only), reconciles text/speakers deterministically, records unresolved conflicts in `disagreements[]`, and persists idempotent `_fusion/<date>` artifacts via **`FusionArtifactStore`** (wired from `storage.ts`). **`fuse` / `fused`** CLI subcommands and plugin schema expose the feature.
> 
> **Day transcript format v2** escapes segment text and speaker labels for safe line-based storage, stamps `formatVersion` in meta, and folds version into **`hashTranscriptBody`**. Shared **`decodeTranscriptBody`** / **`parseTranscriptSegmentLine`** (linear scan) feed fusion reconstruct and user-facing transcript surfaces so escaped content does not leak to display/search.
> 
> Follow-on hardening in the same PR: **`FUSION_ALGO_VERSION`** and fusion config in the day content hash; JSON-safe input hashing; reconstruct clock handling (`24:xx`, cross-midnight, plausible 12h wrap bounds, missing `--:--` ends); cluster/fused intervals from segment extent; reconciliation tweaks (more-complete over truncated trust, distinct untimestamped utterances, `SPEAKER_00` as generic); **`fuseDay`** respects the global wearables master gate; CLI distinguishes **skip** vs **unchanged** when fusion refuses a day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ce4d8b5bb677591c7eddf35c5f205b69e6484a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->