### PR TITLE
fix: close chat stack trace exposure

### DIFF
--- a/packages/remnic-core/src/chat/chat-http.ts
+++ b/packages/remnic-core/src/chat/chat-http.ts
@@ -201,11 +201,23 @@ export async function handleChatMessage(
     return;
   }
 
-  // Strip internal error details from the wire response (CodeQL — no stack
-  // traces or internal messages leak to the client; keep only the tagged reply).
-  const wireResult = result.error
-    ? { reply: result.reply, chatSessionId: result.chatSessionId, ...(result.pendingPlan ? { pendingPlan: result.pendingPlan } : {}) }
-    : result;
+  // Build the public response field-by-field.  Never serialize the engine
+  // result wholesale: an engine failure may carry internal error metadata.
+  const wireResult = {
+    reply: result.reply,
+    chatSessionId: result.chatSessionId,
+    ...(result.pendingPlan
+      ? {
+          pendingPlan: {
+            planId: result.pendingPlan.planId,
+            preview: result.pendingPlan.preview,
+          },
+        }
+      : {}),
+    ...(result.skippedTools
+      ? { skippedTools: result.skippedTools.filter((name): name is string => typeof name === "string") }
+      : {}),
+  };
   respondJson(res, 200, wireResult);
 }
 


### PR DESCRIPTION
## Summary
- serialize chat success responses field-by-field instead of forwarding the engine result object
- preserve stable public error responses and existing pending-plan fields

## Verification
- pnpm exec tsx --test packages/remnic-core/src/chat/chat-http.test.ts
- pnpm run preflight:quick (in progress from the parent release hardening run)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows the chat HTTP success payload at a security-sensitive boundary (information disclosure), but the change is small and scoped to response serialization.
> 
> **Overview**
> **POST `/engram/v1/chat/message`** no longer serializes the full `ChatTurnResult` on success. Responses are built from an explicit allowlist: `reply`, `chatSessionId`, optional `pendingPlan` (`planId` + `preview` only), and optional `skippedTools` (string names only).
> 
> This closes a path where engine failures tagged with internal `error` metadata could still reach clients when the handler returned HTTP 200 with a partial reply. Public error statuses and messages are unchanged; only the success-body shape is tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0946949cdcd58caec0c681ede6af6f1b3ab82595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->