### PR TITLE
fix: harden dependencies and clarify Tier-F provenance

### DIFF
--- a/.changeset/secure-tierf-rollout.md
+++ b/.changeset/secure-tierf-rollout.md
@@ -1,0 +1,28 @@
+---
+"@remnic/replit": patch
+"@remnic/bench": patch
+"@remnic/import-weclone": patch
+"@remnic/cli": patch
+"@remnic/plugin-claude-code": patch
+"@remnic/import-mem0": patch
+"@remnic/connector-weclone": patch
+"@remnic/connector-limitless": patch
+"@remnic/import-lossless-claw": patch
+"@remnic/hermes-provider": patch
+"@remnic/plugin-pi": patch
+"@remnic/coding-graph": patch
+"@remnic/connector-omi": patch
+"@remnic/server": patch
+"@remnic/import-supermemory": patch
+"@remnic/plugin-openclaw": patch
+"@remnic/connector-bee": patch
+"@remnic/belief-ledger": patch
+"@remnic/plugin-codex": patch
+"@remnic/import-gemini": patch
+"@remnic/import-chatgpt": patch
+"@remnic/core": patch
+"@remnic/import-claude": patch
+"@remnic/export-weclone": patch
+---
+
+Security hardening and research-provenance documentation updates.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -104,13 +104,17 @@ full published-benchmark pipeline against a frontier model without a raw
 Anthropic API budget — the operator's Claude Max subscription provides the
 compute.
 
-**Honest labeling:** these artifacts are labeled **"Opus via Claude Code"**
-(`provider: "claude-cli"`, `model: "opus"` on the artifact config) — never
-`tier: "frontier"`. Claude Code adds system-prompt scaffolding and
-model-alias routing that a reviewer cannot reproduce from a raw API call.
-The published headline `tier: "frontier"` number must still come from the
-raw Anthropic Messages API provider. These runs are pipeline-validation
-evidence, not publishable leaderboard numbers.
+**Provenance labeling:** these artifacts are labeled **"Opus via Claude Code"**
+(`provider: "claude-cli"`, `model: "opus"` on the artifact config) and retain
+`tier: "frontier"` when they satisfy the Tier-F artifact contract. Claude Code
+is a valid research harness; its entitlement and invocation details are part of
+the provenance record alongside the model and benchmark configuration. A raw
+Anthropic API run and a Claude Code run are distinct measurement paths, not a
+valid-versus-invalid hierarchy. Reviewers must be able to reproduce the
+declared harness and configuration, and bounded trials must remain clearly
+identified as partial-coverage artifacts rather than full leaderboard runs.
+These artifacts are therefore pipeline-validation evidence until the complete
+uncapped benchmark coverage required by the publication rubric is executed.
 
 ### Bounded-slice results (2026-07-08, commit 798fe8a7a)
 
