### PR TITLE
docs: promote ChatGPT developer-mode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Remnic helps AI agents understand the people they work with: their preferences, 
 
 Remnic is not just a memory store. It is an exploration of the systems layer around user-aware agents: scoped memory, provenance, retrieval quality, correction, boundaries, and evals.
 
+## ChatGPT Integration
+
+Remnic now works inside chatgpt.com. Connect it as a developer-mode app and your assistant can store and recall memories on your own server.
+
+OpenAI no longer blocks built-in memory or tools when you add a custom MCP server. Remnic fills that gap with MCP and OAuth 2.1 support. Your memories stay on your disk as plain text files.
+
+Setup takes a few minutes. Point your HTTPS server URL at ChatGPT, turn on OAuth, and link the app. Full guide: **[docs/integration/chatgpt.md](docs/integration/chatgpt.md)**
+
+
 ## Why this matters
 
 Most agents do not fail because they lack another prompt. They fail because they do not understand the user, the project, the boundaries, or what “good” means in context.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Remnic is not just a memory store. It is an exploration of the systems layer aro
 
 Remnic now works inside chatgpt.com. Connect it as a developer-mode app and your assistant can store and recall memories on your own server.
 
-OpenAI no longer blocks built-in memory or tools when you add a custom MCP server. Remnic fills that gap with MCP and OAuth 2.1 support. Your memories stay on your disk as plain text files.
+OpenAI no longer blocks built-in memory or tools when you add a custom MCP server. Remnic fills that gap with MCP and OAuth 2.1 support. Your memory store stays on your disk as plain text files, and that local store is the source of truth. Note that when ChatGPT calls Remnic's tools, the memory content it reads and writes is also processed by OpenAI's tool pipeline, so treat what you surface accordingly.
 
 Setup takes a few minutes. Point your HTTPS server URL at ChatGPT, turn on OAuth, and link the app. Full guide: **[docs/integration/chatgpt.md](docs/integration/chatgpt.md)**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@
 
 ## Integrations
 
-- [ChatGPT (developer mode)](integration/chatgpt.md) — Public-internet MCP + OAuth 2.1 flow: Tailscale Funnel / Cloudflare Tunnel, `server.oauth` config, local operator approval, troubleshooting
+- [ChatGPT (developer mode)](integration/chatgpt.md) — Give ChatGPT persistent, governed memory on your own infrastructure via MCP + OAuth 2.1. OpenAI no longer disables memory/tools for custom MCP servers, so Remnic works alongside native ChatGPT capabilities.
 - [Connector Setup Guide](integration/connector-setup.md) — Wire Remnic memory to Claude Code, Codex, Cursor, Copilot, Cline, Roo Code, Windsurf, Amp, Replit, Hermes, and any generic MCP client
 - [Pi Coding Agent](integration/pi.md) — Native Pi extension (`@remnic/plugin-pi`) for hooks, slash commands, and compaction coordination
 - [Oh My Pi (omp)](integration/omp.md) — omp rules, MCP server config, and the native omp extension

--- a/docs/integration/chatgpt.md
+++ b/docs/integration/chatgpt.md
@@ -19,7 +19,12 @@ URL. The local operator approves every link request on the server machine.
 
 ## Overview
 
