### PR TITLE
fix(build): migrate ignored pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/.changeset/pnpm-config-migration.md
+++ b/.changeset/pnpm-config-migration.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Migrate `onlyBuiltDependencies` and the esbuild `overrides` pin from the root package.json `pnpm` field to `pnpm-workspace.yaml`. pnpm 10.32.1 no longer reads the `pnpm` field in package.json, so those settings were being silently ignored and pnpm emitted a `[WARN] The "pnpm" field in package.json is no longer read` line that broke `npm run preflight:quick`. The settings now live as top-level keys in `pnpm-workspace.yaml` per https://pnpm.io/settings, and the dead `pnpm` field has been removed.

--- a/package.json
+++ b/package.json
@@ -1036,11 +1036,5 @@
     "turbo": "2.9.14",
     "typescript": "^5.9.3",
     "ajv": "^8.20.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"],
-    "overrides": {
-      "esbuild@>=0.27.3 <0.28.1": "~0.28.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - "packages/*"
+
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild
+  - sharp
+  - koffi
+  - protobufjs
+
+overrides:
+  "esbuild@>=0.27.3 <0.28.1": "~0.28.1"


### PR DESCRIPTION
## Problem
pnpm 10.x no longer reads the `pnpm` field from `package.json` (moved to `pnpm-workspace.yaml` per https://pnpm.io/settings). The repo's `pnpm.onlyBuiltDependencies` and the `esbuild` security-pin `overrides` were therefore **silently ignored**, and pnpm emitted a `[WARN]` that broke `npm run preflight:quick` (the check-test-types wrapper treats the warn as a baseline diagnostic).

## Fix
- Move `onlyBuiltDependencies` + `overrides` from `package.json`'s dead `pnpm` field into top-level `pnpm-workspace.yaml` keys (their new home).
- Remove the ignored `pnpm` field from `package.json`.

## Verification
- Before: `[WARN] The "pnpm" field in package.json is no longer read by pnpm. ... keys ignored: pnpm.onlyBuiltDependencies, pnpm.overrides`.
- After: no WARN line, exit 0. `pnpm config list` now **recognizes** `only-built-dependencies` + the esbuild `[overrides]` entry (previously ignored).
- `pnpm install --lockfile-only`: `pnpm-lock.yaml` unchanged (esbuild already resolved within the pinned `~0.28.1` range).
- Only `package.json` + `pnpm-workspace.yaml` changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config relocation only; same policy values, no lockfile or application code changes.
> 
> **Overview**
> **Restores pnpm 10.x–compatible config** by moving `onlyBuiltDependencies` and the esbuild `overrides` pin out of the root `package.json` `pnpm` block (which pnpm no longer reads) into top-level keys in `pnpm-workspace.yaml`, and deleting the dead `pnpm` field.
> 
> That fixes **silent loss** of native-build allowlisting and the esbuild security pin, and removes the `[WARN] The "pnpm" field in package.json is no longer read` line that was tripping `preflight:quick`. A patch changeset documents the `@remnic/core` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b7f34fc37450aabfbe44e76acf75cfa1bc201f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->