@@ -130,9 +134,11 @@ Both used `--runtime-profile baseline --system-provider claude-cli
 
 Note on artifact fields: the runner records `meta.mode: "full"` (full-mode
 scoring pipeline) with `config.benchmarkOptions.trialLimit` bounding the
-task count — the "(trial)" labels above and the `trial100`/`trial50`
-filename segments carry the partial-coverage signal; these artifacts are
-pipeline-validation evidence, not publishable leaderboard numbers.
+task count — the "(trial)" labels above and the `trial100`/`trial50` filename
+segments carry the partial-coverage signal. The bounded artifacts retain
+`tier: "frontier"` and their Claude Code provenance; they are not full
+leaderboard results because coverage is capped, not because Claude Code is an
+invalid research harness.
 
 A small number of tasks (9/100 locomo, 3/50 longmemeval) hit intermittent
 `claude -p` subprocess failures (exit 1) and scored 0 on those metrics;

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -50,17 +50,20 @@ issue owns one (`related-work.md`). Keeping the rest of the skeleton in a single
    (both `tier: "local"`, model `qwen2.5-7b-32k:latest`). The
    `2026-04-20-*-mock000.json` files are **mocks** and must never be cited as
    results.
-3. **No Tier-F claim without the real run.** A Tier-F responder run (Opus 4.8
-   via `claude -p`) does not exist yet and is blocked on PR #1735 + child #1728.
-   The skeleton leaves §6 Results and §5 Tier-F rows as TODOs.
+3. **No Tier-F claim without the real run.** A complete Tier-F responder run
+   (Opus 4.8 via `claude -p`) is still pending for the full dataset. The
+   bounded artifacts and provider are available; §6 Results and §5 Tier-F rows
+   must distinguish trial coverage from full coverage.
 4. **Lead with MemCorrect (composition framing), not raw Tier-L accuracy.** Per
    Joshua's confirmed decision (2026-07-07). MemCorrect's novelty is a
    composition/protocol claim, **not** "first to measure memory correction" —
    the plan's Novelty section names StateBench / STALE / MemSyco-Bench /
    MemStrata / MemoryAgentBench as prior art that must be engaged.
-5. **Label `claude -p` honestly.** A `claude -p` number is "Opus 4.8 via Claude
-   Code," not a raw-API frontier number. Keep `tier: "frontier"`; carry the
-   label in the artifact `note`/model metadata. Do not invent a new tier value.
+5. **Label `claude -p` with complete provenance.** A `claude -p` number is
+   "Opus 4.8 via Claude Code," a valid research-harness measurement distinct
+   from a raw-API run. Keep `tier: "frontier"` when the artifact contract is
+   satisfied; carry provider, harness, model, isolation, invocation, and
+   artifact labels in metadata. Do not invent a new tier value.
 6. **Keep the corrected KU framing.** `docs/benchmarks/memcorrect.md` already
    reads *"the strongest systems score roughly 70–90%, not ceiling"* (the old
    "near ceiling" wording was removed before this skeleton landed). The §4

--- a/docs/paper/main.md
+++ b/docs/paper/main.md
@@ -287,9 +287,11 @@ softens into overclaim:
 - **MemCorrect v1 synthetic-corpus limits** — deterministic, token-pool-derived
   (no real PII by construction), but synthetic; the corpus does not capture
   every real-world correction shape. Scope to what the corpus tests.
-- **`claude -p` is not a raw-API number** — Claude Code adds system-prompt
-  scaffolding + model-alias routing and is not reproducible without a Claude
-  Code entitlement. Say so.
+- **`claude -p` is a valid research-harness path distinct from raw API.**
+  Claude Code adds system-prompt scaffolding and model-alias routing; record
+  the harness, entitlement, model, isolation, and invocation details as
+  provenance. A result may retain `tier: "frontier"` when the artifact
+  contract is satisfied; bounded trials remain partial-coverage results.
 - `TODO(#1726)`: no drafting blocker — write the prose from the bullets above
   once §5/§6 are populated; do not add limitations that imply un-run
   experiments.

--- a/docs/paper/repro-appendix.md
+++ b/docs/paper/repro-appendix.md
@@ -569,16 +569,19 @@ machine; the training entry point exits with code 2 and an install hint if
 ## A.5 Tier F (frontier) reproduction
 
 The Tier F responder is **Opus 4.8 via Claude Code (`claude -p`)**, through
-the `claude-cli` bench provider — not a raw-API frontier call (there is no
-API budget). This is a hard dependency on PR #1735 (`claude-cli` provider),
-which is **not yet on `main`**; the Tier F run (#1728) is blocked on it.
+the `claude-cli` bench provider. This is a valid research harness and a
+distinct provenance path from the raw Anthropic API; the benchmark artifact
+records the provider, model, harness, isolation settings, and invocation
+configuration. The Tier F run (#1728) uses the same supported artifact schema
+as other frontier runs.
 
-**Honest labelling.** A `claude -p` number is "Opus 4.8 via Claude Code," not
-a raw-API `tier: "frontier"` result. Claude Code adds system-prompt
-scaffolding + model-alias routing and is not reproducible without a Claude
-Code entitlement. The artifact keeps `tier: "frontier"` (the only supported
-value for a non-local run) and carries the label in its `note` + model
-metadata (e.g. model `opus-4-8-via-claude-code`). No new tier value is
+**Provenance labelling.** A `claude -p` result is labeled "Opus 4.8 via Claude
+Code" and retains `tier: "frontier"` when it satisfies the Tier-F artifact
+contract. Claude Code entitlement and model-alias details are part of the
+measurement provenance, not grounds for downgrading the result. Raw API and
+Claude Code runs are distinct measurement paths; neither is inherently the
+valid one. The artifact carries the harness label in its `note` and model
+metadata (for example, `opus-4-8-via-claude-code`). No new tier value is
 invented — `BenchmarkArtifactTier` is `"local" | "frontier"` only and
 `parseBenchmarkArtifact()` rejects anything else.
 

--- a/docs/plans/2026-07-07-evidence-sprint-arxiv-outline.md
+++ b/docs/plans/2026-07-07-evidence-sprint-arxiv-outline.md
@@ -95,8 +95,18 @@ A prior-art sweep (live web research, 2026-07-07) confirms MemCorrect is a **gen
 **Already applied (verified 2026-07-07):** `docs/benchmarks/memcorrect.md` no longer says LongMemEval KU is "near ceiling" — it now reads *"the strongest systems score roughly 70–90%, not ceiling"* and frames KU as checking only newest-fact answer-time behavior. The paper draft must keep this corrected framing; do not re-introduce the old wording.
 
 ### Tier-F responder: `claude -p` / Opus 4.8 IS the path (no API budget)
-There is no budget for a raw-API frontier run, so the Tier-F responder **is** Opus 4.8 via Claude Code headless (`claude -p`), through the `claude-cli` bench provider. **That provider is delivered by PR #1735** (`feat/bench-claude-cli-provider`, modeled on `codex-cli.ts`) and is NOT yet on `main`, so the Tier-F run (#1728) is blocked on #1735 merging first — it is a hard dependency, not an assumed-present tool.
-- **Label it honestly — don't hide it.** A `claude -p` number is "Opus 4.8 via Claude Code," NOT a raw-API `tier: "frontier"` result (Claude Code adds system-prompt scaffolding + model-alias routing, and it isn't reproducible without a Claude Code entitlement). **Do not invent a new `tier` value** — `BenchmarkArtifactTier` is `local|frontier` only and `parseBenchmarkArtifact()` rejects anything else. Label it via the artifact's `note` + model metadata (e.g. model `opus-4-8-via-claude-code`) while keeping `tier: "frontier"`, or land a schema+parser+test change first if a distinct tier is truly wanted. Stated plainly, this is defensible; presenting it *as* a raw-API number is the only thing that would sink credibility.
+There is no budget for a raw-API frontier run, so the Tier-F responder is Opus
+4.8 via Claude Code headless (`claude -p`), through the `claude-cli` bench
+provider. **That provider is delivered by PR #1735** and is now available on
+`main`; this is a valid research harness, not a fallback that invalidates the
+measurement.
+- **Label it with complete provenance.** A `claude -p` number may retain
+  `tier: "frontier"` when it satisfies the artifact contract. Record
+  `provider: "claude-cli"`, the actual model, Claude Code harness details,
+  isolation settings, invocation configuration, artifact note, and model
+  metadata. Raw Anthropic API and Claude Code are distinct measurement paths,
+  not a valid-versus-invalid hierarchy. Do not invent a new `tier` value —
+  `BenchmarkArtifactTier` remains `local|frontier`.
 - **Isolation is mandatory.** Run `claude -p` from a freshly-created empty temp workspace with **`--tools ""`** (the flag that actually disables built-in tools; `--allowedTools` only gates permission prompts) and Claude Code's config-skipping **`--safe-mode`** (the Claude Code equivalent of Codex's `--ignore-user-config`), or it inherits `~/.claude/CLAUDE.md`/project settings and silently contaminates every answer. The delivered `claude-cli` provider (PR #1735) does exactly this — `--tools ""` + `--safe-mode` + isolated cwd + **`--system-prompt`** (full replace, so Claude Code's default coding-agent prompt is dropped entirely — verified via a token-count check: `--system-prompt` sends 0 default-prompt cache tokens vs 1599 for `--append-system-prompt`) carrying the benchmark scoring protocol — all verified against the installed `claude` CLI.
 
 ### Fitting Claude Max x20 session limits (the real constraint)

--- a/packages/remnic-core/src/chat/chat-http.test.ts
+++ b/packages/remnic-core/src/chat/chat-http.test.ts
@@ -116,7 +116,7 @@ test("HTTP chat/message: hides unexpected stack traces and internal paths", asyn
         chatCompletion: async () => {
           throw new Error("secret failure at /srv/remnic/private/token-store.js");
         },
-      },
+      } as never,
       memoryDir,
       configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
     });