-ChatGPT can now persist memories across conversations using **your infrastructure**, not OpenAI's cloud. This integration exposes your local Remnic server to chatgpt.com via a developer-mode app that speaks MCP over OAuth 2.1. The result: every ChatGPT conversation you have can read and write to a memory store that lives on your filesystem as plain markdown, governed by your config, with provenance and lifecycle controls you choose.
+ChatGPT can now persist memories across conversations using **your infrastructure** as the source of truth. This integration exposes your local Remnic server to chatgpt.com via a developer-mode app that speaks MCP over OAuth 2.1. The result: in any ChatGPT conversation where you have enabled the Remnic app, ChatGPT can read and write to a memory store that lives on your filesystem as plain markdown, governed by your config, with provenance and lifecycle controls you choose.
+
+Two privacy and scope notes worth understanding before you connect:
+
+- **Local source of truth, processed by OpenAI.** The canonical memory store lives on your filesystem, and Remnic never sends memory to a third party on its own. But when ChatGPT invokes Remnic's `recall` or `memory_store` tools, the memory content in those requests and responses transits OpenAI's tool pipeline. Remnic's source of truth stays local; the tool inputs and outputs ChatGPT exchanges are processed by OpenAI.
+- **Only in chats where the app is enabled.** Linking the app does not make Remnic a global memory layer across all of ChatGPT. You must open a conversation and select or add the Remnic app (or refer to it) before ChatGPT will use its MCP tools. Chats where the app is not selected will neither read nor write Remnic memory.
 
 The key enabler is recent: OpenAI no longer disables built-in memory and tools when you connect a custom MCP server. That means Remnic works alongside ChatGPT's native capabilities instead of replacing them. You get Remnic's entity tracking, semantic search, and scoped namespaces inside the ChatGPT composer.
 

--- a/docs/integration/chatgpt.md
+++ b/docs/integration/chatgpt.md
@@ -17,9 +17,22 @@ URL. The local operator approves every link request on the server machine.
 > locally against `/mcp` with a bearer token; this guide covers the public
 > flow ChatGPT itself uses.
 
