### PR TITLE
refactor: retire compression-guideline forwarding delegates

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4722,7 +4722,7 @@ export class EngramAccessService {
     if (!resolveCompressionCapabilities(this.orchestrator.config).compressionGuidelineLearning) {
       return { enabled: false, reason: "Compression guideline learning is disabled. Enable `compressionGuidelineLearningEnabled: true`." };
     }
-    return await this.orchestrator.optimizeCompressionGuidelines({
+    return await this.orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({
       dryRun: request.dryRun,
       eventLimit: request.eventLimit,
     });
@@ -4735,7 +4735,7 @@ export class EngramAccessService {
     if (!resolveCompressionCapabilities(this.orchestrator.config).compressionGuidelineLearning) {
       return { enabled: false, reason: "Compression guideline learning is disabled." };
     }
-    return await this.orchestrator.activateCompressionGuidelineDraft({
+    return await this.orchestrator.compressionGuidelineCoordinator.activateCompressionGuidelineDraft({
       expectedContentHash: request.expectedContentHash,
       expectedGuidelineVersion: request.expectedGuidelineVersion,
     });

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3195,7 +3195,9 @@ export class Orchestrator {
   }
 
   // Issue #1526 (seam 4): compression-guideline learning moved to
-  // CompressionGuidelineCoordinator. Thin delegation keeps the
+  // CompressionGuidelineCoordinator. Public forwarding delegates were
+  // removed; callers use the coordinator directly. This private helper
+  // forwards recall-section formatting to the coordinator.
   private async buildCompressionGuidelineRecallSection(): Promise<string | null> {
     return this.compressionGuidelineCoordinator.buildCompressionGuidelineRecallSection();
   }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3194,20 +3194,6 @@ export class Orchestrator {
     return this.consolidationRunCoordinator.run();
   }
 
-  async optimizeCompressionGuidelines(options?: {
-    dryRun?: boolean;
-    eventLimit?: number;
-  }) {
-    return this.compressionGuidelineCoordinator.optimizeCompressionGuidelines(options);
-  }
-
-  async activateCompressionGuidelineDraft(options?: {
-    expectedContentHash?: string;
-    expectedGuidelineVersion?: number;
-  }) {
-    return this.compressionGuidelineCoordinator.activateCompressionGuidelineDraft(options);
-  }
-
   // Issue #1526 (seam 4): compression-guideline learning moved to
   // CompressionGuidelineCoordinator. Thin delegation keeps the
   private async buildCompressionGuidelineRecallSection(): Promise<string | null> {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1917,7 +1917,7 @@ Best for:
           eventLimit?: number;
         };
 
-        const result = await orchestrator.optimizeCompressionGuidelines({
+        const result = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({
           dryRun: dryRun === true,
           eventLimit,
         });
@@ -1963,7 +1963,7 @@ Best for:
           Number.isFinite(params.expectedGuidelineVersion)
             ? Math.floor(params.expectedGuidelineVersion)
             : undefined;
-        const result = await orchestrator.activateCompressionGuidelineDraft({
+        const result = await orchestrator.compressionGuidelineCoordinator.activateCompressionGuidelineDraft({
           ...(expectedContentHash ? { expectedContentHash } : {}),
           ...(typeof expectedGuidelineVersion === "number" ? { expectedGuidelineVersion } : {}),
         });

--- a/tests/orchestrator-compression-guidelines.test.ts
+++ b/tests/orchestrator-compression-guidelines.test.ts
@@ -240,7 +240,7 @@ test("optimizeCompressionGuidelines stages a draft revision without overwriting 
       },
     ]);
 
-    const result = await orchestrator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
+    const result = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
     assert.equal(result.persisted, true);
     assert.equal(typeof result.draftContentHash, "string");
 
@@ -305,12 +305,12 @@ test("optimizeCompressionGuidelines increments staged guideline versions from th
       },
     ]);
 
-    const first = await orchestrator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
+    const first = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
     const firstDraftState = await orchestrator.storage.readCompressionGuidelineDraftState();
     assert.equal(first.nextGuidelineVersion, 5);
     assert.equal(firstDraftState?.guidelineVersion, 5);
 
-    const second = await orchestrator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
+    const second = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 50 });
     const secondDraftState = await orchestrator.storage.readCompressionGuidelineDraftState();
     assert.equal(second.nextGuidelineVersion, 6);
     assert.equal(secondDraftState?.guidelineVersion, 6);
@@ -355,7 +355,7 @@ test("optimizeCompressionGuidelines tags semantic refinement calls as background
       },
     ]);
 
-    const result = await orchestrator.optimizeCompressionGuidelines({
+    const result = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({
       dryRun: false,
       eventLimit: 10,
     });
@@ -394,20 +394,20 @@ test("activateCompressionGuidelineDraft requires reviewed draft identity and rej
       },
     ]);
 
-    const optimizeResult = await orchestrator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 10 });
+    const optimizeResult = await orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines({ dryRun: false, eventLimit: 10 });
     assert.equal(typeof optimizeResult.draftContentHash, "string");
 