--- a/packages/remnic-core/src/chat/chat-http.test.ts
+++ b/packages/remnic-core/src/chat/chat-http.test.ts
@@ -109,6 +109,30 @@ test("HTTP chat/message: 503 when no LLM is available", async () => {
   });
 });
 
+test("HTTP chat/message: hides unexpected stack traces and internal paths", async () => {
+  await withTempDir(async (memoryDir) => {
+    const service = makeService({
+      fallbackLlmRef: {
+        chatCompletion: async () => {
+          throw new Error("secret failure at /srv/remnic/private/token-store.js");
+        },
+      },
+      memoryDir,
+      configRef: parseConfig({ memoryDir, chat: { ...DEFAULT_CHAT_CONFIG, enabled: true } }),
+    });
+    const m = mockRes();
+    await handleChatMessage(mockReq() as never, m as never, { message: "hi" }, {
+      service,
+      config: service.configRef!.chat,
+      memoryDir,
+    });
+    assert.equal(m.status, 200);
+    assert.ok(!m.body.includes("secret failure"));
+    assert.ok(!m.body.includes("/srv/remnic"));
+    assert.ok(!m.body.includes("stack"));
+  });
+});
+
 test("HTTP chat/message: 200 happy path returns reply + chatSessionId", async () => {
   await withTempDir(async (memoryDir) => {
     const service = makeService({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild@>=0.27.3 <0.28.1: 0.28.1
+
 importers:
 
   .:
@@ -751,34 +754,16 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -787,34 +772,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -823,22 +790,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -847,22 +802,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -871,22 +814,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -895,22 +826,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -919,22 +838,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -943,34 +850,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -979,22 +868,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -1003,23 +880,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -1027,34 +892,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -1608,7 +1455,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: 0.28.1
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1791,11 +1638,6 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2814,157 +2656,79 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -3465,9 +3229,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bundle-require@5.1.0(esbuild@0.27.7):
+  bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -3609,35 +3373,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4393,12 +4128,12 @@ snapshots:
 
   tsup@8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ onlyBuiltDependencies:
   - protobufjs
 
 
+overrides:
+  "esbuild@>=0.27.3 <0.28.1": "0.28.1"


### PR DESCRIPTION
## Summary\n- clarify Claude Code as a valid Tier-F research harness with explicit provenance\n- enforce patched esbuild 0.28.1 via pnpm workspace override\n- add chat HTTP stack-trace regression coverage\n- queue patch release for all public @remnic packages\n\n## Verification\n- pnpm exec tsx --test packages/remnic-core/src/chat/chat-http.test.ts\n- pnpm install --frozen-lockfile --lockfile-only\n- node scripts/check-ratchets.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The esbuild override touches the entire install graph; doc changes affect how frontier numbers are described publicly but carry no runtime behavior change beyond the lockfile pin.
> 
> **Overview**
> **Dependency hardening:** Adds a pnpm workspace override forcing **esbuild 0.28.1** (replacing 0.27.x in the lockfile) and queues a **patch** changeset across all public `@remnic/*` packages.
> 
> **Research / benchmark docs:** Rewrites Tier-F **`claude -p`** framing across benchmarks, paper, and evidence-sprint docs—from treating Claude Code as a non-leaderboard path to **explicit provenance**: Opus via Claude Code is a **valid frontier harness**, may keep **`tier: "frontier"`** when the artifact contract is met, and **trial-limited** runs are partial coverage—not invalid measurements. Notes **`claude-cli`** is on `main` where relevant.
> 
> **Tests:** Adds a **chat HTTP** regression test that LLM failures return **200** with a safe reply and **no** internal paths, error text, or stack traces in the response body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67807aaef4006d80c09139e6282e2e9ca433f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->