### PR TITLE
refactor: retire entity-synthesis forwarding delegate

### DIFF
--- a/packages/remnic-core/src/access-admin-ops-surface.ts
+++ b/packages/remnic-core/src/access-admin-ops-surface.ts
@@ -192,7 +192,7 @@ export class AccessAdminOpsSurface {
     });
     if (mode === "apply") {
       try {
-        await this.deps.orchestrator.processEntitySynthesisQueue(
+        await this.deps.orchestrator.entitySynthesisCoordinator.processQueue(
           resolvedNamespace,
           Math.min(boundedBatchSize ?? 5, 5),
         );

--- a/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
@@ -12,14 +12,12 @@
  *     `flattenStructuredSectionEvidence`, `fingerprintEntitySynthesisEvidence`
  *   - the orchestrator method `processEntitySynthesisQueue`
  *
- * The orchestrator constructs one instance and delegates the public entrypoint
- * to it. Storage is resolved per-call via the injected accessor so namespace-
- * scoped and default-namespace calls share one coordinator.
- *
- * Behavior-preserving move from orchestrator.ts. No logic changes — the
- * orchestrator keeps a thin delegating `processEntitySynthesisQueue` so
- * existing call sites (consolidation pass, access-service) and tests that
- * exercise the public API continue to work.
+ * The orchestrator constructs one instance and exposes it as
+ * `orchestrator.entitySynthesisCoordinator`; call sites invoke `processQueue`
+ * directly (issue #1800 removed the orchestrator's forwarding delegate once
+ * every caller migrated). Storage is resolved per-call via the injected
+ * accessor so namespace-scoped and default-namespace calls share one
+ * coordinator.
  */
 
 import { createHash } from "node:crypto";

--- a/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
+++ b/packages/remnic-core/src/orchestration/entity-synthesis-coordinator.ts
@@ -10,7 +10,8 @@
  * Moved here (behavior-preserving):
  *   - module-level helpers `dedupeEntitySynthesisEvidenceEntries`,
  *     `flattenStructuredSectionEvidence`, `fingerprintEntitySynthesisEvidence`
- *   - the orchestrator method `processEntitySynthesisQueue`
+ *   - the queue-processing method, now owned by this coordinator as
+ *     `processQueue` (originally the orchestrator's `processEntitySynthesisQueue`)
  *
  * The orchestrator constructs one instance and exposes it as
  * `orchestrator.entitySynthesisCoordinator`; call sites invoke `processQueue`

--- a/packages/remnic-core/src/orchestration/session-context.ts
+++ b/packages/remnic-core/src/orchestration/session-context.ts
@@ -22,6 +22,7 @@ import { LocalLlmClient } from "../local-llm.js";
 import { log } from "../logger.js";
 import { canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "../namespaces/principal.js";
 import type { ExtractionRunResult } from "./extraction-run.js";
+import type { EntitySynthesisCoordinator } from "./entity-synthesis-coordinator.js";
 import type { BufferTurn, CodingContext, DaySummaryResult, MemoryFile, PluginConfig } from "../types.js";
 import {
   Orchestrator,
@@ -40,10 +41,7 @@ export interface SessionContextDeps {
   getCodingContextForSession(sessionKey: string | undefined): CodingContext | null;
   readonly initPromise: Promise<void> | null;
   readonly localLlm: LocalLlmClient;
-  processEntitySynthesisQueue(
-    namespace?: string,
-    maxEntities?: number,
-  ): Promise<number>;
+  readonly entitySynthesisCoordinator: EntitySynthesisCoordinator;
   queueBufferedExtraction(
     turnsToExtract: BufferTurn[],
     reason: "trigger_mode" | "heartbeat_observer",
@@ -282,7 +280,7 @@ export class SessionContextCoordinator {
     });
     if (options?.dryRun !== true) {
       try {
-        await this.deps.processEntitySynthesisQueue(
+        await this.deps.entitySynthesisCoordinator.processQueue(
           this.deps.storageDirNamespace(targetStorage.dir),
           5,
         );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2092,16 +2092,6 @@ export class Orchestrator {
     return this.storageRouter.storageFor(ns);
   }
 
-  async processEntitySynthesisQueue(
-    namespace?: string,
-    maxEntities: number = 5,
-  ): Promise<number> {
-    // Issue #1526: entity synthesis lifecycle moved to EntitySynthesisCoordinator.
-    // Thin delegation keeps all call sites (consolidation pass, access-service)
-    // and tests that exercise the public API working unchanged.
-    return this.entitySynthesisCoordinator.processQueue(namespace, maxEntities);
-  }
-
   async generateDaySummary(
     memories: string | MemoryFile[],
   ): Promise<DaySummaryResult | null> {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3262,9 +3262,11 @@ test("access service governanceRun skips entity synthesis refresh in shadow mode
       recall: async () => "ctx",
       lastRecall: { get: () => null, getMostRecent: () => null },
       getStorage: async () => storage,
-      processEntitySynthesisQueue: async () => {
-        synthesisCalls += 1;
-        throw new Error("shadow mode must not refresh synthesis");
+      entitySynthesisCoordinator: {
+        processQueue: async () => {
+          synthesisCalls += 1;
+          throw new Error("shadow mode must not refresh synthesis");
+        },
       },
     } as any);
 
@@ -3363,9 +3365,11 @@ test("access service governanceRun preserves apply result when entity synthesis 
       recall: async () => "ctx",
       lastRecall: { get: () => null, getMostRecent: () => null },
       getStorage: async () => storage,
-      processEntitySynthesisQueue: async () => {
-        synthesisCalls += 1;
-        throw new Error("synthetic refresh failure");
+      entitySynthesisCoordinator: {
+        processQueue: async () => {
+          synthesisCalls += 1;
+          throw new Error("synthetic refresh failure");
+        },
       },
     } as any);
 

--- a/tests/entity-synthesis-orchestrator.test.ts
+++ b/tests/entity-synthesis-orchestrator.test.ts
@@ -63,7 +63,7 @@ test("processEntitySynthesisQueue refreshes stale entities in bounded batches", 
     };
 
     const refreshStartedAt = Date.now();
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const refreshFinishedAt = Date.now();
 
     const rawPrimary = await readFile(path.join(memoryDir, "entities", `${primaryCanonical}.md`), "utf-8");
@@ -126,7 +126,7 @@ test("processEntitySynthesisQueue sorts freshest evidence before truncating", as
       return { content: "Jane Doe has refreshed synthesis." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
 
     assert.equal(processed, 1);
     assert.match(capturedPrompt, /Newest event should survive truncation\./);
@@ -174,7 +174,7 @@ test("processEntitySynthesisQueue batches overflow evidence before advancing fre
       return { content: `Jane Doe synthesis batch ${prompts.length}.` };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const rawEntity = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const parsed = parseEntityFile(rawEntity);
 
@@ -231,7 +231,7 @@ test("processEntitySynthesisQueue skips failed targets and continues through the
       return { content: "Project Success has refreshed synthesis." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 2);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 2);
     const rawSuccess = await readFile(
       path.join(memoryDir, "entities", `${succeedingCanonical}.md`),
       "utf-8",
@@ -288,7 +288,7 @@ test("processEntitySynthesisQueue counts failed entities against the maxEntities
       return { content: "Project Success has refreshed synthesis." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const rawSuccess = await readFile(
       path.join(memoryDir, "entities", `${succeedingCanonical}.md`),
       "utf-8",
@@ -352,7 +352,7 @@ test("processEntitySynthesisQueue keeps the newest and oldest repeated facts bef
       return { content: "Jane Doe has refreshed synthesis." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
 
     assert.equal(processed, 1);
     assert.match(capturedPrompt, /Repeated recent fact\./);
@@ -429,7 +429,7 @@ test("processEntitySynthesisQueue treats offset timestamps as newer when filteri
       return { content: "Jane Doe has refreshed synthesis." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
 
     assert.equal(processed, 1);
     assert.match(capturedPrompt, /Offset timestamp should count as new evidence\./);
@@ -481,7 +481,7 @@ test("processEntitySynthesisQueue includes backfilled appended entries alongside
       return { content: "Jane Doe synthesis with backfilled evidence." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const rawEntity = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const parsed = parseEntityFile(rawEntity);
 
@@ -533,8 +533,8 @@ test("processEntitySynthesisQueue does not regress synthesisUpdatedAt for backfi
       return { content: "Jane Doe synthesis with backfilled evidence." };
     };
 
-    const firstProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
-    const secondProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const firstProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
+    const secondProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const rawEntity = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const parsed = parseEntityFile(rawEntity);
 
@@ -595,7 +595,7 @@ test("processEntitySynthesisQueue skips writing synthesis from a stale timeline 
       return { content: "Jane Doe synthesis built from a stale snapshot." };
     };
 
-    const firstProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const firstProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const afterFirstRaw = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const afterFirst = parseEntityFile(afterFirstRaw);
 
@@ -610,7 +610,7 @@ test("processEntitySynthesisQueue skips writing synthesis from a stale timeline 
       return { content: "Jane Doe synthesis after re-reading current evidence." };
     };
 
-    const secondProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const secondProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const afterSecondRaw = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const afterSecond = parseEntityFile(afterSecondRaw);
 
@@ -684,7 +684,7 @@ test("processEntitySynthesisQueue skips writing synthesis when structured sectio
       return { content: "Jane Doe synthesis built from a stale structured snapshot." };
     };
 
-    const firstProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const firstProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const afterFirstRaw = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const afterFirst = parseEntityFile(afterFirstRaw);
 
@@ -700,7 +700,7 @@ test("processEntitySynthesisQueue skips writing synthesis when structured sectio
       return { content: "Jane Doe synthesis after re-reading structured evidence." };
     };
 
-    const secondProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const secondProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const afterSecondRaw = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const afterSecond = parseEntityFile(afterSecondRaw);
 
@@ -751,7 +751,7 @@ test("processEntitySynthesisQueue synthesizes section-only entities", async () =
       return { content: "Acme Corp favors durable teams over frequent reorganizations." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const parsed = parseEntityFile(await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8"));
 
     assert.equal(processed, 1);
@@ -829,7 +829,7 @@ test("processEntitySynthesisQueue includes changed same-count structured evidenc
       return { content: "Jane Doe synthesis rebuilt with the changed belief and fresh timeline evidence." };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const reparsed = parseEntityFile(await readFile(entityPath, "utf-8"));
 
     assert.equal(processed, 1);
@@ -881,7 +881,7 @@ test("processEntitySynthesisQueue does not resynthesize timestampless evidence o
       return { content: "Jane Doe synthesis rebuilt from timestampless evidence." };
     };
 
-    const firstProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const firstProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const firstRawEntity = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const firstParsed = parseEntityFile(firstRawEntity);
 
@@ -892,7 +892,7 @@ test("processEntitySynthesisQueue does not resynthesize timestampless evidence o
     assert.equal(firstParsed.synthesisTimelineCount, firstParsed.timeline.length);
     assert.equal(isEntitySynthesisStale(firstParsed), false);
 
-    const secondProcessed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const secondProcessed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const secondRawEntity = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const secondParsed = parseEntityFile(secondRawEntity);
 
@@ -951,7 +951,7 @@ test("processEntitySynthesisQueue advances freshness using the newest non-empty 
 
     orchestrator.fastChatCompletion = async () => ({ content: "Jane Doe synthesis after mixed evidence." });
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const parsed = parseEntityFile(await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8"));
 
     assert.equal(processed, 1);
@@ -993,7 +993,7 @@ test("processEntitySynthesisQueue treats zero max tokens as disabled", async () 
       return { content: "should not be called" };
     };
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
 
     assert.equal(processed, 0);
     assert.equal(completionCalls, 0);
@@ -1031,7 +1031,7 @@ test("processEntitySynthesisQueue accepts long synthesis responses within the co
 
     orchestrator.fastChatCompletion = async () => ({ content: longSynthesis });
 
-    const processed = await orchestrator.processEntitySynthesisQueue("default", 1);
+    const processed = await orchestrator.entitySynthesisCoordinator.processQueue("default", 1);
     const raw = await readFile(path.join(memoryDir, "entities", `${canonical}.md`), "utf-8");
     const parsed = parseEntityFile(raw);
 

--- a/tests/orchestrator-lifecycle-performance.test.ts
+++ b/tests/orchestrator-lifecycle-performance.test.ts
@@ -43,7 +43,7 @@ test("runDeepSleepGovernanceNow refreshes entity synthesis after apply runs", ()
 
   assert.match(
     source,
-    /if \(options\?\.dryRun !== true\) \{\s*try \{\s*await this\.deps\.processEntitySynthesisQueue\(\s*this\.deps\.storageDirNamespace\(targetStorage\.dir\),\s*5,\s*\);/m,
+    /if \(options\?\.dryRun !== true\) \{\s*try \{\s*await this\.deps\.entitySynthesisCoordinator\.processQueue\(\s*this\.deps\.storageDirNamespace\(targetStorage\.dir\),\s*5,\s*\);/m,
     "deep-sleep apply runs should refresh entity synthesis for the active namespace",
   );
 });


### PR DESCRIPTION
Part of #1800. Migrates access/admin, session-context, and test callers to entitySynthesisCoordinator.processQueue and removes the Orchestrator forwarding delegate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API surface change with behavior-preserving call-site renames; synthesis implementation is untouched.
> 
> **Overview**
> Completes **#1800** by dropping `Orchestrator.processEntitySynthesisQueue` and having all callers use **`orchestrator.entitySynthesisCoordinator.processQueue`** instead.
> 
> **`SessionContextDeps`** now exposes `entitySynthesisCoordinator` (typed) rather than a `processEntitySynthesisQueue` callback. Governance paths in **`access-admin-ops-surface`** and **`session-context`** (`runDeepSleepGovernanceNow`) call the coordinator directly after apply-mode governance, with the same namespace and batch limits as before.
> 
> Tests and access-layer mocks were updated to stub `entitySynthesisCoordinator.processQueue`; coordinator module comments now document the public entrypoint. **No change** to synthesis queue logic inside `EntitySynthesisCoordinator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df67cc2637323c3e481ced09e358bacbc10f83a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->