+## Overview
+
+ChatGPT can now persist memories across conversations using **your infrastructure**, not OpenAI's cloud. This integration exposes your local Remnic server to chatgpt.com via a developer-mode app that speaks MCP over OAuth 2.1. The result: every ChatGPT conversation you have can read and write to a memory store that lives on your filesystem as plain markdown, governed by your config, with provenance and lifecycle controls you choose.
+
+The key enabler is recent: OpenAI no longer disables built-in memory and tools when you connect a custom MCP server. That means Remnic works alongside ChatGPT's native capabilities instead of replacing them. You get Remnic's entity tracking, semantic search, and scoped namespaces inside the ChatGPT composer.
+
+## Quick Start
+
+1. **[Start your Remnic server](#requirements)** and [expose it over public HTTPS](#step-1-expose-the-server-over-public-https) (Tailscale Funnel is fastest).
+2. **[Configure OAuth](#step-2-configure-oauth-in-remnic)** with a `client_id`, `client_secret`, and your public `issuerUrl`.
+3. **[Create a developer-mode app](#step-3-create-the-app-in-chatgpt)** at `chatgpt.com/plugins`, then add the redirect URL to your config.
+4. **[Approve the link request](#step-4-approve-the-link-request-locally)** on your server machine, then start using Remnic tools in [the ChatGPT composer](#step-5-use-the-app-in-the-chatgpt-composer).
+
 ---
 
-## Prerequisites
+## Requirements
 
 - **ChatGPT plan:** Pro, Plus, Business, Enterprise, or Edu on the web. The
   developer-mode MCP flow is a ChatGPT-side feature and is not available on
@@ -369,6 +382,7 @@ re-runs the OAuth approval flow.
 | `remnic oauth pending` says "No pending requests" while the browser is on the approval page | The page is polling the wrong server, or the server is bound to a different port than `issuerUrl` points at. | Check the URL in the browser tab — it should be `<issuerUrl>/authorize?...`, and the page polls `<issuerUrl>/oauth/authorize/poll`. If it shows `127.0.0.1`, the tunnel is not routing correctly. |
 | ChatGPT returns "Invalid client" or "Invalid client_secret" at the token endpoint | `clientId` / `clientSecret` pasted into ChatGPT does not match `server.oauth.clientId` / `server.oauth.clientSecret`. | Remnic enforces the single `tokenEndpointAuthMethod` from your config. Re-copy the values from your config file (no surrounding whitespace, no shell-expanded placeholders) and re-paste into the ChatGPT app. |
 | Operator `remnic oauth approve` returns 401 | The CLI is talking to a Remnic daemon that does not have the same operator bearer token. | The CLI uses the same operator auth as the rest of the daemon-backed commands (`REMNIC_AUTH_TOKEN` / config). Re-check the config / env on the server machine. |
+| ChatGPT shows "Output schema recommended" on Remnic tools | Your Remnic version predates outputSchema support (PR #1844). ChatGPT recommends structured output on all MCP tools but older Remnic versions do not provide it. | Update to the latest Remnic version: `npm install -g @remnic/cli@latest`, then `remnic daemon restart`. The current release ships an `outputSchema` on every MCP tool, which silences the warning. |
 
 ---
 

--- a/docs/integration/chatgpt.md
+++ b/docs/integration/chatgpt.md
@@ -28,12 +28,22 @@ Two privacy and scope notes worth understanding before you connect:
 
 The key enabler is recent: OpenAI no longer disables built-in memory and tools when you connect a custom MCP server. That means Remnic works alongside ChatGPT's native capabilities instead of replacing them. You get Remnic's entity tracking, semantic search, and scoped namespaces inside the ChatGPT composer.
 
+One caveat on native memory: ChatGPT's native memory is **off by default for apps** and must be enabled per app if you want the model's own memories to inform Remnic tool calls. With native memory off, ChatGPT re-evaluates each request without it, so Remnic's tools will not see context the model would otherwise have surfaced from native memory. This does not affect Remnic's own store and recall, which work regardless. See OpenAI's Apps SDK guide on [Memory and tool calls](https://developers.openai.com/apps-sdk/build/mcp-server#memory-and-tool-calls).
+
 ## Quick Start
 
 1. **[Start your Remnic server](#requirements)** and [expose it over public HTTPS](#step-1-expose-the-server-over-public-https) (Tailscale Funnel is fastest).
 2. **[Configure OAuth](#step-2-configure-oauth-in-remnic)** with a `client_id`, `client_secret`, and your public `issuerUrl`.
 3. **[Create a developer-mode app](#step-3-create-the-app-in-chatgpt)** at `chatgpt.com/plugins`, then add the redirect URL to your config.
 4. **[Approve the link request](#step-4-approve-the-link-request-locally)** on your server machine, then start using Remnic tools in [the ChatGPT composer](#step-5-use-the-app-in-the-chatgpt-composer).
+
+> **Native ChatGPT memory is off by default for apps.** Linking Remnic
+> does not turn on ChatGPT's native memory. If you want the model's own
+> memories to inform Remnic tool calls, enable the per-app Memory toggle
+> in the app's settings; otherwise ChatGPT re-evaluates each request
+> without native memory. Remnic's own store and recall work regardless.
+> See OpenAI's Apps SDK guide: [Memory and tool
+> calls](https://developers.openai.com/apps-sdk/build/mcp-server#memory-and-tool-calls).
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -312,10 +312,13 @@ CONNECTING OTHER AGENTS
 
 CHATGPT DEVELOPER MODE (headline integration):
   ChatGPT can now persist memories across conversations using YOUR
-  infrastructure, not OpenAI's cloud. OpenAI no longer disables built-in
+  infrastructure as the source of truth. OpenAI no longer disables built-in
   memory/tools when you connect a custom MCP server. Remnic plugs into
-  that gap as an MCP + OAuth 2.1 integration, giving ChatGPT a
-  persistent, governed, local-first memory store.
+  that gap as an MCP + OAuth 2.1 integration, giving ChatGPT a persistent,
+  governed, local-first memory store. The canonical store stays on your
+  disk; when ChatGPT calls Remnic's tools, those tool inputs/outputs are
+  processed by OpenAI. Remnic is available only in chats where the
+  app/tools are enabled.
 
   docs/integration/chatgpt.md     Full setup guide with Quick Start,
                                   Overview, Requirements, step-by-step OAuth

--- a/llms.txt
+++ b/llms.txt
@@ -318,7 +318,9 @@ CHATGPT DEVELOPER MODE (headline integration):
   governed, local-first memory store. The canonical store stays on your
   disk; when ChatGPT calls Remnic's tools, those tool inputs/outputs are
   processed by OpenAI. Remnic is available only in chats where the
-  app/tools are enabled.
+  app/tools are enabled. Native ChatGPT memory is OFF by default for
+  apps and must be enabled per app; Remnic's own store/recall work
+  regardless (https://developers.openai.com/apps-sdk/build/mcp-server#memory-and-tool-calls).
 
   docs/integration/chatgpt.md     Full setup guide with Quick Start,
                                   Overview, Requirements, step-by-step OAuth

--- a/llms.txt
+++ b/llms.txt
@@ -310,11 +310,21 @@ CONNECTING OTHER AGENTS
   remnic connectors install replit
   pip install remnic-hermes
 
-CHATGPT DEVELOPER MODE (public OAuth + MCP flow):
-  docs/integration/chatgpt.md     chatgpt.com developer mode -> Remnic via
+CHATGPT DEVELOPER MODE (headline integration):
+  ChatGPT can now persist memories across conversations using YOUR
+  infrastructure, not OpenAI's cloud. OpenAI no longer disables built-in
+  memory/tools when you connect a custom MCP server. Remnic plugs into
+  that gap as an MCP + OAuth 2.1 integration, giving ChatGPT a
+  persistent, governed, local-first memory store.
+
+  docs/integration/chatgpt.md     Full setup guide with Quick Start,
+                                  Overview, Requirements, step-by-step OAuth
+                                  flow, troubleshooting, and security notes.
+                                  chatgpt.com developer mode -> Remnic via
                                   Tailscale Funnel or Cloudflare Tunnel, with
                                   server.oauth config and local operator
                                   approval (`remnic oauth pending|approve|deny`).
                                   The OAuth facade in @remnic/server is the
                                   authorization server; the connector id is
                                   `chatgpt` (token prefix remnic_cg_).
+                                  Every MCP tool ships an outputSchema (PR #1844).


### PR DESCRIPTION
## What

Promotes the ChatGPT developer-mode integration so anyone can discover and set it up:

- **README.md**: New prominent "ChatGPT Integration" section highlighting that Remnic now works with chatgpt.com dev-mode apps (store/recall memories in chat), with the key enabler: OpenAI no longer disables built-in memory/tools when you connect a custom MCP server.
- **docs/integration/chatgpt.md**: Added Quick Start (4-step summary), Overview (what/why), Requirements section, and troubleshooting for the "Output schema recommended" hint.
- **docs/README.md** + **llms.txt**: Updated integrations index.

## Voice-guard

README prose is marked **UNGATED** — this PR has not been run through the `voice-guard` skill or `voice_lint.py` per CLAUDE.md's public-content rule. Gate before merging if required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only markdown and llms.txt; no runtime, auth, or API behavior changes.
> 
> **Overview**
> **Documentation-only** changes that surface the ChatGPT developer-mode (MCP + OAuth 2.1) path as a first-class integration.
> 
> The root **README** gains a **ChatGPT Integration** section: chatgpt.com dev-mode apps, local-first store/recall, the point that custom MCP no longer disables native memory/tools, and a clear note that tool payloads still flow through OpenAI when ChatGPT calls Remnic.
> 
> **`docs/integration/chatgpt.md`** is expanded with an **Overview** (local source of truth vs OpenAI tool pipeline, app-scoped usage only), a **Quick Start** (four linked steps), **Requirements** (renamed from Prerequisites), repeated callouts on per-app native memory, and a troubleshooting row for ChatGPT’s **“Output schema recommended”** hint (upgrade to a build with MCP `outputSchema`, PR #1844).
> 
> **`docs/README.md`** and **`llms.txt`** refresh the integrations index with the same positioning and pointers to the full guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa3396c0c68a5b52d51e38298cb80d141ad6514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->