-    const missingIdentity = await orchestrator.activateCompressionGuidelineDraft();
+    const missingIdentity = await orchestrator.compressionGuidelineCoordinator.activateCompressionGuidelineDraft();
     assert.equal(missingIdentity.activated, false);
     assert.equal(missingIdentity.reason, "expected_revision_required");
 
-    const staleIdentity = await orchestrator.activateCompressionGuidelineDraft({
+    const staleIdentity = await orchestrator.compressionGuidelineCoordinator.activateCompressionGuidelineDraft({
       expectedContentHash: "stale-hash",
     });
     assert.equal(staleIdentity.activated, false);
     assert.equal(staleIdentity.reason, "content_hash_mismatch");
 
-    const activated = await orchestrator.activateCompressionGuidelineDraft({
+    const activated = await orchestrator.compressionGuidelineCoordinator.activateCompressionGuidelineDraft({
       expectedContentHash: optimizeResult.draftContentHash ?? undefined,
     });
     assert.equal(activated.activated, true);

--- a/tests/tools-compression-optimize.test.ts
+++ b/tests/tools-compression-optimize.test.ts
@@ -51,27 +51,29 @@ function buildHarness(resultOverride?: {
       sharedContextEnabled: false,
       compoundingEnabled: false,
     },
-    optimizeCompressionGuidelines: async (params?: Record<string, unknown>) => {
-      capturedCalls.push(params ?? {});
-      return {
+    compressionGuidelineCoordinator: {
+      optimizeCompressionGuidelines: async (params?: Record<string, unknown>) => {
+        capturedCalls.push(params ?? {});
+        return {
+          enabled: resultOverride?.enabled ?? true,
+          dryRun: resultOverride?.dryRun ?? false,
+          eventCount: resultOverride?.eventCount ?? 22,
+          previousGuidelineVersion: resultOverride?.previousGuidelineVersion ?? 3,
+          nextGuidelineVersion: resultOverride?.nextGuidelineVersion ?? 4,
+          draftContentHash:
+            resultOverride?.draftContentHash ?? (resultOverride?.dryRun === true ? null : "hash-123"),
+          changedRules: resultOverride?.changedRules ?? 2,
+          semanticRefinementApplied: resultOverride?.semanticRefinementApplied ?? false,
+          persisted: resultOverride?.persisted ?? true,
+        };
+      },
+      activateCompressionGuidelineDraft: async () => ({
         enabled: resultOverride?.enabled ?? true,
-        dryRun: resultOverride?.dryRun ?? false,
-        eventCount: resultOverride?.eventCount ?? 22,
-        previousGuidelineVersion: resultOverride?.previousGuidelineVersion ?? 3,
-        nextGuidelineVersion: resultOverride?.nextGuidelineVersion ?? 4,
-        draftContentHash:
-          resultOverride?.draftContentHash ?? (resultOverride?.dryRun === true ? null : "hash-123"),
-        changedRules: resultOverride?.changedRules ?? 2,
-        semanticRefinementApplied: resultOverride?.semanticRefinementApplied ?? false,
-        persisted: resultOverride?.persisted ?? true,
-      };
+        activated: resultOverride?.activated ?? true,
+        guidelineVersion: resultOverride?.nextGuidelineVersion ?? 4,
+        reason: resultOverride?.reason,
+      }),
     },
-    activateCompressionGuidelineDraft: async () => ({
-      enabled: resultOverride?.enabled ?? true,
-      activated: resultOverride?.activated ?? true,
-      guidelineVersion: resultOverride?.nextGuidelineVersion ?? 4,
-      reason: resultOverride?.reason,
-    }),
     qmd: {
       search: async () => [],
       searchGlobal: async () => [],


### PR DESCRIPTION
Closes #1800\n\nMigrates access-service and tool callers to CompressionGuidelineCoordinator and removes the two forwarding delegates from Orchestrator. Focused tests and ratchet verification were run in the worktree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical delegate removal with no logic changes; tests and mocks were updated to match the new call path.
> 
> **Overview**
> **Compression guideline optimize/activate** no longer goes through `Orchestrator` public methods. Callers now invoke `orchestrator.compressionGuidelineCoordinator.optimizeCompressionGuidelines` and `activateCompressionGuidelineDraft` directly.
> 
> **`EngramAccessService`** (`compressionGuidelinesOptimize` / `compressionGuidelinesActivate`), **MCP tools** in `src/tools.ts`, and **tests** were updated to use the coordinator. The orchestrator comment notes that public forwarding delegates were removed; the private `buildCompressionGuidelineRecallSection` helper still delegates to the coordinator for recall formatting.
> 
> Behavior and capability gating (`compressionGuidelineLearning`) are unchanged—this is a routing cleanup aligned with issue #1526 / #1800.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0357e6a289383e5fb738954ff424186989ca1089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->